### PR TITLE
Added missing type mappings for postgres

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -744,6 +744,7 @@ class PostgreSqlPlatform extends AbstractPlatform
         $this->doctrineTypeMapping = array(
             'smallint'      => 'smallint',
             'int2'          => 'smallint',
+            '_int2'         => 'smallint',
             'serial'        => 'integer',
             'serial4'       => 'integer',
             'int'           => 'integer',
@@ -756,6 +757,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             'bool'          => 'boolean',
             'boolean'       => 'boolean',
             'text'          => 'text',
+            '_text'         => 'text',
             'varchar'       => 'string',
             'interval'      => 'string',
             '_varchar'      => 'string',
@@ -779,6 +781,10 @@ class PostgreSqlPlatform extends AbstractPlatform
             'year'          => 'date',
             'uuid'          => 'guid',
             'bytea'         => 'blob',
+            'unknown'       => 'text',
+            'regprocedure'  => 'string',
+            'inet'          => 'string',
+            'name'          => 'string',
         );
     }
 


### PR DESCRIPTION
We had problems running the migrations-commands with an existing database. Seems like some type-mappings are just missing. This patch fixed the problem for us.
