### PR TITLE
[DBAL-320] Add insert operation to QueryBuilder

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -887,10 +887,10 @@ class QueryBuilder
      *         ->insert('users')
      *         ->values(
      *             array(
-     *                 'name' => 'username'
+     *                 'name' => '?'
      *             )
      *         )
-     *         ->setValue('password', md5('password'));
+     *         ->setValue('password', '?');
      * </code>
      *
      * @param string $column The column into which the value should be inserted.
@@ -914,8 +914,8 @@ class QueryBuilder
      *         ->insert('users')
      *         ->values(
      *             array(
-     *                 'name' => 'username',
-     *                 'password' => md5('password')
+     *                 'name' => '?',
+     *                 'password' => '?'
      *             )
      *         );
      * </code>

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -550,8 +550,8 @@ class QueryBuilder
      *         ->insert('users')
      *         ->values(
      *             array(
-     *                 'name' => 'username',
-     *                 'password' => md5('password')
+     *                 'name' => '?',
+     *                 'password' => '?'
      *             )
      *         );
      * </code>

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -451,6 +451,78 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
         $this->assertSame($qb2, $qb);
     }
 
+    public function testInsertValues()
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->insert('users')
+            ->values(
+                array(
+                    'foo' => '?',
+                    'bar' => '?'
+                )
+            );
+
+        $this->assertEquals(QueryBuilder::INSERT, $qb->getType());
+        $this->assertEquals('INSERT INTO users (foo, bar) VALUES(?, ?)', (string) $qb);
+    }
+
+    public function testInsertReplaceValues()
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->insert('users')
+            ->values(
+                array(
+                    'foo' => '?',
+                    'bar' => '?'
+                )
+            )
+            ->values(
+                array(
+                    'bar' => '?',
+                    'foo' => '?'
+                )
+            );
+
+        $this->assertEquals(QueryBuilder::INSERT, $qb->getType());
+        $this->assertEquals('INSERT INTO users (bar, foo) VALUES(?, ?)', (string) $qb);
+    }
+
+    public function testInsertSetValue()
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->insert('users')
+            ->setValue('foo', 'bar')
+            ->setValue('bar', '?')
+            ->setValue('foo', '?');
+
+        $this->assertEquals(QueryBuilder::INSERT, $qb->getType());
+        $this->assertEquals('INSERT INTO users (foo, bar) VALUES(?, ?)', (string) $qb);
+    }
+
+    public function testInsertValuesSetValue()
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->insert('users')
+            ->values(
+                array(
+                    'foo' => '?'
+                )
+            )
+            ->setValue('bar', '?');
+
+        $this->assertEquals(QueryBuilder::INSERT, $qb->getType());
+        $this->assertEquals('INSERT INTO users (foo, bar) VALUES(?, ?)', (string) $qb);
+    }
+
+    public function testEmptyInsert()
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb2 = $qb->insert();
+
+        $this->assertEquals(QueryBuilder::INSERT, $qb->getType());
+        $this->assertSame($qb2, $qb);
+    }
+
     public function testGetConnection()
     {
         $qb   = new QueryBuilder($this->conn);


### PR DESCRIPTION
This adds the possibility to execute insert statement with `QueryBuilder`. This is another approach to the existing PR #184.
Currently only single inserts are supported, as multi-insert-statements are more complicated and maybe not applicable for standard `QueryBuilder`.
