### PR TITLE
[WIP] [DBAL-407] Refactor exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 download/
 lib/Doctrine/Common/
 vendor/
+*.phpunit.xml

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -645,7 +645,7 @@ class Connection implements DriverConnection
         try {
             $stmt = new Statement($statement, $this);
         } catch (\Exception $ex) {
-            throw DBALException::driverExceptionDuringQuery($ex, $statement);
+            throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $statement);
         }
 
         $stmt->setFetchMode($this->defaultFetchMode);
@@ -698,7 +698,7 @@ class Connection implements DriverConnection
                 $stmt = $this->_conn->query($query);
             }
         } catch (\Exception $ex) {
-            throw DBALException::driverExceptionDuringQuery($ex, $query, $this->resolveParams($params, $types));
+            throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));
         }
 
         $stmt->setFetchMode($this->defaultFetchMode);
@@ -807,7 +807,7 @@ class Connection implements DriverConnection
                     break;
             }
         } catch (\Exception $ex) {
-            throw DBALException::driverExceptionDuringQuery($ex, $args[0]);
+            throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $args[0]);
         }
 
         $statement->setFetchMode($this->defaultFetchMode);
@@ -860,7 +860,7 @@ class Connection implements DriverConnection
                 $result = $this->_conn->exec($query);
             }
         } catch (\Exception $ex) {
-            throw DBALException::driverExceptionDuringQuery($ex, $query, $this->resolveParams($params, $types));
+            throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));
         }
 
         if ($logger) {
@@ -891,7 +891,7 @@ class Connection implements DriverConnection
         try {
             $result = $this->_conn->exec($statement);
         } catch (\Exception $ex) {
-            throw DBALException::driverExceptionDuringQuery($ex, $statement);
+            throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $statement);
         }
 
         if ($logger) {

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -27,6 +27,7 @@ class DBALException extends \Exception
     const ERROR_FOREIGN_KEY_CONSTRAINT = 4;
     const ERROR_NOT_NULL = 5;
     const ERROR_BAD_FIELD_NAME = 6;
+    const ERROR_NON_UNIQUE_FIELD_NAME = 7;
 
     /**
      * @param string $method

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -32,6 +32,7 @@ class DBALException extends \Exception
     const ERROR_SYNTAX = 9;
     const ERROR_UNABLE_TO_OPEN = 10;
     const ERROR_WRITE_READONLY = 11;
+    const ERROR_ACCESS_DENIED = 12;
 
     /**
      * @param string $method

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -21,6 +21,8 @@ namespace Doctrine\DBAL;
 
 class DBALException extends \Exception
 {
+    const ERROR_DUPLICATE_KEY = 1;
+
     /**
      * @param string $method
      *
@@ -74,13 +76,14 @@ class DBALException extends \Exception
     }
 
     /**
+     * @param \Doctrine\DBAL\Driver     $driver
      * @param \Exception $driverEx
      * @param string     $sql
      * @param array      $params
      *
      * @return \Doctrine\DBAL\DBALException
      */
-    public static function driverExceptionDuringQuery(\Exception $driverEx, $sql, array $params = array())
+    public static function driverExceptionDuringQuery(Driver $driver, \Exception $driverEx, $sql, array $params = array())
     {
         $msg = "An exception occurred while executing '".$sql."'";
         if ($params) {

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -30,6 +30,8 @@ class DBALException extends \Exception
     const ERROR_NON_UNIQUE_FIELD_NAME = 7;
     const ERROR_NOT_UNIQUE = 8;
     const ERROR_SYNTAX = 9;
+    const ERROR_UNABLE_TO_OPEN = 10;
+    const ERROR_WRITE_READONLY = 11;
 
     /**
      * @param string $method

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -25,6 +25,7 @@ class DBALException extends \Exception
     const ERROR_UNKNOWN_TABLE = 2;
     const ERROR_TABLE_ALREADY_EXISTS = 3;
     const ERROR_FOREIGN_KEY_CONSTRAINT = 4;
+    const ERROR_NOT_NULL = 5;
 
     /**
      * @param string $method

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -91,7 +91,7 @@ class DBALException extends \Exception
         }
         $msg .= ":\n\n".$driverEx->getMessage();
 
-        return new self($msg, 0, $driverEx);
+        return new self($msg, $driver->convertExceptionCode($driverEx), $driverEx);
     }
 
     /**

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -26,6 +26,7 @@ class DBALException extends \Exception
     const ERROR_TABLE_ALREADY_EXISTS = 3;
     const ERROR_FOREIGN_KEY_CONSTRAINT = 4;
     const ERROR_NOT_NULL = 5;
+    const ERROR_BAD_FIELD_NAME = 6;
 
     /**
      * @param string $method

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -23,6 +23,7 @@ class DBALException extends \Exception
 {
     const ERROR_DUPLICATE_KEY = 1;
     const ERROR_UNKNOWN_TABLE = 2;
+    const ERROR_TABLE_ALREADY_EXISTS = 3;
 
     /**
      * @param string $method

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -22,6 +22,7 @@ namespace Doctrine\DBAL;
 class DBALException extends \Exception
 {
     const ERROR_DUPLICATE_KEY = 1;
+    const ERROR_UNKNOWN_TABLE = 2;
 
     /**
      * @param string $method

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -24,6 +24,7 @@ class DBALException extends \Exception
     const ERROR_DUPLICATE_KEY = 1;
     const ERROR_UNKNOWN_TABLE = 2;
     const ERROR_TABLE_ALREADY_EXISTS = 3;
+    const ERROR_FOREIGN_KEY_CONSTRAINT = 4;
 
     /**
      * @param string $method

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -28,6 +28,7 @@ class DBALException extends \Exception
     const ERROR_NOT_NULL = 5;
     const ERROR_BAD_FIELD_NAME = 6;
     const ERROR_NON_UNIQUE_FIELD_NAME = 7;
+    const ERROR_NOT_UNIQUE = 8;
 
     /**
      * @param string $method

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -29,6 +29,7 @@ class DBALException extends \Exception
     const ERROR_BAD_FIELD_NAME = 6;
     const ERROR_NON_UNIQUE_FIELD_NAME = 7;
     const ERROR_NOT_UNIQUE = 8;
+    const ERROR_SYNTAX = 9;
 
     /**
      * @param string $method

--- a/lib/Doctrine/DBAL/Driver.php
+++ b/lib/Doctrine/DBAL/Driver.php
@@ -72,4 +72,12 @@ interface Driver
      * @return string The name of the database.
      */
     public function getDatabase(Connection $conn);
+
+
+    /**
+     * @param \Exception $exception
+     *
+     * @return int
+     */
+    public function convertExceptionCode(\Exception $exception);
 }

--- a/lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Driver.php
@@ -99,4 +99,12 @@ class Driver implements \Doctrine\DBAL\Driver
 
         return $params['dbname'];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Driver.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Driver.php
@@ -91,4 +91,12 @@ class DB2Driver implements Driver
 
         return $params['dbname'];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
@@ -67,4 +67,12 @@ class Driver implements DriverInterface
 
         return $params['dbname'];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -113,4 +113,12 @@ class Driver implements \Doctrine\DBAL\Driver
 
         return $params['user'];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
@@ -105,4 +105,12 @@ class Driver implements \Doctrine\DBAL\Driver
 
         return $params['dbname'];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -120,8 +120,9 @@ class Driver implements \Doctrine\DBAL\Driver
                 if (strpos($exception->getMessage(), 'Cannot delete or update a parent row: a foreign key constraint fails') !== false) {
                     return DBALException::ERROR_FOREIGN_KEY_CONSTRAINT;
                 }
-
-                return DBALException::ERROR_DUPLICATE_KEY;
+                if (strpos($exception->getMessage(), 'Duplicate entry') !== false) {
+                    return DBALException::ERROR_DUPLICATE_KEY;
+                }
             case '42S02':
                 return DBALException::ERROR_UNKNOWN_TABLE;
             case '42S01':

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -118,6 +118,8 @@ class Driver implements \Doctrine\DBAL\Driver
         switch ($exception->getCode()) {
             case 23000:
                 return DBALException::ERROR_DUPLICATE_KEY;
+            case '42S02':
+                return DBALException::ERROR_UNKNOWN_TABLE;
         }
 
         return 0;

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -117,6 +117,10 @@ class Driver implements \Doctrine\DBAL\Driver
     {
         switch ($exception->getCode()) {
             case 23000:
+                if (strpos($exception->getMessage(), 'Cannot delete or update a parent row: a foreign key constraint fails') !== false) {
+                    return DBALException::ERROR_FOREIGN_KEY_CONSTRAINT;
+                }
+
                 return DBALException::ERROR_DUPLICATE_KEY;
             case '42S02':
                 return DBALException::ERROR_UNKNOWN_TABLE;

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -108,4 +108,12 @@ class Driver implements \Doctrine\DBAL\Driver
         }
         return $conn->query('SELECT DATABASE()')->fetchColumn();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -120,6 +120,8 @@ class Driver implements \Doctrine\DBAL\Driver
                 return DBALException::ERROR_DUPLICATE_KEY;
             case '42S02':
                 return DBALException::ERROR_UNKNOWN_TABLE;
+            case '42S01':
+                return DBALException::ERROR_TABLE_ALREADY_EXISTS;
         }
 
         return 0;

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Driver\PDOMySql;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 
 /**
  * PDO MySql driver.
@@ -114,6 +115,11 @@ class Driver implements \Doctrine\DBAL\Driver
      */
     public function convertExceptionCode(\Exception $exception)
     {
+        switch ($exception->getCode()) {
+            case 23000:
+                return DBALException::ERROR_DUPLICATE_KEY;
+        }
+
         return 0;
     }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
@@ -113,4 +113,12 @@ class Driver implements \Doctrine\DBAL\Driver
 
         return $params['user'];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -99,5 +99,13 @@ class Driver implements \Doctrine\DBAL\Driver
             ? $params['dbname']
             : $conn->query('SELECT CURRENT_DATABASE()')->fetchColumn();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }
 

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -148,6 +148,10 @@ class Driver implements \Doctrine\DBAL\Driver
                 if (strpos($exception->getMessage(), 'ambiguous column name') !== false) {
                     return DBALException::ERROR_NON_UNIQUE_FIELD_NAME;
                 }
+
+                if (strpos($exception->getMessage(), 'syntax error') !== false) {
+                    return DBALException::ERROR_SYNTAX;
+                }
         }
 
         return 0;

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -126,6 +126,10 @@ class Driver implements \Doctrine\DBAL\Driver
                 if (strpos($exception->getMessage(), 'no such table:') !== false) {
                     return DBALException::ERROR_UNKNOWN_TABLE;
                 }
