### PR TITLE
[SQLITE] Remove primary key auto quote

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -293,7 +293,6 @@ class SqlitePlatform extends AbstractPlatform
 
         if (isset($options['primary']) && ! empty($options['primary'])) {
             $keyColumns = array_unique(array_values($options['primary']));
-            $keyColumns = array_map(array($this, 'quoteIdentifier'), $keyColumns);
             $queryFields.= ', PRIMARY KEY('.implode(', ', $keyColumns).')';
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -131,4 +131,25 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     {
         $this->markTestSkipped('SQlite does not support ALTER Table.');
     }
+
+    /**
+     * @group DDC-1845
+     */
+    public function testGenerateTableSqlShouldNotAutoQuotePrimaryKey()
+    {
+        $table = new \Doctrine\DBAL\Schema\Table('test');
+        $table->addColumn('"like"', 'integer', array('notnull' => true, 'autoincrement' => true));
+        $table->setPrimaryKey(array('"like"'));
+
+        $createTableSQL = $this->_platform->getCreateTableSQL($table);
+        $this->assertEquals(
+            'CREATE TABLE test ("like" INTEGER NOT NULL, PRIMARY KEY("like"))',
+            $createTableSQL[0]
+        );
+
+        $this->assertEquals(
+            'ALTER TABLE test ADD PRIMARY KEY ("like")',
+            $this->_platform->getCreatePrimaryKeySQL($table->getIndex('primary'), 'test')
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -16,7 +16,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
 
     public function getGenerateTableSql()
     {
-        return 'CREATE TABLE test (id INTEGER NOT NULL, test VARCHAR(255) DEFAULT NULL, PRIMARY KEY("id"))';
+        return 'CREATE TABLE test (id INTEGER NOT NULL, test VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))';
     }
 
     public function getGenerateTableWithMultiColumnUniqueIndexSql()


### PR DESCRIPTION
Hi guys.

This patch remove the primary key auto quote in sqlite
I think this is a wrong behavior, other drivers does not do the auto quote.

Cheers
