### PR TITLE
Allow underscores in named parameters

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -61,7 +61,7 @@ class SQLParserUtils
                 } else {
                     $name = "";
                     // TODO: Something faster/better to match this than regex?
-                    for ($j = $i; ($j < $stmtLen && preg_match('(([:a-zA-Z0-9]{1}))', $statement[$j])); $j++) {
+                    for ($j = $i; ($j < $stmtLen && preg_match('(([:a-zA-Z0-9_]{1}))', $statement[$j])); $j++) {
                         $name .= $statement[$j];
                     }
                     $paramMap[$name][] = $i; // named parameters can be duplicated!


### PR DESCRIPTION
Underscores are currently not allowed in named parameters due to a very restrictive regex in SQLParserUtils. There's still a TODO item there that suggests replacing the regex with something altogether, but for now I have just added the underscore character to the allowed character class.
