### PR TITLE
Fix binding LOB values in mysqli driver prepared statement

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -165,6 +165,11 @@ class MysqliStatement implements \IteratorAggregate, Statement
             throw new MysqliException($this->_stmt->error, $this->_stmt->errno);
         }
 
+        // We have a result.
+        if (false !== $this->_columnNames) {
+            $this->_stmt->store_result();
+        }
+
         if (null === $this->_columnNames) {
             $meta = $this->_stmt->result_metadata();
             if (false !== $meta) {
@@ -188,11 +193,6 @@ class MysqliStatement implements \IteratorAggregate, Statement
             } else {
                 $this->_columnNames = false;
             }
-        }
-
-        // We have a result.
-        if (false !== $this->_columnNames) {
-            $this->_stmt->store_result();
         }
 
         return true;

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -165,14 +165,12 @@ class MysqliStatement implements \IteratorAggregate, Statement
             throw new MysqliException($this->_stmt->error, $this->_stmt->errno);
         }
 
-        // We have a result.
-        if (false !== $this->_columnNames) {
-            $this->_stmt->store_result();
-        }
-
         if (null === $this->_columnNames) {
             $meta = $this->_stmt->result_metadata();
             if (false !== $meta) {
+                // We have a result.
+                $this->_stmt->store_result();
+
                 $columnNames = array();
                 foreach ($meta->fetch_fields() as $col) {
                     $columnNames[] = $col->name;


### PR DESCRIPTION
Running the DBAL test suite with mysqli driver I get a memory exhaustion in `BlobTest`. This is caused by the `MysqliStatement` trying to bind a LOB value before having stored the result set. According to [this comment](http://php.net/manual/en/mysqli-stmt.bind-result.php#57564) in the PHP docs this is necessary when dealing with LOBs. At least this solves the problem for me.
