### PR TITLE
Use correct classname in exception message

### DIFF
--- a/lib/Doctrine/DBAL/Event/SchemaDropTableEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaDropTableEventArgs.php
@@ -55,7 +55,7 @@ class SchemaDropTableEventArgs extends SchemaEventArgs
     public function __construct($table, AbstractPlatform $platform)
     {
         if ( ! $table instanceof Table && !is_string($table)) {
-            throw new \InvalidArgumentException('SchemaCreateTableEventArgs expects $table parameter to be string or \Doctrine\DBAL\Schema\Table.');
+            throw new \InvalidArgumentException('SchemaDropTableEventArgs expects $table parameter to be string or \Doctrine\DBAL\Schema\Table.');
         }
 
         $this->_table    = $table;


### PR DESCRIPTION
Seems to have been copied-n-pasted from another class at some point
