### PR TITLE
Fix table lock hints on SQL Anywhere

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -60,26 +60,22 @@ class SQLAnywherePlatform extends AbstractPlatform
 
     /**
      * {@inheritdoc}
-     *
-     * @throws \InvalidArgumentException
      */
     public function appendLockHint($fromClause, $lockMode)
     {
         switch (true) {
             case $lockMode === LockMode::NONE:
-                $lockClause = ' WITH (NOLOCK)';
-                break;
-            case $lockMode === LockMode::PESSIMISTIC_READ:
-                $lockClause = ' WITH (UPDLOCK)';
-                break;
-            case $lockMode === LockMode::PESSIMISTIC_WRITE:
-                $lockClause = ' WITH (XLOCK)';
-                break;
-            default:
-                throw new \InvalidArgumentException('Invalid lock mode: ' . $lockMode);
-        }
+                return $fromClause . ' WITH (NOLOCK)';
 
-        return $fromClause . $lockClause;
+            case $lockMode === LockMode::PESSIMISTIC_READ:
+                return $fromClause . ' WITH (UPDLOCK)';
+
+            case $lockMode === LockMode::PESSIMISTIC_WRITE:
+                return $fromClause . ' WITH (XLOCK)';
+
+            default:
+                return $fromClause;
+        }
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -220,29 +220,28 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
         );
     }
 
-    public function testAppendsLockHints()
+    /**
+     * @dataProvider getLockHints
+     */
+    public function testAppendsLockHint($lockMode, $lockHint)
     {
-        $fromClause = 'SELECT * FROM lock_hints';
+        $fromClause = 'FROM users';
+        $expectedResult = $fromClause . $lockHint;
 
-        $this->assertEquals(
-            $fromClause . ' WITH (NOLOCK)',
-            $this->_platform->appendLockHint($fromClause, LockMode::NONE)
-        );
-        $this->assertEquals(
-            $fromClause . ' WITH (UPDLOCK)',
-            $this->_platform->appendLockHint($fromClause, LockMode::PESSIMISTIC_READ)
-        );
-        $this->assertEquals(
-            $fromClause . ' WITH (XLOCK)',
-            $this->_platform->appendLockHint($fromClause, LockMode::PESSIMISTIC_WRITE)
-        );
+        $this->assertSame($expectedResult, $this->_platform->appendLockHint($fromClause, $lockMode));
     }
 
-    public function testCannotAppendInvalidLockHint()
+    public function getLockHints()
     {
-        $this->setExpectedException('\InvalidArgumentException');
-
-        $this->_platform->appendLockHint('SELECT * FROM lock_hints', 'invalid_lock_mode');
+        return array(
+            array(null, ''),
+            array(false, ''),
+            array(true, ''),
+            array(LockMode::NONE, ' WITH (NOLOCK)'),
+            array(LockMode::OPTIMISTIC, ''),
+            array(LockMode::PESSIMISTIC_READ, ' WITH (UPDLOCK)'),
+            array(LockMode::PESSIMISTIC_WRITE, ' WITH (XLOCK)'),
+        );
     }
 
     public function testHasCorrectMaxIdentifierLength()


### PR DESCRIPTION
`SQLAnywherePlatform::appendLockHint()` should not throw an exception if an unknown lock mode is given but rather return the unmodified `FROM` clause instead. This is especially required for ORM to work as it passes `null` by default which currently causes SQL Anywhere platform to throw an exception.
