### PR TITLE
fix named_token

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -33,7 +33,7 @@ use Doctrine\DBAL\Connection;
 class SQLParserUtils
 {
     const POSITIONAL_TOKEN = '\?';
-    const NAMED_TOKEN      = ':[a-zA-Z_][a-zA-Z0-9_]*';
+    const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
 
     // Quote characters within string literals can be preceded by a backslash.
     const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:[^'\\\\]|\\\\'|\\\\\\\\)*'";

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -44,7 +44,8 @@ SQLDATA
             array('SELECT :foo_id', false, array(7 => 'foo_id')), // Ticket DBAL-231
             array('SELECT @rank := 1', false, array()), // Ticket DBAL-398
             array('SELECT @rank := 1 AS rank, :foo AS foo FROM :bar', false, array(27 => 'foo', 44 => 'bar')), // Ticket DBAL-398
-            array('SELECT * FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(30 => 'start_date', 52 =>  'start_date')) // Ticket GH-113
+            array('SELECT * FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(30 => 'start_date', 52 =>  'start_date')), // Ticket GH-113
+            array('SELECT foo::date as date FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(46 => 'start_date', 68 =>  'start_date')) // Ticket GH-259
         );
     }
 


### PR DESCRIPTION
Regex Token Pattern for NAMED_TOKEN does not support sql cast operator ::

For example a query like this:
Select mydate::date from mytable; 

will return  a place holder ':date' instead of ignoring this.

fixed by adjusting the regex to ignore the operator.
