### PR TITLE
Prevent repeat instantiation of reserved keywords class

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -107,6 +107,13 @@ abstract class AbstractPlatform
     protected $_eventManager;
 
     /**
+     * Holds the KeywordList instance for the current platform.
+     *
+     * @var Doctrine\DBAL\Platforms\Keywords\KeywordList
+     */
+    protected $_keywords;
+
+    /**
      * Constructor.
      */
     public function __construct() {}
@@ -2682,11 +2689,20 @@ abstract class AbstractPlatform
      */
     final public function getReservedKeywordsList()
     {
+        // Check for an existing instantiation of the keywords class.
+        if($this->keywords) {
+            return $this->keywords;
+        }
+
         $class = $this->getReservedKeywordsClass();
         $keywords = new $class;
         if ( ! $keywords instanceof \Doctrine\DBAL\Platforms\Keywords\KeywordList) {
             throw DBALException::notSupported(__METHOD__);
         }
+
+        // Store the instance so it doesn't need to be generated on every request.
+        $this->keywords = $keywords;
+
         return $keywords;
     }
 

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2690,7 +2690,7 @@ abstract class AbstractPlatform
     final public function getReservedKeywordsList()
     {
         // Check for an existing instantiation of the keywords class.
-        if($this->keywords) {
+        if ($this->keywords) {
             return $this->keywords;
         }
 


### PR DESCRIPTION
In the getReservedKeywordsList() method in AbstractPlatform the keywords class for the current platform is instantiated on each request.

When running migrations, this method can be called thousands of times resulting in poor performance.

I've simply added an internal variable to hold this instance and check for existence before re-instantiating.
