### PR TITLE
Fix unique indexes in CREATE TABLE statements on SQL Anywhere

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -1266,12 +1266,8 @@ class SQLAnywherePlatform extends AbstractPlatform
 
         if ( ! empty($options['indexes'])) {
             /** @var \Doctrine\DBAL\Schema\Index $index */
-            foreach ((array) $options['indexes'] as $name => $index) {
-                if ($index->isUnique()) {
-                    $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($name, $index);
-                } else {
-                    $indexSql[] = $this->getCreateIndexSQL($index, $tableName);
-                }
+            foreach ((array) $options['indexes'] as $index) {
+                $indexSql[] = $this->getCreateIndexSQL($index, $tableName);
             }
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -52,7 +52,8 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     public function getGenerateTableWithMultiColumnUniqueIndexSql()
     {
         return array(
-            'CREATE TABLE test (foo VARCHAR(255) DEFAULT NULL, bar VARCHAR(255) DEFAULT NULL, CONSTRAINT UNIQ_D87F7E0C8C73652176FF8CAA UNIQUE (foo, bar))',
+            'CREATE TABLE test (foo VARCHAR(255) DEFAULT NULL, bar VARCHAR(255) DEFAULT NULL)',
+            'CREATE UNIQUE INDEX UNIQ_D87F7E0C8C73652176FF8CAA ON test (foo, bar)'
         );
     }
 


### PR DESCRIPTION
SQL Anywhere seems to distinguish between unique indexes and unique constraints. Unique constraints do not allow `NULL` values while unique indexes do.

_A UNIQUE constraint is not the same as a unique index. Columns of a unique index are allowed to be NULL, while columns in a UNIQUE constraint are not. Also, a foreign key can reference either a primary key or a UNIQUE constraint, but cannot reference a unique index since a unique index can include multiple instances of NULL._

The current implementation create unique constraints instead of unique indexes during `CREATE TABLE` statements which causes ORM to fail as all nullable columns in a unique constraint silently get converted to `NOT NULL`.
This PR replace unique constraints by unique indexes in `CREATE TABLE`.
