### PR TITLE
Fix bug with empty or null host connection parameter in Oracle DSN construction

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -50,7 +50,7 @@ class Driver implements \Doctrine\DBAL\Driver
     protected function _constructDsn(array $params)
     {
         $dsn = '';
-        if (isset($params['host'])) {
+        if (isset($params['host']) && $params['host'] != '') {
             $dsn .= '(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)' .
                    '(HOST=' . $params['host'] . ')';
 


### PR DESCRIPTION
Fix bug where empty or null host connection parameter will still construct an Oracle DSN instead of using dbname.
