### PR TITLE
Fixed DBAL-190 doctrine column type comments

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1095,7 +1095,7 @@ abstract class AbstractPlatform
         $sql = $this->_getCreateTableSQL($tableName, $columns, $options);
         if ($this->supportsCommentOnStatement()) {
             foreach ($table->getColumns() AS $column) {
-                if ($column->getComment()) {
+                if ($this->getColumnComment($column)) {
                     $sql[] = $this->getCommentOnColumnSQL($tableName, $column->getName(), $this->getColumnComment($column));
                 }
             }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -326,12 +326,27 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
         $this->assertEquals($this->getAlterTableColumnCommentsSQL(), $this->_platform->getAlterTableSQL($tableDiff));
     }
 
+    public function testCreateTableColumnTypeComments()
+    {
+        $table = new \Doctrine\DBAL\Schema\Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('data', 'array');
+        $table->setPrimaryKey(array('id'));
+
+        $this->assertEquals($this->getCreateTableColumnTypeCommentsSQL(), $this->_platform->getCreateTableSQL($table));
+    }
+
     public function getCreateTableColumnCommentsSQL()
     {
         $this->markTestSkipped('Platform does not support Column comments.');
     }
 
     public function getAlterTableColumnCommentsSQL()
+    {
+        $this->markTestSkipped('Platform does not support Column comments.');
+    }
+
+    public function getCreateTableColumnTypeCommentsSQL()
     {
         $this->markTestSkipped('Platform does not support Column comments.');
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -204,4 +204,9 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
     {
         return array("ALTER TABLE mytable ADD quota INT NOT NULL COMMENT 'A comment', CHANGE bar baz VARCHAR(255) NOT NULL COMMENT 'B comment'");
     }
+
+    public function getCreateTableColumnTypeCommentsSQL()
+    {
+        return array("CREATE TABLE test (id INT NOT NULL, data LONGTEXT NOT NULL COMMENT '(DC2Type:array)', PRIMARY KEY(id)) ENGINE = InnoDB");
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -195,6 +195,14 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function getCreateTableColumnTypeCommentsSQL()
+    {
+        return array(
+            "CREATE TABLE test (id NUMBER(10) NOT NULL, data CLOB NOT NULL, PRIMARY KEY(id))",
+            "COMMENT ON COLUMN test.data IS '(DC2Type:array)'"
+        );
+    }
+
     public function getAlterTableColumnCommentsSQL()
     {
         return array(

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -216,4 +216,12 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
             "COMMENT ON COLUMN mytable.baz IS 'B comment'",
         );
     }
+
+    public function getCreateTableColumnTypeCommentsSQL()
+    {
+        return array(
+            "CREATE TABLE test (id INT NOT NULL, data TEXT NOT NULL, PRIMARY KEY(id))",
+            "COMMENT ON COLUMN test.data IS '(DC2Type:array)'"
+        );
+    }
 }


### PR DESCRIPTION
Column type comment is generated properly only with MySQL, and is not generated on platforms that support comment on column statements (Oracle, PostgreSQL).

http://www.doctrine-project.org/jira/browse/DBAL-190
