### PR TITLE
Fixed a typo in a method name

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -229,7 +229,7 @@ abstract class AbstractPlatform
      * @param array $field
      * @return string
      */
-    public function getGuidTypeDeclartionSQL(array $field)
+    public function getGuidTypeDeclarationSQL(array $field)
     {
         return $this->getVarcharTypeDeclarationSQL($field);
     }

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -623,7 +623,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      * @param array $field
      * @return string
      */
-    public function getGuidTypeDeclartionSQL(array $field)
+    public function getGuidTypeDeclarationSQL(array $field)
     {
         return 'UUID';
     }

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -611,7 +611,7 @@ class SQLServerPlatform extends AbstractPlatform
      * @param array $field
      * @return string
      */
-    public function getGuidTypeDeclartionSQL(array $field)
+    public function getGuidTypeDeclarationSQL(array $field)
     {
         return 'UNIQUEIDENTIFIER';
     }

--- a/lib/Doctrine/DBAL/Types/GuidType.php
+++ b/lib/Doctrine/DBAL/Types/GuidType.php
@@ -31,7 +31,7 @@ class GuidType extends StringType
 {
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        return $platform->getGuidTypeDeclartionSQL($fieldDeclaration);
+        return $platform->getGuidTypeDeclarationSQL($fieldDeclaration);
     }
 
     public function getName()


### PR DESCRIPTION
This renaming is technically a BC break, but as the method is new in 2.3, I think we could still fix the typo without providing a BC layer for it (the ORM does not call the method btw).
@beberlei If you think that we should already provide the BC layer for the method, tell me and I will add it. However, we should then decide if we want the BC for code calling the platform or for custom platforms implementing the method (we cannot provide both).
