### PR TITLE
Prevent autoincrement columns from creating CREATE SEQUENCE statement

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -112,7 +112,9 @@ class Comparator
         foreach ($toSchema->getSequences() as $sequence) {
             $sequenceName = $sequence->getShortestName($toSchema->getName());
             if ( ! $fromSchema->hasSequence($sequenceName)) {
-                $diff->newSequences[] = $sequence;
+                if ( ! $this->isAutoIncrementSequenceInSchema($fromSchema, $sequence)) {
+                    $diff->newSequences[] = $sequence;
+                }
             } else {
                 if ($this->diffSequence($sequence, $fromSchema->getSequence($sequenceName))) {
                     $diff->changedSequences[] = $toSchema->getSequence($sequenceName);

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -864,6 +864,28 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
 
 
     /**
+     * Check that added autoincrement sequence is not populated in newSequences
+     * @group DBAL-562
+     */
+    public function testAutoIncremenetNoSequences()
+    {
+        $oldSchema = new Schema();
+        $table = $oldSchema->createTable("foo");
+        $table->addColumn("id", "integer", array("autoincrement" => true));
+        $table->setPrimaryKey(array("id"));
+
+        $newSchema = new Schema();
+        $table = $newSchema->createTable("foo");
+        $table->addColumn("id", "integer", array("autoincrement" => true));
+        $table->setPrimaryKey(array("id"));
+        $newSchema->createSequence("foo_id_seq");
+
+        $c = new Comparator();
+        $diff = $c->compare($oldSchema, $newSchema);
+
+        $this->assertCount(0, $diff->newSequences);
+    }
+    /**
      * You can get multiple drops for a FK when a table referenced by a foreign
      * key is deleted, as this FK is referenced twice, once on the orphanedForeignKeys
      * array because of the dropped table, and once on changedTables array. We


### PR DESCRIPTION
Related to DDC-1657 doctrine/dbal@79e894b
Add autoincrement sequence check for new sequences
It solves the problem with creating statements in "down" migrations
