### PR TITLE
Fix for decimal fields with precision.

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -163,6 +163,9 @@ class SqliteSchemaManager extends AbstractSchemaManager
             case 'decimal':
             case 'numeric':
                 if (isset($tableColumn['length'])) {
+                    if (strpos($tableColumn['length'], ',') === false) {
+                        $tableColumn['length'] .= ",0";
+                    }                    
                     list($precision, $scale) = array_map('trim', explode(',', $tableColumn['length']));
                 }
                 $length = null;

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -163,7 +163,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
             case 'decimal':
             case 'numeric':
                 if (isset($tableColumn['length'])) {
-                    list($precision, $scale) = array_map('trim', explode(', ', $tableColumn['length']));
+                    list($precision, $scale) = array_map('trim', explode(',', $tableColumn['length']));
                 }
                 $length = null;
                 break;


### PR DESCRIPTION
These fields have no spaces in the length, so the 'explode' fails. Omit the space from the code, and it works. Even if there _were_ a space, it would still work, because of the `array_map("trim", ..)`.

```
arr(7) 
[
    "cid"        => str(2) "11"
    "name"       => str(6) "nummer"
    "type"       => str(7) "DECIMAL"
    "notnull"    => str(1) "1"
    "dflt_value" => str(1) "0"
    "pk"         => str(1) "0"
    "length"     => str(4) "18,9"
]
```
