### PR TITLE
Fixed a PHP warning in DBALException::driverExceptionDuringQuery()

### DIFF
--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\Tests\DBAL;
+
+use Doctrine\DBAL\DBALException;
+
+class DBALExceptionTest extends \Doctrine\Tests\DbalTestCase
+{
+    public function testDriverExceptionDuringQueryAcceptsBinaryData()
+    {
+        $e = DBALException::driverExceptionDuringQuery(new \Exception, '', array('ABC', chr(128)));
+        $this->assertContains('with params ["ABC", "\x80"]', $e->getMessage());
+    }
+}


### PR DESCRIPTION
When a query parameter contains binary data, `driverExceptionDuringQuery()` generates a PHP warning. This is because it internally uses `json_encode()`, which expects valid UTF-8 strings (at least in PHP 5.4.13).

This PR removes the warning with the `@` operator. `json_encode()` will still return a string representation, replacing the binary data with `null`.

I added a test that fails before the fix.
