### PR TITLE
Guid type requires SQL typehint comment

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2573,6 +2573,16 @@ abstract class AbstractPlatform
         return false;
     }
 
+    /**
+     * Does this platform have native guid type.
+     *
+     * @return boolean
+     */
+    public function hasNativeGuidType()
+    {
+        return false;
+    }
+
     public function getIdentityColumnNullInsertSQL()
     {
         return "";

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -155,6 +155,14 @@ class PostgreSqlPlatform extends AbstractPlatform
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function hasNativeGuidType()
+    {
+        return true;
+    }
+
     public function getListDatabasesSQL()
     {
         return 'SELECT datname FROM pg_database';

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -109,6 +109,14 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function hasNativeGuidType()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getCreateDatabaseSQL($name)
     {
         return 'CREATE DATABASE ' . $name;

--- a/lib/Doctrine/DBAL/Types/GuidType.php
+++ b/lib/Doctrine/DBAL/Types/GuidType.php
@@ -38,5 +38,10 @@ class GuidType extends StringType
     {
         return Type::GUID;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }
 

--- a/lib/Doctrine/DBAL/Types/GuidType.php
+++ b/lib/Doctrine/DBAL/Types/GuidType.php
@@ -41,7 +41,7 @@ class GuidType extends StringType
 
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
-        return true;
+        return !$platform->hasNativeGuidType();
     }
 }
 

--- a/tests/Doctrine/Tests/DBAL/Types/GuidTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/GuidTypeTest.php
@@ -27,5 +27,16 @@ class GuidTest extends \Doctrine\Tests\DbalTestCase
     {
         $this->assertNull($this->_type->convertToPHPValue(null, $this->_platform));
     }
-}
 
+    public function testNativeGuidSupport()
+    {
+        $this->assertTrue($this->_type->requiresSQLCommentHint($this->_platform));
+
+        $mock = $this->getMock(get_class($this->_platform));
+        $mock->expects($this->any())
+             ->method('hasNativeGuidType')
+             ->will($this->returnValue(true));
+
+        $this->assertFalse($this->_type->requiresSQLCommentHint($mock));
+    }
+}


### PR DESCRIPTION
Since guid extends the string type, it needs to be type hinted.
