### PR TITLE
Added GUID expression to SQLite platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -49,6 +49,17 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getGuidExpression()
+    {
+        return "HEX(RANDOMBLOB(4)) || '-' || HEX(RANDOMBLOB(2)) || '-4' || "
+            . "SUBSTR(HEX(RANDOMBLOB(2)), 2) || '-' || "
+            . "SUBSTR('89AB', 1 + (ABS(RANDOM()) % 4), 1) || "
+            . "SUBSTR(HEX(RANDOMBLOB(2)), 2) || '-' || HEX(RANDOMBLOB(6))";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getNowExpression($type = 'timestamp')
     {
         switch ($type) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL421Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL421Test.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Ticket;
+
+/**
+ * @group DBAL-421
+ */
+class DBAL421Test extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $platform = $this->_conn->getDatabasePlatform()->getName();
+        if (!in_array($platform, array('mysql', 'sqlite'))) {
+            $this->markTestSkipped('Currently restricted to MySQL and SQLite.');
+        }
+    }
+
+    public function testGuidShouldMatchPattern()
+    {
+        $guid = $this->_conn->query($this->getSelectGuidSql())->fetchColumn();
+        $pattern = '/[0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[8-9A-B][0-9A-F]{3}\-[0-9A-F]{12}/i';
+        $this->assertEquals(1, preg_match($pattern, $guid), "GUID does not match pattern");
+    }
+
+    /**
+     * This test does (of course) not proof that all generated GUIDs are
+     * random, it should however provide some basic confidence.
+     */
+    public function testGuidShouldBeRandom()
+    {
+        $statement = $this->_conn->prepare($this->getSelectGuidSql());
+        $guids = array();
+        for ($i = 0; $i < 99; $i++)
+        {
+            $statement->execute();
+            $guid = $statement->fetchColumn();
+            $this->assertNotContains($guid, $guids, "Duplicate GUID detected");
+            $guids[] = $guid;
+        }
+    }
+
+    private function getSelectGuidSql()
+    {
+        return "SELECT " . $this->_conn->getDatabasePlatform()->getGuidExpression();
+    }
+}


### PR DESCRIPTION
This will add an implementation of getGuidExpression to the SqlitePlatform. It is based on [UUID version 4](http://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29).

Don't know if this is appropriate, but I'm open to suggestions.
