### PR TITLE
MySql TEXT and BLOB type declarations

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -718,10 +718,34 @@ class MySqlPlatform extends AbstractPlatform
     }
 
     /**
-     * {@inheritDoc}
+     * Gets the SQL Snippet used to declare a BLOB column type.
+     *     TINYBLOB   : 2 ^  8 - 1 = 255
+     *     BLOB       : 2 ^ 16 - 1 = 65535
+     *     MEDIUMBLOB : 2 ^ 24 - 1 = 16777215
+     *     LONGBLOB   : 2 ^ 32 - 1 = 4294967295
+     *
+     * @param array $field
+     *
+     * @return string
      */
     public function getBlobTypeDeclarationSQL(array $field)
     {
+        if ( ! empty($field['length']) && is_numeric($field['length'])) {
+            $length = $field['length'];
+
+            if ($length <= 255) {
+                return 'TINYBLOB';
+            }
+
+            if ($length <= 65535) {
+                return 'BLOB';
+            }
+
+            if ($length <= 16777215) {
+                return 'MEDIUMBLOB';
+            }
+        }
+
         return 'LONGBLOB';
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -193,17 +193,26 @@ class MySqlPlatform extends AbstractPlatform
     }
 
     /**
-     * {@inheritDoc}
+     * Gets the SQL snippet used to declare a CLOB column type.
+     *     TINYTEXT   : 2 ^  8 - 1 = 255
+     *     TEXT       : 2 ^ 16 - 1 = 65535
+     *     MEDIUMTEXT : 2 ^ 24 - 1 = 16777215
+     *     LONGTEXT   : 2 ^ 32 - 1 = 4294967295
+     *
+     * @param array $field
+     *
+     * @return string
      */
     public function getClobTypeDeclarationSQL(array $field)
     {
         if ( ! empty($field['length']) && is_numeric($field['length'])) {
             $length = $field['length'];
+
             if ($length <= 255) {
                 return 'TINYTEXT';
             }
 
-            if ($length <= 65532) {
+            if ($length <= 65535) {
                 return 'TEXT';
             }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -9,8 +9,6 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Index;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class MySqlPlatformTest extends AbstractPlatformTestCase
 {
     public function createPlatform()

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -9,6 +9,8 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Index;
 
+require_once __DIR__ . '/../../TestInit.php';
+
 class MySqlPlatformTest extends AbstractPlatformTestCase
 {
     public function createPlatform()
@@ -225,5 +227,29 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
         $diff = new TableDiff("test", array(), array(), array(), array($index), array(), array($unique));
         $sql = $this->_platform->getAlterTableSQL($diff);
         $this->assertEquals(array("ALTER TABLE test DROP INDEX uniq, ADD INDEX idx (col)"), $sql);
+    }
+
+    public function testClobTypeDeclarationSQL()
+    {
+        $this->assertEquals('TINYTEXT', $this->_platform->getClobTypeDeclarationSQL(array('length' => 1)));
+        $this->assertEquals('TINYTEXT', $this->_platform->getClobTypeDeclarationSQL(array('length' => 255)));
+        $this->assertEquals('TEXT', $this->_platform->getClobTypeDeclarationSQL(array('length' => 256)));
+        $this->assertEquals('TEXT', $this->_platform->getClobTypeDeclarationSQL(array('length' => 65535)));
+        $this->assertEquals('MEDIUMTEXT', $this->_platform->getClobTypeDeclarationSQL(array('length' => 65536)));
+        $this->assertEquals('MEDIUMTEXT', $this->_platform->getClobTypeDeclarationSQL(array('length' => 16777215)));
+        $this->assertEquals('LONGTEXT', $this->_platform->getClobTypeDeclarationSQL(array('length' => 16777216)));
+        $this->assertEquals('LONGTEXT', $this->_platform->getClobTypeDeclarationSQL(array()));
+    }
+
+    public function testBlobTypeDeclarationSQL()
+    {
+        $this->assertEquals('TINYBLOB', $this->_platform->getBlobTypeDeclarationSQL(array('length' => 1)));
+        $this->assertEquals('TINYBLOB', $this->_platform->getBlobTypeDeclarationSQL(array('length' => 255)));
+        $this->assertEquals('BLOB', $this->_platform->getBlobTypeDeclarationSQL(array('length' => 256)));
+        $this->assertEquals('BLOB', $this->_platform->getBlobTypeDeclarationSQL(array('length' => 65535)));
+        $this->assertEquals('MEDIUMBLOB', $this->_platform->getBlobTypeDeclarationSQL(array('length' => 65536)));
+        $this->assertEquals('MEDIUMBLOB', $this->_platform->getBlobTypeDeclarationSQL(array('length' => 16777215)));
+        $this->assertEquals('LONGBLOB', $this->_platform->getBlobTypeDeclarationSQL(array('length' => 16777216)));
+        $this->assertEquals('LONGBLOB', $this->_platform->getBlobTypeDeclarationSQL(array()));
     }
 }


### PR DESCRIPTION
Fixed maximum length of MySql TEXT type declaration, this should be 65535 (2 ^ 16 - 1) in stead of 65532.

Added support for TINYBLOB, BLOB, MEDIUMBLOB and LONGBLOB based on the length of the field, the same way as the clob type declarations are determined.

Added tests to prevent regression.
