### PR TITLE
Remove duplicate SQL parts in query generation

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -943,12 +943,12 @@ class QueryBuilder
 
     private function getSQLForSelect()
     {
-        $query = 'SELECT ' . implode(', ', $this->sqlParts['select']) . ' FROM ';
+        $query = 'SELECT ' . implode(', ', array_unique($this->sqlParts['select'])) . ' FROM ';
 
         $fromClauses = array();
         $joinsPending = true;
         $joinAliases = array();
-        
+
         // Loop through all FROM clauses
         foreach ($this->sqlParts['from'] as $from) {
             $fromClause = $from['table'] . ' ' . $from['alias'];
@@ -964,7 +964,7 @@ class QueryBuilder
                 }
                 $joinsPending = false;
             }
-            
+
             $fromClauses[$from['alias']] = $fromClause;
         }
 
@@ -975,12 +975,12 @@ class QueryBuilder
                 throw QueryException::unknownAlias($fromAlias, array_keys($knownAliases));
             }
         }
-        
+
         $query .= implode(', ', $fromClauses)
                 . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '')
-                . ($this->sqlParts['groupBy'] ? ' GROUP BY ' . implode(', ', $this->sqlParts['groupBy']) : '')
+                . ($this->sqlParts['groupBy'] ? ' GROUP BY ' . implode(', ', array_unique($this->sqlParts['groupBy'])) : '')
                 . ($this->sqlParts['having'] !== null ? ' HAVING ' . ((string) $this->sqlParts['having']) : '')
-                . ($this->sqlParts['orderBy'] ? ' ORDER BY ' . implode(', ', $this->sqlParts['orderBy']) : '');
+                . ($this->sqlParts['orderBy'] ? ' ORDER BY ' . implode(', ', array_unique($this->sqlParts['orderBy'])) : '');
 
         return ($this->maxResults === null && $this->firstResult == null)
             ? $query
@@ -996,7 +996,7 @@ class QueryBuilder
     {
         $table = $this->sqlParts['from']['table'] . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
         $query = 'UPDATE ' . $table
-               . ' SET ' . implode(", ", $this->sqlParts['set'])
+               . ' SET ' . implode(", ", array_unique($this->sqlParts['set']))
                . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '');
 
         return $query;

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -211,6 +211,19 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
         $this->assertEquals('SELECT u.*, p.* FROM users u GROUP BY u.id, u.foo, u.bar', (string) $qb);
     }
 
+    public function testSelectDuplicateAddGroupBy()
+    {
+        $qb   = new QueryBuilder($this->conn);
+        $expr = $qb->expr();
+
+        $qb->select('u.*')
+           ->from('users', 'u')
+           ->groupBy('u.id')
+           ->addGroupBy('u.id');
+
+        $this->assertEquals('SELECT u.* FROM users u GROUP BY u.id', (string) $qb);
+    }
+
     public function testSelectHaving()
     {
         $qb   = new QueryBuilder($this->conn);
@@ -332,6 +345,19 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
         $this->assertEquals('SELECT u.*, p.* FROM users u ORDER BY u.name ASC, u.username DESC', (string) $qb);
     }
 
+    public function testSelectDuplicateAddOrderBy()
+    {
+        $qb   = new QueryBuilder($this->conn);
+        $expr = $qb->expr();
+
+        $qb->select('u.*')
+           ->from('users', 'u')
+           ->addOrderBy('u.name', 'ASC')
+           ->addOrderBy('u.name', 'ASC');
+
+        $this->assertEquals('SELECT u.* FROM users u ORDER BY u.name ASC', (string) $qb);
+    }
+
     public function testEmptySelect()
     {
         $qb   = new QueryBuilder($this->conn);
@@ -351,6 +377,18 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->from('users', 'u');
 
         $this->assertEquals('SELECT u.*, p.* FROM users u', (string) $qb);
+    }
+
+    public function testSelectDuplicateAddSelect()
+    {
+        $qb   = new QueryBuilder($this->conn);
+        $expr = $qb->expr();
+
+        $qb->select('u.*')
+           ->addSelect('u.*')
+           ->from('users', 'u');
+
+        $this->assertEquals('SELECT u.* FROM users u', (string) $qb);
     }
 
     public function testEmptyAddSelect()
@@ -375,6 +413,18 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
         $this->assertEquals('SELECT u.*, p.* FROM users u, phonenumbers p', (string) $qb);
     }
 
+    public function testSelectDuplicateFrom()
+    {
+        $qb   = new QueryBuilder($this->conn);
+        $expr = $qb->expr();
+
+        $qb->select('u.*')
+           ->from('users', 'u')
+           ->from('users', 'u');
+
+        $this->assertEquals('SELECT u.* FROM users u', (string) $qb);
+    }
+
     public function testUpdate()
     {
         $qb   = new QueryBuilder($this->conn);
@@ -384,6 +434,17 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
 
         $this->assertEquals(QueryBuilder::UPDATE, $qb->getType());
         $this->assertEquals('UPDATE users u SET u.foo = ?, u.bar = ?', (string) $qb);
+    }
+
+    public function testUpdateDuplicateSet()
+    {
+        $qb   = new QueryBuilder($this->conn);
+        $qb->update('users', 'u')
+           ->set('u.foo', '?')
+           ->set('u.foo', '?');
+
+        $this->assertEquals(QueryBuilder::UPDATE, $qb->getType());
+        $this->assertEquals('UPDATE users u SET u.foo = ?', (string) $qb);
     }
 
     public function testUpdateWithoutAlias()


### PR DESCRIPTION
Presently, it's possible to do this using QueryBuilder:

``` php
$qb->select('u.*')
   ->from('users', 'u')
   ->addOrderBy('u.name', 'ASC')
   ->addOrderBy('u.name', 'ASC'); // duplicate
```

Which produces:

``` sql
SELECT u.* FROM users u ORDER BY u.name ASC, u.name ASC
```

This patch removes duplicates from the `SELECT`, `SET`, `ORDER BY` and `GROUP BY` parts during SQL generation (there's already logic that removes duplicate `FROM` parts).

I've added test cases for each affected keyword as well.
