### PR TITLE
Introduce BinaryType

### DIFF
--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -20,6 +20,7 @@ vendors:
 -  BigInt
 -  String (string with maximum length, for example 255)
 -  Text (strings without maximum length)
+-  Binary (binary string with maximum length, for example 255)
 -  Decimal (restricted floats, *NOTE* Only works with a setlocale()
    configuration that uses decimal points!)
 -  Boolean

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -232,6 +232,28 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Returns the SQL snippet used to declare a BINARY/VARBINARY column type.
+     *
+     * @param array $field The column definition.
+     *
+     * @return string
+     */
+    public function getBinaryTypeDeclarationSQL(array $field)
+    {
+        if ( ! isset($field['length'])) {
+            $field['length'] = $this->getBinaryDefaultLength();
+        }
+
+        $fixed = isset($field['fixed']) ? $field['fixed'] : false;
+
+        if ($field['length'] > $this->getBinaryMaxLength()) {
+            return $this->getBlobTypeDeclarationSQL($field);
+        }
+
+        return $this->getBinaryTypeDeclarationSQLSnippet($field['length'], $fixed);
+    }
+
+    /**
      * Returns the SQL snippet to declare a GUID/UUID field.
      *
      * By default this maps directly to a VARCHAR and only maps to more
@@ -257,6 +279,21 @@ abstract class AbstractPlatform
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
         throw DBALException::notSupported('VARCHARs not supported by Platform.');
+    }
+
+    /**
+     * Returns the SQL snippet used to declare a BINARY/VARBINARY column type.
+     *
+     * @param integer $length The length of the column.
+     * @param boolean $fixed  Whether the column length is fixed.
+     *
+     * @return string
+     *
+     * @throws \Doctrine\DBAL\DBALException If not supported on this platform.
+     */
+    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    {
+        throw DBALException::notSupported('BINARY/VARBINARY column types are not supported by this platform.');
     }
 
     /**
@@ -474,6 +511,26 @@ abstract class AbstractPlatform
      * @return integer
      */
     public function getVarcharDefaultLength()
