### PR TITLE
Add missing type parameters to connection fetch methods

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -438,12 +438,13 @@ class Connection implements DriverConnection
      *
      * @param string $statement The SQL query.
      * @param array  $params    The query parameters.
+     * @param array  $types     The query parameter types.
      *
      * @return array
      */
-    public function fetchAssoc($statement, array $params = array())
+    public function fetchAssoc($statement, array $params = array(), array $types = array())
     {
-        return $this->executeQuery($statement, $params)->fetch(PDO::FETCH_ASSOC);
+        return $this->executeQuery($statement, $params, $types)->fetch(PDO::FETCH_ASSOC);
     }
 
     /**
@@ -452,12 +453,13 @@ class Connection implements DriverConnection
      *
      * @param string $statement The SQL query to be executed.
      * @param array  $params    The prepared statement params.
+     * @param array  $types     The query parameter types.
      *
      * @return array
      */
-    public function fetchArray($statement, array $params = array())
+    public function fetchArray($statement, array $params = array(), array $types = array())
     {
-        return $this->executeQuery($statement, $params)->fetch(PDO::FETCH_NUM);
+        return $this->executeQuery($statement, $params, $types)->fetch(PDO::FETCH_NUM);
     }
 
     /**
@@ -467,12 +469,13 @@ class Connection implements DriverConnection
      * @param string  $statement The SQL query to be executed.
      * @param array   $params    The prepared statement params.
      * @param integer $column    The 0-indexed column number to retrieve.
+     * @param array  $types      The query parameter types.
      *
      * @return mixed
      */
-    public function fetchColumn($statement, array $params = array(), $column = 0)
+    public function fetchColumn($statement, array $params = array(), $column = 0, array $types = array())
     {
-        return $this->executeQuery($statement, $params)->fetchColumn($column);
+        return $this->executeQuery($statement, $params, $types)->fetchColumn($column);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -295,4 +295,140 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
 
         $conn->insert('footable', array());
     }
+
+    public function testFetchAssoc()
+    {
+        $statement = 'SELECT * FROM foo WHERE bar = ?';
+        $params    = array(666);
+        $types     = array(\PDO::PARAM_INT);
+        $result    = array();
+
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+
+        $driverStatementMock = $this->getMock('Doctrine\Tests\Mocks\DriverStatementMock');
+
+        $driverStatementMock->expects($this->once())
+            ->method('fetch')
+            ->with(\PDO::FETCH_ASSOC)
+            ->will($this->returnValue($result));
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\Doctrine\DBAL\Connection $conn */
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setMethods(array('executeQuery'))
+            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
+            ->getMock();
+
+        $conn->expects($this->once())
+            ->method('executeQuery')
+            ->with($statement, $params, $types)
+            ->will($this->returnValue($driverStatementMock));
+
+        $this->assertSame($result, $conn->fetchAssoc($statement, $params, $types));
+    }
+
+    public function testFetchArray()
+    {
+        $statement = 'SELECT * FROM foo WHERE bar = ?';
+        $params    = array(666);
+        $types     = array(\PDO::PARAM_INT);
+        $result    = array();
+
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+
+        $driverStatementMock = $this->getMock('Doctrine\Tests\Mocks\DriverStatementMock');
+
+        $driverStatementMock->expects($this->once())
+            ->method('fetch')
+            ->with(\PDO::FETCH_NUM)
+            ->will($this->returnValue($result));
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\Doctrine\DBAL\Connection $conn */
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setMethods(array('executeQuery'))
+            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
+            ->getMock();
+
+        $conn->expects($this->once())
+            ->method('executeQuery')
+            ->with($statement, $params, $types)
+            ->will($this->returnValue($driverStatementMock));
+
+        $this->assertSame($result, $conn->fetchArray($statement, $params, $types));
+    }
+
+    public function testFetchColumn()
+    {
+        $statement = 'SELECT * FROM foo WHERE bar = ?';
+        $params    = array(666);
+        $types     = array(\PDO::PARAM_INT);
+        $column    = 0;
+        $result    = array();
+
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+
+        $driverStatementMock = $this->getMock('Doctrine\Tests\Mocks\DriverStatementMock');
+
+        $driverStatementMock->expects($this->once())
+            ->method('fetchColumn')
+            ->with($column)
+            ->will($this->returnValue($result));
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\Doctrine\DBAL\Connection $conn */
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setMethods(array('executeQuery'))
+            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
+            ->getMock();
+
+        $conn->expects($this->once())
+            ->method('executeQuery')
+            ->with($statement, $params, $types)
+            ->will($this->returnValue($driverStatementMock));
+
+        $this->assertSame($result, $conn->fetchColumn($statement, $params, $column, $types));
+    }
+
+    public function testFetchAll()
+    {
+        $statement = 'SELECT * FROM foo WHERE bar = ?';
+        $params    = array(666);
+        $types     = array(\PDO::PARAM_INT);
+        $result    = array();
+
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+
+        $driverStatementMock = $this->getMock('Doctrine\Tests\Mocks\DriverStatementMock');
+
+        $driverStatementMock->expects($this->once())
+            ->method('fetchAll')
+            ->will($this->returnValue($result));
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\Doctrine\DBAL\Connection $conn */
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setMethods(array('executeQuery'))
+            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
+            ->getMock();
+
+        $conn->expects($this->once())
+            ->method('executeQuery')
+            ->with($statement, $params, $types)
+            ->will($this->returnValue($driverStatementMock));
+
+        $this->assertSame($result, $conn->fetchAll($statement, $params, $types));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -238,7 +238,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals('foo', $row[1]);
     }
 
