### PR TITLE
Connection quote() ignores returned value from getBindingInfo()

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -565,7 +565,7 @@ class Connection implements DriverConnection
         $this->connect();
 
         list($value, $bindingType) = $this->getBindingInfo($input, $type);
-        return $this->_conn->quote($input, $bindingType);
+        return $this->_conn->quote($value, $bindingType);
     }
 
     /**


### PR DESCRIPTION
Maybe I'm missing something here, but this simple change seems to be necessary to allow for proper type management in quote().  For example, without this change passing a DateTime object as $input with $type = 'date' will resolve the proper string value in getBindingInfo, but then still attempt to pass the DateTime to PDO, which of course doesn't work.
