### PR TITLE
DBAL-200 Missing docs for 1 parameter in Connection::update

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -489,7 +489,7 @@ class Connection implements DriverConnection
      * Executes an SQL UPDATE statement on a table.
      *
      * @param string $tableName The name of the table to update.
-     * @param array $data
+     * @param array $data An associative array containing column-value pairs.
      * @param array $identifier The update criteria. An associative array containing column-value pairs.
      * @param array $types Types of the merged $data and $identifier arrays in that order.
      * @return integer The number of affected rows.


### PR DESCRIPTION
Trivial addition of docs for 1 parameter that was missing in Connection::update. Resolves an open issue so figured it was worth a pull request.
