### PR TITLE
Improve driver exception code conversion

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
@@ -132,6 +132,7 @@ class Driver implements DriverInterface, ExceptionConverterDriver
             case '1143':
             case '1227':
             case '1370':
+            case '2002':
             case '2005':
                 return DBALException::ERROR_ACCESS_DENIED;
 

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
@@ -76,6 +76,9 @@ class Driver implements DriverInterface, ExceptionConverterDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @link http://dev.mysql.com/doc/refman/5.7/en/error-messages-client.html
+     * @link http://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
      */
     public function convertExceptionCode(\Exception $exception)
     {

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
@@ -20,7 +20,6 @@
 namespace Doctrine\DBAL\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 
@@ -80,50 +79,70 @@ class Driver implements DriverInterface, ExceptionConverterDriver
      */
     public function convertExceptionCode(\Exception $exception)
     {
-        if (strpos($exception->getMessage(), 'Table') === 0) {
-            if (strpos($exception->getMessage(), 'doesn\'t exist') !== false) {
-                return DBALException::ERROR_UNKNOWN_TABLE;
-            }
-
-            if (strpos($exception->getMessage(), 'already exists') !== false) {
+        switch ($exception->getCode()) {
+            case '1050':
                 return DBALException::ERROR_TABLE_ALREADY_EXISTS;
-            }
-        }
 
-        if (strpos($exception->getMessage(), 'Unknown column') === 0) {
-            return DBALException::ERROR_BAD_FIELD_NAME;
-        }
+            case '1051':
+            case '1146':
+                return DBALException::ERROR_UNKNOWN_TABLE;
 
-        if (strpos($exception->getMessage(), 'Cannot delete or update a parent row: a foreign key constraint fails') !== false) {
-            return DBALException::ERROR_FOREIGN_KEY_CONSTRAINT;
-        }
+            case '1216':
+            case '1217':
+            case '1451':
+            case '1452':
+                return DBALException::ERROR_FOREIGN_KEY_CONSTRAINT;
 
-        if (strpos($exception->getMessage(), 'Duplicate entry') !== false) {
-            return DBALException::ERROR_DUPLICATE_KEY;
-        }
+            case '1062':
+            case '1557':
+            case '1569':
+            case '1586':
+                return DBALException::ERROR_DUPLICATE_KEY;
 
-        if (strpos($exception->getMessage(), 'Column not found: 1054 Unknown column') !== false) {
-            return DBALException::ERROR_BAD_FIELD_NAME;
-        }
+            case '1054':
+            case '1166':
+            case '1611':
+                return DBALException::ERROR_BAD_FIELD_NAME;
 
-        if (strpos($exception->getMessage(), 'in field list is ambiguous') !== falsE) {
-            return DBALException::ERROR_NON_UNIQUE_FIELD_NAME;
-        }
+            case '1052':
+            case '1060':
+            case '1110':
+                return DBALException::ERROR_NON_UNIQUE_FIELD_NAME;
 
-        if (strpos($exception->getMessage(), 'You have an error in your SQL syntax; check the manual') !== false) {
-            return DBALException::ERROR_SYNTAX;
-        }
+            case '1064':
+            case '1149':
+            case '1287':
+            case '1341':
+            case '1342':
+            case '1343':
+            case '1344':
+            case '1382':
+            case '1479':
+            case '1541':
+            case '1554':
+            case '1626':
+                return DBALException::ERROR_SYNTAX;
 
-        if (strpos($exception->getMessage(), 'Access denied for user') !== false) {
-            return DBALException::ERROR_ACCESS_DENIED;
-        }
+            case '1044':
+            case '1045':
+            case '1046':
+            case '1049':
+            case '1095':
+            case '1142':
+            case '1143':
+            case '1227':
+            case '1370':
+            case '2005':
+                return DBALException::ERROR_ACCESS_DENIED;
 
-        if (strpos($exception->getMessage(), 'getaddrinfo failed: Name or service not known') !== false) {
-            return DBALException::ERROR_ACCESS_DENIED;
-        }
-
-        if (strpos($exception->getMessage(), ' cannot be null')) {
-            return DBALException::ERROR_NOT_NULL;
+            case '1048':
+            case '1121':
+            case '1138':
+            case '1171':
+            case '1252':
+            case '1263':
+            case '1566':
+                return DBALException::ERROR_NOT_NULL;
         }
 
         return 0;

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -121,45 +121,77 @@ class Driver implements \Doctrine\DBAL\Driver, ExceptionConverterDriver
      */
     public function convertExceptionCode(\Exception $exception)
     {
-        switch ($exception->getCode()) {
-            case '42S02':
-                return DBALException::ERROR_UNKNOWN_TABLE;
+        $errorCode = $exception->getCode();
 
-            case '42S01':
+        // Use driver-specific error code instead of SQLSTATE for PDO exceptions if available.
+        if ($exception instanceof \PDOException && null !== $exception->errorInfo[1]) {
+            $errorCode = $exception->errorInfo[1];
+        }
+
+        switch ($errorCode) {
+            case '1050':
                 return DBALException::ERROR_TABLE_ALREADY_EXISTS;
 
-            default:
-                if (strpos($exception->getMessage(), 'Cannot delete or update a parent row: a foreign key constraint fails') !== false) {
-                    return DBALException::ERROR_FOREIGN_KEY_CONSTRAINT;
-                }
+            case '1051':
+            case '1146':
+                return DBALException::ERROR_UNKNOWN_TABLE;
 
-                if (strpos($exception->getMessage(), 'Duplicate entry') !== false) {
-                    return DBALException::ERROR_DUPLICATE_KEY;
-                }
+            case '1216':
+            case '1217':
+            case '1451':
+            case '1452':
+                return DBALException::ERROR_FOREIGN_KEY_CONSTRAINT;
 
-                if (strpos($exception->getMessage(), 'Column not found: 1054 Unknown column') !== false) {
-                    return DBALException::ERROR_BAD_FIELD_NAME;
-                }
+            case '1062':
+            case '1557':
+            case '1569':
+            case '1586':
+                return DBALException::ERROR_DUPLICATE_KEY;
 
-                if (strpos($exception->getMessage(), 'in field list is ambiguous') !== falsE) {
-                    return DBALException::ERROR_NON_UNIQUE_FIELD_NAME;
-                }
+            case '1054':
+            case '1166':
+            case '1611':
+                return DBALException::ERROR_BAD_FIELD_NAME;
 
-                if (strpos($exception->getMessage(), 'You have an error in your SQL syntax; check the manual') !== false) {
-                    return DBALException::ERROR_SYNTAX;
-                }
+            case '1052':
+            case '1060':
+            case '1110':
+                return DBALException::ERROR_NON_UNIQUE_FIELD_NAME;
 
-                if (strpos($exception->getMessage(), 'Access denied for user') !== false) {
-                    return DBALException::ERROR_ACCESS_DENIED;
-                }
+            case '1064':
+            case '1149':
+            case '1287':
+            case '1341':
+            case '1342':
+            case '1343':
+            case '1344':
+            case '1382':
+            case '1479':
+            case '1541':
+            case '1554':
+            case '1626':
+                return DBALException::ERROR_SYNTAX;
 
-                if (strpos($exception->getMessage(), 'getaddrinfo failed: Name or service not known') !== false) {
-                    return DBALException::ERROR_ACCESS_DENIED;
-                }
+            case '1044':
+            case '1045':
+            case '1046':
+            case '1049':
+            case '1095':
+            case '1142':
+            case '1143':
+            case '1227':
+            case '1370':
+            case '2005':
+                return DBALException::ERROR_ACCESS_DENIED;
 
-                if (strpos($exception->getMessage(), ' cannot be null')) {
-                    return DBALException::ERROR_NOT_NULL;
-                }
+            case '1048':
+            case '1121':
+            case '1138':
+            case '1171':
+            case '1252':
+            case '1263':
+            case '1566':
+                return DBALException::ERROR_NOT_NULL;
         }
 
         return 0;

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -118,6 +118,9 @@ class Driver implements \Doctrine\DBAL\Driver, ExceptionConverterDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @link http://dev.mysql.com/doc/refman/5.7/en/error-messages-client.html
+     * @link http://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
      */
     public function convertExceptionCode(\Exception $exception)
     {

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -181,6 +181,7 @@ class Driver implements \Doctrine\DBAL\Driver, ExceptionConverterDriver
             case '1143':
             case '1227':
             case '1370':
+            case '2002':
             case '2005':
                 return DBALException::ERROR_ACCESS_DENIED;
 

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -109,6 +109,8 @@ class Driver implements \Doctrine\DBAL\Driver, ExceptionConverterDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @link http://www.postgresql.org/docs/9.3/static/errcodes-appendix.html
      */
     public function convertExceptionCode(\Exception $exception)
     {

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -112,51 +112,41 @@ class Driver implements \Doctrine\DBAL\Driver, ExceptionConverterDriver
      */
     public function convertExceptionCode(\Exception $exception)
     {
-        if (strpos($exception->getMessage(), 'duplicate key value violates unique constraint') !== false) {
-            return DBALException::ERROR_DUPLICATE_KEY;
-        }
+        switch ($exception->getCode()) {
+            case '23502':
+                return DBALException::ERROR_NOT_NULL;
 
-        if ($exception->getCode() === "42P01") {
-            return DBALException::ERROR_UNKNOWN_TABLE;
-        }
+            case '23503':
+                return DBALException::ERROR_FOREIGN_KEY_CONSTRAINT;
 
-        if ($exception->getCode() === "42P07") {
-            return DBALException::ERROR_TABLE_ALREADY_EXISTS;
-        }
+            case '23505':
+                return DBALException::ERROR_DUPLICATE_KEY;
 
-        if ($exception->getCode() === "23503") {
-            return DBALException::ERROR_FOREIGN_KEY_CONSTRAINT;
-        }
+            case '42601':
+                return DBALException::ERROR_SYNTAX;
 
-        if ($exception->getCode() === "23502") {
-            return DBALException::ERROR_NOT_NULL;
-        }
+            case '42702':
+                return DBALException::ERROR_NON_UNIQUE_FIELD_NAME;
 
-        if ($exception->getCode() === "42703") {
-            return DBALException::ERROR_BAD_FIELD_NAME;
-        }
+            case '42703':
+                return DBALException::ERROR_BAD_FIELD_NAME;
 
-        if ($exception->getCode() === "42702") {
-            return DBALException::ERROR_NON_UNIQUE_FIELD_NAME;
-        }
+            case '42P01':
+                return DBALException::ERROR_UNKNOWN_TABLE;
 
-        if ($exception->getCode() === "42601") {
-            return DBALException::ERROR_SYNTAX;
-        }
+            case '42P07':
+                return DBALException::ERROR_TABLE_ALREADY_EXISTS;
 
-        if (stripos($exception->getMessage(), 'password authentication failed for user') !== false) {
-            return DBALException::ERROR_ACCESS_DENIED;
-        }
-
-        if (stripos($exception->getMessage(), 'Name or service not known') !== false) {
-            return DBALException::ERROR_ACCESS_DENIED;
-        }
-
-        if (stripos($exception->getMessage(), 'does not exist') !== false) {
-            return DBALException::ERROR_ACCESS_DENIED;
+            case '7':
+                // In some case (mainly connection errors) the PDO exception does not provide a SQLSTATE via its code.
+                // The exception code is always set to 7 here.
+                // We have to match against the SQLSTATE in the error message in these cases.
+                if (strpos($exception->getMessage(), 'SQLSTATE[08006]') !== false) {
+                    return DBALException::ERROR_ACCESS_DENIED;
+                }
+                break;
         }
 
         return 0;
     }
 }
-

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -123,6 +123,8 @@ class Driver implements \Doctrine\DBAL\Driver, ExceptionConverterDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @link http://www.sqlite.org/c3ref/c_abort.html
      */
     public function convertExceptionCode(\Exception $exception)
     {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -74,6 +74,8 @@ class Driver implements \Doctrine\DBAL\Driver, ExceptionConverterDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @link http://dcx.sybase.com/index.html#sa160/en/saerrors/sqlerror.html
      */
     public function convertExceptionCode(\Exception $exception)
     {


### PR DESCRIPTION
Drivers should match unique driver-specific error codes instead of substrings in error messages where possible. This PR replaces most of the error string matching. Additionally many more error codes were added to MySQL.
