### PR TITLE
Problem with sequence names, PostgreSQL and MixedCased schemas

### DIFF
--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -237,7 +237,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
             $sequenceName = $sequence['relname'];
         }
 
-        $data = $this->_conn->fetchAll('SELECT min_value, increment_by FROM ' . $sequenceName);
+        $data = $this->_conn->fetchAll('SELECT min_value, increment_by FROM ' . $this->_platform->quoteIdentifier($sequenceName));
         return new Sequence($sequenceName, $data[0]['increment_by'], $data[0]['min_value']);
     }
 


### PR DESCRIPTION
I''m having problems with a doctrine migration in a pgsql database that has a mixed case schema name.

After some investigation I've found the origin of the problem: when the schema manager is going to list sequences it executes a SQL statement to find the minimun sequence value.

This SQL statement is not quoting the sequence name, so the SQL fails with mixed cased schemas.

This trivial commit resolves this problem. I think it could be backported to stable versions of DBAL.
