### PR TITLE
[DBAL-423] Optimize non-native GUID type declaration

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -297,7 +297,7 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL snippet to declare a GUID/UUID field.
      *
-     * By default this maps directly to a VARCHAR and only maps to more
+     * By default this maps directly to a CHAR(36) and only maps to more
      * special datatypes when the underlying databases support this datatype.
      *
      * @param array $field
@@ -306,6 +306,9 @@ abstract class AbstractPlatform
      */
     public function getGuidTypeDeclarationSQL(array $field)
     {
+        $field['length'] = 36;
+        $field['fixed']  = true;
+
         return $this->getVarcharTypeDeclarationSQL($field);
     }
 

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -399,7 +399,9 @@ class Comparator
             $changedProperties[] = 'default';
         }
 
-        if ($properties1['type'] instanceof Types\StringType || $properties1['type'] instanceof Types\BinaryType) {
+        if (($properties1['type'] instanceof Types\StringType && ! $properties1['type'] instanceof Types\GuidType) ||
+            $properties1['type'] instanceof Types\BinaryType
+        ) {
             // check if value of length is set at all, default value assumed otherwise.
             $length1 = $properties1['length'] ?: 255;
             $length2 = $properties2['length'] ?: 255;

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -259,4 +259,24 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
             $platform->getBlobTypeDeclarationSQL($onlineColumns['col_longblob']->toArray())
         );
     }
+
+    /**
+     * @group DBAL-423
+     */
+    public function testDiffListGuidTableColumn()
+    {
+        $offlineTable = new Table('list_guid_table_column');
+        $offlineTable->addColumn('col_guid', 'guid');
+
+        $this->_sm->dropAndCreateTable($offlineTable);
+
+        $onlineTable = $this->_sm->listTableDetails('list_guid_table_column');
+
+        $comparator = new Comparator();
+
+        $this->assertFalse(
+            $comparator->diffTable($offlineTable, $onlineTable),
+            "No differences should be detected with the offline vs online schema."
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -596,4 +596,12 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             "CHANGE `select` `select` VARCHAR(255) NOT NULL COMMENT 'Reserved keyword 3'"
         );
     }
+
+    /**
+     * @group DBAL-423
+     */
+    public function testReturnsGuidTypeDeclarationSQL()
+    {
+        $this->assertSame('CHAR(36)', $this->_platform->getGuidTypeDeclarationSQL(array()));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -946,4 +946,14 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
             $this->_platform->quoteStringLiteral($c)
         );
     }
+
+    /**
+     * @group DBAL-423
+     *
+     * @expectedException \Doctrine\DBAL\DBALException
+     */
+    public function testReturnsGuidTypeDeclarationSQL()
+    {
+        $this->_platform->getGuidTypeDeclarationSQL(array());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -664,4 +664,12 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
             $this->_platform->getCommentOnColumnSQL('mytable', 'id', null)
         );
     }
+
+    /**
+     * @group DBAL-423
+     */
+    public function testReturnsGuidTypeDeclarationSQL()
+    {
+        $this->assertSame('UUID', $this->_platform->getGuidTypeDeclarationSQL(array()));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -255,16 +255,16 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         $query.= 'WHERE (table1.column1 = table2.column2) AND (table1.column1 = table3.column3) AND (table1.column1 = table4.column4) AND (table1.column1 = table5.column5) AND (table1.column1 = table6.column6) AND (table1.column1 = table7.column7) AND (table1.column1 = table8.column8) AND (table2.column2 = table3.column3) AND (table2.column2 = table4.column4) AND (table2.column2 = table5.column5) AND (table2.column2 = table6.column6) ';
         $query.= 'AND (table2.column2 = table7.column7) AND (table2.column2 = table8.column8) AND (table3.column3 = table4.column4) AND (table3.column3 = table5.column5) AND (table3.column3 = table6.column6) AND (table3.column3 = table7.column7) AND (table3.column3 = table8.column8) AND (table4.column4 = table5.column5) AND (table4.column4 = table6.column6) AND (table4.column4 = table7.column7) AND (table4.column4 = table8.column8) ';
         $query.= 'AND (table5.column5 = table6.column6) AND (table5.column5 = table7.column7) AND (table5.column5 = table8.column8) AND (table6.column6 = table7.column7) AND (table6.column6 = table8.column8) AND (table7.column7 = table8.column8)';
-        
+
         $sql = $this->_platform->modifyLimitQuery($query, 10);
-        
+
         $expected = 'SELECT * FROM (SELECT table1.column1, table2.column2, table3.column3, table4.column4, table5.column5, table6.column6, table7.column7, table8.column8, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS doctrine_rownum ';
         $expected.= 'FROM table1, table2, table3, table4, table5, table6, table7, table8 ';
         $expected.= 'WHERE (table1.column1 = table2.column2) AND (table1.column1 = table3.column3) AND (table1.column1 = table4.column4) AND (table1.column1 = table5.column5) AND (table1.column1 = table6.column6) AND (table1.column1 = table7.column7) AND (table1.column1 = table8.column8) AND (table2.column2 = table3.column3) AND (table2.column2 = table4.column4) ';
         $expected.= 'AND (table2.column2 = table5.column5) AND (table2.column2 = table6.column6) AND (table2.column2 = table7.column7) AND (table2.column2 = table8.column8) AND (table3.column3 = table4.column4) AND (table3.column3 = table5.column5) AND (table3.column3 = table6.column6) AND (table3.column3 = table7.column7) AND (table3.column3 = table8.column8) AND (table4.column4 = table5.column5) AND (table4.column4 = table6.column6) ';
         $expected.= 'AND (table4.column4 = table7.column7) AND (table4.column4 = table8.column8) AND (table5.column5 = table6.column6) AND (table5.column5 = table7.column7) AND (table5.column5 = table8.column8) AND (table6.column6 = table7.column7) AND (table6.column6 = table8.column8) AND (table7.column7 = table8.column8)) ';
         $expected.= 'AS doctrine_tbl WHERE doctrine_rownum BETWEEN 1 AND 10';
-        
+
         $this->assertEquals($expected, $sql);
     }
 
