### PR TITLE
Enhancement: expose ping() on pingable-connections.

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -30,6 +30,7 @@ use Doctrine\DBAL\Cache\ResultCacheStatement;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Cache\ArrayStatement;
 use Doctrine\DBAL\Cache\CacheException;
+use Doctrine\DBAL\Driver\PingableConnection;
 
 /**
  * A wrapper around a Doctrine\DBAL\Driver\Connection that adds features like
@@ -1487,5 +1488,18 @@ class Connection implements DriverConnection
     public function createQueryBuilder()
     {
         return new Query\QueryBuilder($this);
+    }
+
+    /**
+     * Ping the server!
+     *
+     * @return bool
+     */
+    public function ping()
+    {
+        if (!($this->_conn instanceof PingableConnection)) {
+            throw ConnectionException::unsupportedFeature('ping');
+        }
+        return $this->_conn->ping();
     }
 }

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1507,6 +1507,7 @@ class Connection implements DriverConnection
 
         try {
             $this->query($this->_platform->getDummySelectSQL());
+
             return true;
         } catch (DBALException $e) {
             // As the underlying connection is unset, the next query will connect again thanks to the lazyness

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1497,9 +1497,10 @@ class Connection implements DriverConnection
      */
     public function ping()
     {
-        if (!($this->_conn instanceof PingableConnection)) {
+        if ( ! ($this->_conn instanceof PingableConnection)) {
             throw ConnectionException::unsupportedFeature('ping');
         }
+
         return $this->_conn->ping();
     }
 }

--- a/lib/Doctrine/DBAL/ConnectionException.php
+++ b/lib/Doctrine/DBAL/ConnectionException.php
@@ -57,12 +57,4 @@ class ConnectionException extends DBALException
     {
         return new self("May not alter the nested transaction with savepoints behavior while a transaction is open.");
     }
-
-    /**
-     * @return \Doctrine\DBAL\ConnectionException
-     */
-    public static function unsupportedFeature($feature)
-    {
-        return new self(sprintf("The '%' feature is not supported by this connection/driver.", $feature));
-    }
 }

--- a/lib/Doctrine/DBAL/ConnectionException.php
+++ b/lib/Doctrine/DBAL/ConnectionException.php
@@ -57,4 +57,12 @@ class ConnectionException extends DBALException
     {
         return new self("May not alter the nested transaction with savepoints behavior while a transaction is open.");
     }
+
+    /**
+     * @return \Doctrine\DBAL\ConnectionException
+     */
+    public static function unsupportedFeature($feature)
+    {
+        return new self(sprintf("The '%' feature is not supported by this connection/driver.", $feature));
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -24,6 +24,7 @@ use \Doctrine\DBAL\Driver\PingableConnection;
 
 /**
  * @author Kim Hemsø Rasmussen <kimhemsoe@gmail.com>
+ * @author Till Klampaeckel <till@php.net>
  */
 class MysqliConnection implements Connection, PingableConnection
 {

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -20,11 +20,12 @@
 namespace Doctrine\DBAL\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\Connection as Connection;
+use \Doctrine\DBAL\Driver\PingableConnection;
 
 /**
  * @author Kim Hemsø Rasmussen <kimhemsoe@gmail.com>
  */
-class MysqliConnection implements Connection
+class MysqliConnection implements Connection, PingableConnection
 {
     /**
      * @var \mysqli
@@ -206,5 +207,15 @@ class MysqliConnection implements Connection
                 mysqli_errno($this->_conn)
             );
         }
+    }
+
+    /**
+     * Pings the server and re-connects when `mysqli.reconnect = 1`
+     *
+     * @return bool
+     */
+    public function ping()
+    {
+        return $this->_conn->ping();
     }
 }

--- a/lib/Doctrine/DBAL/Driver/PingableConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PingableConnection.php
@@ -1,7 +1,39 @@
 <?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
 namespace Doctrine\DBAL\Driver;
 
+/**
+ * An interface for connections which support a "native" ping method.
+ *
+ * @link   www.doctrine-project.org
+ * @since  2.5
+ * @author Till Klampaeckel <till@php.net>
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ */
 interface PingableConnection
 {
+    /**
+     * Pings the database server to determine if the connection is still
+     * available. Return true/false based on if that was successful or not.
+     *
+     * @return bool
+     */
     public function ping();
 }

--- a/lib/Doctrine/DBAL/Driver/PingableConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PingableConnection.php
@@ -1,0 +1,7 @@
+<?php
+namespace Doctrine\DBAL\Driver;
+
+interface PingableConnection
+{
+    public function ping();
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -225,7 +225,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
     public function testPingReturnsTrueWhenConnectionIsPingedOrOpen()
     {
-        $this->_conn->executeQuery($this->_conn->getDatabasePlatform()->getDummySelectSQL());
+        $this->_conn->connect();
         $this->assertTrue($this->_conn->ping());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -216,4 +216,15 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         $this->assertEquals($this->_conn->quote("foo", Type::STRING), $this->_conn->quote("foo", \PDO::PARAM_STR));
     }
+
+    public function testPingDoesNotTriggerConnect()
+    {
+        $this->assertFalse($this->_conn->ping());
+    }
+
+    public function testPingReturnsTrueWhenConnectionIsPingedOrOpen()
+    {
+        $this->_conn->executeQuery($this->_conn->getDatabasePlatform()->getDummySelectSQL());
+        $this->assertTrue($this->_conn->ping());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -193,6 +193,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         try {
             $this->_conn->transactional(function($conn) {
+                /* @var $conn \Doctrine\DBAL\Connection */
                 $conn->executeQuery($conn->getDatabasePlatform()->getDummySelectSQL());
                 throw new \RuntimeException("Ooops!");
             });
@@ -204,7 +205,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
     public function testTransactional()
     {
         $this->_conn->transactional(function($conn) {
-            /* @var $conn Connection */
+            /* @var $conn \Doctrine\DBAL\Connection */
             $conn->executeQuery($conn->getDatabasePlatform()->getDummySelectSQL());
         });
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Mysqli/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Mysqli/ConnectionTest.php
@@ -39,6 +39,12 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->getConnection(array('hello' => 'world')); // use local infile
     }
 
+    public function testPing()
+    {
+        $conn = $this->getConnection(array());
+        $conn->ping();
+    }
+
     private function getConnection(array $driverOptions)
     {
         return new \Doctrine\DBAL\Driver\Mysqli\MysqliConnection(

--- a/tests/Doctrine/Tests/DBAL/Functional/Mysqli/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Mysqli/ConnectionTest.php
@@ -42,7 +42,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
     public function testPing()
     {
         $conn = $this->getConnection(array());
-        $conn->ping();
+        $this->assertTrue($conn->ping());
     }
 
     private function getConnection(array $driverOptions)


### PR DESCRIPTION
This PR introduces a new PingableConnection interface and exposes
a ping method on \Doctrine\DBAL\Connection. For drivers where no
ping is supported, a \Doctrine\DBAL\ConnectionException is thrown.
