### PR TITLE
[PostgresPlatform] Fixing change detection when a default is removed

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -400,7 +400,9 @@ class PostgreSqlPlatform extends AbstractPlatform
                 $sql[] = 'ALTER TABLE ' . $diff->name . ' ' . $query;
             }
             if ($columnDiff->hasChanged('default')) {
-                $query = 'ALTER ' . $oldColumnName . ' SET ' . $this->getDefaultValueDeclarationSQL($column->toArray());
+                $query = 'ALTER ' . $oldColumnName . ((null !== $column->getDefault())
+                       ? ' SET ' . $this->getDefaultValueDeclarationSQL($column->toArray())
+                       : ' DROP DEFAULT');
                 $sql[] = 'ALTER TABLE ' . $diff->name . ' ' . $query;
             }
             if ($columnDiff->hasChanged('notnull')) {


### PR DESCRIPTION
Change detection when the default value is removed from a field is presently broken and produces invalid SQL.  

This patch checks to see if a new default value actually exists before adding the SET DEFAULT '';

Uses DROP DEFAULT when the new default value does not exist 
