### PR TITLE
Update CreateSchemaSqlCollector.php setting default namespace/schema nam...

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2752,6 +2752,18 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Returns the default schema name.
+     *
+     * @return string
+     *
+     * @throws \Doctrine\DBAL\DBALException If not supported on this platform.
+     */
+    protected function getDefaultSchemaName()
+    {
+        throw DBALException::notSupported(__METHOD__);
+    }
+
+    /**
      * Whether this platform supports create database.
      *
      * Some databases don't allow to create and drop databases at all or only with certain tools.

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2758,7 +2758,7 @@ abstract class AbstractPlatform
      *
      * @throws \Doctrine\DBAL\DBALException If not supported on this platform.
      */
-    protected function getDefaultSchemaName()
+    public function getDefaultSchemaName()
     {
         throw DBALException::notSupported(__METHOD__);
     }

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -165,6 +165,14 @@ class PostgreSqlPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getDefaultSchemaName()
+    {
+        return 'public';
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function supportsIdentityColumns()

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -132,6 +132,14 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getDefaultSchemaName()
+    {
+        return 'dbo';
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function hasNativeGuidType()

--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -105,7 +105,15 @@ class CreateSchemaSqlCollector extends AbstractVisitor
      */
     private function getNamespace($asset)
     {
-        $namespace = $asset->getNamespaceName() ?: 'default';
+        $namespace = $asset->getNamespaceName();
+
+        if ($namespace === null) {
+            if ($this->platform instanceof \Doctrine\DBAL\Platforms\SQLServerPlatform) {
+                $namespace = 'dbo';
+            } else {
+                $namespace = 'default';
+            }
+        }
 
         if ( !isset($this->createTableQueries[$namespace])) {
             $this->createTableQueries[$namespace] = array();

--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -107,7 +107,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
     {
         $namespace = $asset->getNamespaceName();
 
-        if ( !isset($namespace)) {
+        if ( !isset($namespace)) {var_dump(get_class($this->platform));
             $namespace = $this->platform->getDefaultSchemaName();
         }
 

--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -23,6 +23,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 
 class CreateSchemaSqlCollector extends AbstractVisitor
 {
@@ -108,7 +109,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
         $namespace = $asset->getNamespaceName();
 
         if ($namespace === null) {
-            if ($this->platform instanceof \Doctrine\DBAL\Platforms\SQLServerPlatform) {
+            if ($this->platform instanceof SQLServerPlatform) {
                 $namespace = 'dbo';
             } else {
                 $namespace = 'default';

--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -23,7 +23,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
 
 class CreateSchemaSqlCollector extends AbstractVisitor
 {
@@ -108,12 +107,8 @@ class CreateSchemaSqlCollector extends AbstractVisitor
     {
         $namespace = $asset->getNamespaceName();
 
-        if ($namespace === null) {
-            if ($this->platform instanceof SQLServerPlatform) {
-                $namespace = 'dbo';
-            } else {
-                $namespace = 'default';
-            }
+        if ( !isset($namespace)) {
+            $namespace = $this->platform->getDefaultSchemaName();
         }
 
         if ( !isset($this->createTableQueries[$namespace])) {

--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -107,8 +107,8 @@ class CreateSchemaSqlCollector extends AbstractVisitor
     {
         $namespace = $asset->getNamespaceName();
 
-        if ( !isset($namespace)) {var_dump(get_class($this->platform));
-            $namespace = $this->platform->getDefaultSchemaName();
+        if ( !isset($namespace)) {
+            $namespace = $this->platform->supportsSchemas() ? $this->platform->getDefaultSchemaName() : 'default';
         }
 
         if ( !isset($this->createTableQueries[$namespace])) {

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -32,6 +32,6 @@ class CreateSchemaSqlCollectorTest extends \PHPUnit_Framework_TestCase
         $sqlCollector = new CreateSchemaSqlCollector($platformMock);
         $sqlCollector->acceptTable($tableMock);
         $sql = $sqlCollector->getQueries();
-        $this->assertEquals('CREATE SCHEMA default', $sql[0]);
+        $this->assertEquals('CREATE SCHEMA public', $sql[0]);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -10,10 +10,10 @@ class CreateSchemaSqlCollectorTest extends \PHPUnit_Framework_TestCase
     {
         $platformMock = $this->getMock(
             'Doctrine\DBAL\Platforms\PostgreSqlPlatform',
-            array('supportsSchemas', 'schemaNeedsCreation', 'getCreateTableSQL', 'supportsSchemas')
+            array('supportsSchemas', 'schemaNeedsCreation', 'getCreateTableSQL')
         );
 
-        $platformMock->expects($this->exactly(1))
+        $platformMock->expects($this->any())
                      ->method('supportsSchemas')
                      ->will($this->returnValue(true));
 

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -10,7 +10,7 @@ class CreateSchemaSqlCollectorTest extends \PHPUnit_Framework_TestCase
     {
         $platformMock = $this->getMock(
             'Doctrine\DBAL\Platforms\PostgreSqlPlatform',
-            array('supportsSchemas', 'schemaNeedsCreation', 'getCreateTableSQL')
+            array('supportsSchemas', 'schemaNeedsCreation', 'getCreateTableSQL', 'supportsSchemas')
         );
 
         $platformMock->expects($this->exactly(1))


### PR DESCRIPTION
The namespace is used as name for the database schema. For SQL Server the default schema name is "dbo" and not "default".
