### PR TITLE
Restore SqlitePlatform#supportsForeignKeyConstraints (no lies!)

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -605,6 +605,14 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function supportsForeignKeyConstraints()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getCreatePrimaryKeySQL(Index $index, $table)
     {
         throw new DBALException('Sqlite platform does not support alter primary key.');

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -433,12 +433,14 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         // dont check for index size here, some platforms automatically add indexes for foreign keys.
         $this->assertFalse($table->hasIndex('foo_idx'));
 
-        $this->assertEquals(1, count($table->getForeignKeys()));
-        $fks = $table->getForeignKeys();
-        $foreignKey = current($fks);
-        $this->assertEquals('alter_table_foreign', strtolower($foreignKey->getForeignTableName()));
-        $this->assertEquals(array('foreign_key_test'), array_map('strtolower', $foreignKey->getColumns()));
-        $this->assertEquals(array('id'), array_map('strtolower', $foreignKey->getForeignColumns()));
+        if ($this->_sm->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            $fks = $table->getForeignKeys();
+            $this->assertCount(1, $fks);
+            $foreignKey = current($fks);
+            $this->assertEquals('alter_table_foreign', strtolower($foreignKey->getForeignTableName()));
+            $this->assertEquals(array('foreign_key_test'), array_map('strtolower', $foreignKey->getColumns()));
+            $this->assertEquals(array('id'), array_map('strtolower', $foreignKey->getForeignColumns()));
+        }
     }
 
     public function testCreateAndListViews()

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 {
     /**
-     * @var Doctrine\DBAL\Platforms\AbstractPlatform
+     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
      */
     protected $_platform;
 
@@ -154,6 +154,21 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
         $fk = new \Doctrine\DBAL\Schema\ForeignKeyConstraint(array('fk_name'), 'foreign', array('id'), 'constraint_fk');
         $sql = $this->_platform->getCreateConstraintSQL($fk, 'test');
         $this->assertEquals($this->getGenerateConstraintForeignKeySql(), $sql);
+    }
+
+    public function testGeneratesForeignKeySqlOnlyWhenSupportingForeignKeys()
+    {
+        $fk = new \Doctrine\DBAL\Schema\ForeignKeyConstraint(array('fk_name'), 'foreign', array('id'), 'constraint_fk');
+
+        if ($this->_platform->supportsForeignKeyConstraints()) {
+            $this->assertInternalType(
+                'string',
+                $this->_platform->getCreateForeignKeySQL($fk, 'test')
+            );
+        } else {
+            $this->setExpectedException('Doctrine\DBAL\DBALException');
+            $this->_platform->getCreateForeignKeySQL($fk, 'test');
+        }
     }
 
     protected function getBitAndComparisonExpressionSql($value1, $value2)


### PR DESCRIPTION
This PR applies a hotfix for broken behavior introduced in DBAL-370 (doctrine/dbal#220).

Basically, the SQLite platform lies about its ability to support foreign key constraint generation. This leads to various failures in the ORM schema tools.

In fact, the platform itself doesn't even generate the foreign key generation SQL, and instead throws a `Doctrine\DBAL\DBALException` (similar to "not implemented" in this particular case). 
The PR introduces a failing test that exposes the (currently) missing feature in the platform and restores the return value of `Doctrine\DBAL\Platforms\SqlitePlatform#supportsForeignKeyConstraints()`.

While SQLite 3.6.19 introduces support for Foreign keys, the DBAL platform still doesn't have it.

Ping @lsmith77 @hason
