### PR TITLE
Set default session value for NLS_NUMERIC_CHARACTERS (Bugfix for DDC-2013)

### DIFF
--- a/lib/Doctrine/DBAL/Event/Listeners/OracleSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/OracleSessionInit.php
@@ -45,6 +45,7 @@ class OracleSessionInit implements EventSubscriber
         'NLS_DATE_FORMAT' => "YYYY-MM-DD HH24:MI:SS",
         'NLS_TIMESTAMP_FORMAT' => "YYYY-MM-DD HH24:MI:SS",
         'NLS_TIMESTAMP_TZ_FORMAT' => "YYYY-MM-DD HH24:MI:SS TZH:TZM",
+        'NLS_NUMERIC_CHARACTERS' => ".,",
     );
 
     /**


### PR DESCRIPTION
Bugfix DDC-2013 - Default Session Value ".," for "NLS_NUMERIC_CHARACTERS". This is needed because Oracle uses other characters for decimal separation depending on the servers locale.

See http://www.doctrine-project.org/jira/browse/DDC-2013
