### PR TITLE
Fix dropping foreign key multiple times with test

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -24,7 +24,7 @@ namespace Doctrine\DBAL\Schema;
  *
  * @copyright Copyright (C) 2005-2009 eZ Systems AS. All rights reserved.
  * @license http://ez.no/licenses/new_bsd New BSD License
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @version $Revision$
@@ -95,6 +95,16 @@ class Comparator
         foreach ($diff->removedTables as $tableName => $table) {
             if (isset($foreignKeysToTable[$tableName])) {
                 $diff->orphanedForeignKeys = array_merge($diff->orphanedForeignKeys, $foreignKeysToTable[$tableName]);
+
+                // deleting duplicated foreign keys present on both on the orphanedForeignKey
+                // and the removedForeignKeys from changedTables
+                foreach ($foreignKeysToTable[$tableName] as $foreignKey) {
+                    if (isset($diff->changedTables[$foreignKey->getLocalTableName()])) {
+                        foreach ($diff->changedTables[$foreignKey->getLocalTableName()]->removedForeignKeys as $key => $removedForeignKey) {
+                            unset($diff->changedTables[$foreignKey->getLocalTableName()]->removedForeignKeys[$key]);
+                        }
+                    }
+                }
             }
         }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -781,6 +781,51 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $diff->removedSequences);
     }
 
+
+    /**
+     * You can get multiple drops for a FK when 
+     */
+    public function testAvoidMultipleDropForeignKey()
+    {
+        $oldSchema = new Schema();
+
+        $tableForeign = $oldSchema->createTable('foreign');
+        $tableForeign->addColumn('id', 'integer');
+
+        $table = $oldSchema->createTable('foo');
+        $table->addColumn('fk', 'integer');
+        $table->addForeignKeyConstraint($tableForeign, array('fk'), array('id'));
+
+
+        $newSchema = new Schema();
+        $table = $newSchema->createTable('foo');
+
+        $c = new Comparator();
+        $diff = $c->compare($oldSchema, $newSchema);
+
+        $this->assertCount(0, $diff->changedTables['foo']->removedForeignKeys);
+
+/*        $tableForeign = new Table("bar");
+        $tableForeign->addColumn('id', 'integer');
+
+        $table1 = new Table("foo");
+        $table1->addColumn('fk', 'integer');
+
+        $table2 = new Table("foo");
+        $table2->addColumn('fk', 'integer');
+        $table2->addForeignKeyConstraint($tableForeign, array('fk'), array('id'));
+
+        $c = new Comparator();
+        $tableDiff = $c->diffTable($table1, $table2);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Schema\TableDiff', $tableDiff);
+        $this->assertEquals(1, count($tableDiff->addedForeignKeys));
+    */
+
+
+    }
+
+
     /**
      * @param SchemaDiff $diff
      * @param int $newTableCount


### PR DESCRIPTION
In some cases the Comparator class returns multiple drops for the same foreign key.
Specifically, in case you have two tables, A & B, with A having a foreign key FK
referencing B, if you drop table B, the resulting diff shows this FK twice,
once on the diff->orphanedForeignKeys array as we're deleting B, and another on
the diff->changedTables array as table A is also being modified. As a result of this you 
get the DROP FOREIGN KEY instruction twice in the final SQL.

I'm not really sure if this change should be done in the Comparator clas or if it's better to 
receive the full diff, even with duplicated drops for FK and later, when generating the final 
SQL, drop the unnecessary ones
