### PR TITLE
Support oci8 in TableGenerator

### DIFF
--- a/lib/Doctrine/DBAL/Id/TableGenerator.php
+++ b/lib/Doctrine/DBAL/Id/TableGenerator.php
@@ -119,20 +119,22 @@ class TableGenerator
             $stmt = $this->conn->executeQuery($sql, array($sequenceName));
 
             if ($row = $stmt->fetch()) {
-                $value = $row['sequence_value'];
-                $value++;
+                $sequence_value = $row[0];
+                $sequence_increment_by = $row[1];
 
-                if ($row['sequence_increment_by'] > 1) {
+                $value = $sequence_value + 1;
+
+                if ($sequence_increment_by > 1) {
                     $this->sequences[$sequenceName] = array(
                         'value' => $value,
-                        'max' => $row['sequence_value'] + $row['sequence_increment_by']
+                        'max' => $sequence_value + $sequence_increment_by
                     );
                 }
 
                 $sql = "UPDATE " . $this->generatorTableName . " ".
                        "SET sequence_value = sequence_value + sequence_increment_by " .
                        "WHERE sequence_name = ? AND sequence_value = ?";
-                $rows = $this->conn->executeUpdate($sql, array($sequenceName, $row['sequence_value']));
+                $rows = $this->conn->executeUpdate($sql, array($sequenceName, $sequence_value));
 
                 if ($rows != 1) {
                     throw new \Doctrine\DBAL\DBALException("Race-condition detected while updating sequence. Aborting generation");


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
[![Build Status](https://secure.travis-ci.org/dpb587/dbal.png?branch=bugfix-TableGenerator)](http://travis-ci.org/dpb587/dbal)

This test was breaking when running under `oci8` due to Oracle's deference to upper case column names. I realize Oracle has built-in sequences and `TableGenerator` is unnecessary, in theory, but it seemed like the class should work if possible. I see pgsql is in the same boat.

Tested with:

```
phpunit -c oci8.phpunit.xml.dist tests/Doctrine/Tests/DBAL/Functional/TableGeneratorTest.php
```

Before:

```
PHPUnit 3.5.13 by Sebastian Bergmann.

EE

Time: 0 seconds, Memory: 10.25Mb

There were 2 errors:

1) Doctrine\Tests\DBAL\Functional\TableGeneratorTest::testNextVal
Exception: [Doctrine\DBAL\DBALException] Error occured while generating ID with TableGenerator, aborted generation: Undefined index: sequence_value

2) Doctrine\Tests\DBAL\Functional\TableGeneratorTest::testNextValNotAffectedByOuterTransactions
Exception: [Doctrine\DBAL\DBALException] Error occured while generating ID with TableGenerator, aborted generation: Undefined index: sequence_value
```

After:

```
PHPUnit 3.5.13 by Sebastian Bergmann.

..

Time: 1 second, Memory: 10.25Mb

OK (2 tests, 5 assertions)
```
