### PR TITLE
Fix for ConversionException throw when the value is empty

### DIFF
--- a/lib/Doctrine/DBAL/Types/ArrayType.php
+++ b/lib/Doctrine/DBAL/Types/ArrayType.php
@@ -38,9 +38,10 @@ class ArrayType extends Type
 
     public function convertToPHPValue($value, \Doctrine\DBAL\Platforms\AbstractPlatform $platform)
     {
-        if ($value === null) {
-            return null;
+        if (empty($value)) {
+            return array();
         }
+
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
         $val = unserialize($value);


### PR DESCRIPTION
Assume we have an entity and we want to add an array field to it. Doing ...

...so, syncing schema changes to the database, we end up with a column that has an empty string.
So, on the next hydration of the entity, instead of getting an entity with an empty array field, we get  a ConversionException because we can unserialize an empty string. 

Instead we need to check, if the string is empty, return empty array (so that in our code we can iterate through it without checking for null).
