### PR TITLE
MsSqlPlatform - doModifyLimitQuery() generates incorrect SELECT query when using SELECT DISTINCT

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MsSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MsSqlPlatform.php
@@ -595,7 +595,11 @@ class MsSqlPlatform extends AbstractPlatform
             }
 
             if ($offset == 0) {
-                $query = preg_replace('/^SELECT\s/i', 'SELECT TOP ' . $count . ' ', $query);
+                if(preg_match('#^SELECT\s+DISTINCT#i', $query) > 0) {
+                    $query = preg_replace('/^SELECT\s+DISTINCT\s/i', 'SELECT DISTINCT TOP ' . $count . ' ', $query);
+                } else {
+                    $query = preg_replace('/^SELECT\s/i', 'SELECT TOP ' . $count . ' ', $query);
+                }
             } else {
                 $orderby = stristr($query, 'ORDER BY');
 


### PR DESCRIPTION
On MSSQL platform the correct syntax is SELECT DISTINCT TOP ... , the current implementation of doModifyLimitQuery() ignores the DISTINCT keyword which results in the incorrect query - ie SELECT TOP DISTINCT ...

I have added a check for the DISTINCT keyword which corrects this issue
