### PR TITLE
accept array as parameter in getConcatExpression

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -768,7 +768,12 @@ abstract class AbstractPlatform
      */
     public function getConcatExpression()
     {
-        return join(' || ' , func_get_args());
+        $args = func_get_args();
+        
+        if(is_array($args[0])){
+            $args = $args[0];
+        }
+        return join(' || ' , $args);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -86,6 +86,10 @@ class MySqlPlatform extends AbstractPlatform
     public function getConcatExpression()
     {
         $args = func_get_args();
+        if(is_array($args[0])){
+            $args = $args[0];
+        }
+        
         return 'CONCAT(' . join(', ', (array) $args) . ')';
     }
 

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -543,7 +543,10 @@ class SQLServerPlatform extends AbstractPlatform
     public function getConcatExpression()
     {
         $args = func_get_args();
-
+        
+        if(is_array($args[0])){
+            $args = $args[0];
+        }
         return '(' . implode(' + ', $args) . ')';
     }
 


### PR DESCRIPTION
The function `getConcatExpression` accepts strings, but as there can be any number of parameters passed to this and while calling from `ConcatFunction` sqlwalker has to walk all the parameters. So it would be better if `getConcatExpression` accepts array. Infact even better if it only accepts array. It would be much cleaner. Also I am opening a pull request in ORM for `ConcatFunction` as it only validates 2 primaryStrings. It should support more than two. SO for that to happen, `getConcatExpression` should accept array as parameter.
