### PR TITLE
Added driver map getter

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -156,6 +156,16 @@ final class DriverManager
     }
 
     /**
+     * Returns the list of supported drivers and their mappings to the driver classes.
+     *
+     * @return array
+     */
+    public static function getDriverMap()
+    {
+        return self::$_driverMap;
+    }
+
+    /**
      * Checks the list of parameters.
      *
      * @param array $params The list of parameters.

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -156,13 +156,13 @@ final class DriverManager
     }
 
     /**
-     * Returns the list of supported drivers and their mappings to the driver classes.
+     * Returns the list of supported drivers.
      *
      * @return array
      */
-    public static function getDriverMap()
+    public static function getAvailableDrivers()
     {
-        return self::$_driverMap;
+        return array_keys(self::$_driverMap);
     }
 
     /**


### PR DESCRIPTION
We can think of several situations where a read access to the supported drivers is required. I personnaly need it in the following use cases : 
- Validating a driver choice in a mutli-platform application installer
- Generating migration classes for all the available platforms

This PR just adds a getter for that list. As it is a harmless and non-BC-break change, it would be great if it could be merged also into the 2.3 version.
