### PR TITLE
Fixing issue when number of positional parameters != number of given types

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -80,7 +80,7 @@ class SQLParserUtils
      * @param string    $query  The SQL query to execute.
      * @param array     $params The parameters to bind to the query.
      * @param array     $types  The types the previous parameters are in.
-     * 
+     *
      * @return array
      */
     static public function expandListParameters($query, $params, $types)
@@ -103,7 +103,7 @@ class SQLParserUtils
             $arrayPositions[$name] = false;
         }
 
-        if (( ! $arrayPositions && $isPositional) || (count($params) != count($types))) {
+        if (( ! $arrayPositions && $isPositional)) {
             return array($query, $params, $types);
         }
 
@@ -130,9 +130,9 @@ class SQLParserUtils
 
                 $types = array_merge(
                     array_slice($types, 0, $needle),
-                    $count ? 
+                    $count ?
                         array_fill(0, $count, $types[$needle] - Connection::ARRAY_PARAM_OFFSET) : // array needles are at PDO::PARAM_* + 100
-                        array(), 
+                        array(),
                     array_slice($types, $needle + 1)
                 );
 
@@ -159,9 +159,9 @@ class SQLParserUtils
                 $pos         += $queryOffset;
                 $queryOffset -= ($paramLen - 1);
                 $paramsOrd[]  = $value;
-                $typesOrd[]   = $types[$paramName];
+                $typesOrd[]   = isset($types[$paramName]) ? $types[$paramName] : \PDO::PARAM_STR;
                 $query        = substr($query, 0, $pos) . '?' . substr($query, ($pos + $paramLen));
-            
+
                 continue;
             }
 

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -236,6 +236,22 @@ SQLDATA
                 array(),
                 array()
             ),
+            array(
+                "SELECT * FROM Foo WHERE foo IN (:foo) OR bar = :bar OR baz = :baz",
+                array('foo' => array(1, 2), 'bar' => 'bar', 'baz' => 'baz'),
+                array('foo' => Connection::PARAM_INT_ARRAY, 'baz' => 'string'),
+                'SELECT * FROM Foo WHERE foo IN (?, ?) OR bar = ? OR baz = ?',
+                array(1, 2, 'bar', 'baz'),
+                array(\PDO::PARAM_INT, \PDO::PARAM_INT, \PDO::PARAM_STR, 'string')
+            ),
+            array(
+                "SELECT * FROM Foo WHERE foo IN (:foo) OR bar = :bar",
+                array('foo' => array(1, 2), 'bar' => 'bar'),
+                array('foo' => Connection::PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (?, ?) OR bar = ?',
+                array(1, 2, 'bar'),
+                array(\PDO::PARAM_INT, \PDO::PARAM_INT, \PDO::PARAM_STR)
+            ),
         );
     }
 


### PR DESCRIPTION
When passing incomplete type information to `Connection::query()`, `SQLParserUtils` currently behaves the wrong way as it ignores all typing information instead falling back to a default (`PDO::PARAM_STR`). I don’t know this place very well, so please review carefully.
