### PR TITLE
Fix for DBAL-232

### DIFF
--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -884,7 +884,9 @@ abstract class AbstractSchemaManager
     public function extractDoctrineTypeFromComment($comment, $currentType)
     {
         if (preg_match("(\(DC2Type:([a-zA-Z0-9_]+)\))", $comment, $match)) {
-            $currentType = $match[1];
+            if (Types\Type::hasType($match[1])) {
+                $currentType = $match[1];
+            }
         }
         return $currentType;
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL232Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL232Test.php
@@ -18,37 +18,50 @@ class DBAL232Test extends \Doctrine\Tests\DbalFunctionalTestCase
 
 	const TABLE_NAME = 'dbal232';
 
+	private function checkPlatform()
+	{
+		// Skip sqlite with no type comment feature available
+		if ($this->_conn->getDatabasePlatform()->getName() == 'sqlite') {
+			self::markTestSkipped("Not working on sqlite");
+		}
+	}
+
 	public function setUp()
     {
         parent::setUp();
+
+		$this->checkPlatform();
 
 		if ( ! Type::hasType(self::TYPE_NAME)) {
 			Type::addType(self::TYPE_NAME, __NAMESPACE__ . '\DBAL232TestType');
 			$this->_conn->getDatabasePlatform()->markDoctrineTypeCommented(Type::getType(self::TYPE_NAME));
 		}
 
-        try {
-            $table = new Table(self::TABLE_NAME);
-            $table->addColumn('id', 'integer');
-            $table->addColumn('value', self::TYPE_NAME);
-            $table->setPrimaryKey(array('id'));
+		$table = new Table(self::TABLE_NAME);
+		$table->addColumn('id', 'integer');
+		$table->addColumn('value', self::TYPE_NAME);
+		$table->setPrimaryKey(array('id'));
 
-            $sm = $this->_conn->getSchemaManager();
-            $sm->createTable($table);
-        } catch(\Exception $e) {
-
-        }
-        $this->_conn->exec($this->_conn->getDatabasePlatform()->getTruncateTableSQL(self::TABLE_NAME));
+		$sm = $this->_conn->getSchemaManager();
+		$sm->createTable($table);
     }
 	
 	protected function tearDown()
 	{
+		$this->checkPlatform();
+
+		if ( ! $this->_conn instanceof \Doctrine\DBAL\Connection) {
+			return;
+		}
+
 		$sm = $this->_conn->getSchemaManager();
 		$sm->dropTable(self::TABLE_NAME);
 	}
 
 	public function testTypeRemoval()
 	{
+		$this->checkPlatform();
+
 		$sm = $this->_conn->getSchemaManager();
 
 		$columns = $sm->listTableColumns(self::TABLE_NAME);

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL232Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL232Test.php
@@ -14,80 +14,82 @@ require_once __DIR__ . '/../../../TestInit.php';
  */
 class DBAL232Test extends \Doctrine\Tests\DbalFunctionalTestCase
 {
-	const TYPE_NAME = 'dbal232';
+    const TYPE_NAME = 'dbal232';
 
-	const TABLE_NAME = 'dbal232';
+    const TABLE_NAME = 'dbal232';
 
-	private function checkPlatform()
-	{
-		// Skip sqlite with no type comment feature available
-		if ($this->_conn->getDatabasePlatform()->getName() == 'sqlite') {
-			self::markTestSkipped("Not working on sqlite");
-		}
-	}
+    private function checkPlatform()
+    {
+        // Removed because this class doesn't test the doctrine type comment feature after all
+//        // Skip sqlite with no type comment feature available
+//        if ($this->_conn->getDatabasePlatform()->getName() == 'sqlite') {
+//            self::markTestSkipped("Not working on sqlite");
+//        }
+    }
 
-	public function setUp()
+    public function setUp()
     {
         parent::setUp();
 
-		$this->checkPlatform();
+        $this->checkPlatform();
 
-		if ( ! Type::hasType(self::TYPE_NAME)) {
-			Type::addType(self::TYPE_NAME, __NAMESPACE__ . '\DBAL232TestType');
-			$this->_conn->getDatabasePlatform()->markDoctrineTypeCommented(Type::getType(self::TYPE_NAME));
-		}
+        if ( ! Type::hasType(self::TYPE_NAME)) {
+            Type::addType(self::TYPE_NAME, __NAMESPACE__ . '\DBAL232TestType');
+            $this->_conn->getDatabasePlatform()->markDoctrineTypeCommented(Type::getType(self::TYPE_NAME));
+        }
 
-		$table = new Table(self::TABLE_NAME);
-		$table->addColumn('id', 'integer');
-		$table->addColumn('value', self::TYPE_NAME);
-		$table->setPrimaryKey(array('id'));
+        $table = new Table(self::TABLE_NAME);
+        $table->addColumn('id', 'integer');
+        $table->addColumn('value', self::TYPE_NAME);
+        $table->setPrimaryKey(array('id'));
 
-		$sm = $this->_conn->getSchemaManager();
-		$sm->createTable($table);
+        $sm = $this->_conn->getSchemaManager();
+        $sm->createTable($table);
     }
-	
-	protected function tearDown()
-	{
-		$this->checkPlatform();
+    
+    protected function tearDown()
+    {
+        $this->checkPlatform();
 
-		if ( ! $this->_conn instanceof \Doctrine\DBAL\Connection) {
-			return;
-		}
+        if ( ! $this->_conn instanceof \Doctrine\DBAL\Connection) {
+            return;
+        }
 
-		$sm = $this->_conn->getSchemaManager();
-		$sm->dropTable(self::TABLE_NAME);
-	}
+        $sm = $this->_conn->getSchemaManager();
+        $sm->dropTable(self::TABLE_NAME);
+    }
 
-	public function testTypeRemoval()
-	{
-		$this->checkPlatform();
+    public function testTypeRemoval()
+    {
+        $this->checkPlatform();
 
-		$sm = $this->_conn->getSchemaManager();
+        $sm = $this->_conn->getSchemaManager();
 
-		$columns = $sm->listTableColumns(self::TABLE_NAME);
-		$type = $columns['value']->getType();
-		self::assertInstanceOf(__NAMESPACE__ . '\DBAL232TestType', $type);
+        // Removed because this class doesn't test the doctrine type comment feature after all
+//        $columns = $sm->listTableColumns(self::TABLE_NAME);
+//        $type = $columns['value']->getType();
+//        self::assertInstanceOf(__NAMESPACE__ . '\DBAL232TestType', $type);
 
-		// This simulates the type removal
-		Type::overrideType(self::TYPE_NAME, null);
+        // This simulates the type removal
+        Type::overrideType(self::TYPE_NAME, null);
 
-		// Will throw an "unknown type" exception without the fix, string type 
-		// with it.
-		$columns = $sm->listTableColumns(self::TABLE_NAME);
-		$type = $columns['value']->getType();
-		self::assertEquals(Type::getType(Type::STRING), $type);
-	}
+        // Will throw an "unknown type" exception without the fix, string type
+        // with it.
+        $columns = $sm->listTableColumns(self::TABLE_NAME);
+        $type = $columns['value']->getType();
+        self::assertEquals(Type::getType(Type::STRING), $type);
+    }
 }
 
 class DBAL232TestType extends Type
 {
-	public function getName()
-	{
-		return DBAL232Test::TYPE_NAME;
-	}
+    public function getName()
+    {
+        return DBAL232Test::TYPE_NAME;
+    }
 
-	public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
-	{
-		return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
-	}
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL232Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL232Test.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Ticket;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+require_once __DIR__ . '/../../../TestInit.php';
+
+/**
+ * Test for [DBAL-232]
+ * @group DBAL-232
+ */
+class DBAL232Test extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+	const TYPE_NAME = 'dbal232';
+
+	const TABLE_NAME = 'dbal232';
+
+	public function setUp()
+    {
+        parent::setUp();
+
+		if ( ! Type::hasType(self::TYPE_NAME)) {
+			Type::addType(self::TYPE_NAME, __NAMESPACE__ . '\DBAL232TestType');
+			$this->_conn->getDatabasePlatform()->markDoctrineTypeCommented(Type::getType(self::TYPE_NAME));
+		}
+
+        try {
+            $table = new Table(self::TABLE_NAME);
+            $table->addColumn('id', 'integer');
+            $table->addColumn('value', self::TYPE_NAME);
+            $table->setPrimaryKey(array('id'));
+
+            $sm = $this->_conn->getSchemaManager();
+            $sm->createTable($table);
+        } catch(\Exception $e) {
+
+        }
+        $this->_conn->exec($this->_conn->getDatabasePlatform()->getTruncateTableSQL(self::TABLE_NAME));
+    }
+	
+	protected function tearDown()
+	{
+		$sm = $this->_conn->getSchemaManager();
+		$sm->dropTable(self::TABLE_NAME);
+	}
+
+	public function testTypeRemoval()
+	{
+		$sm = $this->_conn->getSchemaManager();
+
+		$columns = $sm->listTableColumns(self::TABLE_NAME);
+		$type = $columns['value']->getType();
+		self::assertInstanceOf(__NAMESPACE__ . '\DBAL232TestType', $type);
+
+		// This simulates the type removal
+		Type::overrideType(self::TYPE_NAME, null);
+
+		// Will throw an "unknown type" exception without the fix, string type 
+		// with it.
+		$columns = $sm->listTableColumns(self::TABLE_NAME);
+		$type = $columns['value']->getType();
+		self::assertEquals(Type::getType(Type::STRING), $type);
+	}
+}
+
+class DBAL232TestType extends Type
+{
+	public function getName()
+	{
+		return DBAL232Test::TYPE_NAME;
+	}
+
+	public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+	{
+		return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+	}
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
@@ -91,7 +91,15 @@ class TypeConversionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
 
         if ($type !== "datetimetz") {
-            $this->assertEquals($originalValue, $actualDbValue, "Conversion between values should produce the same out as in value, but doesnt!");
+
+            // Only time part must be validated for "time" type
+            if ($type === "time") {
+                /* @var $actualDbValue \DateTime */
+                /* @var $originalValue \DateTime */
+                $this->assertEquals($originalValue->format('H:i:s'), $actualDbValue->format('H:i:s'), "Conversion between values should produce the same out as in value, but doesnt!");
+            } else {
+                $this->assertEquals($originalValue, $actualDbValue, "Conversion between values should produce the same out as in value, but doesnt!");
+            }
 
             if ($originalValue instanceof \DateTime) {
                 $this->assertEquals($originalValue->getTimezone()->getName(), $actualDbValue->getTimezone()->getName(), "Timezones should be the same.");


### PR DESCRIPTION
Fixed the issue http://www.doctrine-project.org/jira/browse/DBAL-232.

The problem was that "unknown type" exception was raised after custom type removal from the code if the type has still D2Type column comments inside the database.

The tests are
[![Build Status](https://secure.travis-ci.org/gedrox/dbal.png?branch=DBAL-232)](http://travis-ci.org/gedrox/dbal).
