### PR TITLE
auto-quote table and column name in Connection->delete/insert/update()

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -427,6 +427,8 @@ class Connection implements DriverConnection
     {
         $this->connect();
 
+        list($tableName, $identifier) = $this->_platform->quoteArgsAsIdentifiers($tableName, $identifier);
+
         $criteria = array();
 
         foreach (array_keys($identifier) as $columnName) {
@@ -485,6 +487,9 @@ class Connection implements DriverConnection
     public function update($tableName, array $data, array $identifier, array $types = array())
     {
         $this->connect();
+
+        list($tableName, $data, $identifier, $types) = $this->_platform->quoteArgsAsIdentifiers($tableName, $data, $identifier, $types);
+
         $set = array();
         foreach ($data as $columnName => $value) {
             $set[] = $columnName . ' = ?';
@@ -510,6 +515,8 @@ class Connection implements DriverConnection
     public function insert($tableName, array $data, array $types = array())
     {
         $this->connect();
+
+        list($tableName, $data, $types) = $this->_platform->quoteArgsAsIdentifiers($tableName, $data, $types);
 
         // column names are specified as array keys
         $cols = array();

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1350,6 +1350,47 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Quotes its arguments as identifiers.
+     *
+     * @return array quoted arguments
+     */
+    public function quoteArgsAsIdentifiers()
+    {
+        $a = func_get_args();
+        $q = $this->quoteSingleIdentifier('q');
+        $q = $q[0];
+
+        foreach ($a as &$data)
+        {
+            if (is_string($data))
+            {
+                if (isset($data[0]) && $q !== $data[0])
+                {
+                    $data = $this->quoteIdentifier($data);
+                }
+            }
+            else
+            {
+                $quotedData = array();
+
+                foreach ($data as $k => $v)
+                {
+                    if (isset($k[0]) && $q !== $k[0])
+                    {
+                        $k = $this->quoteIdentifier($k);
+                    }
+
+                    $quotedData[$k] = $v;
+                }
+
+                $data = $quotedData;
+            }
+        }
+
+        return $a;
+    }
+
+    /**
      * Create a new foreign key
      *
      * @param ForeignKeyConstraint  $foreignKey    ForeignKey instance


### PR DESCRIPTION
I wonder why quoting of table/column names in Connection->delete/insert/update() is left to the developer and not not done internally by the library?

I made a patch to allow the lib to quote table and column names in a backward-compatible way. I believe that if this feature is not already in the lib, there must be some reason, but I can't understand it right now, nor find a reference to any rational.

Would it be possible to elaborate the reason if possible, while accepting / rejecting the pull request at your will of course?

Many thanks.
