### PR TITLE
[DBAL-544] Fix reference to legacy Query::HYDRATE_* constants in ResultStatement documentation

### DIFF
--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -45,22 +45,27 @@ interface ResultStatement extends \Traversable
     /**
      * Sets the fetch mode to use while iterating this statement.
      *
-     * @param integer $fetchMode
+     * @param integer $fetchMode The fetch mode must be one of the PDO::FETCH_* constants.
      * @param mixed   $arg2
      * @param mixed   $arg3
      *
      * @return boolean
+     *
+     * @see PDO::FETCH_* constants.
      */
     public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null);
 
     /**
-     * @see Query::HYDRATE_* constants
+     * Returns the next row of a result set.
      *
      * @param integer|null $fetchMode Controls how the next row will be returned to the caller.
-     *                                This value must be one of the Query::HYDRATE_* constants,
-     *                                defaulting to Query::HYDRATE_BOTH
+     *                                The value must be one of the PDO::FETCH_* constants,
+     *                                defaulting to PDO::FETCH_BOTH.
      *
-     * @return mixed
+     * @return mixed The return value of this method on success depends on the fetch mode. In all cases, FALSE is
+     *               returned on failure.
+     *
+     * @see PDO::FETCH_* constants.
      */
     public function fetch($fetchMode = null);
 
@@ -68,10 +73,12 @@ interface ResultStatement extends \Traversable
      * Returns an array containing all of the result set rows.
      *
      * @param integer|null $fetchMode Controls how the next row will be returned to the caller.
-     *                                This value must be one of the Query::HYDRATE_* constants,
-     *                                defaulting to Query::HYDRATE_BOTH
+     *                                The value must be one of the PDO::FETCH_* constants,
+     *                                defaulting to PDO::FETCH_BOTH.
      *
      * @return array
+     *
+     * @see PDO::FETCH_* constants.
      */
     public function fetchAll($fetchMode = null);
 


### PR DESCRIPTION
The documentation of the `ResultStatement` interface refers to `Query::HYDRATE_*` constants to use as fetch style. This is wrong. I guess this is a legacy problem from Doctrine 1.
