### PR TITLE
Escaped table name

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1086,7 +1086,7 @@ class QueryBuilder
         if (isset($this->sqlParts['join'][$fromAlias])) {
             foreach ($this->sqlParts['join'][$fromAlias] as $join) {
                 $sql .= ' ' . strtoupper($join['joinType'])
-                      . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']
+                      . ' JOIN ' . "`{$join['joinTable']}`" . ' ' . $join['joinAlias']
                       . ' ON ' . ((string) $join['joinCondition']);
                 $knownAliases[$join['joinAlias']] = true;
 

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -951,7 +951,7 @@ class QueryBuilder
         // Loop through all FROM clauses
         foreach ($this->sqlParts['from'] as $from) {
             $knownAliases[$from['alias']] = true;
-            $fromClause = $from['table'] . ' ' . $from['alias']
+            $fromClause = "`{$from['table']}`" . ' ' . $from['alias']
                 . $this->getSQLForJoins($from['alias'], $knownAliases);
 
             $fromClauses[$from['alias']] = $fromClause;
@@ -982,7 +982,7 @@ class QueryBuilder
     private function getSQLForUpdate()
     {
         $table = $this->sqlParts['from']['table'] . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
-        $query = 'UPDATE ' . $table
+        $query = 'UPDATE ' . "`{$table}`"
                . ' SET ' . implode(", ", $this->sqlParts['set'])
                . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '');
 
@@ -997,7 +997,7 @@ class QueryBuilder
     private function getSQLForDelete()
     {
         $table = $this->sqlParts['from']['table'] . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
-        $query = 'DELETE FROM ' . $table . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '');
+        $query = 'DELETE FROM ' . "`{$table}`" . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '');
 
         return $query;
     }

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -32,7 +32,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
         $qb->select('u.id')
            ->from('users', 'u');
 
-        $this->assertEquals('SELECT u.id FROM users u', (string) $qb);
+        $this->assertEquals('SELECT u.id FROM `users` u', (string) $qb);
     }
 
     public function testSelectWithSimpleWhere()
@@ -44,7 +44,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->from('users', 'u')
            ->where($expr->andX($expr->eq('u.nickname', '?')));
 
-        $this->assertEquals("SELECT u.id FROM users u WHERE u.nickname = ?", (string) $qb);
+        $this->assertEquals("SELECT u.id FROM `users` u WHERE u.nickname = ?", (string) $qb);
     }
 
     public function testSelectWithLeftJoin()
@@ -56,7 +56,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->from('users', 'u')
            ->leftJoin('u', 'phones', 'p', $expr->eq('p.user_id', 'u.id'));
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u LEFT JOIN phones p ON p.user_id = u.id', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u LEFT JOIN `phones` p ON p.user_id = u.id', (string) $qb);
     }
 
     public function testSelectWithJoin()
@@ -68,7 +68,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->from('users', 'u')
            ->Join('u', 'phones', 'p', $expr->eq('p.user_id', 'u.id'));
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u INNER JOIN phones p ON p.user_id = u.id', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u INNER JOIN `phones` p ON p.user_id = u.id', (string) $qb);
     }
 
     public function testSelectWithInnerJoin()
@@ -80,7 +80,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->from('users', 'u')
            ->innerJoin('u', 'phones', 'p', $expr->eq('p.user_id', 'u.id'));
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u INNER JOIN phones p ON p.user_id = u.id', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u INNER JOIN `phones` p ON p.user_id = u.id', (string) $qb);
     }
 
     public function testSelectWithRightJoin()
@@ -92,7 +92,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->from('users', 'u')
            ->rightJoin('u', 'phones', 'p', $expr->eq('p.user_id', 'u.id'));
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u RIGHT JOIN phones p ON p.user_id = u.id', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u RIGHT JOIN `phones` p ON p.user_id = u.id', (string) $qb);
     }
 
     public function testSelectWithAndWhereConditions()
