### PR TITLE
Fix method signature in Doctrine\DBAL\Driver\Connection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -24,6 +24,32 @@ connection parameter to explicitly specify the ``Doctrine\DBAL\Driver\PDOIbm\Dri
 However be aware that you are doing this at your own risk and it will not be guaranteed that
 Doctrine will work as expected.
 
+## Signature for method ``prepare`` changed for Connections
+
+An optionnal parameter: ``$driverOptions = array()`` has been added in the interface ``Doctrine\DBAL\Connection`` (in order to make ``Doctrine\DBAL\Driver\PDOConnection`` compatible with this interface). So the following class have been modified to reflect this change:
+
+- Doctrine\DBAL\Driver\Connection
+- Doctrine\Tests\Mocks\DriverConnectionMock
+- Doctrine\DBAL\Connections\MasterSlaveConnection
+- Doctrine\DBAL\Portability\Connection
+- Doctrine\DBAL\Driver\Mysqli\MysqliConnection
+- Doctrine\DBAL\Driver\IBMDB2\DB2Connection
+- Doctrine\DBAL\Driver\OCI8\OCI8Connection
+- Doctrine\DBAL\Driver\SQLAnywhere\SQLAnywhereConnection
+- Doctrine\DBAL\Driver\SQLSrv\SQLSrvConnection
+
+If you extends the method ``prepare`` of one of those class, or if you implement the interface ``Doctrine\DBAL\Connection`` be sure to add the ``$driverOptions = array()`` parameter in you custom code.
+
+Before:
+```php
+function prepare($prepareString) {
+```
+
+After:
+```php
+function prepare($prepareString, $driverOptions = array()) {
+```
+
 # Upgrade to 2.4
 
 ## Doctrine\DBAL\Schema\Constraint

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,7 +26,7 @@ Doctrine will work as expected.
 
 ## Signature for method ``prepare`` changed for Connections
 
-An optionnal parameter: ``$driverOptions = array()`` has been added in the interface ``Doctrine\DBAL\Connection`` (in order to make ``Doctrine\DBAL\Driver\PDOConnection`` compatible with this interface). So the following class have been modified to reflect this change:
+An optional parameter: ``$driverOptions = array()`` has been added in the interface ``Doctrine\DBAL\Connection`` (in order to make ``Doctrine\DBAL\Driver\PDOConnection`` compatible with this interface). So the following class have been modified to reflect this change:
 
 - Doctrine\DBAL\Driver\Connection
 - Doctrine\Tests\Mocks\DriverConnectionMock

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -693,12 +693,13 @@ class Connection implements DriverConnection
      * Prepares an SQL statement.
      *
      * @param string $statement The SQL statement to prepare.
+     * @param array  $driverOptions
      *
      * @return \Doctrine\DBAL\Driver\Statement The prepared statement.
      *
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function prepare($statement)
+    public function prepare($statement, $driverOptions = array())
     {
         $this->connect();
 

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -367,10 +367,10 @@ class MasterSlaveConnection extends Connection
     /**
      * {@inheritDoc}
      */
-    public function prepare($statement)
+    public function prepare($statement, $driverOptions = array())
     {
         $this->connect('master');
 
-        return parent::prepare($statement);
+        return parent::prepare($statement, $driverOptions);
     }
 }

--- a/lib/Doctrine/DBAL/Driver/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/Connection.php
@@ -33,10 +33,11 @@ interface Connection
      * Prepares a statement for execution and returns a Statement object.
      *
      * @param string $prepareString
+     * @param array  $driverOptions
      *
      * @return \Doctrine\DBAL\Driver\Statement
      */
-    function prepare($prepareString);
+    function prepare($prepareString, $driverOptions = array());
 
     /**
      * Executes an SQL statement, returning a result set as a Statement object.
@@ -53,7 +54,7 @@ interface Connection
      *
      * @return string
      */
-    function quote($input, $type=\PDO::PARAM_STR);
+    function quote($input, $type = \PDO::PARAM_STR);
 
     /**
      * Executes an SQL statement and return the number of affected rows.

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -53,9 +53,9 @@ class DB2Connection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function prepare($sql)
+    public function prepare($sql, $driverOptions = array())
     {
-        $stmt = @db2_prepare($this->_conn, $sql);
+        $stmt = @db2_prepare($this->_conn, $sql, $driverOptions);
         if ( ! $stmt) {
             throw new DB2Exception(db2_stmt_errormsg());
         }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -81,7 +81,7 @@ class MysqliConnection implements Connection, PingableConnection
     /**
      * {@inheritdoc}
      */
-    public function prepare($prepareString)
+    public function prepare($prepareString, $driverOptions = array())
     {
         return new MysqliStatement($this->_conn, $prepareString);
     }
@@ -101,7 +101,7 @@ class MysqliConnection implements Connection, PingableConnection
     /**
      * {@inheritdoc}
      */
-    public function quote($input, $type=\PDO::PARAM_STR)
+    public function quote($input, $type = \PDO::PARAM_STR)
     {
         return "'". $this->_conn->escape_string($input) ."'";
     }

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -69,7 +69,7 @@ class OCI8Connection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function prepare($prepareString)
+    public function prepare($prepareString, $driverOptions = array())
     {
         return new OCI8Statement($this->dbh, $prepareString, $this);
     }

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -142,7 +142,7 @@ class SQLAnywhereConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function prepare($prepareString)
+    public function prepare($prepareString, $driverOptions = array())
     {
         return new SQLAnywhereStatement($this->connection, $prepareString);
     }

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -61,7 +61,7 @@ class SQLSrvConnection implements Connection
     /**
      * {@inheritDoc}
      */
-    public function prepare($sql)
+    public function prepare($sql, $driverOptions = array())
     {
         return new SQLSrvStatement($this->conn, $sql, $this->lastInsertId);
     }

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -127,9 +127,9 @@ class Connection extends \Doctrine\DBAL\Connection
     /**
      * {@inheritdoc}
      */
-    public function prepare($statement)
+    public function prepare($statement, $driverOptions = array())
     {
-        $stmt = new Statement(parent::prepare($statement), $this);
+        $stmt = new Statement(parent::prepare($statement, $driverOptions), $this);
         $stmt->setFetchMode($this->defaultFetchMode);
 
         return $stmt;

--- a/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
@@ -4,9 +4,9 @@ namespace Doctrine\Tests\Mocks;
 
 class DriverConnectionMock implements \Doctrine\DBAL\Driver\Connection
 {
-    public function prepare($prepareString) {}
+    public function prepare($prepareString, $driverOptions = array()) {}
     public function query() {}
-    public function quote($input, $type=\PDO::PARAM_STR) {}
+    public function quote($input, $type = \PDO::PARAM_STR) {}
     public function exec($statement) {}
     public function lastInsertId($name = null) {}
     public function beginTransaction() {}


### PR DESCRIPTION
The method `prepare` must have an optional driverOptions parameter to be compatible with class which implement the interface Doctrine\DBAL\Driver\Connection.

To avoid this problem:

HipHop Fatal error: Declaration of Doctrine\DBAL\Driver\PDOConnection::prepare() must be compatible with that of Doctrine\DBAL\Driver\Connection::prepare() in /home/travis/build/symfony/symfony/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php on line 30
