### PR TITLE
[DBAL-139] [WIP] Finish CACHE option implementation for sequences

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -190,35 +190,39 @@ class OraclePlatform extends AbstractPlatform
                ' START WITH ' . $sequence->getInitialValue() .
                ' MINVALUE ' . $sequence->getInitialValue() .
                ' INCREMENT BY ' . $sequence->getAllocationSize() .
-               $this->getSequenceCacheSQL($sequence);
+               $this->getSequenceCacheClause($sequence);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getAlterSequenceSQL(\Doctrine\DBAL\Schema\Sequence $sequence)
+    public function getAlterSequenceSQL(Sequence $sequence)
     {
         return 'ALTER SEQUENCE ' . $sequence->getQuotedName($this) .
                ' INCREMENT BY ' . $sequence->getAllocationSize()
-               . $this->getSequenceCacheSQL($sequence);
+               . $this->getSequenceCacheClause($sequence);
     }
 
     /**
-     * Cache definition for sequences
+     * Returns the CACHE clause to be used in sequence creation and alteration statements.
+     *
+     * @param Sequence $sequence The sequence to return the CACHE clause for.
      *
      * @return string
      */
-    private function getSequenceCacheSQL(\Doctrine\DBAL\Schema\Sequence $sequence)
+    protected function getSequenceCacheClause(Sequence $sequence)
     {
-        if ($sequence->getCache() === 0) {
-            return ' NOCACHE';
-        } else if ($sequence->getCache() === 1) {
-            return ' NOCACHE';
-        } else if ($sequence->getCache() > 1) {
-            return ' CACHE ' . $sequence->getCache();
+        $cacheSize = $sequence->getCacheSize();
+
+        if (null === $cacheSize) {
+            return '';
         }
 
-        return '';
+        if ($cacheSize < 2) {
+            return ' NOCACHE';
+        }
+
+        return ' CACHE ' . $cacheSize;
     }
 
     /**
@@ -373,7 +377,7 @@ class OraclePlatform extends AbstractPlatform
      */
     public function getListSequencesSQL($database)
     {
-        return "SELECT sequence_name, min_value, increment_by FROM sys.all_sequences ".
+        return "SELECT sequence_name, min_value, increment_by, cache_size FROM sys.all_sequences ".
                "WHERE SEQUENCE_OWNER = '".strtoupper($database)."'";
     }
 

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -22,6 +22,7 @@ namespace Doctrine\DBAL\Platforms;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
@@ -604,37 +605,41 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateSequenceSQL(\Doctrine\DBAL\Schema\Sequence $sequence)
+    public function getCreateSequenceSQL(Sequence $sequence)
     {
         return 'CREATE SEQUENCE ' . $sequence->getQuotedName($this) .
                ' INCREMENT BY ' . $sequence->getAllocationSize() .
                ' MINVALUE ' . $sequence->getInitialValue() .
                ' START ' . $sequence->getInitialValue() .
-               $this->getSequenceCacheSQL($sequence);
+               $this->getSequenceCacheClause($sequence);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getAlterSequenceSQL(\Doctrine\DBAL\Schema\Sequence $sequence)
+    public function getAlterSequenceSQL(Sequence $sequence)
     {
         return 'ALTER SEQUENCE ' . $sequence->getQuotedName($this) .
                ' INCREMENT BY ' . $sequence->getAllocationSize() .
-               $this->getSequenceCacheSQL($sequence);
+               $this->getSequenceCacheClause($sequence);
     }
 
     /**
-     * Cache definition for sequences
+     * Returns the CACHE clause to be used in sequence creation and alteration statements.
+     *
+     * @param Sequence $sequence The sequence to return the CACHE clause for.
      *
      * @return string
      */
-    private function getSequenceCacheSQL(\Doctrine\DBAL\Schema\Sequence $sequence)
+    protected function getSequenceCacheClause(Sequence $sequence)
     {
-        if ($sequence->getCache() > 1) {
-            return ' CACHE ' . $sequence->getCache();
+        $cacheSize = $sequence->getCacheSize();
+
+        if (0 == $cacheSize) {
+            return '';
         }
 
-        return '';
+        return ' CACHE ' . $cacheSize;
     }
 
     /**
@@ -642,7 +647,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getDropSequenceSQL($sequence)
     {
-        if ($sequence instanceof \Doctrine\DBAL\Schema\Sequence) {
+        if ($sequence instanceof Sequence) {
             $sequence = $sequence->getQuotedName($this);
         }
         return 'DROP SEQUENCE ' . $sequence . ' CASCADE';

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywhere12Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywhere12Platform.php
@@ -40,7 +40,8 @@ class SQLAnywhere12Platform extends SQLAnywhere11Platform
         return 'CREATE SEQUENCE ' . $sequence->getQuotedName($this) .
             ' INCREMENT BY ' . $sequence->getAllocationSize() .
             ' START WITH ' . $sequence->getInitialValue() .
-            ' MINVALUE ' . $sequence->getInitialValue();
+            ' MINVALUE ' . $sequence->getInitialValue() .
+            $this->getSequenceCacheClause($sequence);
     }
 
     /**
@@ -49,7 +50,8 @@ class SQLAnywhere12Platform extends SQLAnywhere11Platform
     public function getAlterSequenceSQL(Sequence $sequence)
     {
         return 'ALTER SEQUENCE ' . $sequence->getQuotedName($this) .
-            ' INCREMENT BY ' . $sequence->getAllocationSize();
+            ' INCREMENT BY ' . $sequence->getAllocationSize() .
+            $this->getSequenceCacheClause($sequence);
     }
 
     /**
@@ -85,7 +87,7 @@ class SQLAnywhere12Platform extends SQLAnywhere11Platform
      */
     public function getListSequencesSQL($database)
     {
-        return 'SELECT sequence_name, increment_by, start_with, min_value FROM SYS.SYSSEQUENCE';
+        return 'SELECT sequence_name, increment_by, start_with, min_value, cache FROM SYS.SYSSEQUENCE';
     }
 
     /**
@@ -122,6 +124,28 @@ class SQLAnywhere12Platform extends SQLAnywhere11Platform
     protected function getReservedKeywordsClass()
     {
         return 'Doctrine\DBAL\Platforms\Keywords\SQLAnywhere12Keywords';
+    }
+
+    /**
+     * Returns the CACHE clause to be used in sequence creation and alteration statements.
+     *
+     * @param Sequence $sequence The sequence to return the CACHE clause for.
+     *
+     * @return string
+     */
+    protected function getSequenceCacheClause(Sequence $sequence)
+    {
+        $cacheSize = $sequence->getCacheSize();
+
+        if (null === $cacheSize) {
+            return '';
+        }
+
+        if (0 == $cacheSize) {
+            return ' NOCACHE';
+        }
+
+        return ' CACHE ' . $cacheSize;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -36,7 +36,8 @@ class SQLServer2012Platform extends SQLServer2008Platform
     public function getAlterSequenceSQL(Sequence $sequence)
     {
         return 'ALTER SEQUENCE ' . $sequence->getQuotedName($this) .
-               ' INCREMENT BY ' . $sequence->getAllocationSize();
+               ' INCREMENT BY ' . $sequence->getAllocationSize() .
+               $this->getSequenceCacheClause($sequence);
     }
 
     /**
@@ -47,7 +48,30 @@ class SQLServer2012Platform extends SQLServer2008Platform
         return 'CREATE SEQUENCE ' . $sequence->getQuotedName($this) .
                ' START WITH ' . $sequence->getInitialValue() .
                ' INCREMENT BY ' . $sequence->getAllocationSize() .
-               ' MINVALUE ' . $sequence->getInitialValue();
+               ' MINVALUE ' . $sequence->getInitialValue() .
+               $this->getSequenceCacheClause($sequence);
+    }
+
+    /**
+     * Returns the CACHE clause to be used in sequence creation and alteration statements.
+     *
+     * @param Sequence $sequence The sequence to return the CACHE clause for.
+     *
+     * @return string
+     */
+    protected function getSequenceCacheClause(Sequence $sequence)
+    {
+        $cacheSize = $sequence->getCacheSize();
+
+        if (null === $cacheSize) {
+            return '';
+        }
+
+        if (0 == $cacheSize) {
+            return ' NO CACHE';
+        }
+
+        return ' CACHE ' . $cacheSize;
     }
 
     /**
@@ -67,7 +91,7 @@ class SQLServer2012Platform extends SQLServer2008Platform
      */
     public function getListSequencesSQL($database)
     {
-        return 'SELECT seq.name, seq.increment, seq.start_value FROM sys.sequences AS seq';
+        return 'SELECT seq.name, seq.increment, seq.start_value, seq.cache_size FROM sys.sequences AS seq';
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -162,15 +162,7 @@ class Comparator
      */
     public function diffSequence(Sequence $sequence1, Sequence $sequence2)
     {
-        if ($sequence1->getAllocationSize() != $sequence2->getAllocationSize()) {
-            return true;
-        }
-
-        if ($sequence1->getInitialValue() != $sequence2->getInitialValue()) {
-            return true;
-        }
-
-        return false;
+        return $sequence1->equals($sequence2) === false;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -254,7 +254,12 @@ class OracleSchemaManager extends AbstractSchemaManager
     {
         $sequence = \array_change_key_case($sequence, CASE_LOWER);
 
-        return new Sequence($sequence['sequence_name'], $sequence['increment_by'], $sequence['min_value']);
+        return new Sequence(
+            $sequence['sequence_name'],
+            $sequence['increment_by'],
+            $sequence['min_value'],
+            $sequence['cache_size']
+        );
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -266,9 +266,9 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
             $sequenceName = $sequence['relname'];
         }
 
-        $data = $this->_conn->fetchAll('SELECT min_value, increment_by FROM ' . $this->_platform->quoteIdentifier($sequenceName));
+        $data = $this->_conn->fetchAll('SELECT min_value, increment_by, cache_value FROM ' . $this->_platform->quoteIdentifier($sequenceName));
 
-        return new Sequence($sequenceName, $data[0]['increment_by'], $data[0]['min_value']);
+        return new Sequence($sequenceName, $data[0]['increment_by'], $data[0]['min_value'], $data[0]['cache_value']);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/SQLAnywhereSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLAnywhereSchemaManager.php
@@ -93,7 +93,12 @@ class SQLAnywhereSchemaManager extends AbstractSchemaManager
      */
     protected function _getPortableSequenceDefinition($sequence)
     {
-        return new Sequence($sequence['sequence_name'], $sequence['increment_by'], $sequence['start_with']);
+        return new Sequence(
+            $sequence['sequence_name'],
+            $sequence['increment_by'],
+            $sequence['start_with'],
+            $sequence['cache']
+        );
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -39,7 +39,12 @@ class SQLServerSchemaManager extends AbstractSchemaManager
      */
     protected function _getPortableSequenceDefinition($sequence)
     {
-        return new Sequence($sequence['name'], $sequence['increment'], $sequence['start_value']);
+        return new Sequence(
+            $sequence['name'],
+            $sequence['increment'],
+            $sequence['start_value'],
+            $sequence['cache_size']
+        );
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -295,15 +295,20 @@ class Schema extends AbstractAsset
     /**
      * Creates a new sequence.
      *
-     * @param string  $sequenceName
-     * @param integer $allocationSize
-     * @param integer $initialValue
+     * @param string              $sequenceName   The name of the sequence.
+     * @param integer             $allocationSize The amount to increment by when allocating sequence numbers from the
+     *                                            sequence.
+     * @param integer             $initialValue   The first sequence number to be generated.
+     * @param integer|string|null $cacheSize      The number of preallocated sequence values that are kept in memory.
+     *                                            This has to be a positive integer or numeric character string value.
+     *                                            The value "0" indicates to disable caching.
+     *                                            A null argument indicates to use platform's default cache size.
      *
      * @return \Doctrine\DBAL\Schema\Sequence
      */
-    public function createSequence($sequenceName, $allocationSize=1, $initialValue=1)
+    public function createSequence($sequenceName, $allocationSize = 1, $initialValue = 1, $cacheSize = null)
     {
-        $seq = new Sequence($sequenceName, $allocationSize, $initialValue);
+        $seq = new Sequence($sequenceName, $allocationSize, $initialValue, $cacheSize);
         $this->_addSequence($seq);
 
         return $seq;

--- a/lib/Doctrine/DBAL/Schema/Sequence.php
+++ b/lib/Doctrine/DBAL/Schema/Sequence.php
@@ -41,21 +41,55 @@ class Sequence extends AbstractAsset
     protected $initialValue = 1;
 
     /**
-     * @var integer|null
+     * The number of preallocated sequence values that are kept in memory.
+     *
+     * @var integer|string|null
      */
-    protected $cache = null;
+    private $cacheSize;
 
     /**
-     * @param string  $name
-     * @param integer $allocationSize
-     * @param integer $initialValue
+     * Constructor.
+     *
+     * @param string              $name           The name of the sequence.
+     * @param integer             $allocationSize The amount to increment by when allocating sequence numbers from the
+     *                                            sequence.
+     * @param integer             $initialValue   The first sequence number to be generated.
+     * @param integer|string|null $cacheSize      The number of preallocated sequence values that are kept in memory.
+     *                                            This has to be a positive integer or numeric character string value.
+     *                                            The value "0" indicates to disable caching.
+     *                                            A null argument indicates to use platform's default cache size.
      */
-    public function __construct($name, $allocationSize = 1, $initialValue = 1, $cache = null)
+    public function __construct($name, $allocationSize = 1, $initialValue = 1, $cacheSize = null)
     {
         $this->_setName($name);
         $this->allocationSize = is_numeric($allocationSize) ? $allocationSize : 1;
-        $this->initialValue = is_numeric($initialValue) ? $initialValue : 1;
-        $this->cache = $cache;
+        $this->initialValue   = is_numeric($initialValue) ? $initialValue : 1;
+        $this->setCacheSize($cacheSize);
+    }
+
+    /**
+     * Compares this sequence against the given sequence for equality.
+     *
+     * This equality comparison does not take the sequences' names into account.
+     *
+     * @param Sequence $sequence The sequence to compare against this sequence for equality.
+     *
+     * @return boolean True if the given sequence equals this sequence, false otherwise.
+     */
+    public function equals(Sequence $sequence)
+    {
+        $cacheSize = $sequence->getCacheSize();
+
+        // Additional check to avoid errors with 0 == null and null == 0.
+        if ((null === $this->cacheSize && 0 === $cacheSize) ||
+            (null === $cacheSize && 0 === $this->cacheSize)
+        ) {
+            return false;
+        }
+
+        return $this->allocationSize == $sequence->getAllocationSize() &&
+            $this->initialValue == $sequence->getInitialValue() &&
+            $this->cacheSize == $sequence->getCacheSize();
     }
 
     /**
@@ -75,11 +109,16 @@ class Sequence extends AbstractAsset
     }
 
     /**
-     * @return integer|null
+     * Returns the number of preallocated sequence values that are kept in memory.
+     *
+     * The value "0" indicates that caching is disabled for this sequence.
+     * A null return value indicates that the default cache size is used.
+     *
+     * @return integer|string|null
      */
-    public function getCache()
+    public function getCacheSize()
     {
-        return $this->cache;
+        return $this->cacheSize;
     }
 
     /**
@@ -107,13 +146,48 @@ class Sequence extends AbstractAsset
     }
 
     /**
-     * @param integer $cache
+     * Sets the number of preallocated sequence values that are kept in memory.
      *
-     * @return \Doctrine\DBAL\Schema\Sequence
+     * @param integer|string|null $cacheSize The number of preallocated sequence values that are kept in memory.
+     *                                       This has to be a positive integer or numeric character string value.
+     *                                       The value "0" indicates to disable caching.
+     *                                       A null argument indicates to use platform's default cache size.
+     *
+     * @return \Doctrine\DBAL\Schema\Sequence This sequence instance.
+     *
+     * @throws \InvalidArgumentException if the given cache size is invalid.
      */
-    public function setCache($cache)
+    public function setCacheSize($cacheSize)
     {
-        $this->cache = $cache;
+        if (null === $cacheSize) {
+            $this->cacheSize = null;
+
+            return $this;
+        }
+
+        if ( ! is_int($cacheSize) && ! ctype_digit($cacheSize)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid cache size "%s" specified for sequence "%s". ' .
+                    'Expected cache size to be of type integer or numeric character string.',
+                    is_array($cacheSize) || is_object($cacheSize) ? gettype($cacheSize) : $cacheSize,
+                    $this->_name
+                )
+            );
+        }
+
+        if ($cacheSize < 0) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid cache size "%s" specified for sequence "%s". ' .
+                    'The cache size must be greater or equal to 0.',
+                    $cacheSize,
+                    $this->_name
+                )
+            );
+        }
+
+        $this->cacheSize = $cacheSize;
 
         return $this;
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -60,7 +60,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
             $this->markTestSkipped($this->_conn->getDriver()->getName().' does not support sequences.');
         }
 
-        $sequence = new \Doctrine\DBAL\Schema\Sequence('list_sequences_test_seq', 20, 10);
+        $sequence = new \Doctrine\DBAL\Schema\Sequence('list_sequences_test_seq', 20, 10, 5);
         $this->_sm->createSequence($sequence);
 
         $sequences = $this->_sm->listSequences();
@@ -78,6 +78,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->assertNotNull($foundSequence, "Sequence with name 'list_sequences_test_seq' was not found.");
         $this->assertEquals(20, $foundSequence->getAllocationSize(), "Allocation Size is expected to be 20.");
         $this->assertEquals(10, $foundSequence->getInitialValue(), "Initial Value is expected to be 10.");
+        $this->assertEquals(5, $foundSequence->getCacheSize(), "Cache size is expected to be 5.");
     }
 
     public function testListDatabases()

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywhere12PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywhere12PlatformTest.php
@@ -39,6 +39,17 @@ class SQLAnywhere12PlatformTest extends SQLAnywhere11PlatformTest
             'ALTER SEQUENCE myseq INCREMENT BY 20',
             $this->_platform->getAlterSequenceSQL($sequence)
         );
+
+        $sequence = new Sequence('myseq', 20, 1, 5);
+        $this->assertEquals(
+            'CREATE SEQUENCE myseq INCREMENT BY 20 START WITH 1 MINVALUE 1 CACHE 5',
+            $this->_platform->getCreateSequenceSQL($sequence)
+        );
+        $this->assertEquals(
+            'ALTER SEQUENCE myseq INCREMENT BY 20 CACHE 5',
+            $this->_platform->getAlterSequenceSQL($sequence)
+        );
+
         $this->assertEquals(
             'DROP SEQUENCE myseq',
             $this->_platform->getDropSequenceSQL('myseq')
@@ -52,7 +63,7 @@ class SQLAnywhere12PlatformTest extends SQLAnywhere11PlatformTest
             $this->_platform->getSequenceNextValSQL('myseq')
         );
         $this->assertEquals(
-            'SELECT sequence_name, increment_by, start_with, min_value FROM SYS.SYSSEQUENCE',
+            'SELECT sequence_name, increment_by, start_with, min_value, cache FROM SYS.SYSSEQUENCE',
             $this->_platform->getListSequencesSQL(null)
         );
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -33,6 +33,17 @@ class SQLServer2012PlatformTest extends SQLServerPlatformTest
             'ALTER SEQUENCE myseq INCREMENT BY 20',
             $this->_platform->getAlterSequenceSQL($sequence)
         );
+
+        $sequence = new Sequence('myseq', 20, 1, 5);
+        $this->assertEquals(
+            'CREATE SEQUENCE myseq START WITH 1 INCREMENT BY 20 MINVALUE 1 CACHE 5',
+            $this->_platform->getCreateSequenceSQL($sequence)
+        );
+        $this->assertEquals(
+            'ALTER SEQUENCE myseq INCREMENT BY 20 CACHE 5',
+            $this->_platform->getAlterSequenceSQL($sequence)
+        );
+
         $this->assertEquals(
             'DROP SEQUENCE myseq',
             $this->_platform->getDropSequenceSQL('myseq')

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -436,11 +436,22 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
         $seq1 = new Sequence('foo', 1, 1);
         $seq2 = new Sequence('foo', 1, 2);
         $seq3 = new Sequence('foo', 2, 1);
+        $seq4 = new Sequence('foo', 1, 1);
+        $seq5 = new Sequence('foo', 1, 1, 0);
+        $seq6 = new Sequence('foo', 1, 1, '0');
+        $seq7 = new Sequence('foo', 1, 1, 5);
 
         $c = new Comparator();
 
         $this->assertTrue($c->diffSequence($seq1, $seq2));
         $this->assertTrue($c->diffSequence($seq1, $seq3));
+        $this->assertFalse($c->diffSequence($seq1, $seq4));
+        $this->assertTrue($c->diffSequence($seq1, $seq5));
+        $this->assertTrue($c->diffSequence($seq1, $seq6));
+        $this->assertTrue($c->diffSequence($seq1, $seq7));
+        $this->assertFalse($c->diffSequence($seq5, $seq6));
+        $this->assertTrue($c->diffSequence($seq5, $seq7));
+        $this->assertTrue($c->diffSequence($seq6, $seq7));
     }
 
     public function testRemovedSequence()

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
@@ -99,7 +99,7 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
 
     public function testAddSequences()
     {
-        $sequence = new Sequence("a_seq", 1, 1);
+        $sequence = new Sequence("a_seq", 1, 1, 5);
 
         $schema = new Schema(array(), array($sequence));
 
@@ -108,6 +108,9 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
 
         $sequences = $schema->getSequences();
         $this->assertArrayHasKey('public.a_seq', $sequences);
+        $this->assertSame(1, $sequences['public.a_seq']->getAllocationSize());
+        $this->assertSame(1, $sequences['public.a_seq']->getInitialValue());
+        $this->assertSame(5, $sequences['public.a_seq']->getCacheSize());
     }
 
     public function testSequenceAccessCaseInsensitive()
@@ -135,17 +138,21 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
     public function testCreateSequence()
     {
         $schema = new Schema();
-        $sequence = $schema->createSequence('a_seq', 10, 20);
+        $sequence = $schema->createSequence('a_seq', 10, 20, 5);
 
         $this->assertEquals('a_seq', $sequence->getName());
         $this->assertEquals(10, $sequence->getAllocationSize());
         $this->assertEquals(20, $sequence->getInitialValue());
+        $this->assertEquals(5, $sequence->getCacheSize());
 
         $this->assertTrue($schema->hasSequence("a_seq"));
         $this->assertInstanceOf('Doctrine\DBAL\Schema\Sequence', $schema->getSequence("a_seq"));
 
         $sequences = $schema->getSequences();
         $this->assertArrayHasKey('public.a_seq', $sequences);
+        $this->assertSame(10, $sequences['public.a_seq']->getAllocationSize());
+        $this->assertSame(20, $sequences['public.a_seq']->getInitialValue());
+        $this->assertSame(5, $sequences['public.a_seq']->getCacheSize());
     }
 
     public function testDropSequence()

--- a/tests/Doctrine/Tests/DBAL/Schema/SequenceTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SequenceTest.php
@@ -8,6 +8,95 @@ use Doctrine\DBAL\Schema\Sequence;
 class SequenceTest extends \Doctrine\Tests\DbalTestCase
 {
     /**
+     * @var \Doctrine\DBAL\Schema\Sequence
+     */
+    protected $sequence;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->sequence = new Sequence('foo');
+    }
+
+    public function testConstructs()
+    {
+        $this->assertSame('foo', $this->sequence->getName());
+        $this->assertSame(1, $this->sequence->getAllocationSize());
+        $this->assertSame(1, $this->sequence->getInitialValue());
+        $this->assertNull($this->sequence->getCacheSize());
+    }
+
+    /**
+     * @dataProvider getInvalidCacheSizes
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionOnConstructingWithInvalidCacheSize($cacheSize)
+    {
+        new Sequence('foo', 1, 1, $cacheSize);
+    }
+
+    /**
+     * @dataProvider getValidAllocationSizes
+     */
+    public function testSetsAllocationSize($allocationSize, $expected)
+    {
+        $this->sequence->setAllocationSize($allocationSize);
+
+        $this->assertSame($expected, $this->sequence->getAllocationSize());
+    }
+
+    /**
+     * @dataProvider getValidCacheSizes
+     */
+    public function testSetsCacheSize($cacheSize, $expected)
+    {
+        $this->sequence->setCacheSize($cacheSize);
+
+        $this->assertSame($expected, $this->sequence->getCacheSize());
+    }
+
+    /**
+     * @dataProvider getInvalidCacheSizes
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionOnSettingInvalidCacheSize($cacheSize)
+    {
+        $this->sequence->setCacheSize($cacheSize);
+    }
+
+    /**
+     * @dataProvider getValidInitialValues
+     */
+    public function testSetsInitialValue($initialValue, $expected)
+    {
+        $this->sequence->setInitialValue($initialValue);
+
+        $this->assertSame($expected, $this->sequence->getInitialValue());
+    }
+
+    /**
+     * @dataProvider getEqualityComparisonData
+     */
+    public function testComparesForEquality(Sequence $fromSequence, Sequence $toSequence, $expected)
+    {
+        $this->assertSame($expected, $fromSequence->equals($toSequence));
+    }
+
+    public function testVisits()
+    {
+        /** @var \Doctrine\DBAL\Schema\Visitor\Visitor|\PHPUnit_Framework_MockObject_MockObject $visitor */
+        $visitor = $this->getMock('Doctrine\DBAL\Schema\Visitor\Visitor');
+
+        $visitor->expects($this->once())
+            ->method('acceptSequence')
+            ->with($this->sequence);
+
+        $this->sequence->visit($visitor);
+    }
+
+    /**
      * @group DDC-1657
      */
     public function testIsAutoincrementFor()
@@ -24,5 +113,88 @@ class SequenceTest extends \Doctrine\Tests\DbalTestCase
         $this->assertFalse($sequence2->isAutoIncrementsFor($table));
         $this->assertFalse($sequence3->isAutoIncrementsFor($table));
     }
