### PR TITLE
[DBAL-206] OraclePlatform causes problems with more schemas with same table names

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -480,16 +480,13 @@ END;';
           cols.position,
           r_alc.table_name \"references_table\",
           r_cols.column_name \"foreign_column\"
-     FROM all_cons_columns cols
-LEFT JOIN all_constraints alc
+     FROM usercons_columns cols
+LEFT JOIN user_constraints alc
        ON alc.constraint_name = cols.constraint_name
-      AND alc.owner = cols.owner
-LEFT JOIN all_constraints r_alc
+LEFT JOIN user_constraints r_alc
        ON alc.r_constraint_name = r_alc.constraint_name
-      AND alc.r_owner = r_alc.owner
-LEFT JOIN all_cons_columns r_cols
+LEFT JOIN user_cons_columns r_cols
        ON r_alc.constraint_name = r_cols.constraint_name
-      AND r_alc.owner = r_cols.owner
       AND cols.position = r_cols.position
     WHERE alc.constraint_name = cols.constraint_name
       AND alc.constraint_type = 'R'
@@ -512,8 +509,8 @@ LEFT JOIN all_cons_columns r_cols
             $ownerCondition = "AND c.owner = '".$database."'";
         }
 
-        return "SELECT c.*, d.comments FROM all_tab_columns c ".
-               "INNER JOIN all_col_comments d ON d.OWNER = c.OWNER AND d.TABLE_NAME = c.TABLE_NAME AND d.COLUMN_NAME = c.COLUMN_NAME ".
+        return "SELECT c.*, d.comments FROM user_tab_columns c ".
+               "INNER JOIN user_col_comments d ON d.TABLE_NAME = c.TABLE_NAME AND d.COLUMN_NAME = c.COLUMN_NAME ".
                "WHERE c.table_name = '" . $table . "' ".$ownerCondition." ORDER BY c.column_name";
     }
 


### PR DESCRIPTION
Hi,

OraclePlatform is using the ALL_\* tables to fetch schema information but is only supplying the table name in the where condition. This causes problems when you have multiple schemas with tables that have the same name. Their columns/FK get mixed up.
My colleague and I have traced the problem down to the OraclePlatform class and replaced the ALL_\* tables with USER_*. The fix for that is on github https://github.com/FranPregernik/dbal/commit/c70bc462b49a168105304cdff0086dcd15cc347d.

As mentioned in the commit message the other fix would be to fetch the schema name (user) of the table and add it to the where part of the queries.

this is a pull request for this issue: http://www.doctrine-project.org/jira/browse/DBAL-206
