### PR TITLE
Fix deprecated CLOB type declaration in SQL Server platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1034,7 +1034,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getClobTypeDeclarationSQL(array $field)
     {
-        return 'TEXT';
+        return 'VARCHAR(MAX)';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -126,6 +126,11 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
                 $this->_platform->getVarcharTypeDeclarationSQL(array()),
                 'Long string declaration is not correct'
         );
+        $this->assertSame('VARCHAR(MAX)', $this->_platform->getClobTypeDeclarationSQL(array()));
+        $this->assertSame(
+            'VARCHAR(MAX)',
+            $this->_platform->getClobTypeDeclarationSQL(array('length' => 5, 'fixed' => true))
+        );
     }
 
     public function testPrefersIdentityColumns()


### PR DESCRIPTION
According to the [SQL Server documentation](http://technet.microsoft.com/en-gb/library/ms187993.aspx) the `text` type declaration is deprecated and will be removed in the future. It is encouraged to use `varchar(max)` instead. This has been applied to `SQLServerPlatform::getClobTypeDeclarationSQL()` by this PR.
The `varchar(max)` declaration is BC for all SQL Server versions supported by Doctrine btw.
