### PR TITLE
Used the placeholder in the command help for the name

### DIFF
--- a/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
@@ -69,12 +69,12 @@ with names that are identifiers in this dialect or in other SQL dialects.
 By default SQLite, MySQL, PostgreSQL, MsSQL and Oracle
 keywords are checked:
 
-    <info>doctrine dbal:reserved-words</info>
+    <info>%command.full_name%</info>
 
 If you want to check against specific dialects you can
 pass them to the command:
 
-    <info>doctrine dbal:reserved-words mysql pgsql</info>
+    <info>%command.full_name% mysql pgsql</info>
 
 The following keyword lists are currently shipped with Doctrine:
 


### PR DESCRIPTION
This change will allow to keep the original help message in DoctrineBundle even if we rename the command. I will submit the same PR for the ORM.

@beberlei please include it in the 2.3 branch (and ideally in 2.2 if it is not too much to ask for it). My goal is to stop duplicating the help messages in the bundle as outdated help messages are really a pain for users (see doctrine/DoctrineBundle#89)