+
+                if (strpos($exception->getMessage(), 'already exists') !== false) {
+                    return DBALException::ERROR_TABLE_ALREADY_EXISTS;
+                }
         }
 
         return 0;

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -122,6 +122,10 @@ class Driver implements \Doctrine\DBAL\Driver
         switch ($exception->getCode()) {
             case 23000:
                 return DBALException::ERROR_DUPLICATE_KEY;
+            case 'HY000':
+                if (strpos($exception->getMessage(), 'no such table:') !== false) {
+                    return DBALException::ERROR_UNKNOWN_TABLE;
+                }
         }
 
         return 0;

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -152,6 +152,14 @@ class Driver implements \Doctrine\DBAL\Driver
                 if (strpos($exception->getMessage(), 'syntax error') !== false) {
                     return DBALException::ERROR_SYNTAX;
                 }
+
+                if (strpos($exception->getMessage(), 'unable to open database file') !== false) {
+                    return DBALException::ERROR_UNABLE_TO_OPEN;
+                }
+
+                if (strpos($exception->getMessage(), 'attempt to write a readonly database') !== false) {
+                    return DBALException::ERROR_WRITE_READONLY;
+                }
         }
 
         return 0;

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -124,8 +124,13 @@ class Driver implements \Doctrine\DBAL\Driver
                 if (strpos($exception->getMessage(), 'must be unique') !== false) {
                     return DBALException::ERROR_DUPLICATE_KEY;
                 }
