### PR TITLE
Fix string quoting for OCI8 driver

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -97,7 +97,7 @@ class OCI8Connection implements \Doctrine\DBAL\Driver\Connection
         }
         $value = str_replace("'", "''", $value);
 
-        return "'" . addcslashes($value, "\000\n\r\\\032") . "'";
+        return "'" . addcslashes($value, "\000\n\r\032") . "'";
     }
 
     /**


### PR DESCRIPTION
The Oracle database doesn't require escaping \ between single quotes, so if you pass 'A\\B' into query it will be stored with double slash. I have remove \ from the list of the symbols which need to be escaped.
