### PR TITLE
[DBAL-497] Fixed SQL Server platform replacing 'FROM' in column names during limit

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -845,7 +845,7 @@ class SQLServerPlatform extends AbstractPlatform
             }
 
             //Replace only first occurrence of FROM with $over to prevent changing FROM also in subqueries.
-            $query = preg_replace('/\sFROM/i', ", ROW_NUMBER() OVER ($over) AS doctrine_rownum FROM", $query, 1);
+            $query = preg_replace('/\sFROM\s/i', ", ROW_NUMBER() OVER ($over) AS doctrine_rownum FROM ", $query, 1);
 
             $start = $offset + 1;
             $end = $offset + $limit;


### PR DESCRIPTION
The regex used to replace the FROM clause was in a "starts with" form, which also matched column names that start with the word "FROM". This resulted in column names being replaced with the logic used for limiting, breaking the query once pagination is used. I added a whitespace requirement after "FROM' in the regex as well as a trailing whitespace in the replacement.
