### PR TITLE
convertToPHPValue should match convertToDatabaseValue

### DIFF
--- a/lib/Doctrine/DBAL/Types/BlobType.php
+++ b/lib/Doctrine/DBAL/Types/BlobType.php
@@ -52,7 +52,7 @@ class BlobType extends Type
         } else if ( ! is_resource($value)) {
             throw ConversionException::conversionFailed($value, self::BLOB);
         }
-        return $value;
+        return stream_get_contents($value);
     }
 
     public function getName()

--- a/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
@@ -77,7 +77,6 @@ class BlobTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $blobValue = Type::getType('blob')->convertToPHPValue($row['blobfield'], $this->_conn->getDatabasePlatform());
 
-        $this->assertInternalType('resource', $blobValue);
-        $this->assertEquals($text, stream_get_contents($blobValue));
+        $this->assertEquals($text, $blobValue);
     }
 }


### PR DESCRIPTION
convertToPHPValue return resource which is not match default convertToDatabaseValue that not make any change. Change to return content of the resource.