@@ -105,7 +105,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->where('u.username = ?')
            ->andWhere('u.name = ?');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u WHERE (u.username = ?) AND (u.name = ?)', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u WHERE (u.username = ?) AND (u.name = ?)', (string) $qb);
     }
 
     public function testSelectWithOrWhereConditions()
@@ -118,7 +118,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->where('u.username = ?')
            ->orWhere('u.name = ?');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u WHERE (u.username = ?) OR (u.name = ?)', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u WHERE (u.username = ?) OR (u.name = ?)', (string) $qb);
     }
 
     public function testSelectWithOrOrWhereConditions()
@@ -131,7 +131,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->orWhere('u.username = ?')
            ->orWhere('u.name = ?');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u WHERE (u.username = ?) OR (u.name = ?)', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u WHERE (u.username = ?) OR (u.name = ?)', (string) $qb);
     }
 
     public function testSelectWithAndOrWhereConditions()
@@ -146,7 +146,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->orWhere('u.name = ?')
            ->andWhere('u.name = ?');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u WHERE (((u.username = ?) AND (u.username = ?)) OR (u.name = ?)) AND (u.name = ?)', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u WHERE (((u.username = ?) AND (u.username = ?)) OR (u.name = ?)) AND (u.name = ?)', (string) $qb);
     }
 
     public function testSelectGroupBy()
@@ -158,7 +158,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->from('users', 'u')
            ->groupBy('u.id');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u GROUP BY u.id', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u GROUP BY u.id', (string) $qb);
     }
 
     public function testSelectEmptyGroupBy()
@@ -170,7 +170,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->groupBy(array())
            ->from('users', 'u');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u', (string) $qb);
     }
 
     public function testSelectEmptyAddGroupBy()
@@ -182,7 +182,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->addGroupBy(array())
            ->from('users', 'u');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u', (string) $qb);
     }
 
     public function testSelectAddGroupBy()
@@ -195,7 +195,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->groupBy('u.id')
            ->addGroupBy('u.foo');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u GROUP BY u.id, u.foo', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u GROUP BY u.id, u.foo', (string) $qb);
     }
 
     public function testSelectAddGroupBys()
@@ -208,7 +208,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->groupBy('u.id')
            ->addGroupBy('u.foo', 'u.bar');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u GROUP BY u.id, u.foo, u.bar', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u GROUP BY u.id, u.foo, u.bar', (string) $qb);
     }
 
     public function testSelectHaving()
@@ -221,7 +221,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->groupBy('u.id')
            ->having('u.name = ?');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u GROUP BY u.id HAVING u.name = ?', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u GROUP BY u.id HAVING u.name = ?', (string) $qb);
     }
 
     public function testSelectAndHaving()
@@ -234,7 +234,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->groupBy('u.id')
            ->andHaving('u.name = ?');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u GROUP BY u.id HAVING u.name = ?', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u GROUP BY u.id HAVING u.name = ?', (string) $qb);
     }
 
     public function testSelectHavingAndHaving()
@@ -248,7 +248,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->having('u.name = ?')
            ->andHaving('u.username = ?');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u GROUP BY u.id HAVING (u.name = ?) AND (u.username = ?)', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u GROUP BY u.id HAVING (u.name = ?) AND (u.username = ?)', (string) $qb);
     }
 
     public function testSelectHavingOrHaving()
@@ -262,7 +262,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->having('u.name = ?')
            ->orHaving('u.username = ?');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u GROUP BY u.id HAVING (u.name = ?) OR (u.username = ?)', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u GROUP BY u.id HAVING (u.name = ?) OR (u.username = ?)', (string) $qb);
     }
 
     public function testSelectOrHavingOrHaving()
@@ -276,7 +276,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->orHaving('u.name = ?')
            ->orHaving('u.username = ?');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u GROUP BY u.id HAVING (u.name = ?) OR (u.username = ?)', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u GROUP BY u.id HAVING (u.name = ?) OR (u.username = ?)', (string) $qb);
     }
 
     public function testSelectHavingAndOrHaving()
