### PR TITLE
Added existence check before dropping constraints in postgres

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -113,7 +113,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getDateSubHourExpression($date, $hours)
     {
-        return "(" . $date ." - (" . $hours . " || ' hour')::interval)";    
+        return "(" . $date ." - (" . $hours . " || ' hour')::interval)";
     }
 
     /**
@@ -545,6 +545,26 @@ class PostgreSqlPlatform extends AbstractPlatform
             $sequence = $sequence->getQuotedName($this);
         }
         return 'DROP SEQUENCE ' . $sequence . ' CASCADE';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDropIndexSQL($index, $table = null)
+    {
+        $sql = parent::getDropIndexSQL($index, $table);
+
+        return str_replace('DROP INDEX', 'DROP INDEX IF EXISTS', $sql);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDropConstraintSQL($constraint, $table)
+    {
+        $sql = parent::getDropConstraintSQL($constraint, $table);
+
+        return str_replace('DROP CONSTRAINT', 'DROP CONSTRAINT IF EXISTS', $sql);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -204,6 +204,22 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function testGeneratesDropConstraint()
+    {
+        $this->assertEquals(
+            'ALTER TABLE table_name DROP CONSTRAINT IF EXISTS constraint_name',
+            $this->_platform->getDropConstraintSQL('constraint_name', 'table_name')
+        );
+    }
+
+    public function testGeneratesDropIndex()
+    {
+        $this->assertEquals(
+            'DROP INDEX IF EXISTS index_name',
+            $this->_platform->getDropIndexSQL('index_name')
+        );
+    }
+
     public function testDoesNotPreferIdentityColumns()
     {
         $this->assertFalse($this->_platform->prefersIdentityColumns());


### PR DESCRIPTION
The Schema object generates distinct sql queries for altering a table and for removing a constraint or an index. However, in some cases, the `drop` query may come after an `alter table` query deleting the column to which the index/constraint was bound. In postgres, where dropping a column automatically drops its attached indexes and constraints, executing the queries in that order leads to an sql error (trying to drop something that has already been deleted -> "SQLSTATE[42704]: Undefined object").

This PR introduces a quick fix for that issue (not sure it's the best way though).
