### PR TITLE
Fix modifying limit/offset for statements with subqueries on SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1145,9 +1145,17 @@ class SQLServerPlatform extends AbstractPlatform
         $query   = preg_replace('/\s+ORDER\s+BY\s+([^\)]*)/', '', $query); //Remove ORDER BY from $query
         $format  = 'SELECT * FROM (%s) AS doctrine_tbl WHERE doctrine_rownum BETWEEN %d AND %d';
 
+        // Pattern to match "main" SELECT ... FROM clause (including nested parentheses in select list).
+        $selectFromPattern = '/^(\s*SELECT\s+(?:\((?>[^()]+)|(?:R)*\)|[^(])+)\sFROM\s/i';
+
         if ( ! $orderBy) {
-            //Replace only first occurrence of FROM with OVER to prevent changing FROM also in subqueries.
-            $query = preg_replace('/\sFROM\s/i', ', ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS doctrine_rownum FROM ', $query, 1);
+            //Replace only "main" FROM with OVER to prevent changing FROM also in subqueries.
+            $query = preg_replace(
+                $selectFromPattern,
+                '$1, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS doctrine_rownum FROM ',
+                $query,
+                1
+            );
 
             return sprintf($format, $query, $start, $end);
         }
@@ -1197,7 +1205,7 @@ class SQLServerPlatform extends AbstractPlatform
 
         //Replace only first occurrence of FROM with $over to prevent changing FROM also in subqueries.
         $over  = 'ORDER BY ' . implode(', ', $overColumns);
-        $query = preg_replace('/\sFROM\s/i', ", ROW_NUMBER() OVER ($over) AS doctrine_rownum FROM ", $query, 1);
+        $query = preg_replace($selectFromPattern, "$1, ROW_NUMBER() OVER ($over) AS doctrine_rownum FROM ", $query, 1);
 
         return sprintf($format, $query, $start, $end);
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
@@ -102,6 +102,20 @@ class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertLimitResult(array(2), $sql, 1, 1);
     }
 
+    public function testModifyLimitQuerySubSelect()
+    {
+        $this->_conn->insert('modify_limit_table', array('test_int' => 1));
+        $this->_conn->insert('modify_limit_table', array('test_int' => 2));
+        $this->_conn->insert('modify_limit_table', array('test_int' => 3));
+        $this->_conn->insert('modify_limit_table', array('test_int' => 4));
+
+        $sql = "SELECT *, (SELECT COUNT(*) FROM modify_limit_table) AS cnt FROM modify_limit_table";
+
+        $this->assertLimitResult(array(4, 3, 2, 1), $sql, 10, 0, false);
+        $this->assertLimitResult(array(4, 3), $sql, 2, 0, false);
+        $this->assertLimitResult(array(2, 1), $sql, 2, 2, false);
+    }
+
     public function assertLimitResult($expectedResults, $sql, $limit, $offset, $deterministic = true)
     {
         $p = $this->_conn->getDatabasePlatform();


### PR DESCRIPTION
`SELECT` statements that contains subqueries in the `SELECT` clause do not get properly rewritten with a limit and/or offset applied to it resulting in wrong SQL.

**Example**

``` sql
SELECT foo.id, (SELECT COUNT(*) FROM bar) AS bar_count FROM foo
```

**Expected with a limit of 10**

``` sql
SELECT * FROM (SELECT foo.id, (SELECT COUNT(*) FROM bar) AS bar_count, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS doctrine_rownum FROM foo) AS doctrine_tbl WHERE doctrine_rownum BETWEEN 1 AND 10
```

**Actual with a limit of 10**

``` sql
SELECT * FROM (SELECT foo.id, (SELECT COUNT(*), ROW_NUMBER() OVER (ORDER BY (SELECT 0))  AS doctrine_rownum FROM bar) AS bar_count FROM foo) AS doctrine_tbl WHERE doctrine_rownum BETWEEN 1 AND 10
```

The `ROW_NUMBER() OVER` clause is misplaced into the subselect instead of into the main `FROM` clause.
What this PR does is recursively matching any (nested) parentheses inside the main `SELECT` clause to be able to identify the main `FROM` clause to add the `ROW_NUMBER() OVER` clause to.
This of course is far from perfect for matching all kinds of possible `SELECT` statement syntaxes but it fixes this particular issue, which is pretty common IMO.
