### PR TITLE
Exclude HHVM + PostgreSQL and HHVM + Mysqli from travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,8 @@ script: phpunit --configuration tests/travis/$DB.travis.xml
 matrix:
   allow_failures:
     - php: hhvm
+  exclude:
+      - php: hhvm
+        env: DB=pgsql  # driver currently unsupported by HHVM
+      - php: hhvm
+        env: DB=mysqli # driver currently unsupported by HHVM


### PR DESCRIPTION
HHVM currently does not support `pdo_pgsql` and `mysqli` drivers and therefore it is useless to test those combinations in the Travis build matrix.
