### PR TITLE
Fix Statement class passing bound objects to SQL logger

### DIFF
--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -43,6 +43,10 @@ class Statement implements \IteratorAggregate, DriverStatement
      */
     protected $params = array();
     /**
+     * @var array The parameter types
+     */
+    protected $types = array();
+    /**
      * @var \Doctrine\DBAL\Driver\Statement The underlying driver statement.
      */
     protected $stmt;
@@ -85,13 +89,13 @@ class Statement implements \IteratorAggregate, DriverStatement
     public function bindValue($name, $value, $type = null)
     {
         $this->params[$name] = $value;
+        $this->types[$name] = $type;
         if ($type !== null) {
             if (is_string($type)) {
                 $type = Type::getType($type);
             }
             if ($type instanceof Type) {
                 $value = $type->convertToDatabaseValue($value, $this->platform);
-                $this->params[$name] = $value;
                 $bindingType = $type->getBindingType();
             } else {
                 $bindingType = $type; // PDO::PARAM_* constants
@@ -127,7 +131,7 @@ class Statement implements \IteratorAggregate, DriverStatement
     {
         $logger = $this->conn->getConfiguration()->getSQLLogger();
         if ($logger) {
-            $logger->startQuery($this->sql, $this->params);
+            $logger->startQuery($this->sql, $this->params, $this->types);
         }
 
         $stmt = $this->stmt->execute($params);

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -140,7 +140,7 @@ class Statement implements \IteratorAggregate, DriverStatement
             $logger->stopQuery();
         }
         $this->params = array();
-		$this->types = array();
+        $this->types = array();
         return $stmt;
     }
 

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -91,6 +91,7 @@ class Statement implements \IteratorAggregate, DriverStatement
             }
             if ($type instanceof Type) {
                 $value = $type->convertToDatabaseValue($value, $this->platform);
+                $this->params[$name] = $value;
                 $bindingType = $type->getBindingType();
             } else {
                 $bindingType = $type; // PDO::PARAM_* constants

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -140,6 +140,7 @@ class Statement implements \IteratorAggregate, DriverStatement
             $logger->stopQuery();
         }
         $this->params = array();
+		$this->types = array();
         return $stmt;
     }
 


### PR DESCRIPTION
This commit saves converted parameter values in bindValue() so the later call to the SQL logger in execute() will not pass bound objects without type information.