+
                 if (strpos($exception->getMessage(), 'may not be NULL') !== false) {
                     return DBALException::ERROR_NOT_NULL;
+                }
+
+                if (strpos($exception->getMessage(), 'is not unique') !== false) {
+                    return DBALException::ERROR_NOT_UNIQUE;
                 }
             case 'HY000':
                 if (strpos($exception->getMessage(), 'no such table:') !== false) {

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -18,6 +18,7 @@
  */
 
 namespace Doctrine\DBAL\Driver\PDOSqlite;
+use Doctrine\DBAL\DBALException;
 
 /**
  * The PDO Sqlite driver.
@@ -118,6 +119,11 @@ class Driver implements \Doctrine\DBAL\Driver
      */
     public function convertExceptionCode(\Exception $exception)
     {
+        switch ($exception->getCode()) {
+            case 23000:
+                return DBALException::ERROR_DUPLICATE_KEY;
+        }
+
         return 0;
     }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -121,7 +121,9 @@ class Driver implements \Doctrine\DBAL\Driver
     {
         switch ($exception->getCode()) {
             case 23000:
-                return DBALException::ERROR_DUPLICATE_KEY;
+                if (strpos($exception->getMessage(), 'must be unique') !== false) {
+                    return DBALException::ERROR_DUPLICATE_KEY;
+                }
             case 'HY000':
                 if (strpos($exception->getMessage(), 'no such table:') !== false) {
                     return DBALException::ERROR_UNKNOWN_TABLE;

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -135,6 +135,10 @@ class Driver implements \Doctrine\DBAL\Driver
                 if (strpos($exception->getMessage(), 'already exists') !== false) {
                     return DBALException::ERROR_TABLE_ALREADY_EXISTS;
                 }
+
+                if (strpos($exception->getMessage(), 'has no column named') !== false) {
+                    return DBALException::ERROR_BAD_FIELD_NAME;
+                }
         }
 
         return 0;

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -112,4 +112,12 @@ class Driver implements \Doctrine\DBAL\Driver
 
         return isset($params['path']) ? $params['path'] : null;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -139,6 +139,10 @@ class Driver implements \Doctrine\DBAL\Driver
                 if (strpos($exception->getMessage(), 'has no column named') !== false) {
                     return DBALException::ERROR_BAD_FIELD_NAME;
                 }
+
+                if (strpos($exception->getMessage(), 'ambiguous column name') !== false) {
+                    return DBALException::ERROR_NON_UNIQUE_FIELD_NAME;
+                }
         }
 
         return 0;

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -124,6 +124,9 @@ class Driver implements \Doctrine\DBAL\Driver
                 if (strpos($exception->getMessage(), 'must be unique') !== false) {
                     return DBALException::ERROR_DUPLICATE_KEY;
                 }
+                if (strpos($exception->getMessage(), 'may not be NULL') !== false) {
+                    return DBALException::ERROR_NOT_NULL;
+                }
             case 'HY000':
                 if (strpos($exception->getMessage(), 'no such table:') !== false) {
                     return DBALException::ERROR_UNKNOWN_TABLE;

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
@@ -102,4 +102,12 @@ class Driver implements \Doctrine\DBAL\Driver
 
         return $params['dbname'];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
@@ -83,4 +83,12 @@ class Driver implements \Doctrine\DBAL\Driver
         $params = $conn->getParams();
         return $params['dbname'];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -164,7 +164,12 @@ class Statement implements \IteratorAggregate, DriverStatement
         try {
             $stmt = $this->stmt->execute($params);
         } catch (\Exception $ex) {
-            throw DBALException::driverExceptionDuringQuery($ex, $this->sql, $this->conn->resolveParams($this->params, $this->types));
+            throw DBALException::driverExceptionDuringQuery(
+                $this->conn->getDriver(),
+                $ex,
+                $this->sql,
+                $this->conn->resolveParams($this->params, $this->types)
+            );
         }
 
         if ($logger) {

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -8,7 +8,8 @@ class DBALExceptionTest extends \Doctrine\Tests\DbalTestCase
 {
     public function testDriverExceptionDuringQueryAcceptsBinaryData()
     {
-        $e = DBALException::driverExceptionDuringQuery(new \Exception, '', array('ABC', chr(128)));
+        $driver = $this->getMock('\Doctrine\DBAL\Driver');
+        $e = DBALException::driverExceptionDuringQuery($driver, new \Exception, '', array('ABC', chr(128)));
         $this->assertContains('with params ["ABC", "\x80"]', $e->getMessage());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -73,7 +73,12 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_FOREIGN_KEY_CONSTRAINT);
         $this->_conn->delete('constraint_error_table', array('id' => 1));
+    }
 
+    protected function onNotSuccessfulTest(\Exception $e)
+    {
+        var_dump($e);
+        parent::onNotSuccessfulTest($e);
     }
 }
  

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -115,7 +115,6 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $table2 = $schema->createTable("ambiguous_list_table_2");
         $table2->addColumn('id', 'integer');
 
-
         foreach ($schema->toSql($this->_conn->getDatabasePlatform()) AS $sql) {
             $this->_conn->executeQuery($sql);
         }
@@ -123,7 +122,23 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $sql = 'SELECT id FROM ambiguous_list_table, ambiguous_list_table_2';
         $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_NON_UNIQUE_FIELD_NAME);
         $this->_conn->executeQuery($sql);
+    }
 
+    public function testNotUniqueException()
+    {
+        $schema = new \Doctrine\DBAL\Schema\Schema();
+
+        $table = $schema->createTable("unique_field_table");
+        $table->addColumn('id', 'integer');
+        $table->addUniqueIndex(array('id'));
+
+        foreach ($schema->toSql($this->_conn->getDatabasePlatform()) AS $sql) {
+            $this->_conn->executeQuery($sql);
+        }
+
+        $this->_conn->insert("unique_field_table", array('id' => 5));
+        $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_NOT_UNIQUE);
+        $this->_conn->insert("unique_field_table", array('id' => 5));
     }
 
     protected function onNotSuccessfulTest(\Exception $e)

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -31,5 +31,20 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_UNKNOWN_TABLE);
         $this->_conn->executeQuery($sql);
     }
