### PR TITLE
New mappings for Postgres types, fixed multiple-line sub-query

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -210,7 +210,7 @@ class PostgreSqlPlatform extends AbstractPlatform
                   (
                       SELECT c.oid
                       FROM pg_catalog.pg_class c, pg_catalog.pg_namespace n
-                      WHERE " .$this->getTableWhereClause($table) ." AND n.oid = c.relnamespace
+                      WHERE " .$this->getTableWhereClause($table) ." AND n.oid = c.relnamespace LIMIT 1
                   )
                   AND r.contype = 'f'";
     }
@@ -768,6 +768,11 @@ class PostgreSqlPlatform extends AbstractPlatform
             'numeric'       => 'decimal',
             'year'          => 'date',
             'bytea'         => 'blob',
+            'unknown'       => 'text',
+            '_text'         => 'text',
+            'regprocedure'  => 'string',
+            'inet'          => 'string',
+            'name'          => 'string',
         );
     }
 


### PR DESCRIPTION
- Added a LIMIT 1 to the sub-query in getListTableForeignKeysSQL() because the query was returning multiple values on our database.
- Added some new field types our database has that was preventing the migrations from running.
