### PR TITLE
Create queryBuilder from parts.

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1306,4 +1306,26 @@ class Connection implements DriverConnection
     {
         return new Query\QueryBuilder($this);
     }
+
+    /**
+     * Create a QueryBuilder instance from DQL parts
+     *
+     * @param array $parts
+     *
+     * @return Query\QueryBuilder
+     */
+    public function createQueryBuilderFromParts(array $parts = array())
+    {
+        $queryBuilder = new Query\QueryBuilder($this);
+        foreach ($parts as $name => $part)
+        {
+            if ($part) {
+                if (is_array($part) && $name != 'join') {
+                    $part = current($part);
+                }
+                $queryBuilder->add($name, $part);
+            }
+        }
+        return $queryBuilder;
+    }
 }

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1314,7 +1314,7 @@ class Connection implements DriverConnection
      *
      * @return Query\QueryBuilder
      */
-    public function createQueryBuilderFromParts(array $parts = array())
+    public function setDQLParts(array $parts = array())
     {
         $queryBuilder = new Query\QueryBuilder($this);
         foreach ($parts as $name => $part)


### PR DESCRIPTION
Add a feature that can create a queryBuilder from queryBuilder parts.

This can be used when a query is build and needs to be stored somehow and restore it later.
