### PR TITLE
Enhanced Master-Slave Connection

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\Tests\DbalFunctionalTestCase;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Types\Type;
 
 /**
  * @group DBAL-20
@@ -27,12 +28,22 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
             $sm = $this->_conn->getSchemaManager();
             $sm->createTable($table);
 
+            $table = new \Doctrine\DBAL\Schema\Table("master_slave_table2");
+            $table->addColumn('test_int', 'integer');
+            $table->setPrimaryKey(array('test_int'));
 
-        } catch(\Exception $e) {
+            $sm = $this->_conn->getSchemaManager();
+            $sm->createTable($table);
+        } catch (\Exception $e) {
+
         }
 
         $this->_conn->executeUpdate('DELETE FROM master_slave_table');
         $this->_conn->insert('master_slave_table', array('test_int' => 1));
+
+        $this->_conn->executeUpdate('DELETE FROM master_slave_table2');
+        $this->_conn->insert('master_slave_table2', array('test_int' => 2));
+        $this->_conn->insert('master_slave_table2', array('test_int' => 3));
     }
 
     public function createMasterSlaveConnection($keepSlave = false)
@@ -67,6 +78,81 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
 
         $this->assertEquals(1, $data[0]['num']);
         $this->assertFalse($conn->isConnectedToMaster());
+    }
+
+    public function testNoMasterOnQuery()
+    {
+        $conn = $this->createMasterSlaveConnection();
+
+        $sql = "SELECT count(*) as num FROM master_slave_table";
+        $statement = $conn->query($sql);
+        $data = $statement->fetchAll();
+        $data[0] = array_change_key_case($data[0], CASE_LOWER);
+
+        $this->assertEquals(1, $data[0]['num']);
+        $this->assertFalse($conn->isConnectedToMaster());
+    }
+
+    public function testNoMasterOnPrepare()
+    {
+        $conn = $this->createMasterSlaveConnection();
+
+        $sql = "SELECT count(*) as num FROM master_slave_table";
+        $statement = $conn->prepare($sql);
+        $statement->execute();
+        $data = $statement->fetchAll();
+        $data[0] = array_change_key_case($data[0], CASE_LOWER);
+
+        $this->assertEquals(1, $data[0]['num']);
+        $this->assertFalse($conn->isConnectedToMaster());
+    }
+
+    /**
+     * @dataProvider sqlDataProvider
+     */
+    public function testMasterOrSlaveOnExecuteQuery($sql, $params, $types, $connectedToMaster)
+    {
+        $conn = $this->createMasterSlaveConnection();
+        $this->assertFalse($conn->isConnectedToMaster());
+
+        $conn->executeQuery($sql, $params, $types);
+
+        $this->assertEquals($connectedToMaster, $conn->isConnectedToMaster());
+    }
+
+    /**
+     * @dataProvider sqlDataProvider
+     */
+    public function testMasterOrSlaveOnPrepare($sql, $params, $types, $connectedToMaster)
+    {
+        $conn = $this->createMasterSlaveConnection();
+        $this->assertFalse($conn->isConnectedToMaster());
+
+        $statement = $conn->prepare($sql);
+
+        foreach ($params as $key=>$param) {
+            $statement->bindValue($key+1, $param, $types[$key]);
+        }
+
+        $this->assertEquals($connectedToMaster, $conn->isConnectedToMaster());
+    }
+
+    public function sqlDataProvider()
+    {
+        return array(
+            array('INSERT INTO master_slave_table (test_int) VALUES (?)', array(4), array(Type::INTEGER), true),
+            array('SELECT test_int FROM master_slave_table WHERE test_int=?', array(2), array(Type::INTEGER), false),
+            array('select test_int from master_slave_table where test_int=?', array(2), array(Type::INTEGER), false),
+            array('SELECT test_int AS select_data FROM master_slave_table WHERE test_int=?', array(2), array(Type::INTEGER), false),
+            array('SELECT test_int AS insert_data FROM master_slave_table WHERE test_int=?', array(2), array(Type::INTEGER), false),
+            array('SELECT test_int FROM master_slave_table WHERE test_int=(SELECT MIN(test_int) FROM master_slave_table2)', array(), array(), false),
+            array('UPDATE master_slave_table SET test_int=(SELECT MIN(test_int) FROM master_slave_table2)', array(), array(), true),
+            array('TRUNCATE TABLE master_slave_table2', array(), array(), true),
+            array('INSERT INTO master_slave_table2 SELECT * FROM master_slave_table', array(), array(), true),
+            array('UPDATE master_slave_table SET test_int=?', array(3), array(Type::INTEGER), true),
+            array('update master_slave_table set test_int=?', array(3), array(Type::INTEGER), true),
+            array('DELETE FROM master_slave_table WHERE test_int=?', array(3), array(Type::INTEGER), true),
+        );
     }
 
     public function testMasterOnWriteOperation()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no? |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

Current implementation of MasterSlaveConnection is very restrictive. The slave is picked up only when `executeQuery` is used. If appliacation uses `prepare` method in queries, every `SELECT` is done on master and this is bad for performance of master.

This PR changes how and when it picks the slave or master:
1. Slave if master was never picked before and ONLY if `getWrappedConnection`, `query`, `prepare`, or `executeQuery` is used and the query begins with `SELECT` (case insensitive) string.
2. Master picked when `exec`, `executeUpdate`, `insert`, `delete`, `update`, `createSavepoint`, `releaseSavepoint`, `beginTransaction`, `rollback`, `commit` is called.
3. Master picked when `query`, `prepare` or `executeQuery` is called and the query doesn't begin with `SELECT` (case insensitive) string.
4. If master was picked once during the lifetime of the connection it will always get picked afterwards.
5. One slave connection is randomly picked ONCE during a request.
