### PR TITLE
fix SQLServerPlatform locking hints

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -34,6 +34,7 @@ use Doctrine\DBAL\Schema\Table;
  * @author Roman Borschel <roman@code-factory.org>
  * @author Jonathan H. Wage <jonwage@gmail.com>
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Steve Müller <st.mueller@dzh-online.de>
  */
 class SQLServerPlatform extends AbstractPlatform
 {
@@ -845,16 +846,19 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function appendLockHint($fromClause, $lockMode)
     {
-        // @todo correct
+        $tableHint = '';
+
+        if ($lockMode == \Doctrine\DBAL\LockMode::NONE) {
+            $tableHint = ' WITH (READUNCOMMITTED)'; // equivalent to NOLOCK
+        }
         if ($lockMode == \Doctrine\DBAL\LockMode::PESSIMISTIC_READ) {
-            return $fromClause . ' WITH (tablockx)';
+            $tableHint = ' WITH (READCOMMITTED)';
         }
-
         if ($lockMode == \Doctrine\DBAL\LockMode::PESSIMISTIC_WRITE) {
-            return $fromClause . ' WITH (tablockx)';
+            $tableHint = ' WITH (SERIALIZABLE)'; // equivalent to HOLDLOCK
         }
 
-        return $fromClause;
+        return $fromClause . $tableHint;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -20,6 +20,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -846,19 +847,19 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function appendLockHint($fromClause, $lockMode)
     {
-        $tableHint = '';
-
-        if ($lockMode == \Doctrine\DBAL\LockMode::NONE) {
-            $tableHint = ' WITH (READUNCOMMITTED)'; // equivalent to NOLOCK
-        }
-        if ($lockMode == \Doctrine\DBAL\LockMode::PESSIMISTIC_READ) {
-            $tableHint = ' WITH (READCOMMITTED)';
-        }
-        if ($lockMode == \Doctrine\DBAL\LockMode::PESSIMISTIC_WRITE) {
-            $tableHint = ' WITH (SERIALIZABLE)'; // equivalent to HOLDLOCK
+        if ($lockMode == LockMode::NONE) {
+            return $fromClause . ' WITH (READUNCOMMITTED)'; // equivalent to NOLOCK
         }
 
-        return $fromClause . $tableHint;
+        if ($lockMode == LockMode::PESSIMISTIC_READ) {
+            return $fromClause . ' WITH (READCOMMITTED)';
+        }
+
+        if ($lockMode == LockMode::PESSIMISTIC_WRITE) {
+            return $fromClause . ' WITH (SERIALIZABLE)'; // equivalent to HOLDLOCK
+        }
+
+        return $fromClause;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -847,19 +847,21 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function appendLockHint($fromClause, $lockMode)
     {
-        if ($lockMode == LockMode::NONE) {
-            return $fromClause . ' WITH (NOLOCK)';
+        switch ($lockMode) {
+            case LockMode::NONE:
+                $lockClause = ' WITH (NOLOCK)';
+                break;
+            case LockMode::PESSIMISTIC_READ:
+                $lockClause = ' WITH (HOLDLOCK, ROWLOCK)';
+                break;
+            case LockMode::PESSIMISTIC_WRITE:
+                $lockClause = ' WITH (UPDLOCK, ROWLOCK)';
+                break;
+            default:
+                $lockClause = '';
         }
 
-        if ($lockMode == LockMode::PESSIMISTIC_READ) {
-            return $fromClause . ' WITH (HOLDLOCK, ROWLOCK)';
-        }
-
-        if ($lockMode == LockMode::PESSIMISTIC_WRITE) {
-            return $fromClause . ' WITH (UPDLOCK, ROWLOCK)';
-        }
-
-        return $fromClause;
+        return $fromClause . $lockClause;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -848,15 +848,15 @@ class SQLServerPlatform extends AbstractPlatform
     public function appendLockHint($fromClause, $lockMode)
     {
         if ($lockMode == LockMode::NONE) {
-            return $fromClause . ' WITH (READUNCOMMITTED)'; // equivalent to NOLOCK
+            return $fromClause . ' WITH (NOLOCK)';
         }
 
         if ($lockMode == LockMode::PESSIMISTIC_READ) {
-            return $fromClause . ' WITH (READCOMMITTED)';
+            return $fromClause . ' WITH (HOLDLOCK, ROWLOCK)';
         }
 
         if ($lockMode == LockMode::PESSIMISTIC_WRITE) {
-            return $fromClause . ' WITH (SERIALIZABLE)'; // equivalent to HOLDLOCK
+            return $fromClause . ' WITH (UPDLOCK, ROWLOCK)';
         }
 
         return $fromClause;


### PR DESCRIPTION
This should completely implement the locking hints of the SQLServerPlatform according to http://msdn.microsoft.com/en-us/library/aa213026%28v=sql.80%29.aspx.
