### PR TITLE
Exclude HHVM + PostgreSQL build matrix on Travis for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
     - php: hhvm
   exclude:
       - php: hhvm
-        env: DB=pgsql  # driver currently unsupported by HHVM
+        env: DB=pgsql POSTGRESQL_VERSION=9.1 # driver currently unsupported by HHVM
+      - php: hhvm
+        env: DB=pgsql POSTGRESQL_VERSION=9.2 # driver currently unsupported by HHVM
+      - php: hhvm
+        env: DB=pgsql POSTGRESQL_VERSION=9.3 # driver currently unsupported by HHVM
       - php: hhvm
         env: DB=mysqli # driver currently unsupported by HHVM


### PR DESCRIPTION
PR #498 introduced an extended build matrix for different PostgreSQL versions on Travis which should be excluded for HHVM as it does not currently support PostgreSQL.
