### PR TITLE
Adding method to list view columns

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2396,6 +2396,19 @@ abstract class AbstractPlatform
     }
 
     /**
+     * @param string      $table
+     * @param string|null $database
+     *
+     * @return string
+     *
+     * @throws \Doctrine\DBAL\DBALException If not supported on this platform.
+     */
+    public function getListViewColumnsSQL($table, $database = null)
+    {
+        throw DBALException::notSupported(__METHOD__);
+    }
+
+    /**
      * @return string
      *
      * @throws \Doctrine\DBAL\DBALException If not supported on this platform.

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -542,6 +542,22 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getListTableColumnsSQL($table, $database = null)
     {
+        return $this->getListColumnsSQL($table, 'U');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getListViewColumnsSQL($table, $database = null)
+    {
+        return $this->getListColumnsSQL($table, 'V');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getListColumnsSQL($table, $type)
+    {
         return "SELECT    col.name,
                           type.name AS type,
                           col.max_length AS length,
@@ -559,7 +575,7 @@ class SQLServerPlatform extends AbstractPlatform
                 LEFT JOIN sys.default_constraints def
                 ON        col.default_object_id = def.object_id
                 AND       col.object_id = def.parent_object_id
-                WHERE     obj.type = 'U'
+                WHERE     obj.type = '$type'
                 AND       obj.name = '$table'";
     }
 


### PR DESCRIPTION
This method adds functionality to list the columns of a view.
MySQL can also do this in information_schema.views
I didn't implement other platforms awaiting merge or comments.

If this gets merged then the schema manager can have better support for views. Right now you can only get the view names. Then you can also get the column definitions. Of course more stuff has to be added before this is possible. But this is the first PR.
