### PR TITLE
Add a test when the port is empty

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -37,7 +37,7 @@ class Driver implements \Doctrine\DBAL\Driver
         if (isset($params['host']) && $params['host'] != '') {
             $dsn .= 'host=' . $params['host'] . ' ';
         }
-        if (isset($params['port']) AND $params['port'] != '') {
+        if (isset($params['port']) && $params['port'] != '') {
             $dsn .= 'port=' . $params['port'] . ' ';
         }
         if (isset($params['dbname'])) {

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -37,7 +37,7 @@ class Driver implements \Doctrine\DBAL\Driver
         if (isset($params['host']) && $params['host'] != '') {
             $dsn .= 'host=' . $params['host'] . ' ';
         }
-        if (isset($params['port'])) {
+        if (isset($params['port']) AND $params['port'] != '') {
             $dsn .= 'port=' . $params['port'] . ' ';
         }
         if (isset($params['dbname'])) {


### PR DESCRIPTION
Hi,

There is a miss test if the port is empty in the array $params. The result is a PDOException with the message "could not connect to server: Can't assign requested address..."

I see the error when I don't set the port of the server on the interface configurator of sf2. In the parameters.ini, I have 'database_port=""'

I hope that will help you.

BR,
Maxime
