### PR TITLE
added the possibility to use column names as keys for the types in Connection::insert()

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -498,8 +498,15 @@ class Connection implements DriverConnection
     {
         $this->connect();
         $set = array();
+
+        $i = 0;
         foreach ($data as $columnName => $value) {
-            $set[] = $columnName . ' = ?';
+            $set[$i] = $columnName . ' = ?';
+            if (isset($types[$columnName])) {
+                $types[$i] = $types[$columnName];
+                unset($types[$columnName]);
+            }
+            ++$i;
         }
 
         $params = array_merge(array_values($data), array_values($identifier));
@@ -527,9 +534,15 @@ class Connection implements DriverConnection
         $cols = array();
         $placeholders = array();
 
+        $i = 0;
         foreach ($data as $columnName => $value) {
-            $cols[] = $columnName;
-            $placeholders[] = '?';
+            $cols[$i] = $columnName;
+            $placeholders[$i] = '?';
+            if (isset($types[$columnName])) {
+                $types[$i] = $types[$columnName];
+                unset($types[$columnName]);
+            }
+            ++$i;
         }
 
         $query = 'INSERT INTO ' . $tableName


### PR DESCRIPTION
The Connection::insert() method takes an array of types as its third argument:

``` php
$conn->insert('foo', array('foo' => 'foo', 'date' => new \DateTime()), array(2 => 'datetime'));
```

But without looking at the implementation, I'm sure you would have written the following instead:

``` php
$conn->insert('foo', array('foo' => 'foo', 'date' => new \DateTime()), array('date' => 'datetime'));
```

But unfortunately, that's does not work. This commit add support for this, and of course, the old way still works.
