### PR TITLE
Add method ResultStatement::rowCount()

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -66,6 +66,14 @@ class ArrayStatement implements \IteratorAggregate, ResultStatement
     /**
      * {@inheritdoc}
      */
+    public function rowCount()
+    {
+        return count($this->data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function columnCount()
     {
         return $this->columnCount;

--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -34,6 +34,16 @@ interface ResultStatement extends \Traversable
     public function closeCursor();
 
     /**
+     * Returns the number of rows in the result set
+     *
+     * @return integer              Returns the number of rows in the result set represented
+     *                              by the PDOStatement object. If there is no result set,
+     *                              this method should return 0.
+     */
+    public function rowCount();
+
+
+    /**
      * Returns the number of columns in the result set
      *
      * @return integer The number of columns in the result set represented


### PR DESCRIPTION
Sometimes it is required to get the number of rows in a result before
fetching the data itself. PDO provide PDO_Statement::rowCount() for
this, wich is now be added to the ResultStatement interface.
This will only affect the class ArrayStatement, because it is the only
statement implementation, that does not provide rowCount().
