### PR TITLE
more extensive host parameter check required

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -50,7 +50,7 @@ class Driver implements \Doctrine\DBAL\Driver
     private function _constructDsn(array $params)
     {
         $dsn = '';
-        if (isset($params['host'])) {
+        if (isset($params['host']) && $params['host']) {
             $dsn .= '(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)' .
                    '(HOST=' . $params['host'] . ')';
 


### PR DESCRIPTION
$params['host'] should not only be set, it should also contain a value. 
Now, problems occur when using inherited config files (ex.: development environment inherits from production environment):

[production]
database.host = 'production-host';

[development]
database.host = ;

The development can't use a TNS name notation since it is always set, but has value null or empty string.
