### PR TITLE
[DBAL-592] Fix schema comparison with FK that contain quoted column names.

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -322,11 +322,11 @@ class Comparator
      */
     public function diffForeignKey(ForeignKeyConstraint $key1, ForeignKeyConstraint $key2)
     {
-        if (array_map('strtolower', $key1->getLocalColumns()) != array_map('strtolower', $key2->getLocalColumns())) {
+        if (array_map('strtolower', $key1->getUnquotedLocalColumns()) != array_map('strtolower', $key2->getUnquotedLocalColumns())) {
             return true;
         }
 
-        if (array_map('strtolower', $key1->getForeignColumns()) != array_map('strtolower', $key2->getForeignColumns())) {
+        if (array_map('strtolower', $key1->getUnquotedForeignColumns()) != array_map('strtolower', $key2->getUnquotedForeignColumns())) {
             return true;
         }
 

--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -164,6 +164,26 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
     }
 
     /**
+     * Returns unquoted representation of local table column names for comparison with other FK
+     *
+     * @return array
+     */
+    public function getUnquotedLocalColumns()
+    {
+        return array_map(array($this, 'trimQuotes'), $this->getLocalColumns());
+    }
+
+    /**
+     * Returns unquoted representation of foreign table column names for comparison with other FK
+     *
+     * @return array
+     */
+    public function getUnquotedForeignColumns()
+    {
+        return array_map(array($this, 'trimQuotes'), $this->getForeignColumns());
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @see getLocalColumns


### PR DESCRIPTION
In case `QuoteStrategy` decides to quote column names for FK, schema comparator (and in effect - schema tool), will be stuck in an `ALTER TABLE * DROP FOREIGN KEY` loop, because it doesn't recognise old indexes with matching column names.

The problem lies inside Comparator, which relied on column names that might or might not be quoted (depending on platform, schema and dbal settings). The comparison must be performed on **unquoted** column names both ways, as it is already performed for normal indexes, table names and columns names.

Tests will come shortly.
