### PR TITLE
Support for MySQL's MyISAM and other non-InnoDB engines

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -54,6 +54,7 @@ use Doctrine\DBAL\Event\SchemaAlterTableRenameColumnEventArgs;
  * @author Roman Borschel <roman@code-factory.org>
  * @author Lukas Smith <smith@pooteeweet.org> (PEAR MDB2 library)
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Kévin Dunglas <dunglas@gmail.com>
  * @todo   Remove any unnecessary methods.
  */
 abstract class AbstractPlatform
@@ -2715,6 +2716,18 @@ abstract class AbstractPlatform
     public function supportsForeignKeyConstraints()
     {
         return true;
+    }
+
+    /**
+     * Whether the platform supports foreign key constraints between given tables.
+     *
+     * @param \Doctrine\DBAL\Schema\Table $localTable
+     * @param \Doctrine\DBAL\Schema\Table $referencedTable
+     * @return boolean
+     */
+    public function supportsForeignKeyConstraintBetween(Table $localTable, Table $referencedTable)
+    {
+        return $this->supportsForeignKeyConstraints();
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -32,6 +32,7 @@ use Doctrine\DBAL\Schema\Table;
  * @since  2.0
  * @author Roman Borschel <roman@code-factory.org>
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Kévin Dunglas <dunglas@gmail.com>
  * @todo   Rename: MySQLPlatform
  */
 class MySqlPlatform extends AbstractPlatform
@@ -361,6 +362,21 @@ class MySqlPlatform extends AbstractPlatform
     public function supportsInlineColumnComments()
     {
         return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsForeignKeyConstraintBetween(Table $localTable, Table $referencedTable)
+    {
+        // Foreign key are supported only between InnoDB tables
+        $localTableOptions = $localTable->getOptions();
+        $referencedTableOptions = $referencedTable->getOptions();
+
+        return (!isset ($localTableOptions['engine'])
+                || strtoupper($localTableOptions['engine']) === 'INNODB')
+            && (!isset ($referencedTableOptions['engine'])
+                || strtoupper($referencedTableOptions['engine']) === 'INNODB');
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -26,6 +26,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  * @author Steve Müller <st.mueller@dzh-online.de>
+ * @author Kévin Dunglas <dunglas@gmail.com>
  * @link   www.doctrine-project.org
  * @since  2.0
  */
@@ -201,6 +202,17 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
     public function getForeignTableName()
     {
         return $this->_foreignTableName->getName();
+    }
+
+    /**
+     * Returns the referenced table
+     * the foreign key constraint is associated with.
+     *
+     * @return Table|Identifier
+     */
+    public function getForeignTable()
+    {
+        return $this->_foreignTableName;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -24,6 +24,9 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
 class CreateSchemaSqlCollector extends AbstractVisitor
 {
     /**
@@ -75,7 +78,13 @@ class CreateSchemaSqlCollector extends AbstractVisitor
     {
         $namespace = $this->getNamespace($localTable);
 
-        if ($this->platform->supportsForeignKeyConstraints()) {
+        if ($fkConstraint->getForeignTable() instanceof Table) {
+            $supportsForeignKeys = $this->platform->supportsForeignKeyConstraintBetween($localTable, $fkConstraint->getForeignTable());
+        } else {
+            $supportsForeignKeys = $this->platform->supportsForeignKeyConstraints();
+        }
+
+        if ($supportsForeignKeys) {
             $this->createFkConstraintQueries[$namespace] = array_merge(
                 $this->createFkConstraintQueries[$namespace],
                 (array) $this->platform->getCreateForeignKeySQL(

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -510,4 +510,12 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     {
         $this->_platform->schemaNeedsCreation('schema');
     }
+
+    public function testSupportsForeignKeyConstraintBetween()
+    {
+        $table1 = new Table('table1');
+        $table2 = new Table('table2');
+
+        $this->assertEquals($this->_platform->supportsForeignKeyConstraints(), $this->_platform->supportsForeignKeyConstraintBetween($table1, $table2));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Index;
 
-
 class MySqlPlatformTest extends AbstractPlatformTestCase
 {
     public function createPlatform()
@@ -317,5 +316,14 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
             array('ALTER TABLE alter_table_add_pk DROP INDEX idx_id, ADD PRIMARY KEY (id)'),
             $this->_platform->getAlterTableSQL($comparator->diffTable($table, $diffTable))
         );
+    }
+
+    public function testSupportsForeignKeyConstraintBetween()
+    {
+        $tableInnoDB = new Table('innodb_table', array(), array(), array(), 0, array('engine' => 'InnoDB'));
+        $tableMemory = new Table('innodb_memory', array(), array(), array(), 0, array('engine' => 'memory'));
+
+        $this->assertTrue($this->_platform->supportsForeignKeyConstraintBetween($tableInnoDB, $tableInnoDB));
+        $this->assertFalse($this->_platform->supportsForeignKeyConstraintBetween($tableInnoDB, $tableMemory));
     }
 }


### PR DESCRIPTION
Don't generate foreign keys for MySQL tables that are not InnoDB.

This PR adds a `supportsForeignKeyConstraintBetween($table1, $table2)` method to Platforms allowing to check if foreign keys between two tables are supported (e.g. on MySQL: InnoDB to InnoDB FK is OK, Memory to InnoFB is not).

The MySQL implementation is also provided and `CreateSchemaSqlCollector` has been adapted to use this feature. 

This PR is related to https://github.com/doctrine/doctrine2/pull/865