-}
 
+    public function getEqualityComparisonData()
+    {
+        return array(
+            array(new Sequence('foo'), new Sequence('foo'), true),
+            array(new Sequence('foo'), new Sequence('bar'), true),
+            array(new Sequence('bar'), new Sequence('foo'), true),
+            array(new Sequence('foo', 5), new Sequence('foo', '5'), true),
+            array(new Sequence('foo', 5), new Sequence('foo', 10), false),
+            array(new Sequence('foo', 5, 5), new Sequence('foo', 5, '5'), true),
+            array(new Sequence('foo', 5, 5), new Sequence('foo', 5, 10), false),
+            array(new Sequence('foo', 5, 5, 0), new Sequence('foo', 5, 5, 0), true),
+            array(new Sequence('foo', 5, 5, '0'), new Sequence('foo', 5, 5, 0), true),
+            array(new Sequence('foo', 5, 5, 0), new Sequence('foo', 5, 5, '0'), true),
+            array(new Sequence('foo', 5, 5, '666'), new Sequence('foo', 5, 5, 666), true),
+            array(new Sequence('foo', 5, 5, 666), new Sequence('foo', 5, 5, '666'), true),
+            array(new Sequence('foo', 5, 5, null), new Sequence('foo', 5, 5, 0), false),
+            array(new Sequence('foo', 5, 5, 0), new Sequence('foo', 5, 5, null), false),
+            array(new Sequence('foo', 5, 5, null), new Sequence('foo', 5, 5, '0'), false),
+            array(new Sequence('foo', 5, 5, '0'), new Sequence('foo', 5, 5, null), false),
+            array(new Sequence('foo', 5, 5, 5), new Sequence('foo', 5, 5, 10), false),
+        );
+    }
+
+    public function getInvalidCacheSizes()
+    {
+        return array(
+            array(false),
+            array(true),
+            array(1.0),
+            array('1.0'),
+            array(1e4),
+            array('1e4'),
+            array('foo'),
+            array(array()),
+            array(array(666)),
+            array(new \stdClass()),
+            array(-1),
+            array('-1')
+        );
+    }
+
+    public function getValidAllocationSizes()
+    {
+        return array(
+            array(666, 666),
+            array('666', '666'),
+            array(null, 1),
+            array(false, 1),
+            array(true, 1),
+            array('foo', 1),
+            array(array(), 1),
+            array(array(666), 1),
+            array(new \stdClass(), 1),
+        );
+    }
+
+    public function getValidCacheSizes()
+    {
+        return array(
+            array(0, 0),
+            array('0', '0'),
+            array(1, 1),
+            array('1', '1'),
+            array(666, 666),
+            array('666', '666'),
+            array(null, null),
+        );
+    }
+
+    public function getValidInitialValues()
+    {
+        return array(
+            array(666, 666),
+            array('666', '666'),
+            array(null, 1),
+            array(false, 1),
+            array(true, 1),
+            array('foo', 1),
+            array(array(), 1),
+            array(array(666), 1),
+            array(new \stdClass(), 1),
+        );
+    }
+}


