### PR TITLE
Don't add 'NOT NULL' to the 'ALTER TABLE' when that hasn't changed

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -629,7 +629,13 @@ LEFT JOIN user_cons_columns r_cols
              * Do not add query part if only comment has changed
              */
             if ( ! ($columnHasChangedComment && count($columnDiff->changedProperties) === 1)) {
-                $fields[] = $column->getQuotedName($this). ' ' . $this->getColumnDeclarationSQL('', $column->toArray());
+                $columnInfo = $column->toArray();
+
+                if ( ! $columnDiff->hasChanged('notnull')) {
+                    $columnInfo['notnull'] = false;
+                }
+
+                $fields[] = $column->getQuotedName($this) . ' ' . $this->getColumnDeclarationSQL('', $columnInfo);
             }
 
             if ($columnHasChangedComment) {

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -308,4 +308,26 @@ class OraclePlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") REFERENCES "foo-bar" ("create", bar, "foo-bar")',
         );
     }
+
+    public function testAlterTableNotNULL()
+    {
+        $tableDiff = new \Doctrine\DBAL\Schema\TableDiff('mytable');
+        $tableDiff->changedColumns['foo'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'foo', new \Doctrine\DBAL\Schema\Column(
+                'foo', \Doctrine\DBAL\Types\Type::getType('string'), array('default' => 'bla', 'notnull' => true)
+            ),
+            array('type')
+        );
+        $tableDiff->changedColumns['bar'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'bar', new \Doctrine\DBAL\Schema\Column(
+                'baz', \Doctrine\DBAL\Types\Type::getType('string'), array('default' => 'bla', 'notnull' => true)
+            ),
+            array('type', 'notnull')
+        );
+
+        $expectedSql = array(
+            "ALTER TABLE mytable MODIFY (foo  VARCHAR2(255) DEFAULT 'bla', baz  VARCHAR2(255) DEFAULT 'bla' NOT NULL)",
+	);
+        $this->assertEquals($expectedSql, $this->_platform->getAlterTableSQL($tableDiff));
+    }
 }


### PR DESCRIPTION
Without this Oracle gives the error [ORA-01442: column to be modified to NOT NULL is already NOT NULL](http://ora-01442.ora-code.com/)
