### PR TITLE
[DBAL-367] Add missing Oracle binary_float and binary_double type mappings

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -862,6 +862,8 @@ LEFT JOIN user_cons_columns r_cols
             'timestamp'         => 'datetime',
             'timestamptz'       => 'datetimetz',
             'float'             => 'float',
+            'binary_float'      => 'float',
+            'binary_double'     => 'float',
             'long'              => 'string',
             'clob'              => 'text',
             'nclob'             => 'text',

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -165,6 +165,8 @@ class OracleSchemaManager extends AbstractSchemaManager
                 $length = null;
                 break;
             case 'float':
+            case 'binary_float':
+            case 'binary_double':
                 $precision = $tableColumn['data_precision'];
                 $scale = $tableColumn['data_scale'];
                 $length = null;


### PR DESCRIPTION
This adds missing type mappings `binary_float` and `binary_double` to the Oracle platform.
This is a fix for [DBAL-367](http://www.doctrine-project.org/jira/browse/DBAL-367).
