### PR TITLE
[#DBAL-172] QueryBuilder joins are omitted if the table alias is not present in the "from" clause

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -280,7 +280,7 @@ class SQLServerPlatform extends AbstractPlatform
         $columnSql = array();
 
         if ($diff->newName !== false) {
-            $queryParts[] = "sp_RENAME '" . $diff->name . "', '" . $diff->newName . "'";
+            $queryParts[] = 'RENAME TO ' . $diff->newName;
         }
 
         foreach ($diff->addedColumns AS $fieldName => $column) {

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -961,10 +961,10 @@ class QueryBuilder
                 foreach ($this->sqlParts['join'] as $joins) {
                     foreach ($joins as $join) {
                         $fromClause .= ' ' . strtoupper($join['joinType'])
-                        . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']
-                        . ' ON ' . ((string) $join['joinCondition']);
+                            . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']
+                            . ' ON ' . ((string) $join['joinCondition']);
+                        $joinAliases[$join['joinAlias']] = true;
                     }
-                    $joinAliases[$join['joinAlias']] = true;
                 }
                 $joinsPending = false;
             }

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -963,8 +963,8 @@ class QueryBuilder
                         $fromClause .= ' ' . strtoupper($join['joinType'])
                         . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']
                         . ' ON ' . ((string) $join['joinCondition']);
+                        $joinAliases[$join['joinAlias']] = true;
                     }
-                    $joinAliases[$join['joinAlias']] = true;
                 }
                 $joinsPending = false;
             }

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -950,29 +950,35 @@ class QueryBuilder
         $query = 'SELECT ' . implode(', ', $this->sqlParts['select']) . ' FROM ';
 
         $fromClauses = array();
-
+        $joinsPending = true;
+        $joinAliases = array();
+        
         // Loop through all FROM clauses
         foreach ($this->sqlParts['from'] as $from) {
             $fromClause = $from['table'] . ' ' . $from['alias'];
-
-            if (isset($this->sqlParts['join'][$from['alias']])) {
-                foreach ($this->sqlParts['join'][$from['alias']] as $join) {
-                    $fromClause .= ' ' . strtoupper($join['joinType'])
-                                 . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']
-                                 . ' ON ' . ((string) $join['joinCondition']);
+            if ($joinsPending && isset($this->sqlParts['join'][$from['alias']])) {
+                // Loop through all JOIN clauses
+                foreach ($this->sqlParts['join'] as $joins) {
+                    foreach ($joins as $join) {
+                        $fromClause .= ' ' . strtoupper($join['joinType'])
+                        . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']
+                        . ' ON ' . ((string) $join['joinCondition']);
+                    }
+                    $joinAliases[$join['joinAlias']] = true;
                 }
+                $joinsPending = false;
             }
-
             $fromClauses[$from['alias']] = $fromClause;
         }
-
-        // loop through all JOIN clasues for validation purpose
+        
+        // check all aliases used in JOINS for validation
+        $knownAliases = array_merge($fromClauses,$joinAliases);
         foreach ($this->sqlParts['join'] as $fromAlias => $joins) {
-            if ( ! isset($fromClauses[$fromAlias]) ) {
-                throw QueryException::unknownFromAlias($fromAlias, array_keys($fromClauses));
+            if ( ! isset($knownAliases[$fromAlias]) ) {
+                throw QueryException::unknownAlias($fromAlias, array_keys($knownAliases));
             }
         }
-
+        
         $query .= implode(', ', $fromClauses)
                 . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '')
                 . ($this->sqlParts['groupBy'] ? ' GROUP BY ' . implode(', ', $this->sqlParts['groupBy']) : '')
@@ -983,7 +989,7 @@ class QueryBuilder
             ? $query
             : $this->connection->getDatabasePlatform()->modifyLimitQuery($query, $this->maxResults, $this->firstResult);
     }
-
+    
     /**
      * Converts this instance into an UPDATE string in SQL.
      *

--- a/lib/Doctrine/DBAL/Query/QueryException.php
+++ b/lib/Doctrine/DBAL/Query/QueryException.php
@@ -29,12 +29,10 @@ use Doctrine\DBAL\DBALException;
  */
 class QueryException extends DBALException
 {
-    static public function unknownFromAlias($alias, $registeredAliases)
+    static public function unknownAlias($alias, $registeredAliases)
     {
         return new self("The given alias '" . $alias . "' is not part of " .
-            "any FROM clause table. The currently registered FROM-clause " .
-            "aliases are: " . implode(", ", $registeredAliases) . ". Join clauses " .
-            "are bound to from clauses to provide support for mixing of multiple " .
-            "from and join clauses.");
+            "any FROM or JOIN clause table. The currently registered " .
+            "aliases are: " . implode(", ", $registeredAliases) . ".");
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -561,12 +561,13 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
                 ->join("l", "location_tree_pos", "p", "l.id = p.tree_id")
                 ->rightJoin("l", "hotel", "h", "h.location_id = l.id")
                 ->leftJoin("l", "offer_location", "ol", "l.id=ol.location_id")
-                ->leftJoin("ol", "mds_offer", "mdso", "ol.offer_id = mdso.offer_id")
+                ->leftJoin("olx", "mds_offer", "mdso", "ol.offer_id = mdso.offer_id")
                 ->leftJoin("h", "mds_hotel", "mdsh", "h.id = mdsh.hotel_id")
                 ->where("p.parent_id IN (:ids)")
                 ->andWhere("(mdso.xcode IS NOT NULL OR mdsh.xcode IS NOT NULL)");
 
-        $this->setExpectedException('Doctrine\DBAL\Query\QueryException', "The given alias 'ol' is not part of any FROM clause table. The currently registered FROM-clause aliases are: l");
+        $this->setExpectedException('Doctrine\DBAL\Query\QueryException', "The given alias 'olx' is not part of any FROM or JOIN clause table. The currently registered aliases are: l, p, h, ol, mdso, mdsh.");
         $this->assertEquals('', $qb->getSQL());
     }
+    
 }


