### PR TITLE
phpdoc in Table::addForeignKey() update

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -326,11 +326,11 @@ class Table extends AbstractAsset
      *
      * Name is inferred from the local columns.
      *
-     * @param \Doctrine\DBAL\Schema\Table $foreignTable
-     * @param array                       $localColumnNames
-     * @param array                       $foreignColumnNames
-     * @param array                       $options
-     * @param string|null                 $constraintName
+     * @param \Doctrine\DBAL\Schema\Table|string  $foreignTable Table schema instance or table name
+     * @param array                               $localColumnNames
+     * @param array                               $foreignColumnNames
+     * @param array                               $options
+     * @param string|null                         $constraintName
      *
      * @return \Doctrine\DBAL\Schema\Table
      */

--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -348,10 +348,10 @@ class Table extends AbstractAsset
      *
      * @deprecated Use {@link addForeignKeyConstraint}
      *
-     * @param \Doctrine\DBAL\Schema\Table $foreignTable
-     * @param array                       $localColumnNames
-     * @param array                       $foreignColumnNames
-     * @param array                       $options
+     * @param \Doctrine\DBAL\Schema\Table|string    $foreignTable Table schema instance or table name
+     * @param array                                 $localColumnNames
+     * @param array                                 $foreignColumnNames
+     * @param array                                 $options
      *
      * @return \Doctrine\DBAL\Schema\Table
      */
@@ -365,11 +365,11 @@ class Table extends AbstractAsset
      *
      * @deprecated Use {@link addForeignKeyConstraint}
      *
-     * @param string                      $name
-     * @param \Doctrine\DBAL\Schema\Table $foreignTable
-     * @param array                       $localColumnNames
-     * @param array                       $foreignColumnNames
-     * @param array                       $options
+     * @param string                                $name
+     * @param \Doctrine\DBAL\Schema\Table|string    $foreignTable Table schema instance or table name
+     * @param array                                 $localColumnNames
+     * @param array                                 $foreignColumnNames
+     * @param array                                 $options
      *
      * @return \Doctrine\DBAL\Schema\Table
      *


### PR DESCRIPTION
Added significant typehint in PhpDoc: `$foreignTable` param in `addForeignKeyConstraint()` can be just string name of table.

It unobvious in IDE hinting and treated as wrong param. It even can confuse developer, forcing him use foreign keys additions only using existing tables. That was my case, for example :confused: Lost time till found out, that Table schema not necessary to exist for Foreign Key referring .
