### PR TITLE
Adding support for datetimeoffset for MSSQL Server 2008

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -63,6 +63,14 @@ class SQLServer2008Platform extends SQLServer2005Platform
 
     /**
      * @override
+     */
+    public function getDateTimeTzFormatString()
+    {
+        return 'Y-m-d H:i:s.u P';
+    }
+
+    /**
+     * @override
 	 */
     public function getDateFormatString()
     {


### PR DESCRIPTION
The format for datetimeoffset is not 'Y-m-d H:i:s.u' but 'Y-m-d H:i:s.u P':
http://msdn.microsoft.com/en-us/library/bb630289(v=sql.100).aspx