+    {
+        return 255;
+    }
+
+    /**
+     * Gets the maximum length of a binary field.
+     *
+     * @return integer
+     */
+    public function getBinaryMaxLength()
+    {
+        return 4000;
+    }
+
+    /**
+     * Gets the default length of a binary field.
+     *
+     * @return integer
+     */
+    public function getBinaryDefaultLength()
     {
         return 255;
     }

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -26,6 +26,22 @@ use Doctrine\DBAL\Schema\TableDiff;
 class DB2Platform extends AbstractPlatform
 {
     /**
+     * {@inheritdoc}
+     */
+    public function getBinaryMaxLength()
+    {
+        return 32704;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinaryDefaultLength()
+    {
+        return 1;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getBlobTypeDeclarationSQL(array $field)
@@ -47,6 +63,8 @@ class DB2Platform extends AbstractPlatform
             'date'          => 'date',
             'varchar'       => 'string',
             'character'     => 'string',
+            'varbinary'     => 'binary',
+            'binary'        => 'binary',
             'clob'          => 'text',
             'blob'          => 'blob',
             'decimal'       => 'decimal',
@@ -63,6 +81,14 @@ class DB2Platform extends AbstractPlatform
     {
         return $fixed ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(255)')
                 : ($length ? 'VARCHAR(' . $length . ')' : 'VARCHAR(255)');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    {
+        return $fixed ? 'BINARY(' . ($length ?: 255) . ')' : 'VARBINARY(' . ($length ?: 255) . ')';
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -253,6 +253,14 @@ class MySqlPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    {
+        return $fixed ? 'BINARY(' . ($length ?: 255) . ')' : 'VARBINARY(' . ($length ?: 255) . ')';
+    }
+
+    /**
      * Gets the SQL snippet used to declare a CLOB column type.
      *     TINYTEXT   : 2 ^  8 - 1 = 255
      *     TEXT       : 2 ^ 16 - 1 = 65535
@@ -809,8 +817,8 @@ class MySqlPlatform extends AbstractPlatform
             'blob'          => 'blob',
             'mediumblob'    => 'blob',
             'tinyblob'      => 'blob',
-            'binary'        => 'blob',
-            'varbinary'     => 'blob',
+            'binary'        => 'binary',
+            'varbinary'     => 'binary',
             'set'           => 'simple_array',
         );
     }
@@ -819,6 +827,14 @@ class MySqlPlatform extends AbstractPlatform
      * {@inheritDoc}
      */
     public function getVarcharMaxLength()
+    {
+        return 65535;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinaryMaxLength()
     {
         return 65535;
     }

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -310,6 +310,22 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
+    public function getBinaryDefaultLength()
+    {
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinaryMaxLength()
+    {
+        return 32767;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getBlobTypeDeclarationSQL(array $field)
     {
         return 'LONG BINARY';
@@ -1320,6 +1336,16 @@ class SQLAnywherePlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    {
+        return $fixed
+            ? 'BINARY(' . ($length ?: $this->getBinaryDefaultLength()) . ')'
+            : 'VARBINARY(' . ($length ?: $this->getBinaryDefaultLength()) . ')';
+    }
+
+    /**
      * Returns the SQL snippet for creating a table constraint.
      *
      * @param Constraint  $constraint The table constraint to create the SQL snippet for.
@@ -1447,11 +1473,11 @@ class SQLAnywherePlatform extends AbstractPlatform
             'smalldatetime' => 'datetime',
             'time' => 'time',
             'timestamp' => 'datetime',
-            'binary' => 'blob',
+            'binary' => 'binary',
             'image' => 'blob',
             'long binary' => 'blob',
             'uniqueidentifier' => 'guid',
-            'varbinary' => 'blob',
+            'varbinary' => 'binary',
         );
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1030,6 +1030,22 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    {
+        return $fixed ? 'BINARY(' . ($length ?: 255) . ')' : 'VARBINARY(' . ($length ?: 255) . ')';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinaryMaxLength()
+    {
+        return 8000;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getClobTypeDeclarationSQL(array $field)
@@ -1258,8 +1274,8 @@ class SQLServerPlatform extends AbstractPlatform
             'nchar' => 'string',
             'nvarchar' => 'string',
             'ntext' => 'text',
-            'binary' => 'blob',
-            'varbinary' => 'blob',
+            'binary' => 'binary',
+            'varbinary' => 'binary',
             'image' => 'blob',
             'uniqueidentifier' => 'guid',
         );

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -362,6 +362,30 @@ class SqlitePlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    {
+        return 'BLOB';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinaryMaxLength()
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinaryDefaultLength()
+    {
+        return 0;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getClobTypeDeclarationSQL(array $field)

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -385,7 +385,11 @@ class Comparator
             $changedProperties[] = 'unsigned';
         }
 
-        if ($column1->getType() instanceof \Doctrine\DBAL\Types\StringType) {
+        $column1Type = $column1->getType();
+
+        if ($column1Type instanceof \Doctrine\DBAL\Types\StringType ||
+            $column1Type instanceof \Doctrine\DBAL\Types\BinaryType
+        ) {
             // check if value of length is set at all, default value assumed otherwise.
             $length1 = $column1->getLength() ?: 255;
             $length2 = $column2->getLength() ?: 255;

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -128,6 +128,7 @@ class MySqlSchemaManager extends AbstractSchemaManager
 
         switch ($dbType) {
             case 'char':
+            case 'binary':
                 $fixed = true;
                 break;
             case 'float':

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -79,18 +79,13 @@ class SQLServerSchemaManager extends AbstractSchemaManager
                 break;
         }
 
+        if ('char' === $dbType || 'nchar' === $dbType || 'binary' === $dbType) {
+            $fixed = true;
+        }
+
         $type                   = $this->_platform->getDoctrineTypeMapping($dbType);
         $type                   = $this->extractDoctrineTypeFromComment($tableColumn['comment'], $type);
         $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);
-
-        switch ($type) {
-            case 'char':
-                $fixed = true;
-                break;
-            case 'text':
-                $fixed = false;
-                break;
-        }
 
         $options = array(
             'length'        => ($length == 0 || !in_array($type, array('text', 'string'))) ? null : $length,

--- a/lib/Doctrine/DBAL/Types/BinaryType.php
+++ b/lib/Doctrine/DBAL/Types/BinaryType.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * Type that maps ab SQL BINARY/VARBINARY to a PHP resource stream.
+ *
+ * @author Steve Müller <st.mueller@dzh-online.de>
+ * @since  2.5
+ */
+class BinaryType extends Type
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getBinaryTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            $value = fopen('data://text/plain;base64,' . base64_encode($value), 'r');
+        }
+
+        if ( ! is_resource($value)) {
+            throw ConversionException::conversionFailed($value, self::BINARY);
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return Type::BINARY;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBindingType()
+    {
+        return \PDO::PARAM_LOB;
+    }
+}

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -48,6 +48,7 @@ abstract class Type
     const SMALLINT = 'smallint';
     const STRING = 'string';
     const TEXT = 'text';
+    const BINARY = 'binary';
     const BLOB = 'blob';
     const FLOAT = 'float';
     const GUID = 'guid';
@@ -81,6 +82,7 @@ abstract class Type
         self::TIME => 'Doctrine\DBAL\Types\TimeType',
         self::DECIMAL => 'Doctrine\DBAL\Types\DecimalType',
         self::FLOAT => 'Doctrine\DBAL\Types\FloatType',
+        self::BINARY => 'Doctrine\DBAL\Types\BinaryType',
         self::BLOB => 'Doctrine\DBAL\Types\BlobType',
         self::GUID => 'Doctrine\DBAL\Types\GuidType',
     );

--- a/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
@@ -23,6 +23,7 @@ class BlobTest extends \Doctrine\Tests\DbalFunctionalTestCase
             $table->addColumn('id', 'integer');
             $table->addColumn('clobfield', 'text');
             $table->addColumn('blobfield', 'blob');
+            $table->addColumn('binaryfield', 'binary', array('length' => 50));
             $table->setPrimaryKey(array('id'));
 
             $sm = $this->_conn->getSchemaManager();
@@ -36,8 +37,8 @@ class BlobTest extends \Doctrine\Tests\DbalFunctionalTestCase
     public function testInsert()
     {
         $ret = $this->_conn->insert('blob_table',
-            array('id' => 1, 'clobfield' => 'test', 'blobfield' => 'test'),
-            array(\PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_LOB)
+            array('id' => 1, 'clobfield' => 'test', 'blobfield' => 'test', 'binaryfield' => 'test'),
+            array(\PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_LOB, \PDO::PARAM_LOB)
         );
         $this->assertEquals(1, $ret);
     }
@@ -45,8 +46,8 @@ class BlobTest extends \Doctrine\Tests\DbalFunctionalTestCase
     public function testSelect()
     {
         $ret = $this->_conn->insert('blob_table',
-            array('id' => 1, 'clobfield' => 'test', 'blobfield' => 'test'),
-            array(\PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_LOB)
+            array('id' => 1, 'clobfield' => 'test', 'blobfield' => 'test', 'binaryfield' => 'test'),
+            array(\PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_LOB, \PDO::PARAM_LOB)
         );
 
         $this->assertBlobContains('test');
@@ -55,17 +56,31 @@ class BlobTest extends \Doctrine\Tests\DbalFunctionalTestCase
     public function testUpdate()
     {
         $ret = $this->_conn->insert('blob_table',
-            array('id' => 1, 'clobfield' => 'test', 'blobfield' => 'test'),
-            array(\PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_LOB)
+            array('id' => 1, 'clobfield' => 'test', 'blobfield' => 'test', 'binaryfield' => 'test'),
+            array(\PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_LOB, \PDO::PARAM_LOB)
         );
 
         $this->_conn->update('blob_table',
-            array('blobfield' => 'test2'),
+            array('blobfield' => 'test2', 'binaryfield' => 'test2'),
             array('id' => 1),
-            array(\PDO::PARAM_LOB, \PDO::PARAM_INT)
+            array(\PDO::PARAM_LOB, \PDO::PARAM_LOB, \PDO::PARAM_INT)
         );
 
         $this->assertBlobContains('test2');
+        $this->assertBinaryContains('test2');
+    }
+
+    private function assertBinaryContains($text)
+    {
+        $rows = $this->_conn->fetchAll('SELECT * FROM blob_table');
+
+        $this->assertEquals(1, count($rows));
+        $row = array_change_key_case($rows[0], CASE_LOWER);
+
+        $blobValue = Type::getType('binary')->convertToPHPValue($row['binaryfield'], $this->_conn->getDatabasePlatform());
+
+        $this->assertInternalType('resource', $blobValue);
+        $this->assertEquals($text, stream_get_contents($blobValue));
     }
 
     private function assertBlobContains($text)

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/DrizzleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/DrizzleSchemaManagerTest.php
@@ -2,11 +2,28 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
-use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Schema\Schema;
-
 require_once __DIR__ . '/../../../TestInit.php';
 
 class DrizzleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
+    public function testListTableWithBinary()
+    {
+        $tableName = 'test_binary_table';
+
+        $table = new \Doctrine\DBAL\Schema\Table($tableName);
+        $table->addColumn('id', 'integer');
+        $table->addColumn('column_varbinary', 'binary', array());
+        $table->addColumn('column_binary', 'binary', array('fixed' => true));
+        $table->setPrimaryKey(array('id'));
+
+        $this->_sm->createTable($table);
+
+        $table = $this->_sm->listTableDetails($tableName);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BinaryType', $table->getColumn('column_varbinary')->getType());
+        $this->assertFalse($table->getColumn('column_varbinary')->getFixed());
+
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BinaryType', $table->getColumn('column_binary')->getType());
+        $this->assertFalse($table->getColumn('column_binary')->getFixed());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -36,4 +36,25 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertHasTable($tables, 'list_tables_test_new_name');
     }
+
+    public function testListTableWithBinary()
+    {
+        $tableName = 'test_binary_table';
+
+        $table = new \Doctrine\DBAL\Schema\Table($tableName);
+        $table->addColumn('id', 'integer');
+        $table->addColumn('column_varbinary', 'binary', array());
+        $table->addColumn('column_binary', 'binary', array('fixed' => true));
+        $table->setPrimaryKey(array('id'));
+
+        $this->_sm->createTable($table);
+
+        $table = $this->_sm->listTableDetails($tableName);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BinaryType', $table->getColumn('column_varbinary')->getType());
+        $this->assertFalse($table->getColumn('column_varbinary')->getFixed());
+
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BinaryType', $table->getColumn('column_binary')->getType());
+        $this->assertFalse($table->getColumn('column_binary')->getFixed());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -280,6 +280,27 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertFalse($diff);
     }
+
+    public function testListTableWithBinary()
+    {
+        $tableName = 'test_binary_table';
+
+        $table = new \Doctrine\DBAL\Schema\Table($tableName);
+        $table->addColumn('id', 'integer');
+        $table->addColumn('column_varbinary', 'binary', array());
+        $table->addColumn('column_binary', 'binary', array('fixed' => true));
+        $table->setPrimaryKey(array('id'));
+
+        $this->_sm->createTable($table);
+
+        $table = $this->_sm->listTableDetails($tableName);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BlobType', $table->getColumn('column_varbinary')->getType());
+        $this->assertFalse($table->getColumn('column_varbinary')->getFixed());
+
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BlobType', $table->getColumn('column_binary')->getType());
+        $this->assertFalse($table->getColumn('column_binary')->getFixed());
+    }
 }
 
 class MoneyType extends Type

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -722,4 +722,25 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->assertSame('', $columns['column5']->getDefault());
         $this->assertSame('666', $columns['column6']->getDefault());
     }
+
+    public function testListTableWithBinary()
+    {
+        $tableName = 'test_binary_table';
+
+        $table = new \Doctrine\DBAL\Schema\Table($tableName);
+        $table->addColumn('id', 'integer');
+        $table->addColumn('column_varbinary', 'binary', array());
+        $table->addColumn('column_binary', 'binary', array('fixed' => true));
+        $table->setPrimaryKey(array('id'));
+
+        $this->_sm->createTable($table);
+
+        $table = $this->_sm->listTableDetails($tableName);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BinaryType', $table->getColumn('column_varbinary')->getType());
+        $this->assertFalse($table->getColumn('column_varbinary')->getFixed());
+
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BinaryType', $table->getColumn('column_binary')->getType());
+        $this->assertTrue($table->getColumn('column_binary')->getFixed());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -72,4 +72,25 @@ EOS
 
         $this->assertEquals($expected, $this->_sm->listTableForeignKeys('user'));
     }
+
+    public function testListTableWithBinary()
+    {
+        $tableName = 'test_binary_table';
+
+        $table = new \Doctrine\DBAL\Schema\Table($tableName);
+        $table->addColumn('id', 'integer');
+        $table->addColumn('column_varbinary', 'binary', array());
+        $table->addColumn('column_binary', 'binary', array('fixed' => true));
+        $table->setPrimaryKey(array('id'));
+
+        $this->_sm->createTable($table);
+
+        $table = $this->_sm->listTableDetails($tableName);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BlobType', $table->getColumn('column_varbinary')->getType());
+        $this->assertFalse($table->getColumn('column_varbinary')->getFixed());
+
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BlobType', $table->getColumn('column_binary')->getType());
+        $this->assertFalse($table->getColumn('column_binary')->getFixed());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Mocks/MockPlatform.php
+++ b/tests/Doctrine/Tests/DBAL/Mocks/MockPlatform.php
@@ -31,6 +31,14 @@ class MockPlatform extends \Doctrine\DBAL\Platforms\AbstractPlatform
         return 'DUMMYCLOB';
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinaryTypeDeclarationSQL(array $field)
+    {
+        return 'DUMMYBINARY';
+    }
+
     public function getVarcharDefaultLength()
     {
         return 255;

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -547,4 +547,32 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     {
         $this->_platform->getIdentitySequenceName('mytable', 'mycolumn');
     }
+
+    public function testReturnsBinaryDefaultLength()
+    {
+        $this->assertSame($this->getBinaryDefaultLength(), $this->_platform->getBinaryDefaultLength());
+    }
+
+    protected function getBinaryDefaultLength()
+    {
+        return 255;
+    }
+
+    public function testReturnsBinaryMaxLength()
+    {
+        $this->assertSame($this->getBinaryMaxLength(), $this->_platform->getBinaryMaxLength());
+    }
+
+    protected function getBinaryMaxLength()
+    {
+        return 4000;
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\DBALException
+     */
+    public function testReturnsBinaryTypeDeclarationSQL()
+    {
+        $this->_platform->getBinaryTypeDeclarationSQL(array());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -361,4 +361,27 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     {
         $this->assertSame('COL', $this->_platform->getSQLResultCasing('cOl'));
     }
+
+    protected function getBinaryDefaultLength()
+    {
+        return 1;
+    }
+
+    protected function getBinaryMaxLength()
+    {
+        return 32704;
+    }
+
+    public function testReturnsBinaryTypeDeclarationSQL()
+    {
+        $this->assertSame('VARBINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(array()));
+        $this->assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 0)));
+        $this->assertSame('VARBINARY(32704)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 32704)));
+        $this->assertSame('BLOB(1M)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 32705)));
+
+        $this->assertSame('BINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true)));
+        $this->assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 0)));
+        $this->assertSame('BINARY(32704)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 32704)));
+        $this->assertSame('BLOB(1M)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 32705)));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -379,4 +379,35 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
             "ALTER TABLE mytable ADD PRIMARY KEY (foo)",
         ), $sql);
     }
+
+    public function testInitializesDoctrineTypeMappings()
+    {
+        $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('binary'));
+        $this->assertSame('binary', $this->_platform->getDoctrineTypeMapping('binary'));
+
+        $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('varbinary'));
+        $this->assertSame('binary', $this->_platform->getDoctrineTypeMapping('varbinary'));
+    }
+
+    protected function getBinaryMaxLength()
+    {
+        return 65535;
+    }
+
+    public function testReturnsBinaryTypeDeclarationSQL()
+    {
+        $this->assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array()));
+        $this->assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 0)));
+        $this->assertSame('VARBINARY(65535)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 65535)));
+        $this->assertSame('MEDIUMBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 65536)));
+        $this->assertSame('MEDIUMBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 16777215)));
+        $this->assertSame('LONGBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 16777216)));
+
+        $this->assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true)));
+        $this->assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 0)));
+        $this->assertSame('BINARY(65535)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 65535)));
+        $this->assertSame('MEDIUMBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 65536)));
+        $this->assertSame('MEDIUMBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 16777215)));
+        $this->assertSame('LONGBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 16777216)));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -752,4 +752,36 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     {
         $this->assertFalse($this->_platform->canEmulateSchemas());
     }
+
+    public function testInitializesDoctrineTypeMappings()
+    {
+        $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('binary'));
+        $this->assertSame('binary', $this->_platform->getDoctrineTypeMapping('binary'));
+
+        $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('varbinary'));
+        $this->assertSame('binary', $this->_platform->getDoctrineTypeMapping('varbinary'));
+    }
+
+    protected function getBinaryDefaultLength()
+    {
+        return 1;
+    }
+
+    protected function getBinaryMaxLength()
+    {
+        return 32767;
+    }
+
+    public function testReturnsBinaryTypeDeclarationSQL()
+    {
+        $this->assertSame('VARBINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(array()));
+        $this->assertSame('VARBINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 0)));
+        $this->assertSame('VARBINARY(32767)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 32767)));
+        $this->assertSame('LONG BINARY', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 32768)));
+
+        $this->assertSame('BINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true)));
+        $this->assertSame('BINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 0)));
+        $this->assertSame('BINARY(32767)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 32767)));
+        $this->assertSame('LONG BINARY', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 32768)));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -665,15 +665,33 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         $this->assertSame('text', $this->_platform->getDoctrineTypeMapping('ntext'));
 
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('binary'));
-        $this->assertSame('blob', $this->_platform->getDoctrineTypeMapping('binary'));
+        $this->assertSame('binary', $this->_platform->getDoctrineTypeMapping('binary'));
 
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('varbinary'));
-        $this->assertSame('blob', $this->_platform->getDoctrineTypeMapping('varbinary'));
+        $this->assertSame('binary', $this->_platform->getDoctrineTypeMapping('varbinary'));
 
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('image'));
         $this->assertSame('blob', $this->_platform->getDoctrineTypeMapping('image'));
 
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('uniqueidentifier'));
         $this->assertSame('guid', $this->_platform->getDoctrineTypeMapping('uniqueidentifier'));
