### PR TITLE
Make doctrine and sqlite friends

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -254,10 +254,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
     {
-        $autoinc = ! empty($columnDef['autoincrement']) ? ' AUTOINCREMENT' : '';
-        $pk = ! empty($columnDef['primary']) && ! empty($autoinc) ? ' PRIMARY KEY' : '';
-
-        return 'INTEGER' . $pk . $autoinc;
+        return 'INTEGER';
     }
 
     /**
@@ -293,15 +290,7 @@ class SqlitePlatform extends AbstractPlatform
     {
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
-        $autoinc = false;
-        foreach($columns as $field) {
-            if (isset($field['autoincrement']) && $field['autoincrement']) {
-                $autoinc = true;
-                break;
-            }
-        }
-
-        if ( ! $autoinc && isset($options['primary']) && ! empty($options['primary'])) {
+        if (isset($options['primary']) && ! empty($options['primary'])) {
             $keyColumns = array_unique(array_values($options['primary']));
             $keyColumns = array_map(array($this, 'quoteIdentifier'), $keyColumns);
             $queryFields.= ', PRIMARY KEY('.implode(', ', $keyColumns).')';

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -93,18 +93,21 @@ class SqliteSchemaManager extends AbstractSchemaManager
 
         // fetch regular indexes
         foreach($tableIndexes AS $tableIndex) {
-            $keyName = $tableIndex['name'];
-            $idx = array();
-            $idx['key_name'] = $keyName;
-            $idx['primary'] = false;
-            $idx['non_unique'] = $tableIndex['unique']?false:true;
+            // Ignore indexes with reserved names, e.g. autoindexes
+            if (strpos($tableIndex['name'], 'sqlite_') !== 0) {
+                $keyName = $tableIndex['name'];
+                $idx = array();
+                $idx['key_name'] = $keyName;
+                $idx['primary'] = false;
+                $idx['non_unique'] = $tableIndex['unique']?false:true;
 
-            $stmt = $this->_conn->executeQuery( "PRAGMA INDEX_INFO ( '{$keyName}' )" );
-            $indexArray = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+                $stmt = $this->_conn->executeQuery( "PRAGMA INDEX_INFO ( '{$keyName}' )" );
+                $indexArray = $stmt->fetchAll(\PDO::FETCH_ASSOC);
 
-            foreach ( $indexArray as $indexColumnRow ) {
-                $idx['column_name'] = $indexColumnRow['name'];
-                $indexBuffer[] = $idx;
+                foreach ( $indexArray as $indexColumnRow ) {
+                    $idx['column_name'] = $indexColumnRow['name'];
+                    $indexBuffer[] = $idx;
+                }
             }
         }
 

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -174,7 +174,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
             'default'  => $default,
             'precision' => $precision,
             'scale'     => $scale,
-            'autoincrement' => (bool) $tableColumn['pk'],
+            'autoincrement' => false,
         );
 
         return new Column($tableColumn['name'], \Doctrine\DBAL\Types\Type::getType($type), $options);

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -137,6 +137,10 @@ class SqliteSchemaManager extends AbstractSchemaManager
         if  ($default == 'NULL') {
             $default = null;
         }
+        if ($default !== null) {
+            // SQLite returns strings wrapped in single quotes, so we need to strip them
+            $default = preg_replace("/^'(.*)'$/", '\1', $default);
+        }
         $notnull = (bool) $tableColumn['notnull'];
 
         if ( ! isset($tableColumn['name'])) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -99,7 +99,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $table = new \Doctrine\DBAL\Schema\Table('list_table_columns');
         $table->addColumn('id', 'integer', array('notnull' => true));
         $table->addColumn('test', 'string', array('length' => 255, 'notnull' => false));
-        $table->addColumn('foo', 'text', array('notnull' => true));
+        $table->addColumn('foo', 'text', array('notnull' => true, 'default' => 'expected default'));
         $table->addColumn('bar', 'decimal', array('precision' => 10, 'scale' => 4, 'notnull' => false));
         $table->addColumn('baz1', 'datetime');
         $table->addColumn('baz2', 'time');
@@ -138,7 +138,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->assertEquals(false,  $columns['foo']->getunsigned());
         $this->assertEquals(false,  $columns['foo']->getfixed());
         $this->assertEquals(true,   $columns['foo']->getnotnull());
-        $this->assertEquals(null,   $columns['foo']->getdefault());
+        $this->assertEquals('expected default',   $columns['foo']->getdefault());
         $this->assertInternalType('array',  $columns['foo']->getPlatformOptions());
 
         $this->assertEquals('bar',  strtolower($columns['bar']->getname()));

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -199,7 +199,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->assertEquals(3, count($tableIndexes));
 
         $this->assertArrayHasKey('primary', $tableIndexes, 'listTableIndexes() has to return a "primary" array key.');
-        $this->assertEquals(array('id'), array_map('strtolower', $tableIndexes['primary']->getColumns()));
+        $this->assertEquals(array('id', 'other_id'), array_map('strtolower', $tableIndexes['primary']->getColumns()));
         $this->assertTrue($tableIndexes['primary']->isUnique());
         $this->assertTrue($tableIndexes['primary']->isPrimary());
 
@@ -505,7 +505,8 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $table = new \Doctrine\DBAL\Schema\Table($name, array(), array(), array(), false, $options);
         $table->setSchemaConfig($this->_sm->createSchemaConfig());
         $table->addColumn('id', 'integer', array('notnull' => true));
-        $table->setPrimaryKey(array('id'));
+        $table->addColumn('other_id', 'integer', array('notnull' => true));
+        $table->setPrimaryKey(array('id', 'other_id'));
         $table->addColumn('test', 'string', array('length' => 255));
         $table->addColumn('foreign_key_test', 'integer');
         return $table;

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -57,4 +57,12 @@ class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $this->_sm->renameTable('oldname', 'newname');
     }
+    
+    public function testAutoincrementDetection()
+    {
+      $this->markTestSkipped(
+          'There is currently no reliable way to determine whether an SQLite column is marked as '
+          . 'auto-increment. So, while it does support a single identity column, we cannot with '
+          . 'certainty determine which it is.');
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -16,7 +16,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
 
     public function getGenerateTableSql()
     {
-        return 'CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, test VARCHAR(255) DEFAULT NULL)';
+        return 'CREATE TABLE test (id INTEGER NOT NULL, test VARCHAR(255) DEFAULT NULL, PRIMARY KEY("id"))';
     }
 
     public function getGenerateTableWithMultiColumnUniqueIndexSql()
@@ -66,11 +66,11 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             $this->_platform->getIntegerTypeDeclarationSQL(array())
         );
         $this->assertEquals(
-            'INTEGER AUTOINCREMENT',
+            'INTEGER',
             $this->_platform->getIntegerTypeDeclarationSQL(array('autoincrement' => true))
         );
         $this->assertEquals(
-            'INTEGER PRIMARY KEY AUTOINCREMENT',
+            'INTEGER',
             $this->_platform->getIntegerTypeDeclarationSQL(
                 array('autoincrement' => true, 'primary' => true))
         );


### PR DESCRIPTION
Hi,

Schema processing for SQLite is broken in a number of common situations. These patches fix handling of the following:
- String column defaults: For columns with a default value that is a string, SQLite returns them wrapped in single quotes. Doctrine does not strip these, so it would treat a value "`foobar`" as "`'foobar'`" (with single quotes as part of the value).
- Auto-increment: SQLite handling of auto-increment is unusual. In particular, it supports it only on an integer column which is the sole primary key for a table. In addition, it will automatically increment values of an integer primary key column regardless of whether it has been defined as autoincrement BUT, unlike autoincrement, these values are not guaranteed to be unique.  
  Most problematically, there is no way (without parsing the "create" statements stored in sqlite_master) to determine whether a column is marked as auto-incrementing. Doctrine was treating SQLite integer primary keys as auto-incrementing, but this is not correct and does not work for composite primary keys.
- Composite primary keys: As a side-effect of Doctrine treating integer primary keys in SQLite as auto-incrementing and of how SQLite requires autoincrement and primary keys to be declared, it would generate invalid create statements for composite keys in SQLite.
- Special indexes: SQLite sometimes automatically generates indexes, which Doctrine treated the same as any other. Because they are internal, however, their names are reserved, so they could not be used to recreate the same index and, since they are automatic, they aren't actually a part of the defined schema.

I've added to the tests to catch these situations in the future as well.

Best regards,
Miquel
