### PR TITLE
Optimize autoload prefix in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "doctrine/common": ">=2.3-dev,<2.5-dev"
     },
     "autoload": {
-        "psr-0": { "Doctrine\\DBAL": "lib/" }
+        "psr-0": { "Doctrine\\DBAL\\": "lib/" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
By having more specific autoload prefixes it is possible to reduce the number of stat calls made.
