### PR TITLE
Add SQL Server 2012 platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/Keywords/MsSQLKeywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/MsSQLKeywords.php
@@ -32,11 +32,17 @@ namespace Doctrine\DBAL\Platforms\Keywords;
  */
 class MsSQLKeywords extends KeywordList
 {
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'MsSQL';
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function getKeywords()
     {
         return array(
@@ -238,13 +244,7 @@ class MsSQLKeywords extends KeywordList
             'CURRENT_TIME',
             'GRANT',
             'OPENDATASOURCE',
-            'SELECT',
-            'SEMANTICKEYPHRASETABLE',
-            'SEMANTICSIMILARITYDETAILSTABLE',
-            'SEMANTICSIMILARITYTABLE',
-            'TRY_CONVERT',
-            'WITHIN',
-            'SEQUENCE'
+            'SELECT'
         );
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/Keywords/MsSQLKeywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/MsSQLKeywords.php
@@ -28,6 +28,7 @@ namespace Doctrine\DBAL\Platforms\Keywords;
  * @since       2.0
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  * @author      David Coallier <davidc@php.net>
+ * @author      Steve Müller <st.mueller@dzh-online.de>
  */
 class MsSQLKeywords extends KeywordList
 {
@@ -238,6 +239,12 @@ class MsSQLKeywords extends KeywordList
             'GRANT',
             'OPENDATASOURCE',
             'SELECT',
+            'SEMANTICKEYPHRASETABLE',
+            'SEMANTICSIMILARITYDETAILSTABLE',
+            'SEMANTICSIMILARITYTABLE',
+            'TRY_CONVERT',
+            'WITHIN',
+            'SEQUENCE'
         );
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2012Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2012Keywords.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Platforms\Keywords;
+
+/**
+ * SQL Server 2012 reserved keywords list.
+ *
+ * @license BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link    www.doctrine-project.com
+ * @since   2.0
+ * @author  Steve Müller <st.mueller@dzh-online.de>
+ */
+class SQLServer2012Keywords extends MsSQLKeywords
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'SQLServer2012';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getKeywords()
+    {
+        return array_merge(parent::getKeywords(),
+            'SEMANTICKEYPHRASETABLE',
+            'SEMANTICSIMILARITYDETAILSTABLE',
+            'SEMANTICSIMILARITYTABLE',
+            'TRY_CONVERT',
+            'WITHIN',
+            'SEQUENCE'
+        );
+    }
+}

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2012Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2012Keywords.php
@@ -24,7 +24,7 @@ namespace Doctrine\DBAL\Platforms\Keywords;
  *
  * @license BSD http://www.opensource.org/licenses/bsd-license.php
  * @link    www.doctrine-project.com
- * @since   2.0
+ * @since   2.3
  * @author  Steve Müller <st.mueller@dzh-online.de>
  */
 class SQLServer2012Keywords extends MsSQLKeywords
@@ -42,13 +42,13 @@ class SQLServer2012Keywords extends MsSQLKeywords
      */
     protected function getKeywords()
     {
-        return array_merge(parent::getKeywords(),
+        return array_merge(parent::getKeywords(), array(
             'SEMANTICKEYPHRASETABLE',
             'SEMANTICSIMILARITYDETAILSTABLE',
             'SEMANTICSIMILARITYTABLE',
             'TRY_CONVERT',
             'WITHIN',
             'SEQUENCE'
-        );
+        ));
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -75,7 +75,7 @@ class SQLServer2012Platform extends SQLServer2008Platform
      */
     public function getSequenceNextValSQL($sequenceName)
     {
-        throw 'SELECT NEXT VALUE FOR ' . $sequenceName;
+        return 'SELECT NEXT VALUE FOR ' . $sequenceName;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\DBAL\Schema\Sequence;
+
+/**
+ * Platform to ensure compatibility of Doctrine with SQLServer2012 version.
+ *
+ * Differences to SQL Server 2008 and before are that sequences are introduced.
+ *
+ * @author Steve Müller <st.mueller@dzh-online.de>
+ */
+class SQLServer2012Platform extends SQLServer2008Platform
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getAlterSequenceSQL(Sequence $sequence)
+    {
+        return 'ALTER SEQUENCE ' . $sequence->getQuotedName($this) .
+               ' INCREMENT BY ' . $sequence->getAllocationSize();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCreateSequenceSQL(Sequence $sequence)
+    {
+        return 'CREATE SEQUENCE ' . $sequence->getQuotedName($this) .
+               ' START WITH ' . $sequence->getInitialValue() .
+               ' INCREMENT BY ' . $sequence->getAllocationSize() .
+               ' MINVALUE ' . $sequence->getInitialValue();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDropSequenceSQL($sequence)
+    {
+        if ($sequence instanceof Sequence) {
+            $sequence = $sequence->getQuotedName($this);
+        }
+
+        return 'DROP SEQUENCE ' . $sequence;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListSequencesSQL($database)
+    {
+        return 'SELECT seq.name, seq.increment, seq.start_value FROM sys.sequences AS seq';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSequenceNextValSQL($sequenceName)
+    {
+        throw 'SELECT NEXT VALUE FOR ' . $sequenceName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsSequences()
+    {
+        return true;
+    }
+}

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -85,4 +85,12 @@ class SQLServer2012Platform extends SQLServer2008Platform
     {
         return true;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getReservedKeywordsClass()
+    {
+        return 'Doctrine\DBAL\Platforms\Keywords\SQLServer2012Keywords';
+    }
 }

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -30,10 +30,19 @@ use Doctrine\DBAL\Driver\SQLSrv\SQLSrvException;
  * @author      Konsta Vesterinen <kvesteri@cc.hut.fi>
  * @author      Lukas Smith <smith@pooteeweet.org> (PEAR MDB2 library)
  * @author      Juozas Kaziukenas <juozas@juokaz.com>
+ * @author      Steve Müller <st.mueller@dzh-online.de>
  * @since       2.0
  */
 class SQLServerSchemaManager extends AbstractSchemaManager
 {
+    /**
+     * {@inheritdoc}
+     */
+    protected function _getPortableSequenceDefinition($sequence)
+    {
+        return new Sequence($sequence['name'], $sequence['increment'], $sequence['start_value']);
+    }
+
     /**
      * @override
      */

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Platforms;
+
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Doctrine\DBAL\Schema\Sequence;
+
+class SQLServer2012PlatformTest extends SQLServerPlatformTest
+{
+    public function createPlatform()
+    {
+        return new SQLServer2012Platform;
+    }
+
+    public function testSupportsSequences()
+    {
+        $this->assertTrue($this->_platform->supportsSequences());
+    }
+
+    public function testDoesNotPreferSequences()
+    {
+        $this->assertFalse($this->_platform->prefersSequences());
+    }
+
+    public function testGeneratesSequenceSqlCommands()
+    {
+        $sequence = new Sequence('myseq', 20, 1);
+        $this->assertEquals(
+            'CREATE SEQUENCE myseq START WITH 1 INCREMENT BY 20 MINVALUE 1',
+            $this->_platform->getCreateSequenceSQL($sequence)
+        );
+        $this->assertEquals(
+            'ALTER SEQUENCE myseq INCREMENT BY 20',
+            $this->_platform->getAlterSequenceSQL($sequence)
+        );
+        $this->assertEquals(
+            'DROP SEQUENCE myseq',
+            $this->_platform->getDropSequenceSQL('myseq')
+        );
+        $this->assertEquals(
+            "SELECT NEXT VALUE FOR myseq",
+            $this->_platform->getSequenceNextValSQL('myseq')
+        );
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -114,6 +114,11 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         $this->assertTrue($this->_platform->prefersIdentityColumns());
     }
 
+    public function testDoesNotPreferSequences()
+    {
+        $this->assertFalse($this->_platform->prefersSequences());
+    }
+
     public function testSupportsIdentityColumns()
     {
         $this->assertTrue($this->_platform->supportsIdentityColumns());
@@ -122,6 +127,11 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     public function testDoesNotSupportSavePoints()
     {
         $this->assertTrue($this->_platform->supportsSavepoints());
+    }
+
+    public function testSupportsSequences()
+    {
+        $this->assertTrue($this->_platform->supportsSequences());
     }
 
     public function getGenerateIndexSql()
@@ -226,6 +236,23 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     {
         $idx = new \Doctrine\DBAL\Schema\Index('idx', array('id'), false, true);
         $this->assertEquals('ALTER TABLE tbl ADD PRIMARY KEY (id)', $this->_platform->getCreateIndexSQL($idx, 'tbl'));
+    }
+
+    public function testGeneratesSequenceSqlCommands()
+    {
+        $sequence = new \Doctrine\DBAL\Schema\Sequence('myseq', 20, 1);
+        $this->assertEquals(
+            'CREATE SEQUENCE myseq START WITH 1 INCREMENT BY 20 MINVALUE 1',
+            $this->_platform->getCreateSequenceSQL($sequence)
+        );
+        $this->assertEquals(
+            'DROP SEQUENCE myseq',
+            $this->_platform->getDropSequenceSQL('myseq')
+        );
+        $this->assertEquals(
+            "SELECT NEXT VALUE FOR myseq",
+            $this->_platform->getSequenceNextValSQL('myseq')
+        );
     }
 
     protected function getQuotedColumnInPrimaryKeySQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -114,11 +114,6 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         $this->assertTrue($this->_platform->prefersIdentityColumns());
     }
 
-    public function testDoesNotPreferSequences()
-    {
-        $this->assertFalse($this->_platform->prefersSequences());
-    }
-
     public function testSupportsIdentityColumns()
     {
         $this->assertTrue($this->_platform->supportsIdentityColumns());
@@ -127,11 +122,6 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     public function testDoesNotSupportSavePoints()
     {
         $this->assertTrue($this->_platform->supportsSavepoints());
-    }
-
-    public function testSupportsSequences()
-    {
-        $this->assertTrue($this->_platform->supportsSequences());
     }
 
     public function getGenerateIndexSql()
@@ -236,23 +226,6 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     {
         $idx = new \Doctrine\DBAL\Schema\Index('idx', array('id'), false, true);
         $this->assertEquals('ALTER TABLE tbl ADD PRIMARY KEY (id)', $this->_platform->getCreateIndexSQL($idx, 'tbl'));
-    }
-
-    public function testGeneratesSequenceSqlCommands()
-    {
-        $sequence = new \Doctrine\DBAL\Schema\Sequence('myseq', 20, 1);
-        $this->assertEquals(
-            'CREATE SEQUENCE myseq START WITH 1 INCREMENT BY 20 MINVALUE 1',
-            $this->_platform->getCreateSequenceSQL($sequence)
-        );
-        $this->assertEquals(
-            'DROP SEQUENCE myseq',
-            $this->_platform->getDropSequenceSQL('myseq')
-        );
-        $this->assertEquals(
-            "SELECT NEXT VALUE FOR myseq",
-            $this->_platform->getSequenceNextValSQL('myseq')
-        );
     }
 
     protected function getQuotedColumnInPrimaryKeySQL()


### PR DESCRIPTION
This adds the platform for SQL Server 2012 introducing sequences. I don't exactly know if sequences should be preferred for ID generation or not so I left identity columns preferred for ID generation. Also added new keywords to MsSqlKeywords since SQL Server 2008.
