### PR TITLE
Fix storage of binary data for array and object types

### DIFF
--- a/lib/Doctrine/DBAL/Types/ArrayType.php
+++ b/lib/Doctrine/DBAL/Types/ArrayType.php
@@ -45,12 +45,11 @@ class ArrayType extends Type
         }
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
-        // check for plain vs base64 encoded serialized data
-        if (strpos($value, 'a:') === 0 ||strpos($value, 'b:') === 0) {
-            $val = unserialize($value);
-        } else {
-            $val = unserialize(base64_decode($value));
+        // check for base64 encoded serialized data
+        if (strpos($value, ':') !== 1) {
+            $value = base64_decode($value);
         }
+        $val = unserialize($value);
         if ($val === false && $value != 'b:0;') {
             throw ConversionException::conversionFailed($value, $this->getName());
         }

--- a/lib/Doctrine/DBAL/Types/ArrayType.php
+++ b/lib/Doctrine/DBAL/Types/ArrayType.php
@@ -35,7 +35,7 @@ class ArrayType extends Type
 
     public function convertToDatabaseValue($value, \Doctrine\DBAL\Platforms\AbstractPlatform $platform)
     {
-        return serialize($value);
+        return base64_encode(serialize($value));
     }
 
     public function convertToPHPValue($value, \Doctrine\DBAL\Platforms\AbstractPlatform $platform)
@@ -45,7 +45,12 @@ class ArrayType extends Type
         }
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
-        $val = unserialize($value);
+        // check for plain vs base64 encoded serialized data
+        if (strpos($value, 'a:') === 0 ||strpos($value, 'b:') === 0) {
+            $val = unserialize($value);
+        } else {
+            $val = unserialize(base64_decode($value));
+        }
         if ($val === false && $value != 'b:0;') {
             throw ConversionException::conversionFailed($value, $this->getName());
         }

--- a/lib/Doctrine/DBAL/Types/ArrayType.php
+++ b/lib/Doctrine/DBAL/Types/ArrayType.php
@@ -46,7 +46,7 @@ class ArrayType extends Type
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
         // check for base64 encoded serialized data
-        if (strpos($value, ':') !== 1) {
+        if (strpos($value, ':') !== 1 && strpos($value, ';') !== 1) {
             $value = base64_decode($value);
         }
         $val = unserialize($value);

--- a/lib/Doctrine/DBAL/Types/ObjectType.php
+++ b/lib/Doctrine/DBAL/Types/ObjectType.php
@@ -46,7 +46,7 @@ class ObjectType extends Type
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
         // check for base64 encoded serialized data
-        if (strpos($value, ':') !== 1) {
+        if (strpos($value, ':') !== 1 && strpos($value, ';') !== 1) {
             $value = base64_decode($value);
         }
         $val = unserialize($value);

--- a/lib/Doctrine/DBAL/Types/ObjectType.php
+++ b/lib/Doctrine/DBAL/Types/ObjectType.php
@@ -35,7 +35,7 @@ class ObjectType extends Type
 
     public function convertToDatabaseValue($value, \Doctrine\DBAL\Platforms\AbstractPlatform $platform)
     {
-        return serialize($value);
+        return base64_encode(serialize($value));
     }
 
     public function convertToPHPValue($value, \Doctrine\DBAL\Platforms\AbstractPlatform $platform)
@@ -45,7 +45,12 @@ class ObjectType extends Type
         }
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
-        $val = unserialize($value);
+        // check for plain vs base64 encoded serialized data
+        if (strpos($value, 'O:') === 0 || strpos($value, 'b:') === 0) {
+            $val = unserialize($value);
+        } else {
+            $val = unserialize(base64_decode($value));
+        }
         if ($val === false && $value !== 'b:0;') {
             throw ConversionException::conversionFailed($value, $this->getName());
         }

--- a/lib/Doctrine/DBAL/Types/ObjectType.php
+++ b/lib/Doctrine/DBAL/Types/ObjectType.php
@@ -45,12 +45,11 @@ class ObjectType extends Type
         }
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
-        // check for plain vs base64 encoded serialized data
-        if (strpos($value, 'O:') === 0 || strpos($value, 'b:') === 0) {
-            $val = unserialize($value);
-        } else {
-            $val = unserialize(base64_decode($value));
+        // check for base64 encoded serialized data
+        if (strpos($value, ':') !== 1) {
+            $value = base64_decode($value);
         }
+        $val = unserialize($value);
         if ($val === false && $value !== 'b:0;') {
             throw ConversionException::conversionFailed($value, $this->getName());
         }

--- a/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
@@ -53,9 +53,19 @@ class ArrayTest extends \Doctrine\Tests\DbalTestCase
         $this->_type->convertToPHPValue('abcdefg', $this->_platform);
     }
 
