### PR TITLE
Update SQLServerPlatform.php by adding methods related to schema.

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -166,6 +166,22 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getCreateSchemaSQL($schemaName)
+    {
+        return 'CREATE SCHEMA ' . $schemaName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function schemaNeedsCreation($schemaName)
+    {
+        return $schemaName !== 'dbo';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDropForeignKeySQL($foreignKey, $table)
     {
         if ($foreignKey instanceof ForeignKeyConstraint) {

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -317,4 +317,23 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE [quoted] ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ([create], foo, [bar]) REFERENCES [foo-bar] ([create], bar, [foo-bar])',
         );
     }
+
+    public function testGetCreateSchemaSQL()
+    {
+        $schemaName = 'schema';
+        $sql = $this->_platform->getCreateSchemaSQL($schemaName);
+        $this->assertEquals('CREATE SCHEMA ' . $schemaName, $sql);
+    }
+
+    public function testSchemaNeedsCreation()
+    {
+        $schemaNames = array(
+            'dbo' => false,
+            'schema' => true,
+        );
+        foreach ($schemaNames as $name => $expected) {
+            $actual = $this->_platform->schemaNeedsCreation($name);
+            $this->assertEquals($expected, $actual);
+        }
+    }
 }


### PR DESCRIPTION
The platform indicates support for schema's here: https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php#L129

But is missing relevant methods:
schemaNeedsCreation() --> to detect if schema creation is needed
and
getCreateSchemaSQL() --> to create a schema
