### PR TITLE
Fix integer type mapping in SQL Anywhere 16

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -1500,6 +1500,7 @@ class SQLAnywherePlatform extends AbstractPlatform
             'double' => 'float',
             'float' => 'float',
             'int' => 'integer',
+            'integer' => 'integer',
             'unsigned int' => 'integer',
             'numeric' => 'decimal',
             'smallint' => 'smallint',

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -755,6 +755,9 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
 
     public function testInitializesDoctrineTypeMappings()
     {
+        $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('integer'));
+        $this->assertSame('integer', $this->_platform->getDoctrineTypeMapping('integer'));
+
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('binary'));
         $this->assertSame('binary', $this->_platform->getDoctrineTypeMapping('binary'));
 


### PR DESCRIPTION
SQL Anywhere 16 seems to have changed the return value of integer type columns from `int` to `integer` when introspecting table columns. This causes the functional test suite to fail.
