### PR TITLE
Portability wrapper _defaultFetchMode

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -177,7 +177,7 @@ class Connection implements DriverConnection
     /**
      * @var integer
      */
-    protected $_defaultFetchMode = PDO::FETCH_ASSOC;
+    protected $defaultFetchMode = PDO::FETCH_ASSOC;
 
     /**
      * Initializes a new instance of the Connection class.
@@ -373,7 +373,7 @@ class Connection implements DriverConnection
      */
     public function setFetchMode($fetchMode)
     {
-        $this->_defaultFetchMode = $fetchMode;
+        $this->defaultFetchMode = $fetchMode;
     }
 
     /**
@@ -648,7 +648,7 @@ class Connection implements DriverConnection
             throw DBALException::driverExceptionDuringQuery($ex, $statement);
         }
 
-        $stmt->setFetchMode($this->_defaultFetchMode);
+        $stmt->setFetchMode($this->defaultFetchMode);
 
         return $stmt;
     }
@@ -701,7 +701,7 @@ class Connection implements DriverConnection
             throw DBALException::driverExceptionDuringQuery($ex, $query, $this->resolveParams($params, $types));
         }
 
-        $stmt->setFetchMode($this->_defaultFetchMode);
+        $stmt->setFetchMode($this->defaultFetchMode);
 
         if ($logger) {
             $logger->stopQuery();
@@ -745,7 +745,7 @@ class Connection implements DriverConnection
             $stmt = new ResultCacheStatement($this->executeQuery($query, $params, $types), $resultCache, $cacheKey, $realKey, $qcp->getLifetime());
         }
 
-        $stmt->setFetchMode($this->_defaultFetchMode);
+        $stmt->setFetchMode($this->defaultFetchMode);
 
         return $stmt;
     }
@@ -810,7 +810,7 @@ class Connection implements DriverConnection
             throw DBALException::driverExceptionDuringQuery($ex, $args[0]);
         }
 
-        $statement->setFetchMode($this->_defaultFetchMode);
+        $statement->setFetchMode($this->defaultFetchMode);
 
         if ($logger) {
             $logger->stopQuery();

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -177,7 +177,7 @@ class Connection implements DriverConnection
     /**
      * @var integer
      */
-    private $_defaultFetchMode = PDO::FETCH_ASSOC;
+    protected $_defaultFetchMode = PDO::FETCH_ASSOC;
 
     /**
      * Initializes a new instance of the Connection class.

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -22,6 +22,13 @@ namespace Doctrine\DBAL\Portability;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 
+/**
+ * Portability wrapper for a Connection.
+ *
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ */
 class Connection extends \Doctrine\DBAL\Connection
 {
     const PORTABILITY_ALL               = 255;
@@ -105,7 +112,10 @@ class Connection extends \Doctrine\DBAL\Connection
      */
     public function executeQuery($query, array $params = array(), $types = array(), QueryCacheProfile $qcp = null)
     {
-        return new Statement(parent::executeQuery($query, $params, $types, $qcp), $this);
+        $stmt = new Statement(parent::executeQuery($query, $params, $types, $qcp), $this);
+        $stmt->setFetchMode($this->_defaultFetchMode);
+
+        return $stmt;
     }
 
     /**
@@ -113,7 +123,10 @@ class Connection extends \Doctrine\DBAL\Connection
      */
     public function prepare($statement)
     {
-        return new Statement(parent::prepare($statement), $this);
+        $stmt = new Statement(parent::prepare($statement), $this);
+        $stmt->setFetchMode($this->_defaultFetchMode);
+
+        return $stmt;
     }
 
     /**
@@ -124,7 +137,9 @@ class Connection extends \Doctrine\DBAL\Connection
         $this->connect();
 
         $stmt = call_user_func_array(array($this->_conn, 'query'), func_get_args());
+        $stmt = new Statement($stmt, $this);
+        $stmt->setFetchMode($this->_defaultFetchMode);
 
-        return new Statement($stmt, $this);
+        return $stmt;
     }
 }

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -113,7 +113,7 @@ class Connection extends \Doctrine\DBAL\Connection
     public function executeQuery($query, array $params = array(), $types = array(), QueryCacheProfile $qcp = null)
     {
         $stmt = new Statement(parent::executeQuery($query, $params, $types, $qcp), $this);
-        $stmt->setFetchMode($this->_defaultFetchMode);
+        $stmt->setFetchMode($this->defaultFetchMode);
 
         return $stmt;
     }
@@ -124,7 +124,7 @@ class Connection extends \Doctrine\DBAL\Connection
     public function prepare($statement)
     {
         $stmt = new Statement(parent::prepare($statement), $this);
-        $stmt->setFetchMode($this->_defaultFetchMode);
+        $stmt->setFetchMode($this->defaultFetchMode);
 
         return $stmt;
     }
@@ -138,7 +138,7 @@ class Connection extends \Doctrine\DBAL\Connection
 
         $stmt = call_user_func_array(array($this->_conn, 'query'), func_get_args());
         $stmt = new Statement($stmt, $this);
-        $stmt->setFetchMode($this->_defaultFetchMode);
+        $stmt->setFetchMode($this->defaultFetchMode);
 
         return $stmt;
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
@@ -25,6 +25,11 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
     }
 
+    /**
+     * @param   integer     $portabilityMode
+     * @param   integer     $case
+     * @return  Connection
+     */
     private function getPortableConnection($portabilityMode = \Doctrine\DBAL\Portability\Connection::PORTABILITY_ALL, $case = \PDO::CASE_LOWER)
     {
         if (!$this->portableConnection) {
@@ -67,15 +72,39 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
 
         $stmt = $this->getPortableConnection()->query('SELECT * FROM portability_table');
-        while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+        while (($row = $stmt->fetch(\PDO::FETCH_ASSOC))) {
             $this->assertFetchResultRow($row);
         }
 
         $stmt = $this->getPortableConnection()->prepare('SELECT * FROM portability_table');
         $stmt->execute();
-
-        while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+        while (($row = $stmt->fetch(\PDO::FETCH_ASSOC))) {
             $this->assertFetchResultRow($row);
+        }
+    }
+
+    public function testConnFetchMode()
+    {
+        $conn = $this->getPortableConnection();
+        $conn->setFetchMode(\PDO::FETCH_ASSOC);
+
+        $rows = $conn->fetchAll('SELECT * FROM portability_table');
+        $this->assertFetchResultRows($rows);
+
+        $stmt = $conn->query('SELECT * FROM portability_table');
+        foreach ($stmt as $row) {
+          $this->assertFetchResultRow($row);
+        }
+
+        $stmt = $conn->query('SELECT * FROM portability_table');
+        while (($row = $stmt->fetch())) {
+          $this->assertFetchResultRow($row);
+        }
+
+        $stmt = $conn->prepare('SELECT * FROM portability_table');
+        $stmt->execute();
+        while (($row = $stmt->fetch())) {
+          $this->assertFetchResultRow($row);
         }
     }
 
@@ -93,5 +122,6 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertArrayHasKey('test_string', $row, "Case should be lowered.");
         $this->assertEquals(3, strlen($row['test_string']), "test_string should be rtrimed to length of three for CHAR(32) column.");
         $this->assertNull($row['test_null']);
+        $this->assertArrayNotHasKey(0, $row, "PDO::FETCH_ASSOC should not return numerical keys.");
     }
 }


### PR DESCRIPTION
The Portability wrapper did not properly use the _defaultFetchMode when the method setFetchMode() was used on the Connection. Since the defaultFetchMode for the portability wrapper is set to PDO::FETCH_BOTH, I couldn't change this to the desired format.
