### PR TITLE
Added a missing method in the Constraint interface

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Constraint.php
+++ b/lib/Doctrine/DBAL/Schema/Constraint.php
@@ -21,10 +21,12 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
 /**
  * Marker interface for contraints
  *
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @version $Revision$
@@ -33,6 +35,8 @@ namespace Doctrine\DBAL\Schema;
 interface Constraint
 {
     public function getName();
+
+    public function getQuotedName(AbstractPlatform $platform);
 
     public function getColumns();
 }


### PR DESCRIPTION
This adds a missing method in the Constraint interface. The method is already defined in AbstractAsset which is extended by both classes implementing the interface. the AbstractPlatform is calling this method on objects after checking they are implementing the interface. So either the method should be part of the interface, or all places using the interface as typehint should be refactored to check for the classes (examples can be found [here](https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php#L1029) and [there](https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php#L1254)).

Adding a method in an interface is technically a BC break but this method is not really a public extension point. what do you think @beberlei ?