### PR DESCRIPTION
Apparently that fix has never been included, don't know why exactly. But there are use cases where you want to join multiple tables without selecting any data from the joined tables.

Ie. a query like this one :
SELECT COUNT(DISTINCT news.id) FROM cb_newspages news 
INNER JOIN nodeversion nv ON nv.refId = news.id AND nv.refEntityname='Entity\News' 
INNER JOIN nodetranslation nt ON nv.nodetranslation = nt.id 
INNER JOIN node n ON nt.node = n.id 
WHERE nt.lang = 'nl' AND n.deleted != 1

could be written with the querybuilder (using this patch) as follows :

```
    $querybuilder->select('COUNT(DISTINCT news.id)')
        ->from('cb_newspages', 'news')
        ->innerJoin('news', 'nodeversion', 'nv', 'nv.refId = news.id AND nv.refEntityname=\'Entity\\\\News\'')
        ->innerJoin('nv', 'nodetranslation', 'nt', 'nv.nodetranslation = nt.id')
        ->innerJoin('nt', 'node', 'n', 'nt.node = n.id')
        ->where('nt.lang = :lang AND n.deleted != 1')
        ->setParameter('lang', $locale);
```

When you use an alias that isn't chained or used in a from clause it will still trigger a QueryException (as before).

ie.
        $querybuilder->select('COUNT(DISTINCT news.id)')
            ->from('cb_newspages', 'news')
            ->innerJoin('news', 'nodeversion', 'nv', 'nv.refId = news.id AND nv.refEntityname=\'Entity\\News\'')
            ->innerJoin('invalid', 'nodetranslation', 'nt', 'nv.nodetranslation = nt.id')
            ->innerJoin('nt', 'node', 'n', 'nt.node = n.id')
            ->where('nt.lang = :lang AND n.deleted != 1')
            ->setParameter('lang', $locale);

Will trigger the following QueryException :

"The given alias 'invalid' is not part of any FROM or JOIN clause table. The currently registered aliases are: news, nv, nt, n."
