### PR TITLE
Upgrading doctrine/common 2.4 (via composer)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ env:
   - DB=mysqli
 
 before_script:
+  - composer update --dev --prefer-source
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests_tmp;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests_tmp;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi"
   - sh -c "if [ '$DB' = 'mysqli' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi"
-  - git submodule update --init
 
 script: phpunit --configuration tests/travis/$DB.travis.xml
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": "2.3.*"
+        "doctrine/common": ">=2.3.0,<2.5-dev"
     },
     "autoload": {
         "psr-0": { "Doctrine\\DBAL": "lib/" }

--- a/tests/Doctrine/Tests/TestInit.php
+++ b/tests/Doctrine/Tests/TestInit.php
@@ -6,17 +6,12 @@ namespace Doctrine\Tests;
 
 error_reporting(E_ALL | E_STRICT);
 
-require_once __DIR__ . '/../../../lib/vendor/doctrine-common/lib/Doctrine/Common/ClassLoader.php';
+if (file_exists(__DIR__ . '/../../../vendor/autoload.php')) {
+    $loader = require_once __DIR__ . '/../../../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../../../autoload.php')) {
+    $loader = require __DIR__ . '/../../../vendor/autoload.php';
+} else {
+    throw new \RuntimeException('Could not locate composer autoloader');
+}
 
-$classLoader = new \Doctrine\Common\ClassLoader('Doctrine\Common', __DIR__ . '/../../../lib/vendor/doctrine-common/lib');
-$classLoader->register();
-
-$classLoader = new \Doctrine\Common\ClassLoader('Doctrine\DBAL', __DIR__ . '/../../../lib');
-$classLoader->register();
-
-$classLoader = new \Doctrine\Common\ClassLoader('Doctrine\Tests', __DIR__ . '/../../');
-$classLoader->register();
-
-$classLoader = new \Doctrine\Common\ClassLoader('Symfony', __DIR__ . "/../../../lib/vendor");
-$classLoader->register();
-
+$loader->add('Doctrine\Tests', __DIR__ . '/../../');


### PR DESCRIPTION
This PR introduces changes necessary to make the DBAL recognize `"doctrine/common": "2.4"` as compatible as discussed in https://groups.google.com/d/topic/doctrine-dev/8WjzboENQgg/discussion

Ping @dbu
