### PR TITLE
Support OCI8 statements crossing transactions [DBAL-202]

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -60,7 +60,7 @@ class OCI8Connection implements \Doctrine\DBAL\Driver\Connection
      */
     public function prepare($prepareString)
     {
-        return new OCI8Statement($this->_dbh, $prepareString, $this->_executeMode);
+        return new OCI8Statement($this->_dbh, $prepareString, $this);
     }
 
     /**
@@ -108,6 +108,14 @@ class OCI8Connection implements \Doctrine\DBAL\Driver\Connection
     public function lastInsertId($name = null)
     {
         //TODO: throw exception or support sequences?
+    }
+
+    /**
+     * Return the current execution mode.
+     */
+    public function getExecuteMode()
+    {
+        return $this->_executeMode;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -34,7 +34,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
     /** Statement handle. */
     protected $_dbh;
     protected $_sth;
-    protected $_executeMode;
+    protected $_conn;
     protected static $_PARAM = ':param';
     protected static $fetchStyleMap = array(
         PDO::FETCH_BOTH => OCI_BOTH,
@@ -52,13 +52,13 @@ class OCI8Statement implements \IteratorAggregate, Statement
      * @param resource $dbh The connection handle.
      * @param string $statement The SQL statement.
      */
-    public function __construct($dbh, $statement, $executeMode)
+    public function __construct($dbh, $statement, OCI8Connection $conn)
     {
         list($statement, $paramMap) = self::convertPositionalToNamedPlaceholders($statement);
         $this->_sth = oci_parse($dbh, $statement);
         $this->_dbh = $dbh;
         $this->_paramMap = $paramMap;
-        $this->_executeMode = $executeMode;
+        $this->_conn = $conn;
     }
 
     /**
@@ -180,7 +180,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
             }
         }
 
-        $ret = @oci_execute($this->_sth, $this->_executeMode);
+        $ret = @oci_execute($this->_sth, $this->_conn->getExecuteMode());
         if ( ! $ret) {
             throw OCI8Exception::fromErrorInfo($this->errorInfo());
         }

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -15,20 +15,12 @@ class OCI8StatementTest extends \Doctrine\Tests\DbalTestCase
         parent::setUp();
     }
 
-    protected function getMockOCI8Statement()
-    {
-        $dbh = null;
-        $statement = "update table set field1 = ?, field2 = ? where field3 = ?";
-        $executeMode = OCI_COMMIT_ON_SUCCESS;
-
-        return $this->getMock('\Doctrine\DBAL\Driver\OCI8\OCI8Statement',
-		    array('bindValue', 'errorInfo'),
-            array(null, $statement, $executeMode), '', false);
-    }
-
     /**
      * This scenario shows that when the first parameter is not null
      * it properly sets $hasZeroIndex to 1 and calls bindValue starting at 1.
+     *
+     * This also verifies that the statement will check with the connection to
+     * see what the current execution mode is.
      *
      * The expected exception is due to oci_execute failing due to no valid connection.
      *
@@ -37,7 +29,9 @@ class OCI8StatementTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testExecute(array $params)
     {
-        $statement = $this->getMockOCI8Statement();
+        $statement = $this->getMock('\Doctrine\DBAL\Driver\OCI8\OCI8Statement',
+            array('bindValue', 'errorInfo'),
+            array(), '', false);
 
         $statement->expects($this->at(0))
             ->method('bindValue')
@@ -57,6 +51,16 @@ class OCI8StatementTest extends \Doctrine\Tests\DbalTestCase
                 $this->equalTo(3),
                 $this->equalTo($params[2])
           );
+
+        // can't pass to constructor since we don't have a real database handle,
+        // but execute must check the connection for the executeMode
+        $conn = $this->getMock('\Doctrine\DBAL\Driver\OCI8\OCI8Connection', array('getExecuteMode'), array(), '', false);
+        $conn->expects($this->once())
+            ->method('getExecuteMode');
+
+        $reflProperty = new \ReflectionProperty($statement, '_conn');
+        $reflProperty->setAccessible(true);
+        $reflProperty->setValue($statement, $conn);
 
         $statement->execute($params);
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL202Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL202Test.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Ticket;
+
+/**
+ * @group DBAL-202
+ */
+class DBAL202Test extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if ($this->_conn->getDatabasePlatform()->getName() != 'oracle') {
+            $this->markTestSkipped('OCI8 only test');
+        }
+
+        if ($this->_conn->getSchemaManager()->tablesExist('DBAL202')) {
+            $this->_conn->executeQuery('DELETE FROM DBAL202');
+        } else {
+            $table = new \Doctrine\DBAL\Schema\Table('DBAL202');
+            $table->addColumn('id', 'integer');
+            $table->setPrimaryKey(array('id'));
+
+            $this->_conn->getSchemaManager()->createTable($table);
+        }
+    }
+
+    public function testStatementRollback()
+    {
+        $stmt = $this->_conn->prepare('INSERT INTO DBAL202 VALUES (8)');
+        $this->_conn->beginTransaction();
+        $stmt->execute();
+        $this->_conn->rollback();
+
+        $this->assertEquals(0, $this->_conn->query('SELECT COUNT(1) FROM DBAL202')->fetchColumn());
+    }
+
+    public function testStatementCommit()
+    {
+        $stmt = $this->_conn->prepare('INSERT INTO DBAL202 VALUES (8)');
+        $this->_conn->beginTransaction();
+        $stmt->execute();
+        $this->_conn->commit();
+
+        $this->assertEquals(1, $this->_conn->query('SELECT COUNT(1) FROM DBAL202')->fetchColumn());
+    }
+}


