### PR TITLE
Document possible Sqlite datetime issues.

### DIFF
--- a/docs/en/reference/known-vendor-issues.rst
+++ b/docs/en/reference/known-vendor-issues.rst
@@ -73,6 +73,22 @@ type therefore behave like the DateTime type.
 Sqlite
 ------
 
+DateTime
+~~~~~~~~~~
+
+Unlike most database management systems, Sqlite does not convert supplied
+datetime strings to an internal storage format before storage. Instead, Sqlite
+stores them as verbatim strings (i.e. as they are entered) and expects the user
+to use the ``DATETIME()`` function when reading data which then converts the
+stored values to datetime strings.
+Because Doctrine is not using the ``DATETIME()`` function, you may end up with
+"Could not convert database value ... to Doctrine Type datetime." exceptions
+when trying to convert database values to ``\DateTime`` objects using
+
+.. code-block:: php
+
+    \Doctrine\DBAL\Types\Type::getType('datetime')->convertToPhpValue(...)
+
 DateTimeTz
 ~~~~~~~~~~
 


### PR DESCRIPTION
This may also be considered a Doctrine bug instead.

```
SQLite version 3.7.17 2013-05-20 00:56:22
Enter ".help" for instructions
Enter SQL statements terminated with a ";"
sqlite> create table tbl1(dt datetime);
sqlite> insert into tbl1 (dt) VALUES ('2013-05-20 00:56');
sqlite> insert into tbl1 (dt) VALUES ('foo');
sqlite> select * from tbl1;
2013-05-20 00:56
foo
sqlite> select datetime(dt) from tbl1;
2013-05-20 00:56:00

sqlite>
```

Discovered via https://github.com/owncloud/core/issues/6327
Refs https://github.com/owncloud/core/commit/f8088ecd29af75072f96a3841709faf72c6e8fa1
