### PR TITLE
HHVM compatibility: func_get_args

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -220,14 +220,14 @@ class SQLSrvStatement implements IteratorAggregate, Statement
      */
     public function fetch($fetchMode = null)
     {
+        $args = func_get_args();
         $fetchMode = $fetchMode ?: $this->defaultFetchMode;
         if (isset(self::$fetchMap[$fetchMode])) {
             return sqlsrv_fetch_array($this->stmt, self::$fetchMap[$fetchMode]);
         } else if ($fetchMode == PDO::FETCH_OBJ || $fetchMode == PDO::FETCH_CLASS) {
             $className = null;
             $ctorArgs = null;
-            if (func_num_args() >= 2) {
-                $args = func_get_args();
+            if (count($args) >= 2) {
                 $className = $args[1];
                 $ctorArgs = (isset($args[2])) ? $args[2] : array();
             }

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -743,8 +743,8 @@ class QueryBuilder
      */
     public function andWhere($where)
     {
-        $where = $this->getQueryPart('where');
         $args = func_get_args();
+        $where = $this->getQueryPart('where');
 
         if ($where instanceof CompositeExpression && $where->getType() === CompositeExpression::TYPE_AND) {
             $where->addMultiple($args);
@@ -776,8 +776,8 @@ class QueryBuilder
      */
     public function orWhere($where)
     {
-        $where = $this->getQueryPart('where');
         $args = func_get_args();
+        $where = $this->getQueryPart('where');
 
         if ($where instanceof CompositeExpression && $where->getType() === CompositeExpression::TYPE_OR) {
             $where->addMultiple($args);
@@ -869,8 +869,8 @@ class QueryBuilder
      */
     public function andHaving($having)
     {
-        $having = $this->getQueryPart('having');
         $args = func_get_args();
+        $having = $this->getQueryPart('having');
 
         if ($having instanceof CompositeExpression && $having->getType() === CompositeExpression::TYPE_AND) {
             $having->addMultiple($args);
@@ -892,8 +892,8 @@ class QueryBuilder
      */
     public function orHaving($having)
     {
-        $having = $this->getQueryPart('having');
         $args = func_get_args();
+        $having = $this->getQueryPart('having');
 
         if ($having instanceof CompositeExpression && $having->getType() === CompositeExpression::TYPE_OR) {
             $having->addMultiple($args);


### PR DESCRIPTION
All func_get_args() calls have been moved to the top of the methods because HHVM doesn't keep a copy of the original args for performance reasons.

See facebook/hiphop-php#1027 for details.
