### PR TITLE
Change default MySQL table collation to utf8_unicode_ci

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -376,7 +376,7 @@ class MySqlPlatform extends AbstractPlatform
         }
 
         if ( ! isset($options['collate'])) {
-            $options['collate'] = 'utf8_general_ci';
+            $options['collate'] = 'utf8_unicode_ci';
         }
 
         $query .= 'DEFAULT CHARACTER SET ' . $options['charset'];

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -22,18 +22,18 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
         $table->addColumn("Bar", "integer");
 
         $sql = $this->_platform->getCreateTableSQL($table);
-        $this->assertEquals('CREATE TABLE Foo (Bar INT NOT NULL) DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE = InnoDB', array_shift($sql));
+        $this->assertEquals('CREATE TABLE Foo (Bar INT NOT NULL) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB', array_shift($sql));
     }
 
     public function getGenerateTableSql()
     {
-        return 'CREATE TABLE test (id INT AUTO_INCREMENT NOT NULL, test VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE = InnoDB';
+        return 'CREATE TABLE test (id INT AUTO_INCREMENT NOT NULL, test VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB';
     }
 
     public function getGenerateTableWithMultiColumnUniqueIndexSql()
     {
         return array(
-            'CREATE TABLE test (foo VARCHAR(255) DEFAULT NULL, bar VARCHAR(255) DEFAULT NULL, UNIQUE INDEX UNIQ_D87F7E0C8C73652176FF8CAA (foo, bar)) DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE = InnoDB'
+            'CREATE TABLE test (foo VARCHAR(255) DEFAULT NULL, bar VARCHAR(255) DEFAULT NULL, UNIQUE INDEX UNIQ_D87F7E0C8C73652176FF8CAA (foo, bar)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB'
         );
     }
 
@@ -197,7 +197,7 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
 
     public function getCreateTableColumnCommentsSQL()
     {
-        return array("CREATE TABLE test (id INT NOT NULL COMMENT 'This is a comment', PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE = InnoDB");
+        return array("CREATE TABLE test (id INT NOT NULL COMMENT 'This is a comment', PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB");
     }
 
     public function getAlterTableColumnCommentsSQL()
@@ -207,7 +207,7 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
 
     public function getCreateTableColumnTypeCommentsSQL()
     {
-        return array("CREATE TABLE test (id INT NOT NULL, data LONGTEXT NOT NULL COMMENT '(DC2Type:array)', PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE = InnoDB");
+        return array("CREATE TABLE test (id INT NOT NULL, data LONGTEXT NOT NULL COMMENT '(DC2Type:array)', PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB");
     }
 
     /**


### PR DESCRIPTION
I think default table collation should be changed to `utf8_unicode_ci`, as it handles properly a much wider array of characters (Cyrillic, for example) at a generally negligible cost of performance.

`utf8_general_ci` simply does not work properly with too many languages and should be avoided as a default.
