### PR TITLE
Fix composite primary key introspection on Sqlite

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -167,7 +167,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $stmt = $this->_conn->executeQuery("PRAGMA TABLE_INFO ('$tableName')");
         $indexArray = $stmt->fetchAll(\PDO::FETCH_ASSOC);
         foreach ($indexArray as $indexColumnRow) {
-            if ($indexColumnRow['pk'] == "1") {
+            if ($indexColumnRow['pk'] != "0") {
                 $indexBuffer[] = array(
                     'key_name' => 'primary',
                     'primary' => true,


### PR DESCRIPTION
Running the Sqlite testsuite I get the following error:

``` bash
There was 1 failure:

1) Doctrine\Tests\DBAL\Functional\Schema\SqliteSchemaManagerTest::testListTableIndexes
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     0 => 'id'
-    1 => 'other_id'
 )

/home/deeky/dev/doctrine/dbal/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php:272
```

This is due to the schema manager not correctly building composite primary keys on Sqlite. I don't know why this does not fail on Travis but accoding to the [official documentation](http://www.sqlite.org/pragma.html#pragma_table_info) this approach is the correct implementation.
I did not add a dedicated test for this as there obviously already is one that covers this.
