### PR TITLE
Fixed: MySQL Driver didn't return Database name if DBAL was initialized using existing PDO instance

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -71,7 +71,7 @@ class Driver implements \Doctrine\DBAL\Driver
         if (isset($params['charset'])) {
             $dsn .= 'charset=' . $params['charset'] . ';';
         }
-        
+
         return $dsn;
     }
 
@@ -93,6 +93,10 @@ class Driver implements \Doctrine\DBAL\Driver
     public function getDatabase(\Doctrine\DBAL\Connection $conn)
     {
         $params = $conn->getParams();
-        return $params['dbname'];
+
+        if (isset($params['dbname'])) {
+            return $params['dbname'];
+        }
+        return $conn->query('SELECT DATABASE()')->fetchColumn();
     }
 }


### PR DESCRIPTION
Fixed: MySQL Driver didn't return Database name if DBAL was initialized using existing PDO instance
