### PR TITLE
DBAL-522 - SQLParserUtils always throws exceptions on null bound params

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -212,12 +212,12 @@ class SQLParserUtils
      */
     static private function extractParam($paramName, $paramsOrTypes, $isParam, $defaultValue = null)
     {
-        if (isset($paramsOrTypes[$paramName])) {
+        if (array_key_exists($paramName, $paramsOrTypes)) {
             return $paramsOrTypes[$paramName];
         }
 
         // Hash keys can be prefixed with a colon for compatibility
-        if (isset($paramsOrTypes[':' . $paramName])) {
+        if (array_key_exists(':' . $paramName, $paramsOrTypes)) {
             return $paramsOrTypes[':' . $paramName];
         }
 

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -286,6 +286,23 @@ SQLDATA
                 array(1, 2, 'bar'),
                 array(\PDO::PARAM_INT, \PDO::PARAM_INT, \PDO::PARAM_STR)
             ),
+            // DBAL-522 - null valued parameters are not considered
+            array(
+                'INSERT INTO Foo (foo, bar) values (:foo, :bar)',
+                array('foo' => 1, 'bar' => null),
+                array(':foo' => \PDO::PARAM_INT, ':bar' => \PDO::PARAM_NULL),
+                'INSERT INTO Foo (foo, bar) values (?, ?)',
+                array(1, null),
+                array(\PDO::PARAM_INT, \PDO::PARAM_NULL)
+            ),
+            array(
+                'INSERT INTO Foo (foo, bar) values (?, ?)',
+                array(1, null),
+                array(\PDO::PARAM_INT, \PDO::PARAM_NULL),
+                'INSERT INTO Foo (foo, bar) values (?, ?)',
+                array(1, null),
+                array(\PDO::PARAM_INT, \PDO::PARAM_NULL)
+            ),
         );
     }
 


### PR DESCRIPTION
Hotfix for [DBAL-522](http://www.doctrine-project.org/jira/browse/DBAL-522)

Demonstrates that NULL parameters are handled incorrectly by `Doctrine\DBAL\SqlParserUtils` as of 2.3.4.

Basically, following usage always throws an exception:

``` php
$conn->executeQuery(
    'INSERT INTO FOO (foo, bar) values (:foo, :bar)', 
    array('foo' => 1, 'bar' => null)
);
```
