### PR TITLE
Added method to return indexed array for Connection

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -630,6 +630,19 @@ class Connection implements DriverConnection
     }
 
     /**
+     * Prepares and executes an SQL query and returns the result as an indexed array.
+     *
+     * @param string $statement The SQL query to be executed.
+     * @param array  $params    The prepared statement params.
+     *
+     * @return array
+     */
+    public function fetchAllIndexed($sql, array $params = array(), $types = array())
+    {
+        return $this->executeQuery($sql, $params, $types)->fetchAll(PDO::FETCH_NUM);
+    }
+
+    /**
      * Prepares an SQL statement.
      *
      * @param string $statement The SQL statement to prepare.


### PR DESCRIPTION
Code speaks for itself..
Did not find a test for fetchAll() in ConnectionTest.php so didn't make a test for this function either. Works though.
Function name is up for debate. Possibly needs to be refactored so that fetchAll() accepts PDO fetch style types as described here:
http://www.php.net/manual/en/pdostatement.fetch.php
and
http://php.net/manual/en/pdostatement.fetchall.php
