### PR TITLE
Conditionaly upgrade utf8 to utf8mb4 for MySQL 5.5.3

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -42,7 +42,12 @@ class MysqliConnection implements Connection
         }
 
         if (isset($params['charset'])) {
-            $this->_conn->set_charset($params['charset']);
+            if (50503 <= $this->_conn->server_version && 0 === strcasecmp($params['charset'], 'utf8')) {
+                $this->_conn->set_charset('utf8mb4');
+            }
+            else {
+                $this->_conn->set_charset($params['charset']);
+            }
         }
     }
 

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -39,6 +39,23 @@ class Driver implements \Doctrine\DBAL\Driver
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
     {
+        if (isset($params['charset']) && 0 === strcasecmp($params['charset'], 'utf8')) {
+            try {
+                $conn = new \Doctrine\DBAL\Driver\PDOConnection(
+                    $this->_constructPdoDsn(array('charset' => 'utf8mb4') + $params),
+                    $username,
+                    $password,
+                    $driverOptions
+                );
+                return $conn;
+
+            } catch(\PDOException $e) {
+                if (2019 !== $e->getCode()) {
+                    throw $e;
+                }
+            }
+        }
+
         $conn = new \Doctrine\DBAL\Driver\PDOConnection(
             $this->_constructPdoDsn($params),
             $username,

--- a/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
@@ -53,8 +53,8 @@ class MysqlSessionInit implements EventSubscriber
      */
     public function __construct($charset = 'utf8', $collation = false)
     {
-        $this->_charset = $charset;
-        $this->_collation = $collation;
+        $this->_charset = strtolower($charset);
+        $this->_collation = strtolower($collation);
     }
 
     /**
@@ -63,8 +63,18 @@ class MysqlSessionInit implements EventSubscriber
      */
     public function postConnect(ConnectionEventArgs $args)
     {
-        $collation = ($this->_collation) ? " COLLATE ".$this->_collation : "";
-        $args->getConnection()->executeUpdate("SET NAMES ".$this->_charset . $collation);
+        $collation = ($this->_collation) ? " COLLATE ".$this->_collation : " ";
+        $sql = "SET NAMES ".$this->_charset . $collation;
+
+        $mb4 = str_replace('utf8 ', 'utf8mb4 ', $sql);
+        $mb4 = str_replace('utf8_', 'utf8mb4_', $mb4);
+
+        if ($mb4 !== $sql)
+        {
+            $sql .= '/*!50503,' . $mb4 . '*/';
+        }
+
+        $args->getConnection()->executeUpdate($sql);
     }
 
     public function getSubscribedEvents()

--- a/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
@@ -67,8 +67,8 @@ class MysqlSessionInit implements EventSubscriber
         $sql = 'SET NAMES ' . $this->_charset . $collation;
 
         $mb4 = str_replace(
-            array('utf8 ', 'utf8mb4 '),
-            array('utf8_', 'utf8mb4_'),
+            array('utf8 ', 'utf8_'),
+            array('utf8mb4 ', 'utf8mb4_'),
             $sql
         );
 

--- a/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
@@ -66,11 +66,13 @@ class MysqlSessionInit implements EventSubscriber
         $collation = $this->_collation ? ' COLLATE ' . $this->_collation : ' ';
         $sql = 'SET NAMES ' . $this->_charset . $collation;
 
-        $mb4 = str_replace('utf8 ', 'utf8mb4 ', $sql);
-        $mb4 = str_replace('utf8_', 'utf8mb4_', $mb4);
+        $mb4 = str_replace(
+            array('utf8 ', 'utf8mb4 '),
+            array('utf8_', 'utf8mb4_'),
+            $sql
+        );
 
-        if ($mb4 !== $sql)
-        {
+        if ($mb4 !== $sql) {
             $sql .= '/*!50503,' . $mb4 . '*/';
         }
 

--- a/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
@@ -51,9 +51,9 @@ class MysqlSessionInit implements EventSubscriber
      * @param string $charset
      * @param string $collation
      */
-    public function __construct($charset = 'utf8', $collation = false)
+    public function __construct($charset = 'utf8', $collation = '')
     {
-        $this->_charset = strtolower($charset);
+        $this->_charset   = strtolower($charset);
         $this->_collation = strtolower($collation);
     }
 
@@ -63,8 +63,8 @@ class MysqlSessionInit implements EventSubscriber
      */
     public function postConnect(ConnectionEventArgs $args)
     {
-        $collation = ($this->_collation) ? " COLLATE ".$this->_collation : " ";
-        $sql = "SET NAMES ".$this->_charset . $collation;
+        $collation = $this->_collation ? ' COLLATE ' . $this->_collation : ' ';
+        $sql = 'SET NAMES ' . $this->_charset . $collation;
 
         $mb4 = str_replace('utf8 ', 'utf8mb4 ', $sql);
         $mb4 = str_replace('utf8_', 'utf8mb4_', $mb4);


### PR DESCRIPTION
See http://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html

As utf8mb4 is a superset of utf8, this should be transparent and backward compatible.
For those really requiring the "utf8" meant by MySQL, they can use explicitely the utf8mb3 charset.
But IMHO by default, Doctrine should really use utf8mb4, which is what everybody expect from a charset named "utf8".