@@ -919,5 +919,13 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
             "EXEC sp_RENAME N'[schema].[table].[create]', N'[select]', N'INDEX'",
             "EXEC sp_RENAME N'[schema].[table].[foo]', N'[bar]', N'INDEX'",
         );
+    }
+
+    /**
+     * @group DBAL-423
+     */
+    public function testReturnsGuidTypeDeclarationSQL()
+    {
+        $this->assertSame('UNIQUEIDENTIFIER', $this->_platform->getGuidTypeDeclarationSQL(array()));
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -463,4 +463,12 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             'RENAME INDEX "schema"."foo" TO "bar"',
         );
     }
+
+    /**
+     * @group DBAL-423
+     */
+    public function testReturnsGuidTypeDeclarationSQL()
+    {
+        $this->assertSame('CHAR(36)', $this->_platform->getGuidTypeDeclarationSQL(array()));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -484,4 +484,12 @@ class OraclePlatformTest extends AbstractPlatformTestCase
             'ALTER INDEX "schema"."foo" RENAME TO "bar"',
         );
     }
+
+    /**
+     * @group DBAL-423
+     */
+    public function testReturnsGuidTypeDeclarationSQL()
+    {
+        $this->assertSame('CHAR(36)', $this->_platform->getGuidTypeDeclarationSQL(array()));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -855,4 +855,12 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
             'ALTER INDEX "foo" ON "schema"."table" RENAME TO "bar"',
         );
     }
+
+    /**
+     * @group DBAL-423
+     */
+    public function testReturnsGuidTypeDeclarationSQL()
+    {
+        $this->assertSame('UNIQUEIDENTIFIER', $this->_platform->getGuidTypeDeclarationSQL(array()));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -552,4 +552,12 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'when used with schemas.'
         );
     }
+
+    /**
+     * @group DBAL-423
+     */
+    public function testReturnsGuidTypeDeclarationSQL()
+    {
+        $this->assertSame('CHAR(36)', $this->_platform->getGuidTypeDeclarationSQL(array()));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -1107,4 +1107,19 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $comparator->compare($fromSchema, $toSchema));
     }
+
+    public function testCompareGuidColumns()
+    {
+        $comparator = new Comparator();
+
+        $column1 = new Column('foo', Type::getType('guid'), array('comment' => 'GUID 1'));
+        $column2 = new Column(
+            'foo',
+            Type::getType('guid'),
+            array('notnull' => false, 'length' => '36', 'fixed' => true, 'default' => 'NEWID()', 'comment' => 'GUID 2.')
+        );
+
+        $this->assertEquals(array('notnull', 'default', 'comment'), $comparator->diffColumn($column1, $column2));
+        $this->assertEquals(array('notnull', 'default', 'comment'), $comparator->diffColumn($column2, $column1));
+    }
 }


### PR DESCRIPTION
Currently non-native GUID type is mapped to `VARCHAR(255)` which is not effective as GUID always has a fixed length of 36 characters. Therefore it should be mapped to `CHAR(36)` instead.
