### PR TITLE
Update SQLServer2008Platform.php (support  MS SQL Server type datetimeoffset(6))

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -52,6 +52,14 @@ class SQLServer2008Platform extends SQLServer2005Platform
     {
         return 'TIME(0)';
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration)
+    {
+        return 'DATETIMEOFFSET(6)';
+    }
 
     /**
      * {@inheritDoc}
@@ -96,6 +104,7 @@ class SQLServer2008Platform extends SQLServer2005Platform
         $this->doctrineTypeMapping['datetime2'] = 'datetime';
         $this->doctrineTypeMapping['date'] = 'date';
         $this->doctrineTypeMapping['time'] = 'time';
+        $this->doctrineTypeMapping['datetimeoffset'] = 'datetimetz';
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -52,6 +52,14 @@ class SQLServer2008Platform extends SQLServer2005Platform
     {
         return 'TIME(0)';
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration)
+    {
+        return 'datetimeoffset(6)';
+    }
 
     /**
      * {@inheritDoc}

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -58,7 +58,7 @@ class SQLServer2008Platform extends SQLServer2005Platform
      */
     public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration)
     {
-        return 'datetimeoffset(6)';
+        return 'DATETIMEOFFSET(6)';
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -957,7 +957,6 @@ class SQLServerPlatform extends AbstractPlatform
             'real' => 'float',
             'double' => 'float',
             'double precision' => 'float',
-            'datetimeoffset' => 'datetimetz',
             'smalldatetime' => 'datetime',
             'datetime' => 'datetime',
             'char' => 'string',

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\SQLServer2008Platform;
-use Doctrine\DBAL\Schema\Sequence;
 
 class SQLServer2008PlatformTest extends SQLServerPlatformTest
 {

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Platforms;
+
+use Doctrine\DBAL\Platforms\SQLServer2008Platform;
+use Doctrine\DBAL\Schema\Sequence;
+
+class SQLServer2008PlatformTest extends SQLServerPlatformTest
+{
+    public function createPlatform()
+    {
+        return new SQLServer2008Platform;
+    }
+
+    public function testGeneratesTypeDeclarationForDateTimeTz()
+    {
+        $this->assertEquals(
+            'DATETIMEOFFSET(6)',
+            $this->_platform->getDateTimeTzTypeDeclarationSQL(
+                array())
+        );
+    }
+}


### PR DESCRIPTION
Added support of  maps a Doctrine datetimetz type to a MS SQL SERVER type datetimeoffset(6)
