### PR TITLE
Unsigned is missing on the column data.

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -948,6 +948,7 @@ abstract class AbstractPlatform
             if(strtolower($columnData['type']) == "string" && $columnData['length'] === null) {
                 $columnData['length'] = 255;
             }
+            $columnData['unsigned'] = $column->getUnsigned();
             $columnData['precision'] = $column->getPrecision();
             $columnData['scale'] = $column->getScale();
             $columnData['default'] = $column->getDefault();


### PR DESCRIPTION
Adding the option of unsigned field. I made this change after using doctrine-migrations and detect that the fields marked as unsigned was being ignored and generated as signed.

Example of what has been generated before this change:

  ++ migrating 20110527182534

```
 -> CREATE TABLE tb_user (id INT AUTO_INCREMENT NOT NULL, facebook BIGINT NOT NULL, first_name VARCHAR(45) NOT NULL, middle_name VARCHAR(45) DEFAULT NULL, last_name VARCHAR(45) NOT NULL, email VARCHAR(60) NOT NULL, gender VARCHAR(1) DEFAULT NULL, profile_url VARCHAR(120) DEFAULT NULL, access_role VARCHAR(30) NOT NULL, created_at DATETIME NOT NULL, last_visit DATETIME NOT NULL, UNIQUE INDEX UNIQUE_KEY_EMAIL (email), UNIQUE INDEX UNIQUE_KEY_FACEBOOK (facebook), PRIMARY KEY(id)) ENGINE = InnoDB
```

Example of what is generated now, after the change:

  ++ migrating 20110527182534

```
 -> CREATE TABLE tb_user (id INT UNSIGNED AUTO_INCREMENT NOT NULL, facebook BIGINT UNSIGNED NOT NULL, first_name VARCHAR(45) NOT NULL, middle_name VARCHAR(45) DEFAULT NULL, last_name VARCHAR(45) NOT NULL, email VARCHAR(60) NOT NULL, gender VARCHAR(1) DEFAULT NULL, profile_url VARCHAR(120) DEFAULT NULL, access_role VARCHAR(30) NOT NULL, created_at DATETIME NOT NULL, last_visit DATETIME NOT NULL, UNIQUE INDEX UNIQUE_KEY_EMAIL (email), UNIQUE INDEX UNIQUE_KEY_FACEBOOK (facebook), PRIMARY KEY(id)) ENGINE = InnoDB
```
