### PR TITLE
Fix fetchColumn not caching

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -71,7 +71,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
      *
      * @var bool
      */
-    private $emptied = false;
+    private $atEndOfStatement = false;
 
     /**
      * @var array
@@ -108,7 +108,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
     {
         $savedInCache = true;
         $this->statement->closeCursor();
-        if ($this->emptied && $this->data !== null) {
+        if ($this->atEndOfStatement && $this->data !== null) {
             $data = $this->resultCache->fetch($this->cacheKey);
             if ( ! $data) {
                 $data = array();
@@ -178,7 +178,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
                 throw new \InvalidArgumentException("Invalid fetch-style given for caching result.");
             }
         }
-        $this->emptied = true;
+        $this->atEndOfStatement = true;
         return false;
     }
 
@@ -218,7 +218,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
             // TODO: verify this is correct behavior
             return false;
         }
-        $this->emptied = true;
+        $this->atEndOfStatement = true;
         return $row[$columnIndex];
     }
 

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -106,7 +106,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
      */
     public function closeCursor()
     {
-    	$savedInCache = true;
+        $savedInCache = true;
         $this->statement->closeCursor();
         if ($this->emptied && $this->data !== null) {
             $data = $this->resultCache->fetch($this->cacheKey);

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -106,6 +106,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
      */
     public function closeCursor()
     {
+    	$savedInCache = true;
         $this->statement->closeCursor();
         if ($this->emptied && $this->data !== null) {
             $data = $this->resultCache->fetch($this->cacheKey);
@@ -113,10 +114,10 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
                 $data = array();
             }
             $data[$this->realKey] = $this->data;
-
-            $this->resultCache->save($this->cacheKey, $data, $this->lifetime);
+            $savedInCache = $this->resultCache->save($this->cacheKey, $data, $this->lifetime);
             unset($this->data);
         }
+        return $savedInCache;
     }
 
     /**
@@ -217,6 +218,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
             // TODO: verify this is correct behavior
             return false;
         }
+        $this->emptied = true;
         return $row[$columnIndex];
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -74,7 +74,7 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
         $this->assertCacheNonCacheSelectSameFetchModeAreEqual($expectedResult, \PDO::FETCH_COLUMN);
     }
-    
+	
     public function testMixingFetch()
     {
         $numExpectedResult = array();
@@ -206,7 +206,6 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $data = $this->hydrateStmt($stmt);
     }
     
-
     private function hydrateStmt($stmt, $fetchMode = \PDO::FETCH_ASSOC)
     {
         $data = array();

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -65,7 +65,7 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
         $this->assertCacheNonCacheSelectSameFetchModeAreEqual($expectedResult, \PDO::FETCH_BOTH);
     }
-	
+
     public function testFetchColumn()
     {
         $expectedResult = array();
@@ -74,7 +74,7 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
         $this->assertCacheNonCacheSelectSameFetchModeAreEqual($expectedResult, \PDO::FETCH_COLUMN);
     }
-	
+
     public function testMixingFetch()
     {
         $numExpectedResult = array();
@@ -184,7 +184,7 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals(2, count($this->sqlLogger->queries), "two hits");
         $this->assertEquals(1, count($secondCache->fetch("emptycachekey")));
     }
-    
+
     public function testFetchColumnCache()
     {
     	$stmt = $this->_conn->executeQuery("SELECT test_int FROM caching ORDER BY test_int ASC", array(), array(), new QueryCacheProfile(10, "testcachekey"));
@@ -195,17 +195,16 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
     	$row = $stmt->fetchColumn(0);
     	$this->assertEquals(1, count($this->sqlLogger->queries), "just one dbal hit");
     }
-    
+ 
     public function testFailedResultCacheSaveReturnsFalse(){
-    	$mockCache = $this->getMock('\Doctrine\Common\Cache\ArrayCache');
-    	$mockCache->expects($this->once())
+        $mockCache = $this->getMock('\Doctrine\Common\Cache\ArrayCache');
+        $mockCache->expects($this->once())
     	          ->method('save')
     	          ->will($this->returnValue(false));
-    	
-    	$stmt = $this->_conn->executeQuery("SELECT * FROM caching ORDER BY test_int ASC", array(), array(), new QueryCacheProfile(10, "emptycachekey", $mockCache));
+        $stmt = $this->_conn->executeQuery("SELECT * FROM caching ORDER BY test_int ASC", array(), array(), new QueryCacheProfile(10, "emptycachekey", $mockCache));
         $data = $this->hydrateStmt($stmt);
     }
-    
+
     private function hydrateStmt($stmt, $fetchMode = \PDO::FETCH_ASSOC)
     {
         $data = array();


### PR DESCRIPTION
Column cache wasn't working because the emptied flag is only set
when fetch no longer returns a row. With fetch column the code
only calls fetch once and so emptied flag never gets set.

Created two test cases, one to test fetchColumn, and one to test 
that the return value is false if the data doesn't get saved in the cache.
