### PR TITLE
Fix for DBAL-172

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -946,29 +946,36 @@ class QueryBuilder
         $query = 'SELECT ' . implode(', ', $this->sqlParts['select']) . ' FROM ';
 
         $fromClauses = array();
-
+        $joinsPending = true;
+        $joinAliases = array();
+        
         // Loop through all FROM clauses
         foreach ($this->sqlParts['from'] as $from) {
             $fromClause = $from['table'] . ' ' . $from['alias'];
 
-            if (isset($this->sqlParts['join'][$from['alias']])) {
-                foreach ($this->sqlParts['join'][$from['alias']] as $join) {
-                    $fromClause .= ' ' . strtoupper($join['joinType'])
-                                 . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']
-                                 . ' ON ' . ((string) $join['joinCondition']);
+            if ($joinsPending && isset($this->sqlParts['join'][$from['alias']])) {
+                foreach ($this->sqlParts['join'] as $joins) {
+                    foreach ($joins as $join) {
+                        $fromClause .= ' ' . strtoupper($join['joinType'])
+                                     . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']
+                                     . ' ON ' . ((string) $join['joinCondition']);
+                        $joinAliases[$join['joinAlias']] = true;
+                    }
                 }
+                $joinsPending = false;
             }
-
+            
             $fromClauses[$from['alias']] = $fromClause;
         }
 
         // loop through all JOIN clauses for validation purpose
+        $knownAliases = array_merge($fromClauses,$joinAliases);
         foreach ($this->sqlParts['join'] as $fromAlias => $joins) {
-            if ( ! isset($fromClauses[$fromAlias]) ) {
-                throw QueryException::unknownFromAlias($fromAlias, array_keys($fromClauses));
+            if ( ! isset($knownAliases[$fromAlias]) ) {
+                throw QueryException::unknownAlias($fromAlias, array_keys($knownAliases));
             }
         }
-
+        
         $query .= implode(', ', $fromClauses)
                 . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '')
                 . ($this->sqlParts['groupBy'] ? ' GROUP BY ' . implode(', ', $this->sqlParts['groupBy']) : '')

--- a/lib/Doctrine/DBAL/Query/QueryException.php
+++ b/lib/Doctrine/DBAL/Query/QueryException.php
@@ -29,12 +29,10 @@ use Doctrine\DBAL\DBALException;
  */
 class QueryException extends DBALException
 {
-    static public function unknownFromAlias($alias, $registeredAliases)
+    static public function unknownAlias($alias, $registeredAliases)
     {
         return new self("The given alias '" . $alias . "' is not part of " .
-            "any FROM clause table. The currently registered FROM-clause " .
-            "aliases are: " . implode(", ", $registeredAliases) . ". Join clauses " .
-            "are bound to from clauses to provide support for mixing of multiple " .
-            "from and join clauses.");
+            "any FROM or JOIN clause table. The currently registered " .
+            "aliases are: " . implode(", ", $registeredAliases) . ".");
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -556,17 +556,14 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
     {
         $qb = new QueryBuilder($this->conn);
 
-        $qb->select("l.id", "mdsh.xcode", "mdso.xcode")
-                ->from("location_tree", "l")
-                ->join("l", "location_tree_pos", "p", "l.id = p.tree_id")
-                ->rightJoin("l", "hotel", "h", "h.location_id = l.id")
-                ->leftJoin("l", "offer_location", "ol", "l.id=ol.location_id")
-                ->leftJoin("ol", "mds_offer", "mdso", "ol.offer_id = mdso.offer_id")
-                ->leftJoin("h", "mds_hotel", "mdsh", "h.id = mdsh.hotel_id")
-                ->where("p.parent_id IN (:ids)")
-                ->andWhere("(mdso.xcode IS NOT NULL OR mdsh.xcode IS NOT NULL)");
+        $qb->select('COUNT(DISTINCT news.id)')
+            ->from('cb_newspages', 'news')
+            ->innerJoin('news', 'nodeversion', 'nv', 'nv.refId = news.id AND nv.refEntityname=\'News\'')
+            ->innerJoin('invalid', 'nodetranslation', 'nt', 'nv.nodetranslation = nt.id')
+            ->innerJoin('nt', 'node', 'n', 'nt.node = n.id')
+            ->where('nt.lang = :lang AND n.deleted != 1');
 
-        $this->setExpectedException('Doctrine\DBAL\Query\QueryException', "The given alias 'ol' is not part of any FROM clause table. The currently registered FROM-clause aliases are: l");
+        $this->setExpectedException('Doctrine\DBAL\Query\QueryException', "The given alias 'invalid' is not part of any FROM or JOIN clause table. The currently registered aliases are: news, nv, nt, n.");
         $this->assertEquals('', $qb->getSQL());
     }
 }


### PR DESCRIPTION
Apparently a real fix has never been included, don't know why exactly. But there are use cases where you want to join multiple tables without selecting any data from the joined tables.

Ie. a query like this one :
SELECT COUNT(DISTINCT news.id) FROM cb_newspages news 
INNER JOIN nodeversion nv ON nv.refId = news.id AND nv.refEntityname='News' 
INNER JOIN nodetranslation nt ON nv.nodetranslation = nt.id 
INNER JOIN node n ON nt.node = n.id 
WHERE nt.lang = 'nl' AND n.deleted != 1

could be written with the querybuilder (using this patch) as follows :

```
    $querybuilder->select('COUNT(DISTINCT news.id)')
        ->from('cb_newspages', 'news')
        ->innerJoin('news', 'nodeversion', 'nv', 'nv.refId = news.id AND nv.refEntityname=\'Entity\\\\News\'')
        ->innerJoin('nv', 'nodetranslation', 'nt', 'nv.nodetranslation = nt.id')
        ->innerJoin('nt', 'node', 'n', 'nt.node = n.id')
        ->where('nt.lang = :lang AND n.deleted != 1')
        ->setParameter('lang', $locale);
```

When you use an alias that isn't chained or used in a from clause it will still trigger a QueryException (as before).
ie.

```
    $querybuilder->select('COUNT(DISTINCT news.id)')
        ->from('cb_newspages', 'news')
        ->innerJoin('news', 'nodeversion', 'nv', 'nv.refId = news.id AND nv.refEntityname=\'Entity\\\\News\'')
        ->innerJoin('invalid', 'nodetranslation', 'nt', 'nv.nodetranslation = nt.id')
        ->innerJoin('nt', 'node', 'n', 'nt.node = n.id')
        ->where('nt.lang = :lang AND n.deleted != 1')
        ->setParameter('lang', $locale);
```

Will trigger the following QueryException :

"The given alias 'invalid' is not part of any FROM or JOIN clause table. The currently registered aliases are: news, nv, nt, n."
