### PR TITLE
Fix statement for getTableWhereClause method

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -345,7 +345,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             list($schema, $table) = explode(".", $table);
             $schema = "'" . $schema . "'";
         } else {
-            $schema = "ANY(string_to_array((select replace(setting,'\"\$user\"',user) from pg_catalog.pg_settings where name = 'search_path'),','))";
+            $schema = "ANY(string_to_array((select replace(replace(setting,'\"\$user\"',user),' ','') from pg_catalog.pg_settings where name = 'search_path'),','))";
         }
         $whereClause .= "$classAlias.relname = '" . $table . "' AND $namespaceAlias.nspname = $schema";
 


### PR DESCRIPTION
If you have a role "postgres" in PostgreSQL that is described like this:

``` sql
-- Role: postgres
CREATE ROLE postgres LOGIN
  ENCRYPTED PASSWORD 'md53175bce1d3201d16594cebf9d7eb3f9d'
  SUPERUSER INHERIT CREATEDB CREATEROLE REPLICATION;
ALTER ROLE postgres IN DATABASE sf_test
  SET search_path = "$user", public, access, geographic, rrhh;
```

At the time when I execute the statement (Part of $schema value in the line 348 without replace spaces):

``` sql
SELECT string_to_array((select replace(setting,"$user",user) from pg_catalog.pg_settings where name = 'search_path'),',')
```

I fetch this result:

``` sql
{postgres," public"," access"," geographic"," rrhh"}
```

Look the space character that is on the start of each string.This error does not match any namespace to which the role has access. This is critical when you have PostgreSQL database and you work with schemas.
