### PR TITLE
Removed duplicate table check so that ManyToMany relationships can have two owning entities

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -107,10 +107,6 @@ class Schema extends AbstractAsset
     protected function _addTable(Table $table)
     {
         $tableName = $table->getFullQualifiedName($this->getName());
-        if(isset($this->_tables[$tableName])) {
-            throw SchemaException::tableAlreadyExists($tableName);
-        }
-
         $this->_tables[$tableName] = $table;
         $table->setSchemaConfig($this->_schemaConfig);
     }

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
@@ -47,17 +47,6 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
         $schema->getTable("unknown");
     }
 
-    public function testCreateTableTwiceThrowsException()
-    {
-        $this->setExpectedException("Doctrine\DBAL\Schema\SchemaException");
-
-        $tableName = "foo";
-        $table = new Table($tableName);
-        $tables = array($table, $table);
-
-        $schema = new Schema($tables);
-    }
-
     public function testRenameTable()
     {
         $tableName = "foo";


### PR DESCRIPTION
Whenever there is a ManyToMany relationship with both entities needing ownership, running doctrine:schema:update throws an exception due to a duplicate table definition when, in fact, it is the same table.