+    }
+
+    protected function getBinaryMaxLength()
+    {
+        return 8000;
+    }
+
+    public function testReturnsBinaryTypeDeclarationSQL()
+    {
+        $this->assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array()));
+        $this->assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 0)));
+        $this->assertSame('VARBINARY(8000)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 8000)));
+        $this->assertSame('VARBINARY(MAX)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 8001)));
+
+        $this->assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true)));
+        $this->assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 0)));
+        $this->assertSame('BINARY(8000)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 8000)));
+        $this->assertSame('VARBINARY(MAX)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 8001)));
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -302,4 +302,25 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") REFERENCES "foo-bar" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE)',
         );
     }
+
+    protected function getBinaryDefaultLength()
+    {
+        return 0;
+    }
+
+    protected function getBinaryMaxLength()
+    {
+        return 0;
+    }
+
+    public function testReturnsBinaryTypeDeclarationSQL()
+    {
+        $this->assertSame('BLOB', $this->_platform->getBinaryTypeDeclarationSQL(array()));
+        $this->assertSame('BLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 0)));
+        $this->assertSame('BLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 9999999)));
+
+        $this->assertSame('BLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true)));
+        $this->assertSame('BLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 0)));
+        $this->assertSame('BLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 9999999)));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -935,6 +935,28 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, Comparator::compareSchemas($oldSchema, $newSchema));
     }
 
+    public function testCompareChangedBinaryColumn()
+    {
+        $oldSchema = new Schema();
+
+        $tableFoo = $oldSchema->createTable('foo');
+        $tableFoo->addColumn('id', 'binary');
+
+        $newSchema = new Schema();
+        $table = $newSchema->createTable('foo');
+        $table->addColumn('id', 'binary', array('length' => 42, 'fixed' => true));
+
+        $expected = new SchemaDiff();
+        $expected->fromSchema = $oldSchema;
+        $tableDiff = $expected->changedTables['foo'] = new TableDiff('foo');
+        $tableDiff->fromTable = $tableFoo;
+        $columnDiff = $tableDiff->changedColumns['id'] = new ColumnDiff('id', $table->getColumn('id'));
+        $columnDiff->fromColumn = $tableFoo->getColumn('id');
+        $columnDiff->changedProperties = array('length', 'fixed');
+
+        $this->assertEquals($expected, Comparator::compareSchemas($oldSchema, $newSchema));
+    }
+
     /**
      * @group DBAL-617
      */

--- a/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Types;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\DBAL\Mocks;
+
+require_once __DIR__ . '/../../TestInit.php';
+
+class BinaryTest extends \Doctrine\Tests\DbalTestCase
+{
+    /**
+     * @var \Doctrine\Tests\DBAL\Mocks\MockPlatform
+     */
+    protected $platform;
+
+    /**
+     * @var \Doctrine\DBAL\Types\BinaryType
+     */
+    protected $type;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->platform = new \Doctrine\Tests\DBAL\Mocks\MockPlatform();
+        $this->type     = Type::getType('binary');
+    }
+
+    public function testReturnsBindingType()
+    {
+        $this->assertSame(\PDO::PARAM_LOB, $this->type->getBindingType());
+    }
+
+    public function testReturnsName()
+    {
+        $this->assertSame(Type::BINARY, $this->type->getName());
+    }
+
+    public function testReturnsSQLDeclaration()
+    {
+        $this->assertSame('DUMMYBINARY', $this->type->getSQLDeclaration(array(), $this->platform));
+    }
+
+    public function testBinaryNullConvertsToPHPValue()
+    {
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testBinaryStringConvertsToPHPValue()
+    {
+        $databaseValue = 'binary string';
+        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
+
+        $this->assertInternalType('resource', $phpValue);
+        $this->assertEquals($databaseValue, stream_get_contents($phpValue));
+    }
+
+    public function testBinaryResourceConvertsToPHPValue()
+    {
+        $databaseValue = fopen('data://text/plain;base64,' . base64_encode('binary string'), 'r');
+        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
+
+        $this->assertSame($databaseValue, $phpValue);
+    }
+
+    /**
+     * @dataProvider getInvalidDatabaseValues
+     * @expectedException \Doctrine\DBAL\Types\ConversionException
+     */
+    public function testThrowsConversionExceptionOnInvalidDatabaseValue($value)
+    {
+        $this->type->convertToPHPValue($value, $this->platform);
+    }
+
+    public function getInvalidDatabaseValues()
+    {
+        return array(
+            array(false),
+            array(true),
+            array(0),
+            array(1),
+            array(-1),
+            array(0.0),
+            array(1.1),
+            array(-1.1),
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a `BinaryType` as an equivalent to `StringType` for binary strings of varying and fixed length as an alternative to `BlobType` for smaller data requirements. Most of the vendors have native support for `BINARY` and `VARBINARY` types which get mapped to this type. Currently `Sqlite` and `PostgreSQL` don't support them and mapping falls back to their native `BLOB` types when `BinaryType` is used in the application.
Please not that the added methods `AbstractPlatform::getBinaryMaxLength()` and `AbstractPlatform::getBinaryDefaultLength()` are not used consistently throughout the platforms. I decided to adopt each platform's behaviour concerning default and max lengths evaluation if favour of implementing it the "correct" way. The reason for this is that those values are not properly defined and used throughout the platform and I guess changing this behaviour would be a BC break.
An example to illustrate what I mean:
Most of the vendors use a default length for `VARCHAR` / `CHAR` / `VARBINARY` / `BINARY` of `1` when you don't provide a length specifier in the declaration. However most of the platforms use a default of `255` and there are even many places where this value is hardcoded. At least this is my understanding of the default value.
