### PR TITLE
DebugStack should ignore stopQuery when disabled

### DIFF
--- a/lib/Doctrine/DBAL/Logging/DebugStack.php
+++ b/lib/Doctrine/DBAL/Logging/DebugStack.php
@@ -61,7 +61,8 @@ class DebugStack implements SQLLogger
      */
     public function stopQuery()
     {
-        $this->queries[$this->currentQuery]['executionMS'] = microtime(true) - $this->start;
+        if ($this->enabled) {
+            $this->queries[$this->currentQuery]['executionMS'] = microtime(true) - $this->start;
+        }
     }
 }
-

--- a/tests/Doctrine/Tests/DBAL/Logging/DebugStackTest.php
+++ b/tests/Doctrine/Tests/DBAL/Logging/DebugStackTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Logging;
+
+require_once __DIR__ . '/../../TestInit.php';
+
+class DebugStackTest extends \Doctrine\Tests\DbalTestCase
+{
+    public function setUp()
+    {
+        $this->logger = new \Doctrine\DBAL\Logging\DebugStack();
+    }
+
+    public function tearDown()
+    {
+        unset($this->logger);
+    }
+
+    public function testLoggedQuery()
+    {
+        $this->logger->startQuery('SELECT column FROM table');
+        $this->assertEquals(
+            array(
+                1 => array(
+                    'sql' => 'SELECT column FROM table',
+                    'params' => null,
+                    'types' => null,
+                    'executionMS' => 0,
+                ),
+            ),
+            $this->logger->queries
+        );
+
+        $this->logger->stopQuery();
+        $this->assertGreaterThan(0, $this->logger->queries[1]['executionMS']);
+    }
+
+    public function testLoggedQueryDisabled()
+    {
+        $this->logger->enabled = false;
+        $this->logger->startQuery('SELECT column FROM table');
+        $this->assertEquals(array(), $this->logger->queries);
+
+        $this->logger->stopQuery();
+        $this->assertEquals(array(), $this->logger->queries);
+    }
+}


### PR DESCRIPTION
I noticed that DebugStack was adding an empty element when it was disabled. This PR changes it to match startQuery with its behavior.

```
1) Doctrine\Tests\DBAL\Logging\DebugStackTest::testLoggedQueryDisabled
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array
 (
+    [0] => Array
+        (
+            [executionMS] => 1341871660.9651
+        )
+
 )
```

I've submitted the PR to 2.0.x since that's where the bug is first seen and is still listed as stable on doctrine-project.org. Preferably this could also be applied to newer branches as well, or I can also submit separate PRs.
