### PR TITLE
HHVM compatibility: implement declared interfaces

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -41,4 +41,39 @@ class PDOConnection extends PDO implements Connection
         $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, array('Doctrine\DBAL\Driver\PDOStatement', array()));
         $this->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepare($prepareString)
+    {
+        return parent::prepare($prepareString);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function query()
+    {
+        $args = func_get_args();
+        $sql = $args[0];
+
+        return parent::query($sql);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function quote($input, $type=\PDO::PARAM_STR)
+    {
+        return parent::quote($input, $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lastInsertId($name = null)
+    {
+        return parent::lastInsertId($name);
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -45,9 +45,9 @@ class PDOConnection extends PDO implements Connection
     /**
      * {@inheritdoc}
      */
-    public function prepare($prepareString)
+    public function prepare($prepareString, $driverOptions = array())
     {
-        return parent::prepare($prepareString);
+        return parent::prepare($prepareString, $driverOptions);
     }
 
     /**
@@ -56,15 +56,27 @@ class PDOConnection extends PDO implements Connection
     public function query()
     {
         $args = func_get_args();
-        $sql = $args[0];
+        $argsCount = count($args);
 
-        return parent::query($sql);
+        if ($argsCount == 4) {
+            return parent::query($args[0], $args[1], $args[2], $args[3]);
+        }
+
+        if ($argsCount == 3) {
+            return parent::query($args[0], $args[1], $args[2]);
+        }
+
+        if ($argsCount == 2) {
+            return parent::query($args[0], $args[1]);
+        }
+
+        return parent::query($args[0]);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function quote($input, $type=\PDO::PARAM_STR)
+    public function quote($input, $type = \PDO::PARAM_STR)
     {
         return parent::quote($input, $type);
     }

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -83,11 +83,11 @@ class PDOStatement extends \PDOStatement implements Statement
      */
     public function fetch($fetchMode = null, $cursorOrientation = null, $cursorOffset = null)
     {
-        if ($fetchMode == null && $cursorOrientation == null && $cursorOffset === null) {
+        if ($fetchMode === null && $cursorOrientation === null && $cursorOffset === null) {
             return parent::fetch();
         }
 
-        if ($cursorOrientation == null && $cursorOffset === null) {
+        if ($cursorOrientation === null && $cursorOffset === null) {
             return parent::fetch($fetchMode);
         }
 
@@ -103,15 +103,15 @@ class PDOStatement extends \PDOStatement implements Statement
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
-        if ($fetchMode == null && $fetchArgument == null && $ctorArgs == null) {
+        if ($fetchMode === null && $fetchArgument === null && $ctorArgs === null) {
             return parent::fetchAll();
         }
 
-        if ($fetchArgument == null && $ctorArgs == null) {
+        if ($fetchArgument === null && $ctorArgs === null) {
             return parent::fetchAll($fetchMode);
         }
 
-        if ($ctorArgs == null) {
+        if ($ctorArgs === null) {
             return parent::fetchAll($fetchMode, $fetchArgument);
         }
 

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -28,9 +28,9 @@ namespace Doctrine\DBAL\Driver;
 class PDOStatement extends \PDOStatement implements Statement
 {
     /**
-     * Private constructor.
+     * Protected constructor.
      */
-    private function __construct()
+    protected function __construct()
     {
     }
 
@@ -52,5 +52,53 @@ class PDOStatement extends \PDOStatement implements Statement
         }
 
         return parent::setFetchMode($fetchMode, $arg2, $arg3);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindValue($param, $value, $type = null)
+    {
+        return parent::bindValue($param, $value, $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindParam($column, &$variable, $type = null, $length = null)
+    {
+        return parent::bindParam($column, $variable, $type, $length);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($params = null)
+    {
+        return parent::execute($params);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch($fetchMode = null)
+    {
+        return parent::fetch($fetchMode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAll($fetchMode = null)
+    {
+        return parent::fetchAll($fetchMode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchColumn($columnIndex = 0)
+    {
+        return parent::fetchColumn($columnIndex);
     }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -57,7 +57,7 @@ class PDOStatement extends \PDOStatement implements Statement
     /**
      * {@inheritdoc}
      */
-    public function bindValue($param, $value, $type = null)
+    public function bindValue($param, $value, $type = \PDO::PARAM_STR)
     {
         return parent::bindValue($param, $value, $type);
     }
@@ -65,9 +65,9 @@ class PDOStatement extends \PDOStatement implements Statement
     /**
      * {@inheritdoc}
      */
-    public function bindParam($column, &$variable, $type = null, $length = null)
+    public function bindParam($column, &$variable, $type = \PDO::PARAM_STR, $length = null, $driverOptions = array())
     {
-        return parent::bindParam($column, $variable, $type, $length);
+        return parent::bindParam($column, $variable, $type, $length, $driverOptions);
     }
 
     /**
@@ -81,17 +81,41 @@ class PDOStatement extends \PDOStatement implements Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchMode = null)
+    public function fetch($fetchMode = null, $cursorOrientation = null, $cursorOffset = null)
     {
-        return parent::fetch($fetchMode);
+        if ($fetchMode == null && $cursorOrientation == null && $cursorOffset === null) {
+            return parent::fetch();
+        }
+
+        if ($cursorOrientation == null && $cursorOffset === null) {
+            return parent::fetch($fetchMode);
+        }
+
+        if ($cursorOffset === null) {
+            return parent::fetch($fetchMode, $cursorOrientation);
+        }
+
+        return parent::fetch($fetchMode, $cursorOrientation, $cursorOffset);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
-        return parent::fetchAll($fetchMode);
+        if ($fetchMode == null && $fetchArgument == null && $ctorArgs == null) {
+            return parent::fetchAll();
+        }
+
+        if ($fetchArgument == null && $ctorArgs == null) {
+            return parent::fetchAll($fetchMode);
+        }
+
+        if ($ctorArgs == null) {
+            return parent::fetchAll($fetchMode, $fetchArgument);
+        }
+
+        return parent::fetchAll($fetchMode, $fetchArgument, $ctorArgs);
     }
 
     /**


### PR DESCRIPTION
HHVM does not allow declaration of interface implementation without real implementation of methods which parameters differs from parent class.
