### PR TITLE
Fix SQL Server drivers and functional test suites

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -51,6 +51,8 @@ interfaces to use. It can be configured in one of three ways:
       extension.
       **Note that this driver caused problems in our tests. Prefer the oci8 driver if possible.**
    -  ``pdo_sqlsrv``: A Microsoft SQL Server driver that uses pdo\_sqlsrv PDO
+      **Note that this driver caused problems in our tests. Prefer the sqlsrv driver if possible.**
+   -  ``sqlsrv``: A Microsoft SQL Server driver that uses the sqlsrv PHP extension.
    -  ``oci8``: An Oracle driver that uses the oci8 PHP extension.
    -  ``sqlanywhere``: A SAP Sybase SQL Anywhere driver that uses the sqlanywhere PHP extension.
 
@@ -192,8 +194,8 @@ pdo\_oci / oci8
 -  ``charset`` (string): The charset used when connecting to the
    database.
 
-pdo\_sqlsrv
-^^^^^^^^^^^
+pdo\_sqlsrv / sqlsrv
+^^^^^^^^^^^^^^^^^^^^
 
 
 -  ``user`` (string): Username to use when connecting to the

--- a/docs/en/reference/known-vendor-issues.rst
+++ b/docs/en/reference/known-vendor-issues.rst
@@ -48,7 +48,7 @@ that detects the format automatically:
 ::
 
     use Doctrine\DBAL\Types\Type;
-    
+
     Type::overrideType('datetime', 'Doctrine\DBAL\Types\VarDateTimeType');
     Type::overrideType('datetimetz', 'Doctrine\DBAL\Types\VarDateTimeType');
     Type::overrideType('time', 'Doctrine\DBAL\Types\VarDateTimeType');
@@ -180,7 +180,18 @@ that detects the format automatically:
 ::
 
     use Doctrine\DBAL\Types\Type;
-    
+
     Type::overrideType('datetime', 'Doctrine\DBAL\Types\VarDateTime');
     Type::overrideType('datetimetz', 'Doctrine\DBAL\Types\VarDateTime');
     Type::overrideType('time', 'Doctrine\DBAL\Types\VarDateTime');
+
+PDO_SQLSRV: VARBINARY/BLOB columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``PDO_SQLSRV`` driver currently has a bug when binding values to
+VARBINARY/BLOB columns with ``bindValue`` in prepared statements.
+This raises an implicit conversion from data type error as it tries
+to convert a character type value to a binary type value even if
+you explicitly define the value as ``\PDO::PARAM_LOB`` type.
+Therefore it is highly encouraged to use the native ``sqlsrv``
+driver instead which does not have this limitation.

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -65,7 +65,7 @@ class PDOStatement extends \PDOStatement implements Statement
     /**
      * {@inheritdoc}
      */
-    public function bindParam($column, &$variable, $type = \PDO::PARAM_STR, $length = null, $driverOptions = array())
+    public function bindParam($column, &$variable, $type = \PDO::PARAM_STR, $length = null, $driverOptions = null)
     {
         return parent::bindParam($column, $variable, $type, $length, $driverOptions);
     }

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -537,8 +537,6 @@ class SQLServerPlatform extends AbstractPlatform
 
             $sql[] = "sp_RENAME '". $diff->name. ".". $oldColumnName . "', '".$column->getQuotedName($this)."', 'COLUMN'";
 