+
+    public function testTableAlreadyExists()
+    {
+        $table = new \Doctrine\DBAL\Schema\Table("duplicatekey_table");
+        $table->addColumn('id', 'integer', array());
+        $table->setPrimaryKey(array('id'));
+
+        $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_TABLE_ALREADY_EXISTS);
+        foreach ($this->_conn->getDatabasePlatform()->getCreateTableSQL($table) AS $sql) {
+            $this->_conn->executeQuery($sql);
+        }
+        foreach ($this->_conn->getDatabasePlatform()->getCreateTableSQL($table) AS $sql) {
+            $this->_conn->executeQuery($sql);
+        }
+    }
 }
  

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -9,7 +9,6 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
     public function testDuplicateKeyException()
     {
-        /* @var $sm \Doctrine\DBAL\Schema\AbstractSchemaManager */
         $table = new \Doctrine\DBAL\Schema\Table("duplicatekey_table");
         $table->addColumn('id', 'integer', array());
         $table->setPrimaryKey(array('id'));
@@ -54,6 +53,7 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
 
         $schema = new \Doctrine\DBAL\Schema\Schema();
+        
         $table = $schema->createTable("constraint_error_table");
         $table->addColumn('id', 'integer', array());
         $table->setPrimaryKey(array('id'));
@@ -73,6 +73,23 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_FOREIGN_KEY_CONSTRAINT);
         $this->_conn->delete('constraint_error_table', array('id' => 1));
