### PR TITLE
Decode hex-encoded clobs/blobs when using pgsql on windows

### DIFF
--- a/lib/Doctrine/DBAL/Types/ObjectType.php
+++ b/lib/Doctrine/DBAL/Types/ObjectType.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 
 /**
  * Type that maps a PHP object to a clob SQL type.
@@ -54,6 +55,10 @@ class ObjectType extends Type
         }
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
+        // unpack postgres blobs if the driver was not built against a recent libpq
+        if (defined('PHP_WINDOWS_VERSION_BUILD') && $platform instanceof PostgreSqlPlatform && substr($value, 0, 1) === 'x') {
+            $value = pack('H*', substr($value, 1));
+        }
         $val = unserialize($value);
         if ($val === false && $value !== 'b:0;') {
             throw ConversionException::conversionFailed($value, $this->getName());


### PR DESCRIPTION
http://stackoverflow.com/a/15112973 explains the why. It'd be great to offer support for this natively. I run an `->executeQuery('SET bytea_output=escape')` every time now as a workaround but that's not very nice.
