### PR TITLE
SQLParserUtils triggered an error when feeding it Type instances instead of PDO param type ints

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -90,7 +90,7 @@ class SQLParserUtils
         $bindIndex = -1;
         foreach ($types AS $name => $type) {
             ++$bindIndex;
-            if (is_int($type) && ($type === Connection::PARAM_INT_ARRAY || $type == Connection::PARAM_STR_ARRAY)) {
+            if ($type === Connection::PARAM_INT_ARRAY || $type === Connection::PARAM_STR_ARRAY) {
                 if ($isPositional) {
                     $name = $bindIndex;
                 }

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -90,7 +90,7 @@ class SQLParserUtils
         $bindIndex = -1;
         foreach ($types AS $name => $type) {
             ++$bindIndex;
-            if ($type === Connection::PARAM_INT_ARRAY || $type == Connection::PARAM_STR_ARRAY) {
+            if (is_int($type) && ($type === Connection::PARAM_INT_ARRAY || $type == Connection::PARAM_STR_ARRAY)) {
                 if ($isPositional) {
                     $name = $bindIndex;
                 }


### PR DESCRIPTION
Title says it all. If-statement failed when trying to convert `\Doctrine\DBAL\Type\Type` instances to an int for comparison.
