### PR TITLE
[DBAL-54] [DBAL-420] Cannot drop schema using IDENTITY strategy in PostgreSQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -491,7 +491,7 @@ class PostgreSqlPlatform extends AbstractPlatform
         if ($sequence instanceof \Doctrine\DBAL\Schema\Sequence) {
             $sequence = $sequence->getQuotedName($this);
         }
-        return 'DROP SEQUENCE ' . $sequence;
+        return 'DROP SEQUENCE ' . $sequence . ' CASCADE';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -195,7 +195,7 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
             $this->_platform->getCreateSequenceSQL($sequence)
         );
         $this->assertEquals(
-            'DROP SEQUENCE myseq',
+            'DROP SEQUENCE myseq CASCADE',
             $this->_platform->getDropSequenceSQL('myseq')
         );
         $this->assertEquals(


### PR DESCRIPTION
DBAL-54 was fixed in commit 3d55dc8eec235c09d64b061456295a1951299496 by
changing SQL queries order. However it was later reintroduced.

This patch uses a different, more future-proof way, approach by using
DROP SEQUENCE ... CASCADE syntax, and thus does not depend on queries order.
