### PR TITLE
Support for Postgres SET NULL, SET DEFAULT, and NO ACTION foreign key detection in the PostgresSQLSchema Manager

### DIFF
--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -38,10 +38,10 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         $onUpdate = null;
         $onDelete = null;
 
-        if (preg_match('(ON UPDATE ([a-zA-Z0-9]+))', $tableForeignKey['condef'], $match)) {
+        if (preg_match('(ON UPDATE ([a-zA-Z0-9]+( (NULL|ACTION|DEFAULT))?))', $tableForeignKey['condef'], $match)) {
             $onUpdate = $match[1];
         }
-        if (preg_match('(ON DELETE ([a-zA-Z0-9]+))', $tableForeignKey['condef'], $match)) {
+        if (preg_match('(ON DELETE ([a-zA-Z0-9]+( (NULL|ACTION|DEFAULT))?))', $tableForeignKey['condef'], $match)) {
             $onDelete = $match[1];
         }
 


### PR DESCRIPTION
Previous regex was incorrectly parsing these values and would only pull the first word, causing DBAL to php fatal error later when it cannot match "SET" to "SET NULL"
