### PR TITLE
Fix row count retrieval for SELECT statements in SQL Anywhere driver

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -185,6 +185,10 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
 
         $this->result = sasql_stmt_result_metadata($this->stmt);
 
+        if ($this->result &&  ! sasql_stmt_store_result($this->stmt)) {
+            throw SQLAnywhereException::fromSQLAnywhereError($this->conn, $this->stmt);
+        }
+
         return true;
     }
 
@@ -286,6 +290,10 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
      */
     public function rowCount()
     {
+        if ($this->result) {
+            return sasql_stmt_num_rows($this->stmt);
+        }
+
         return sasql_stmt_affected_rows($this->stmt);
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -272,6 +272,15 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals('foo', $testString);
     }
 
+    public function testRowCount()
+    {
+        $sql = 'SELECT * FROM fetch_table';
+        $stmt = $this->_conn->prepare($sql);
+        $stmt->execute();
+
+        $this->assertEquals(1, $stmt->rowCount());
+    }
+
     /**
      * @group DDC-697
      */

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -274,6 +274,10 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
     public function testRowCount()
     {
+        if ($this->_conn->getDatabasePlatform()->getName() == 'sqlite') {
+            $this->markTestSkipped('Test does not work on sqlite as sqlite does not return the number of results.');
+        }
+
         $sql = 'SELECT * FROM fetch_table';
         $stmt = $this->_conn->prepare($sql);
         $stmt->execute();


### PR DESCRIPTION
The SQL Anywhere driver always tries to return the affected rows when calling `SQLAnywhereStatement::rowCount()`. This is okay for DML statments but always returns `0` for SELECT statements. This patch enables retrieving num rows for SELECT statements.
Also added a test that applies to all driver to ensure that they are all able to return the num rows of the resultset.
