### PR TITLE
[DBAL-81] Add possibility to set the auto-commit mode for a connection

### DIFF
--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -117,4 +117,36 @@ class Configuration
 
         return null;
     }
+
+    /**
+     * Sets the default auto-commit mode for connections.
+     *
+     * If a connection is in auto-commit mode, then all its SQL statements will be executed and committed as individual
+     * transactions. Otherwise, its SQL statements are grouped into transactions that are terminated by a call to either
+     * the method commit or the method rollback. By default, new connections are in auto-commit mode.
+     *
+     * @param boolean $autoCommit True to enable auto-commit mode; false to disable it.
+     *
+     * @see   getAutoCommit
+     */
+    public function setAutoCommit($autoCommit)
+    {
+        $this->_attributes['autoCommit'] = (boolean) $autoCommit;
+    }
+
+    /**
+     * Returns the default auto-commit mode for connections.
+     *
+     * @return boolean True if auto-commit mode is enabled by default for connections, false otherwise.
+     *
+     * @see    setAutoCommit
+     */
+    public function getAutoCommit()
+    {
+        if (isset($this->_attributes['autoCommit'])) {
+            return $this->_attributes['autoCommit'];
+        }
+
+        return true;
+    }
 }

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1159,7 +1159,7 @@ class Connection implements DriverConnection
     /**
      * Commits all current nesting transactions.
      */
-    public function commitAll()
+    private function commitAll()
     {
         while (0 !== $this->_transactionNestingLevel) {
             if (false === $this->autoCommit && 1 === $this->_transactionNestingLevel) {
@@ -1218,24 +1218,6 @@ class Connection implements DriverConnection
         } else {
             $this->_isRollbackOnly = true;
             --$this->_transactionNestingLevel;
-        }
-    }
-
-    /**
-     * Cancel any database changes done during all current nesting transactions.
-     */
-    public function rollBackAll()
-    {
-        while (0 !== $this->_transactionNestingLevel) {
-            if (false === $this->autoCommit && 1 === $this->_transactionNestingLevel) {
-                // When in no auto-commit mode, the last nesting commit immediately starts a new transaction.
-                // Therefore we need to do the final commit here and then leave to avoid an infinite loop.
-                $this->rollBack();
-
-                return;
-            }
-
-            $this->rollBack();
         }
     }
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -232,6 +232,7 @@ class Connection implements DriverConnection
         $this->_platform->setEventManager($eventManager);
 
         $this->_transactionIsolationLevel = $this->_platform->getDefaultTransactionIsolationLevel();
+        $this->autoCommit = $config->getAutoCommit();
     }
 
     /**

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -382,9 +382,9 @@ class Connection implements DriverConnection
      *
      * @see    setAutoCommit
      */
