### PR TITLE
Quote identifiers to avoid errors with CamelCased table|view|sequences names

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -206,7 +206,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getListTablesSQL()
     {
-        return "SELECT tablename AS table_name, schemaname AS schema_name
+        return "SELECT quote_ident(tablename) AS table_name, schemaname AS schema_name
                 FROM pg_tables WHERE schemaname NOT LIKE 'pg_%' AND schemaname != 'information_schema' AND tablename != 'geometry_columns' AND tablename != 'spatial_ref_sys'";
     }
 
@@ -215,7 +215,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getListViewsSQL($database)
     {
-        return 'SELECT viewname, definition FROM pg_views';
+        return 'SELECT quote_ident(viewname) as viewname, definition FROM pg_views';
     }
 
     /**
@@ -223,7 +223,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getListTableForeignKeysSQL($table, $database = null)
     {
-        return "SELECT r.conname, pg_catalog.pg_get_constraintdef(r.oid, true) as condef
+        return "SELECT quote_ident(r.conname) as conname, pg_catalog.pg_get_constraintdef(r.oid, true) as condef
                   FROM pg_catalog.pg_constraint r
                   WHERE r.conrelid =
                   (
@@ -256,7 +256,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     public function getListTableConstraintsSQL($table)
     {
         return "SELECT
-                    relname
+                    quote_ident(relname) as relname
                 FROM
                     pg_class
                 WHERE oid IN (
@@ -276,7 +276,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getListTableIndexesSQL($table, $currentDatabase = null)
     {
-        return "SELECT relname, pg_index.indisunique, pg_index.indisprimary,
+        return "SELECT quote_ident(relname) as relname, pg_index.indisunique, pg_index.indisprimary,
                        pg_index.indkey, pg_index.indrelid
                  FROM pg_class, pg_index
                  WHERE oid IN (
@@ -314,7 +314,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     {
         return "SELECT
                     a.attnum,
-                    a.attname AS field,
+                    quote_ident(a.attname) AS field,
                     t.typname AS type,
                     format_type(a.atttypid, a.atttypmod) AS complete_type,
                     (SELECT t1.typname FROM pg_catalog.pg_type t1 WHERE t1.oid = t.typbasetype) AS domain_type,


### PR DESCRIPTION
If you will have Camel Cased table name e.g: `tmp.SomeNiceTable`, PostgreSQL is case insensitive when queries are passed by driver but is case sensitive when looks for objects so:

```
SELECT * FROM tmp.SomeNiceTable;
```

results in error:

```
relation "public.somenicetable" does not exist
```

We should use 

```
SELECT * FROM tmp."SomeNiceTable";
```

form for queries, `quote_ident` do the job for Us, but it is not available 
in versions prior to 7.3 (http://www.postgresql.org/docs/7.3/static/functions-string.html)
