### PR TITLE
Enable caching of results with fetch type PDO::FETCH_COLUMN

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -68,6 +68,10 @@ class ArrayStatement implements \IteratorAggregate, ResultStatement
                 return array_values($row);
             } else if ($fetchStyle === PDO::FETCH_BOTH) {
                 return array_merge($row, array_values($row));
+            } else if ($fetchStyle === PDO::FETCH_COLUMN) {
+                return reset($row);
+            } else {
+                throw new \InvalidArgumentException("Invalid fetch-style given for fetching result.");
             }
         }
         return false;

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -169,6 +169,8 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
                 return array_values($row);
             } else if ($fetchStyle == PDO::FETCH_BOTH) {
                 return array_merge($row, array_values($row));
+            } else if ($fetchStyle == PDO::FETCH_COLUMN) {
+                return reset($row);
             } else {
                 throw new \InvalidArgumentException("Invalid fetch-style given for caching result.");
             }


### PR DESCRIPTION
This should enable caching of results retrieved by PDO::FETCH_COLUMN fetch type.
Before this exception "Invalid fetch-style given for caching result" was raised.
