### PR TITLE
missing call to logger in Connection->exec(), cleanups

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -614,9 +614,9 @@ class Connection implements DriverConnection
 
         $this->connect();
 
-        $hasLogger = $this->_config->getSQLLogger() !== null;
-        if ($hasLogger) {
-            $this->_config->getSQLLogger()->startQuery($query, $params, $types);
+        $logger = $this->_config->getSQLLogger();
+        if ($logger) {
+            $logger->startQuery($query, $params, $types);
         }
 
         if ($params) {
@@ -633,8 +633,8 @@ class Connection implements DriverConnection
             $stmt = $this->_conn->query($query);
         }
 
-        if ($hasLogger) {
-            $this->_config->getSQLLogger()->stopQuery();
+        if ($logger) {
+            $logger->stopQuery();
         }
 
         return $stmt;
@@ -708,7 +708,7 @@ class Connection implements DriverConnection
 
         $args = func_get_args();
 
-        $logger = $this->getConfiguration()->getSQLLogger();
+        $logger = $this->_config->getSQLLogger();
         if ($logger) {
             $logger->startQuery($args[0]);
         }
@@ -738,9 +738,9 @@ class Connection implements DriverConnection
     {
         $this->connect();
 
-        $hasLogger = $this->_config->getSQLLogger() !== null;
-        if ($hasLogger) {
-            $this->_config->getSQLLogger()->startQuery($query, $params, $types);
+        $logger = $this->_config->getSQLLogger();
+        if ($logger) {
+            $logger->startQuery($query, $params, $types);
         }
 
         if ($params) {
@@ -758,8 +758,8 @@ class Connection implements DriverConnection
             $result = $this->_conn->exec($query);
         }
 
-        if ($hasLogger) {
-            $this->_config->getSQLLogger()->stopQuery();
+        if ($logger) {
+            $logger->stopQuery();
         }
 
         return $result;
@@ -774,7 +774,19 @@ class Connection implements DriverConnection
     public function exec($statement)
     {
         $this->connect();
-        return $this->_conn->exec($statement);
+
+        $logger = $this->_config->getSQLLogger();
+        if ($logger) {
+            $logger->startQuery($statement);
+        }
+
+        $result = $this->_conn->exec($statement);
+
+        if ($logger) {
+            $logger->stopQuery();
+        }
+
+        return $result;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -123,15 +123,15 @@ class Statement implements \IteratorAggregate, DriverStatement
      */
     public function execute($params = null)
     {
-        $hasLogger = $this->conn->getConfiguration()->getSQLLogger();
-        if ($hasLogger) {
-            $this->conn->getConfiguration()->getSQLLogger()->startQuery($this->sql, $this->params);
+        $logger = $this->conn->getConfiguration()->getSQLLogger();
+        if ($logger) {
+            $logger->startQuery($this->sql, $this->params);
         }
 
         $stmt = $this->stmt->execute($params);
 
-        if ($hasLogger) {
-            $this->conn->getConfiguration()->getSQLLogger()->stopQuery();
+        if ($logger) {
+            $logger->stopQuery();
         }
         $this->params = array();
         return $stmt;


### PR DESCRIPTION
Connection->exec() didn't call the logger. This is fixed.

The patch also cleans up the way the logger is plugged at various places to make it more consistent. This is just local cleanups, and doesn't change anything else.