-    public function getAutoCommit()
+    public function isAutoCommit()
     {
-        return $this->autoCommit;
+        return true === $this->autoCommit;
     }
 
     /**
@@ -399,7 +399,7 @@ class Connection implements DriverConnection
      *
      * @param boolean $autoCommit True to enable auto-commit mode; false to disable it.
      *
-     * @see   getAutoCommit
+     * @see   isAutoCommit
      */
     public function setAutoCommit($autoCommit)
     {

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -118,7 +118,7 @@ class Connection implements DriverConnection
     private $_isConnected = false;
 
     /**
-     * Whether to automatically commit DML and DDL statements.
+     * The current auto-commit mode of this connection.
      *
      * @var boolean
      */

--- a/tests/Doctrine/Tests/DBAL/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConfigurationTest.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\DBAL;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\Tests\DbalTestCase;
+
+require_once __DIR__ . '/../TestInit.php';
+
+/**
+ * Unit tests for the configuration container.
+ *
+ * @author Steve Müller <st.mueller@dzh-online.de>
+ */
+class ConfigurationTest extends DbalTestCase
+{
+    /**
+     * The configuration container instance under test.
+     *
+     * @var \Doctrine\DBAL\Configuration
+     */
+    protected $config;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->config = new Configuration();
+    }
+
+    /**
+     * Tests that the default auto-commit mode for connections can be retrieved from the configuration container.
+     *
+     * @group DBAL-81
+     */
+    public function testReturnsDefaultConnectionAutoCommitMode()
+    {
+        $this->assertTrue($this->config->getAutoCommit());
+    }
+
+    /**
+     * Tests that the default auto-commit mode for connections can be set in the configuration container.
+     *
+     * @group DBAL-81
+     */
+    public function testSetsDefaultConnectionAutoCommitMode()
+    {
+        $this->config->setAutoCommit(false);
+
+        $this->assertFalse($this->config->getAutoCommit());
+
+        $this->config->setAutoCommit(0);
+
+        $this->assertFalse($this->config->getAutoCommit());
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -179,50 +179,6 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
     /**
      * @group DBAL-81
      */
-    public function testCommitAll()
-    {
-        $driverConnectionMock = $this->getMock('Doctrine\DBAL\Driver\Connection');
-        $driverConnectionMock->expects($this->once())
-            ->method('commit');
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
-        $driverMock->expects($this->any())
-            ->method('connect')
-            ->will($this->returnValue($driverConnectionMock));
-        $conn = new Connection(array('platform' => new Mocks\MockPlatform()), $driverMock);
-
-        $conn->connect();
-        $conn->beginTransaction();
-        $conn->beginTransaction();
-        $conn->commitAll();
-
-        $this->assertFalse($conn->isTransactionActive());
-    }
-
-    /**
-     * @group DBAL-81
-     */
-    public function testRollBackAll()
-    {
-        $driverConnectionMock = $this->getMock('Doctrine\DBAL\Driver\Connection');
-        $driverConnectionMock->expects($this->once())
-            ->method('rollback');
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
-        $driverMock->expects($this->any())
-            ->method('connect')
-            ->will($this->returnValue($driverConnectionMock));
-        $conn = new Connection(array('platform' => new Mocks\MockPlatform()), $driverMock);
-
-        $conn->connect();
-        $conn->beginTransaction();
-        $conn->beginTransaction();
-        $conn->rollBackAll();
-
-        $this->assertFalse($conn->isTransactionActive());
-    }
-
-    /**
-     * @group DBAL-81
-     */
     public function testIsAutoCommit()
     {
         $this->assertTrue($this->_conn->isAutoCommit());

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Events;
+use Doctrine\Tests\Mocks\DriverConnectionMock;
 
 class ConnectionTest extends \Doctrine\Tests\DbalTestCase
 {
@@ -173,5 +174,149 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
         $logger = new \Doctrine\DBAL\Logging\DebugStack();
         $this->_conn->getConfiguration()->setSQLLogger($logger);
         $this->assertSame($logger, $this->_conn->getConfiguration()->getSQLLogger());
+    }
+
+    /**
+     * @group DBAL-81
+     */
+    public function testCommitAll()
+    {
+        $driverConnectionMock = $this->getMock('Doctrine\DBAL\Driver\Connection');
+        $driverConnectionMock->expects($this->once())
+            ->method('commit');
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue($driverConnectionMock));
+        $conn = new Connection(array('platform' => new Mocks\MockPlatform()), $driverMock);
+
+        $conn->connect();
+        $conn->beginTransaction();
+        $conn->beginTransaction();
+        $conn->commitAll();
+
+        $this->assertFalse($conn->isTransactionActive());
+    }
+
+    /**
+     * @group DBAL-81
+     */
+    public function testRollBackAll()
+    {
+        $driverConnectionMock = $this->getMock('Doctrine\DBAL\Driver\Connection');
+        $driverConnectionMock->expects($this->once())
+            ->method('rollback');
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue($driverConnectionMock));
+        $conn = new Connection(array('platform' => new Mocks\MockPlatform()), $driverMock);
+
+        $conn->connect();
+        $conn->beginTransaction();
+        $conn->beginTransaction();
+        $conn->rollBackAll();
+
+        $this->assertFalse($conn->isTransactionActive());
+    }
+
+    /**
+     * @group DBAL-81
+     */
+    public function testGetAutoCommit()
+    {
+        $this->assertTrue($this->_conn->getAutoCommit());
+    }
+
+    /**
+     * @group DBAL-81
+     */
+    public function testSetAutoCommit()
+    {
+        $this->_conn->setAutoCommit(false);
+        $this->assertFalse($this->_conn->getAutoCommit());
+        $this->_conn->setAutoCommit(0);
+        $this->assertFalse($this->_conn->getAutoCommit());
+    }
+
+    /**
+     * @group DBAL-81
+     */
+    public function testConnectStartsTransactionInNoAutoCommitMode()
+    {
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+        $conn = new Connection(array('platform' => new Mocks\MockPlatform()), $driverMock);
+
+        $conn->setAutoCommit(false);
+
+        $this->assertFalse($conn->isTransactionActive());
+
+        $conn->connect();
+
+        $this->assertTrue($conn->isTransactionActive());
+    }
+
+    /**
+     * @group DBAL-81
+     */
+    public function testCommitStartsTransactionInNoAutoCommitMode()
+    {
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+        $conn = new Connection(array('platform' => new Mocks\MockPlatform()), $driverMock);
+
+        $conn->setAutoCommit(false);
+        $conn->connect();
+        $conn->commit();
+
+        $this->assertTrue($conn->isTransactionActive());
+    }
+
+    /**
+     * @group DBAL-81
+     */
+    public function testRollBackStartsTransactionInNoAutoCommitMode()
+    {
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+        $conn = new Connection(array('platform' => new Mocks\MockPlatform()), $driverMock);
+
+        $conn->setAutoCommit(false);
+        $conn->connect();
+        $conn->rollBack();
+
+        $this->assertTrue($conn->isTransactionActive());
+    }
+
+    /**
+     * @group DBAL-81
+     */
+    public function testSwitchingAutoCommitModeCommitsAllCurrentTransactions()
+    {
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+        $conn = new Connection(array('platform' => new Mocks\MockPlatform()), $driverMock);
+
+        $conn->connect();
+        $conn->beginTransaction();
+        $conn->beginTransaction();
+        $conn->setAutoCommit(false);
+
+        $this->assertSame(1, $conn->getTransactionNestingLevel());
+
+        $conn->beginTransaction();
+        $conn->beginTransaction();
+        $conn->setAutoCommit(true);
+
+        $this->assertFalse($conn->isTransactionActive());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -223,9 +223,9 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
     /**
      * @group DBAL-81
      */
-    public function testGetAutoCommit()
+    public function testIsAutoCommit()
     {
-        $this->assertTrue($this->_conn->getAutoCommit());
+        $this->assertTrue($this->_conn->isAutoCommit());
     }
 
     /**
@@ -234,9 +234,9 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
     public function testSetAutoCommit()
     {
         $this->_conn->setAutoCommit(false);
-        $this->assertFalse($this->_conn->getAutoCommit());
+        $this->assertFalse($this->_conn->isAutoCommit());
         $this->_conn->setAutoCommit(0);
-        $this->assertFalse($this->_conn->getAutoCommit());
+        $this->assertFalse($this->_conn->isAutoCommit());
     }
 
     /**


### PR DESCRIPTION
This PR makes auto-commit mode configurable for a connection (as proposed in [DBAL-81](http://www.doctrine-project.org/jira/browse/DBAL-81)).
The implementation adds methods to get and set the auto-commit mode on a connection object. When NOT in auto-commit mode, each `commit()` and `rollBack()` call automatically start a new transaction after the operation is finished. Aditionally a call to `connect()` starts a new transaction if not already connected.
When IN auto-commit mode, the behaviour is the same as it is with the current implementation.
When switching auto-commit mode, all current active transactions are committed.
