### PR TITLE
[MySqlPlatform] Fixing Truncate bug for tables with foreign key constraints

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -686,4 +686,14 @@ class MySqlPlatform extends AbstractPlatform
     {
         return 'Doctrine\DBAL\Platforms\Keywords\MySQLKeywords';
     }
+
+    /**
+     * @override
+     */
+    public function getTruncateTableSQL($tableName, $cascade = false)
+    {
+        return 'SET foreign_key_checks = 0;'
+              .'TRUNCATE TABLE ' . $tableName . ';'
+              .'SET foreign_key_checks = 1;';
+    }
 }


### PR DESCRIPTION
According to the MySQL documentation: "The TRUNCATE TABLE statement does not invoke ON DELETE triggers", and does not allow the truncation of a table with foreign key constraints.
In order to truncate a table with foreign keys, "SET foreign_key_checks = 0;" must be executed before truncating and reenabled afterward with "SET foreign_key_checks = 1;"

This bug is documented on https://github.com/doctrine/datafixtures/issues/17
