### PR TITLE
Added ExpressionBuilder::nolike() method

### DIFF
--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -248,6 +248,19 @@ class ExpressionBuilder
     {
         return $this->comparison($x, 'LIKE', $y);
     }
+    
+    /**
+     * Creates a NOT LIKE() comparison expression with the given arguments.
+     *
+     * @param string $x Field in string format to be inspected by NOT LIKE() comparison.
+     * @param mixed $y Argument to be used in NOT LIKE() comparison.
+     *
+     * @return string
+     */
+    public function notlike($x, $y)
+    {
+        return $this->comparison($x, 'NOT LIKE', $y);
+    }
 
     /**
      * Quotes a given input parameter.

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -257,7 +257,7 @@ class ExpressionBuilder
      *
      * @return string
      */
-    public function notlike($x, $y)
+    public function notLike($x, $y)
     {
         return $this->comparison($x, 'NOT LIKE', $y);
     }


### PR DESCRIPTION
While working on a project in which I'm using the Dbal QueryBuilder, I found that the API doesn't provide a notlike() method, which I definitely need. 
In the end, using the like() method I solve the problem, but in an ugly way(IMO): $qb->expr()->like('a.host NOT', $qb->expr()->literal('%.com'))

That's why I think there should exists the notlike() method in the API. 
Thoughts? 
