### PR TITLE
Add DBAL\TypeAwareObject.

### DIFF
--- a/lib/Doctrine/DBAL/TypeAwareObject.php
+++ b/lib/Doctrine/DBAL/TypeAwareObject.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL;
+
+/**
+ * Interface for SQL loggers.
+ *
+ * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @link    www.doctrine-project.org
+ * @since   2.2.3
+ * @version $Revision$
+ */
+
+interface TypeAwareObject{
+    /**
+     * Return DBAL type of this object, it must a compatible constant:
+     * - Type (\Doctrine\DBAL\Types\Type::*)
+     * - Connection (\Doctrine\DBAL\Connection::PARAM_*)
+     *
+     * @return mixed This object type constant
+     */
+     public function getDBALType();
+}


### PR DESCRIPTION
This PR adds a common interface for custom object values that requires some PHP <-> SQL conversions, which allows to specify what DBAL type must be used for conversion.