+    }
+    
+    public function testNotNullException()
+    {
+        $schema = new \Doctrine\DBAL\Schema\Schema();
+
+        $table = $schema->createTable("notnull_table");
+        $table->addColumn('id', 'integer', array());
+        $table->addColumn('value', 'integer', array('notnull' => true));
+        $table->setPrimaryKey(array('id'));
+
+        foreach ($schema->toSql($this->_conn->getDatabasePlatform()) AS $sql) {
+            $this->_conn->executeQuery($sql);
+        }
+
+        $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_NOT_NULL);
+        $this->_conn->insert("notnull_table", array('id' => 1));
     }
 
     protected function onNotSuccessfulTest(\Exception $e)

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -141,6 +141,21 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->_conn->insert("unique_field_table", array('id' => 5));
     }
 
+    public function testSyntaxErrorException()
+    {
+        $table = new \Doctrine\DBAL\Schema\Table("syntax_error_table");
+        $table->addColumn('id', 'integer', array());
+        $table->setPrimaryKey(array('id'));
+
+        foreach ($this->_conn->getDatabasePlatform()->getCreateTableSQL($table) AS $sql) {
+            $this->_conn->executeQuery($sql);
+        }
+
+        $sql = 'SELECT id FRO syntax_error_table';
+        $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_SYNTAX);
+        $this->_conn->executeQuery($sql);
+    }
+
     protected function onNotSuccessfulTest(\Exception $e)
     {
         parent::onNotSuccessfulTest($e);

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -29,7 +29,7 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->_conn->executeQuery($sql);
     }
 
