### PR TITLE
2.0.0 beta4 - Fix DDC 629

### DIFF
--- a/build.properties.dev
+++ b/build.properties.dev
@@ -1,4 +1,5 @@
-version_name=2.0.0BETA3
+version_name=2.0.1
+dependencies.common=2.0.1
 stability=beta
 build.dir=build
 dist.dir=dist

--- a/build.xml
+++ b/build.xml
@@ -154,7 +154,7 @@
            <dependencies>
                <php minimum_version="5.3.2" />
                <pear minimum_version="1.6.0" recommended_version="1.6.1" />
-               <package name="DoctrineCommon" channel="pear.doctrine-project.org" minimum_version="2.0.0BETA4" />
+               <package name="DoctrineCommon" channel="pear.doctrine-project.org" minimum_version="${dependencies.common}" />
            </dependencies>
            <dirroles key="bin">script</dirroles>
            <ignore>Doctrine/Common/</ignore>

--- a/build.xml
+++ b/build.xml
@@ -174,9 +174,12 @@
     </target>
 
     <target name="git-tag">
-        <exec command="grep '${version}' ${project.basedir}/lib/Doctrine/DBAL/Version.php" checkreturn="true"/>
+        <exec command="grep '${version}-DEV' ${project.basedir}/lib/Doctrine/DBAL/Version.php" checkreturn="true"/>
+        <exec command="sed 's/${version}-DEV/${version}/' ${project.basedir}/lib/Doctrine/DBAL/Version.php > ${project.basedir}/lib/Doctrine/DBAL/Version2.php" passthru="true" />
+        <exec command="mv ${project.basedir}/lib/Doctrine/DBAL/Version2.php ${project.basedir}/lib/Doctrine/DBAL/Version.php" passthru="true" />
+        <exec command="git add ${project.basedir}/lib/Doctrine/DBAL/Version.php" passthru="true" />
+        <exec command="git commit -m 'Release {$version}'" />
         <exec command="git tag -a ${version}" passthru="true" />
-        <exec command="git push origin ${version}" passthru="true" />
     </target>
 
     <target name="pirum-release">
@@ -191,11 +194,10 @@
     <target name="update-dev-version">
         <exec command="grep '${version}' ${project.basedir}/lib/Doctrine/DBAL/Version.php" checkreturn="true"/>
         <propertyprompt propertyName="next_version" defaultValue="${version}" promptText="Enter next version string (without -DEV)" />
-        <exec command="sed 's/${version}-DEV/${next_version}-DEV/' ${project.basedir}/lib/Doctrine/DBAL/Version.php > ${project.basedir}/lib/Doctrine/DBAL/Version2.php" passthru="true" />
+        <exec command="sed 's/${version}/${next_version}-DEV/' ${project.basedir}/lib/Doctrine/DBAL/Version.php > ${project.basedir}/lib/Doctrine/DBAL/Version2.php" passthru="true" />
         <exec command="mv ${project.basedir}/lib/Doctrine/DBAL/Version2.php ${project.basedir}/lib/Doctrine/DBAL/Version.php" passthru="true" />
         <exec command="git add ${project.basedir}/lib/Doctrine/DBAL/Version.php" passthru="true" />
