### PR TITLE
[DBAL-472] Fix altering column from notnull to null in Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -686,7 +686,7 @@ LEFT JOIN user_cons_columns r_cols
                     $columnInfo['notnull'] = false;
                 }
 
-                $fields[] = $column->getQuotedName($this) . ' ' . $this->getColumnDeclarationSQL('', $columnInfo);
+                $fields[] = $column->getQuotedName($this) . $this->getColumnDeclarationSQL('', $columnInfo);
             }
 
             if ($columnHasChangedComment) {
@@ -734,6 +734,31 @@ LEFT JOIN user_cons_columns r_cols
         }
 
         return array_merge($sql, $tableSql, $columnSql);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnDeclarationSQL($name, array $field)
+    {
+        if (isset($field['columnDefinition'])) {
+            $columnDef = $this->getCustomTypeDeclarationSQL($field);
+        } else {
+            $default = $this->getDefaultValueDeclarationSQL($field);
+
+            $notnull = empty($field['notnull']) ? ' NULL' : ' NOT NULL';
+
+            $unique = (isset($field['unique']) && $field['unique']) ?
+                ' ' . $this->getUniqueFieldDeclarationSQL() : '';
+
+            $check = (isset($field['check']) && $field['check']) ?
+                ' ' . $field['check'] : '';
+
+            $typeDecl = $field['type']->getSqlDeclaration($field, $this);
+            $columnDef = $typeDecl . $default . $notnull . $unique . $check;
+        }
+
+        return $name . ' ' . $columnDef;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -57,4 +57,35 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertInstanceOf('Doctrine\DBAL\Types\BinaryType', $table->getColumn('column_binary')->getType());
         $this->assertFalse($table->getColumn('column_binary')->getFixed());
     }
+
+    /**
+     * @group DBAL-472
+     */
+    public function testAlterTableColumnNotNull()
+    {
+        $comparator = new Schema\Comparator();
+        $tableName  = 'list_table_column_notnull';
+        $table      = new Schema\Table($tableName);
+
+        $table->addColumn('id', 'integer');
+        $table->addColumn('foo', 'integer');
+        $table->setPrimaryKey(array('id'));
+
+        $this->_sm->dropAndCreateTable($table);
+
+        $columns = $this->_sm->listTableColumns($tableName);
+
+        $this->assertTrue($columns['id']->getNotnull());
+        $this->assertTrue($columns['foo']->getNotnull());
+
+        $diffTable = clone $table;
+        $diffTable->changeColumn('foo', array('notnull' => false));
+
+        $this->_sm->alterTable($comparator->diffTable($table, $diffTable));
+
+        $columns = $this->_sm->listTableColumns($tableName);
+
+        $this->assertTrue($columns['id']->getNotnull());
+        $this->assertFalse($columns['foo']->getNotnull());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -63,13 +63,13 @@ class OraclePlatformTest extends AbstractPlatformTestCase
 
     public function getGenerateTableSql()
     {
-        return 'CREATE TABLE test (id NUMBER(10) NOT NULL, test VARCHAR2(255) DEFAULT NULL, PRIMARY KEY(id))';
+        return 'CREATE TABLE test (id NUMBER(10) NOT NULL, test VARCHAR2(255) DEFAULT NULL NULL, PRIMARY KEY(id))';
     }
 
     public function getGenerateTableWithMultiColumnUniqueIndexSql()
     {
         return array(
-            'CREATE TABLE test (foo VARCHAR2(255) DEFAULT NULL, bar VARCHAR2(255) DEFAULT NULL)',
+            'CREATE TABLE test (foo VARCHAR2(255) DEFAULT NULL NULL, bar VARCHAR2(255) DEFAULT NULL NULL)',
             'CREATE UNIQUE INDEX UNIQ_D87F7E0C8C73652176FF8CAA ON test (foo, bar)',
         );
     }
@@ -77,8 +77,8 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     public function getGenerateAlterTableSql()
     {
         return array(
-            'ALTER TABLE mytable ADD (quota NUMBER(10) DEFAULT NULL)',
-            "ALTER TABLE mytable MODIFY (baz  VARCHAR2(255) DEFAULT 'def' NOT NULL, bloo  NUMBER(1) DEFAULT '0' NOT NULL)",
+            'ALTER TABLE mytable ADD (quota NUMBER(10) DEFAULT NULL NULL)',
+            "ALTER TABLE mytable MODIFY (baz VARCHAR2(255) DEFAULT 'def' NOT NULL, bloo NUMBER(1) DEFAULT '0' NOT NULL)",
             "ALTER TABLE mytable DROP (foo)",
             "ALTER TABLE mytable RENAME TO userlist",
         );
@@ -326,9 +326,15 @@ class OraclePlatformTest extends AbstractPlatformTestCase
             ),
             array('type', 'notnull')
         );
+        $tableDiff->changedColumns['metar'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'metar', new \Doctrine\DBAL\Schema\Column(
+                'metar', \Doctrine\DBAL\Types\Type::getType('string'), array('length' => 2000, 'notnull' => false)
+            ),
+            array('notnull')
+        );
 
         $expectedSql = array(
-            "ALTER TABLE mytable MODIFY (foo  VARCHAR2(255) DEFAULT 'bla', baz  VARCHAR2(255) DEFAULT 'bla' NOT NULL)",
+            "ALTER TABLE mytable MODIFY (foo VARCHAR2(255) DEFAULT 'bla' NULL, baz VARCHAR2(255) DEFAULT 'bla' NOT NULL, metar VARCHAR2(2000) DEFAULT NULL NULL)",
 	);
         $this->assertEquals($expectedSql, $this->_platform->getAlterTableSQL($tableDiff));
     }


### PR DESCRIPTION
Oracle requires an explicit `NULL` clause when altering a column from `NOT NULL` to `NULL`. Otherwise the existing notnull constraint remains unchanged.
This PR changes Oracles column declaration SQL snippet to always specify `NULL` and `NOT NULL` in `CREATE TABLE` and `ALTER TABLE` statements. This is a perfectly valid syntax and also functional tested.
