### PR TITLE
Update DecimalType.php

### DIFF
--- a/lib/Doctrine/DBAL/Types/DecimalType.php
+++ b/lib/Doctrine/DBAL/Types/DecimalType.php
@@ -22,7 +22,7 @@ namespace Doctrine\DBAL\Types;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
- * Type that maps an SQL DECIMAL to a PHP double.
+ * Type that maps an SQL DECIMAL to a PHP string.
  *
  * @since 2.0
  */


### PR DESCRIPTION
The "decimal" mapping type does not map to float/double anymore:
https://github.com/doctrine/dbal/commit/9f51afa210d5c0165dfe6c622e07e42aa54c09fb#lib/Doctrine/DBAL/Types/DecimalType.php

Thank you.
