### PR TITLE
Add SMALLSERIAL type support on PostgreSQL 9.2 platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSQL92Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSQL92Platform.php
@@ -39,6 +39,18 @@ class PostgreSQL92Platform extends PostgreSqlPlatform
     /**
      * {@inheritdoc}
      */
+    public function getSmallIntTypeDeclarationSQL(array $field)
+    {
+        if ( ! empty($field['autoincrement'])) {
+            return 'SMALLSERIAL';
+        }
+
+        return parent::getSmallIntTypeDeclarationSQL($field);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function hasNativeJsonType()
     {
         return true;

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL92PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL92PlatformTest.php
@@ -30,6 +30,24 @@ class PostgreSQL92PlatformTest extends AbstractPostgreSqlPlatformTestCase
         $this->assertSame('JSON', $this->_platform->getJsonTypeDeclarationSQL(array()));
     }
 
+    public function testReturnsSmallIntTypeDeclarationSQL()
+    {
+        $this->assertSame(
+            'SMALLSERIAL',
+            $this->_platform->getSmallIntTypeDeclarationSQL(array('autoincrement' => true))
+        );
+
+        $this->assertSame(
+            'SMALLINT',
+            $this->_platform->getSmallIntTypeDeclarationSQL(array('autoincrement' => false))
+        );
+
+        $this->assertSame(
+            'SMALLINT',
+            $this->_platform->getSmallIntTypeDeclarationSQL(array())
+        );
+    }
+
     /**
      * @group DBAL-553
      */


### PR DESCRIPTION
Since PostgreSQL 9.2 there also is autoincrement support for `SMALLINT` type columns. The type to use is called `SMALLSERIAL`. This PR adds support for smallint autoincrement columns on `PostgreSQL92Platform`.
Please not that no further type mapping is necessarry, as `SMALLSERIAL` columns internally map to smallint in PostgreSQL which is already covered by `PostgreSQLPlatform`.
