### PR TITLE
Array types are not working for existing entities (without prefilling the database correctly)

### DIFF
--- a/lib/Doctrine/DBAL/Types/ArrayType.php
+++ b/lib/Doctrine/DBAL/Types/ArrayType.php
@@ -38,8 +38,8 @@ class ArrayType extends Type
 
     public function convertToPHPValue($value, \Doctrine\DBAL\Platforms\AbstractPlatform $platform)
     {
-        if ($value === null) {
-            return null;
+        if ($value == null) {
+            return array();
         }
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;


### PR DESCRIPTION
Assume we have an entity and we want to add an array field to it. Doing so, syncing schema changes to the database, we end up with a column that has an empty string.
So, on the next hydration of the entity, instead of getting an entity with an empty array field, we get  a ConversionException because we can unserialize an empty string. 

Instead we need to check, if the string is empty, return empty array (so that in our code we can iterate through it without checking for null).

The same problem applies to object types
