### PR TITLE
Fix WriteTest DateTime assertion for different platform formats

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -203,9 +203,9 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $row = array_change_key_case($row, \CASE_LOWER);
         $this->assertEquals(1, $row['test_int']);
-        $this->assertEquals($datetimeString, $row['test_datetime']);        
+        $this->assertStringStartsWith($datetimeString, $row['test_datetime']);
     }
-    
+
     /**
      * @group DBAL-209
      * @expectedException \Doctrine\DBAL\DBALException


### PR DESCRIPTION
There is a test in `WriteTests` that asserts for a DateTime string which is not aware of the specific platform format and thus fails when the driver does not return the DateTime format `Y-m-d`.
