### PR TITLE
Fixed a typo on ImportCommand

### DIFF
--- a/lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php
@@ -110,7 +110,7 @@ EOT
                     $rs = $stmt->execute();
 
                     if ($rs) {
-                        $printer->writeln('OK!');
+                        $output->writeln('OK!');
                     } else {
                         $error = $stmt->errorInfo();
 


### PR DESCRIPTION
Variable $printer doesn't exists and throws a Fatal error. It must be $output.