-    public function testTableAlreadyExists()
+    public function testTableAlreadyExistsException()
     {
         $table = new \Doctrine\DBAL\Schema\Table("alreadyexist_table");
         $table->addColumn('id', 'integer', array());
@@ -88,6 +88,21 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_NOT_NULL);
         $this->_conn->insert("notnull_table", array('id' => 1));
+    }
+
+    public function testBadFieldNameException()
+    {
+        $schema = new \Doctrine\DBAL\Schema\Schema();
+
+        $table = $schema->createTable("non_unique_table");
+        $table->addColumn('id', 'integer', array('unique' => true));
+
+        foreach ($schema->toSql($this->_conn->getDatabasePlatform()) AS $sql) {
+            $this->_conn->executeQuery($sql);
+        }
+
+        $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_BAD_FIELD_NAME);
+        $this->_conn->insert("non_unique_table", array('name' => 5));
     }
 
     protected function onNotSuccessfulTest(\Exception $e)

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -94,15 +94,36 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         $schema = new \Doctrine\DBAL\Schema\Schema();
 
-        $table = $schema->createTable("non_unique_table");
-        $table->addColumn('id', 'integer', array('unique' => true));
+        $table = $schema->createTable("bad_fieldname_table");
+        $table->addColumn('id', 'integer', array());
 
         foreach ($schema->toSql($this->_conn->getDatabasePlatform()) AS $sql) {
             $this->_conn->executeQuery($sql);
         }
 
         $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_BAD_FIELD_NAME);
-        $this->_conn->insert("non_unique_table", array('name' => 5));
+        $this->_conn->insert("bad_fieldname_table", array('name' => 5));
+    }
+
+    public function testNonUniqueFieldNameException()
+    {
+        $schema = new \Doctrine\DBAL\Schema\Schema();
+
+        $table = $schema->createTable("ambiguous_list_table");
+        $table->addColumn('id', 'integer');
+
+        $table2 = $schema->createTable("ambiguous_list_table_2");
+        $table2->addColumn('id', 'integer');
+
+
+        foreach ($schema->toSql($this->_conn->getDatabasePlatform()) AS $sql) {
+            $this->_conn->executeQuery($sql);
+        }
+
+        $sql = 'SELECT id FROM ambiguous_list_table, ambiguous_list_table_2';
+        $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_NON_UNIQUE_FIELD_NAME);
+        $this->_conn->executeQuery($sql);
+
     }
 
     protected function onNotSuccessfulTest(\Exception $e)

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -3,8 +3,6 @@ namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\DBALException;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
     public function testDuplicateKeyException()
@@ -94,8 +92,11 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
     protected function onNotSuccessfulTest(\Exception $e)
     {
-        var_dump($e);
         parent::onNotSuccessfulTest($e);
+        if ("PHPUnit_Framework_SkippedTestError" == get_class($e)) {
+            return;
+        }
+        var_dump($e);
     }
 }
  

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace Doctrine\Tests\DBAL\Functional;
+
+use Doctrine\DBAL\DBALException;
+
+require_once __DIR__ . '/../../TestInit.php';
+
+class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+    public function testDuplicateKeyException()
+    {
+        /* @var $sm \Doctrine\DBAL\Schema\AbstractSchemaManager */
+        $table = new \Doctrine\DBAL\Schema\Table("duplicatekey_table");
+        $table->addColumn('id', 'integer', array());
+        $table->setPrimaryKey(array('id'));
+
+        foreach ($this->_conn->getDatabasePlatform()->getCreateTableSQL($table) AS $sql) {
+            $this->_conn->executeQuery($sql);
+        }
+
+        $this->_conn->insert("duplicatekey_table", array('id' => 1));
+
+        $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_DUPLICATE_KEY);
+        $this->_conn->insert("duplicatekey_table", array('id' => 1));
+    }
+}
+ 

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -23,5 +23,13 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_DUPLICATE_KEY);
         $this->_conn->insert("duplicatekey_table", array('id' => 1));
     }
