### PR TITLE
Fix SchemaManagerFunctionalTestCase composite foreign keys test

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -639,7 +639,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->_sm->createTable($this->getTestCompositeTable('test_create_fk4'));
 
         $foreignKey = new \Doctrine\DBAL\Schema\ForeignKeyConstraint(
-            array('id', 'foreign_key_test'), 'test_create_fk4', array('id', 'other_id'), 'foreign_key_test_fk'
+            array('id', 'foreign_key_test'), 'test_create_fk4', array('id', 'other_id'), 'foreign_key_test_fk2'
         );
 
         $this->_sm->createForeignKey($foreignKey, 'test_create_fk3');


### PR DESCRIPTION
This PR fixes a bug in the <code>SchemaManagerFunctionalTestCase</code> composite foreign keys test I encountered today. In SQL Server the test case fails because both <code>testListForeignKeys</code> and <code>testListForeignKeysComposite</code> tests create a foreign key with the same name which is not possible for one single DB in SQL Server.
I don't know if this applies to other RDBMS also but this should also fix the others.
