### PR TITLE
DBAL-392 Moving entity relationship doesn't move foreign key in mysql table

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -317,6 +317,10 @@ class Comparator
             return true;
         }
 
+        if (strtolower($key1->getForeignTableName()) != strtolower($key2->getForeignTableName())) {
+            return true;
+        }
+
         if ($key1->onUpdate() != $key2->onUpdate()) {
             return true;
         }

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -486,6 +486,29 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($tableDiff->changedForeignKeys));
     }
 
+    public function testMovedForeignKeyForeignTable()
+    {
+        $tableForeign = new Table("bar");
+        $tableForeign->addColumn('id', 'integer');
+
+        $tableForeign2 = new Table("bar2");
+        $tableForeign2->addColumn('id', 'integer');
+
+        $table1 = new Table("foo");
+        $table1->addColumn('fk', 'integer');
+        $table1->addForeignKeyConstraint($tableForeign, array('fk'), array('id'));
+
+        $table2 = new Table("foo");
+        $table2->addColumn('fk', 'integer');
+        $table2->addForeignKeyConstraint($tableForeign2, array('fk'), array('id'));
+
+        $c = new Comparator();
+        $tableDiff = $c->diffTable($table1, $table2);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Schema\TableDiff', $tableDiff);
+        $this->assertEquals(1, count($tableDiff->changedForeignKeys));
+    }
+
     public function testTablesCaseInsensitive()
     {
         $schemaA = new Schema();


### PR DESCRIPTION
I've added a basic test and a possible fix for http://www.doctrine-project.org/jira/browse/DBAL-392

The problem is that changing only the foreign key's foreign table doesn't set the foreign key as changed
