### PR TITLE
Replace all the 'private' by 'protected' visibility modifiers

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -24,9 +24,9 @@ use PDO;
 
 class ArrayStatement implements ResultStatement
 {
-    private $data;
-    private $columnCount = 0;
-    private $num = 0;
+    protected $data;
+    protected $columnCount = 0;
+    protected $num = 0;
 
     public function __construct(array $data)
     {

--- a/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
+++ b/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
@@ -33,15 +33,15 @@ class QueryCacheProfile
     /**
      * @var Cache
      */
-    private $resultCacheDriver;
+    protected $resultCacheDriver;
     /**
      * @var int
      */
-    private $lifetime = 0;
+    protected $lifetime = 0;
     /**
      * @var string
      */
-    private $cacheKey;
+    protected $cacheKey;
 
     /**
      * @param int $lifetime

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -43,40 +43,40 @@ class ResultCacheStatement implements ResultStatement
     /**
      * @var \Doctrine\Common\Cache\Cache
      */
-    private $resultCache;
+    protected $resultCache;
 
     /**
      *
      * @var string
      */
-    private $cacheKey;
+    protected $cacheKey;
 
     /**
      * @var string
      */
-    private $realKey;
+    protected $realKey;
 
     /**
      * @var int
      */
-    private $lifetime;
+    protected $lifetime;
 
     /**
      * @var Doctrine\DBAL\Driver\Statement
      */
-    private $statement;
+    protected $statement;
 
     /**
      * Did we reach the end of the statement?
      * 
      * @var bool
      */
-    private $emptied = false;
+    protected $emptied = false;
 
     /**
      * @var array
      */
-    private $data;
+    protected $data;
 
     /**
      * @param Statement $stmt

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -114,35 +114,35 @@ class Connection implements DriverConnection
      *
      * @var boolean
      */
-    private $_isConnected = false;
+    protected $_isConnected = false;
 
     /**
      * The transaction nesting level.
      *
      * @var integer
      */
-    private $_transactionNestingLevel = 0;
+    protected $_transactionNestingLevel = 0;
 
     /**
      * The currently active transaction isolation level.
      *
      * @var integer
      */
-    private $_transactionIsolationLevel;
+    protected $_transactionIsolationLevel;
 
     /**
      * If nested transations should use savepoints
      *
      * @var integer
      */
-    private $_nestTransactionsWithSavepoints;
+    protected $_nestTransactionsWithSavepoints;
 
     /**
      * The parameters used during creation of the Connection instance.
      *
      * @var array
      */
-    private $_params = array();
+    protected $_params = array();
 
     /**
      * The DatabasePlatform object that provides information about the
@@ -171,7 +171,7 @@ class Connection implements DriverConnection
      *
      * @var boolean
      */
-    private $_isRollbackOnly = false;
+    protected $_isRollbackOnly = false;
 
     /**
      * Initializes a new instance of the Connection class.
@@ -1101,7 +1101,7 @@ class Connection implements DriverConnection
      * @internal Duck-typing used on the $stmt parameter to support driver statements as well as
      *           raw PDOStatement instances.
      */
-    private function _bindTypedValues($stmt, array $params, array $types)
+    protected function _bindTypedValues($stmt, array $params, array $types)
     {
         // Check whether parameters are positional or named. Mixing is not allowed, just like in PDO.
         if (is_int(key($params))) {
@@ -1140,7 +1140,7 @@ class Connection implements DriverConnection
      * @param mixed $type The type to bind (PDO or DBAL)
      * @return array [0] => the (escaped) value, [1] => the binding type
      */
-    private function getBindingInfo($value, $type)
+    protected function getBindingInfo($value, $type)
     {
         if (is_string($type)) {
             $type = Type::getType($type);

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -23,7 +23,7 @@ namespace Doctrine\DBAL\Driver\IBMDB2;
 
 class DB2Connection implements \Doctrine\DBAL\Driver\Connection
 {
-    private $_conn = null;
+    protected $_conn = null;
 
     public function __construct(array $params, $username, $password, $driverOptions = array())
     {

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -23,15 +23,15 @@ namespace Doctrine\DBAL\Driver\IBMDB2;
 
 class DB2Statement implements \Doctrine\DBAL\Driver\Statement
 {
-    private $_stmt = null;
+    protected $_stmt = null;
 
-    private $_bindParam = array();
+    protected $_bindParam = array();
 
     /**
      * DB2_BINARY, DB2_CHAR, DB2_DOUBLE, or DB2_LONG 
      * @var <type>
      */
-    static private $_typeMap = array(
+    static protected $_typeMap = array(
         \PDO::PARAM_INT => DB2_LONG,
         \PDO::PARAM_STR => DB2_CHAR,
     );

--- a/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
@@ -62,7 +62,7 @@ class Driver implements \Doctrine\DBAL\Driver
      *
      * @return string  The DSN.
      */
-    private function _constructPdoDsn(array $params)
+    protected function _constructPdoDsn(array $params)
     {
         $dsn = 'ibm:';
         if (isset($params['host'])) {

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -53,7 +53,7 @@ class Driver implements \Doctrine\DBAL\Driver
      *
      * @return string  The DSN.
      */
-    private function _constructPdoDsn(array $params)
+    protected function _constructPdoDsn(array $params)
     {
         $dsn = 'mysql:';
         if (isset($params['host']) && $params['host'] != '') {

--- a/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
@@ -46,7 +46,7 @@ class Driver implements \Doctrine\DBAL\Driver
      *
      * @return string  The DSN.
      */
-    private function _constructPdoDsn(array $params)
+    protected function _constructPdoDsn(array $params)
     {
         $dsn = 'oci:';
         if (isset($params['host'])) {

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -31,7 +31,7 @@ class Driver implements \Doctrine\DBAL\Driver
      *
      * @return string The DSN.
      */
-    private function _constructPdoDsn(array $params)
+    protected function _constructPdoDsn(array $params)
     {
         $dsn = 'pgsql:';
         if (isset($params['host']) && $params['host'] != '') {

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
@@ -43,7 +43,7 @@ class Driver implements \Doctrine\DBAL\Driver
      *
      * @return string  The DSN.
      */
-    private function _constructPdoDsn(array $params)
+    protected function _constructPdoDsn(array $params)
     {
         $dsn = 'sqlsrv:server=';
 		

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -29,5 +29,5 @@ namespace Doctrine\DBAL\Driver;
  */
 class PDOStatement extends \PDOStatement implements Statement
 {
-    private function __construct() {}
+    protected function __construct() {}
 }

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -35,7 +35,7 @@ final class DriverManager
      * @var array
      * @todo REMOVE. Users should directly supply class names instead.
      */
-     private static $_driverMap = array(
+     protected static $_driverMap = array(
             'pdo_mysql'  => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
             'pdo_sqlite' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
             'pdo_pgsql'  => 'Doctrine\DBAL\Driver\PDOPgSql\Driver',
@@ -47,7 +47,7 @@ final class DriverManager
             );
 
     /** Private constructor. This class cannot be instantiated. */
-    private function __construct() { }
+    protected function __construct() { }
 
     /**
      * Creates a connection object based on the specified parameters.
@@ -138,7 +138,7 @@ final class DriverManager
      *
      * @param array $params
      */
-    private static function _checkParams(array $params)
+    protected static function _checkParams(array $params)
     {        
         // check existance of mandatory parameters
         

--- a/lib/Doctrine/DBAL/Event/ConnectionEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/ConnectionEventArgs.php
@@ -38,7 +38,7 @@ class ConnectionEventArgs extends EventArgs
     /**
      * @var Connection
      */
-    private $_connection = null;
+    protected $_connection = null;
 
     public function __construct(Connection $connection)
     {

--- a/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
@@ -38,12 +38,12 @@ class MysqlSessionInit implements EventSubscriber
     /**
      * @var string
      */
-    private $_charset;
+    protected $_charset;
 
     /**
      * @var string
      */
-    private $_collation;
+    protected $_collation;
 
     /**
      * Configure Charset and Collation options of MySQL Client for each Connection

--- a/lib/Doctrine/DBAL/Events.php
+++ b/lib/Doctrine/DBAL/Events.php
@@ -31,7 +31,7 @@ namespace Doctrine\DBAL;
  */
 final class Events
 {
-    private function __construct() {}
+    protected function __construct() {}
 
     const postConnect = 'postConnect';
 }

--- a/lib/Doctrine/DBAL/LockMode.php
+++ b/lib/Doctrine/DBAL/LockMode.php
@@ -38,5 +38,5 @@ class LockMode
     const PESSIMISTIC_READ = 2;
     const PESSIMISTIC_WRITE = 4;
 
-    final private function __construct() { }
+    final protected function __construct() { }
 }

--- a/lib/Doctrine/DBAL/Platforms/Keywords/KeywordList.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/KeywordList.php
@@ -30,7 +30,7 @@ namespace Doctrine\DBAL\Platforms\Keywords;
  */
 abstract class KeywordList
 {
-    private $keywords = null;
+    protected $keywords = null;
     
     /**
      * Check if the given word is a keyword of this dialect/vendor platform.

--- a/lib/Doctrine/DBAL/Platforms/Keywords/ReservedKeywordsValidator.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/ReservedKeywordsValidator.php
@@ -33,12 +33,12 @@ class ReservedKeywordsValidator implements Visitor
     /**
      * @var KeywordList[]
      */
-    private $keywordLists = array();
+    protected $keywordLists = array();
     
     /**
      * @var array
      */
-    private $violations = array();
+    protected $violations = array();
     
     public function __construct(array $keywordLists)
     {
@@ -54,7 +54,7 @@ class ReservedKeywordsValidator implements Visitor
      * @param string $word
      * @return array
      */
-    private function isReservedWord($word)
+    protected function isReservedWord($word)
     {
         if ($word[0] == "`") {
             $word = str_replace('`', '', $word);
@@ -69,7 +69,7 @@ class ReservedKeywordsValidator implements Visitor
         return $keywordLists;
     }
     
-    private function addViolation($asset, $violatedPlatforms)
+    protected function addViolation($asset, $violatedPlatforms)
     {
         if (!$violatedPlatforms) {
             return;

--- a/lib/Doctrine/DBAL/Platforms/MsSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MsSqlPlatform.php
@@ -257,7 +257,7 @@ class MsSqlPlatform extends AbstractPlatform
      * @param Index $index
      * @return string
      */
-    private function _appendUniqueConstraintDefinition($sql, Index $index)
+    protected function _appendUniqueConstraintDefinition($sql, Index $index)
     {
         $fields = array();
         foreach ($index->getColumns() as $field => $definition) {

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -259,7 +259,7 @@ class PostgreSqlPlatform extends AbstractPlatform
                  ) AND pg_index.indexrelid = oid";
     }
 
-    private function getTableWhereClause($table, $classAlias = 'c', $namespaceAlias = 'n')
+    protected function getTableWhereClause($table, $classAlias = 'c', $namespaceAlias = 'n')
     {
         $whereClause = "";
         if (strpos($table, ".") !== false) {

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -41,12 +41,12 @@ class Connection extends \Doctrine\DBAL\Connection
     /**
      * @var int
      */
-    private $portability = self::PORTABILITY_NONE;
+    protected $portability = self::PORTABILITY_NONE;
     
     /**
      * @var int
      */
-    private $case = \PDO::CASE_NATURAL;
+    protected $case = \PDO::CASE_NATURAL;
     
     public function connect()
     {

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -36,17 +36,17 @@ class Statement implements \Doctrine\DBAL\Driver\Statement
     /**
      * @var int
      */
-    private $portability;
+    protected $portability;
     
     /**
      * @var Doctrine\DBAL\Driver\Statement
      */
-    private $stmt;
+    protected $stmt;
     
     /**
      * @var int
      */
-    private $case;
+    protected $case;
 
     /**
      * Wraps <tt>Statement</tt> and applies portability measures

--- a/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
+++ b/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
@@ -43,12 +43,12 @@ class CompositeExpression implements \Countable
     /**
      * @var string Holds the instance type of composite expression
      */
-    private $type;
+    protected $type;
     
     /**
      * @var array Each expression part of the composite expression
      */
-    private $parts = array();
+    protected $parts = array();
     
     /**
      * Constructor.

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -42,7 +42,7 @@ class ExpressionBuilder
     /**
      * @var Doctrine\DBAL\Connection DBAL Connection
      */
-    private $connection = null;
+    protected $connection = null;
 
     /**
      * Initializes a new <tt>ExpressionBuilder</tt>.

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -52,12 +52,12 @@ class QueryBuilder
     /**
      * @var Doctrine\DBAL\Connection DBAL Connection
      */
-    private $connection = null;
+    protected $connection = null;
 
     /**
      * @var array The array of SQL parts collected.
      */
-    private $sqlParts = array(
+    protected $sqlParts = array(
         'select'  => array(),
         'from'    => array(),
         'join'    => array(),
@@ -71,44 +71,44 @@ class QueryBuilder
     /**
      * @var string The complete SQL string for this query.
      */
-    private $sql;
+    protected $sql;
 
     /**
      * @var array The query parameters.
      */
-    private $params = array();
+    protected $params = array();
 
     /**
      * @var array The parameter type map of this query.
      */
-    private $paramTypes = array();
+    protected $paramTypes = array();
 
     /**
      * @var integer The type of query this is. Can be select, update or delete.
      */
-    private $type = self::SELECT;
+    protected $type = self::SELECT;
 
     /**
      * @var integer The state of the query object. Can be dirty or clean.
      */
-    private $state = self::STATE_CLEAN;
+    protected $state = self::STATE_CLEAN;
 
     /**
      * @var integer The index of the first result to retrieve.
      */
-    private $firstResult = null;
+    protected $firstResult = null;
 
     /**
      * @var integer The maximum number of results to retrieve.
      */
-    private $maxResults = null;
+    protected $maxResults = null;
 
     /**
      * The counter of bound parameters used with {@see bindValue)
      *
      * @var int
      */
-    private $boundCounter = 0;
+    protected $boundCounter = 0;
 
     /**
      * Initializes a new <tt>QueryBuilder</tt>.
@@ -945,7 +945,7 @@ class QueryBuilder
      *
      * @return string
      */
-    private function getSQLForSelect()
+    protected function getSQLForSelect()
     {
         $query = 'SELECT ' . implode(', ', $this->sqlParts['select']) . ' FROM ';
 
@@ -989,7 +989,7 @@ class QueryBuilder
      *
      * @return string
      */
-    private function getSQLForUpdate()
+    protected function getSQLForUpdate()
     {
         $table = $this->sqlParts['from']['table'] . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
         $query = 'UPDATE ' . $table
@@ -1004,7 +1004,7 @@ class QueryBuilder
      *
      * @return string
      */
-    private function getSQLForDelete()
+    protected function getSQLForDelete()
     {
         $table = $this->sqlParts['from']['table'] . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
         $query = 'DELETE FROM ' . $table . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '');

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -244,7 +244,7 @@ class Comparator
      * 
      * @param TableDiff $tableDifferences
      */
-    private function detectColumnRenamings(TableDiff $tableDifferences)
+    protected function detectColumnRenamings(TableDiff $tableDifferences)
     {
         $renameCandidates = array();
         foreach ($tableDifferences->addedColumns AS $addedColumnName => $addedColumn) {

--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -151,7 +151,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * @param  string $event
      * @return string|null
      */
-    private function _onEvent($event)
+    protected function _onEvent($event)
     {
         if (isset($this->_options[$event])) {
             $onEvent = strtoupper($this->_options[$event]);

--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -201,7 +201,7 @@ class Table extends AbstractAsset
      * @param bool $isPrimary
      * @return Table
      */
-    private function _createIndex(array $columnNames, $indexName, $isUnique, $isPrimary)
+    protected function _createIndex(array $columnNames, $indexName, $isUnique, $isPrimary)
     {
         if (preg_match('(([^a-zA-Z0-9_]+))', $indexName)) {
             throw SchemaException::indexNameInvalid($indexName);

--- a/lib/Doctrine/DBAL/Schema/View.php
+++ b/lib/Doctrine/DBAL/Schema/View.php
@@ -35,7 +35,7 @@ class View extends AbstractAsset
     /**
      * @var string
      */
-    private $_sql;
+    protected $_sql;
 
     public function __construct($name, $sql)
     {

--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -35,23 +35,23 @@ class CreateSchemaSqlCollector implements Visitor
     /**
      * @var array
      */
-    private $_createTableQueries = array();
+    protected $_createTableQueries = array();
 
     /**
      * @var array
      */
-    private $_createSequenceQueries = array();
+    protected $_createSequenceQueries = array();
 
     /**
      * @var array
      */
-    private $_createFkConstraintQueries = array();
+    protected $_createFkConstraintQueries = array();
 
     /**
      *
      * @var \Doctrine\DBAL\Platforms\AbstractPlatform
      */
-    private $_platform = null;
+    protected $_platform = null;
 
     /**
      * @param AbstractPlatform $platform

--- a/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
@@ -43,23 +43,23 @@ class DropSchemaSqlCollector implements Visitor
     /**
      * @var \SplObjectStorage
      */
-    private $constraints;
+    protected $constraints;
 
     /**
      * @var \SplObjectStorage
      */
-    private $sequences;
+    protected $sequences;
 
     /**
      * @var \SplObjectStorage
      */
-    private $tables;
+    protected $tables;
 
     /**
      *
      * @var \Doctrine\DBAL\Platforms\AbstractPlatform
      */
-    private $platform;
+    protected $platform;
 
     /**
      * @param AbstractPlatform $platform

--- a/lib/Doctrine/DBAL/Schema/Visitor/Graphviz.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/Graphviz.php
@@ -31,7 +31,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform,
 
 class Graphviz implements \Doctrine\DBAL\Schema\Visitor\Visitor
 {
-    private $output = '';
+    protected $output = '';
 
     public function acceptColumn(Table $table, Column $column)
     {
@@ -82,7 +82,7 @@ class Graphviz implements \Doctrine\DBAL\Schema\Visitor\Visitor
         );
     }
 
-    private function createTableLabel( Table $table )
+    protected function createTableLabel( Table $table )
     {
         // Start the table
         $label = '<<TABLE CELLSPACING="0" BORDER="1" ALIGN="LEFT">';
@@ -111,7 +111,7 @@ class Graphviz implements \Doctrine\DBAL\Schema\Visitor\Visitor
         return $label;
     }
 
-    private function createNode( $name, $options )
+    protected function createNode( $name, $options )
     {
         $node = $name . " [";
         foreach( $options as $key => $value )
@@ -122,7 +122,7 @@ class Graphviz implements \Doctrine\DBAL\Schema\Visitor\Visitor
         return $node;
     }
 
-    private function createNodeRelation( $node1, $node2, $options )
+    protected function createNodeRelation( $node1, $node2, $options )
     {
         $relation = $node1 . ' -> ' . $node2 . ' [';
         foreach( $options as $key => $value )

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -37,23 +37,23 @@ class Statement implements DriverStatement
     /**
      * @var string The SQL statement.
      */
-    private $_sql;
+    protected $_sql;
     /**
      * @var array The bound parameters.
      */
-    private $_params = array();
+    protected $_params = array();
     /**
      * @var Doctrine\DBAL\Driver\Statement The underlying driver statement.
      */
-    private $_stmt;
+    protected $_stmt;
     /**
      * @var Doctrine\DBAL\Platforms\AbstractPlatform The underlying database platform.
      */
-    private $_platform;
+    protected $_platform;
     /**
      * @var Doctrine\DBAL\Connection The connection this statement is bound to and executed on.
      */
-    private $_conn;
+    protected $_conn;
 
     /**
      * Creates a new <tt>Statement</tt> for the given SQL and <tt>Connection</tt>.

--- a/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
@@ -29,7 +29,7 @@ use Doctrine\DBAL\Platforms\Keywords\ReservedKeywordsValidator;
 
 class ReservedWordsCommand extends Command
 {
-    private $keywordListClasses = array(
+    protected $keywordListClasses = array(
         'mysql'     => 'Doctrine\DBAL\Platforms\Keywords\MySQLKeywords',
         'mssql'     => 'Doctrine\DBAL\Platforms\Keywords\MsSQLKeywords',
         'sqlite'    => 'Doctrine\DBAL\Platforms\Keywords\SQLiteKeywords',

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -50,10 +50,10 @@ abstract class Type
     const FLOAT = 'float';
 
     /** Map of already instantiated type objects. One instance per type (flyweight). */
-    private static $_typeObjects = array();
+    protected static $_typeObjects = array();
 
     /** The map of supported doctrine mapping types. */
-    private static $_typesMap = array(
+    protected static $_typesMap = array(
         self::TARRAY => 'Doctrine\DBAL\Types\ArrayType',
         self::OBJECT => 'Doctrine\DBAL\Types\ObjectType',
         self::BOOLEAN => 'Doctrine\DBAL\Types\BooleanType',
@@ -72,7 +72,7 @@ abstract class Type
     );
 
     /* Prevent instantiation and force use of the factory method. */
-    final private function __construct() {}
+    final protected function __construct() {}
 
     /**
      * Converts a value from its PHP representation to its database representation

--- a/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
@@ -68,7 +68,7 @@ class BlobTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertBlobContains('test2');
     }
 
-    private function assertBlobContains($text)
+    protected function assertBlobContains($text)
     {
         $rows = $this->_conn->fetchAll('SELECT * FROM blob_table');
 

--- a/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/../../TestInit.php';
 
 class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
-    private static $tableCreated = false;
+    protected static $tableCreated = false;
 
     public function setUp()
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
@@ -14,9 +14,9 @@ require_once __DIR__ . '/../../TestInit.php';
  */
 class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
-    static private $hasTable = false;
+    static protected $hasTable = false;
 
-    private $portableConnection;
+    protected $portableConnection;
 
     public function tearDown()
     {
@@ -25,7 +25,7 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
     }
 
-    private function getPortableConnection($portabilityMode = \Doctrine\DBAL\Portability\Connection::PORTABILITY_ALL, $case = \PDO::CASE_LOWER)
+    protected function getPortableConnection($portabilityMode = \Doctrine\DBAL\Portability\Connection::PORTABILITY_ALL, $case = \PDO::CASE_LOWER)
     {
         if (!$this->portableConnection) {
             $params = $this->_conn->getParams();

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -12,8 +12,8 @@ require_once __DIR__ . '/../../TestInit.php';
  */
 class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
-    private $expectedResult = array(array('test_int' => 100, 'test_string' => 'foo'), array('test_int' => 200, 'test_string' => 'bar'), array('test_int' => 300, 'test_string' => 'baz'));
-    private $sqlLogger;
+    protected $expectedResult = array(array('test_int' => 100, 'test_string' => 'foo'), array('test_int' => 200, 'test_string' => 'bar'), array('test_int' => 300, 'test_string' => 'baz'));
+    protected $sqlLogger;
 
     public function setUp()
     {
@@ -158,7 +158,7 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals(1, count($secondCache->fetch("emptycachekey")));
     }
 
-    private function hydrateStmt($stmt, $fetchStyle = \PDO::FETCH_ASSOC)
+    protected function hydrateStmt($stmt, $fetchStyle = \PDO::FETCH_ASSOC)
     {
         $data = array();
         while ($row = $stmt->fetch($fetchStyle)) {

--- a/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../../TestInit.php';
 
 class TypeConversionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
-    static private $typeCounter = 0;
+    static protected $typeCounter = 0;
 
     public function setUp()
     {

--- a/tests/Doctrine/Tests/DBAL/Platforms/ReservedKeywordsValidatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/ReservedKeywordsValidatorTest.php
@@ -12,7 +12,7 @@ class ReservedKeywordsValidatorTest extends \Doctrine\Tests\DbalTestCase
     /**
      * @var ReservedKeywordsValidator
      */
-    private $validator;
+    protected $validator;
     
     public function setUp()
     {

--- a/tests/Doctrine/Tests/DBAL/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Platforms/MySQLSchemaTest.php
@@ -14,12 +14,12 @@ class MySQLSchemaTest extends \PHPUnit_Framework_TestCase
     /**
      * @var Comparator
      */
-    private $comparator;
+    protected $comparator;
     /**
      *
      * @var \Doctrine\DBAL\Platforms\AbstractPlatform
      */
-    private $platform;
+    protected $platform;
 
     public function setUp()
     {

--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -9,7 +9,7 @@ class DbalFunctionalTestCase extends DbalTestCase
      *
      * @var \Doctrine\DBAL\Connection
      */
-    private static $_sharedConn;
+    protected static $_sharedConn;
 
     /**
      * @var \Doctrine\DBAL\Connection

--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -4,10 +4,10 @@ namespace Doctrine\Tests\Mocks;
 
 class ConnectionMock extends \Doctrine\DBAL\Connection
 {
-    private $_fetchOneResult;
-    private $_platformMock;
-    private $_lastInsertId = 0;
-    private $_inserts = array();
+    protected $_fetchOneResult;
+    protected $_platformMock;
+    protected $_lastInsertId = 0;
+    protected $_inserts = array();
 
     public function __construct(array $params, $driver, $config = null, $eventManager = null)
     {

--- a/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
+++ b/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
@@ -4,9 +4,9 @@ namespace Doctrine\Tests\Mocks;
 
 class DatabasePlatformMock extends \Doctrine\DBAL\Platforms\AbstractPlatform
 {
-    private $_sequenceNextValSql = "";
-    private $_prefersIdentityColumns = true;
-    private $_prefersSequences = false;
+    protected $_sequenceNextValSql = "";
+    protected $_prefersIdentityColumns = true;
+    protected $_prefersSequences = false;
 
     /**
      * @override

--- a/tests/Doctrine/Tests/Mocks/DriverMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverMock.php
@@ -5,9 +5,9 @@ namespace Doctrine\Tests\Mocks;
 
 class DriverMock implements \Doctrine\DBAL\Driver
 {
-    private $_platformMock;
+    protected $_platformMock;
 
-    private $_schemaManagerMock;
+    protected $_schemaManagerMock;
 
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
     {

--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -10,7 +10,7 @@ namespace Doctrine\Tests\Mocks;
  */
 class HydratorMockStatement implements \Doctrine\DBAL\Driver\Statement
 {
-    private $_resultSet;    
+    protected $_resultSet;    
     
     /**
      * Creates a new mock statement that will serve the provided fake result set to clients.

--- a/tests/Doctrine/Tests/Mocks/TaskMock.php
+++ b/tests/Doctrine/Tests/Mocks/TaskMock.php
@@ -37,7 +37,7 @@ class TaskMock extends \Doctrine\Common\Cli\Tasks\AbstractTask
      */
     static public $instances = array();
 
-    private $runCounter = 0;
+    protected $runCounter = 0;
 
     /**
      * Constructor of Task Mock Object.


### PR DESCRIPTION
Hi there!

I have started some preliminary work to move the Drupal project to Doctrine DBAL. We already have a heavy (custom) DBAL based on PDO, and we have the need to sub-class a few classes (especially \DBAL\Statement) that contain private modifiers.

Any reason not to make those protected? There is not a ton of reasons to use private in PHP, other then on final classes.

Damien
