### PR TITLE
added fix to postgres search_path support

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -32,7 +32,7 @@ class Driver implements \Doctrine\DBAL\Driver
             $password,
             $realDriverOptions
          );
-         if ($this->search_path){
+         if ($this->search_path) {
             $connection->setSearchPath($this->search_path);
          }	
         return $connection;
@@ -42,12 +42,13 @@ class Driver implements \Doctrine\DBAL\Driver
      *
      * @return driver Options to pass to the connection
      */
-    private function filterAndSetLocalOptions($driverOptions){
+    private function filterAndSetLocalOptions($driverOptions)
+    {
         $realDriverOptions = array();		
-        foreach( $driverOptions as $key=>$value){
-            if ($key == 'search_path'){
+        foreach ( $driverOptions as $key=>$value) {
+            if ($key == 'search_path') {
                 $this->search_path = $value;
-            }else{
+            } else {
                 $realDriverOptions[$key]=$value;
             }
         }

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms;
  */
 class Driver implements \Doctrine\DBAL\Driver
 {
+    private $search_path;
     /**
      * Attempts to connect to the database and returns a driver connection on success.
      *
@@ -18,14 +19,29 @@ class Driver implements \Doctrine\DBAL\Driver
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
     {
-        return new \Doctrine\DBAL\Driver\PDOConnection(
+ 		$realDriverOptions = $this->filterAndSetLocalOptions($driverOptions);
+ 		$connection =  new PgSqlConnection(
             $this->_constructPdoDsn($params),
             $username,
             $password,
-            $driverOptions
-        );
+            $realDriverOptions
+        	);
+        	if ($this->search_path){
+				$connection->setSearchPath($this->search_path);
+			}	
+			return $connection;
     }
-
+	private function filterAndSetLocalOptions($driverOptions){
+			$realDriverOptions = array();		
+			foreach( $driverOptions as $key=>$value){
+				if ($key == 'search_path'){
+					$this->search_path = $value;
+				}else{
+					$realDriverOptions[$key]=$value;
+				}
+			}
+			return $realDriverOptions;		
+		}
     /**
      * Constructs the Postgres PDO DSN.
      *
@@ -34,10 +50,10 @@ class Driver implements \Doctrine\DBAL\Driver
     private function _constructPdoDsn(array $params)
     {
         $dsn = 'pgsql:';
-        if (isset($params['host']) && $params['host'] != '') {
+        if (isset($params['host'])) {
             $dsn .= 'host=' . $params['host'] . ' ';
         }
-        if (isset($params['port']) && $params['port'] != '') {
+        if (isset($params['port'])) {
             $dsn .= 'port=' . $params['port'] . ' ';
         }
         if (isset($params['dbname'])) {

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -11,7 +11,13 @@ use Doctrine\DBAL\Platforms;
  */
 class Driver implements \Doctrine\DBAL\Driver
 {
+    /**
+     * Contains the search_path from database driver config
+     *
+     * @var string
+     */
     private $search_path;
+    
     /**
      * Attempts to connect to the database and returns a driver connection on success.
      *

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -19,29 +19,34 @@ class Driver implements \Doctrine\DBAL\Driver
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
     {
- 		$realDriverOptions = $this->filterAndSetLocalOptions($driverOptions);
- 		$connection =  new PgSqlConnection(
+        $realDriverOptions = $this->filterAndSetLocalOptions($driverOptions);
+        $connection =  new PgSqlConnection(
             $this->_constructPdoDsn($params),
             $username,
             $password,
             $realDriverOptions
-        	);
-        	if ($this->search_path){
-				$connection->setSearchPath($this->search_path);
-			}	
-			return $connection;
+         );
+         if ($this->search_path){
+            $connection->setSearchPath($this->search_path);
+         }	
+        return $connection;
     }
-	private function filterAndSetLocalOptions($driverOptions){
-			$realDriverOptions = array();		
-			foreach( $driverOptions as $key=>$value){
-				if ($key == 'search_path'){
-					$this->search_path = $value;
-				}else{
-					$realDriverOptions[$key]=$value;
-				}
-			}
-			return $realDriverOptions;		
-		}
+    /**
+     * Filter and set options meant for this driver
+     *
+     * @return driver Options to pass to the connection
+     */
+    private function filterAndSetLocalOptions($driverOptions){
+        $realDriverOptions = array();		
+        foreach( $driverOptions as $key=>$value){
+            if ($key == 'search_path'){
+                $this->search_path = $value;
+            }else{
+                $realDriverOptions[$key]=$value;
+            }
+        }
+        return $realDriverOptions;		
+    }
     /**
      * Constructs the Postgres PDO DSN.
      *
@@ -50,10 +55,10 @@ class Driver implements \Doctrine\DBAL\Driver
     private function _constructPdoDsn(array $params)
     {
         $dsn = 'pgsql:';
-        if (isset($params['host'])) {
+        if (isset($params['host']) && $params['host'] != '') {
             $dsn .= 'host=' . $params['host'] . ' ';
         }
-        if (isset($params['port'])) {
+        if (isset($params['port']) && $params['port'] != '') {
             $dsn .= 'port=' . $params['port'] . ' ';
         }
         if (isset($params['dbname'])) {

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/PgSqlConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/PgSqlConnection.php
@@ -23,21 +23,11 @@ namespace Doctrine\DBAL\Driver\PDOPgSql;
 
 class PgSqlConnection extends \Doctrine\DBAL\Driver\PDOConnection implements \Doctrine\DBAL\Driver\Connection
 {
-	private $search_path;
-	public function __construct($dsn, $user = null, $password = null, array $options = null)
-    	{
-       	parent::__construct($dsn, $user, $password, $options);
-    	}
-
 	public function setSearchPath($searchPath)
 	{
-		$this->search_path = $searchPath;
-		$sql = 	"SET search_path TO ".$searchPath;
+		$sql = "SET search_path TO ".$searchPath;
 		$stmt = $this->prepare($sql);
 		$stmt->execute();
 		return;
-	}
-	public function getSearchPath(){
-		return $this->search_path;
 	}
 }

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/PgSqlConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/PgSqlConnection.php
@@ -1,7 +1,5 @@
 <?php
 /*
- *  $Id$
- *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -23,11 +21,11 @@ namespace Doctrine\DBAL\Driver\PDOPgSql;
 
 class PgSqlConnection extends \Doctrine\DBAL\Driver\PDOConnection implements \Doctrine\DBAL\Driver\Connection
 {
-	public function setSearchPath($searchPath)
-	{
-		$sql = "SET search_path TO ".$searchPath;
-		$stmt = $this->prepare($sql);
-		$stmt->execute();
-		return;
-	}
+    public function setSearchPath($searchPath)
+    {
+        $sql = "SET search_path TO ".$searchPath;
+        $stmt = $this->prepare($sql);
+        $stmt->execute();
+        return;
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/PgSqlConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/PgSqlConnection.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+*/
+
+namespace Doctrine\DBAL\Driver\PDOPgSql;
+
+class PgSqlConnection extends \Doctrine\DBAL\Driver\PDOConnection implements \Doctrine\DBAL\Driver\Connection
+{
+	private $search_path;
+	public function __construct($dsn, $user = null, $password = null, array $options = null)
+    	{
+       	parent::__construct($dsn, $user, $password, $options);
+    	}
+
+	public function setSearchPath($searchPath)
+	{
+		$this->search_path = $searchPath;
+		$sql = 	"SET search_path TO ".$searchPath;
+		$stmt = $this->prepare($sql);
+		$stmt->execute();
+		return;
+	}
+	public function getSearchPath(){
+		return $this->search_path;
+	}
+}

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchema.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchema.php
@@ -44,12 +44,15 @@ class PostgreSqlSchema extends Schema
     /**
      * set search_path_array from string
      */
-    protected function setSearchPathArray($search_path)
+	protected function setSearchPathArray($search_path)
     {
+        $this->search_path_array = array();
         if ($search_path) {
-            $this->search_path_array = explode(",",$search_path);
-        } else {
-            $this->search_path_array = array();
+            $tmp = explode(",",$search_path);
+            foreach ($tmp as $dbSchema)
+            {
+                array_push($this->search_path_array, trim($dbSchema));
+            }
         }
         return;
     }

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchema.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchema.php
@@ -1,23 +1,23 @@
 <?php
 /*
- *  $Id$
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * This software consists of voluntary contributions made by many individuals
- * and is licensed under the LGPL. For more information, see
- * <http://www.doctrine-project.org>.
- */
+*  $Id$
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* This software consists of voluntary contributions made by many individuals
+* and is licensed under the LGPL. For more information, see
+* <http://www.doctrine-project.org>.
+*/
 
 namespace Doctrine\DBAL\Schema;
 
@@ -25,87 +25,115 @@ use Doctrine\DBAL\Schema\Visitor\CreateSchemaSqlCollector;
 use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 
+/**
+* Schema class extended for postgresql.
+* Supports search_path
+*/
 class PostgreSqlSchema extends Schema
-{	private $search_path_array;
+{	
+    /**
+     * (database schema) search_path from the DB
+     *
+     * @var array
+     */
+    private $search_path_array;
 
-   public function setSearchPathArray($search_path){
-  		if ($search_path){
-			$this->search_path_array = explode(",",$search_path);
-		}else{
-			$this->search_path_array = array();
-		}
+    /**
+     * set search_path_array from string
+     */
+    protected function setSearchPathArray($search_path){
+        if ($search_path){
+            $this->search_path_array = explode(",",$search_path);
+        }else{
+            $this->search_path_array = array();
+        }
+        return;
+    }
+    
+    /**
+     * set search path for this schema
+     *
+     * @param string $search_path The psql schema search path.
+     */
+    public function setSearchPath($search_path){
+        $this->setSearchPathArray( $search_path);
+        return;
+    }
+    
+    /**
+     * search a DB object in the list of objects (tables or sequences)
+     *
+     * @param string $tableName Name of the object in the form schema.name or name.
+     * @param array $hayStack List of known objects
+     * @return object $result Returns the object
+     */     
+    protected function searchObject($tableName,$hayStack){
+      $tableName = strtolower($tableName);		
+      $tableData = $this->splitNameToParts($tableName);
+      if ( $tableData['schema'] ){
+         if (array_key_exists($tableName,$hayStack)){
+            return $hayStack[$tableName];
+         }
+      }else{
+         foreach($this->search_path_array as $dbSchema){
+            $fullName = $dbSchema.".".$tableData['name'];
+            if (array_key_exists($fullName,$hayStack)){
+               return $hayStack[$fullName];
+            }	
+         }
+      }
+      return false;
+   }	 	
+   public function hasTable($tableName)
+      {
+         $table = $this->searchObject($tableName,$this->_tables);
+         if ($table !== false){
+            return 1;
+         }
+      return 0;
    }
-	public function setSearchPath($search_path){
-		$this->setSearchPathArray( $search_path);
-	}
-	
-	public function searchObject($tableName,$hayStack){
-		$tableName = strtolower($tableName);		
-		$tableData = $this->splitNameToParts($tableName);
-		if ( $tableData['schema'] ){
-			if (array_key_exists($tableName,$hayStack)){
-				return $hayStack[$tableName];
-			}
-		}else{
-			foreach($this->search_path_array as $dbSchema){
-				$fullName = $dbSchema.".".$tableData['name'];
-				if (array_key_exists($fullName,$hayStack)){
-					return $hayStack[$fullName];
-				}	
-			}
-		}
-		return false;
-	}	 	
-	public function hasTable($tableName)
-    	{
-			$table = $this->searchObject($tableName,$this->_tables);
-			if ($table !== false){
-		   	return 1;
-			}
-		return 0;
-	}
-	public function getTable($tableName)
-	{
-		$table = $this->searchObject($tableName,$this->_tables);		
-		if ($table !== false){
-			return $table;
-		}
-		throw SchemaException::tableDoesNotExist($tableName);
-	}
+   public function getTable($tableName)
+   {
+      $table = $this->searchObject($tableName,$this->_tables);		
+      if ($table !== false){
+         return $table;
+      }
+      throw SchemaException::tableDoesNotExist($tableName);
+   }
 
 	
    public function getTableBySchemaAndName($tableName){
-   	if (!isset($this->_tables[$tableName])) {
-   		return false;
-   	}
-   	return $this->tables[$table];
+      if (!isset($this->_tables[$tableName])) {
+         return false;
+      }
+      return $this->tables[$table];
    }
   
-	public function hasSequence($sequenceName)
-	{
-		$sequence = $this->searchObject($sequenceName,$this->_sequences);
-			if ($sequence !== false){
-		   	return 1;
-			}
-		return 0;
-	}
+   public function hasSequence($sequenceName)
+   {
+      $sequence = $this->searchObject($sequenceName,$this->_sequences);
+         if ($sequence !== false){
+            return 1;
+         }
+      return 0;
+   }
 	
-	public function getSequence($sequenceName)
-	{
-		$sequence = $this->searchObject($sequenceName,$this->_sequences);		
-		if ($sequence !== false){
-			return $sequence;
-		}
-		throw SchemaException::tableDoesNotExist($sequenceName);
-	}
+   public function getSequence($sequenceName)
+   {
+      $sequence = $this->searchObject($sequenceName,$this->_sequences);		
+      if ($sequence !== false){
+         return $sequence;
+      }
+      throw SchemaException::tableDoesNotExist($sequenceName);
+   }
 
-	private function splitNameToParts($name){
-		$r = array( 'schema' => false, 'name' => $name );
-		$dotPos = stripos($name,'.');
-		if ($dotPos){
-			$r['schema'] = substr($name,0,$dotPos);
-			$r['name'] = substr($name,$dotPos+1);
-		}
-		return $r;	
-	}    
+   private function splitNameToParts($name){
+      $r = array( 'schema' => false, 'name' => $name );
+      $dotPos = stripos($name,'.');
+      if ($dotPos){
+         $r['schema'] = substr($name,0,$dotPos);
+         $r['name'] = substr($name,$dotPos+1);
+      }
+      return $r;	
+   }    
 }

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchema.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchema.php
@@ -1,0 +1,111 @@
+<?php
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Visitor\CreateSchemaSqlCollector;
+use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
+use Doctrine\DBAL\Schema\Visitor\Visitor;
+
+class PostgreSqlSchema extends Schema
+{	private $search_path_array;
+
+   public function setSearchPathArray($search_path){
+  		if ($search_path){
+			$this->search_path_array = explode(",",$search_path);
+		}else{
+			$this->search_path_array = array();
+		}
+   }
+	public function setSearchPath($search_path){
+		$this->setSearchPathArray( $search_path);
+	}
+	
+	public function searchObject($tableName,$hayStack){
+		$tableName = strtolower($tableName);		
+		$tableData = $this->splitNameToParts($tableName);
+		if ( $tableData['schema'] ){
+			if (array_key_exists($tableName,$hayStack)){
+				return $hayStack[$tableName];
+			}
+		}else{
+			foreach($this->search_path_array as $dbSchema){
+				$fullName = $dbSchema.".".$tableData['name'];
+				if (array_key_exists($fullName,$hayStack)){
+					return $hayStack[$fullName];
+				}	
+			}
+		}
+		return false;
+	}	 	
+	public function hasTable($tableName)
+    	{
+			$table = $this->searchObject($tableName,$this->_tables);
+			if ($table !== false){
+		   	return 1;
+			}
+		return 0;
+	}
+	public function getTable($tableName)
+	{
+		$table = $this->searchObject($tableName,$this->_tables);		
+		if ($table !== false){
+			return $table;
+		}
+		throw SchemaException::tableDoesNotExist($tableName);
+	}
+
+	
+   public function getTableBySchemaAndName($tableName){
+   	if (!isset($this->_tables[$tableName])) {
+   		return false;
+   	}
+   	return $this->tables[$table];
+   }
+  
+	public function hasSequence($sequenceName)
+	{
+		$sequence = $this->searchObject($sequenceName,$this->_sequences);
+			if ($sequence !== false){
+		   	return 1;
+			}
+		return 0;
+	}
+	
+	public function getSequence($sequenceName)
+	{
+		$sequence = $this->searchObject($sequenceName,$this->_sequences);		
+		if ($sequence !== false){
+			return $sequence;
+		}
+		throw SchemaException::tableDoesNotExist($sequenceName);
+	}
+
+	private function splitNameToParts($name){
+		$r = array( 'schema' => false, 'name' => $name );
+		$dotPos = stripos($name,'.');
+		if ($dotPos){
+			$r['schema'] = substr($name,0,$dotPos);
+			$r['name'] = substr($name,$dotPos+1);
+		}
+		return $r;	
+	}    
+}

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchema.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchema.php
@@ -26,9 +26,15 @@ use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 
 /**
-* Schema class extended for postgresql.
-* Supports search_path
-*/
+ * Schema class extended for postgresql.
+ * Supports search_path
+ * Object representation of a database schema
+ *
+ * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @link    www.doctrine-project.org
+ * @version $Revision$
+ * @author  Thomas Warwaris <code@warwaris.at>
+ */
 class PostgreSqlSchema extends Schema
 {	
     /**
@@ -68,72 +74,93 @@ class PostgreSqlSchema extends Schema
      * @return object $result Returns the object
      */     
     protected function searchObject($tableName,$hayStack){
-      $tableName = strtolower($tableName);		
-      $tableData = $this->splitNameToParts($tableName);
-      if ( $tableData['schema'] ){
-         if (array_key_exists($tableName,$hayStack)){
-            return $hayStack[$tableName];
-         }
-      }else{
-         foreach($this->search_path_array as $dbSchema){
-            $fullName = $dbSchema.".".$tableData['name'];
-            if (array_key_exists($fullName,$hayStack)){
-               return $hayStack[$fullName];
-            }	
-         }
-      }
-      return false;
-   }	 	
-   public function hasTable($tableName)
-      {
-         $table = $this->searchObject($tableName,$this->_tables);
-         if ($table !== false){
+        $tableName = strtolower($tableName);		
+        $tableData = $this->splitNameToParts($tableName);
+        if ( $tableData['schema'] ){
+            if (array_key_exists($tableName,$hayStack)){
+                return $hayStack[$tableName];
+            }
+        }else{
+            foreach($this->search_path_array as $dbSchema){
+                $fullName = $dbSchema.".".$tableData['name'];
+                if (array_key_exists($fullName,$hayStack)){
+                    return $hayStack[$fullName];
+                }	
+            }
+        }
+        return false;
+    }
+   
+    /**
+     * check if a table exists by name
+     *
+     * @param string $tableName
+     * @return bool
+     */ 	 	
+    public function hasTable($tableName){
+        $table = $this->searchObject($tableName,$this->_tables);
+        if ($table !== false){
             return 1;
-         }
-      return 0;
-   }
-   public function getTable($tableName)
-   {
-      $table = $this->searchObject($tableName,$this->_tables);		
-      if ($table !== false){
-         return $table;
-      }
-      throw SchemaException::tableDoesNotExist($tableName);
-   }
+        }
+        return 0;
+    }
+    
+    /**
+     * return a table by name
+     *
+     * @param string $tableName
+     * @return Table
+     */ 	 	
+    public function getTable($tableName){
+        $table = $this->searchObject($tableName,$this->_tables);		
+        if ($table !== false){
+            return $table;
+        }
+        throw SchemaException::tableDoesNotExist($tableName);
+    }
 
-	
-   public function getTableBySchemaAndName($tableName){
-      if (!isset($this->_tables[$tableName])) {
-         return false;
-      }
-      return $this->tables[$table];
-   }
-  
-   public function hasSequence($sequenceName)
-   {
-      $sequence = $this->searchObject($sequenceName,$this->_sequences);
-         if ($sequence !== false){
+    /**
+     * check if a sequence exists by name
+     * 
+     * @param string $sequenceName
+     * @return bool
+     */ 	 	
+    public function hasSequence($sequenceName)
+    {
+        $sequence = $this->searchObject($sequenceName,$this->_sequences);
+        if ($sequence !== false){
             return 1;
-         }
-      return 0;
-   }
+        }
+        return 0;
+    }
 	
-   public function getSequence($sequenceName)
-   {
-      $sequence = $this->searchObject($sequenceName,$this->_sequences);		
-      if ($sequence !== false){
-         return $sequence;
-      }
-      throw SchemaException::tableDoesNotExist($sequenceName);
-   }
+    /**
+     * return a sequence by name
+     * @param string $sequenceName
+     * @return Sequence
+     */ 
+    public function getSequence($sequenceName)
+    {
+        $sequence = $this->searchObject($sequenceName,$this->_sequences);		
+        if ($sequence !== false){
+            return $sequence;
+        }
+        throw SchemaException::tableDoesNotExist($sequenceName);
+    }
 
-   private function splitNameToParts($name){
-      $r = array( 'schema' => false, 'name' => $name );
-      $dotPos = stripos($name,'.');
-      if ($dotPos){
-         $r['schema'] = substr($name,0,$dotPos);
-         $r['name'] = substr($name,$dotPos+1);
-      }
-      return $r;	
-   }    
+    /**
+     * split a DB object name into schema and name part on the first dot
+     *
+     * @param string $name
+     * @return array $return array returning the schema (or false) in ['schema'] and the name in ['name']
+     */ 
+    protected function splitNameToParts($name){
+        $r = array( 'schema' => false, 'name' => $name );
+        $dotPos = stripos($name,'.');
+        if ($dotPos){
+            $r['schema'] = substr($name,0,$dotPos);
+            $r['name'] = substr($name,$dotPos+1);
+        }
+        return $r;	
+    }        
 }

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchema.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchema.php
@@ -1,7 +1,5 @@
 <?php
 /*
-*  $Id$
-*
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,7 +30,6 @@ use Doctrine\DBAL\Schema\Visitor\Visitor;
  *
  * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
  * @link    www.doctrine-project.org
- * @version $Revision$
  * @author  Thomas Warwaris <code@warwaris.at>
  */
 class PostgreSqlSchema extends Schema
@@ -47,10 +44,11 @@ class PostgreSqlSchema extends Schema
     /**
      * set search_path_array from string
      */
-    protected function setSearchPathArray($search_path){
-        if ($search_path){
+    protected function setSearchPathArray($search_path)
+    {
+        if ($search_path) {
             $this->search_path_array = explode(",",$search_path);
-        }else{
+        } else {
             $this->search_path_array = array();
         }
         return;
@@ -61,7 +59,8 @@ class PostgreSqlSchema extends Schema
      *
      * @param string $search_path The psql schema search path.
      */
-    public function setSearchPath($search_path){
+    public function setSearchPath($search_path)
+    {
         $this->setSearchPathArray( $search_path);
         return;
     }
@@ -73,17 +72,18 @@ class PostgreSqlSchema extends Schema
      * @param array $hayStack List of known objects
      * @return object $result Returns the object
      */     
-    protected function searchObject($tableName,$hayStack){
+    protected function searchObject($tableName,$hayStack)
+    {
         $tableName = strtolower($tableName);		
         $tableData = $this->splitNameToParts($tableName);
-        if ( $tableData['schema'] ){
-            if (array_key_exists($tableName,$hayStack)){
+        if ( $tableData['schema'] ) {
+            if (array_key_exists($tableName,$hayStack)) {
                 return $hayStack[$tableName];
             }
-        }else{
-            foreach($this->search_path_array as $dbSchema){
+        } else {
+            foreach($this->search_path_array as $dbSchema) {
                 $fullName = $dbSchema.".".$tableData['name'];
-                if (array_key_exists($fullName,$hayStack)){
+                if (array_key_exists($fullName,$hayStack)) {
                     return $hayStack[$fullName];
                 }	
             }
@@ -97,12 +97,13 @@ class PostgreSqlSchema extends Schema
      * @param string $tableName
      * @return bool
      */ 	 	
-    public function hasTable($tableName){
+    public function hasTable($tableName)
+    {
         $table = $this->searchObject($tableName,$this->_tables);
         if ($table !== false){
-            return 1;
+            return true;
         }
-        return 0;
+        return false;
     }
     
     /**
@@ -111,9 +112,10 @@ class PostgreSqlSchema extends Schema
      * @param string $tableName
      * @return Table
      */ 	 	
-    public function getTable($tableName){
+    public function getTable($tableName)
+    {
         $table = $this->searchObject($tableName,$this->_tables);		
-        if ($table !== false){
+        if ($table !== false) {
             return $table;
         }
         throw SchemaException::tableDoesNotExist($tableName);
@@ -128,10 +130,10 @@ class PostgreSqlSchema extends Schema
     public function hasSequence($sequenceName)
     {
         $sequence = $this->searchObject($sequenceName,$this->_sequences);
-        if ($sequence !== false){
-            return 1;
+        if ($sequence !== false) {
+            return true;
         }
-        return 0;
+        return false;
     }
 	
     /**
@@ -142,7 +144,7 @@ class PostgreSqlSchema extends Schema
     public function getSequence($sequenceName)
     {
         $sequence = $this->searchObject($sequenceName,$this->_sequences);		
-        if ($sequence !== false){
+        if ($sequence !== false) {
             return $sequence;
         }
         throw SchemaException::tableDoesNotExist($sequenceName);
@@ -154,10 +156,11 @@ class PostgreSqlSchema extends Schema
      * @param string $name
      * @return array $return array returning the schema (or false) in ['schema'] and the name in ['name']
      */ 
-    protected function splitNameToParts($name){
+    protected function splitNameToParts($name)
+    {
         $r = array( 'schema' => false, 'name' => $name );
         $dotPos = stripos($name,'.');
-        if ($dotPos){
+        if ($dotPos) {
             $r['schema'] = substr($name,0,$dotPos);
             $r['name'] = substr($name,$dotPos+1);
         }

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -29,7 +29,6 @@ namespace Doctrine\DBAL\Schema;
  * @author      Lukas Smith <smith@pooteeweet.org> (PEAR MDB2 library)
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  * @author      Thomas Warwaris <code@warwaris.at>
- * @version     $Revision$
  * @since       2.0
  */
 class PostgreSqlSchemaManager extends AbstractSchemaManager
@@ -40,10 +39,11 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
      * @param string $search_path Search path, given by the database
      * @return string $search_path Search path, to use in schema objects
      */ 
-    private function replaceUserInSearchPath($search_path){
-	   $usr = $this->_conn->getUsername();
-		$r = str_replace('"$user"',$usr,$search_path);
-		return $r;
+    private function replaceUserInSearchPath($search_path)
+    {
+       $usr = $this->_conn->getUsername();
+        $r = str_replace('"$user"',$usr,$search_path);
+        return $r;
     }
     
     /**
@@ -51,17 +51,18 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
      *
      * @return string $search_path to use in schema objects
      */
-    private function getSearchPathFromDb(){
-		  $sql = 'SHOW search_path';
-		  $stmt = $this->_conn->executeQuery($sql);
+    private function getSearchPathFromDb()
+    {
+        $sql = 'SHOW search_path';
+        $stmt = $this->_conn->executeQuery($sql);
         $res = $stmt->fetchAll();
-        if (array_key_exists(0,$res)){
-      	 $search_path = $this->replaceUserInSearchPath($res[0][0]);
-      	 return $search_path;
-		  }
-		  // todo: this should be an error, because no search path was given by the DB      
-		  return $this->_conn->getUsername().",public";	
-	   }	
+        if (array_key_exists(0,$res)) {
+            $search_path = $this->replaceUserInSearchPath($res[0][0]);
+            return $search_path;
+        }
+        // todo: this should be an error, because no search path was given by the DB      
+        return $this->_conn->getUsername().",public";	
+    }	
 
     /**
      * Return a schema object.
@@ -90,7 +91,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         $onDelete = null;
 
         if (preg_match('(ON UPDATE ([a-zA-Z0-9]+( (NULL|ACTION|DEFAULT))?))', $tableForeignKey['condef'], $match)) { 
-        $onUpdate = $match[1];
+            $onUpdate = $match[1];
         }
         if (preg_match('(ON DELETE ([a-zA-Z0-9]+( (NULL|ACTION|DEFAULT))?))', $tableForeignKey['condef'], $match)) {
             $onDelete = $match[1];

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -67,10 +67,10 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         $onUpdate = null;
         $onDelete = null;
 
-        if (preg_match('(ON UPDATE ([a-zA-Z0-9]+))', $tableForeignKey['condef'], $match)) {
-            $onUpdate = $match[1];
+        if (preg_match('(ON UPDATE ([a-zA-Z0-9]+( (NULL|ACTION|DEFAULT))?))', $tableForeignKey['condef'], $match)) { 
+        $onUpdate = $match[1];
         }
-        if (preg_match('(ON DELETE ([a-zA-Z0-9]+))', $tableForeignKey['condef'], $match)) {
+        if (preg_match('(ON DELETE ([a-zA-Z0-9]+( (NULL|ACTION|DEFAULT))?))', $tableForeignKey['condef'], $match)) {
             $onDelete = $match[1];
         }
 


### PR DESCRIPTION
use of multiple postgres schemas is limited to hardcoded table names because the schema object is unaware of the search path.

Introduced a new driver option search_path to configure session search path from doctrine.
Derived a schema object, that is aware of the search_path of the session and able to locate tables and sequences by that search_path.
