### PR TITLE
Fix Postgres Date Add/Sub functions for dynamic values

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -99,22 +99,22 @@ class PostgreSqlPlatform extends AbstractPlatform
 
     public function getDateAddDaysExpression($date, $days)
     {
-        return "(" . $date . "+ interval '" . $days . " day')";
+        return "($date + ($days || ' day')::interval)";
     }
 
     public function getDateSubDaysExpression($date, $days)
     {
-        return "(" . $date . "- interval '" . $days . " day')";
+        return "($date - ($days || ' day')::interval)";
     }
 
     public function getDateAddMonthExpression($date, $months)
     {
-        return "(" . $date . "+ interval '" . $months . " month')";
+        return "($date + ($months || ' month')::interval)";
     }
 
     public function getDateSubMonthExpression($date, $months)
     {
-        return "(" . $date . "- interval '" . $months . " month')";
+        return "($date - ($months || ' month')::interval)";
     }
     
     /**


### PR DESCRIPTION
I wanted to fetch the interval from a column. This didn't work in the old implementation.

For example this query:
SELECT item ... WHERE item.last_modification < DATE_SUB( CURRENT_DATE(), item.max_age, 'month')
works now, but produced wrong SQL in the old implementation
