### PR TITLE
Fix dropping foreign key multiple times with test

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -24,7 +24,7 @@ namespace Doctrine\DBAL\Schema;
  *
  * @copyright Copyright (C) 2005-2009 eZ Systems AS. All rights reserved.
  * @license http://ez.no/licenses/new_bsd New BSD License
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @version $Revision$
@@ -46,7 +46,7 @@ class Comparator
     /**
      * Returns a SchemaDiff object containing the differences between the schemas $fromSchema and $toSchema.
      *
-     * The returned differences are returned in such a way that they contain the
+     * The returned diferences are returned in such a way that they contain the
      * operations to change the schema stored in $fromSchema to the schema that is
      * stored in $toSchema.
      *
@@ -95,6 +95,16 @@ class Comparator
         foreach ($diff->removedTables as $tableName => $table) {
             if (isset($foreignKeysToTable[$tableName])) {
                 $diff->orphanedForeignKeys = array_merge($diff->orphanedForeignKeys, $foreignKeysToTable[$tableName]);
+
+                // deleting duplicated foreign keys present on both on the orphanedForeignKey
+                // and the removedForeignKeys from changedTables
+                foreach ($foreignKeysToTable[$tableName] as $foreignKey) {
+                    if (isset($diff->changedTables[$foreignKey->getLocalTableName()])) {
+                        foreach ($diff->changedTables[$foreignKey->getLocalTableName()]->removedForeignKeys as $key => $removedForeignKey) {
+                            unset($diff->changedTables[$foreignKey->getLocalTableName()]->removedForeignKeys[$key]);
+                        }
+                    }
+                }
             }
         }
 
@@ -262,7 +272,7 @@ class Comparator
 
     /**
      * Try to find columns that only changed their name, rename operations maybe cheaper than add/drop
-     * however ambiguities between different possibilities should not lead to renaming at all.
+     * however ambiguouties between different possibilites should not lead to renaming at all.
      *
      * @param TableDiff $tableDifferences
      */

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -46,7 +46,7 @@ class Comparator
     /**
      * Returns a SchemaDiff object containing the differences between the schemas $fromSchema and $toSchema.
      *
-     * The returned diferences are returned in such a way that they contain the
+     * The returned differences are returned in such a way that they contain the
      * operations to change the schema stored in $fromSchema to the schema that is
      * stored in $toSchema.
      *
@@ -272,7 +272,7 @@ class Comparator
 
     /**
      * Try to find columns that only changed their name, rename operations maybe cheaper than add/drop
-     * however ambiguouties between different possibilites should not lead to renaming at all.
+     * however ambiguities between different possibilities should not lead to renaming at all.
      *
      * @param TableDiff $tableDifferences
      */

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -99,9 +99,11 @@ class Comparator
                 // deleting duplicated foreign keys present on both on the orphanedForeignKey
                 // and the removedForeignKeys from changedTables
                 foreach ($foreignKeysToTable[$tableName] as $foreignKey) {
-                    if (isset($diff->changedTables[$foreignKey->getLocalTableName()])) {
-                        foreach ($diff->changedTables[$foreignKey->getLocalTableName()]->removedForeignKeys as $key => $removedForeignKey) {
-                            unset($diff->changedTables[$foreignKey->getLocalTableName()]->removedForeignKeys[$key]);
+                    // strtolower the table name to make if compatible with getShortestName
+                    $localTableName = strtolower($foreignKey->getLocalTableName());
+                    if (isset($diff->changedTables[$localTableName])) {
+                        foreach ($diff->changedTables[$localTableName]->removedForeignKeys as $key => $removedForeignKey) {
+                            unset($diff->changedTables[$localTableName]->removedForeignKeys[$key]);
                         }
                     }
                 }

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -781,6 +781,32 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $diff->removedSequences);
     }
 
+
+    /**
+     * You can get multiple drops for a FK when 
+     */
+    public function testAvoidMultipleDropForeignKey()
+    {
+        $oldSchema = new Schema();
+
+        $tableForeign = $oldSchema->createTable('foreign');
+        $tableForeign->addColumn('id', 'integer');
+
+        $table = $oldSchema->createTable('foo');
+        $table->addColumn('fk', 'integer');
+        $table->addForeignKeyConstraint($tableForeign, array('fk'), array('id'));
+
+
+        $newSchema = new Schema();
+        $table = $newSchema->createTable('foo');
+
+        $c = new Comparator();
+        $diff = $c->compare($oldSchema, $newSchema);
+
+        $this->assertCount(0, $diff->changedTables['foo']->removedForeignKeys);
+    }
+
+
     /**
      * @param SchemaDiff $diff
      * @param int $newTableCount

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -783,7 +783,10 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
 
 
     /**
-     * You can get multiple drops for a FK when 
+     * You can get multiple drops for a FK when a table referenced by a foreign
+     * key is deleted, as this FK is referenced twice, once on the orphanedForeignKeys
+     * array because of the dropped table, and once on changedTables array. We
+     * now check that the key is present once.
      */
     public function testAvoidMultipleDropForeignKey()
     {
@@ -804,6 +807,7 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
         $diff = $c->compare($oldSchema, $newSchema);
 
         $this->assertCount(0, $diff->changedTables['foo']->removedForeignKeys);
+        $this->assertCount(1, $diff->orphanedForeignKeys);
     }
 
 


### PR DESCRIPTION
In some cases the Comparator class returns multiple drops for the same foreign key.
Specifically, in case you have two tables, A & B, with A having a foreign key FK
referencing B, if you drop table B, the resulting diff shows this FK twice,
once on the diff->orphanedForeignKeys array as we're deleting B, and another on
the diff->changedTables array as table A is also being modified. As a result of this you
get the DROP FOREIGN KEY instruction twice in the final SQL.
