### PR TITLE
Allow easier overriding of the DateTime class

### DIFF
--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -28,6 +28,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class DateTimeType extends Type
 {
+    protected $class = 'DateTime';
+
     public function getName()
     {
         return Type::DATETIME;
@@ -50,7 +52,8 @@ class DateTimeType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat($platform->getDateTimeFormatString(), $value);
+        $class = $this->class;
+        $val = $class::createFromFormat($platform->getDateTimeFormatString(), $value);
         if (!$val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateTimeFormatString());
         }

--- a/lib/Doctrine/DBAL/Types/DateTimeTzType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeTzType.php
@@ -48,6 +48,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class DateTimeTzType extends Type
 {
+    protected $class = 'DateTime';
+
     public function getName()
     {
         return Type::DATETIMETZ;
@@ -70,7 +72,8 @@ class DateTimeTzType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat($platform->getDateTimeTzFormatString(), $value);
+        $class = $this->class;
+        $val = $class::createFromFormat($platform->getDateTimeTzFormatString(), $value);
         if (!$val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateTimeTzFormatString());
         }

--- a/lib/Doctrine/DBAL/Types/DateType.php
+++ b/lib/Doctrine/DBAL/Types/DateType.php
@@ -28,6 +28,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class DateType extends Type
 {
+    protected $class = 'DateTime';
+
     public function getName()
     {
         return Type::DATE;
@@ -50,7 +52,8 @@ class DateType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat('!'.$platform->getDateFormatString(), $value);
+        $class = $this->class;
+        $val = $class::createFromFormat('!'.$platform->getDateFormatString(), $value);
         if (!$val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateFormatString());
         }

--- a/lib/Doctrine/DBAL/Types/TimeType.php
+++ b/lib/Doctrine/DBAL/Types/TimeType.php
@@ -28,6 +28,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class TimeType extends Type
 {
+    protected $class = 'DateTime';
+
     public function getName()
     {
         return Type::TIME;
@@ -59,7 +61,8 @@ class TimeType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat($platform->getTimeFormatString(), $value);
+        $class = $this->class;
+        $val = $class::createFromFormat($platform->getTimeFormatString(), $value);
         if (!$val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getTimeFormatString());
         }


### PR DESCRIPTION
If this can be backported to 2.2, it'd be nice.

The goal is that we have to override the Date\* Types in our code to support PKs on Date fields, but at the moment that requires duplicating all the code from those classes, which sucks a bit for maintenance.
