### PR TITLE
Allow passing empty arrays as parameters

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -130,11 +130,13 @@ class SQLParserUtils
 
                 $types = array_merge(
                     array_slice($types, 0, $needle),
-                    array_fill(0, $count, $types[$needle] - Connection::ARRAY_PARAM_OFFSET), // array needles are at PDO::PARAM_* + 100
+                    $count ? 
+                        array_fill(0, $count, $types[$needle] - Connection::ARRAY_PARAM_OFFSET) : // array needles are at PDO::PARAM_* + 100
+                        array(), 
                     array_slice($types, $needle + 1)
                 );
 
-                $expandStr  = implode(", ", array_fill(0, $count, "?"));
+                $expandStr  = $count ? implode(", ", array_fill(0, $count, "?")) : 'NULL';
                 $query      = substr($query, 0, $needlePos) . $expandStr . substr($query, $needlePos + 1);
 
                 $paramOffset += ($count - 1); // Grows larger by number of parameters minus the replaced needle.
@@ -164,7 +166,7 @@ class SQLParserUtils
             }
 
             $count      = count($value);
-            $expandStr  = $count > 0 ? implode(', ', array_fill(0, $count, '?')) : '?';
+            $expandStr  = $count > 0 ? implode(', ', array_fill(0, $count, '?')) : 'NULL';
 
             foreach ($value as $val) {
                 $paramsOrd[] = $val;

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -108,21 +108,21 @@ SQLDATA
                 array(1, 2, 3, 4, 5),
                 array(\PDO::PARAM_INT, \PDO::PARAM_INT, \PDO::PARAM_INT, \PDO::PARAM_INT, \PDO::PARAM_INT)
             ),
-            //  Positional : Empty "integer" array DDC-1978
+            // Positional: Empty "integer" array DDC-1978
             array(
                 "SELECT * FROM Foo WHERE foo IN (?)",
-                array('foo'=>array()),
-                array('foo'=>Connection::PARAM_INT_ARRAY),
-                'SELECT * FROM Foo WHERE foo IN (?)',
+                array(array()),
+                array(Connection::PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (NULL)',
                 array(),
                 array()
             ),
-            //  Positional : Empty "str" array DDC-1978
+            // Positional: Empty "str" array DDC-1978
             array(
                 "SELECT * FROM Foo WHERE foo IN (?)",
-                array('foo'=>array()),
-                array('foo'=>Connection::PARAM_STR_ARRAY),
-                'SELECT * FROM Foo WHERE foo IN (?)',
+                array(array()),
+                array(Connection::PARAM_STR_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (NULL)',
                 array(),
                 array()
             ),
@@ -145,7 +145,6 @@ SQLDATA
                 array(1,'Some String'),
                 array(\PDO::PARAM_INT, \PDO::PARAM_STR)
             ),
-
             //  Named parameters : Very simple with one needle
             array(
                 "SELECT * FROM Foo WHERE foo IN (:foo)",
@@ -224,7 +223,7 @@ SQLDATA
                 "SELECT * FROM Foo WHERE foo IN (:foo)",
                 array('foo'=>array()),
                 array('foo'=>Connection::PARAM_INT_ARRAY),
-                'SELECT * FROM Foo WHERE foo IN (?)',
+                'SELECT * FROM Foo WHERE foo IN (NULL)',
                 array(),
                 array()
             ),
@@ -233,7 +232,7 @@ SQLDATA
                 "SELECT * FROM Foo WHERE foo IN (:foo) OR bar IN (:bar)",
                 array('foo'=>array(), 'bar'=>array()),
                 array('foo'=>Connection::PARAM_STR_ARRAY, 'bar'=>Connection::PARAM_STR_ARRAY),
-                'SELECT * FROM Foo WHERE foo IN (?) OR bar IN (?)',
+                'SELECT * FROM Foo WHERE foo IN (NULL) OR bar IN (NULL)',
                 array(),
                 array()
             ),


### PR DESCRIPTION
Right now something like

``` php
$entityManager
    ->createQuery("SELECT e FROM Entity e WHERE e IN (:entities)")
    ->execute(array('entities' => array()));
```

produces a `Warning: array_fill(): Number of elements must be positive`
