### PR TITLE
Fix ModifyLimitQueryTest

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
@@ -117,7 +117,7 @@ class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
         if ($deterministic) {
             $this->assertEquals($expectedResults, $data);
         } else {
-            $this->assertEquals(count($expectedResults), count($data));
+            $this->assertCount(count($expectedResults), $data);
         }
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
@@ -43,7 +43,7 @@ class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->_conn->insert('modify_limit_table', array('test_int' => 3));
         $this->_conn->insert('modify_limit_table', array('test_int' => 4));
 
-        $sql = "SELECT * FROM modify_limit_table";
+        $sql = "SELECT * FROM modify_limit_table ORDER BY test_int ASC";
 
         $this->assertLimitResult(array(1, 2, 3, 4), $sql, 10, 0);
         $this->assertLimitResult(array(1, 2), $sql, 2, 0);
@@ -61,25 +61,25 @@ class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->_conn->insert('modify_limit_table2', array('test_int' => 2));
         $this->_conn->insert('modify_limit_table2', array('test_int' => 2));
 
-        $sql = "SELECT modify_limit_table.test_int FROM modify_limit_table INNER JOIN modify_limit_table2 ON modify_limit_table.test_int = modify_limit_table2.test_int";
+        $sql = "SELECT modify_limit_table.test_int FROM modify_limit_table INNER JOIN modify_limit_table2 ON modify_limit_table.test_int = modify_limit_table2.test_int ORDER BY modify_limit_table.test_int DESC";
 
-        $this->assertLimitResult(array(1, 1, 1, 2, 2), $sql, 10, 0);
-        $this->assertLimitResult(array(1, 1, 1), $sql, 3, 0);
-        $this->assertLimitResult(array(2, 2), $sql, 2, 3);
+        $this->assertLimitResult(array(2, 2, 1, 1, 1), $sql, 10, 0);
+        $this->assertLimitResult(array(1, 1, 1), $sql, 3, 2);
+        $this->assertLimitResult(array(2, 2), $sql, 2, 0);
     }
 
-    public function testModifyLimitQueryOrderBy()
+    public function testModifyLimitQueryNonDeterministic()
     {
         $this->_conn->insert('modify_limit_table', array('test_int' => 1));
         $this->_conn->insert('modify_limit_table', array('test_int' => 2));
         $this->_conn->insert('modify_limit_table', array('test_int' => 3));
         $this->_conn->insert('modify_limit_table', array('test_int' => 4));
 
-        $sql = "SELECT * FROM modify_limit_table ORDER BY test_int DESC";
+        $sql = "SELECT * FROM modify_limit_table";
 
-        $this->assertLimitResult(array(4, 3, 2, 1), $sql, 10, 0);
-        $this->assertLimitResult(array(4, 3), $sql, 2, 0);
-        $this->assertLimitResult(array(2, 1), $sql, 2, 2);
+        $this->assertLimitResult(array(4, 3, 2, 1), $sql, 10, 0, false);
+        $this->assertLimitResult(array(4, 3), $sql, 2, 0, false);
+        $this->assertLimitResult(array(2, 1), $sql, 2, 2, false);
     }
 
     public function testModifyLimitQueryGroupBy()
@@ -95,13 +95,14 @@ class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $sql = "SELECT modify_limit_table.test_int FROM modify_limit_table " .
                "INNER JOIN modify_limit_table2 ON modify_limit_table.test_int = modify_limit_table2.test_int ".
-               "GROUP BY modify_limit_table.test_int";
+               "GROUP BY modify_limit_table.test_int " .
+               "ORDER BY modify_limit_table.test_int ASC";
         $this->assertLimitResult(array(1, 2), $sql, 10, 0);
         $this->assertLimitResult(array(1), $sql, 1, 0);
         $this->assertLimitResult(array(2), $sql, 1, 1);
     }
 
-    public function assertLimitResult($expectedResults, $sql, $limit, $offset)
+    public function assertLimitResult($expectedResults, $sql, $limit, $offset, $deterministic = true)
     {
         $p = $this->_conn->getDatabasePlatform();
         $data = array();
@@ -109,6 +110,14 @@ class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
             $row = array_change_key_case($row, CASE_LOWER);
             $data[] = $row['test_int'];
         }
-        $this->assertEquals($expectedResults, $data);
+
+        /**
+         * Do not assert the order of results when results are non-deterministic
+         */
+        if ($deterministic) {
+            $this->assertEquals($expectedResults, $data);
+        } else {
+            $this->assertEquals(count($expectedResults), count($data));
+        }
     }
 }


### PR DESCRIPTION
The functional <code>ModifyLimitQueryTest</code> makes false expectations about the query results. <code>LIMIT</code> queries without <code>ORDER BY</code> clause return non-deterministic results, therefore the test cannot make any expectations about which values are returned and in which order. You can only expect a certain number of results.
The test might still work on platforms like mysql when you assume results to be in an ascending order, because the database might put the results of a non-deterministic query in an ascending order by default. Still this is not reliable and not all vendors do that.
This PR changes the tests to have an ordered, deterministic results by default to have more reliable expectations. Also one test about a non-deterministic query was added, which just asserts the number of results returned.
