### PR TITLE
Besides the table name, the column name has to be quoted in column comments

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1314,7 +1314,7 @@ abstract class AbstractPlatform
         if ($this->supportsCommentOnStatement()) {
             foreach ($table->getColumns() as $column) {
                 if ($this->getColumnComment($column)) {
-                    $sql[] = $this->getCommentOnColumnSQL($tableName, $column->getName(), $this->getColumnComment($column));
+                    $sql[] = $this->getCommentOnColumnSQL($tableName, $column->getQuotedName($this), $this->getColumnComment($column));
                 }
             }
         }


### PR DESCRIPTION
This prevents ORA-00904: "HERE_BE_COLUMN_NAME": invalid identifier.

Discovered via https://github.com/owncloud/core/issues/5324
