### PR TITLE
Fix WriteTest for platforms supporting both sequences and identity columns

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -175,8 +175,8 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
     public function testLastInsertIdNoSequenceGiven()
     {
-        if ( ! $this->_conn->getDatabasePlatform()->supportsSequences()) {
-            $this->markTestSkipped('Test only works on platforms with sequences.');
+        if ( ! $this->_conn->getDatabasePlatform()->supportsSequences() || $this->_conn->getDatabasePlatform()->supportsIdentityColumns()) {
+            $this->markTestSkipped("Test only works consistently on platforms that support sequences and don't support identity columns.");
         }
 
         $this->assertFalse($this->_conn->lastInsertId( null ));


### PR DESCRIPTION
The test `WriteTest::testLastInsertIdNoSequenceGiven()` does not work if the tested platform supports both sequences and identity columns and when the driver is able to return distinguished information about the last inserted sequence ID and identity column ID.
The problem here is that both sequence IDs and identity column IDs get inserted into the database in the tests before. Therefore a driver that is capable of distinguishing between last inserted sequence and identity column IDs returns the last inserted identity column ID when `Connection::lastInsertId(null)` is called in this particular test.
The behaviour of `Connection:lastInsertId()` is very inconsistent throughout the drivers and therefore a true expectation can only be made if the tested platform supports sequences but not identity columns.
