### PR TITLE
Fix #DBAL-615 - ALTER with reserved keywords

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
@@ -396,7 +396,7 @@ class DrizzlePlatform extends AbstractPlatform
         $queryParts = array();
 
         if ($diff->newName !== false) {
-            $queryParts[] =  'RENAME TO ' . $diff->newName;
+            $queryParts[] =  'RENAME TO ' . $this->quoteSingleIdentifier($diff->newName);
         }
 
         foreach ($diff->addedColumns as $column) {
@@ -446,7 +446,7 @@ class DrizzlePlatform extends AbstractPlatform
 
         if ( ! $this->onSchemaAlterTable($diff, $tableSql)) {
             if (count($queryParts) > 0) {
-                $sql[] = 'ALTER TABLE ' . $diff->name . ' ' . implode(", ", $queryParts);
+                $sql[] = 'ALTER TABLE ' . $this->quoteSingleIdentifier($diff->name) . ' ' . implode(", ", $queryParts);
             }
             $sql = array_merge(
                 $this->getPreAlterTableIndexForeignKeySQL($diff),

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -527,7 +527,7 @@ class MySqlPlatform extends AbstractPlatform
         $columnSql = array();
         $queryParts = array();
         if ($diff->newName !== false) {
-            $queryParts[] = 'RENAME TO ' . $diff->newName;
+            $queryParts[] = 'RENAME TO ' . $this->quoteSingleIdentifier($diff->newName);
         }
 
         foreach ($diff->addedColumns as $column) {
@@ -577,7 +577,7 @@ class MySqlPlatform extends AbstractPlatform
 
         if ( ! $this->onSchemaAlterTable($diff, $tableSql)) {
             if (count($queryParts) > 0) {
-                $sql[] = 'ALTER TABLE ' . $diff->name . ' ' . implode(", ", $queryParts);
+                $sql[] = 'ALTER TABLE ' . $this->quoteSingleIdentifier($diff->name) . ' ' . implode(", ", $queryParts);
             }
             $sql = array_merge(
                 $this->getPreAlterTableIndexForeignKeySQL($diff),

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -613,7 +613,8 @@ LEFT JOIN user_cons_columns r_cols
         }
 
         if (count($fields)) {
-            $sql[] = 'ALTER TABLE ' . $diff->name . ' ADD (' . implode(', ', $fields) . ')';
+            $sql[] = 'ALTER TABLE ' . $this->quoteSingleIdentifier($diff->name) .
+                     ' ADD (' . implode(', ', $fields) . ')';
         }
 
         $fields = array();
@@ -648,7 +649,8 @@ LEFT JOIN user_cons_columns r_cols
         }
 
         if (count($fields)) {
-            $sql[] = 'ALTER TABLE ' . $diff->name . ' MODIFY (' . implode(', ', $fields) . ')';
+            $sql[] = 'ALTER TABLE ' . $this->quoteSingleIdentifier($diff->name) .
+                     ' MODIFY (' . implode(', ', $fields) . ')';
         }
 
         foreach ($diff->renamedColumns as $oldColumnName => $column) {
@@ -656,7 +658,8 @@ LEFT JOIN user_cons_columns r_cols
                 continue;
             }
 
-            $sql[] = 'ALTER TABLE ' . $diff->name . ' RENAME COLUMN ' . $oldColumnName .' TO ' . $column->getQuotedName($this);
+            $sql[] = 'ALTER TABLE ' . $this->quoteSingleIdentifier($diff->name) .
+                     ' RENAME COLUMN ' . $oldColumnName .' TO ' . $column->getQuotedName($this);
         }
 
         $fields = array();
@@ -669,14 +672,16 @@ LEFT JOIN user_cons_columns r_cols
         }
 
         if (count($fields)) {
-            $sql[] = 'ALTER TABLE ' . $diff->name . ' DROP (' . implode(', ', $fields).')';
+            $sql[] = 'ALTER TABLE ' . $this->quoteSingleIdentifier($diff->name) .
+                     ' DROP (' . implode(', ', $fields).')';
         }
 
         $tableSql = array();
 
         if ( ! $this->onSchemaAlterTable($diff, $tableSql)) {
             if ($diff->newName !== false) {
-                $sql[] = 'ALTER TABLE ' . $diff->name . ' RENAME TO ' . $diff->newName;
+                $sql[] = 'ALTER TABLE ' . $this->quoteSingleIdentifier($diff->name) .
+                         ' RENAME TO ' . $this->quoteSingleIdentifier($diff->newName);
             }
 
             $sql = array_merge($sql, $this->_getAlterTableIndexForeignKeySQL($diff), $commentsSQL);

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -467,7 +467,7 @@ class SQLServerPlatform extends AbstractPlatform
         }
 
         foreach ($queryParts as $query) {
-            $sql[] = 'ALTER TABLE ' . $diff->name . ' ' . $query;
+            $sql[] = 'ALTER TABLE ' . $this->quoteSingleIdentifier($diff->name) . ' ' . $query;
         }
 
         $sql = array_merge($sql, $this->_getAlterTableIndexForeignKeySQL($diff));

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -220,6 +220,9 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 
     abstract public function getGenerateAlterTableSql();
 
+    /**
+     * @group DBAL-374
+     */
     public function testGeneratesTableAlterationSql()
     {
         $expectedSql = $this->getGenerateAlterTableSql();
@@ -370,6 +373,7 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 
     /**
      * @group DBAL-42
+     * @group DBAL-374
      */
     public function testAlterTableColumnComments()
     {
@@ -443,6 +447,7 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     abstract protected function getQuotedColumnInPrimaryKeySQL();
     abstract protected function getQuotedColumnInIndexSQL();
     abstract protected function getQuotedColumnInForeignKeySQL();
+    abstract protected function getQuotedIdentifiersInAlterSQL();
 
     /**
      * @group DBAL-374
@@ -493,6 +498,30 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 
         $sql = $this->_platform->getCreateTableSQL($table, AbstractPlatform::CREATE_FOREIGNKEYS);
         $this->assertEquals($this->getQuotedColumnInForeignKeySQL(), $sql);
+    }
+
+    /**
+     * @group DBAL-615
+     */
+    public function testQuotedIdentifiersInAlterQueries()
+    {
+        $table1 = new Table('`quoted`');
+        $table1->addColumn('create', 'string');
+
+        $table2 = new Table('`quoted`');
+        $table2->addColumn('order', 'string');
+
+        $diff = new TableDiff('quoted');
+        $diff->removedColumns = array(
+            $table1->getColumn('create')
+        );
+        $diff->addedColumns = array(
+            $table2->getColumn('order')
+        );
+        $diff->fromTable = $table1;
+
+        $sql = $this->_platform->getAlterTableSQL($diff);
+        $this->assertEquals($this->getQuotedIdentifiersInAlterSQL(), $sql);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -47,7 +47,7 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
     public function getGenerateAlterTableSql()
     {
         return array(
-            "ALTER TABLE mytable RENAME TO userlist, ADD quota INT DEFAULT NULL, DROP foo, CHANGE bar baz VARCHAR(255) DEFAULT 'def' NOT NULL, CHANGE bloo bloo TINYINT(1) DEFAULT '0' NOT NULL"
+            "ALTER TABLE `mytable` RENAME TO `userlist`, ADD quota INT DEFAULT NULL, DROP foo, CHANGE bar baz VARCHAR(255) DEFAULT 'def' NOT NULL, CHANGE bloo bloo TINYINT(1) DEFAULT '0' NOT NULL"
         );
     }
 
@@ -209,7 +209,7 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
 
     public function getAlterTableColumnCommentsSQL()
     {
-        return array("ALTER TABLE mytable ADD quota INT NOT NULL COMMENT 'A comment', CHANGE foo foo VARCHAR(255) NOT NULL, CHANGE bar baz VARCHAR(255) NOT NULL COMMENT 'B comment'");
+        return array("ALTER TABLE `mytable` ADD quota INT NOT NULL COMMENT 'A comment', CHANGE foo foo VARCHAR(255) NOT NULL, CHANGE bar baz VARCHAR(255) NOT NULL COMMENT 'B comment'");
     }
 
     public function getCreateTableColumnTypeCommentsSQL()
@@ -245,6 +245,13 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
     {
         return array(
             'CREATE TABLE `quoted` (`create` VARCHAR(255) NOT NULL, INDEX IDX_22660D028FD6E0FB (`create`)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB'
+        );
+    }
+
+    protected function getQuotedIdentifiersInAlterSQL()
+    {
+        return array(
+            'ALTER TABLE `quoted` ADD `order` VARCHAR(255) NOT NULL, DROP `create`'
         );
     }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -75,10 +75,10 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     public function getGenerateAlterTableSql()
     {
         return array(
-            'ALTER TABLE mytable ADD (quota NUMBER(10) DEFAULT NULL)',
-            "ALTER TABLE mytable MODIFY (baz  VARCHAR2(255) DEFAULT 'def' NOT NULL, bloo  NUMBER(1) DEFAULT '0' NOT NULL)",
-            "ALTER TABLE mytable DROP (foo)",
-            "ALTER TABLE mytable RENAME TO userlist",
+            'ALTER TABLE "mytable" ADD (quota NUMBER(10) DEFAULT NULL)',
+            "ALTER TABLE \"mytable\" MODIFY (baz  VARCHAR2(255) DEFAULT 'def' NOT NULL, bloo  NUMBER(1) DEFAULT '0' NOT NULL)",
+            'ALTER TABLE "mytable" DROP (foo)',
+            'ALTER TABLE "mytable" RENAME TO "userlist"',
         );
     }
 
@@ -267,7 +267,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     public function getAlterTableColumnCommentsSQL()
     {
         return array(
-            "ALTER TABLE mytable ADD (quota NUMBER(10) NOT NULL)",
+            'ALTER TABLE "mytable" ADD (quota NUMBER(10) NOT NULL)',
             "COMMENT ON COLUMN mytable.quota IS 'A comment'",
             "COMMENT ON COLUMN mytable.foo IS ''",
             "COMMENT ON COLUMN mytable.baz IS 'B comment'",
@@ -289,6 +289,14 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     protected function getQuotedColumnInPrimaryKeySQL()
     {
         return array('CREATE TABLE "quoted" ("create" VARCHAR2(255) NOT NULL, PRIMARY KEY("create"))');
+    }
+
+    protected function getQuotedIdentifiersInAlterSQL()
+    {
+        return array(
+            'ALTER TABLE "quoted" ADD ("order" VARCHAR2(255) NOT NULL)',
+            'ALTER TABLE "quoted" DROP ("create")'
+        );
     }
 
     protected function getQuotedColumnInIndexSQL()
@@ -326,7 +334,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         );
 
         $expectedSql = array(
-            "ALTER TABLE mytable MODIFY (foo  VARCHAR2(255) DEFAULT 'bla', baz  VARCHAR2(255) DEFAULT 'bla' NOT NULL)",
+            "ALTER TABLE \"mytable\" MODIFY (foo  VARCHAR2(255) DEFAULT 'bla', baz  VARCHAR2(255) DEFAULT 'bla' NOT NULL)",
 	);
         $this->assertEquals($expectedSql, $this->_platform->getAlterTableSQL($tableDiff));
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -28,15 +28,15 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
     public function getGenerateAlterTableSql()
     {
         return array(
-            'ALTER TABLE mytable ADD quota INT DEFAULT NULL',
-            'ALTER TABLE mytable DROP foo',
-            'ALTER TABLE mytable ALTER bar TYPE VARCHAR(255)',
-            "ALTER TABLE mytable ALTER bar SET  DEFAULT 'def'",
-            'ALTER TABLE mytable ALTER bar SET NOT NULL',
-            'ALTER TABLE mytable ALTER bloo TYPE BOOLEAN',
-            "ALTER TABLE mytable ALTER bloo SET  DEFAULT 'false'",
-            'ALTER TABLE mytable ALTER bloo SET NOT NULL',
-            'ALTER TABLE mytable RENAME TO userlist',
+            'ALTER TABLE "mytable" ADD quota INT DEFAULT NULL',
+            'ALTER TABLE "mytable" DROP foo',
+            'ALTER TABLE "mytable" ALTER bar TYPE VARCHAR(255)',
+            "ALTER TABLE \"mytable\" ALTER bar SET  DEFAULT 'def'",
+            'ALTER TABLE "mytable" ALTER bar SET NOT NULL',
+            'ALTER TABLE "mytable" ALTER bloo TYPE BOOLEAN',
+            "ALTER TABLE \"mytable\" ALTER bloo SET  DEFAULT 'false'",
+            'ALTER TABLE "mytable" ALTER bloo SET NOT NULL',
+            'ALTER TABLE "mytable" RENAME TO userlist',
         );
     }
 
@@ -252,7 +252,7 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
     public function getAlterTableColumnCommentsSQL()
     {
         return array(
-            "ALTER TABLE mytable ADD quota INT NOT NULL",
+            'ALTER TABLE "mytable" ADD quota INT NOT NULL',
             "COMMENT ON COLUMN mytable.quota IS 'A comment'",
             "COMMENT ON COLUMN mytable.foo IS NULL",
             "COMMENT ON COLUMN mytable.baz IS 'B comment'",
@@ -289,6 +289,14 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES "foreign" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES foo ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") REFERENCES "foo-bar" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
+        );
+    }
+
+    protected function getQuotedIdentifiersInAlterSQL()
+    {
+        return array(
+            'ALTER TABLE "quoted" ADD "order" VARCHAR(255) NOT NULL',
+            'ALTER TABLE "quoted" DROP "create"'
         );
     }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -28,11 +28,11 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     public function getGenerateAlterTableSql()
     {
         return array(
-            'ALTER TABLE mytable ADD quota INT',
-            'ALTER TABLE mytable DROP COLUMN foo',
-            'ALTER TABLE mytable ALTER COLUMN baz NVARCHAR(255) NOT NULL',
-            "ALTER TABLE mytable ADD CONSTRAINT DF_6B2BD609_78240498 DEFAULT 'def' FOR baz",
-            'ALTER TABLE mytable ALTER COLUMN bloo BIT NOT NULL',
+            'ALTER TABLE [mytable] ADD quota INT',
+            'ALTER TABLE [mytable] DROP COLUMN foo',
+            'ALTER TABLE [mytable] ALTER COLUMN baz NVARCHAR(255) NOT NULL',
+            "ALTER TABLE [mytable] ADD CONSTRAINT DF_6B2BD609_78240498 DEFAULT 'def' FOR baz",
+            'ALTER TABLE [mytable] ALTER COLUMN bloo BIT NOT NULL',
             "sp_RENAME 'mytable', 'userlist'",
             "DECLARE @sql NVARCHAR(MAX) = N''; " .
             "SELECT @sql += N'EXEC sp_rename N''' + dc.name + ''', N''' " .
@@ -317,4 +317,13 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE [quoted] ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ([create], foo, [bar]) REFERENCES [foo-bar] ([create], bar, [foo-bar])',
         );
     }
+
+    protected function getQuotedIdentifiersInAlterSQL()
+    {
+        return array(
+            'ALTER TABLE [quoted] ADD [order] NVARCHAR(255) NOT NULL',
+            'ALTER TABLE [quoted] DROP COLUMN [create]'
+        );
+    }
+
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -302,4 +302,16 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") REFERENCES "foo-bar" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE)',
         );
     }
+
+    protected function getQuotedIdentifiersInAlterSQL()
+    {
+        return array(
+            'CREATE TEMPORARY TABLE __temp__quoted AS SELECT "create" FROM "quoted"',
+            'DROP TABLE "quoted"',
+            'CREATE TABLE quoted ("create" VARCHAR(255) NOT NULL, "order" VARCHAR(255) NOT NULL)',
+            'INSERT INTO quoted ("create") SELECT "create" FROM __temp__quoted',
+            'DROP TABLE __temp__quoted'
+        );
+    }
+
 }


### PR DESCRIPTION
PR #302 introduced platform quoting for manipulation of PK, FK and indexes. Alter queries are left unquoted, which means that ALTER with table names that happen to be reserved platform keywords, will fail.
For example:

``` sql
ALTER TABLE order DROP FOREIGN KEY FK_F5299398D5289B7F;
ALTER TABLE set DROP FOREIGN KEY FK_E61425DC1BF22D93;
ALTER TABLE storage ADD CONSTRAINT FK_547A1B3487068541 FOREIGN KEY (`addressId`) REFERENCES `address` (`id`);
```

http://www.doctrine-project.org/jira/browse/DBAL-615

After merging changes from this PR, the above together with MySQL platform becomes :

``` sql
ALTER TABLE `order` DROP FOREIGN KEY FK_F5299398D5289B7F;
ALTER TABLE `set` DROP FOREIGN KEY FK_E61425DC1BF22D93;
ALTER TABLE `storage` ADD CONSTRAINT FK_547A1B3487068541 FOREIGN KEY (`addressId`) REFERENCES `address` (`id`);
```
