### PR TITLE
Made custom Oracle NLS_DATE_FORMAT more compatible with Doctrine.

### DIFF
--- a/lib/Doctrine/DBAL/Event/Listeners/OracleSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/OracleSessionInit.php
@@ -45,7 +45,7 @@ class OracleSessionInit implements EventSubscriber
 {
     protected $_defaultSessionVars = array(
         'NLS_TIME_FORMAT' => "HH24:MI:SS",
-        'NLS_DATE_FORMAT' => "YYYY-MM-DD HH24:MI:SS",
+        'NLS_DATE_FORMAT' => 'YYYY-MM-DD "00:00:00"',
         'NLS_TIMESTAMP_FORMAT' => "YYYY-MM-DD HH24:MI:SS",
         'NLS_TIMESTAMP_TZ_FORMAT' => "YYYY-MM-DD HH24:MI:SS TZH:TZM",
     );


### PR DESCRIPTION
The supplied NLS_DATE_FORMAT setting did not work out of the box for me. Doctrine wants the time part of the date string to be "00:00:00" but the existing format string results in Oracle returning a non-midnight time. This patch fixes the issue.