### PR DESCRIPTION
Bug Fix: yes
Feature addition: no
Backwards compatibility break: no
[![Build Status](https://secure.travis-ci.org/dpb587/dbal.png?branch=ticket-dbal-202)](http://travis-ci.org/dpb587/dbal)

Scenario is documented in JIRA [DBAL-202](http://www.doctrine-project.org/jira/browse/DBAL-202). Basically in oci8 if you prepare a statement outside of a transaction, start a transaction, execute the statement, rollback the transaction - the statement will still have been executed. Whether it's the correct behavior or not, it seems like it should match PDO's behavior.

This implementation affects the API, so it should probably be carefully reviewed.

A separate test script is available at [https://gist.github.com/2515100](gist.github.com/2515100).

```
$ php -v ; php --re oci8 | head -1
PHP 5.3.3-7+squeeze3 with Suhosin-Patch (cli) (built: Jun 28 2011 08:24:40) 
Copyright (c) 1997-2009 The PHP Group
Zend Engine v2.3.0, Copyright (c) 1998-2010 Zend Technologies
    with Xdebug v2.1.1, Copyright (c) 2002-2011, by Derick Rethans
    with Suhosin v0.9.32.1, Copyright (c) 2007-2010, by SektionEins GmbH
Extension [ <persistent> extension #52 oci8 version 1.4.2 ] {
$ phpunit -c oci8.phpunit.xml.dist tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
PHPUnit 3.5.13 by Sebastian Bergmann.

..

Time: 0 seconds, Memory: 7.50Mb

OK (2 tests, 2 assertions)
$ phpunit -c oci8.phpunit.xml.dist tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL202Test.php
PHPUnit 3.5.13 by Sebastian Bergmann.

..

Time: 7 seconds, Memory: 9.50Mb
OK (2 tests, 6 assertions)
```

I had to drop the the following tests to run through the oracle test suite (seemed like my test user didn't have enough permissions for the temp db tests), but all other tests pass.

```
$ rm tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
$ rm tests/Doctrine/Tests/DBAL/Functional/TableGeneratorTest.php # see pull 136
$ rm tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
$ phpunit -c oci8.phpunit.xml.dist
PHPUnit 3.5.13 by Sebastian Bergmann.

...............................................................  63 / 747 (  8%)
.......SSSS.....S........S......................S...........S.. 126 / 747 ( 16%)
.............................SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS 189 / 747 ( 25%)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS 252 / 747 ( 33%)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS.............S........ 315 / 747 ( 42%)
...S...S...SSS................................................. 378 / 747 ( 50%)
............................................................... 441 / 747 ( 59%)
.....SSS....................................................... 504 / 747 ( 67%)
............................................................... 567 / 747 ( 75%)
..............S................................................ 630 / 747 ( 84%)
............................................................... 693 / 747 ( 92%)
......................................................

Time: 33 seconds, Memory: 46.00Mb

OK, but incomplete or skipped tests!
Tests: 747, Assertions: 1145, Skipped: 156.
```