-    public function testNullConversion()
+    public function testPlainNullConversion()
     {
         $this->assertNull($this->_type->convertToPHPValue(null, $this->_platform));
+    }
+
+    public function testNullConversion()
+    {
+        $this->assertNull($this->_type->convertToPHPValue(serialize(null), $this->_platform));
+    }
+
+    public function testNullConversionForBase64()
+    {
+        $this->assertNull($this->_type->convertToPHPValue(base64_encode(serialize(null)), $this->_platform));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
@@ -39,6 +39,13 @@ class ArrayTest extends \Doctrine\Tests\DbalTestCase
         );
     }
 
+    public function testArrayConvertsBase64ToPHPValue()
+    {
+        $this->assertTrue(
+            is_array($this->_type->convertToPHPValue(base64_encode(serialize(array())), $this->_platform))
+        );
+    }
+
     public function testConversionFailure()
     {
         error_reporting( (E_ALL | E_STRICT) - \E_NOTICE );

--- a/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
@@ -65,4 +65,12 @@ class ArrayTest extends \Doctrine\Tests\DbalTestCase
     {
         $this->assertFalse($this->_type->convertToPHPValue(serialize(false), $this->_platform));
     }
+
+    /**
+     * @group DBAL-73
+     */
+    public function testFalseConversionForBase64()
+    {
+        $this->assertFalse($this->_type->convertToPHPValue(base64_encode(serialize(false)), $this->_platform));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
@@ -58,4 +58,12 @@ class ObjectTest extends \Doctrine\Tests\DbalTestCase
     {
         $this->assertFalse($this->_type->convertToPHPValue(serialize(false), $this->_platform));
     }
+
+    /**
+     * @group DBAL-73
+     */
+    public function testFalseConversionForBase64()
+    {
+        $this->assertFalse($this->_type->convertToPHPValue(base64_encode(serialize(false)), $this->_platform));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
@@ -46,9 +46,19 @@ class ObjectTest extends \Doctrine\Tests\DbalTestCase
         $this->_type->convertToPHPValue('abcdefg', $this->_platform);
     }
 
-    public function testNullConversion()
+    public function testPlainNullConversion()
     {
         $this->assertNull($this->_type->convertToPHPValue(null, $this->_platform));
+    }
+
+    public function testNullConversion()
+    {
+        $this->assertNull($this->_type->convertToPHPValue(serialize(null), $this->_platform));
+    }
+
+    public function testNullConversionForBase64()
+    {
+        $this->assertNull($this->_type->convertToPHPValue(base64_encode(serialize(null)), $this->_platform));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
@@ -34,6 +34,11 @@ class ObjectTest extends \Doctrine\Tests\DbalTestCase
         $this->assertInternalType('object', $this->_type->convertToPHPValue(serialize(new \stdClass), $this->_platform));
     }
 
+    public function testObjectConvertsBase64ToPHPValue()
+    {
+        $this->assertInternalType('object', $this->_type->convertToPHPValue(base64_encode(serialize(new \stdClass)), $this->_platform));
+    }
+
     public function testConversionFailure()
     {
         error_reporting( (E_ALL | E_STRICT) - \E_NOTICE );


### PR DESCRIPTION
serialize() returns binary data (NUL bytes) and not all platforms
handle that in CLOB fields (e.g. PostgreSQL).

This change uses base64 encoding to work around that, and transparently
reads (old) non-base64 data as well.

Fixes DBAL-368
