### PR TITLE
Fixed SQL placeholder parsing

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -32,6 +32,13 @@ use Doctrine\DBAL\Connection;
  */
 class SQLParserUtils
 {
+    const POSITIONAL_TOKEN = '\?';
+    const NAMED_TOKEN      = ':[a-zA-Z_][a-zA-Z0-9_]*';
+
+    // Quote characters within string literals can be preceded by a backslash.
+    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:[^'\\\\]|\\\\'|\\\\\\\\)*'";
+    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:[^"\\\\]|\\\\"|\\\\\\\\)*"';
+
     /**
      * Get an array of the placeholders in an sql statements as keys and their positions in the query string.
      *
@@ -49,27 +56,18 @@ class SQLParserUtils
             return array();
         }
 
-        $count = 0;
-        $inLiteral = false; // a valid query never starts with quotes
-        $stmtLen = strlen($statement);
+        $token = ($isPositional) ? self::POSITIONAL_TOKEN : self::NAMED_TOKEN;
         $paramMap = array();
-        for ($i = 0; $i < $stmtLen; $i++) {
-            if ($statement[$i] == $match && !$inLiteral && ($isPositional || $statement[$i+1] != '=')) {
-                // real positional parameter detected
+
+        foreach (self::getUnquotedStatementFragments($statement) as $fragment) {
+            preg_match_all("/$token/", $fragment[0], $matches, PREG_OFFSET_CAPTURE);
+            foreach ($matches[0] as $placeholder) {
                 if ($isPositional) {
-                    $paramMap[$count] = $i;
+                    $paramMap[] = $placeholder[1] + $fragment[1];
                 } else {
-                    $name = "";
-                    // TODO: Something faster/better to match this than regex?
-                    for ($j = $i + 1; ($j < $stmtLen && preg_match('(([a-zA-Z0-9_]{1}))', $statement[$j])); $j++) {
-                        $name .= $statement[$j];
-                    }
-                    $paramMap[$i] = $name; // named parameters can be duplicated!
-                    $i = $j;
+                    $pos = $placeholder[1] + $fragment[1];
+                    $paramMap[$pos] = substr($placeholder[0], 1, strlen($placeholder[0]));
                 }
-                ++$count;
-            } else if ($statement[$i] == "'" || $statement[$i] == '"') {
-                $inLiteral = ! $inLiteral; // switch state!
             }
         }
 
@@ -179,5 +177,24 @@ class SQLParserUtils
         }
 
         return array($query, $paramsOrd, $typesOrd);
+    }
+
+    /**
+     * Slice the SQL statement around pairs of quotes and
+     * return string fragments of SQL outside of quoted literals.
+     * Each fragment is captured as a 2-element array:
+     *
+     * 0 => matched fragment string,
+     * 1 => offset of fragment in $statement
+     *
+     * @param string $statement
+     * @return array
+     */
+    static private function getUnquotedStatementFragments($statement)
+    {
+        $literal = self::ESCAPED_SINGLE_QUOTED_TEXT . '|' . self::ESCAPED_DOUBLE_QUOTED_TEXT;
+        preg_match_all("/([^'\"]+)(?:$literal)?/s", $statement, $fragments, PREG_OFFSET_CAPTURE);
+
+        return $fragments[1];
     }
 }

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -28,6 +28,13 @@ class SQLParserUtilsTest extends \Doctrine\Tests\DbalTestCase
             array("SELECT '?' FROM foo", true, array()),
             array('SELECT "?" FROM foo WHERE bar = ?', true, array(32)),
             array("SELECT '?' FROM foo WHERE bar = ?", true, array(32)),
+            array(
+<<<'SQLDATA'
+SELECT * FROM foo WHERE bar = 'it\'s a trap? \\' OR bar = ?
+AND baz = "\"quote\" me on it? \\" OR baz = ?
+SQLDATA
+                , true, array(58, 104)
+            ),
 
             // named
             array('SELECT :foo FROM :bar', false, array(7 => 'foo', 17 => 'bar')),
@@ -37,6 +44,7 @@ class SQLParserUtilsTest extends \Doctrine\Tests\DbalTestCase
             array('SELECT :foo_id', false, array(7 => 'foo_id')), // Ticket DBAL-231
             array('SELECT @rank := 1', false, array()), // Ticket DBAL-398
             array('SELECT @rank := 1 AS rank, :foo AS foo FROM :bar', false, array(27 => 'foo', 44 => 'bar')), // Ticket DBAL-398
+            array('SELECT * FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(30 => 'start_date', 52 =>  'start_date')) // Ticket GH-113
         );
     }
 


### PR DESCRIPTION
I reworked DoctrineSQLParser to fix these problems:
### Named placeholder patterns

The parser used a pattern that would match multiple colons, so junk like `:fir:stNa::m:e` was a "valid" placeholder name.

The parser neglected the underscore so `:first_name` was invalid and only captured `:first`.

This is cleaned up so placeholder names are consistent with PHP variable names: "starts with a letter or underscore, followed by any number of letters, numbers, or underscores".
### Quote characters in strings

The parser had a simplistic way of matching quote pairs, ignoring that a quote character could be escaped by a backslash inside a string.

It now recognizes `'it\'s a trap?'` as a whole literal string instead of breaking out after `it\` and parsing the `?` as a SQL placeholder.
### Speed

The original algorithm looped a regular expression over each character position in the whole statement. The new algorithm handles matching in two steps:
- One regular expression to select unquoted SQL.
- One regular expression to match placeholder tokens in the result.

I measured the result to be over 100% faster given the simple strings from the test case (even with 2 new runs added to the test data). The improvement would be greater on longer statements:

```
Doctrine\DBAL\SQLParserUtils::getPlaceholderPositions
| version:     | invocation count: | total inclusive time: |
| original     | 37                | 5719                  |
| this patch   | 39                | 2380                  |
```
