### PR TITLE
Fix driver error while introspecting sequences in SQL Server 2012

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -67,7 +67,14 @@ class SQLServer2012Platform extends SQLServer2008Platform
      */
     public function getListSequencesSQL($database)
     {
-        return 'SELECT seq.name, seq.increment, seq.start_value FROM sys.sequences AS seq';
+        return 'SELECT seq.name,
+                       CAST(
+                           seq.increment AS VARCHAR(MAX)
+                       ) AS increment, -- CAST avoids driver error for sql_variant type
+                       CAST(
+                           seq.start_value AS VARCHAR(MAX)
+                       ) AS start_value -- CAST avoids driver error for sql_variant type
+                FROM   sys.sequences AS seq';
     }
 
     /**


### PR DESCRIPTION
It seems the SQL Server drivers don't like SQL Server's special `sql_variant` data type when retrieving data from such columns. Therefore introspecting Sequences in SQL Server 2012 generates the following error:

``` php
Fatal error: Unexpected SQL type encountered in calc_string_size. in C:\cygwin\home\Administrator\dev\dbal\lib\Doctrine\DBAL\Driver\SQLSrv\SQLSrvStatement.php on line 226
```

A workaround this limitation is to cast the specific columns to `VARCHAR` in the query.
