### PR TITLE
DBAL-398: Do not treat assignment operator as a parameter

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -54,7 +54,7 @@ class SQLParserUtils
         $stmtLen = strlen($statement);
         $paramMap = array();
         for ($i = 0; $i < $stmtLen; $i++) {
-            if ($statement[$i] == $match && !$inLiteral && (!$isPositional && $statement[$i+1] != '=')) {
+            if ($statement[$i] == $match && !$inLiteral && ($isPositional || $statement[$i+1] != '=')) {
                 // real positional parameter detected
                 if ($isPositional) {
                     $paramMap[$count] = $i;

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -54,7 +54,7 @@ class SQLParserUtils
         $stmtLen = strlen($statement);
         $paramMap = array();
         for ($i = 0; $i < $stmtLen; $i++) {
-            if ($statement[$i] == $match && !$inLiteral) {
+            if ($statement[$i] == $match && !$inLiteral && (!$isPositional && $statement[$i+1] != '=')) {
                 // real positional parameter detected
                 if ($isPositional) {
                     $paramMap[$count] = $i;

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -35,6 +35,8 @@ class SQLParserUtilsTest extends \Doctrine\Tests\DbalTestCase
             array('SELECT ":foo" FROM Foo WHERE bar IN (:name1, :name2)', false, array(37 => 'name1', 45 => 'name2')),
             array("SELECT ':foo' FROM Foo WHERE bar IN (:name1, :name2)", false, array(37 => 'name1', 45 => 'name2')),
             array('SELECT :foo_id', false, array(7 => 'foo_id')), // Ticket DBAL-231
+            array('SELECT @rank := 1', false, array()), // Ticket DBAL-398
+            array('SELECT @rank := 1 AS rank, :foo AS foo FROM :bar', false, array(27 => 'foo', 44 => 'bar')), // Ticket DBAL-398
         );
     }
 


### PR DESCRIPTION
A native (mysql) query should be able to use the assignment operator := but currently the SQLParserUtils method treats that as a missing parameter.

The patch solves the issue, but it looks like a higher-level fix might be desired that also handles the regular expression better.