### PR DESCRIPTION
@beberlei Started implementation for [DBAL-139](http://www.doctrine-project.org/jira/browse/DBAL-139) in commit https://github.com/doctrine/dbal/commit/e8efcd7621e85003f3ce496bc26a108b53371838 and https://github.com/doctrine/dbal/commit/d397c005dd3ff3d48a81eeb47c2a0d74d6b7400d which was first drafted in PR #202. It's about adding a cache option for sequences.

**The following missing aspects of the implementation were added:**
- SQL Server support
- SQL Anywhere support
- Reverse engineering the cache option with the schema managers
- Comparator implementation
- Schema::createSequence() adjustment
- More tests

**Additional optimizations:**
- Rename `$cache` to `$cacheSize` in Sequence (unified naming with `$allocationSize`)
- More strict input validation for cache size values in Sequence to avoid SQL generation errors
- Better API documentation
- Unified `getSequenceCacheClause()` method on all platforms

**Todo:**
- Fix comparator issues (see below)
- Finish test suite for this (depends on comparator issues solution)

**Comparator issues**
The comparator will get into trouble when comparing cache size values. To get an understanding of this I'll first explain how cache size values evaluate to the database:
- `null` -> No cache size specified, don't generate cache clause for sequences and use platform's default
- `0` -> Explicitly disable caching for sequences, generates `NOCACHE` clause on platforms
- every other positive value is an explicite specification of the cache size and results in `CACHE <size>` clause

Now there are two problems.

First one is that a value of `1` has a special meaning on some platforms, too. Oracle does not accept it and throws an error as the minimum allowed value is `2`. PostgreSQL allows a value of `1` but in fact interprets it as `NOCACHE`. SQL Server and SQL Anywhere accept a value of `1` but the behaviour is unclear compared to an explicite `NOCACHE` on these platforms. Now I am assuming that a cache size of `1` maybe also physically has the same effect as if specifying no cache at all and that this is more of a "compatibility" value and we maybe should not allow it at all to preserve portability throughout the vendors.

The second problem is the `null` value for `$cacheSize` in Sequences. This tells the vendor to use it's own specific default cache size which differs on all platforms. The comparator will always mark a sequence as _changed_ then when `null` was initially defined for the sequence and the sequence is introspected from database again. This will lead to repeated `ALTER SEQUENCE` statements in the schema tool which is not good. Also we cannot determine in the platform itself if the sequence has really changed as there currently is no `SequenceDiff` class which could get passed to `AbstractPlatform::getAlterSequenceSQL()`. Instead we only get the changed sequence object. I have put together some [examples](https://gist.github.com/deeky666/6c4e47a275b1c9e7c068) to clarify on what I mean as it is hard to explain.

So I'm asking for opinions and input on this :)