-    public function testFetchRow()
+    public function testFetchAssoc()
     {
         $sql = "SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?";
         $row = $this->_conn->fetchAssoc($sql, array(1, 'foo'));
@@ -251,6 +251,37 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals('foo', $row['test_string']);
     }
 
+    public function testFetchAssocWithTypes()
+    {
+        $datetimeString = '2010-01-01 10:10:10';
+        $datetime = new \DateTime($datetimeString);
+        $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
+        $row = $this->_conn->fetchAssoc($sql, array(1, $datetime), array(PDO::PARAM_STR, Type::DATETIME));
+
+        $this->assertTrue($row !== false);
+
+        $row = array_change_key_case($row, \CASE_LOWER);
+
+        $this->assertEquals(1, $row['test_int']);
+        $this->assertStringStartsWith($datetimeString, $row['test_datetime']);
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\DBALException
+     */
+    public function testFetchAssocWithMissingTypes()
+    {
+        if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\Mysqli\Driver ||
+            $this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLSrv\Driver) {
+            $this->markTestSkipped('mysqli and sqlsrv actually supports this');
+        }
+
+        $datetimeString = '2010-01-01 10:10:10';
+        $datetime = new \DateTime($datetimeString);
+        $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
+        $row = $this->_conn->fetchAssoc($sql, array(1, $datetime));
+    }
+
     public function testFetchArray()
     {
         $sql = "SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?";
@@ -258,6 +289,37 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $this->assertEquals(1, $row[0]);
         $this->assertEquals('foo', $row[1]);
+    }
+
+    public function testFetchArrayWithTypes()
+    {
+        $datetimeString = '2010-01-01 10:10:10';
+        $datetime = new \DateTime($datetimeString);
+        $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
+        $row = $this->_conn->fetchArray($sql, array(1, $datetime), array(PDO::PARAM_STR, Type::DATETIME));
+
+        $this->assertTrue($row !== false);
+
+        $row = array_change_key_case($row, \CASE_LOWER);
+
+        $this->assertEquals(1, $row[0]);
+        $this->assertStringStartsWith($datetimeString, $row[1]);
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\DBALException
+     */
+    public function testFetchArrayWithMissingTypes()
+    {
+        if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\Mysqli\Driver ||
+            $this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLSrv\Driver) {
+            $this->markTestSkipped('mysqli and sqlsrv actually supports this');
+        }
+
+        $datetimeString = '2010-01-01 10:10:10';
+        $datetime = new \DateTime($datetimeString);
+        $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
+        $row = $this->_conn->fetchArray($sql, array(1, $datetime));
     }
 
     public function testFetchColumn()
@@ -271,6 +333,34 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $testString = $this->_conn->fetchColumn($sql, array(1, 'foo'), 1);
 
         $this->assertEquals('foo', $testString);
+    }
+
+    public function testFetchColumnWithTypes()
+    {
+        $datetimeString = '2010-01-01 10:10:10';
+        $datetime = new \DateTime($datetimeString);
+        $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
+        $column = $this->_conn->fetchColumn($sql, array(1, $datetime), 1, array(PDO::PARAM_STR, Type::DATETIME));
+
+        $this->assertTrue($column !== false);
+
+        $this->assertStringStartsWith($datetimeString, $column);
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\DBALException
+     */
+    public function testFetchColumnWithMissingTypes()
+    {
+        if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\Mysqli\Driver ||
+            $this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLSrv\Driver) {
+            $this->markTestSkipped('mysqli and sqlsrv actually supports this');
+        }
+
+        $datetimeString = '2010-01-01 10:10:10';
+        $datetime = new \DateTime($datetimeString);
+        $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
+        $column = $this->_conn->fetchColumn($sql, array(1, $datetime), 1);
     }
 
     /**

--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -46,7 +46,7 @@ class ConnectionMock extends \Doctrine\DBAL\Connection
     /**
      * @override
      */
-    public function fetchColumn($statement, array $params = array(), $colnum = 0)
+    public function fetchColumn($statement, array $params = array(), $colnum = 0, array $types = array())
     {
         return $this->_fetchOneResult;
     }


### PR DESCRIPTION
Some `fetch*()` methods are missing the `$type` parameter in `Doctrine\DBAL\Connection`. This is a replacement for PR #186.
