### PR TITLE
Changed scope of getFullQualifiedAssetName() from private to protected t...

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -165,7 +165,7 @@ class Schema extends AbstractAsset
      *
      * @return string
      */
-    private function getFullQualifiedAssetName($name)
+    protected function getFullQualifiedAssetName($name)
     {
         if ($this->isIdentifierQuoted($name)) {
             $name = $this->trimQuotes($name);


### PR DESCRIPTION
...o promote extension

During a retrofit of Doctrine DBAL to a legacy DB it was necessary to abstract away from the core Schema class to allow de-normalisation of asset names.
