### PR TITLE
fixed bug on schema comparator, prevent multiple rename candidates for a single original field

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -282,7 +282,6 @@ class Comparator
                 list($removedColumn, $addedColumn) = $candidateColumns[0];
                 $removedColumnName = strtolower($removedColumn->getName());
                 $addedColumnName = strtolower($addedColumn->getName());
-                
                 if ( ! isset($tableDifferences->renamedColumns[$removedColumnName])) {
                     $tableDifferences->renamedColumns[$removedColumnName] = $addedColumn;
                     unset($tableDifferences->addedColumns[$addedColumnName]);

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -282,6 +282,7 @@ class Comparator
                 list($removedColumn, $addedColumn) = $candidateColumns[0];
                 $removedColumnName = strtolower($removedColumn->getName());
                 $addedColumnName = strtolower($addedColumn->getName());
+
                 if ( ! isset($tableDifferences->renamedColumns[$removedColumnName])) {
                     $tableDifferences->renamedColumns[$removedColumnName] = $addedColumn;
                     unset($tableDifferences->addedColumns[$addedColumnName]);

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -282,10 +282,13 @@ class Comparator
                 list($removedColumn, $addedColumn) = $candidateColumns[0];
                 $removedColumnName = strtolower($removedColumn->getName());
                 $addedColumnName = strtolower($addedColumn->getName());
-
-                $tableDifferences->renamedColumns[$removedColumnName] = $addedColumn;
-                unset($tableDifferences->addedColumns[$addedColumnName]);
-                unset($tableDifferences->removedColumns[$removedColumnName]);
+                
+                if (!isset($tableDifferences->renamedColumns[$removedColumnName]))
+                {
+                    $tableDifferences->renamedColumns[$removedColumnName] = $addedColumn;
+                    unset($tableDifferences->addedColumns[$addedColumnName]);
+                    unset($tableDifferences->removedColumns[$removedColumnName]);
+                }
             }
         }
     }

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -283,8 +283,7 @@ class Comparator
                 $removedColumnName = strtolower($removedColumn->getName());
                 $addedColumnName = strtolower($addedColumn->getName());
                 
-                if (!isset($tableDifferences->renamedColumns[$removedColumnName]))
-                {
+                if ( ! isset($tableDifferences->renamedColumns[$removedColumnName])) {
                     $tableDifferences->renamedColumns[$removedColumnName] = $addedColumn;
                     unset($tableDifferences->addedColumns[$addedColumnName]);
                     unset($tableDifferences->removedColumns[$removedColumnName]);

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -229,7 +229,7 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $tableDiff->removedColumns, "Nothing should be removed.");
         $this->assertCount(0, $tableDiff->changedColumns, "Nothing should be changed as all fields old & new have diff names.");
     }
