### PR TITLE
removedColumns in TableDiff

### DIFF
--- a/lib/Doctrine/DBAL/Schema/TableDiff.php
+++ b/lib/Doctrine/DBAL/Schema/TableDiff.php
@@ -61,7 +61,7 @@ class TableDiff
     /**
      * All removed fields
      *
-     * @var array(string=>bool)
+     * @var array(string=>Column)
      */
     public $removedColumns = array();
 


### PR DESCRIPTION
getAlterTableSQL(TableDiff $diff) expects an array of (string=>Column) for $removedColumns
