### PR TITLE
Fix table alteration on Drizzle

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
@@ -439,7 +439,7 @@ class DrizzlePlatform extends AbstractPlatform
             // Do not generate column alteration clause if type is binary and only fixed property has changed.
             // Drizzle only supports binary type columns with variable length.
             // Avoids unnecessary table alteration statements.
-            if ($column['type'] instanceof BinaryType &&
+            if ($columnArray['type'] instanceof BinaryType &&
                 $columnDiff->hasChanged('fixed') &&
                 count($columnDiff->changedProperties) === 1
             ) {


### PR DESCRIPTION
PR #452 silently introduced a bug in `DrizzlePlatform::getAlterTableSQL()` which gets fixed by this PR.
