### PR TITLE
Oci8 improvements

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -36,7 +36,9 @@ class Driver implements \Doctrine\DBAL\Driver
         return new OCI8Connection(
             $username,
             $password,
-            $this->_constructDsn($params)
+            $this->_constructDsn($params),
+            isset($params['charset']) ? $params['charset'] : null,
+            isset($params['session_mode']) ? $params['session_mode'] : OCI_DEFAULT
         );
     }
 
@@ -65,10 +67,6 @@ class Driver implements \Doctrine\DBAL\Driver
             $dsn .= '))';
         } else {
             $dsn .= $params['dbname'];
-        }
-
-        if (isset($params['charset'])) {
-            $dsn .= ';charset=' . $params['charset'];
         }
 
         return $dsn;

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -30,11 +30,11 @@ class OCI8Connection implements \Doctrine\DBAL\Driver\Connection
 {
     private $_dbh;
     
-    public function __construct($username, $password, $db)
+    public function __construct($username, $password, $db, $charset = null, $session_mode = OCI_DEFAULT)
     {
-        $this->_dbh = @oci_connect($username, $password, $db);
+        $this->_dbh = @oci_connect($username, $password, $db, $charset, $session_mode);
         if (!$this->_dbh) {
-            throw new OCI8Exception($this->errorInfo());
+            throw OCI8Exception::fromErrorInfo($this->errorInfo());
         }
     }
     
@@ -93,7 +93,12 @@ class OCI8Connection implements \Doctrine\DBAL\Driver\Connection
     
     public function errorCode()
     {
-        $error = oci_error($this->_dbh);
+        if (!is_resource($this->_dbh)) {
+            $error = oci_error();
+        } else {
+            $error = oci_error($this->_dbh);
+        }
+        
         if ($error !== false) {
             $error = $error['code'];
         }
@@ -102,6 +107,9 @@ class OCI8Connection implements \Doctrine\DBAL\Driver\Connection
     
     public function errorInfo()
     {
+        if (!is_resource($this->_dbh)) {
+            return oci_error();
+        }
         return oci_error($this->_dbh);
     }
     

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -41,6 +41,7 @@ class OCI8Statement implements \Doctrine\DBAL\Driver\Statement
         PDO::FETCH_NUM => OCI_NUM
     );
     private $_paramMap = array();
+    private $_connection;
 
     /**
      * Creates a new OCI8Statement that uses the given connection handle and SQL statement.
@@ -48,9 +49,10 @@ class OCI8Statement implements \Doctrine\DBAL\Driver\Statement
      * @param resource $dbh The connection handle.
      * @param string $statement The SQL statement.
      */
-    public function __construct($dbh, $statement)
+    public function __construct($connection, $statement)
     {
-        $this->_sth = oci_parse($dbh, $this->_convertPositionalToNamedPlaceholders($statement));
+        $this->_connection = $connection;
+        $this->_sth = oci_parse($connection->getDbh(), $this->_convertPositionalToNamedPlaceholders($statement));
     }
 
     /**
@@ -146,7 +148,7 @@ class OCI8Statement implements \Doctrine\DBAL\Driver\Statement
             }
         }
 
-        $ret = @oci_execute($this->_sth, OCI_DEFAULT);
+        $ret = @oci_execute($this->_sth, $this->_connection->getExecutionMode());
         if ( ! $ret) {
             throw OCI8Exception::fromErrorInfo($this->errorInfo());
         }


### PR DESCRIPTION
Hi!

I made some OCI8 improvements, that should be added into doctrine/master. I described them in commit logs.

Here they are:

Added new parameters into OCI8Connection constructor - $charset and $session_mode
Charset is 4th parameter of oci_connect and cannot be specified as part of TNS string like in PDOOci.
I've added session_mode param, because OCI_DEFAULT mode is insufficient when new user/database will be created and it is necessary to connect as OCI_SYSDBA. I saw some CREATE USER statements in schema manager, so this param is just in case.

Fixed error handling in OCI8Connection. When oci_connect failed, $_dbh is boolean, so cannot be used in oci_error();

OCI8Statement is using for all statements OCI_DEFAULT which is the same like OCI_NO_AUTO_COMMIT - therefor any changes that are made without transaction are rolled back.

Now the OCI8 Driver act like any other driver - commit after execute by default, and starting transaction when invoked $conn->beginTransaction()

Thank you for mergin the changes into core.
