### PR TITLE
[DBAL-702] Add sslmode connection option to pdo_pgsql driver

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -156,6 +156,10 @@ pdo\_pgsql
 -  ``host`` (string): Hostname of the database to connect to.
 -  ``port`` (integer): Port of the database to connect to.
 -  ``dbname`` (string): Name of the database/schema to connect to.
+-  ``sslmode`` (string): Determines whether or with what priority
+   a SSL TCP/IP connection will be negotiated with the server.
+   See the list of available modes:
+   `http://www.postgresql.org/docs/9.1/static/libpq-connect.html#LIBPQ-CONNECT-SSLMODE`
 
 PostgreSQL behaves differently with regard to booleans when you use
 ``PDO::ATTR_EMULATE_PREPARES`` or not. To switch from using ``'true'``

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -58,14 +58,21 @@ class Driver implements \Doctrine\DBAL\Driver, ExceptionConverterDriver
     private function _constructPdoDsn(array $params)
     {
         $dsn = 'pgsql:';
+
         if (isset($params['host']) && $params['host'] != '') {
             $dsn .= 'host=' . $params['host'] . ' ';
         }
+
         if (isset($params['port']) && $params['port'] != '') {
             $dsn .= 'port=' . $params['port'] . ' ';
         }
+
         if (isset($params['dbname'])) {
             $dsn .= 'dbname=' . $params['dbname'] . ' ';
+        }
+
+        if (isset($params['sslmode'])) {
+            $dsn .= 'sslmode=' . $params['sslmode'] . ' ';
         }
 
         return $dsn;


### PR DESCRIPTION
Allows specifying whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server in `pdo_pgsql` driver as requested in [DBAL-702](http://www.doctrine-project.org/jira/browse/DBAL-702).
See: http://www.php.net/manual/en/ref.pdo-pgsql.connection.php#112685
