### PR TITLE
The "bindParam" method of OCI8Statement is not using the "length" parameter

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -112,7 +112,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function bindParam($column, &$variable, $type = null,$length = null)
+    public function bindParam($column, &$variable, $type = null, $length = null)
     {
         $column = isset($this->_paramMap[$column]) ? $this->_paramMap[$column] : $column;
 
@@ -122,7 +122,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
 
             return oci_bind_by_name($this->_sth, $column, $lob, -1, OCI_B_BLOB);
         } else {
-            return oci_bind_by_name($this->_sth, $column, $variable);
+            return oci_bind_by_name($this->_sth, $column, $variable, $length);
         }
     }
 


### PR DESCRIPTION
I've fixed the `OCI8Statement::bindParam` method in order to pass the "length" parameter when the type is not a LOB

https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php#L112

As noted on the description of the function on the PHP manual (for the IN binds), this is leading to a truncation of the values to the size of the PHP variable.

http://www.php.net/manual/en/function.oci-bind-by-name.php 
