### PR TITLE
Don't return warnings as errors in sqlsrv driver

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -47,6 +47,10 @@ class SQLSrvConnection implements Connection
      */
     public function __construct($serverName, $connectionOptions)
     {
+        if ( ! sqlsrv_configure('WarningsReturnAsErrors', 0)) {
+            throw SQLSrvException::fromSqlSrvErrors();
+        }
+
         $this->conn = sqlsrv_connect($serverName, $connectionOptions);
         if ( ! $this->conn) {
             throw SQLSrvException::fromSqlSrvErrors();


### PR DESCRIPTION
The SQL Server platforms use `sp_rename` stored procedure for renaming schema objects like tables, indexes or columns. SQL Server raises a warning when invoking this stored procedure, although the result is as expected:

``` php
Doctrine\DBAL\Driver\SQLSrv\SQLSrvException: SQLSTATE [01000, 15477]: [Microsoft][SQL Server Native Client 11.0][SQL Server]Vorsicht: Wenn Sie Teile eines Objektnamens ändern, werden Skripts und gespeicherte Prozeduren möglicherweise funktionsunfähig.
```

This PR configures the sqlsrv driver not to handle warnings returned from the server as errors to prevent this. The PDO_SQLSRV driver silences warnings, too.
