### PR TITLE
Quote column names during insert, if necessary

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -528,7 +528,7 @@ class Connection implements DriverConnection
         $placeholders = array();
 
         foreach ($data as $columnName => $value) {
-            $cols[] = $columnName;
+            $cols[] = $this->quoteIdentifier($columnName);
             $placeholders[] = '?';
         }
 


### PR DESCRIPTION
This fixes an issue I ran into where if I tried to insert something with a column name that required quoting, I would have to manually quote it myself.
