### PR TITLE
Fix SQL Server default constraints

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -60,6 +60,10 @@ class SQLServerSchemaManager extends AbstractSchemaManager
 
         while ($default != ($default2 = preg_replace("/^\((.*)\)$/", '$1', $default))) {
             $default = trim($default2, "'");
+
+            if ($default == 'getdate()') {
+                $default = $this->_platform->getCurrentTimestampSQL();
+            }
         }
 
         switch ($dbType) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -52,4 +52,116 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertEquals($collation, $columns[$columnName]->getPlatformOption('collate'));
     }
+
+    public function testDefaultContraints()
+    {
+        $table = new Table('sqlsrv_df_constraints');
+        $table->addColumn('no_default', 'string');
+        $table->addColumn('df_integer', 'integer', array('default' => 666));
+        $table->addColumn('df_string_1', 'string', array('default' => 'foobar'));
+        $table->addColumn('df_string_2', 'string', array('default' => 'Doctrine rocks!!!'));
+        $table->addColumn('df_string_3', 'string', array('default' => 'another default value'));
+        $table->addColumn('df_string_4', 'string', array('default' => 'column to rename'));
+        $table->addColumn('df_boolean', 'boolean', array('default' => true));
+
+        $this->_sm->createTable($table);
+        $columns = $this->_sm->listTableColumns('sqlsrv_df_constraints');
+
+        $this->assertNull($columns['no_default']->getDefault());
+        $this->assertEquals(666, $columns['df_integer']->getDefault());
+        $this->assertEquals('foobar', $columns['df_string_1']->getDefault());
+        $this->assertEquals('Doctrine rocks!!!', $columns['df_string_2']->getDefault());
+        $this->assertEquals('another default value', $columns['df_string_3']->getDefault());
+        $this->assertEquals(1, $columns['df_boolean']->getDefault());
+
+        $diff = new TableDiff(
+            'sqlsrv_df_constraints',
+            array(
+                new Column('df_current_timestamp', Type::getType('datetime'), array('default' => 'CURRENT_TIMESTAMP'))
+            ),
+            array(
+                'df_integer' => new ColumnDiff(
+                    'df_integer',
+                    new Column('df_integer', Type::getType('integer'), array('default' => 0)),
+                    array('default'),
+                    new Column('df_integer', Type::getType('integer'), array('default' => 666))
+                ),
+                'df_string_2' => new ColumnDiff(
+                    'df_string_2',
+                    new Column('df_string_2', Type::getType('string')),
+                    array('default'),
+                    new Column('df_string_2', Type::getType('string'), array('default' => 'Doctrine rocks!!!'))
+                ),
+                'df_string_3' => new ColumnDiff(
+                    'df_string_3',
+                    new Column('df_string_3', Type::getType('string'), array('length' => 50, 'default' => 'another default value')),
+                    array('length'),
+                    new Column('df_string_3', Type::getType('string'), array('length' => 50, 'default' => 'another default value'))
+                ),
+                'df_boolean' => new ColumnDiff(
+                    'df_boolean',
+                    new Column('df_boolean', Type::getType('boolean'), array('default' => false)),
+                    array('default'),
+                    new Column('df_boolean', Type::getType('boolean'), array('default' => true))
+                )
+            ),
+            array(
+                'df_string_1' => new Column('df_string_1', Type::getType('string'))
+            ),
+            array(),
+            array(),
+            array(),
+            $table
+        );
+        $diff->newName = 'sqlsrv_default_constraints';
+        $diff->renamedColumns['df_string_4'] = new Column(
+            'df_string_renamed',
+            Type::getType('string'),
+            array('default' => 'column to rename')
+        );
+
+        $this->_sm->alterTable($diff);
+        $columns = $this->_sm->listTableColumns('sqlsrv_default_constraints');
+
+        $this->assertNull($columns['no_default']->getDefault());
+        $this->assertEquals('CURRENT_TIMESTAMP', $columns['df_current_timestamp']->getDefault());
+        $this->assertEquals(0, $columns['df_integer']->getDefault());
+        $this->assertNull($columns['df_string_2']->getDefault());
+        $this->assertEquals('another default value', $columns['df_string_3']->getDefault());
+        $this->assertEquals(0, $columns['df_boolean']->getDefault());
+        $this->assertEquals('column to rename', $columns['df_string_renamed']->getDefault());
+
+        /**
+         * Test that column default constraints can still be referenced after table rename
+         */
+        $diff = new TableDiff(
+            'sqlsrv_default_constraints',
+            array(),
+            array(
+                'df_current_timestamp' => new ColumnDiff(
+                    'df_current_timestamp',
+                    new Column('df_current_timestamp', Type::getType('datetime')),
+                    array('default'),
+                    new Column('df_current_timestamp', Type::getType('datetime'), array('default' => 'CURRENT_TIMESTAMP'))
+                ),
+                'df_integer' => new ColumnDiff(
+                    'df_integer',
+                    new Column('df_integer', Type::getType('integer'), array('default' => 666)),
+                    array('default'),
+                    new Column('df_integer', Type::getType('integer'), array('default' => 0))
+                )
+            ),
+            array(),
+            array(),
+            array(),
+            array(),
+            $table
+        );
+
+        $this->_sm->alterTable($diff);
+        $columns = $this->_sm->listTableColumns('sqlsrv_default_constraints');
+
+        $this->assertNull($columns['df_current_timestamp']->getDefault());
+        $this->assertEquals(666, $columns['df_integer']->getDefault());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -14,13 +14,13 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
 
     public function getGenerateTableSql()
     {
-        return 'CREATE TABLE test (id INT IDENTITY NOT NULL, test NVARCHAR(255) NULL, PRIMARY KEY (id))';
+        return 'CREATE TABLE test (id INT IDENTITY NOT NULL, test NVARCHAR(255), PRIMARY KEY (id))';
     }
 
     public function getGenerateTableWithMultiColumnUniqueIndexSql()
     {
         return array(
-            'CREATE TABLE test (foo NVARCHAR(255) NULL, bar NVARCHAR(255) NULL)',
+            'CREATE TABLE test (foo NVARCHAR(255), bar NVARCHAR(255))',
             'CREATE UNIQUE INDEX UNIQ_D87F7E0C8C73652176FF8CAA ON test (foo, bar) WHERE foo IS NOT NULL AND bar IS NOT NULL'
         );
     }
@@ -28,11 +28,19 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     public function getGenerateAlterTableSql()
     {
         return array(
-            'ALTER TABLE mytable ADD quota INT NULL',
+            'ALTER TABLE mytable ADD quota INT',
             'ALTER TABLE mytable DROP COLUMN foo',
-            'ALTER TABLE mytable ALTER COLUMN baz NVARCHAR(255) DEFAULT \'def\' NOT NULL',
-            'ALTER TABLE mytable ALTER COLUMN bloo BIT DEFAULT \'0\' NOT NULL',
+            'ALTER TABLE mytable ALTER COLUMN baz NVARCHAR(255) NOT NULL',
+            "ALTER TABLE mytable ADD CONSTRAINT DF_6B2BD609_78240498 DEFAULT 'def' FOR baz",
+            'ALTER TABLE mytable ALTER COLUMN bloo BIT NOT NULL',
             "sp_RENAME 'mytable', 'userlist'",
+            "DECLARE @sql NVARCHAR(MAX) = N''; " .
+            "SELECT @sql += N'EXEC sp_rename N''' + dc.name + ''', N''' " .
+            "+ REPLACE(dc.name, '6B2BD609', 'E2B58069') + ''', ''OBJECT'';' " .
+            "FROM sys.default_constraints dc " .
+            "JOIN sys.tables tbl ON dc.parent_object_id = tbl.object_id " .
+            "WHERE tbl.name = 'userlist';" .
+            "EXEC sp_executesql @sql"
         );
     }
 


### PR DESCRIPTION
This PR fixes altering column default values. In SQL Server column default values are stored in constraints. <code>CREATE TABLE</code> statements with column declarations like <code>some_column NVARCHAR(50) NOT NULL DEFAULT 'default value'</code> internally creates a default constraint with an automatically generated name in the the system table `sys.default_constraints`. <code>ALTER TABLE</code> statements do not support the <code>DEFAULT</code> clause in column alteration declarations, leading in SQL syntax errors. Thus changing a column's default value is currently not possible. 
To alter a column's default value, the old column's default constraint hast to be dropped and recreated again. As a default constraint has to be referenced by name to be dropped, we need to create each default constraint with an own unique name. This PR generates separate statements for default constraint declarations. It generates a unique name consisting of the table name and the column name the default constraint is created for.
<code>DF_TABLE_NAME_HASH%_%COLUMN_NAME_HASH%</code>
