### PR TITLE
Fix index flags

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Index.php
+++ b/lib/Doctrine/DBAL/Schema/Index.php
@@ -259,7 +259,7 @@ class Index extends AbstractAsset implements Constraint
      */
     public function addFlag($flag)
     {
-        $this->flags[strtolower($flag)] = true;
+        $this->_flags[strtolower($flag)] = true;
 
         return $this;
     }
@@ -273,7 +273,7 @@ class Index extends AbstractAsset implements Constraint
      */
     public function hasFlag($flag)
     {
-        return isset($this->flags[strtolower($flag)]);
+        return isset($this->_flags[strtolower($flag)]);
     }
 
     /**
@@ -285,6 +285,6 @@ class Index extends AbstractAsset implements Constraint
      */
     public function removeFlag($flag)
     {
-        unset($this->flags[strtolower($flag)]);
+        unset($this->_flags[strtolower($flag)]);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/IndexTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/IndexTest.php
@@ -89,13 +89,16 @@ class IndexTest extends \PHPUnit_Framework_TestCase
     {
         $idx1 = $this->createIndex();
         $this->assertFalse($idx1->hasFlag('clustered'));
+        $this->assertEmpty($idx1->getFlags());
 
         $idx1->addFlag('clustered');
         $this->assertTrue($idx1->hasFlag('clustered'));
         $this->assertTrue($idx1->hasFlag('CLUSTERED'));
+        $this->assertSame(array('clustered'), $idx1->getFlags());
 
         $idx1->removeFlag('clustered');
         $this->assertFalse($idx1->hasFlag('clustered'));
+        $this->assertEmpty($idx1->getFlags());
     }
 
     /**


### PR DESCRIPTION
`Index` does not consistently use the defined property `$_flags` throughout the flag methods. Therefore `Index::getFlags()` does not return the defined flags.
