### PR TITLE
[DBAL-567] Add charset option for pdo_pgsql driver

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -156,6 +156,8 @@ pdo\_pgsql
 -  ``host`` (string): Hostname of the database to connect to.
 -  ``port`` (integer): Port of the database to connect to.
 -  ``dbname`` (string): Name of the database/schema to connect to.
+-  ``charset`` (string): The charset used when connecting to the
+   database.
 -  ``sslmode`` (string): Determines whether or with what priority
    a SSL TCP/IP connection will be negotiated with the server.
    See the list of available modes:

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -71,6 +71,10 @@ class Driver implements \Doctrine\DBAL\Driver, ExceptionConverterDriver
             $dsn .= 'dbname=' . $params['dbname'] . ' ';
         }
 
+        if (isset($params['charset'])) {
+            $dsn .= "options='--client_encoding=" . $params['charset'] . "'";
+        }
+
         if (isset($params['sslmode'])) {
             $dsn .= 'sslmode=' . $params['sslmode'] . ' ';
         }


### PR DESCRIPTION
This allows specifying the charset for `pdo_pgsql` driver connections.
