### PR TITLE
[DBAL-569] Add support for column comments / commented types in SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -79,7 +79,9 @@ class SQLServerSchemaManager extends AbstractSchemaManager
                 break;
         }
 
-        $type = $this->_platform->getDoctrineTypeMapping($dbType);
+        $type                   = $this->_platform->getDoctrineTypeMapping($dbType);
+        $type                   = $this->extractDoctrineTypeFromComment($tableColumn['comment'], $type);
+        $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);
 
         switch ($type) {
             case 'char':
@@ -91,14 +93,15 @@ class SQLServerSchemaManager extends AbstractSchemaManager
         }
 
         $options = array(
-            'length' => ($length == 0 || !in_array($type, array('text', 'string'))) ? null : $length,
-            'unsigned' => false,
-            'fixed' => (bool) $fixed,
-            'default' => $default !== 'NULL' ? $default : null,
-            'notnull' => (bool) $tableColumn['notnull'],
-            'scale' => $tableColumn['scale'],
-            'precision' => $tableColumn['precision'],
+            'length'        => ($length == 0 || !in_array($type, array('text', 'string'))) ? null : $length,
+            'unsigned'      => false,
+            'fixed'         => (bool) $fixed,
+            'default'       => $default !== 'NULL' ? $default : null,
+            'notnull'       => (bool) $tableColumn['notnull'],
+            'scale'         => $tableColumn['scale'],
+            'precision'     => $tableColumn['precision'],
             'autoincrement' => (bool) $tableColumn['autoincrement'],
+            'comment'       => $tableColumn['comment'] !== '' ? $tableColumn['comment'] : null,
         );
 
         $platformOptions = array(

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -164,4 +164,169 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertNull($columns['df_current_timestamp']->getDefault());
         $this->assertEquals(666, $columns['df_integer']->getDefault());
     }
