### PR TITLE
Fix Oracle test suite

### DIFF
--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -113,14 +113,16 @@ class OracleSchemaManager extends AbstractSchemaManager
             $tableColumn['column_name'] = '';
         }
 
-        if ($tableColumn['data_default'] === 'NULL') {
+        // Default values returned from database sometimes have trailing spaces.
+        $tableColumn['data_default'] = trim($tableColumn['data_default']);
+
+        if ($tableColumn['data_default'] === '' || $tableColumn['data_default'] === 'NULL') {
             $tableColumn['data_default'] = null;
         }
 
         if (null !== $tableColumn['data_default']) {
             // Default values returned from database are enclosed in single quotes.
-            // Sometimes trailing spaces are also encountered.
-            $tableColumn['data_default'] = trim(trim($tableColumn['data_default']), "'");
+            $tableColumn['data_default'] = trim($tableColumn['data_default'], "'");
         }
 
         $precision = null;

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
 use Doctrine\DBAL\Schema;
+use Doctrine\Tests\TestUtil;
 
 require_once __DIR__ . '/../../../TestInit.php';
 
@@ -87,5 +88,18 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertTrue($columns['id']->getNotnull());
         $this->assertFalse($columns['foo']->getNotnull());
+    }
+
+    public function testListDatabases()
+    {
+        // We need the temp connection that has privileges to create a database.
+        $sm = TestUtil::getTempConnection()->getSchemaManager();
+
+        $sm->dropAndCreateDatabase('c##test_create_database');
+
+        $databases = $this->_sm->listDatabases();
+        $databases = \array_map('strtolower', $databases);
+
+        $this->assertEquals(true, \in_array('c##test_create_database', $databases));
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
@@ -34,8 +34,9 @@ class TemporaryTableTest extends \Doctrine\Tests\DbalFunctionalTestCase
      */
     public function testDropTemporaryTableNotAutoCommitTransaction()
     {
-        if ($this->_conn->getDatabasePlatform()->getName() == 'sqlanywhere') {
-            $this->markTestSkipped("Test does not work on SQL Anywhere.");
+        if ($this->_conn->getDatabasePlatform()->getName() == 'sqlanywhere' ||
+            $this->_conn->getDatabasePlatform()->getName() == 'oracle') {
+            $this->markTestSkipped("Test does not work on Oracle and SQL Anywhere.");
         }
 
         $platform = $this->_conn->getDatabasePlatform();
@@ -71,8 +72,9 @@ class TemporaryTableTest extends \Doctrine\Tests\DbalFunctionalTestCase
      */
     public function testCreateTemporaryTableNotAutoCommitTransaction()
     {
-        if ($this->_conn->getDatabasePlatform()->getName() == 'sqlanywhere') {
-            $this->markTestSkipped("Test does not work on SQL Anywhere.");
+        if ($this->_conn->getDatabasePlatform()->getName() == 'sqlanywhere' ||
+            $this->_conn->getDatabasePlatform()->getName() == 'oracle') {
+            $this->markTestSkipped("Test does not work on Oracle and SQL Anywhere.");
         }
 
         $platform = $this->_conn->getDatabasePlatform();


### PR DESCRIPTION
Final fixes for the Oracle test suite to run again without errors:

``` bash
deeky@98N-MUELLER-STEVE:~/dev/doctrine/dbal$ phpunit -c oci8.phpunit.xml
PHPUnit 3.7.27 by Sebastian Bergmann.

Configuration read from /home/deeky/dev/doctrine/dbal/oci8.phpunit.xml

..........................................................SSS   61 / 1578 (  3%)
S.............................S.SS...SSSSSSSSSSSSSS.S.SSSSS..  122 / 1578 (  7%)
..SSS.....................SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS  183 / 1578 ( 11%)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS..........S.......S  244 / 1578 ( 15%)
......SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS  305 / 1578 ( 19%)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS  366 / 1578 ( 23%)
S..SSS..SS.S.........................S.......................  427 / 1578 ( 27%)
.............................................................  488 / 1578 ( 30%)
.............................................................  549 / 1578 ( 34%)
.............................................................  610 / 1578 ( 38%)
...........................................................S.  671 / 1578 ( 42%)
.............................................................  732 / 1578 ( 46%)
.....................................S......S................  793 / 1578 ( 50%)
.............................................................  854 / 1578 ( 54%)
......................S.....S................................  915 / 1578 ( 57%)
.............................................................  976 / 1578 ( 61%)
............................................................. 1037 / 1578 ( 65%)
............................................................. 1098 / 1578 ( 69%)
.......................................................SSS... 1159 / 1578 ( 73%)
............................................................. 1220 / 1578 ( 77%)
............................................................. 1281 / 1578 ( 81%)
............................................................. 1342 / 1578 ( 85%)
................S............................................ 1403 / 1578 ( 88%)
............................................................. 1464 / 1578 ( 92%)
.....S..SSS.................................................. 1525 / 1578 ( 96%)
.....................................................

Time: 2.19 minutes, Memory: 50.25Mb

OK, but incomplete or skipped tests!
Tests: 1578, Assertions: 2852, Skipped: 246.
```

**Changes**
- Skip tests for unsupported rollback of DDL statements during transactions
- Fix default NULL value (again) containing trailing whitespace when retrieved from database
- Fix drop and create database test by utilizing temporary connection in favour of real connection which has sufficient privileges and changing database name to match Oracle 12c requirements

And finally... HALLELUJAH! :+1: 
