### PR TITLE
Fix foreign key columns order in Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -558,7 +558,8 @@ LEFT JOIN user_cons_columns r_cols
       AND cols.position = r_cols.position
     WHERE alc.constraint_name = cols.constraint_name
       AND alc.constraint_type = 'R'
-      AND alc.table_name = '".$table."'";
+      AND alc.table_name = '".$table."'
+ ORDER BY alc.constraint_name ASC, cols.position ASC";
     }
 
     /**


### PR DESCRIPTION
The order of columns in foreign key constraints is not synchronized by the Oracle platform.

**Failing test:**

``` bash
Doctrine\Tests\DBAL\Functional\Schema\OracleSchemaManagerTest::testListForeignKeysComposite
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'id'
-    1 => 'foreign_key_test'
+    0 => 'foreign_key_test'
+    1 => 'id'
 )

/home/deeky/dev/doctrine/dbal/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php:672
```
