### PR TITLE
Escape primary field name in create table sql query

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1212,6 +1212,8 @@ abstract class AbstractPlatform
             $columnData['comment'] = $this->getColumnComment($column);
 
             if (in_array($column->getName(), $options['primary'])) {
+                $key = array_search($column->getName(), $options['primary']);
+                $options['primary'][$key] = $column->getQuotedName($this);
                 $columnData['primary'] = true;
             }
 


### PR DESCRIPTION
Fixes primary fields name in CreateTableSQL for Abstract Platform
