### PR TITLE
Fixes a bug caused by unquoted reserved table name being referenced during schema creation

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2004,7 +2004,7 @@ abstract class AbstractPlatform
 
         $sql .= implode(', ', $foreignKey->getLocalColumns())
               . ') REFERENCES '
-              . $foreignKey->getForeignTableName() . ' ('
+              . $foreignKey->getQuotedForeignTableName($this) . ' ('
               . implode(', ', $foreignKey->getForeignColumns()) . ')';
 
         return $sql;

--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -22,6 +22,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Visitor\Visitor;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class ForeignKeyConstraint extends AbstractAsset implements Constraint
 {

--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -110,6 +110,24 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
     }
 
     /**
+     * Get the quoted representation of this asset but only if it was defined with one. Otherwise
+     * return the plain unquoted value as inserted.
+     *
+     * @param AbstractPlatform $platform
+     * @return string
+     */
+    public function getQuotedForeignTableName(AbstractPlatform $platform)
+    {
+        $keywords = $platform->getReservedKeywordsList();
+        $parts = explode(".", $this->getForeignTableName());
+        foreach ($parts AS $k => $v) {
+            $parts[$k] = ($this->_quoted || $keywords->isKeyword($v)) ? $platform->quoteIdentifier($v) : $v;
+        }
+
+        return implode(".", $parts);
+    }
+
+    /**
      * @return array
      */
     public function getForeignColumns()


### PR DESCRIPTION
When creating a schema with tables with reserved names and relationships between them, the schema creation tool failed to write valid SQL in MySQL due to unquoted table names. For example:

```
CREATE TABLE `Group` (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL DEFAULT NULL, PRIMARY KEY(id)) ENGINE = InnoDB;
CREATE TABLE User (id INT AUTO_INCREMENT NOT NULL, username VARCHAR(255) NOT NULL PRIMARY KEY(id)) ENGINE = InnoDB;
CREATE TABLE UserHasGroup (user_id INT NOT NULL, group_id INT NOT NULL, INDEX IDX_617A865CA76ED395 (user_id), INDEX IDX_617A865CFE54D947 (group_id), PRIMARY KEY(user_id, group_id)) ENGINE = InnoDB;
ALTER TABLE UserHasGroup ADD CONSTRAINT FK_617A865CA76ED395 FOREIGN KEY (user_id) REFERENCES User (id);
ALTER TABLE UserHasGroup ADD CONSTRAINT FK_617A865CFE54D947 FOREIGN KEY (group_id) REFERENCES Group (id);
```

This fix creates a small function for creating quoted foreign key table names.
