### PR TITLE
Fix SQLServerPlatform regular expression SQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -34,6 +34,7 @@ use Doctrine\DBAL\Schema\Table;
  * @author Roman Borschel <roman@code-factory.org>
  * @author Jonathan H. Wage <jonwage@gmail.com>
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Steve Müller <st.mueller@dzh-online.de>
  */
 class SQLServerPlatform extends AbstractPlatform
 {
@@ -453,14 +454,6 @@ class SQLServerPlatform extends AbstractPlatform
     public function getDropViewSQL($name)
     {
         return 'DROP VIEW ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getRegexpExpression()
-    {
-        return 'RLIKE';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -36,9 +36,16 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    /**
+     * @expectedException Doctrine\DBAL\DBALException
+     */
+    public function testDoesNotSupportRegexp()
+    {
+        $this->_platform->getRegexpExpression();
+    }
+
     public function testGeneratesSqlSnippets()
     {
-        $this->assertEquals('RLIKE', $this->_platform->getRegexpExpression(), 'Regular expression operator is not correct');
         $this->assertEquals('"', $this->_platform->getIdentifierQuoteCharacter(), 'Identifier quote character is not correct');
         $this->assertEquals('(column1 + column2 + column3)', $this->_platform->getConcatExpression('column1', 'column2', 'column3'), 'Concatenation expression is not correct');
     }


### PR DESCRIPTION
SQL Server has no native support for regular expressions. Furthermore there is no "RLIKE" expression in T-SQL. This PR fixes this.
