### PR TITLE
Set minimum PHP version to 5.3.6

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -74,7 +74,7 @@
             <stability release="${pear.stability}" api="${pear.stability}" />
             <notes>-</notes>
             <dependencies>
-                <php minimum_version="5.3.2" />
+                <php minimum_version="5.3.6" />
                 <pear minimum_version="1.6.0" recommended_version="1.6.1" />
                 <package name="DoctrineCommon" channel="pear.doctrine-project.org" minimum_version="${dependencies.common}" />
                 <package name="Console" channel="pear.symfony.com" minimum_version="${dependencies.sfconsole}" />

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.3.6",
         "doctrine/common": ">=2.3-dev,<2.5-dev"
     },
     "autoload": {


### PR DESCRIPTION
Since ->setCharset() has been removed, minimum PHP version has to be raised to 5.3.6: the new way of doing charset, throught the DSN, works only after bug https://bugs.php.net/bug.php?id=47802 has been fixed.
