### PR TITLE
Added MySQL unsigned attribute on table creation

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -942,6 +942,8 @@ abstract class AbstractPlatform
             $columnData['type'] = $column->getType();
             $columnData['length'] = $column->getLength();
             $columnData['notnull'] = $column->getNotNull();
+            $columnData['scale'] = $column->getScale();
+            $columnData['unsigned'] = $column->getUnsigned();
             $columnData['fixed'] = $column->getFixed();
             $columnData['unique'] = false; // TODO: what do we do about this?
             $columnData['version'] = ($column->hasPlatformOption("version"))?$column->getPlatformOption('version'):false;


### PR DESCRIPTION
I noticed that the MySQL schema generator was ignoring the unsigned attribute when tables are generated.  

It was working properly for updates, just not creates.

I noticed the scale attribute was missing as well, so I added that as well.

I hope this helps.  Keep up the great work.
