### PR TITLE
Added a leading backslash to FQCN in @return and @param PHPDoc

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -584,7 +584,7 @@ class Connection implements DriverConnection
      * Prepares an SQL statement.
      *
      * @param string $statement The SQL statement to prepare.
-     * @return Doctrine\DBAL\Driver\Statement The prepared statement.
+     * @return \Doctrine\DBAL\Driver\Statement The prepared statement.
      */
     public function prepare($statement)
     {
@@ -603,7 +603,7 @@ class Connection implements DriverConnection
      * @param array $params The parameters to bind to the query, if any.
      * @param array $types The types the previous parameters are in.
      * @param QueryCacheProfile $qcp
-     * @return Doctrine\DBAL\Driver\Statement The executed statement.
+     * @return \Doctrine\DBAL\Driver\Statement The executed statement.
      * @internal PERF: Directly prepares a driver statement, not a wrapper.
      */
     public function executeQuery($query, array $params = array(), $types = array(), QueryCacheProfile $qcp = null)
@@ -700,7 +700,7 @@ class Connection implements DriverConnection
      *
      * @param string $statement
      * @param integer $fetchType
-     * @return Doctrine\DBAL\Driver\Statement
+     * @return \Doctrine\DBAL\Driver\Statement
      */
     public function query()
     {
@@ -1015,7 +1015,7 @@ class Connection implements DriverConnection
     /**
      * Gets the wrapped driver connection.
      *
-     * @return Doctrine\DBAL\Driver\Connection
+     * @return \Doctrine\DBAL\Driver\Connection
      */
     public function getWrappedConnection()
     {
@@ -1028,7 +1028,7 @@ class Connection implements DriverConnection
      * Gets the SchemaManager that can be used to inspect or change the
      * database schema through the connection.
      *
-     * @return Doctrine\DBAL\Schema\AbstractSchemaManager
+     * @return \Doctrine\DBAL\Schema\AbstractSchemaManager
      */
     public function getSchemaManager()
     {

--- a/lib/Doctrine/DBAL/Driver.php
+++ b/lib/Doctrine/DBAL/Driver.php
@@ -34,7 +34,7 @@ interface Driver
      * @param string $username The username to use when connecting.
      * @param string $password The password to use when connecting.
      * @param array $driverOptions The driver options to use when connecting.
-     * @return Doctrine\DBAL\Driver\Connection The database connection.
+     * @return \Doctrine\DBAL\Driver\Connection The database connection.
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array());
 
@@ -42,7 +42,7 @@ interface Driver
      * Gets the DatabasePlatform instance that provides all the metadata about
      * the platform this driver connects to.
      *
-     * @return Doctrine\DBAL\Platforms\AbstractPlatform The database platform.
+     * @return \Doctrine\DBAL\Platforms\AbstractPlatform The database platform.
      */
     public function getDatabasePlatform();
 
@@ -50,8 +50,8 @@ interface Driver
      * Gets the SchemaManager that can be used to inspect and change the underlying
      * database schema of the platform this driver connects to.
      *
-     * @param  Doctrine\DBAL\Connection $conn
-     * @return Doctrine\DBAL\SchemaManager
+     * @param  \Doctrine\DBAL\Connection $conn
+     * @return \Doctrine\DBAL\SchemaManager
      */
     public function getSchemaManager(Connection $conn);
 
@@ -65,7 +65,7 @@ interface Driver
     /**
      * Get the name of the database connected to for this driver.
      *
-     * @param  Doctrine\DBAL\Connection $conn
+     * @param  \Doctrine\DBAL\Connection $conn
      * @return string $database
      */
     public function getDatabase(Connection $conn);

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Driver.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Driver.php
@@ -37,7 +37,7 @@ class DB2Driver implements Driver
      * @param string $username The username to use when connecting.
      * @param string $password The password to use when connecting.
      * @param array $driverOptions The driver options to use when connecting.
-     * @return Doctrine\DBAL\Driver\Connection The database connection.
+     * @return \Doctrine\DBAL\Driver\Connection The database connection.
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
     {
@@ -65,7 +65,7 @@ class DB2Driver implements Driver
      * Gets the DatabasePlatform instance that provides all the metadata about
      * the platform this driver connects to.
      *
-     * @return Doctrine\DBAL\Platforms\AbstractPlatform The database platform.
+     * @return \Doctrine\DBAL\Platforms\AbstractPlatform The database platform.
      */
     public function getDatabasePlatform()
     {
@@ -76,8 +76,8 @@ class DB2Driver implements Driver
      * Gets the SchemaManager that can be used to inspect and change the underlying
      * database schema of the platform this driver connects to.
      *
-     * @param  Doctrine\DBAL\Connection $conn
-     * @return Doctrine\DBAL\SchemaManager
+     * @param  \Doctrine\DBAL\Connection $conn
+     * @return \Doctrine\DBAL\SchemaManager
      */
     public function getSchemaManager(Connection $conn)
     {
@@ -97,7 +97,7 @@ class DB2Driver implements Driver
     /**
      * Get the name of the database connected to for this driver.
      *
-     * @param  Doctrine\DBAL\Connection $conn
+     * @param  \Doctrine\DBAL\Connection $conn
      * @return string $database
      */
     public function getDatabase(\Doctrine\DBAL\Connection $conn)

--- a/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
@@ -44,7 +44,7 @@ class Driver implements \Doctrine\DBAL\Driver
      * @param string $username
      * @param string $password
      * @param array $driverOptions
-     * @return Doctrine\DBAL\Driver\Connection
+     * @return \Doctrine\DBAL\Driver\Connection
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
     {
@@ -83,7 +83,7 @@ class Driver implements \Doctrine\DBAL\Driver
      * Gets the DatabasePlatform instance that provides all the metadata about
      * the platform this driver connects to.
      *
-     * @return Doctrine\DBAL\Platforms\AbstractPlatform The database platform.
+     * @return \Doctrine\DBAL\Platforms\AbstractPlatform The database platform.
      */
     public function getDatabasePlatform()
     {
@@ -94,8 +94,8 @@ class Driver implements \Doctrine\DBAL\Driver
      * Gets the SchemaManager that can be used to inspect and change the underlying
      * database schema of the platform this driver connects to.
      *
-     * @param  Doctrine\DBAL\Connection $conn
-     * @return Doctrine\DBAL\SchemaManager
+     * @param  \Doctrine\DBAL\Connection $conn
+     * @return \Doctrine\DBAL\SchemaManager
      */
     public function getSchemaManager(Connection $conn)
     {
@@ -115,7 +115,7 @@ class Driver implements \Doctrine\DBAL\Driver
     /**
      * Get the name of the database connected to for this driver.
      *
-     * @param  Doctrine\DBAL\Connection $conn
+     * @param  \Doctrine\DBAL\Connection $conn
      * @return string $database
      */
     public function getDatabase(\Doctrine\DBAL\Connection $conn)

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -35,7 +35,7 @@ class Driver implements \Doctrine\DBAL\Driver
      * @param string $username
      * @param string $password
      * @param array $driverOptions
-     * @return Doctrine\DBAL\Driver\Connection
+     * @return \Doctrine\DBAL\Driver\Connection
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
     {

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -14,7 +14,7 @@ class Driver implements \Doctrine\DBAL\Driver
     /**
      * Attempts to connect to the database and returns a driver connection on success.
      *
-     * @return Doctrine\DBAL\Driver\Connection
+     * @return \Doctrine\DBAL\Driver\Connection
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
     {

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -95,8 +95,8 @@ class Driver implements \Doctrine\DBAL\Driver
     /**
      * Gets the schema manager that is relevant for this driver.
      *
-     * @param Doctrine\DBAL\Connection $conn
-     * @return Doctrine\DBAL\Schema\SqliteSchemaManager
+     * @param \Doctrine\DBAL\Connection $conn
+     * @return \Doctrine\DBAL\Schema\SqliteSchemaManager
      */
     public function getSchemaManager(\Doctrine\DBAL\Connection $conn)
     {

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -91,9 +91,9 @@ final class DriverManager
      * The driver class to use.
      *
      * @param array $params The parameters.
-     * @param Doctrine\DBAL\Configuration The configuration to use.
-     * @param Doctrine\Common\EventManager The event manager to use.
-     * @return Doctrine\DBAL\Connection
+     * @param \Doctrine\DBAL\Configuration The configuration to use.
+     * @param \Doctrine\Common\EventManager The event manager to use.
+     * @return \Doctrine\DBAL\Connection
      */
     public static function getConnection(
             array $params,

--- a/lib/Doctrine/DBAL/Event/ConnectionEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/ConnectionEventArgs.php
@@ -46,7 +46,7 @@ class ConnectionEventArgs extends EventArgs
     }
 
     /**
-     * @return Doctrine\DBAL\Connection
+     * @return \Doctrine\DBAL\Connection
      */
     public function getConnection()
     {
@@ -54,7 +54,7 @@ class ConnectionEventArgs extends EventArgs
     }
 
     /**
-     * @return Doctrine\DBAL\Driver
+     * @return \Doctrine\DBAL\Driver
      */
     public function getDriver()
     {
@@ -62,7 +62,7 @@ class ConnectionEventArgs extends EventArgs
     }
 
     /**
-     * @return Doctrine\DBAL\Platforms\AbstractPlatform
+     * @return \Doctrine\DBAL\Platforms\AbstractPlatform
      */
     public function getDatabasePlatform()
     {
@@ -70,7 +70,7 @@ class ConnectionEventArgs extends EventArgs
     }
 
     /**
-     * @return Doctrine\DBAL\Schema\AbstractSchemaManager
+     * @return \Doctrine\DBAL\Schema\AbstractSchemaManager
      */
     public function getSchemaManager()
     {

--- a/lib/Doctrine/DBAL/Event/SchemaCreateTableEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaCreateTableEventArgs.php
@@ -61,7 +61,7 @@ class SchemaCreateTableEventArgs extends SchemaEventArgs
      * @param \Doctrine\DBAL\Schema\Table $table
      * @param array $columns
      * @param array $options
-     * @param Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
      */
     public function __construct(Table $table, array $columns, array $options, AbstractPlatform $platform)
     {

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -96,7 +96,7 @@ class Connection extends \Doctrine\DBAL\Connection
      * Prepares an SQL statement.
      *
      * @param string $statement The SQL statement to prepare.
-     * @return Doctrine\DBAL\Driver\Statement The prepared statement.
+     * @return \Doctrine\DBAL\Driver\Statement The prepared statement.
      */
     public function prepare($statement)
     {

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -56,8 +56,8 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
     /**
      * Wraps <tt>Statement</tt> and applies portability measures
      *
-     * @param Doctrine\DBAL\Driver\Statement $stmt
-     * @param Doctrine\DBAL\Connection $conn
+     * @param \Doctrine\DBAL\Driver\Statement $stmt
+     * @param \Doctrine\DBAL\Connection $conn
      */
     public function __construct($stmt, Connection $conn)
     {

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -47,7 +47,7 @@ class ExpressionBuilder
     /**
      * Initializes a new <tt>ExpressionBuilder</tt>.
      *
-     * @param Doctrine\DBAL\Connection $connection DBAL Connection
+     * @param \Doctrine\DBAL\Connection $connection DBAL Connection
      */
     public function __construct(Connection $connection)
     {

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -113,7 +113,7 @@ class QueryBuilder
     /**
      * Initializes a new <tt>QueryBuilder</tt>.
      *
-     * @param Doctrine\DBAL\Connection $connection DBAL Connection
+     * @param \Doctrine\DBAL\Connection $connection DBAL Connection
      */
     public function __construct(Connection $connection)
     {
@@ -134,7 +134,7 @@ class QueryBuilder
      * For more complex expression construction, consider storing the expression
      * builder object in a local variable.
      *
-     * @return Doctrine\DBAL\Query\ExpressionBuilder
+     * @return \Doctrine\DBAL\Query\ExpressionBuilder
      */
     public function expr()
     {
@@ -154,7 +154,7 @@ class QueryBuilder
     /**
      * Get the associated DBAL Connection for this query builder.
      *
-     * @return Doctrine\DBAL\Connection
+     * @return \Doctrine\DBAL\Connection
      */
     public function getConnection()
     {
@@ -306,7 +306,7 @@ class QueryBuilder
      * Sets the position of the first result to retrieve (the "offset").
      *
      * @param integer $firstResult The first result to return.
-     * @return Doctrine\DBAL\Query\QueryBuilder This QueryBuilder instance.
+     * @return \Doctrine\DBAL\Query\QueryBuilder This QueryBuilder instance.
      */
     public function setFirstResult($firstResult)
     {
@@ -330,7 +330,7 @@ class QueryBuilder
      * Sets the maximum number of results to retrieve (the "limit").
      *
      * @param integer $maxResults The maximum number of results to retrieve.
-     * @return Doctrine\DBAL\Query\QueryBuilder This QueryBuilder instance.
+     * @return \Doctrine\DBAL\Query\QueryBuilder This QueryBuilder instance.
      */
     public function setMaxResults($maxResults)
     {
@@ -359,7 +359,7 @@ class QueryBuilder
      * @param string $sqlPartName
      * @param string $sqlPart
      * @param string $append
-     * @return Doctrine\DBAL\Query\QueryBuilder This QueryBuilder instance.
+     * @return \Doctrine\DBAL\Query\QueryBuilder This QueryBuilder instance.
      */
     public function add($sqlPartName, $sqlPart, $append = false)
     {

--- a/lib/Doctrine/DBAL/Schema/Column.php
+++ b/lib/Doctrine/DBAL/Schema/Column.php
@@ -102,7 +102,7 @@ class Column extends AbstractAsset
      * Create a new Column
      *
      * @param string $columnName
-     * @param Doctrine\DBAL\Types\Type $type
+     * @param \Doctrine\DBAL\Types\Type $type
      * @param int $length
      * @param bool $notNull
      * @param mixed $default

--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -156,7 +156,7 @@ class Schema extends AbstractAsset
     /**
      * @throws SchemaException
      * @param  string $sequenceName
-     * @return Doctrine\DBAL\Schema\Sequence
+     * @return \Doctrine\DBAL\Schema\Sequence
      */
     public function getSequence($sequenceName)
     {
@@ -168,7 +168,7 @@ class Schema extends AbstractAsset
     }
 
     /**
-     * @return Doctrine\DBAL\Schema\Sequence[]
+     * @return \Doctrine\DBAL\Schema\Sequence[]
      */
     public function getSequences()
     {

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -59,7 +59,7 @@ class Statement implements \IteratorAggregate, DriverStatement
      * Creates a new <tt>Statement</tt> for the given SQL and <tt>Connection</tt>.
      *
      * @param string $sql The SQL of the statement.
-     * @param Doctrine\DBAL\Connection The connection on which the statement should be executed.
+     * @param \Doctrine\DBAL\Connection The connection on which the statement should be executed.
      */
     public function __construct($sql, Connection $conn)
     {
@@ -238,7 +238,7 @@ class Statement implements \IteratorAggregate, DriverStatement
     /**
      * Gets the wrapped driver statement.
      *
-     * @return Doctrine\DBAL\Driver\Statement
+     * @return \Doctrine\DBAL\Driver\Statement
      */
     public function getWrappedStatement()
     {

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -133,7 +133,7 @@ abstract class Type
      * @static
      * @throws DBALException
      * @param string $name The name of the type (as returned by getName()).
-     * @return Doctrine\DBAL\Types\Type
+     * @return \Doctrine\DBAL\Types\Type
      */
     public static function getType($name)
     {

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -28,7 +28,7 @@ class TestUtil
      * 1) Each invocation of this method returns a NEW database connection.
      * 2) The database is dropped and recreated to ensure it's clean.
      *
-     * @return Doctrine\DBAL\Connection The database connection instance.
+     * @return \Doctrine\DBAL\Connection The database connection instance.
      */
     public static function getConnection()
     {


### PR DESCRIPTION
PHPDoc should only contain FQCN with a leading backslash, imported classnames or relative classnames. Doctrine ORM is using this convention in the latest versions, so i updated the DBAL library.
