### PR TITLE
[DBAL-464] Fix dropping primary key with autoincrement column in MySQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -598,6 +598,19 @@ class MySqlPlatform extends AbstractPlatform
         $table = $diff->name;
 
         foreach ($diff->removedIndexes as $remKey => $remIndex) {
+            // Dropping primary keys requires to unset autoincrement attribute on the particular column first.
+            if ($remIndex->isPrimary() && $diff->fromTable instanceof Table) {
+                foreach ($remIndex->getColumns() as $columnName) {
+                    $column = $diff->fromTable->getColumn($columnName);
+
+                    if ($column->getAutoincrement() === true) {
+                        $column->setAutoincrement(false);
+
+                        $sql[] = 'ALTER TABLE ' . $table . ' MODIFY ' .
+                            $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray());
+                    }
+                }
+            }
 
             foreach ($diff->addedIndexes as $addKey => $addIndex) {
                 if ($remIndex->getColumns() == $addIndex->getColumns()) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -111,5 +111,10 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $comparator = new Comparator();
 
         $this->_sm->alterTable($comparator->diffTable($table, $diffTable));
+
+        $table = $this->_sm->listTableDetails("drop_primary_key");
+
+        $this->assertFalse($table->hasPrimaryKey());
+        $this->assertFalse($table->getColumn('id')->getAutoincrement());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -93,7 +93,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     }
 
     /**
-     * @group 464
+     * @group DBAL-464
      */
     public function testDropPrimaryKeyWithAutoincrementColumn()
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -91,4 +91,25 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertFalse($table->hasIndex('idx_id'));
         $this->assertTrue($table->hasPrimaryKey());
     }
+
+    /**
+     * @group 464
+     */
+    public function testDropPrimaryKeyWithAutoincrementColumn()
+    {
+        $table = new Table("drop_primary_key");
+        $table->addColumn('id', 'integer', array('primary' => true, 'autoincrement' => true));
+        $table->addColumn('foo', 'integer', array('primary' => true));
+        $table->setPrimaryKey(array('id', 'foo'));
+
+        $this->_sm->dropAndCreateTable($table);
+
+        $diffTable = clone $table;
+
+        $diffTable->dropPrimaryKey();
+
+        $comparator = new Comparator();
+
+        $this->_sm->alterTable($comparator->diffTable($table, $diffTable));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -320,7 +320,7 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
     }
 
     /**
-     * @group 464
+     * @group DBAL-464
      */
     public function testDropPrimaryKeyWithAutoincrementColumn()
     {

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -318,4 +318,29 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
             $this->_platform->getAlterTableSQL($comparator->diffTable($table, $diffTable))
         );
     }
+
+    /**
+     * @group 464
+     */
+    public function testDropPrimaryKeyWithAutoincrementColumn()
+    {
+        $table = new Table("drop_primary_key");
+        $table->addColumn('id', 'integer', array('primary' => true, 'autoincrement' => true));
+        $table->addColumn('foo', 'integer', array('primary' => true));
+        $table->addColumn('bar', 'integer');
+        $table->setPrimaryKey(array('id', 'foo'));
+
+        $comparator = new Comparator();
+        $diffTable = clone $table;
+
+        $diffTable->dropPrimaryKey();
+
+        $this->assertEquals(
+            array(
+                'ALTER TABLE drop_primary_key MODIFY id INT NOT NULL',
+                'ALTER TABLE drop_primary_key DROP PRIMARY KEY'
+            ),
+            $this->_platform->getAlterTableSQL($comparator->diffTable($table, $diffTable))
+        );
+    }
 }


### PR DESCRIPTION
This PR fixes a table alteration scenario in MySQL, where a primary key is to be dropped that contains an autoincrement column. MySQL requires the autoincrement column attribute to be removed first before dropping the primary key. Otherwise the table alteration will fail.