-    
+
     public function testCompareRemovedIndex()
     {
         $schema1 = new Schema( array(

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -210,6 +210,26 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $c->diffColumn($column1, $column1));
     }
 
+    public function testCompareChangeColumns_MultipleNewColumnsRename()
+    {
+        $tableA = new Table("foo");
+        $tableA->addColumn('datefield1', 'datetime');
+
+        $tableB = new Table("foo");
+        $tableB->addColumn('new_datefield1', 'datetime');
+        $tableB->addColumn('new_datefield2', 'datetime');
+
+        $c = new Comparator();
+        $tableDiff = $c->diffTable($tableA, $tableB);
+
+        $this->assertEquals(1, count($tableDiff->renamedColumns), "we should have one rename datefield1 => new_datefield1.");
+        $this->assertArrayHasKey('datefield1', $tableDiff->renamedColumns, "'datefield1' should be set to be renamed to new_datefield1");
+        $this->assertEquals(1, count($tableDiff->addedColumns), "'new_datefield2' should be added");
+        $this->assertArrayHasKey('new_datefield2', $tableDiff->addedColumns, "'new_datefield2' should be added, not created through renaming!");
+        $this->assertEquals(0, count($tableDiff->removedColumns), "Nothing should be removed.");
+        $this->assertEquals(0, count($tableDiff->changedColumns), "Nothing should be changed as all fields old & new have diff names.");
+    }
+    
     public function testCompareRemovedIndex()
     {
         $schema1 = new Schema( array(

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -222,12 +222,12 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
         $c = new Comparator();
         $tableDiff = $c->diffTable($tableA, $tableB);
 
-        $this->assertEquals(1, count($tableDiff->renamedColumns), "we should have one rename datefield1 => new_datefield1.");
+        $this->assertCount(1, $tableDiff->renamedColumns, "we should have one rename datefield1 => new_datefield1.");
         $this->assertArrayHasKey('datefield1', $tableDiff->renamedColumns, "'datefield1' should be set to be renamed to new_datefield1");
-        $this->assertEquals(1, count($tableDiff->addedColumns), "'new_datefield2' should be added");
+        $this->assertCount(1, $tableDiff->addedColumns, "'new_datefield2' should be added");
         $this->assertArrayHasKey('new_datefield2', $tableDiff->addedColumns, "'new_datefield2' should be added, not created through renaming!");
-        $this->assertEquals(0, count($tableDiff->removedColumns), "Nothing should be removed.");
-        $this->assertEquals(0, count($tableDiff->changedColumns), "Nothing should be changed as all fields old & new have diff names.");
+        $this->assertCount(0, $tableDiff->removedColumns, "Nothing should be removed.");
+        $this->assertCount(0, $tableDiff->changedColumns, "Nothing should be changed as all fields old & new have diff names.");
     }
     
     public function testCompareRemovedIndex()


### PR DESCRIPTION
Starting with the following Entity

```
/**
 * @Table(name="user")
 * @Entity
 */
class User
{
    /**
     * @var integer $id
     * @Column(name="id", type="integer", length=4)
     * @Id
     * @GeneratedValue(strategy="IDENTITY")
     */
    private $id;

    /**
     * @var \DateTime $date_alerted_email
     * @Column(name="date_alerted", type="datetime", nullable=true)
     */
    private $date_alerted;
}
```

Upon  making the following alterations (remove date_alerted, and add two additional columns of the same type but different names):

```
/**
 * @Table(name="user")
 * @Entity
 */
class User
{
    /**
     * @var integer $id
     * @Column(name="id", type="integer", length=4)
     * @Id
     * @GeneratedValue(strategy="IDENTITY")
     */
    private $id;

    /**
     * @var \DateTime $date_alerted_email
     * @Column(name="date_alerted_email", type="datetime", nullable=true)
     */
    private $date_alerted_email;

    /**
     * @var \DateTime $date_alerted_js
     * @Column(name="date_alerted_js", type="datetime", nullable=true)
     */
    private $date_alerted_js;
}
```

The doctrine cli schema tool used to run the update (dump sql) produces the following result:

```
ALTER TABLE user CHANGE date_alerted date_alerted_js DATETIME DEFAULT NULL
```

Expected result:

```
ALTER TABLE message ADD date_alerted_js DATETIME DEFAULT NULL, CHANGE date_alerted date_alerted_email DATETIME DEFAULT NULL
```
## What went wrong

Upon running diffTable($from, $to) in \Doctrine\DBAL\Schema\Comparator.php line 69 both new columns are added to the "addedColumns" array, and the one removed column is correctly present in the removedColumns array.

The first iteration on detectColumnRenamings (line 272) puts the two NEW columns up as rename candidates as expected, however they share the original field name. 

When iterating over the rename candidates no further checks are done and these entries are added to the renamedColumns array. The last overwrites the original as they share the same array key and the original gets ignored. 

My change checks the renamedColumns array for the existence of the old column name. It only becomes a rename candidate if the original field hasn't already used previously. Otherwise it remains in the addedColumns array.

In the example above these changes will produce 1 change column and 1 add column as expected.
