### PR TITLE
Fix Index construction

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Index.php
+++ b/lib/Doctrine/DBAL/Schema/Index.php
@@ -29,7 +29,7 @@ class Index extends AbstractAsset implements Constraint
      *
      * @var Identifier[]
      */
-    protected $_columns;
+    protected $_columns = array();
 
     /**
      * @var boolean


### PR DESCRIPTION
This PR fixes an uncommon but possible use case where an `Index` is constructed with an empty columns array. Following calls to `Index::getColumns()` lead to a PHP warning `array_keys() expects parameter 1 to be array, null given` as the `$_columns` property is not properly initialized.
