### PR TITLE
Add getBindingType() method in DecimalType

### DIFF
--- a/lib/Doctrine/DBAL/Types/DecimalType.php
+++ b/lib/Doctrine/DBAL/Types/DecimalType.php
@@ -42,4 +42,9 @@ class DecimalType extends Type
     {
         return (null === $value) ? null : $value;
     }
+
+    public function getBindingType()
+    {
+        return \PDO::PARAM_INT;
+    }
 }


### PR DESCRIPTION
Hi,

I was trying to use the findBy method from the repository, where some of the criteria data were negative floats values. I didn't get any results, though I had coincidental records in the BD with that criteria.

After searching I found this issue: http://stackoverflow.com/questions/8300208/php-pdo-prepare-negatives-become-positive

So, it seemed the problem was caused for the same reason. I've added the getBindingType() returning the PDO::PARAM_INT constant and now my findBy is returning the results correctly.
