### PR TITLE
Add SQLServerPlatform supports schemas

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -107,6 +107,14 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function supportsSchemas()
+    {
+        return true;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getCreateDatabaseSQL($name)

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -119,6 +119,11 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         $this->assertTrue($this->_platform->supportsIdentityColumns());
     }
 
+    public function testSupportsSchemas()
+    {
+        $this->assertTrue($this->_platform->supportsSchemas());
+    }
+
     public function testDoesNotSupportSavePoints()
     {
         $this->assertTrue($this->_platform->supportsSavepoints());


### PR DESCRIPTION
SQL Server supports schemas. This PR modifies SQLServerPlatform to return true when asked for schema support.
