### PR TITLE
[DBAL-232] Fix reverse engineering undefined custom doctrine types

### DIFF
--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -1040,7 +1040,10 @@ abstract class AbstractSchemaManager
     public function extractDoctrineTypeFromComment($comment, $currentType)
     {
         if (preg_match("(\(DC2Type:([a-zA-Z0-9_]+)\))", $comment, $match)) {
-            $currentType = $match[1];
+            // Only apply extracted Doctrine type if it is registered.
+            if (Types\Type::hasType($match[1])) {
+                $currentType = $match[1];
+            }
         }
 
         return $currentType;


### PR DESCRIPTION
This PR fixes [DBAL-232](http://www.doctrine-project.org/jira/browse/DBAL-232).
