### PR TITLE
PDO bug workaround

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -47,4 +47,13 @@ class PDOStatement extends \PDOStatement implements Statement
 
         return parent::setFetchMode($fetchMode, $arg2, $arg3);
     }
+    
+   public function bindValue($parameter, $value, $data_type = \PDO::PARAM_STR)
+   {
+      if ($data_type == \PDO::PARAM_BOOL)
+      {
+         $data_type = \PDO::PARAM_INT;
+      }
+      return parent::bindValue($parameter, $value, $data_type);
+   }    
 }


### PR DESCRIPTION
In combination of PHP 5.4 and Doctrine 2 (upto 2.4Beta1) there's a bug with "boolean" type of field.
Ref link: http://stackoverflow.com/questions/10242312/pdo-bindvalue-with-pdoparam-bool-causes-statement-execute-to-fail-silently

This patch binds int instead of bool and everything goes working fine.
