### PR TITLE
support schema creation for psql platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1488,6 +1488,32 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Returns the SQL to create a named schema.
+     *
+     * @param string $schemaName
+     *
+     * @return string
+     * @throws \Doctrine\DBAL\DBALException If not supported on this platform.
+     */
+    public function getCreateSchemaSQL($schemaName)
+    {
+        throw DBALException::notSupported(__METHOD__);
+    }
+
+    /**
+     * Checks whether the schema $schemaName needs creating.
+     *
+     * @param string $schemaName
+     *
+     * @return boolean
+     * @throws \Doctrine\DBAL\DBALException If not supported on this platform.
+     */
+    public function schemaNeedsCreation($schemaName)
+    {
+        throw DBALException::notSupported(__METHOD__);
+    }
+
+    /**
      * Quotes a string so that it can be safely used as a table or column name,
      * even if it is a reserved word of the platform. This also detects identifier
      * chains separated by dot and quotes them independently.

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -534,6 +534,22 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getCreateSchemaSQL($schemaName)
+    {
+        return 'CREATE SCHEMA ' . $schemaName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function schemaNeedsCreation($schemaName)
+    {
+        return !in_array($schemaName, array('default', 'public'));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDropForeignKeySQL($foreignKey, $table)
     {
         return $this->getDropConstraintSQL($foreignKey, $table);

--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -135,8 +135,9 @@ class CreateSchemaSqlCollector extends AbstractVisitor
         $sql = array();
 
         foreach (array_keys($this->createTableQueries) as $namespace) {
-            if ($this->platform->supportsSchemas()) {
-                // TODO: Create Schema here
+            if ($this->platform->supportsSchemas() && $this->platform->schemaNeedsCreation($namespace)) {
+                $query = $this->platform->getCreateSchemaSQL($namespace);
+                array_push($sql, $query);
             }
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -494,4 +494,20 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
         $sql = $this->_platform->getCreateTableSQL($table, AbstractPlatform::CREATE_FOREIGNKEYS);
         $this->assertEquals($this->getQuotedColumnInForeignKeySQL(), $sql);
     }
+
+    /**
+     * @expectedException \Doctrine\DBAL\DBALException
+     */
+    public function testGetCreateSchemaSQL()
+    {
+        $this->_platform->getCreateSchemaSQL('schema');
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\DBALException
+     */
+    public function testSchemaNeedsCreation()
+    {
+        $this->_platform->schemaNeedsCreation('schema');
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -314,5 +314,24 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
         $this->assertEquals('1', $platform->convertBooleans(true));
         $this->assertEquals('0', $platform->convertBooleans(false));
     }
-}
 
+    public function testGetCreateSchemaSQL()
+    {
+        $schemaName = 'schema';
+        $sql = $this->_platform->getCreateSchemaSQL($schemaName);
+        $this->assertEquals('CREATE SCHEMA ' . $schemaName, $sql);
+    }
+
+    public function testSchemaNeedsCreation()
+    {
+        $schemaNames = array(
+            'default' => false,
+            'public' => false,
+            'schema' => true,
+        );
+        foreach ($schemaNames as $name => $expected) {
+            $actual = $this->_platform->schemaNeedsCreation($name);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Schema\Visitor;
+
+use \Doctrine\DBAL\Schema\Visitor\CreateSchemaSqlCollector;
+
+class CreateSchemaSqlCollectorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetQueriesForPsql()
+    {
+        $platformMock = $this->getMock(
+            'Doctrine\DBAL\Platforms\PostgreSqlPlatform',
+            array('supportsSchemas', 'schemaNeedsCreation', 'getCreateTableSQL')
+        );
+
+        $platformMock->expects($this->exactly(1))
+                     ->method('supportsSchemas')
+                     ->will($this->returnValue(true));
+
+        $platformMock->expects($this->any())
+                     ->method('schemaNeedsCreation')
+                     ->will($this->returnValue(true));
+
+        $platformMock->expects($this->any())
+                     ->method('getCreateTableSQL')
+                     ->will($this->returnValue(array('foo')));
+
+        $tableMock = $this->getMockBuilder('\Doctrine\DBAL\Schema\Table')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+
+        $sqlCollector = new CreateSchemaSqlCollector($platformMock);
+        $sqlCollector->acceptTable($tableMock);
+        $sql = $sqlCollector->getQueries();
+        $this->assertEquals('CREATE SCHEMA default', $sql[0]);
+    }
+}


### PR DESCRIPTION
This implements handling schema creation for PostgreSQL, similar to #328, but platform-specific code is in the appropriate class. Tests included.
