### PR TITLE
Fix SQLServerPlatform adds unique constraint to ADD PRIMARY KEY statement

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -256,7 +256,7 @@ class SQLServerPlatform extends AbstractPlatform
     {
         $constraint = parent::getCreateIndexSQL($index, $table);
 
-        if ($index->isUnique()) {
+        if ($index->isUnique() && $index->isPrimary() === false) {
             $constraint = $this->_appendUniqueConstraintDefinition($constraint, $index);
         }
 

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -256,7 +256,7 @@ class SQLServerPlatform extends AbstractPlatform
     {
         $constraint = parent::getCreateIndexSQL($index, $table);
 
-        if ($index->isUnique() && $index->isPrimary() === false) {
+        if ($index->isUnique() && !$index->isPrimary()) {
             $constraint = $this->_appendUniqueConstraintDefinition($constraint, $index);
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -221,4 +221,10 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         $idx->addFlag('nonclustered');
         $this->assertEquals('ALTER TABLE tbl ADD PRIMARY KEY NONCLUSTERED (id)', $this->_platform->getCreatePrimaryKeySQL($idx, 'tbl'));
     }
+
+    public function testAlterAddPrimaryKey()
+    {
+        $idx = new \Doctrine\DBAL\Schema\Index('idx', array('id'), false, true);
+        $this->assertEquals('ALTER TABLE tbl ADD PRIMARY KEY (id)', $this->_platform->getCreateIndexSQL($idx, 'tbl'));
+    }
 }


### PR DESCRIPTION
Currently when executing an ALTER TABLE statement with SQL Server, the query will be:

`ALTER TABLE foo ADD PRIMARY KEY (id) WHERE id IS NOT NULL`

should be

`ALTER TABLE foo ADD PRIMARY KEY (id)`

This will happen when adding primary keys via ALTER TABLE.
