### PR TITLE
[FIX] Sqlserver Portability

### DIFF
--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -64,8 +64,8 @@ class Connection extends \Doctrine\DBAL\Connection
                     $params['portability'] = $params['portability'] & self::PORTABILITY_SQLITE;
                 } else if ($this->_platform->getName() === "drizzle") {
                     $params['portability'] = self::PORTABILITY_DRIZZLE;
-                } else if ($this->_platform->getName() === 'sqlsrv') {
-                    $params['portability'] = $params['portabililty'] & self::PORTABILITY_SQLSRV;
+                } else if ($this->_platform->getName() === 'mssql') {
+                    $params['portability'] = $params['portability'] & self::PORTABILITY_SQLSRV;
                 } else {
                     $params['portability'] = $params['portability'] & self::PORTABILITY_OTHERVENDORS;
                 }

--- a/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use PDO;
+use Doctrine\DBAL\Portability\Connection as ConnectionPortability;
 
 require_once __DIR__ . '/../../TestInit.php';
 
@@ -93,5 +94,25 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertArrayHasKey('test_string', $row, "Case should be lowered.");
         $this->assertEquals(3, strlen($row['test_string']), "test_string should be rtrimed to length of three for CHAR(32) column.");
         $this->assertNull($row['test_null']);
+    }
+
+    public function testPortabilitySqlServer()
+    {
+        $portability = ConnectionPortability::PORTABILITY_SQLSRV;
+        $params = array(
+            'portability' => $portability
+        );
+
+        $driverMock = $this->getMock('Doctrine\\DBAL\\Driver\\PDOSqlsrv\\Driver', array('connect'));
+
+        $driverMock->expects($this->once())
+                   ->method('connect')
+                   ->will($this->returnValue(null));
+
+        $connection = new ConnectionPortability($params, $driverMock);
+
+        $connection->connect($params);
+
+        $this->assertEquals($portability, $connection->getPortability());
     }
 }


### PR DESCRIPTION
- name platform 'sqlsrv' nonexistent and E_NOTICE index array.