@@ -291,7 +291,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->orHaving('u.username = ?')
            ->andHaving('u.username = ?');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u GROUP BY u.id HAVING ((u.name = ?) OR (u.username = ?)) AND (u.username = ?)', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u GROUP BY u.id HAVING ((u.name = ?) OR (u.username = ?)) AND (u.username = ?)', (string) $qb);
     }
 
     public function testSelectOrderBy()
@@ -303,7 +303,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->from('users', 'u')
            ->orderBy('u.name');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u ORDER BY u.name ASC', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u ORDER BY u.name ASC', (string) $qb);
     }
 
     public function testSelectAddOrderBy()
@@ -316,7 +316,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->orderBy('u.name')
            ->addOrderBy('u.username', 'DESC');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u ORDER BY u.name ASC, u.username DESC', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u ORDER BY u.name ASC, u.username DESC', (string) $qb);
     }
 
     public function testSelectAddAddOrderBy()
@@ -329,7 +329,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->addOrderBy('u.name')
            ->addOrderBy('u.username', 'DESC');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u ORDER BY u.name ASC, u.username DESC', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u ORDER BY u.name ASC, u.username DESC', (string) $qb);
     }
 
     public function testEmptySelect()
@@ -350,7 +350,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->addSelect('p.*')
            ->from('users', 'u');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u', (string) $qb);
     }
 
     public function testEmptyAddSelect()
@@ -372,7 +372,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->from('users', 'u')
            ->from('phonenumbers', 'p');
 
-        $this->assertEquals('SELECT u.*, p.* FROM users u, phonenumbers p', (string) $qb);
+        $this->assertEquals('SELECT u.*, p.* FROM `users` u, `phonenumbers` p', (string) $qb);
     }
 
     public function testUpdate()
@@ -383,7 +383,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->set('u.bar', '?');
 
         $this->assertEquals(QueryBuilder::UPDATE, $qb->getType());
-        $this->assertEquals('UPDATE users u SET u.foo = ?, u.bar = ?', (string) $qb);
+        $this->assertEquals('UPDATE `users` u SET u.foo = ?, u.bar = ?', (string) $qb);
     }
 
     public function testUpdateWithoutAlias()
@@ -393,7 +393,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->set('foo', '?')
            ->set('bar', '?');
 
-        $this->assertEquals('UPDATE users SET foo = ?, bar = ?', (string) $qb);
+        $this->assertEquals('UPDATE `users` SET foo = ?, bar = ?', (string) $qb);
     }
 
     public function testUpdateWhere()
@@ -403,7 +403,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
            ->set('u.foo', '?')
            ->where('u.foo = ?');
 
-        $this->assertEquals('UPDATE users u SET u.foo = ? WHERE u.foo = ?', (string) $qb);
+        $this->assertEquals('UPDATE `users` u SET u.foo = ? WHERE u.foo = ?', (string) $qb);
     }
 
     public function testEmptyUpdate()
@@ -430,7 +430,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
         $qb->delete('users');
 
         $this->assertEquals(QueryBuilder::DELETE, $qb->getType());
-        $this->assertEquals('DELETE FROM users', (string) $qb);
+        $this->assertEquals('DELETE FROM `users`', (string) $qb);
     }
 
     public function testDeleteWhere()
@@ -439,7 +439,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
         $qb->delete('users', 'u')
            ->where('u.foo = ?');
 
-        $this->assertEquals('DELETE FROM users u WHERE u.foo = ?', (string) $qb);
+        $this->assertEquals('DELETE FROM `users` u WHERE u.foo = ?', (string) $qb);
     }
 
     public function testEmptyDelete()
@@ -497,9 +497,9 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
 
         $qb->select('u.*')->from('users', 'u')->where('u.name = ?');
 
-        $this->assertEquals('SELECT u.* FROM users u WHERE u.name = ?', (string)$qb);
+        $this->assertEquals('SELECT u.* FROM `users` u WHERE u.name = ?', (string)$qb);
         $qb->resetQueryPart('where');
-        $this->assertEquals('SELECT u.* FROM users u', (string)$qb);
+        $this->assertEquals('SELECT u.* FROM `users` u', (string)$qb);
     }
 
     public function testResetQueryParts()
