### PR TITLE
[DBAL-685] Add servicename connection parameter to Oracle drivers

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -179,6 +179,14 @@ pdo\_oci / oci8
 -  ``host`` (string): Hostname of the database to connect to.
 -  ``port`` (integer): Port of the database to connect to.
 -  ``dbname`` (string): Name of the database/schema to connect to.
+-  ``servicename`` (string): Optional name by which clients can
+   connect to the database instance. Will be used as Oracle's
+   ``SID`` connection parameter if given and defaults to Doctrine's
+   ``dbname`` connection parameter value.
+-  ``service`` (boolean): Whether to use Oracle's ``SERVICE_NAME``
+   connection parameter in favour of ``SID`` when connecting. The
+   value for this will be read from Doctrine's ``servicename`` if
+   given, ``dbname`` otherwise.
 -  ``pooled`` (boolean): Whether to enable database resident
    connection pooling.
 -  ``charset`` (string): The charset used when connecting to the

--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -66,18 +66,24 @@ class Driver implements \Doctrine\DBAL\Driver
                 $dsn .= '(PORT=1521)';
             }
 
-            $database = 'SID=' . $params['dbname'];
+            $serviceName = $params['dbname'];
+
+            if ( ! empty($params['servicename'])) {
+                $serviceName = $params['servicename'];
+            }
+
+            $service = 'SID=' . $serviceName;
             $pooled   = '';
 
             if (isset($params['service']) && $params['service'] == true) {
-                $database = 'SERVICE_NAME=' . $params['dbname'];
+                $service = 'SERVICE_NAME=' . $serviceName;
             }
 
             if (isset($params['pooled']) && $params['pooled'] == true) {
                 $pooled = '(SERVER=POOLED)';
             }
 
-            $dsn .= '))(CONNECT_DATA=(' . $database . ')' . $pooled . '))';
+            $dsn .= '))(CONNECT_DATA=(' . $service . ')' . $pooled . '))';
         } else {
             $dsn .= $params['dbname'];
         }

--- a/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
@@ -68,18 +68,24 @@ class Driver implements \Doctrine\DBAL\Driver
                 $dsn .= '(PORT=1521)';
             }
 
-            $database = 'SID=' . $params['dbname'];
-            $pooled   = '';
+            $serviceName = $params['dbname'];
+
+            if ( ! empty($params['servicename'])) {
+                $serviceName = $params['servicename'];
+            }
+
+            $service = 'SID=' . $serviceName;
+            $pooled  = '';
 
             if (isset($params['service']) && $params['service'] == true) {
-                $database = 'SERVICE_NAME=' . $params['dbname'];
+                $service = 'SERVICE_NAME=' . $serviceName;
             }
 
             if (isset($params['pooled']) && $params['pooled'] == true) {
                 $pooled = '(SERVER=POOLED)';
             }
 
-            $dsn .= '))(CONNECT_DATA=(' . $database . ')' . $pooled . '))';
+            $dsn .= '))(CONNECT_DATA=(' . $service . ')' . $pooled . '))';
         } else {
             $dsn .= $params['dbname'];
         }


### PR DESCRIPTION
Currently Doctrine's Oracle drivers do not distinguish between `SID` / `SERVICE_NAME` and `DBNAME` connection parameters which do not necessarily have to be the same in every database environment setup. The `SID` is the unique name of the database instance to connect to and can be superseded by a more general `SERVICE_NAME` which can be configured to contain multiple database instances in a HA environment on server side. For each individual database environment setup to work we need to be able to specify different values for `SID` / `SERVICE_NAME` and `DBNAME`.
This PR adds an additonal `servicename` connection parameter which is used instead of `dbname` for the `SID` / `SERVICE_NAME` connection parameters **IF** given. I also updated the docs to cover this and another parameter `service` which was introduced in [DBAL-141](http://www.doctrine-project.org/jira/browse/DBAL-141) but never got documented.
