### PR TITLE
fix getShowDatabasesSQL() in SQLServerPlatform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -382,7 +382,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getShowDatabasesSQL()
     {
-        return 'SHOW DATABASES';
+        return 'exec sp_databases';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -67,7 +67,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     {
         $dropDatabaseExpectation = 'DROP DATABASE foobar';
 
-        $this->assertEquals('SHOW DATABASES', $this->_platform->getShowDatabasesSQL());
+        $this->assertEquals('exec sp_databases', $this->_platform->getShowDatabasesSQL());
         $this->assertEquals('CREATE DATABASE foobar', $this->_platform->getCreateDatabaseSQL('foobar'));
         $this->assertEquals($dropDatabaseExpectation, $this->_platform->getDropDatabaseSQL('foobar'));
         $this->assertEquals('DROP TABLE foobar', $this->_platform->getDropTableSQL('foobar'));


### PR DESCRIPTION
The getShowDatabasesSQL() in SQLServerPlatform returns invalid SQL. Maybe copy/paste error from MySqlPlatform? This PR fixes this to return the correct statement.