@@ -508,9 +508,9 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
 
         $qb->select('u.*')->from('users', 'u')->where('u.name = ?')->orderBy('u.name');
 
-        $this->assertEquals('SELECT u.* FROM users u WHERE u.name = ? ORDER BY u.name ASC', (string)$qb);
+        $this->assertEquals('SELECT u.* FROM `users` u WHERE u.name = ? ORDER BY u.name ASC', (string)$qb);
         $qb->resetQueryParts(array('where', 'orderBy'));
-        $this->assertEquals('SELECT u.* FROM users u', (string)$qb);
+        $this->assertEquals('SELECT u.* FROM `users` u', (string)$qb);
     }
 
     public function testCreateNamedParameter()
@@ -521,7 +521,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
             $qb->expr()->eq('u.name', $qb->createNamedParameter(10, \PDO::PARAM_INT))
         );
 
-        $this->assertEquals('SELECT u.* FROM users u WHERE u.name = :dcValue1', (string)$qb);
+        $this->assertEquals('SELECT u.* FROM `users` u WHERE u.name = :dcValue1', (string)$qb);
         $this->assertEquals(10, $qb->getParameter('dcValue1'));
     }
 
@@ -533,7 +533,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
             $qb->expr()->eq('u.name', $qb->createNamedParameter(10, \PDO::PARAM_INT, ':test'))
         );
 
-        $this->assertEquals('SELECT u.* FROM users u WHERE u.name = :test', (string)$qb);
+        $this->assertEquals('SELECT u.* FROM `users` u WHERE u.name = :test', (string)$qb);
         $this->assertEquals(10, $qb->getParameter('test'));
     }
 
@@ -545,7 +545,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
             $qb->expr()->eq('u.name', $qb->createPositionalParameter(10, \PDO::PARAM_INT))
         );
 
-        $this->assertEquals('SELECT u.* FROM users u WHERE u.name = ?', (string)$qb);
+        $this->assertEquals('SELECT u.* FROM `users` u WHERE u.name = ?', (string)$qb);
         $this->assertEquals(10, $qb->getParameter(1));
     }
 
@@ -582,7 +582,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
             ->where('nt.lang = ?')
             ->andWhere('n.deleted = 0');
 
-        $this->assertEquals("SELECT COUNT(DISTINCT news.id) FROM newspages news INNER JOIN nodeversion nv ON nv.refId = news.id AND nv.refEntityname='Entity\\News' INNER JOIN nodetranslation nt ON nv.nodetranslation = nt.id INNER JOIN node n ON nt.node = n.id WHERE (nt.lang = ?) AND (n.deleted = 0)", $qb->getSQL());
+        $this->assertEquals("SELECT COUNT(DISTINCT news.id) FROM `newspages` news INNER JOIN `nodeversion` nv ON nv.refId = news.id AND nv.refEntityname='Entity\\News' INNER JOIN `nodetranslation` nt ON nv.nodetranslation = nt.id INNER JOIN `node` n ON nt.node = n.id WHERE (nt.lang = ?) AND (n.deleted = 0)", $qb->getSQL());
     }
 
     /**
@@ -600,6 +600,6 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
             ->where('u.id = a.user_id')
             ->andWhere('p.read = 1');
 
-        $this->assertEquals('SELECT DISTINCT u.id FROM users u INNER JOIN permissions p ON p.user_id = u.id, articles a INNER JOIN comments c ON c.article_id = a.id WHERE (u.id = a.user_id) AND (p.read = 1)', $qb->getSQL());
+        $this->assertEquals('SELECT DISTINCT u.id FROM `users` u INNER JOIN `permissions` p ON p.user_id = u.id, articles a INNER JOIN `comments` c ON c.article_id = a.id WHERE (u.id = a.user_id) AND (p.read = 1)', $qb->getSQL());
     }
 }


### PR DESCRIPTION
Escaped table name to avoid issues with reserved table name.
ex:
SELECT \* FROM `order` WHERE user = 1;
