### PR TITLE
Fixed reference to non-existing class in docblock

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -984,7 +984,7 @@ class Connection implements DriverConnection
      * Gets the SchemaManager that can be used to inspect or change the
      * database schema through the connection.
      *
-     * @return Doctrine\DBAL\Schema\SchemaManager
+     * @return Doctrine\DBAL\Schema\AbstractSchemaManager
      */
     public function getSchemaManager()
     {


### PR DESCRIPTION
Doc block referenced the Schema/SchemaManager, however it does not exist, it should point to the AbstractSchemaManager.
