### PR TITLE
Revert "remove unnecessary code from Connection::insert"

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -548,13 +548,22 @@ class Connection implements DriverConnection
     {
         $this->connect();
 
+        // column names are specified as array keys
+        $cols = array();
+        $placeholders = array();
+
+        foreach ($data as $columnName => $value) {
+            $cols[] = $columnName;
+            $placeholders[] = '?';
+        }
+
         if ( ! is_int(key($types))) {
             $types = $this->extractTypeValues($data, $types);
         }
 
         $query = 'INSERT INTO ' . $tableName
-               . ' (' . implode(', ', array_keys($data)) . ')'
-               . ' VALUES (' . implode(', ', array_fill(0, count($data), '?')) . ')';
+               . ' (' . implode(', ', $cols) . ')'
+               . ' VALUES (' . implode(', ', $placeholders) . ')';
 
         return $this->executeUpdate($query, array_values($data), $types);
     }


### PR DESCRIPTION
This reverts commit 5b86fad8740135ed2cfee9b6da0b7ddc50f8a066 which was breaking inserts without explicitly set values. This can happen when using an auto increment primary key in conjunction with all other columns having a default. The insert should still be possible in this case, even if the row just contains defaults or null values afterwards.
