### PR TITLE
specified stable 2.4.* releases of doctrine/common in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": "2.4.*@beta"
+        "doctrine/common": "2.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
There are no beta release tags for 2.4 of `doctrine/common`, and 2.4 stable has been released - so bumping version.
