### PR TITLE
Make all Statement classes Traversable

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -22,11 +22,12 @@ namespace Doctrine\DBAL\Cache;
 use Doctrine\DBAL\Driver\ResultStatement;
 use PDO;
 
-class ArrayStatement implements ResultStatement
+class ArrayStatement implements \IteratorAggregate, ResultStatement
 {
     private $data;
     private $columnCount = 0;
     private $num = 0;
+    private $defaultFetchStyle = PDO::FETCH_BOTH;
 
     public function __construct(array $data)
     {
@@ -44,6 +45,17 @@ class ArrayStatement implements ResultStatement
     public function columnCount()
     {
         return $this->columnCount;
+    }
+
+    public function setFetchMode($fetchStyle)
+    {
+        $this->defaultFetchStyle = $fetchStyle;
+    }
+
+    public function getIterator()
+    {
+        $data = $this->fetchAll($this->defaultFetchStyle);
+        return new \ArrayIterator($data);
     }
 
     public function fetch($fetchStyle = PDO::FETCH_BOTH)

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -38,7 +38,7 @@ use PDO;
  * Also you have to realize that the cache will load the whole result into memory at once to ensure 2.
  * This means that the memory usage for cached results might increase by using this feature.
  */
-class ResultCacheStatement implements ResultStatement
+class ResultCacheStatement implements \IteratorAggregate, ResultStatement
 {
     /**
      * @var \Doctrine\Common\Cache\Cache
@@ -77,6 +77,11 @@ class ResultCacheStatement implements ResultStatement
      * @var array
      */
     private $data;
+
+    /**
+     * @var int
+     */
+    private $defaultFetchStyle = PDO::FETCH_BOTH;
 
     /**
      * @param Statement $stmt
@@ -125,6 +130,17 @@ class ResultCacheStatement implements ResultStatement
     public function columnCount()
     {
         return $this->statement->columnCount();
+    }
+
+    public function setFetchMode($fetchStyle)
+    {
+        $this->defaultFetchStyle = $fetchStyle;
+    }
+
+    public function getIterator()
+    {
+        $data = $this->fetchAll($this->defaultFetchStyle);
+        return new \ArrayIterator($data);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -27,7 +27,7 @@ use \PDO;
  * @since 2.0
  * @author Roman Borschel <roman@code-factory.org>
  */
-class OCI8Statement implements \Doctrine\DBAL\Driver\Statement
+class OCI8Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
 {
     /** Statement handle. */
     protected $_dbh;
@@ -40,6 +40,7 @@ class OCI8Statement implements \Doctrine\DBAL\Driver\Statement
         PDO::FETCH_NUM => OCI_NUM,
         PDO::PARAM_LOB => OCI_B_BLOB,
     );
+    protected $_defaultFetchStyle = PDO::FETCH_BOTH;
     protected $_paramMap = array();
 
     /**
@@ -181,6 +182,23 @@ class OCI8Statement implements \Doctrine\DBAL\Driver\Statement
             throw OCI8Exception::fromErrorInfo($this->errorInfo());
         }
         return $ret;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFetchMode($fetchStyle = PDO::FETCH_BOTH)
+    {
+        $this->_defaultFetchStyle = $fetchStyle;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        $data = $this->fetchAll($this->_defaultFetchStyle);
+        return new \ArrayIterator($data);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -30,4 +30,13 @@ namespace Doctrine\DBAL\Driver;
 class PDOStatement extends \PDOStatement implements Statement
 {
     private function __construct() {}
+
+    public function setFetchMode($fetchStyle, $params = NULL)
+    {
+        // This thin wrapper is necessary to shield against the weird signature
+        // of PDOStatement::setFetchMode(): even if the second and third
+        // parameters are optional, PHP will not let us remove it from this
+        // declaration.
+        return parent::setFetchMode($fetchStyle);
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -26,7 +26,7 @@ use PDO;
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
-interface ResultStatement
+interface ResultStatement extends \Traversable
 {
     /**
      * Closes the cursor, enabling the statement to be executed again.
@@ -45,6 +45,14 @@ interface ResultStatement
      *                              this method should return 0.
      */
     function columnCount();
+
+    /**
+     * setFetchMode
+     * Set the fetch mode to use while iterating this statement.
+     *
+     * @param integer $fetchStyle
+     */
+    public function setFetchMode($fetchStyle);
 
     /**
      * fetch

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -30,7 +30,7 @@ use PDO;
  * @since       2.0
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  */
-class Statement implements \Doctrine\DBAL\Driver\Statement
+class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
 {
 
     /**
@@ -47,6 +47,11 @@ class Statement implements \Doctrine\DBAL\Driver\Statement
      * @var int
      */
     private $case;
+
+    /** 
+     * @var int
+     */
+    private $defaultFetchStyle = PDO::FETCH_BOTH;
 
     /**
      * Wraps <tt>Statement</tt> and applies portability measures
@@ -94,6 +99,17 @@ class Statement implements \Doctrine\DBAL\Driver\Statement
     public function execute($params = null)
     {
         return $this->stmt->execute($params);
+    }
+
+    public function setFetchMode($fetchStyle)
+    {
+        $this->defaultFetchStyle = $fetchStyle;
+    }
+
+    public function getIterator()
+    {
+        $data = $this->fetchAll($this->defaultFetchStyle);
+        return new \ArrayIterator($data);
     }
 
     public function fetch($fetchStyle = PDO::FETCH_BOTH)

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -32,7 +32,7 @@ use PDO,
  * @author Roman Borschel <roman@code-factory.org>
  * @since 2.0
  */
-class Statement implements DriverStatement
+class Statement implements \IteratorAggregate, DriverStatement
 {
     /**
      * @var string The SQL statement.
@@ -175,6 +175,16 @@ class Statement implements DriverStatement
     public function errorInfo()
     {
         return $this->_stmt->errorInfo();
+    }
+
+    public function setFetchMode($fetchStyle)
+    {
+        return $this->_stmt->setFetchMode($fetchStyle);
+    }
+
+    public function getIterator()
+    {
+        return $this->_stmt;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -99,6 +99,28 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals(1, $column);
     }
 
+    public function testPrepareWithIterator()
+    {
+        $paramInt = 1;
+        $paramStr = 'foo';
+
+        $sql = "SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?";
+        $stmt = $this->_conn->prepare($sql);
+        $this->assertInstanceOf('Doctrine\DBAL\Statement', $stmt);
+
+        $stmt->bindParam(1, $paramInt);
+        $stmt->bindParam(2, $paramStr);
+        $stmt->execute();
+
+        $rows = array();
+        $stmt->setFetchMode(\PDO::FETCH_ASSOC);
+        foreach ($stmt as $row) {
+            $rows[] = array_change_key_case($row, \CASE_LOWER);
+        }
+
+        $this->assertEquals(array('test_int' => 1, 'test_string' => 'foo'), $rows[0]);
+    }
+
     public function testPrepareWithQuoted()
     {
         $table = 'fetch_table';

--- a/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
@@ -61,6 +61,11 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertFetchResultRows($rows);
 
         $stmt = $this->getPortableConnection()->query('SELECT * FROM portability_table');
+        foreach ($stmt as $row) {
+            $this->assertFetchResultRow($row);
+        }
+
+        $stmt = $this->getPortableConnection()->query('SELECT * FROM portability_table');
         while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
             $this->assertFetchResultRow($row);
         }


### PR DESCRIPTION
This is one thing we are using and abusing inside Drupal.

This patch makes `Driver\ResultStatement` traversable, and implement the glue that is needed in all the statement wrappers.

[I only tested this on `pdo_mysql`... but tried to religiously respect the massively inconsistent code style between each file :)]

Damien
