### PR TITLE
Fix dropping table without autoincrement trigger in Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -311,7 +311,7 @@ class OracleSchemaManager extends AbstractSchemaManager
      */
     public function dropTable($name)
     {
-        $this->dropAutoincrement($name);
+        $this->tryMethod('dropAutoincrement', $name);
 
         parent::dropTable($name);
     }


### PR DESCRIPTION
Autoincrement primary key columns are implemented as a triggers that emulate autoincrementation in Oracle. Dropping tables with Oracle's schema manager first drops those triggers before actually dropping the table. However when there is no such trigger (either if the primary key was not defined as autoincrement column or the trigger could not be found on database side) dropping the table via schema manager fails silently and the table still exists. Dropping those triggers should not cause the schema manager to skip executing the `DROP TABLE` statement. Therefore this PR wraps dropping the trigger into a `tryMethod()` so that it can fail and still call the actual `dropTable` operation.
This also fixes a lot of failing functional tests in Oracle's test suite where tables without autoincrement primary keys column are created and dropped.