+
+    public function testUnknownTableException()
+    {
+        $sql = "SELECT * FROM unknown_table";
+
+        $this->setExpectedException('\Doctrine\DBAL\DBALException', null, DBALException::ERROR_UNKNOWN_TABLE);
+        $this->_conn->executeQuery($sql);
+    }
 }
  

--- a/tests/Doctrine/Tests/Mocks/DriverMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverMock.php
@@ -69,4 +69,9 @@ class DriverMock implements \Doctrine\DBAL\Driver
     {
         return;
     }
+
+    public function convertExceptionCode(\Exception $exception)
+    {
+        return 0;
+    }
 }


### PR DESCRIPTION
### MySQL
- [x] 1048  SQLSTATE: 23000 (ER_BAD_NULL_ERROR) Column '%s' cannot be null
- [ ] 1049  SQLSTATE: 42000 (ER_BAD_DB_ERROR) Unknown database '%s'
- [x] 1050  SQLSTATE: 42S01 (ER_TABLE_EXISTS_ERROR) Table '%s' already exists
- [x] 1051  SQLSTATE: 42S02 (ER_BAD_TABLE_ERROR) Unknown table '%s'
- [x] 1052  SQLSTATE: 23000 (ER_NON_UNIQ_ERROR) Column '%s' in %s is ambiguous
- [ ] 1054  SQLSTATE: 42S22 (ER_BAD_FIELD_ERROR) Unknown column '%s' in '%s'
- [ ] 1055  SQLSTATE: 42000 (ER_WRONG_FIELD_WITH_GROUP) '%s' isn't in GROUP BY
- [ ] 1056  SQLSTATE: 42000 (ER_WRONG_GROUP_FIELD) Can't group on '%s'
- [ ] 1057  SQLSTATE: 42000 (ER_WRONG_SUM_SELECT) Statement has sum functions and columns in same statement
- [ ] 1058  SQLSTATE: 21S01 (ER_WRONG_VALUE_COUNT) Column count doesn't match value count
- [ ] 1059  SQLSTATE: 42000 (ER_TOO_LONG_IDENT) Identifier name '%s' is too long
- [ ] 1060  SQLSTATE: 42S21 (ER_DUP_FIELDNAME) Duplicate column name '%s'
- [ ] 1061  SQLSTATE: 42000 (ER_DUP_KEYNAME) Duplicate key name '%s'
- [x] 1062  SQLSTATE: 23000 (ER_DUP_ENTRY) Duplicate entry '%s' for key %d
- [ ] 1063  SQLSTATE: 42000 (ER_WRONG_FIELD_SPEC) Incorrect column specifier for column '%s'
- [ ] 1064  SQLSTATE: 42000 (ER_PARSE_ERROR) %s near '%s' at line %d
- [ ] 1065  SQLSTATE: HY000 (ER_EMPTY_QUERY) Query was empty
- [ ] 1066  SQLSTATE: 42000 (ER_NONUNIQ_TABLE) Not unique table/alias: '%s'
- [ ] 1067  SQLSTATE: 42000 (ER_INVALID_DEFAULT) Invalid default value for '%s'
- [ ] 1068  SQLSTATE: 42000 (ER_MULTIPLE_PRI_KEY) Multiple primary key defined
- [ ] 1069  SQLSTATE: 42000 (ER_TOO_MANY_KEYS) Too many keys specified; max %d keys allowed
- [ ] 1070  SQLSTATE: 42000 (ER_TOO_MANY_KEY_PARTS) Too many key parts specified; max %d parts allowed
- [ ] 1071  SQLSTATE: 42000 (ER_TOO_LONG_KEY) Specified key was too long; max key length is %d bytes
- [ ] 1072  SQLSTATE: 42000 (ER_KEY_COLUMN_DOES_NOT_EXITS) Key column '%s' doesn't exist in table
- [x] 1217  SQLSTATE: 23000 (ER_ROW_IS_REFERENCED) Cannot delete or update a parent row: a foreign key constraint fails
- [ ] 1146  SQLSTATE: 42S02 (ER_NO_SUCH_TABLE) Table '%s.%s' doesn't exist
- [ ] 1147  SQLSTATE: 42000 (ER_NONEXISTING_TABLE_GRANT) There is no such grant defined for user '%s' on host '%s' on table '%s'
- [ ] 1149  SQLSTATE: 42000 (ER_SYNTAX_ERROR) You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use
