### PR TITLE
[DBAL-624] Fix parsing parameters in comments

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -56,8 +56,9 @@ class SQLParserUtils
             return array();
         }
 
-        $token = ($isPositional) ? self::POSITIONAL_TOKEN : self::NAMED_TOKEN;
-        $paramMap = array();
+        $statement = self::getUncommentedStatement($statement);
+        $token     = ($isPositional) ? self::POSITIONAL_TOKEN : self::NAMED_TOKEN;
+        $paramMap  = array();
 
         foreach (self::getUnquotedStatementFragments($statement) as $fragment) {
             preg_match_all("/$token/", $fragment[0], $matches, PREG_OFFSET_CAPTURE);
@@ -180,6 +181,34 @@ class SQLParserUtils
         }
 
         return array($query, $paramsOrd, $typesOrd);
+    }
+
+    /**
+     * Strips comments from the given statement.
+     *
+     * @param string $statement Statement to uncomment.
+     *
+     * @return string The uncommented statement.
+     */
+    static private function getUncommentedStatement($statement)
+    {
+        $comments = '@
+            (([\'"`]).*?[^\\\]\2) # $1 : Skip single, double and backtick quoted expressions
+            |(                    # $3 : Match comments
+                (?:\#|--).*?$     # - Single line comments
+                |                 # - Multi line (nested) comments
+                 /\*              #   . comment open marker
+                    (?: [^/*]     #   . non comment-marker characters
+                        |/(?!\*)  #   . ! not a comment open
+                        |\*(?!/)  #   . ! not a comment close
+                        |(?R)     #   . recursive case
+                    )*            #   . repeat eventually
+                \*\/              #   . comment close marker
+            )\s*                  # Trim after comments
+            |(?<=;)\s+            # Trim after semi-colon
+            @msx';
+
+        return trim(preg_replace($comments, '$1', $statement));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -37,6 +37,35 @@ AND baz = "\"quote\" me on it? \\" OR baz = ?
 SQLDATA
                 , true, array(58, 104)
             ),
+            array(
+<<<'SQLDATA'
+# ?
+-- ?
+/* ? */
+/* ?
+*/
+/*
+? */
+/*
+?
+*/
+/* ? /* ? */*/
+-- ? -- ? # ? /* ?
+SELECT -- ?
+       ?,
+       /* ?
+       ? */
+       ?, --?
+       '--?',
+       "--?",
+       `--?`
+FROM baz #:?
+/*
+
+    ?
+    */
+SQLDATA
+            , true, array(7, 17)), // Ticket DBAL-624
 
             // named
             array('SELECT :foo FROM :bar', false, array(7 => 'foo', 17 => 'bar')),
@@ -49,6 +78,35 @@ SQLDATA
             array('SELECT * FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(30 => 'start_date', 52 =>  'start_date')), // Ticket GH-113
             array('SELECT foo::date as date FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(46 => 'start_date', 68 =>  'start_date')), // Ticket GH-259
             array('SELECT `d.ns:col_name` FROM my_table d WHERE `d.date` >= :param1', false, array(57 => 'param1')), // Ticket DBAL-552
+            array(
+<<<'SQLDATA'
+# :comment1
+-- :comment2
+/* :comment3 */
+/* :comment4
+*/
+/*
+:comment5 */
+/*
+:comment6
+*/
+/* :comment7 /* :comment8 */*/
+-- :comment9 -- :comment10 # :comment11 /* :comment12
+SELECT -- :comment13
+       :foo,
+       /* :comment14
+       :comment15 */
+       :bar, --:comment16
+       '--:param1',
+       "--:param2",
+       `--:param3`
+FROM baz #:comment17
+/*
+
+    :comment 18
+    */
+SQLDATA
+            , false, array(7 => 'foo', 20 => 'bar')), // Ticket DBAL-624
         );
     }
 


### PR DESCRIPTION
Parameter placeholders should not be parsed out of comments in statements.
