### PR TITLE
Create the online table before listing it.

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -250,6 +250,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         }
 
         $offlineTable = $this->createListTableColumns();
+        $this->_sm->dropAndCreateTable($offlineTable);
         $onlineTable = $this->_sm->listTableDetails('list_table_columns');
 
         $comparator = new \Doctrine\DBAL\Schema\Comparator();


### PR DESCRIPTION
`phpunit --filter testDiffListTableColumns` fails because the test is currently relying on another test to have created the list_table_columns table.

It also fails in our driver, which is now packaged separately and so runs a slightly different test order.

I assume that was not the intention when the test was created. So, this branch adds the CREATE TABLE.