+
+    /**
+     * @group DBAL-543
+     */
+    public function testColumnComments()
+    {
+        $table = new Table('sqlsrv_column_comment');
+        $table->addColumn('id', 'integer', array('autoincrement' => true));
+        $table->addColumn('comment_null', 'integer', array('comment' => null));
+        $table->addColumn('comment_false', 'integer', array('comment' => false));
+        $table->addColumn('comment_empty_string', 'integer', array('comment' => ''));
+        $table->addColumn('comment_integer_0', 'integer', array('comment' => 0));
+        $table->addColumn('comment_float_0', 'integer', array('comment' => 0.0));
+        $table->addColumn('comment_string_0', 'integer', array('comment' => '0'));
+        $table->addColumn('comment', 'integer', array('comment' => 'Doctrine 0wnz you!'));
+        $table->addColumn('`comment_quoted`', 'integer', array('comment' => 'Doctrine 0wnz comments for explicitely quoted columns!'));
+        $table->addColumn('create', 'integer', array('comment' => 'Doctrine 0wnz comments for reserved keyword columns!'));
+        $table->addColumn('commented_type', 'object');
+        $table->addColumn('commented_type_with_comment', 'array', array('comment' => 'Doctrine array type.'));
+        $table->setPrimaryKey(array('id'));
+
+        $this->_sm->createTable($table);
+
+        $columns = $this->_sm->listTableColumns("sqlsrv_column_comment");
+        $this->assertEquals(12, count($columns));
+        $this->assertNull($columns['id']->getComment());
+        $this->assertNull($columns['comment_null']->getComment());
+        $this->assertNull($columns['comment_false']->getComment());
+        $this->assertNull($columns['comment_empty_string']->getComment());
+        $this->assertEquals('0', $columns['comment_integer_0']->getComment());
+        $this->assertEquals('0', $columns['comment_float_0']->getComment());
+        $this->assertEquals('0', $columns['comment_string_0']->getComment());
+        $this->assertEquals('Doctrine 0wnz you!', $columns['comment']->getComment());
+        $this->assertEquals('Doctrine 0wnz comments for explicitely quoted columns!', $columns['comment_quoted']->getComment());
+        $this->assertEquals('Doctrine 0wnz comments for reserved keyword columns!', $columns['[create]']->getComment());
+        $this->assertNull($columns['commented_type']->getComment());
+        $this->assertEquals('Doctrine array type.', $columns['commented_type_with_comment']->getComment());
+
+        $tableDiff = new TableDiff('sqlsrv_column_comment');
+        $tableDiff->fromTable = $table;
+        $tableDiff->addedColumns['added_comment_none'] = new Column('added_comment_none', Type::getType('integer'));
+        $tableDiff->addedColumns['added_comment_null'] = new Column('added_comment_null', Type::getType('integer'), array('comment' => null));
+        $tableDiff->addedColumns['added_comment_false'] = new Column('added_comment_false', Type::getType('integer'), array('comment' => false));
+        $tableDiff->addedColumns['added_comment_empty_string'] = new Column('added_comment_empty_string', Type::getType('integer'), array('comment' => ''));
+        $tableDiff->addedColumns['added_comment_integer_0'] = new Column('added_comment_integer_0', Type::getType('integer'), array('comment' => 0));
+        $tableDiff->addedColumns['added_comment_float_0'] = new Column('added_comment_float_0', Type::getType('integer'), array('comment' => 0.0));
+        $tableDiff->addedColumns['added_comment_string_0'] = new Column('added_comment_string_0', Type::getType('integer'), array('comment' => '0'));
+        $tableDiff->addedColumns['added_comment'] = new Column('added_comment', Type::getType('integer'), array('comment' => 'Doctrine'));
+        $tableDiff->addedColumns['`added_comment_quoted`'] = new Column('`added_comment_quoted`', Type::getType('integer'), array('comment' => 'rulez'));
+        $tableDiff->addedColumns['select'] = new Column('select', Type::getType('integer'), array('comment' => '666'));
+        $tableDiff->addedColumns['added_commented_type'] = new Column('added_commented_type', Type::getType('object'));
+        $tableDiff->addedColumns['added_commented_type_with_comment'] = new Column('added_commented_type_with_comment', Type::getType('array'), array('comment' => '666'));
+
+        $tableDiff->renamedColumns['comment_float_0'] = new Column('comment_double_0', Type::getType('decimal'), array('comment' => 'Double for real!'));
+
+        // Add comment to non-commented column.
+        $tableDiff->changedColumns['id'] = new ColumnDiff(
+            'id',
+            new Column('id', Type::getType('integer'), array('autoincrement' => true, 'comment' => 'primary')),
+            array('comment'),
+            new Column('id', Type::getType('integer'), array('autoincrement' => true))
+        );
+
+        // Remove comment from null-commented column.
+        $tableDiff->changedColumns['comment_null'] = new ColumnDiff(
+            'comment_null',
+            new Column('comment_null', Type::getType('string')),
+            array('type'),
+            new Column('comment_null', Type::getType('integer'), array('comment' => null))
+        );
+
+        // Add comment to false-commented column.
+        $tableDiff->changedColumns['comment_false'] = new ColumnDiff(
+            'comment_false',
+            new Column('comment_false', Type::getType('integer'), array('comment' => 'false')),
+            array('comment'),
+            new Column('comment_false', Type::getType('integer'), array('comment' => false))
+        );
+
+        // Change type to custom type from empty string commented column.
+        $tableDiff->changedColumns['comment_empty_string'] = new ColumnDiff(
+            'comment_empty_string',
+            new Column('comment_empty_string', Type::getType('object')),
+            array('type'),
+            new Column('comment_empty_string', Type::getType('integer'), array('comment' => ''))
+        );
+
+        // Change comment to false-comment from zero-string commented column.
+        $tableDiff->changedColumns['comment_string_0'] = new ColumnDiff(
+            'comment_string_0',
+            new Column('comment_string_0', Type::getType('integer'), array('comment' => false)),
+            array('comment'),
+            new Column('comment_string_0', Type::getType('integer'), array('comment' => '0'))
+        );
+
+        // Remove comment from regular commented column.
+        $tableDiff->changedColumns['comment'] = new ColumnDiff(
+            'comment',
+            new Column('comment', Type::getType('integer')),
+            array('comment'),
+            new Column('comment', Type::getType('integer'), array('comment' => 'Doctrine 0wnz you!'))
+        );
+
+        // Change comment and change type to custom type from regular commented column.
+        $tableDiff->changedColumns['`comment_quoted`'] = new ColumnDiff(
+            '`comment_quoted`',
+            new Column('`comment_quoted`', Type::getType('array'), array('comment' => 'Doctrine array.')),
+            array('comment', 'type'),
+            new Column('`comment_quoted`', Type::getType('integer'), array('comment' => 'Doctrine 0wnz you!'))
+        );
+
+        // Remove comment and change type to custom type from regular commented column.
+        $tableDiff->changedColumns['create'] = new ColumnDiff(
+            'create',
+            new Column('create', Type::getType('object')),
+            array('comment', 'type'),
+            new Column('create', Type::getType('integer'), array('comment' => 'Doctrine 0wnz comments for reserved keyword columns!'))
+        );
+
+        // Add comment and change custom type to regular type from non-commented column.
+        $tableDiff->changedColumns['commented_type'] = new ColumnDiff(
+            'commented_type',
+            new Column('commented_type', Type::getType('integer'), array('comment' => 'foo')),
+            array('comment', 'type'),
+            new Column('commented_type', Type::getType('object'))
+        );
+
+        // Remove comment from commented custom type column.
+        $tableDiff->changedColumns['commented_type_with_comment'] = new ColumnDiff(
+            'commented_type_with_comment',
+            new Column('commented_type_with_comment', Type::getType('array')),
+            array('comment'),
+            new Column('commented_type_with_comment', Type::getType('array'), array('comment' => 'Doctrine array type.'))
+        );
+
+        $tableDiff->removedColumns['comment_integer_0'] = new Column('comment_integer_0', Type::getType('integer'), array('comment' => 0));
+
+        $this->_sm->alterTable($tableDiff);
+
+        $columns = $this->_sm->listTableColumns("sqlsrv_column_comment");
+        $this->assertEquals(23, count($columns));
+        $this->assertEquals('primary', $columns['id']->getComment());
+        $this->assertNull($columns['comment_null']->getComment());
+        $this->assertEquals('false', $columns['comment_false']->getComment());
+        $this->assertNull($columns['comment_empty_string']->getComment());
+        $this->assertEquals('0', $columns['comment_double_0']->getComment());
+        $this->assertNull($columns['comment_string_0']->getComment());
+        $this->assertNull($columns['comment']->getComment());
+        $this->assertEquals('Doctrine array.', $columns['comment_quoted']->getComment());
+        $this->assertNull($columns['[create]']->getComment());
+        $this->assertEquals('foo', $columns['commented_type']->getComment());
+        $this->assertNull($columns['commented_type_with_comment']->getComment());
+        $this->assertNull($columns['added_comment_none']->getComment());
+        $this->assertNull($columns['added_comment_null']->getComment());
+        $this->assertNull($columns['added_comment_false']->getComment());
+        $this->assertNull($columns['added_comment_empty_string']->getComment());
+        $this->assertEquals('0', $columns['added_comment_integer_0']->getComment());
+        $this->assertEquals('0', $columns['added_comment_float_0']->getComment());
+        $this->assertEquals('0', $columns['added_comment_string_0']->getComment());
+        $this->assertEquals('Doctrine', $columns['added_comment']->getComment());
+        $this->assertEquals('rulez', $columns['added_comment_quoted']->getComment());
+        $this->assertEquals('666', $columns['[select]']->getComment());
+        $this->assertNull($columns['added_commented_type']->getComment());
+        $this->assertEquals('666', $columns['added_commented_type_with_comment']->getComment());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -522,7 +522,9 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
      */
     public function testGetColumnComment()
     {
-        if (!$this->_conn->getDatabasePlatform()->supportsInlineColumnComments() && !$this->_conn->getDatabasePlatform()->supportsCommentOnStatement()) {
+        if ( ! $this->_conn->getDatabasePlatform()->supportsInlineColumnComments() &&
+             ! $this->_conn->getDatabasePlatform()->supportsCommentOnStatement() &&
+             ! $this->_conn->getDatabasePlatform()->getName() == 'mssql') {
             $this->markTestSkipped('Database does not support column comments.');
         }
 
@@ -556,7 +558,9 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
      */
     public function testAutomaticallyAppendCommentOnMarkedColumns()
     {
-        if (!$this->_conn->getDatabasePlatform()->supportsInlineColumnComments() && !$this->_conn->getDatabasePlatform()->supportsCommentOnStatement()) {
+        if ( ! $this->_conn->getDatabasePlatform()->supportsInlineColumnComments() &&
+             ! $this->_conn->getDatabasePlatform()->supportsCommentOnStatement() &&
+             ! $this->_conn->getDatabasePlatform()->getName() == 'mssql') {
             $this->markTestSkipped('Database does not support column comments.');
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -524,7 +524,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
     {
         if ( ! $this->_conn->getDatabasePlatform()->supportsInlineColumnComments() &&
              ! $this->_conn->getDatabasePlatform()->supportsCommentOnStatement() &&
-             ! $this->_conn->getDatabasePlatform()->getName() == 'mssql') {
+            $this->_conn->getDatabasePlatform()->getName() != 'mssql') {
             $this->markTestSkipped('Database does not support column comments.');
         }
 
@@ -560,7 +560,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
     {
         if ( ! $this->_conn->getDatabasePlatform()->supportsInlineColumnComments() &&
              ! $this->_conn->getDatabasePlatform()->supportsCommentOnStatement() &&
-             ! $this->_conn->getDatabasePlatform()->getName() == 'mssql') {
+            $this->_conn->getDatabasePlatform()->getName() != 'mssql') {
             $this->markTestSkipped('Database does not support column comments.');
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL461Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL461Test.php
@@ -28,6 +28,7 @@ class DBAL461Test extends \PHPUnit_Framework_TestCase
             'precision' => 0,
             'autoincrement' => false,
             'collation' => 'foo',
+            'comment' => null,
         ));
 
         $this->assertEquals('Decimal', (string)$column->getType());


### PR DESCRIPTION
SQL Server has no native support for column comments. Therefore commented types are currently not supported for SQL Server leading to repeated ALTER TABLE statements by schema tool when using types that require column comments.
However there is a way to store column comments. Using SQL Server's extended properties functionality, it is possible to store metadata for columns. This is also the way SQL Server Management Studio stores "Description" property for columns.
This PR implements this to be able to use comments for columns and enable support for commented types.

The PR is not 100% finished, yet as we need to find a way to generate the correct statements in the following table alteration scenarios:
- Renamed column that also requires a comment change (either due to changed comment or change from or to a commented type that required/requires a column comment change.
- Changed column where `$columnDiff->fromColumn` is not set.

Using extended properties we need to know whether a column comment has to be added, updated or removed in order to generate the appropriate SQL statement. This is due to SQL Server having a different stored procedure for each operation. Using the wrong stored procedure leads to an error.
Therefore we always need to know the type and comment information from the column to change from in a table alteration scenario. Unfortunately we don't have that if a column is marked as renamed in the table diff or if it is marked as changed but no `$columnDiff->fromColumn` is set (this is the case in some tests actually).

Awaiting feedback how to proceed in thos scenarios.
