### PR TITLE
Add typehint info to core types for use by entity generator.

### DIFF
--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -73,6 +73,14 @@ abstract class Type
         self::GUID => 'Doctrine\DBAL\Types\GuidType',
     );
 
+    /** The map of typehints to use within the entity generator for built in types */
+    private static $_typeHintsMap = array(
+        self::DATE => 'DateTime',
+        self::DATETIME => 'DateTime',
+        self::DATETIMETZ => 'DateTime',
+        self::TIME => 'DateTime',
+    );
+
     /* Prevent instantiation and force use of the factory method. */
     final private function __construct() {}
 
@@ -227,6 +235,16 @@ abstract class Type
     public static function getTypesMap()
     {
         return self::$_typesMap;
+    }
+
+    /**
+     * Get an array of the typehints to use within the entity generator for built in types
+     *
+     * @return array $typeHintsMap
+     */
+    public static function getTypeHintsMap()
+    {
+        return self::$_typeHintsMap;
     }
 
     public function __toString()


### PR DESCRIPTION
So as you probably know, the EntityGenerator doesn't typehint the setters for the DateTime types (datetime, date, datetimetz, time) - which has just caused me to miss an obvious error, and judging from google, plenty of others before me too.

So I've added it - you'll have a pull request in a sec on the doctrine2 repo for that, but it needs this change too - which provides the mapping info.
