### PR TITLE
params not passed from execute to logger

### DIFF
--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -129,7 +129,7 @@ class Statement implements \IteratorAggregate, DriverStatement
      */
     public function execute($params = null)
     {
-        if(is_array($params)) {
+        if (is_array($params)) {
             $this->params = $params;
         }
         

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -129,6 +129,10 @@ class Statement implements \IteratorAggregate, DriverStatement
      */
     public function execute($params = null)
     {
+        if(is_array($params)) {
+            $this->params = $params;
+        }
+        
         $logger = $this->conn->getConfiguration()->getSQLLogger();
         if ($logger) {
             $logger->startQuery($this->sql, $this->params, $this->types);

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Doctrine\Tests\DBAL;
+
+require_once __DIR__ . '/../TestInit.php';
+
+use Doctrine\DBAL\Statement;
+//use Doctrine\Common\EventManager;
+//use Doctrine\DBAL\Configuration;
+//use Doctrine\DBAL\Events;
+
+class StatementTest extends \Doctrine\Tests\DbalTestCase
+{
+    /**
+     *
+     * @var \Doctrine\DBAL\Connection 
+     */
+    private $conn;
+    
+    /**
+     *
+     * @var \Doctrine\DBAL\Configuration 
+     */
+    private $configuration;
+    
+    public function setUp()
+    {
+        $pdoStatement = $this->getMock('\PDOStatment', array('execute', 'bindParam', 'bindValue'));
+        $platform = new \Doctrine\Tests\DBAL\Mocks\MockPlatform();
+        $driverConnection = $this->getMock('\Doctrine\DBAL\Driver\Connection');
+        $driverConnection->expects($this->any())
+                ->method('prepare')
+                ->will($this->returnValue($pdoStatement));
+        
+        $driver = $this->getMock('\Doctrine\DBAL\Driver');
+        $constructorArgs = array(
+            array(
+                'platform' => $platform
+            ),
+            $driver
+        );
+        $this->conn = $this->getMock('\Doctrine\DBAL\Connection', array(), $constructorArgs);
+        $this->conn->expects($this->atLeastOnce())
+                ->method('getWrappedConnection')
+                ->will($this->returnValue($driverConnection));
+        
+        $this->configuration = $this->getMock('\Doctrine\DBAL\Configuration');
+        $this->conn->expects($this->any())
+                ->method('getConfiguration')
+                ->will($this->returnValue($this->configuration));
+    }
+    
+    public function testExecuteCallsLoggerStartQueryWithParametersWhenValuesBound()
+    {
+        $name = 'foo';
+        $var = 'bar';
+        $type = \PDO::PARAM_STR;
+        $values = array($name => $var);
+        $types = array($name => $type);
+        $sql = '';
+        
+        $logger = $this->getMock('\Doctrine\DBAL\Logging\SQLLogger');
+        $logger->expects($this->once())
+                ->method('startQuery')
+                ->with($this->equalTo($sql), $this->equalTo($values), $this->equalTo($types));
+        
+        $this->configuration->expects($this->once())
+                ->method('getSQLLogger')
+                ->will($this->returnValue($logger));
+        
+        $statement = new Statement('', $this->conn);
+        $statement->bindValue($name, $var, $type);
+        $statement->execute();
+    }
+    
+    public function testExecuteCallsLoggerStartQueryWithParametersWhenParamsPassedToExecute()
+    {
+        $name = 'foo';
+        $var = 'bar';
+        $values = array($name => $var);
+        $types = array();
+        $sql = '';
+        
+        $logger = $this->getMock('\Doctrine\DBAL\Logging\SQLLogger');
+        $logger->expects($this->once())
+                ->method('startQuery')
+                ->with($this->equalTo($sql), $this->equalTo($values), $this->equalTo($types));
+        
+        $this->configuration->expects($this->once())
+                ->method('getSQLLogger')
+                ->will($this->returnValue($logger));
+        
+        $statement = new Statement('', $this->conn);
+        $statement->execute($values);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -63,7 +63,7 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
                 ->method('getSQLLogger')
                 ->will($this->returnValue($logger));
         
-        $statement = new Statement('', $this->conn);
+        $statement = new Statement($sql, $this->conn);
         $statement->bindValue($name, $var, $type);
         $statement->execute();
     }
@@ -85,7 +85,7 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
                 ->method('getSQLLogger')
                 ->will($this->returnValue($logger));
         
-        $statement = new Statement('', $this->conn);
+        $statement = new Statement($sql, $this->conn);
         $statement->execute($values);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -2,12 +2,7 @@
 
 namespace Doctrine\Tests\DBAL;
 
-require_once __DIR__ . '/../TestInit.php';
-
 use Doctrine\DBAL\Statement;
-//use Doctrine\Common\EventManager;
-//use Doctrine\DBAL\Configuration;
-//use Doctrine\DBAL\Events;
 
 class StatementTest extends \Doctrine\Tests\DbalTestCase
 {


### PR DESCRIPTION
When parameters are passed to Doctrine\DBAL\Statement::execute, they are not passed to any enabled logger(s).
