### PR TITLE
Delete always content from table master_slave_table between tests.

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -27,9 +27,12 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
             $sm = $this->_conn->getSchemaManager();
             $sm->createTable($table);
 
-            $this->_conn->insert('master_slave_table', array('test_int' => 1));
+
         } catch(\Exception $e) {
         }
+
+        $this->_conn->executeUpdate('DELETE FROM master_slave_table');
+        $this->_conn->insert('master_slave_table', array('test_int' => 1));
     }
 
     public function createMasterSlaveConnection($keepSlave = false)


### PR DESCRIPTION
Fixes that we are currently failing master slave tests.
