### PR TITLE
OCI8 Change private properties and methods to protected

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -47,7 +47,7 @@ class Driver implements \Doctrine\DBAL\Driver
      *
      * @return string The DSN.
      */
-    private function _constructDsn(array $params)
+    protected function _constructDsn(array $params)
     {
         $dsn = '';
         if (isset($params['host'])) {

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -26,9 +26,9 @@ namespace Doctrine\DBAL\Driver\OCI8;
  */
 class OCI8Connection implements \Doctrine\DBAL\Driver\Connection
 {
-    private $_dbh;
+    protected $_dbh;
 
-    private $_executeMode = OCI_COMMIT_ON_SUCCESS;
+    protected $_executeMode = OCI_COMMIT_ON_SUCCESS;
 
     /**
      * Create a Connection to an Oracle Database using oci8 extension.

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -30,15 +30,15 @@ use \PDO;
 class OCI8Statement implements \Doctrine\DBAL\Driver\Statement
 {
     /** Statement handle. */
-    private $_sth;
-    private $_executeMode;
-    private static $_PARAM = ':param';
-    private static $fetchStyleMap = array(
+    protected $_sth;
+    protected $_executeMode;
+    protected static $_PARAM = ':param';
+    protected static $fetchStyleMap = array(
         PDO::FETCH_BOTH => OCI_BOTH,
         PDO::FETCH_ASSOC => OCI_ASSOC,
         PDO::FETCH_NUM => OCI_NUM
     );
-    private $_paramMap = array();
+    protected $_paramMap = array();
 
     /**
      * Creates a new OCI8Statement that uses the given connection handle and SQL statement.


### PR DESCRIPTION
Shouldn't be the properties in OCI8\* classes protected instead of private?

I would like to build custom OCI8 driver that is dervied from Doctrine\DBAL\Driver\OCI8.
