### PR TITLE
[DBAL-752] Fix integer type declaration SQL on SQLite

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -225,7 +225,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getIntegerTypeDeclarationSQL(array $field)
     {
-        return $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'INTEGER' . $this->_getCommonIntegerTypeDeclarationSQL($field);
     }
 
     /**
@@ -233,7 +233,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getBigIntTypeDeclarationSQL(array $field)
     {
-        return $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'BIGINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
     }
 
     /**
@@ -241,7 +241,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getTinyIntTypeDeclarationSql(array $field)
     {
-        return $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'TINYINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
     }
 
     /**
@@ -249,7 +249,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getSmallIntTypeDeclarationSQL(array $field)
     {
-        return $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'SMALLINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
     }
 
     /**
@@ -257,7 +257,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getMediumIntTypeDeclarationSql(array $field)
     {
-        return $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'MEDIUMINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
     }
 
     /**
@@ -289,7 +289,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
     {
-        return 'INTEGER';
+        return ! empty($columnDef['unsigned']) ? ' UNSIGNED' : '';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL752Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL752Test.php
@@ -24,9 +24,14 @@ class DBAL752Test extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         $this->_conn->exec(<<<SQL
 CREATE TABLE dbal752_unsigneds (
-    id  BIGINT UNSIGNED,
-    flag SMALLINT UNSIGNED,
-    masks  INTEGER UNSIGNED
+    small SMALLINT,
+    small_unsigned SMALLINT UNSIGNED,
+    medium MEDIUMINT,
+    medium_unsigned MEDIUMINT UNSIGNED,
+    "integer" INTEGER,
+    integer_unsigned INTEGER UNSIGNED,
+    big BIGINT,
+    big_unsigned BIGINT UNSIGNED
 );
 SQL
         );
@@ -35,11 +40,23 @@ SQL
 
         $fetchedTable = $schemaManager->listTableDetails('dbal752_unsigneds');
 
-        $this->assertEquals('bigint', $fetchedTable->getColumn('id')->getType()->getName());
-        $this->assertEquals('smallint', $fetchedTable->getColumn('flag')->getType()->getName());
-        $this->assertEquals('integer', $fetchedTable->getColumn('masks')->getType()->getName());
-        $this->assertTrue($fetchedTable->getColumn('id')->getUnsigned());
-        $this->assertTrue($fetchedTable->getColumn('flag')->getUnsigned());
-        $this->assertTrue($fetchedTable->getColumn('masks')->getUnsigned());
+        $this->assertEquals('smallint', $fetchedTable->getColumn('small')->getType()->getName());
+        $this->assertEquals('smallint', $fetchedTable->getColumn('small_unsigned')->getType()->getName());
+        $this->assertEquals('integer', $fetchedTable->getColumn('medium')->getType()->getName());
+        $this->assertEquals('integer', $fetchedTable->getColumn('medium_unsigned')->getType()->getName());
+        $this->assertEquals('integer', $fetchedTable->getColumn('integer')->getType()->getName());
+        $this->assertEquals('integer', $fetchedTable->getColumn('integer_unsigned')->getType()->getName());
+        $this->assertEquals('bigint', $fetchedTable->getColumn('big')->getType()->getName());
+        $this->assertEquals('bigint', $fetchedTable->getColumn('big_unsigned')->getType()->getName());
+
+        $this->assertTrue($fetchedTable->getColumn('small_unsigned')->getUnsigned());
+        $this->assertTrue($fetchedTable->getColumn('medium_unsigned')->getUnsigned());
+        $this->assertTrue($fetchedTable->getColumn('integer_unsigned')->getUnsigned());
+        $this->assertTrue($fetchedTable->getColumn('big_unsigned')->getUnsigned());
+
+        $this->assertFalse($fetchedTable->getColumn('small')->getUnsigned());
+        $this->assertFalse($fetchedTable->getColumn('medium')->getUnsigned());
+        $this->assertFalse($fetchedTable->getColumn('integer')->getUnsigned());
+        $this->assertFalse($fetchedTable->getColumn('big')->getUnsigned());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -63,6 +63,90 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $this->assertTrue($this->_platform->prefersIdentityColumns());
     }
 
+    /**
+     * @group DBAL-752
+     */
+    public function testGeneratesTypeDeclarationForTinyIntegers()
+    {
+        $this->assertEquals(
+            'TINYINT',
+            $this->_platform->getTinyIntTypeDeclarationSQL(array())
+        );
+        $this->assertEquals(
+            'TINYINT',
+            $this->_platform->getTinyIntTypeDeclarationSQL(array('autoincrement' => true))
+        );
+        $this->assertEquals(
+            'TINYINT',
+            $this->_platform->getTinyIntTypeDeclarationSQL(
+                array('autoincrement' => true, 'primary' => true))
+        );
+        $this->assertEquals(
+            'TINYINT',
+            $this->_platform->getTinyIntTypeDeclarationSQL(array('unsigned' => false))
+        );
+        $this->assertEquals(
+            'TINYINT UNSIGNED',
+            $this->_platform->getTinyIntTypeDeclarationSQL(array('unsigned' => true))
+        );
+    }
+
+    /**
+     * @group DBAL-752
+     */
+    public function testGeneratesTypeDeclarationForSmallIntegers()
+    {
+        $this->assertEquals(
+            'SMALLINT',
+            $this->_platform->getSmallIntTypeDeclarationSQL(array())
+        );
+        $this->assertEquals(
+            'SMALLINT',
+            $this->_platform->getSmallIntTypeDeclarationSQL(array('autoincrement' => true))
+        );
+        $this->assertEquals(
+            'SMALLINT',
+            $this->_platform->getSmallIntTypeDeclarationSQL(
+                array('autoincrement' => true, 'primary' => true))
+        );
+        $this->assertEquals(
+            'SMALLINT',
+            $this->_platform->getSmallIntTypeDeclarationSQL(array('unsigned' => false))
+        );
+        $this->assertEquals(
+            'SMALLINT UNSIGNED',
+            $this->_platform->getSmallIntTypeDeclarationSQL(array('unsigned' => true))
+        );
+    }
+
+    /**
+     * @group DBAL-752
+     */
+    public function testGeneratesTypeDeclarationForMediumIntegers()
+    {
+        $this->assertEquals(
+            'MEDIUMINT',
+            $this->_platform->getMediumIntTypeDeclarationSQL(array())
+        );
+        $this->assertEquals(
+            'MEDIUMINT',
+            $this->_platform->getMediumIntTypeDeclarationSQL(array('autoincrement' => true))
+        );
+        $this->assertEquals(
+            'MEDIUMINT',
+            $this->_platform->getMediumIntTypeDeclarationSQL(
+                array('autoincrement' => true, 'primary' => true))
+        );
+        $this->assertEquals(
+            'MEDIUMINT',
+            $this->_platform->getMediumIntTypeDeclarationSQL(array('unsigned' => false))
+        );
+        $this->assertEquals(
+            'MEDIUMINT UNSIGNED',
+            $this->_platform->getMediumIntTypeDeclarationSQL(array('unsigned' => true))
+        );
+    }
+
     public function testGeneratesTypeDeclarationForIntegers()
     {
         $this->assertEquals(
@@ -77,6 +161,42 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'INTEGER',
             $this->_platform->getIntegerTypeDeclarationSQL(
                 array('autoincrement' => true, 'primary' => true))
+        );
+        $this->assertEquals(
+            'INTEGER',
+            $this->_platform->getIntegerTypeDeclarationSQL(array('unsigned' => false))
+        );
+        $this->assertEquals(
+            'INTEGER UNSIGNED',
+            $this->_platform->getIntegerTypeDeclarationSQL(array('unsigned' => true))
+        );
+    }
+
+    /**
+     * @group DBAL-752
+     */
+    public function testGeneratesTypeDeclarationForBigIntegers()
+    {
+        $this->assertEquals(
+            'BIGINT',
+            $this->_platform->getBigIntTypeDeclarationSQL(array())
+        );
+        $this->assertEquals(
+            'BIGINT',
+            $this->_platform->getBigIntTypeDeclarationSQL(array('autoincrement' => true))
+        );
+        $this->assertEquals(
+            'BIGINT',
+            $this->_platform->getBigIntTypeDeclarationSQL(
+                array('autoincrement' => true, 'primary' => true))
+        );
+        $this->assertEquals(
+            'BIGINT',
+            $this->_platform->getBigIntTypeDeclarationSQL(array('unsigned' => false))
+        );
+        $this->assertEquals(
+            'BIGINT UNSIGNED',
+            $this->_platform->getBigIntTypeDeclarationSQL(array('unsigned' => true))
         );
     }
 


### PR DESCRIPTION
This PR is complementary to https://github.com/doctrine/dbal/commit/6bd046d3bb1212bfd2808368a7143c9d95e3c157 and fixes also the type declaration SQL for integers on SQLite.
