### PR TITLE
Portability column forced to lowercase

### DIFF
--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -46,7 +46,7 @@ class Connection extends \Doctrine\DBAL\Connection
     /**
      * @var int
      */
-    private $case = \PDO::CASE_NATURAL;
+    private $case;
     
     public function connect()
     {

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -118,7 +118,7 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
         
         $row = $this->fixRow($row,
             $this->portability & (Connection::PORTABILITY_EMPTY_TO_NULL|Connection::PORTABILITY_RTRIM),
-            ($fetchStyle == PDO::FETCH_ASSOC || $fetchStyle == PDO::FETCH_BOTH) && ($this->portability & Connection::PORTABILITY_FIX_CASE)
+            !is_null($this->case) && ($fetchStyle == PDO::FETCH_ASSOC || $fetchStyle == PDO::FETCH_BOTH) && ($this->portability & Connection::PORTABILITY_FIX_CASE)
         );
         
         return $row;
@@ -133,7 +133,7 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
         }
         
         $iterateRow = $this->portability & (Connection::PORTABILITY_EMPTY_TO_NULL|Connection::PORTABILITY_RTRIM);
-        $fixCase = ($fetchStyle == PDO::FETCH_ASSOC || $fetchStyle == PDO::FETCH_BOTH) && ($this->portability & Connection::PORTABILITY_FIX_CASE);
+        $fixCase = !is_null($this->case) && ($fetchStyle == PDO::FETCH_ASSOC || $fetchStyle == PDO::FETCH_BOTH) && ($this->portability & Connection::PORTABILITY_FIX_CASE);
         if (!$iterateRow && !$fixCase) {
             return $rows;
         }


### PR DESCRIPTION
When using a PDOConnection and the Portability wrapper, the default value \PDO::CASE_NATURAL int(0) and PHP constant CASE_LOWER int(0) got mixed up. The case conversion for PDOConnection is handled by the PDO module but got lowered in PHP because of the default case value.
