### PR TITLE
The primary key columns don't have to be in the same order as the table columns

### DIFF
--- a/docs/en/reference/known-vendor-issues.rst
+++ b/docs/en/reference/known-vendor-issues.rst
@@ -95,6 +95,14 @@ DateTimeTz
 Sqlite does not support saving timezones or offsets. The DateTimeTz
 type therefore behave like the DateTime type.
 
+Reverse engineering primary key order
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+SQLite versions < 3.7.16 only return that a column is part of the primary key,
+but not the order. This is only a problem with tables where the order of the
+columns in the table is not the same as the order in the primary key. Tables
+created with Doctrine use the order of the columns as defined in the primary
+key.
+
 IBM DB2
 -------
 

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -167,6 +167,15 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $stmt = $this->_conn->executeQuery("PRAGMA TABLE_INFO ('$tableName')");
         $indexArray = $stmt->fetchAll(\PDO::FETCH_ASSOC);
         usort($indexArray, function($a, $b) {
+            if ($a['pk'] == $b['pk']) {
+                return $a['cid'] - $b['cid'];
+            }
+            if ($a['pk'] == "0" && $b['pk'] != "0") {
+                return 1;
+            }
+            if ($a['pk'] != "0" && $b['pk'] == "0") {
+                return -1;
+            }
             return $a['pk'] - $b['pk'];
         });
         foreach ($indexArray as $indexColumnRow) {

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -166,9 +166,12 @@ class SqliteSchemaManager extends AbstractSchemaManager
         // fetch primary
         $stmt = $this->_conn->executeQuery("PRAGMA TABLE_INFO ('$tableName')");
         $indexArray = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        usort($indexArray, function($a, $b) {
+            return $a['pk'] - $b['pk'];
+        });
         foreach ($indexArray as $indexColumnRow) {
             if ($indexColumnRow['pk'] != "0") {
-                $indexBuffer[$indexColumnRow['pk']] = array(
+                $indexBuffer[] = array(
                     'key_name' => 'primary',
                     'primary' => true,
                     'non_unique' => false,
@@ -176,7 +179,6 @@ class SqliteSchemaManager extends AbstractSchemaManager
                 );
             }
         }
-        ksort($indexBuffer);
 
         // fetch regular indexes
         foreach ($tableIndexes as $tableIndex) {

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -168,7 +168,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $indexArray = $stmt->fetchAll(\PDO::FETCH_ASSOC);
         foreach ($indexArray as $indexColumnRow) {
             if ($indexColumnRow['pk'] != "0") {
-                $indexBuffer[] = array(
+                $indexBuffer[$indexColumnRow['pk']] = array(
                     'key_name' => 'primary',
                     'primary' => true,
                     'non_unique' => false,
@@ -176,6 +176,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
                 );
             }
         }
+        ksort($indexBuffer);
 
         // fetch regular indexes
         foreach ($tableIndexes as $tableIndex) {

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -170,12 +170,6 @@ class SqliteSchemaManager extends AbstractSchemaManager
             if ($a['pk'] == $b['pk']) {
                 return $a['cid'] - $b['cid'];
             }
-            if ($a['pk'] == "0" && $b['pk'] != "0") {
-                return 1;
-            }
-            if ($a['pk'] != "0" && $b['pk'] == "0") {
-                return -1;
-            }
             return $a['pk'] - $b['pk'];
         });
         foreach ($indexArray as $indexColumnRow) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -93,4 +93,23 @@ EOS
         $this->assertInstanceOf('Doctrine\DBAL\Types\BlobType', $table->getColumn('column_binary')->getType());
         $this->assertFalse($table->getColumn('column_binary')->getFixed());
     }
+
+    public function testNonDefaultPKOrder()
+    {
+        $this->_conn->executeQuery(<<<EOS
+CREATE TABLE non_default_pk_order (
+    id INTEGER,
+    other_id INTEGER,
+    PRIMARY KEY(other_id, id)
+)
+EOS
+        );
+
+        $tableIndexes = $this->_sm->listTableIndexes('non_default_pk_order');
+
+         $this->assertEquals(1, count($tableIndexes));
+
+        $this->assertArrayHasKey('primary', $tableIndexes, 'listTableIndexes() has to return a "primary" array key.');
+        $this->assertEquals(array('other_id', 'id'), array_map('strtolower', $tableIndexes['primary']->getColumns()));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -96,6 +96,10 @@ EOS
 
     public function testNonDefaultPKOrder()
     {
+        $version = \SQLite3::version();
+        if(version_compare($version['versionString'], '3.7.16', '<')) {
+            $this->markTestSkipped('This version of sqlite doesn\'t return the order of the Primary Key.');
+        }
         $this->_conn->executeQuery(<<<EOS
 CREATE TABLE non_default_pk_order (
     id INTEGER,


### PR DESCRIPTION
This happens when the columns are created in a different order then in the PK. This doesn't happen with Doctrine, as the order is taken from the PK.
