### PR TITLE
Fix data not being cached in ResultCache

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -107,16 +107,19 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
     public function closeCursor()
     {
         $this->statement->closeCursor();
-        if ($this->emptied && $this->data !== null) {
+        if (!$this->emptied && $this->data !== null) {
             $data = $this->resultCache->fetch($this->cacheKey);
             if ( ! $data) {
                 $data = array();
             }
             $data[$this->realKey] = $this->data;
 
-            $this->resultCache->save($this->cacheKey, $data, $this->lifetime);
+            if(!$this->resultCache->save($this->cacheKey, $data, $this->lifetime)){
+            	return false;
+            }
             unset($this->data);
         }
+        return true;
     }
 
     /**


### PR DESCRIPTION
The ResultCacheStatement has a small logic error, it tested for emptied
being true when it should have tested for emptied being false. The
comments also statement that the function returns a boolean, however the
function didn't return a boolean.

This is my first time committing to a larger open source project like dbal. Very worried I'll of done something wrong, please go easy / teach me.
