### PR TITLE
Changed 'implements' by 'extends' on SQLAzureFederationsSynchronizer

### DIFF
--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizer.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizer.php
@@ -36,7 +36,7 @@ use Doctrine\DBAL\Sharding\SingleDatabaseSynchronizer;
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
-class SQLAzureFederationsSynchronizer implements AbstractSchemaSynchronizer
+class SQLAzureFederationsSynchronizer extends AbstractSchemaSynchronizer
 {
     const FEDERATION_TABLE_FEDERATED   = 'azure.federated';
     const FEDERATION_DISTRIBUTION_NAME = 'azure.federatedOnDistributionName';


### PR DESCRIPTION
This error was introduced with the changes commited on SHA: doctrine/dbal@12f381f1254f756114267e1a1e71d0a783bfaf1c
