### PR TITLE
DBAL-74 OracleSchemaManager - assume char_length as the length of character columns

### DIFF
--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -145,10 +145,12 @@ class OracleSchemaManager extends AbstractSchemaManager
             case 'varchar':
             case 'varchar2':
             case 'nvarchar2':
+                $length = $tableColumn['char_length'];
                 $fixed = false;
                 break;
             case 'char':
             case 'nchar':
+                $length = $tableColumn['char_length'];
                 $fixed = true;
                 break;
             case 'date':


### PR DESCRIPTION
This is the fix for http://www.doctrine-project.org/jira/browse/DBAL-74
