### PR TITLE
SQL Server doModifyLimitQuery() quoting of doctrine_rownum causes error

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -704,7 +704,7 @@ class SQLServerPlatform extends AbstractPlatform
                 $start = $offset + 1;
                 $end = $offset + $limit;
 
-                $query = "SELECT * FROM (SELECT ROW_NUMBER() OVER ($over) AS \"doctrine_rownum\", $query) AS doctrine_tbl WHERE \"doctrine_rownum\" BETWEEN $start AND $end";
+                $query = "SELECT * FROM (SELECT ROW_NUMBER() OVER ($over) AS doctrine_rownum, $query) AS doctrine_tbl WHERE doctrine_rownum BETWEEN $start AND $end";
             }
         }
 


### PR DESCRIPTION
SQL Server doesn't like the quoted alias for doctrine_rownum and fails when setting setMaxResults() and setFirstResult() in query, returning an error like "Conversion failed when converting the varchar value 'doctrine_rownum' to data type int. (severity 16)"

Not sure why the column alias is quoted as have never seen that used before.