-            // todo: Find a way how to implement column comment alteration statements for renamed columns.
-
             $columnDef = $column->toArray();
 
             /**

--- a/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
@@ -17,6 +17,10 @@ class BlobTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         parent::setUp();
 
+        if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\PDOSqlsrv\Driver) {
+            $this->markTestSkipped('This test does not work on pdo_sqlsrv driver due to a bug. See: http://social.msdn.microsoft.com/Forums/sqlserver/en-US/5a755bdd-41e9-45cb-9166-c9da4475bb94/how-to-set-null-for-varbinarymax-using-bindvalue-using-pdosqlsrv?forum=sqldriverforphp');
+        }
+
         try {
             /* @var $sm \Doctrine\DBAL\Schema\AbstractSchemaManager */
             $table = new \Doctrine\DBAL\Schema\Table("blob_table");

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -212,7 +212,8 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
      */
     public function testFetchAllWithMissingTypes()
     {
-        if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\Mysqli\Driver) {
+        if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\Mysqli\Driver ||
+            $this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLSrv\Driver) {
             $this->markTestSkipped('mysqli actually supports this');
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -214,7 +214,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\Mysqli\Driver ||
             $this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLSrv\Driver) {
-            $this->markTestSkipped('mysqli actually supports this');
+            $this->markTestSkipped('mysqli and sqlsrv actually supports this');
         }
 
         $datetimeString = '2010-01-01 10:10:10';

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -559,7 +559,10 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
             'id', new \Doctrine\DBAL\Schema\Column(
                 'id', \Doctrine\DBAL\Types\Type::getType('integer'), array('primary' => true)
             ),
-            array('comment')
+            array('comment'),
+            new \Doctrine\DBAL\Schema\Column(
+                'id', \Doctrine\DBAL\Types\Type::getType('integer'), array('comment' => 'This is a comment')
+            )
         );
 
         $this->_sm->alterTable($tableDiff);

--- a/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/FunctionalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/FunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Doctrine\Tests\DBAL\Sharding\SQLAzure;
 
-use Doctrine\DBAL\Sharding\SQLAzure\SQLAzureSchemaSynchronizer;
+use Doctrine\DBAL\Sharding\SQLAzure\SQLAzureFederationsSynchronizer;
 
 class FunctionalTest extends AbstractTestCase
 {
@@ -9,7 +9,7 @@ class FunctionalTest extends AbstractTestCase
     {
         $schema = $this->createShopSchema();
 
-        $synchronizer = new SQLAzureSchemaSynchronizer($this->conn, $this->sm);
+        $synchronizer = new SQLAzureFederationsSynchronizer($this->conn, $this->sm);
         $synchronizer->dropAllSchema();
         $synchronizer->createSchema($schema);
 

--- a/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizerTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Doctrine\Tests\DBAL\Sharding\SQLAzure;
 
-use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Sharding\SQLAzure\SQLAzureFederationsSynchronizer;
 
 class SQLAzureFederationsSynchronizerTest extends AbstractTestCase


### PR DESCRIPTION
This should finally fix the functional test suites for SQL Server's `sqlsrv` and `pdo_sqlsrv` drivers. It introduces the following changes:
- Support for custom classes and constructor arguments with \PDO::FETCH_CLASS fetch mode when using `SQLSrvStatement::setFetchMode()`
- Fix fetch modes for `SQLSrvStatement::fetchAll()`
- Fix `SQLSrvStatement::fetchColumn()` for empty result sets
- Skip `BlobTest` for `pdo_sqlsrv` driver due to a bug in the driver when binding values to varbinary/blob type columns. See [DBAL-122](http://www.doctrine-project.org/jira/browse/DBAL-122) and [MSDN Post](http://social.msdn.microsoft.com/Forums/sqlserver/en-US/5a755bdd-41e9-45cb-9166-c9da4475bb94/how-to-set-null-for-varbinarymax-using-bindvalue-using-pdosqlsrv?forum=sqldriverforphp)
- Mention `pdo_sqlsrv` driver varbinary/blob limitations in documentation
- Add `sqlsrv` driver configuration documentation
- Fix schema manager functional test for retrieving column comments
- Fix SQL Azure functional tests (referenced non-existent classes)
- Fix `PDOConnection::bindParam()` signature's `$driverOptions` default value as `pdo_sqlsrv` driver errors with the wrong signature. See [here](http://php.net/manual/de/pdostatement.bindparam.php)

Please also note that the functional test suite will still fail if the underlying SQL Server database does not support SQL Azure as there currently is no reasonable way to distinguish those tests from SQL Server. Otherwise the tests now all pass!
