### PR TITLE
Fix column default value introspection in Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -113,8 +113,14 @@ class OracleSchemaManager extends AbstractSchemaManager
             $tableColumn['column_name'] = '';
         }
 
-        if (stripos($tableColumn['data_default'], 'NULL') !== null) {
+        if ($tableColumn['data_default'] === 'NULL') {
             $tableColumn['data_default'] = null;
+        }
+
+        if (null !== $tableColumn['data_default']) {
+            // Default values returned from database are enclosed in single quotes.
+            // Sometimes trailing spaces are also encountered.
+            $tableColumn['data_default'] = trim(trim($tableColumn['data_default']), "'");
         }
 
         $precision = null;


### PR DESCRIPTION
A bug in `OracleSchemaManager` cause a column's default value always to be null. Besides that default values are enclosed in single quotes when retrieved from database which is not evaluated by the schema manager, either.
This PR also fixes the default value tests in Oracle's functional test suite.
