### PR TITLE
fix SQLServerPlatform GUID expression

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -468,7 +468,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getGuidExpression()
     {
-        return 'UUID()';
+        return 'NEWID()';
     }
 
     /**


### PR DESCRIPTION
The GUID expression UUID() does not exist in SQLServer. Instead NEWID() is used. This PR fixes this.

See: http://msdn.microsoft.com/en-us/library/ms190348.aspx
