### PR TITLE
Removed an unused method in AbstractPlatform.

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2567,6 +2567,10 @@ abstract class AbstractPlatform
         return false;
     }
 
+    /**
+     * @deprecated
+     * @todo Remove in 3.0
+     */
     public function getIdentityColumnNullInsertSQL()
     {
         return "";


### PR DESCRIPTION
AbstractPlatform::getIdentityColumnNullInsertSQL() is not used anywhere, probably a leftover.
