### PR TITLE
Escape fields for prevent errors using reserved words like read

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -341,6 +341,7 @@ class MySqlPlatform extends AbstractPlatform
     {
         return 'DROP DATABASE ' . $name;
     }
+
     /**
      * Get declaration if a number of fields in bulk
      * 
@@ -355,6 +356,7 @@ class MySqlPlatform extends AbstractPlatform
     {
         return parent::getColumnDeclarationSQL(sprintf('`%s`', trim($name, '`')), $field);
     }
+
     /**
      * create a new table
      *

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -341,7 +341,20 @@ class MySqlPlatform extends AbstractPlatform
     {
         return 'DROP DATABASE ' . $name;
     }
-
+    /**
+     * Get declaration if a number of fields in bulk
+     * 
+     * @param string $name   name the field to be declared.
+     * @param array  $field  associative array with the name of the properties
+     *
+     * @see AbstractPlatform::getColumnDeclarationSQL()
+     *
+     * @return string
+     */
+    public function getColumnDeclarationSQL($name, array $field)
+    {
+        return parent::getColumnDeclarationSQL(sprintf('`%s`', trim($name, '`')), $field);
+    }
     /**
      * create a new table
      *


### PR DESCRIPTION
Escape fields for prevent errors using reserved words like read in mysql platform.
