### PR TITLE
Fixing error code on DBALException (forwarding SQL Error Code). 

### DIFF
--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -44,7 +44,7 @@ class DBALException extends \Exception
         }
         $msg .= ":\n\n".$driverEx->getMessage();
 
-        return new self($msg, 0, $driverEx);
+        return new self($msg, $driverEx->getCode(), $driverEx);
     }
 
     /**


### PR DESCRIPTION
'0' was the previous hardcoded error code. I'm just forwarding whatever SQL Error code might occur during a query.

Previous to this fix, we'd have to check for whatever Exception was thrown before DBALException in order to get the error code.

Useful when trying to come up with user-friendly error messages.
