### PR TITLE
blobs added for mysql platforms

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -674,6 +674,10 @@ class MySqlPlatform extends AbstractPlatform
             'decimal'       => 'decimal',
             'numeric'       => 'decimal',
             'year'          => 'date',
+            'tinyblob'      => 'text',
+            'blob'          => 'text',
+            'mediumblob'    => 'text',
+            'longblob'      => 'text,
         );
     }
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -677,7 +677,7 @@ class MySqlPlatform extends AbstractPlatform
             'tinyblob'      => 'text',
             'blob'          => 'text',
             'mediumblob'    => 'text',
-            'longblob'      => 'text,
+            'longblob'      => 'text',
         );
     }
 


### PR DESCRIPTION
The blobs are missing in the method MySqlPlatform::initializeDoctrineTypeMappings() so the blobs could not be accepted. 