-        <exec command="git commit -m 'Bump Dev Version to ${next_version}'" passthru="true" />
-        <exec command="git push origin master" passthru="true" />
+        <exec command="git commit -m 'Bump Dev Version to ${next_version}-DEV'" passthru="true" />
     </target>
 
     <target name="release" depends="git-tag,build-packages,distribute-download,pirum-release,update-dev-version" />

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1007,7 +1007,7 @@ class Connection implements DriverConnection
         // Check whether parameters are positional or named. Mixing is not allowed, just like in PDO.
         if (is_int(key($params))) {
             // Positional parameters
-            $typeOffset = isset($types[0]) ? -1 : 0;
+            $typeOffset = array_key_exists(0, $types) ? -1 : 0;
             $bindIndex = 1;
             foreach ($params as $position => $value) {
                 $typeIndex = $bindIndex + $typeOffset;

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -201,9 +201,18 @@ abstract class AbstractSchemaManager
      *
      * @return Table[]
      */
-    public function listTables()
+    public function listTables(array $classes)
     {
-        $tableNames = $this->listTableNames();
+        if(!empty($classes)){
+            foreach($classes as $class){
+                $tableNames[] = $class->table['name'];
+                foreach($class->associationMappings as $associationMapping)
+                    if($associationMapping['isOwningSide'] && !\is_null($associationMapping['joinTable']['name']))
+                        $tableNames[] = $associationMapping['joinTable']['name'];
+            }
+        } else {
+            $tableNames = $this->listTableNames();
+        }
 
         $tables = array();
         foreach ($tableNames AS $tableName) {
@@ -751,13 +760,13 @@ abstract class AbstractSchemaManager
      * 
      * @return Schema
      */
-    public function createSchema()
+    public function createSchema(array $classes = null)
     {
         $sequences = array();
         if($this->_platform->supportsSequences()) {
             $sequences = $this->listSequences();
         }
-        $tables = $this->listTables();
+        $tables = $this->listTables($classes);
 
         return new Schema($tables, $sequences, $this->createSchemaConfig());
     }

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -204,12 +204,14 @@ abstract class AbstractSchemaManager
     public function listTables(array $classes)
     {
         if(!empty($classes)){
+
             foreach($classes as $class){
                 $tableNames[] = $class->table['name'];
                 foreach($class->associationMappings as $associationMapping)
-                    if($associationMapping['isOwningSide'] && !\is_null($associationMapping['joinTable']['name']))
+                    if($associationMapping['isOwningSide'] && array_key_exists('joinTable', $associationMapping) && !\is_null($associationMapping['joinTable']['name']))
                         $tableNames[] = $associationMapping['joinTable']['name'];
             }
+
         } else {
             $tableNames = $this->listTableNames();
         }

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -201,7 +201,7 @@ abstract class AbstractSchemaManager
      *
      * @return Table[]
      */
-    public function listTables(array $classes)
+    public function listTables($classes)
     {
         if(!empty($classes)){
 

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -36,7 +36,7 @@ class Version
     /**
      * Current Doctrine Version
      */
-    const VERSION = '2.0.1-DEV';
+    const VERSION = '2.0.1';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -36,7 +36,7 @@ class Version
     /**
      * Current Doctrine Version
      */
-    const VERSION = '2.0.0-DEV';
+    const VERSION = '2.0.1-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Functional;
 use Doctrine\DBAL\Types\Type;
+use PDO;
 
 require_once __DIR__ . '/../../TestInit.php';
 
@@ -23,6 +24,18 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         }
         $this->_conn->executeUpdate('DELETE FROM write_table');
+    }
+
+    /**
+     * @group DBAL-80
+     */
+    public function testExecuteUpdateFirstTypeIsNull()
+    {
+        $sql = "INSERT INTO write_table (test_string, test_int) VALUES (?, ?)";
+        $this->_conn->executeUpdate($sql, array("text", 1111), array(null, PDO::PARAM_INT));
+
+        $sql = "SELECT * FROM write_table WHERE test_string = ? AND test_int = ?";
+        $this->assertTrue((bool)$this->_conn->fetchColumn($sql, array("text", 1111)));
     }
 
     public function testExecuteUpdate()


### PR DESCRIPTION
Modified so SchemaTool->dropSchema($classes) will use the $classes param to create the schema when dropping tables (see comit https://github.com/tomglue/doctrine2/commit/2853dd9cb5935a2d808dc0725bdb4d855a75c65d / pull request https://github.com/doctrine/dbal/pull/8).
Following this AbstractSchemaManager in dbal submodule was updated, so the listTables() method, used by the createSchema() method, will use $classes param supplied.
This is useful when using Doctrine for a Wordpress plugin where you only desire to drop tables created using Doctrine, and not all the tables in the database.
