### PR TITLE
Add Symfony Console dependency to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         "php": ">=5.3.2",
         "doctrine/common": ">=2.3-dev,<2.5-dev"
     },
+    "suggest": {
+        "symfony/console": "Allows use of the command line interface"
+    },
     "autoload": {
         "psr-0": { "Doctrine\\DBAL\\": "lib/" }
     },


### PR DESCRIPTION
The DBAL component offers a command-line tool based on Symfony Console, but this one is not present as a dependency in `composer.json`.

This PR adds the dependency.
