### PR TITLE
Fixed the doctrine/common constraint and added the branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,14 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": "2.*"
+        "doctrine/common": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Doctrine\\DBAL": "lib/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.3.x-dev"
+        }
     }
 }


### PR DESCRIPTION
The change in the requirements requires doctrine/common#144 to be merged and parsed by Packagist, otherwise `2.3.*` would not match anything.
