### PR TITLE
Fix reserved keyword conflicts in TemporaryTableTest

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
@@ -22,7 +22,7 @@ class TemporaryTableTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         if ($this->_conn) {
             try {
-                $tempTable = $this->_conn->getDatabasePlatform()->getTemporaryTableName("temporary");
+                $tempTable = $this->_conn->getDatabasePlatform()->getTemporaryTableName("my_temporary");
                 $this->_conn->exec($this->_conn->getDatabasePlatform()->getDropTemporaryTableSQL($tempTable));
             } catch(\Exception $e) { }
         }
@@ -36,7 +36,7 @@ class TemporaryTableTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         $platform = $this->_conn->getDatabasePlatform();
         $columnDefinitions = array("id" => array("type" => Type::getType("integer"), "notnull" => true));
-        $tempTable = $platform->getTemporaryTableName("temporary");
+        $tempTable = $platform->getTemporaryTableName("my_temporary");
 
         $createTempTableSQL = $platform->getCreateTemporaryTableSnippetSQL() . ' ' . $tempTable . ' ('
                 . $platform->getColumnDeclarationListSQL($columnDefinitions) . ')';
@@ -69,7 +69,7 @@ class TemporaryTableTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         $platform = $this->_conn->getDatabasePlatform();
         $columnDefinitions = array("id" => array("type" => Type::getType("integer"), "notnull" => true));
-        $tempTable = $platform->getTemporaryTableName("temporary");
+        $tempTable = $platform->getTemporaryTableName("my_temporary");
 
         $createTempTableSQL = $platform->getCreateTemporaryTableSnippetSQL() . ' ' . $tempTable . ' ('
                 . $platform->getColumnDeclarationListSQL($columnDefinitions) . ')';


### PR DESCRIPTION
The functional `TemporaryTableTest` uses `temporary` as table name for the temporary table being created. This leads to errors on vendors that use `temporary` as a reserved keyword. This PR changes the table name to a non-conflicting one to avoid problems. This patch is necessary in order for the test to pass on SQL Anywhere (PR #293).
