### PR TITLE
[DBAL-563] Add definition of sequence emulated identity platforms

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2619,6 +2619,37 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Whether the platform emulates identity columns through sequences.
+     *
+     * Some platforms that do not support identity columns natively
+     * but support sequences can emulate identity columns by using
+     * sequences.
+     *
+     * @return boolean
+     */
+    public function usesSequenceEmulatedIdentityColumns()
+    {
+        return false;
+    }
+
+    /**
+     * Returns the name of the sequence for a particular identity column in a particular table.
+     *
+     * @param string $tableName  The name of the table to return the sequence name for.
+     * @param string $columnName The name of the identity column in the table to return the sequence name for.
+     *
+     * @return string
+     *
+     * @throws \Doctrine\DBAL\DBALException If not supported on this platform.
+     *
+     * @see    usesSequenceEmulatedIdentityColumns
+     */
+    public function getIdentitySequenceName($tableName, $columnName)
+    {
+        throw DBALException::notSupported(__METHOD__);
+    }
+
+    /**
      * Whether the platform supports indexes.
      *
      * @return boolean

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -448,7 +448,7 @@ BEGIN
   END IF;
 END;';
 
-        $sequenceName = $table . '_' . $name . '_SEQ';
+        $sequenceName = $this->getIdentitySequenceName($table, $name);
         $sequence = new Sequence($sequenceName, $start);
         $sql[] = $this->getCreateSequenceSQL($sequence);
 
@@ -693,6 +693,22 @@ LEFT JOIN user_cons_columns r_cols
     public function prefersSequences()
     {
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function usesSequenceEmulatedIdentityColumns()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentitySequenceName($tableName, $columnName)
+    {
+        return $tableName . '_' . $columnName . '_SEQ';
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -113,7 +113,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getDateSubHourExpression($date, $hours)
     {
-        return "(" . $date ." - (" . $hours . " || ' hour')::interval)";    
+        return "(" . $date ." - (" . $hours . " || ' hour')::interval)";
     }
 
     /**
@@ -178,6 +178,22 @@ class PostgreSqlPlatform extends AbstractPlatform
     public function supportsIdentityColumns()
     {
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function usesSequenceEmulatedIdentityColumns()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentitySequenceName($tableName, $columnName)
+    {
+        return $tableName . '_' . $columnName . '_seq';
     }
 
     /**
@@ -466,7 +482,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             if ($columnDiff->hasChanged('autoincrement')) {
                 if ($column->getAutoincrement()) {
                     // add autoincrement
-                    $seqName = $diff->name . '_' . $oldColumnName . '_seq';
+                    $seqName = $this->getIdentitySequenceName($diff->name, $oldColumnName);
 
                     $sql[] = "CREATE SEQUENCE " . $seqName;
                     $sql[] = "SELECT setval('" . $seqName . "', (SELECT MAX(" . $oldColumnName . ") FROM " . $diff->getName()->getQuotedName($this) . "))";

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -510,4 +510,21 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     {
         $this->_platform->schemaNeedsCreation('schema');
     }
+
+    /**
+     * @group DBAL-563
+     */
+    public function testUsesSequenceEmulatedIdentityColumns()
+    {
+        $this->assertFalse($this->_platform->usesSequenceEmulatedIdentityColumns());
+    }
+
+    /**
+     * @group DBAL-563
+     * @expectedException \Doctrine\DBAL\DBALException
+     */
+    public function testReturnsIdentitySequenceName()
+    {
+        $this->_platform->getIdentitySequenceName('mytable', 'mycolumn');
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -330,4 +330,20 @@ class OraclePlatformTest extends AbstractPlatformTestCase
 	);
         $this->assertEquals($expectedSql, $this->_platform->getAlterTableSQL($tableDiff));
     }
+
+    /**
+     * @group DBAL-563
+     */
+    public function testUsesSequenceEmulatedIdentityColumns()
+    {
+        $this->assertTrue($this->_platform->usesSequenceEmulatedIdentityColumns());
+    }
+
+    /**
+     * @group DBAL-563
+     */
+    public function testReturnsIdentitySequenceName()
+    {
+        $this->assertSame('mytable_mycolumn_SEQ', $this->_platform->getIdentitySequenceName('mytable', 'mycolumn'));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -410,4 +410,20 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
 
         $this->assertEquals($expectedSql, $sql);
     }
+
+    /**
+     * @group DBAL-563
+     */
+    public function testUsesSequenceEmulatedIdentityColumns()
+    {
+        $this->assertTrue($this->_platform->usesSequenceEmulatedIdentityColumns());
+    }
+
+    /**
+     * @group DBAL-563
+     */
+    public function testReturnsIdentitySequenceName()
+    {
+        $this->assertSame('mytable_mycolumn_seq', $this->_platform->getIdentitySequenceName('mytable', 'mycolumn'));
+    }
 }


### PR DESCRIPTION
Currently identity columns on Oracle are implemented with a [trigger and sequence workaround](https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Platforms/OraclePlatform.php#L431) to be compatible with IDENTITY generator strategy in ORM. However, using this strategy, the last insert ID is never returned when persisting, as the sequence name generated by DBAL [is not passed to the ID-Generator instance in ORM](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php#L450) and thus [not passed to the driver](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Id/IdentityGenerator.php#L55) when calling `IdentityGenerator::generate()`. Therefore the Oracle driver always returns null in this case. This makes this strategy unusable.
A similar case is given in PostgreSQL where `SERIAL` identity columns need a sequence in order to work. There is a [hackish implementation](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php#L453) available in ORM for this case which makes it work.
It is possible that other vendors (when implemented) encounter the same issue. For this reason I tried to create a general solution with this PR.
ORM needs to know which platforms do not have native support for identity columns but can emulate them with sequences. To prepare this I added platform methods that identify a platform being able to do so. Platforms supporting this have to return the name of the sequence used for an identity column in a table. ORM can later make use of this and pass it to the `IdentityGenerator` so that the underlying driver in return is able to supply the last insert ID.
Current supporting platforms are PostgreSQL and Oracle.
