### PR TITLE
2.0.0 beta4 - Fix DDC 629

### DIFF
--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -201,9 +201,18 @@ abstract class AbstractSchemaManager
      *
      * @return Table[]
      */
-    public function listTables()
+    public function listTables(array $classes)
     {
-        $tableNames = $this->listTableNames();
+        if(!empty($classes)){
+            foreach($classes as $class){
+                $tableNames[] = $class->table['name'];
+                foreach($class->associationMappings as $associationMapping)
+                    if($associationMapping['isOwningSide'] && !\is_null($associationMapping['joinTable']['name']))
+                        $tableNames[] = $associationMapping['joinTable']['name'];
+            }
+        } else {
+            $tableNames = $this->listTableNames();
+        }
 
         $tables = array();
         foreach ($tableNames AS $tableName) {
@@ -751,13 +760,13 @@ abstract class AbstractSchemaManager
      * 
      * @return Schema
      */
-    public function createSchema()
+    public function createSchema(array $classes = null)
     {
         $sequences = array();
         if($this->_platform->supportsSequences()) {
             $sequences = $this->listSequences();
         }
-        $tables = $this->listTables();
+        $tables = $this->listTables($classes);
 
         return new Schema($tables, $sequences, $this->createSchemaConfig());
     }


### PR DESCRIPTION
Modified so SchemaTool->dropSchema($classes) will use the $classes param to create the schema when dropping tables. 
Following this AbstractSchemaManager in dbal submodule was updated (see following pull request, commit: https://github.com/tomglue/dbal/commit/938af084f5576e2b0ec82f70aaad18fe5119b659), so the listTables() method, used by the createSchema() method, will use $classes param supplied.
This is useful when using Doctrine for a Wordpress plugin where you only desire to drop tables created using Doctrine, and not all the tables in the database.
