### PR TITLE
Default fetch mode for Connection and fixing it for Statement classes

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -27,7 +27,7 @@ class ArrayStatement implements \IteratorAggregate, ResultStatement
     private $data;
     private $columnCount = 0;
     private $num = 0;
-    private $defaultFetchStyle = PDO::FETCH_BOTH;
+    private $defaultFetchMode = PDO::FETCH_BOTH;
 
     public function __construct(array $data)
     {
@@ -47,13 +47,13 @@ class ArrayStatement implements \IteratorAggregate, ResultStatement
         return $this->columnCount;
     }
 
-    public function setFetchMode($fetchStyle, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
         if ($arg2 !== null || $arg3 !== null) {
             throw new \InvalidArgumentException("Caching layer does not support 2nd/3rd argument to setFetchMode()");
         }
 
-        $this->defaultFetchStyle = $fetchStyle;
+        $this->defaultFetchMode = $fetchMode;
     }
 
     public function getIterator()
@@ -62,18 +62,18 @@ class ArrayStatement implements \IteratorAggregate, ResultStatement
         return new \ArrayIterator($data);
     }
 
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchMode = null)
     {
         if (isset($this->data[$this->num])) {
             $row = $this->data[$this->num++];
-            $fetchStyle = $fetchStyle ?: $this->defaultFetchStyle;
-            if ($fetchStyle === PDO::FETCH_ASSOC) {
+            $fetchMode = $fetchMode ?: $this->defaultFetchMode;
+            if ($fetchMode === PDO::FETCH_ASSOC) {
                 return $row;
-            } else if ($fetchStyle === PDO::FETCH_NUM) {
+            } else if ($fetchMode === PDO::FETCH_NUM) {
                 return array_values($row);
-            } else if ($fetchStyle === PDO::FETCH_BOTH) {
+            } else if ($fetchMode === PDO::FETCH_BOTH) {
                 return array_merge($row, array_values($row));
-            } else if ($fetchStyle === PDO::FETCH_COLUMN) {
+            } else if ($fetchMode === PDO::FETCH_COLUMN) {
                 return reset($row);
             } else {
                 throw new \InvalidArgumentException("Invalid fetch-style given for fetching result.");
@@ -82,10 +82,10 @@ class ArrayStatement implements \IteratorAggregate, ResultStatement
         return false;
     }
 
-    public function fetchAll($fetchStyle = null)
+    public function fetchAll($fetchMode = null)
     {
         $rows = array();
-        while ($row = $this->fetch($fetchStyle)) {
+        while ($row = $this->fetch($fetchMode)) {
             $rows[] = $row;
         }
         return $rows;

--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -58,14 +58,15 @@ class ArrayStatement implements \IteratorAggregate, ResultStatement
 
     public function getIterator()
     {
-        $data = $this->fetchAll($this->defaultFetchStyle);
+        $data = $this->fetchAll();
         return new \ArrayIterator($data);
     }
 
-    public function fetch($fetchStyle = PDO::FETCH_BOTH)
+    public function fetch($fetchStyle = null)
     {
         if (isset($this->data[$this->num])) {
             $row = $this->data[$this->num++];
+            $fetchStyle = $fetchStyle ?: $this->defaultFetchStyle;
             if ($fetchStyle === PDO::FETCH_ASSOC) {
                 return $row;
             } else if ($fetchStyle === PDO::FETCH_NUM) {
@@ -81,7 +82,7 @@ class ArrayStatement implements \IteratorAggregate, ResultStatement
         return false;
     }
 
-    public function fetchAll($fetchStyle = PDO::FETCH_BOTH)
+    public function fetchAll($fetchStyle = null)
     {
         $rows = array();
         while ($row = $this->fetch($fetchStyle)) {

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -139,7 +139,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
 
     public function getIterator()
     {
-        $data = $this->fetchAll($this->defaultFetchStyle);
+        $data = $this->fetchAll();
         return new \ArrayIterator($data);
     }
 
@@ -153,7 +153,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
      *
      * @return mixed
      */
-    public function fetch($fetchStyle = PDO::FETCH_BOTH)
+    public function fetch($fetchStyle = null)
     {
         if ($this->data === null) {
             $this->data = array();
@@ -162,6 +162,8 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
         $row = $this->statement->fetch(PDO::FETCH_ASSOC);
         if ($row) {
             $this->data[] = $row;
+
+            $fetchStyle = $fetchStyle ?: $this->defaultFetchStyle;
 
             if ($fetchStyle == PDO::FETCH_ASSOC) {
                 return $row;
@@ -188,7 +190,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
      *
      * @return array
      */
-    public function fetchAll($fetchStyle = PDO::FETCH_BOTH)
+    public function fetchAll($fetchStyle = null)
     {
         $rows = array();
         while ($row = $this->fetch($fetchStyle)) {

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -81,7 +81,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
     /**
      * @var int
      */
-    private $defaultFetchStyle = PDO::FETCH_BOTH;
+    private $defaultFetchMode = PDO::FETCH_BOTH;
 
     /**
      * @param Statement $stmt
@@ -132,9 +132,9 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
         return $this->statement->columnCount();
     }
 
-    public function setFetchMode($fetchStyle, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
-        $this->defaultFetchStyle = $fetchStyle;
+        $this->defaultFetchMode = $fetchMode;
     }
 
     public function getIterator()
@@ -147,13 +147,13 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
      * fetch
      *
      * @see Query::HYDRATE_* constants
-     * @param integer $fetchStyle           Controls how the next row will be returned to the caller.
+     * @param integer $fetchMode            Controls how the next row will be returned to the caller.
      *                                      This value must be one of the Query::HYDRATE_* constants,
      *                                      defaulting to Query::HYDRATE_BOTH
      *
      * @return mixed
      */
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchMode = null)
     {
         if ($this->data === null) {
             $this->data = array();
@@ -163,15 +163,15 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
         if ($row) {
             $this->data[] = $row;
 
-            $fetchStyle = $fetchStyle ?: $this->defaultFetchStyle;
+            $fetchMode = $fetchMode ?: $this->defaultFetchMode;
 
-            if ($fetchStyle == PDO::FETCH_ASSOC) {
+            if ($fetchMode == PDO::FETCH_ASSOC) {
                 return $row;
-            } else if ($fetchStyle == PDO::FETCH_NUM) {
+            } else if ($fetchMode == PDO::FETCH_NUM) {
                 return array_values($row);
-            } else if ($fetchStyle == PDO::FETCH_BOTH) {
+            } else if ($fetchMode == PDO::FETCH_BOTH) {
                 return array_merge($row, array_values($row));
-            } else if ($fetchStyle == PDO::FETCH_COLUMN) {
+            } else if ($fetchMode == PDO::FETCH_COLUMN) {
                 return reset($row);
             } else {
                 throw new \InvalidArgumentException("Invalid fetch-style given for caching result.");
@@ -184,16 +184,16 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
     /**
      * Returns an array containing all of the result set rows
      *
-     * @param integer $fetchStyle           Controls how the next row will be returned to the caller.
+     * @param integer $fetchMode            Controls how the next row will be returned to the caller.
      *                                      This value must be one of the Query::HYDRATE_* constants,
      *                                      defaulting to Query::HYDRATE_BOTH
      *
      * @return array
      */
-    public function fetchAll($fetchStyle = null)
+    public function fetchAll($fetchMode = null)
     {
         $rows = array();
-        while ($row = $this->fetch($fetchStyle)) {
+        while ($row = $this->fetch($fetchMode)) {
             $rows[] = $row;
         }
         return $rows;

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -173,7 +173,7 @@ class Connection implements DriverConnection
      */
     private $_isRollbackOnly = false;
 
-    private $_defaultFetchStyle = PDO::FETCH_ASSOC;
+    private $_defaultFetchMode = PDO::FETCH_ASSOC;
 
     /**
      * Initializes a new instance of the Connection class.
@@ -361,11 +361,11 @@ class Connection implements DriverConnection
     /**
      * setFetchMode
      *
-     * @param integer $fetchStyle
+     * @param integer $fetchMode
      */
-    public function setFetchMode($fetchStyle)
+    public function setFetchMode($fetchMode)
     {
-        $this->_defaultFetchStyle = $fetchStyle;
+        $this->_defaultFetchMode = $fetchMode;
     }
 
     /**
@@ -605,7 +605,7 @@ class Connection implements DriverConnection
         $this->connect();
 
         $stmt = new Statement($statement, $this);
-        $stmt->setFetchMode($this->_defaultFetchStyle);
+        $stmt->setFetchMode($this->_defaultFetchMode);
 
         return $stmt;
     }
@@ -650,7 +650,7 @@ class Connection implements DriverConnection
             $stmt = $this->_conn->query($query);
         }
 
-        $stmt->setFetchMode($this->_defaultFetchStyle);
+        $stmt->setFetchMode($this->_defaultFetchMode);
 
         if ($logger) {
             $logger->stopQuery();
@@ -691,7 +691,7 @@ class Connection implements DriverConnection
             $stmt = new ResultCacheStatement($this->executeQuery($query, $params, $types), $resultCache, $cacheKey, $realKey, $qcp->getLifetime());
         }
 
-        $stmt->setFetchMode($this->_defaultFetchStyle);
+        $stmt->setFetchMode($this->_defaultFetchMode);
 
         return $stmt;
     }
@@ -740,7 +740,7 @@ class Connection implements DriverConnection
         }
 
         $statement = call_user_func_array(array($this->_conn, 'query'), $args);
-        $statement->setFetchMode($this->_defaultFetchStyle);
+        $statement->setFetchMode($this->_defaultFetchMode);
 
         if ($logger) {
             $logger->stopQuery();

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -29,7 +29,7 @@ class DB2Statement implements \IteratorAggregate, Statement
 
     private $_bindParam = array();
 
-    private $_defaultFetchStyle = \PDO::FETCH_BOTH;
+    private $_defaultFetchMode = \PDO::FETCH_BOTH;
 
     /**
      * DB2_BINARY, DB2_CHAR, DB2_DOUBLE, or DB2_LONG
@@ -148,9 +148,9 @@ class DB2Statement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function setFetchMode($fetchStyle, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
-        $this->_defaultFetchStyle = $fetchStyle;
+        $this->_defaultFetchMode = $fetchMode;
     }
 
     /**
@@ -165,10 +165,10 @@ class DB2Statement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchMode = null)
     {
-        $fetchStyle = $fetchStyle ?: $this->_defaultFetchStyle;
-        switch ($fetchStyle) {
+        $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
+        switch ($fetchMode) {
             case \PDO::FETCH_BOTH:
                 return db2_fetch_both($this->_stmt);
             case \PDO::FETCH_ASSOC:
@@ -176,17 +176,17 @@ class DB2Statement implements \IteratorAggregate, Statement
             case \PDO::FETCH_NUM:
                 return db2_fetch_array($this->_stmt);
             default:
-                throw new DB2Exception("Given Fetch-Style " . $fetchStyle . " is not supported.");
+                throw new DB2Exception("Given Fetch-Style " . $fetchMode . " is not supported.");
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchStyle = null)
+    public function fetchAll($fetchMode = null)
     {
         $rows = array();
-        while ($row = $this->fetch($fetchStyle)) {
+        while ($row = $this->fetch($fetchMode)) {
             $rows[] = $row;
         }
         return $rows;

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -158,7 +158,7 @@ class DB2Statement implements \IteratorAggregate, Statement
      */
     public function getIterator()
     {
-        $data = $this->fetchAll($this->_defaultFetchStyle);
+        $data = $this->fetchAll();
         return new \ArrayIterator($data);
     }
 
@@ -185,7 +185,6 @@ class DB2Statement implements \IteratorAggregate, Statement
      */
     public function fetchAll($fetchStyle = null)
     {
-        $fetchStyle = $fetchStyle ?: $this->_defaultFetchStyle;
         $rows = array();
         while ($row = $this->fetch($fetchStyle)) {
             $rows[] = $row;

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -148,7 +148,7 @@ class DB2Statement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function setFetchMode($fetchStyle = \PDO::FETCH_BOTH, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchStyle, $arg2 = null, $arg3 = null)
     {
         $this->_defaultFetchStyle = $fetchStyle;
     }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -253,18 +253,18 @@ class MysqliStatement implements \IteratorAggregate, Statement
     {
         $fetchStyle = $fetchStyle ?: $this->_defaultFetchStyle;
 
-        $a = array();
+        $rows = array();
         if (PDO::FETCH_COLUMN == $fetchStyle) {
-            while (($value = $this->fetchColumn()) !== false) {
-                $a[] = $value;
+            while (($row = $this->fetchColumn()) !== false) {
+                $rows[] = $row;
             }
         } else {
             while (($row = $this->fetch($fetchStyle)) !== null) {
-                $a[] = $row;
+                $rows[] = $row;
             }
         }
 
-        return $a;
+        return $rows;
     }
 
     /**
@@ -336,7 +336,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
      */
     public function getIterator()
     {
-        $data = $this->fetchAll($this->_defaultFetchStyle);
+        $data = $this->fetchAll();
         return new \ArrayIterator($data);
     }
 }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -326,7 +326,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function setFetchMode($fetchMode = PDO::FETCH_BOTH, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
         $this->_defaultFetchStyle = $fetchMode;
     }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -60,7 +60,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
      */
     protected $_values = array();
 
-    protected $_defaultFetchStyle = PDO::FETCH_BOTH;
+    protected $_defaultFetchMode = PDO::FETCH_BOTH;
 
     public function __construct(\mysqli $conn, $prepareString)
     {
@@ -216,7 +216,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchMode = null)
     {
         $values = $this->_fetch();
         if (null === $values) {
@@ -227,9 +227,9 @@ class MysqliStatement implements \IteratorAggregate, Statement
             throw new MysqliException($this->_stmt->error, $this->_stmt->errno);
         }
 
-        $fetchStyle = $fetchStyle ?: $this->_defaultFetchStyle;
+        $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
 
-        switch ($fetchStyle) {
+        switch ($fetchMode) {
             case PDO::FETCH_NUM:
                 return $values;
 
@@ -242,24 +242,24 @@ class MysqliStatement implements \IteratorAggregate, Statement
                 return $ret;
 
             default:
-                throw new MysqliException("Unknown fetch type '{$fetchStyle}'");
+                throw new MysqliException("Unknown fetch type '{$fetchMode}'");
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchStyle = null)
+    public function fetchAll($fetchMode = null)
     {
-        $fetchStyle = $fetchStyle ?: $this->_defaultFetchStyle;
+        $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
 
         $rows = array();
-        if (PDO::FETCH_COLUMN == $fetchStyle) {
+        if (PDO::FETCH_COLUMN == $fetchMode) {
             while (($row = $this->fetchColumn()) !== false) {
                 $rows[] = $row;
             }
         } else {
-            while (($row = $this->fetch($fetchStyle)) !== null) {
+            while (($row = $this->fetch($fetchMode)) !== null) {
                 $rows[] = $row;
             }
         }
@@ -328,7 +328,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
      */
     public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
-        $this->_defaultFetchStyle = $fetchMode;
+        $this->_defaultFetchMode = $fetchMode;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -79,7 +79,7 @@ class OCI8Connection implements \Doctrine\DBAL\Driver\Connection
     {
         $args = func_get_args();
         $sql = $args[0];
-        //$fetchStyle = $args[1];
+        //$fetchMode = $args[1];
         $stmt = $this->prepare($sql);
         $stmt->execute();
         return $stmt;

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -79,7 +79,7 @@ class OCI8Connection implements \Doctrine\DBAL\Driver\Connection
     {
         $args = func_get_args();
         $sql = $args[0];
-        //$fetchMode = $args[1];
+        //$fetchStyle = $args[1];
         $stmt = $this->prepare($sql);
         $stmt->execute();
         return $stmt;

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -190,7 +190,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function setFetchMode($fetchStyle = PDO::FETCH_BOTH, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchStyle, $arg2 = null, $arg3 = null)
     {
         $this->_defaultFetchStyle = $fetchStyle;
     }

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -36,14 +36,14 @@ class OCI8Statement implements \IteratorAggregate, Statement
     protected $_sth;
     protected $_conn;
     protected static $_PARAM = ':param';
-    protected static $fetchStyleMap = array(
+    protected static $fetchModeMap = array(
         PDO::FETCH_BOTH => OCI_BOTH,
         PDO::FETCH_ASSOC => OCI_ASSOC,
         PDO::FETCH_NUM => OCI_NUM,
         PDO::PARAM_LOB => OCI_B_BLOB,
         PDO::FETCH_COLUMN => OCI_NUM,
     );
-    protected $_defaultFetchStyle = PDO::FETCH_BOTH;
+    protected $_defaultFetchMode = PDO::FETCH_BOTH;
     protected $_paramMap = array();
 
     /**
@@ -190,9 +190,9 @@ class OCI8Statement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function setFetchMode($fetchStyle, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
-        $this->_defaultFetchStyle = $fetchStyle;
+        $this->_defaultFetchMode = $fetchMode;
     }
 
     /**
@@ -207,41 +207,41 @@ class OCI8Statement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchMode = null)
     {
-        $fetchStyle = $fetchStyle ?: $this->_defaultFetchStyle;
-        if ( ! isset(self::$fetchStyleMap[$fetchStyle])) {
-            throw new \InvalidArgumentException("Invalid fetch style: " . $fetchStyle);
+        $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
+        if ( ! isset(self::$fetchModeMap[$fetchMode])) {
+            throw new \InvalidArgumentException("Invalid fetch style: " . $fetchMode);
         }
 
-        return oci_fetch_array($this->_sth, self::$fetchStyleMap[$fetchStyle] | OCI_RETURN_NULLS | OCI_RETURN_LOBS);
+        return oci_fetch_array($this->_sth, self::$fetchModeMap[$fetchMode] | OCI_RETURN_NULLS | OCI_RETURN_LOBS);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchStyle = null)
+    public function fetchAll($fetchMode = null)
     {
-        $fetchStyle = $fetchStyle ?: $this->_defaultFetchStyle;
-        if ( ! isset(self::$fetchStyleMap[$fetchStyle])) {
-            throw new \InvalidArgumentException("Invalid fetch style: " . $fetchStyle);
+        $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
+        if ( ! isset(self::$fetchModeMap[$fetchMode])) {
+            throw new \InvalidArgumentException("Invalid fetch style: " . $fetchMode);
         }
 
         $result = array();
-        if (self::$fetchStyleMap[$fetchStyle] === OCI_BOTH) {
-            while ($row = $this->fetch($fetchStyle)) {
+        if (self::$fetchModeMap[$fetchMode] === OCI_BOTH) {
+            while ($row = $this->fetch($fetchMode)) {
                 $result[] = $row;
             }
         } else {
             $fetchStructure = OCI_FETCHSTATEMENT_BY_ROW;
-            if ($fetchStyle == PDO::FETCH_COLUMN) {
+            if ($fetchMode == PDO::FETCH_COLUMN) {
                 $fetchStructure = OCI_FETCHSTATEMENT_BY_COLUMN;
             }
 
             oci_fetch_all($this->_sth, $result, 0, -1,
-                    self::$fetchStyleMap[$fetchStyle] | OCI_RETURN_NULLS | $fetchStructure | OCI_RETURN_LOBS);
+                    self::$fetchModeMap[$fetchMode] | OCI_RETURN_NULLS | $fetchStructure | OCI_RETURN_LOBS);
 
-            if ($fetchStyle == PDO::FETCH_COLUMN) {
+            if ($fetchMode == PDO::FETCH_COLUMN) {
                 $result = $result[0];
             }
         }

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -200,7 +200,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
      */
     public function getIterator()
     {
-        $data = $this->fetchAll($this->_defaultFetchStyle);
+        $data = $this->fetchAll();
         return new \ArrayIterator($data);
     }
 

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -31,20 +31,20 @@ class PDOStatement extends \PDOStatement implements Statement
 {
     private function __construct() {}
 
-    public function setFetchMode($fetchStyle, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
         // This thin wrapper is necessary to shield against the weird signature
         // of PDOStatement::setFetchMode(): even if the second and third
         // parameters are optional, PHP will not let us remove it from this
         // declaration.
         if ($arg2 === null && $arg3 === null) {
-            return parent::setFetchMode($fetchStyle);
+            return parent::setFetchMode($fetchMode);
         }
 
         if ($arg3 === null) {
-            return parent::setFetchMode($fetchStyle, $arg2);
+            return parent::setFetchMode($fetchMode, $arg2);
         }
 
-        return parent::setFetchMode($fetchStyle, $arg2, $arg3);
+        return parent::setFetchMode($fetchMode, $arg2, $arg3);
     }
 }

--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -64,7 +64,7 @@ interface ResultStatement extends \Traversable
      *
      * @return mixed
      */
-    function fetch($fetchStyle = PDO::FETCH_BOTH);
+    function fetch($fetchStyle = null);
 
     /**
      * Returns an array containing all of the result set rows
@@ -75,7 +75,7 @@ interface ResultStatement extends \Traversable
      *
      * @return array
      */
-    function fetchAll($fetchStyle = PDO::FETCH_BOTH);
+    function fetchAll($fetchStyle = null);
 
     /**
      * fetchColumn

--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -50,32 +50,32 @@ interface ResultStatement extends \Traversable
      * setFetchMode
      * Set the fetch mode to use while iterating this statement.
      *
-     * @param integer $fetchStyle
+     * @param integer $fetchMode
      */
-    function setFetchMode($fetchStyle, $arg2 = null, $arg3 = null);
+    function setFetchMode($fetchMode, $arg2 = null, $arg3 = null);
 
     /**
      * fetch
      *
      * @see Query::HYDRATE_* constants
-     * @param integer $fetchStyle           Controls how the next row will be returned to the caller.
+     * @param integer $fetchMode            Controls how the next row will be returned to the caller.
      *                                      This value must be one of the Query::HYDRATE_* constants,
      *                                      defaulting to Query::HYDRATE_BOTH
      *
      * @return mixed
      */
-    function fetch($fetchStyle = null);
+    function fetch($fetchMode = null);
 
     /**
      * Returns an array containing all of the result set rows
      *
-     * @param integer $fetchStyle           Controls how the next row will be returned to the caller.
+     * @param integer $fetchMode            Controls how the next row will be returned to the caller.
      *                                      This value must be one of the Query::HYDRATE_* constants,
      *                                      defaulting to Query::HYDRATE_BOTH
      *
      * @return array
      */
-    function fetchAll($fetchStyle = null);
+    function fetchAll($fetchMode = null);
 
     /**
      * fetchColumn

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -175,7 +175,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
         }
     }
 
-    public function setFetchMode($fetchStyle = PDO::FETCH_BOTH, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchStyle, $arg2 = null, $arg3 = null)
     {
         $this->defaultFetchStyle = $fetchStyle;
     }

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -75,7 +75,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
      *
      * @param int
      */
-    private $defaultFetchStyle = PDO::FETCH_BOTH;
+    private $defaultFetchMode = PDO::FETCH_BOTH;
 
     /**
      * @var int|null
@@ -175,9 +175,9 @@ class SQLSrvStatement implements IteratorAggregate, Statement
         }
     }
 
-    public function setFetchMode($fetchStyle, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
-        $this->defaultFetchStyle = $fetchStyle;
+        $this->defaultFetchMode = $fetchMode;
     }
 
     /**
@@ -192,12 +192,12 @@ class SQLSrvStatement implements IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchMode = null)
     {
-        $fetchStyle = $fetchStyle ?: $this->defaultFetchStyle;
-        if (isset(self::$fetchMap[$fetchStyle])) {
-            return sqlsrv_fetch_array($this->stmt, self::$fetchMap[$fetchStyle]);
-        } else if ($fetchStyle == PDO::FETCH_OBJ || $fetchStyle == PDO::FETCH_CLASS) {
+        $fetchMode = $fetchMode ?: $this->defaultFetchMode;
+        if (isset(self::$fetchMap[$fetchMode])) {
+            return sqlsrv_fetch_array($this->stmt, self::$fetchMap[$fetchMode]);
+        } else if ($fetchMode == PDO::FETCH_OBJ || $fetchMode == PDO::FETCH_CLASS) {
             $className = null;
             $ctorArgs = null;
             if (func_num_args() >= 2) {
@@ -214,7 +214,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchStyle = null)
+    public function fetchAll($fetchMode = null)
     {
         $className = null;
         $ctorArgs = null;
@@ -225,7 +225,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
         }
 
         $rows = array();
-        while ($row = $this->fetch($fetchStyle, $className, $ctorArgs)) {
+        while ($row = $this->fetch($fetchMode, $className, $ctorArgs)) {
             $rows[] = $row;
         }
         return $rows;

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -185,7 +185,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
      */
     public function getIterator()
     {
-        $data = $this->fetchAll($this->defaultFetchStyle);
+        $data = $this->fetchAll();
         return new \ArrayIterator($data);
     }
 
@@ -194,7 +194,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
      */
     public function fetch($fetchStyle = null)
     {
-        $fetchStyle = ($fetchStyle)?:$this->defaultFetchStyle;
+        $fetchStyle = $fetchStyle ?: $this->defaultFetchStyle;
         if (isset(self::$fetchMap[$fetchStyle])) {
             return sqlsrv_fetch_array($this->stmt, self::$fetchMap[$fetchStyle]);
         } else if ($fetchStyle == PDO::FETCH_OBJ || $fetchStyle == PDO::FETCH_CLASS) {

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -51,7 +51,7 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
     /**
      * @var int
      */
-    private $defaultFetchStyle = PDO::FETCH_BOTH;
+    private $defaultFetchMode = PDO::FETCH_BOTH;
 
     /**
      * Wraps <tt>Statement</tt> and applies portability measures
@@ -101,10 +101,10 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
         return $this->stmt->execute($params);
     }
 
-    public function setFetchMode($fetchStyle, $arg1 = null, $arg2 = null)
+    public function setFetchMode($fetchMode, $arg1 = null, $arg2 = null)
     {
-        $this->defaultFetchStyle = $fetchStyle;
-        $this->stmt->setFetchMode($fetchStyle, $arg1, $arg2);
+        $this->defaultFetchMode = $fetchMode;
+        $this->stmt->setFetchMode($fetchMode, $arg1, $arg2);
     }
 
     public function getIterator()
@@ -113,32 +113,32 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
         return new \ArrayIterator($data);
     }
 
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchMode = null)
     {
-        $fetchStyle = $fetchStyle ?: $this->defaultFetchStyle;
+        $fetchMode = $fetchMode ?: $this->defaultFetchMode;
 
-        $row = $this->stmt->fetch($fetchStyle);
+        $row = $this->stmt->fetch($fetchMode);
 
         $row = $this->fixRow($row,
             $this->portability & (Connection::PORTABILITY_EMPTY_TO_NULL|Connection::PORTABILITY_RTRIM),
-            !is_null($this->case) && ($fetchStyle == PDO::FETCH_ASSOC || $fetchStyle == PDO::FETCH_BOTH) && ($this->portability & Connection::PORTABILITY_FIX_CASE)
+            !is_null($this->case) && ($fetchMode == PDO::FETCH_ASSOC || $fetchMode == PDO::FETCH_BOTH) && ($this->portability & Connection::PORTABILITY_FIX_CASE)
         );
 
         return $row;
     }
 
-    public function fetchAll($fetchStyle = null, $columnIndex = 0)
+    public function fetchAll($fetchMode = null, $columnIndex = 0)
     {
-        $fetchStyle = $fetchStyle ?: $this->defaultFetchStyle;
+        $fetchMode = $fetchMode ?: $this->defaultFetchMode;
 
         if ($columnIndex != 0) {
-            $rows = $this->stmt->fetchAll($fetchStyle, $columnIndex);
+            $rows = $this->stmt->fetchAll($fetchMode, $columnIndex);
         } else {
-            $rows = $this->stmt->fetchAll($fetchStyle);
+            $rows = $this->stmt->fetchAll($fetchMode);
         }
 
         $iterateRow = $this->portability & (Connection::PORTABILITY_EMPTY_TO_NULL|Connection::PORTABILITY_RTRIM);
-        $fixCase = !is_null($this->case) && ($fetchStyle == PDO::FETCH_ASSOC || $fetchStyle == PDO::FETCH_BOTH) && ($this->portability & Connection::PORTABILITY_FIX_CASE);
+        $fixCase = !is_null($this->case) && ($fetchMode == PDO::FETCH_ASSOC || $fetchMode == PDO::FETCH_BOTH) && ($this->portability & Connection::PORTABILITY_FIX_CASE);
         if ( ! $iterateRow && !$fixCase) {
             return $rows;
         }

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -109,12 +109,14 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
 
     public function getIterator()
     {
-        $data = $this->fetchAll($this->defaultFetchStyle);
+        $data = $this->fetchAll();
         return new \ArrayIterator($data);
     }
 
-    public function fetch($fetchStyle = PDO::FETCH_BOTH)
+    public function fetch($fetchStyle = null)
     {
+        $fetchStyle = $fetchStyle ?: $this->defaultFetchStyle;
+
         $row = $this->stmt->fetch($fetchStyle);
 
         $row = $this->fixRow($row,
@@ -125,8 +127,10 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
         return $row;
     }
 
-    public function fetchAll($fetchStyle = PDO::FETCH_BOTH, $columnIndex = 0)
+    public function fetchAll($fetchStyle = null, $columnIndex = 0)
     {
+        $fetchStyle = $fetchStyle ?: $this->defaultFetchStyle;
+
         if ($columnIndex != 0) {
             $rows = $this->stmt->fetchAll($fetchStyle, $columnIndex);
         } else {

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -201,7 +201,7 @@ class Statement implements \IteratorAggregate, DriverStatement
      * @return mixed The return value of this function on success depends on the fetch type.
      *               In all cases, FALSE is returned on failure.
      */
-    public function fetch($fetchStyle = PDO::FETCH_BOTH)
+    public function fetch($fetchStyle = null)
     {
         return $this->stmt->fetch($fetchStyle);
     }
@@ -213,7 +213,7 @@ class Statement implements \IteratorAggregate, DriverStatement
      * @param mixed $fetchArgument
      * @return array An array containing all of the remaining rows in the result set.
      */
-    public function fetchAll($fetchStyle = PDO::FETCH_BOTH, $fetchArgument = 0)
+    public function fetchAll($fetchStyle = null, $fetchArgument = 0)
     {
         if ($fetchArgument !== 0) {
             return $this->stmt->fetchAll($fetchStyle, $fetchArgument);

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -184,9 +184,9 @@ class Statement implements \IteratorAggregate, DriverStatement
         return $this->stmt->errorInfo();
     }
 
-    public function setFetchMode($fetchStyle, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
-        return $this->stmt->setFetchMode($fetchStyle, $arg2, $arg3);
+        return $this->stmt->setFetchMode($fetchMode, $arg2, $arg3);
     }
 
     public function getIterator()
@@ -197,28 +197,28 @@ class Statement implements \IteratorAggregate, DriverStatement
     /**
      * Fetches the next row from a result set.
      *
-     * @param integer $fetchStyle
+     * @param integer $fetchMode
      * @return mixed The return value of this function on success depends on the fetch type.
      *               In all cases, FALSE is returned on failure.
      */
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchMode = null)
     {
-        return $this->stmt->fetch($fetchStyle);
+        return $this->stmt->fetch($fetchMode);
     }
 
     /**
      * Returns an array containing all of the result set rows.
      *
-     * @param integer $fetchStyle
+     * @param integer $fetchMode
      * @param mixed $fetchArgument
      * @return array An array containing all of the remaining rows in the result set.
      */
-    public function fetchAll($fetchStyle = null, $fetchArgument = 0)
+    public function fetchAll($fetchMode = null, $fetchArgument = 0)
     {
         if ($fetchArgument !== 0) {
-            return $this->stmt->fetchAll($fetchStyle, $fetchArgument);
+            return $this->stmt->fetchAll($fetchMode, $fetchArgument);
         }
-        return $this->stmt->fetchAll($fetchStyle);
+        return $this->stmt->fetchAll($fetchMode);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -189,7 +189,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
     public function testFetchBoth()
     {
         $sql = "SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?";
-        $row = $this->_conn->executeQuery($sql, array(1, 'foo'))->fetch();
+        $row = $this->_conn->executeQuery($sql, array(1, 'foo'))->fetch(\PDO::FETCH_BOTH);
 
         $this->assertTrue($row !== false);
 

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -101,13 +101,13 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertStandardAndIteratorFetchAreEqual(\PDO::FETCH_NUM);
     }
 
-    public function assertStandardAndIteratorFetchAreEqual($fetchStyle)
+    public function assertStandardAndIteratorFetchAreEqual($fetchMode)
     {
         $stmt = $this->_conn->executeQuery("SELECT * FROM caching ORDER BY test_int ASC", array(), array(), new QueryCacheProfile(10, "testcachekey"));
-        $data = $this->hydrateStmt($stmt, $fetchStyle);
+        $data = $this->hydrateStmt($stmt, $fetchMode);
 
         $stmt = $this->_conn->executeQuery("SELECT * FROM caching ORDER BY test_int ASC", array(), array(), new QueryCacheProfile(10, "testcachekey"));
-        $data_iterator = $this->hydrateStmtIterator($stmt, $fetchStyle);
+        $data_iterator = $this->hydrateStmtIterator($stmt, $fetchMode);
 
         $this->assertEquals($data, $data_iterator);
     }
@@ -145,18 +145,18 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals(2, count($this->sqlLogger->queries));
     }
 
-    public function assertCacheNonCacheSelectSameFetchModeAreEqual($expectedResult, $fetchStyle)
+    public function assertCacheNonCacheSelectSameFetchModeAreEqual($expectedResult, $fetchMode)
     {
         $stmt = $this->_conn->executeQuery("SELECT * FROM caching ORDER BY test_int ASC", array(), array(), new QueryCacheProfile(10, "testcachekey"));
 
         $this->assertEquals(2, $stmt->columnCount());
-        $data = $this->hydrateStmt($stmt, $fetchStyle);
+        $data = $this->hydrateStmt($stmt, $fetchMode);
         $this->assertEquals($expectedResult, $data);
 
         $stmt = $this->_conn->executeQuery("SELECT * FROM caching ORDER BY test_int ASC", array(), array(), new QueryCacheProfile(10, "testcachekey"));
 
         $this->assertEquals(2, $stmt->columnCount());
-        $data = $this->hydrateStmt($stmt, $fetchStyle);
+        $data = $this->hydrateStmt($stmt, $fetchMode);
         $this->assertEquals($expectedResult, $data);
         $this->assertEquals(1, count($this->sqlLogger->queries), "just one dbal hit");
     }
@@ -185,20 +185,20 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals(1, count($secondCache->fetch("emptycachekey")));
     }
 
-    private function hydrateStmt($stmt, $fetchStyle = \PDO::FETCH_ASSOC)
+    private function hydrateStmt($stmt, $fetchMode = \PDO::FETCH_ASSOC)
     {
         $data = array();
-        while ($row = $stmt->fetch($fetchStyle)) {
+        while ($row = $stmt->fetch($fetchMode)) {
             $data[] = is_array($row) ? array_change_key_case($row, CASE_LOWER) : $row;
         }
         $stmt->closeCursor();
         return $data;
     }
 
-    private function hydrateStmtIterator($stmt, $fetchStyle = \PDO::FETCH_ASSOC)
+    private function hydrateStmtIterator($stmt, $fetchMode = \PDO::FETCH_ASSOC)
     {
         $data = array();
-        $stmt->setFetchMode($fetchStyle);
+        $stmt->setFetchMode($fetchMode);
         foreach ($stmt as $row) {
             $data[] = is_array($row) ? array_change_key_case($row, CASE_LOWER) : $row;
         }

--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -27,7 +27,7 @@ class HydratorMockStatement implements \Doctrine\DBAL\Driver\Statement
      *
      * @return array
      */
-    public function fetchAll($fetchStyle = null, $columnIndex = null, array $ctorArgs = null)
+    public function fetchAll($fetchMode = null, $columnIndex = null, array $ctorArgs = null)
     {
         return $this->_resultSet;
     }
@@ -44,7 +44,7 @@ class HydratorMockStatement implements \Doctrine\DBAL\Driver\Statement
      * Fetches the next row in the result set.
      *
      */
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchMode = null)
     {
         $current = current($this->_resultSet);
         next($this->_resultSet);


### PR DESCRIPTION
Resubmitting after renaming branches on my side.

CS should be ok.

Fixes default fetch mode inconsistencies on Statement classes.

Adds default fetch mode at Connection level, used for ->fetchAll() and for auto-setting default fetch mode on returned statements. Defaults to FETCH_ASSOC so that Connection->fetchAll() remains the same, but break nackward compatibility for returned statements, who used to default to FETCH_BOTH. The BC break still seams necessary to fix two things : first, it allows changing fetch mode for Connection->fetchAll(), then it makes returned statements consistent with Connection->fetchAll().
