### PR TITLE
Use int values instead of strings for PostgreSQL booleans

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -515,28 +515,6 @@ class PostgreSqlPlatform extends AbstractPlatform
         return $sql;
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * Postgres wants boolean values converted to the strings 'true'/'false'.
-     */
-    public function convertBooleans($item)
-    {
-        if (is_array($item)) {
-            foreach ($item as $key => $value) {
-                if (is_bool($value) || is_numeric($item)) {
-                    $item[$key] = ($value) ? 'true' : 'false';
-                }
-            }
-        } else {
-           if (is_bool($item) || is_numeric($item)) {
-               $item = ($item) ? 'true' : 'false';
-           }
-        }
-
-        return $item;
-    }
-
     public function getSequenceNextValSQL($sequenceName)
     {
         return "SELECT NEXTVAL('" . $sequenceName . "')";

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,6 +32,7 @@
     <var name="db_name" value="doctrine_tests" />
     <var name="db_port" value="3306"/>
     -->
+    <!--<var name="db_options_PDO::ATTR_EMULATE_PREPARES" value="true" /> Any driver options can be added with db_options_*-->
     <!--<var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit">-->
     
     <!-- Database for temporary connections (i.e. to drop/create the main database) -->

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -112,8 +112,8 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
             try {
                 $table = new \Doctrine\DBAL\Schema\Table("ddc1372_foobar");
                 $table->addColumn('id', 'integer');
-                $table->addColumn('foo','string');
-                $table->addColumn('bar','string');
+                $table->addColumn('foo','integer');
+                $table->addColumn('bar','integer');
                 $table->setPrimaryKey(array('id'));
 
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -34,7 +34,7 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
             "ALTER TABLE mytable ALTER bar SET  DEFAULT 'def'",
             'ALTER TABLE mytable ALTER bar SET NOT NULL',
             'ALTER TABLE mytable ALTER bloo TYPE BOOLEAN',
-            "ALTER TABLE mytable ALTER bloo SET  DEFAULT 'false'",
+            "ALTER TABLE mytable ALTER bloo SET  DEFAULT '0'",
             'ALTER TABLE mytable ALTER bloo SET NOT NULL',
             'ALTER TABLE mytable RENAME TO userlist',
         );


### PR DESCRIPTION
## The Problem:

The current implementation for PostgreSQL uses strings 'true' and 'false' which are not working with PDO::ATTR_EMULATE_PREPARES.
## Solution:

Use ints like in the default platform implementation.
## Comments
- There are only 2 options working both with or without emulation: ints and booleans, but booleans are more complicated to implement.
- Tested only on my local php 5.4.9
- Fixed NamedParametersTest to use int columns instead of strings (does not work with PDO::ATTR_EMULATE_PREPARES when compare string column IN array of ints)
- Fixed DbalFunctionalTestCase sql parameters dumping (found while fixing NamedParametersTest)
- Added support for driver options configuration via phpunit config globals
