### PR TITLE
fixed unquoted oldColumnName when changing column definition in MySQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -436,7 +436,7 @@ class MySqlPlatform extends AbstractPlatform
             $column = $columnDiff->column;
             $columnArray = $column->toArray();
             $columnArray['comment'] = $this->getColumnComment($column);
-            $queryParts[] =  'CHANGE ' . ($columnDiff->oldColumnName) . ' '
+            $queryParts[] =  'CHANGE ' . $this->quoteIdentifier($columnDiff->oldColumnName) . ' '
                     . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnArray);
         }
 
@@ -447,7 +447,7 @@ class MySqlPlatform extends AbstractPlatform
 
             $columnArray = $column->toArray();
             $columnArray['comment'] = $this->getColumnComment($column);
-            $queryParts[] =  'CHANGE ' . $oldColumnName . ' '
+            $queryParts[] =  'CHANGE ' . $this->quoteIdentifier($oldColumnName) . ' '
                     . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnArray);
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -202,7 +202,7 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
 
     public function getAlterTableColumnCommentsSQL()
     {
-        return array("ALTER TABLE mytable ADD quota INT NOT NULL COMMENT 'A comment', CHANGE bar baz VARCHAR(255) NOT NULL COMMENT 'B comment'");
+        return array("ALTER TABLE mytable ADD quota INT NOT NULL COMMENT 'A comment', CHANGE `bar` baz VARCHAR(255) NOT NULL COMMENT 'B comment'");
     }
 
     public function getCreateTableColumnTypeCommentsSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -40,7 +40,7 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
     public function getGenerateAlterTableSql()
     {
         return array(
-            "ALTER TABLE mytable RENAME TO userlist, ADD quota INT DEFAULT NULL, DROP foo, CHANGE bar baz VARCHAR(255) DEFAULT 'def' NOT NULL, CHANGE bloo bloo TINYINT(1) DEFAULT '0' NOT NULL"
+            "ALTER TABLE mytable RENAME TO userlist, ADD quota INT DEFAULT NULL, DROP foo, CHANGE `bar` baz VARCHAR(255) DEFAULT 'def' NOT NULL, CHANGE `bloo` bloo TINYINT(1) DEFAULT '0' NOT NULL"
         );
     }
 


### PR DESCRIPTION
before: 
`ALTER TABLE AlertCondition CHANGE fulltext `fulltext` VARCHAR(255) DEFAULT NULL` failed.

after: 
`ALTER TABLE AlertCondition CHANGE `fulltext` `fulltext` VARCHAR(255) DEFAULT NULL` passes.
