### PR TITLE
Fix unsigned columns in MySql

### DIFF
--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -100,7 +100,7 @@ class MySqlSchemaManager extends AbstractSchemaManager
             $decimal = strtok('(), ') ? strtok('(), '):null;
         }
         $type = array();
-        $unsigned = $fixed = null;
+        $fixed = null;
 
         if ( ! isset($tableColumn['name'])) {
             $tableColumn['name'] = '';
@@ -147,7 +147,7 @@ class MySqlSchemaManager extends AbstractSchemaManager
 
         $options = array(
             'length'        => $length,
-            'unsigned'      => (bool) $unsigned,
+            'unsigned'      => (bool) (strpos($tableColumn['type'], 'unsigned') !== false),
             'fixed'         => (bool) $fixed,
             'default'       => isset($tableColumn['default']) ? $tableColumn['default'] : null,
             'notnull'       => (bool) ($tableColumn['null'] != 'YES'),


### PR DESCRIPTION
Unsigned column properties were never set. In consequence all migrations diff were trying to change the column definition when it was already changed. See symfony/symfony#3560

Would it be also nice to add some test to avoid regressions, but i don't know where it would be a nice place to put them.
