### PR TITLE
Fix mysqli driver options

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -48,6 +48,8 @@ class MysqliConnection implements Connection, PingableConnection
 
         $this->_conn = mysqli_init();
 
+        $this->setDriverOptions($driverOptions);
+
         $previousHandler = set_error_handler(function () {
         });
 
@@ -62,8 +64,6 @@ class MysqliConnection implements Connection, PingableConnection
         if (isset($params['charset'])) {
             $this->_conn->set_charset($params['charset']);
         }
-
-        $this->setDriverOptions($driverOptions);
     }
 
     /**


### PR DESCRIPTION
Some mysqli driver options have to be set before actually performing a database connect. `MYSQLI_OPT_LOCAL_INFILE` for example needs to be set before connect and cannot be changed afterwards. I encountered this issue today while trying to perform a `LOAD DATA local INFILE` statement with this driver. Setting the driver options before connect solved the issue.
I wanted to add a test for this but to be honest I have no idea how to test that the driver options are set before connect as both actions happen during construction of the mysqli connection instance.
