### PR TITLE
Implement SQL Anywhere driver exception conversion

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -21,6 +21,7 @@ namespace Doctrine\DBAL\Driver\SQLAnywhere;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 use Doctrine\DBAL\Platforms\SQLAnywhere12Platform;
 use Doctrine\DBAL\Schema\SQLAnywhereSchemaManager;
 
@@ -31,7 +32,7 @@ use Doctrine\DBAL\Schema\SQLAnywhereSchemaManager;
  * @link   www.doctrine-project.org
  * @since  2.5
  */
-class Driver implements \Doctrine\DBAL\Driver
+class Driver implements ExceptionConverterDriver
 {
     /**
      * {@inheritdoc}

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Driver\SQLAnywhere;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\SQLAnywhere12Platform;
 use Doctrine\DBAL\Schema\SQLAnywhereSchemaManager;
 
@@ -96,6 +97,40 @@ class Driver implements \Doctrine\DBAL\Driver
             ),
             isset($params['persistent']) ? $params['persistent'] : false
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertExceptionCode(\Exception $exception)
+    {
+        switch ($exception->getCode()) {
+            case '-100':
+            case '-103':
+            case '-832':
+                return DBALException::ERROR_ACCESS_DENIED;
+            case '-143':
+                return DBALException::ERROR_BAD_FIELD_NAME;
+            case '-193':
+            case '-196':
+                return DBALException::ERROR_DUPLICATE_KEY;
+            case '-198':
+                return DBALException::ERROR_FOREIGN_KEY_CONSTRAINT;
+            case '-144':
+                return DBALException::ERROR_NON_UNIQUE_FIELD_NAME;
+            case '-184':
+            case '-195':
+                return DBALException::ERROR_NOT_NULL;
+            case '-131':
+                return DBALException::ERROR_SYNTAX;
+            case '-110':
+                return DBALException::ERROR_TABLE_ALREADY_EXISTS;
+            case '-141':
+            case '-1041':
+                return DBALException::ERROR_UNKNOWN_TABLE;
+        }
+
+        return $exception->getCode();
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -130,7 +130,7 @@ class Driver implements \Doctrine\DBAL\Driver
                 return DBALException::ERROR_UNKNOWN_TABLE;
         }
 
-        return $exception->getCode();
+        return 0;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -32,7 +32,7 @@ use Doctrine\DBAL\Schema\SQLAnywhereSchemaManager;
  * @link   www.doctrine-project.org
  * @since  2.5
  */
-class Driver implements ExceptionConverterDriver
+class Driver implements \Doctrine\DBAL\Driver, ExceptionConverterDriver
 {
     /**
      * {@inheritdoc}

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -36,7 +36,8 @@ class Driver implements \Doctrine\DBAL\Driver
     /**
      * {@inheritdoc}
      *
-     * @throws SQLAnywhereException
+     * @throws \Doctrine\DBAL\DBALException if there was a problem establishing the connection.
+     * @throws SQLAnywhereException         if a mandatory connection parameter is missing.
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
     {
@@ -52,18 +53,22 @@ class Driver implements \Doctrine\DBAL\Driver
             throw new SQLAnywhereException("Missing 'dbname' in configuration for sqlanywhere driver.");
         }
 
-        return new SQLAnywhereConnection(
-            $this->buildDsn(
-                $params['host'],
-                isset($params['port']) ? $params['port'] : null,
-                $params['server'],
-                $params['dbname'],
-                $username,
-                $password,
-                $driverOptions
-            ),
-            isset($params['persistent']) ? $params['persistent'] : false
-        );
+        try {
+            return new SQLAnywhereConnection(
+                $this->buildDsn(
+                    $params['host'],
+                    isset($params['port']) ? $params['port'] : null,
+                    $params['server'],
+                    $params['dbname'],
+                    $username,
+                    $password,
+                    $driverOptions
+                ),
+                isset($params['persistent']) ? $params['persistent'] : false
+            );
+        } catch (SQLAnywhereException $e) {
+            throw DBALException::driverException($this, $e);
+        }
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -34,39 +34,6 @@ use Doctrine\DBAL\Schema\SQLAnywhereSchemaManager;
 class Driver implements \Doctrine\DBAL\Driver
 {
     /**
-     * Build the connection string for given connection parameters and driver options.
-     *
-     * @param string  $host          Host address to connect to.
-     * @param integer $port          Port to use for the connection (default to SQL Anywhere standard port 2683).
-     * @param string  $server        Database server name on the host to connect to.
-     *                               SQL Anywhere allows multiple database server instances on the same host,
-     *                               therefore specifying the server instance name to use is mandatory.
-     * @param string  $dbname        Name of the database on the server instance to connect to.
-     * @param string  $username      User name to use for connection authentication.
-     * @param string  $password      Password to use for connection authentication.
-     * @param array   $driverOptions Additional parameters to use for the connection.
-     *
-     * @return string
-     */
-    public function buildDsn($host, $port, $server, $dbname, $username = null, $password = null, array $driverOptions = array())
-    {
-        $port = $port ?: 2683;
-
-        return
-            'LINKS=tcpip(HOST=' . $host . ';PORT=' . $port . ';DoBroadcast=Direct)' .
-            ';ServerName=' . $server .
-            ';DBN=' . $dbname .
-            ';UID=' . $username .
-            ';PWD=' . $password .
-            ';' . implode(
-                ';',
-                array_map(function ($key, $value) {
-                    return $key . '=' . $value;
-                }, array_keys($driverOptions), $driverOptions)
-            );
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @throws SQLAnywhereException
@@ -165,5 +132,38 @@ class Driver implements \Doctrine\DBAL\Driver
     public function getSchemaManager(Connection $conn)
     {
         return new SQLAnywhereSchemaManager($conn);
+    }
+
+    /**
+     * Build the connection string for given connection parameters and driver options.
+     *
+     * @param string  $host          Host address to connect to.
+     * @param integer $port          Port to use for the connection (default to SQL Anywhere standard port 2683).
+     * @param string  $server        Database server name on the host to connect to.
+     *                               SQL Anywhere allows multiple database server instances on the same host,
+     *                               therefore specifying the server instance name to use is mandatory.
+     * @param string  $dbname        Name of the database on the server instance to connect to.
+     * @param string  $username      User name to use for connection authentication.
+     * @param string  $password      Password to use for connection authentication.
+     * @param array   $driverOptions Additional parameters to use for the connection.
+     *
+     * @return string
+     */
+    private function buildDsn($host, $port, $server, $dbname, $username = null, $password = null, array $driverOptions = array())
+    {
+        $port = $port ?: 2683;
+
+        return
+            'LINKS=tcpip(HOST=' . $host . ';PORT=' . $port . ';DoBroadcast=Direct)' .
+            ';ServerName=' . $server .
+            ';DBN=' . $dbname .
+            ';UID=' . $username .
+            ';PWD=' . $password .
+            ';' . implode(
+                ';',
+                array_map(function ($key, $value) {
+                    return $key . '=' . $value;
+                }, array_keys($driverOptions), $driverOptions)
+            );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -2,6 +2,7 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 
 class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -2,7 +2,6 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 
 class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {


### PR DESCRIPTION
This fixes the SQL Anywhere driver to implement the new exception conversion.
The `ExceptionTest::testConnectionException()` test still fails though as exceptions occurring during connect are thrown in `Connection::connect()` which is not caught and transformed into a wrapped `DBALException`. I feel like this is an implementation error in either `Connection` or a false assumption in `ExceptionTest::testConnectionException()`. At least I think this is not a driver problem. Maybe there should be a `DBALException::driverExceptionDuringConnect()` that is called if an exception is raised in `Connection::connect()`.
