### PR TITLE
Improve readability of EchoSQLLogger output format

### DIFF
--- a/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
+++ b/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
@@ -39,10 +39,15 @@ class EchoSQLLogger implements SQLLogger
         echo $sql . PHP_EOL;
 
         if ($params) {
-            var_dump($params);
-        }
+            $dump = $params;
+            if ($types)
+                foreach ($params as $index => $param) {
+                    $dump[$types[$index] . " index: " . $index] = $param;
+                    unset($dump[$index]);
+                }
 
-        if ($types) {
+            var_dump($dump);
+    	} else if ($types) {
             var_dump($types);
         }
     }


### PR DESCRIPTION
When using EchoSQLLogger, the output format is a bit clumsy, and can be very hard to interpret. Here is just a fix to condensate a bit the output format when parameters and types are available.

Before:

```
array(4) {
  [0] =>
  array(1) {
    'NaPingSchd' =>
    int(2)
  }
  [1] =>
  int(60)
  [2] =>
  int(43200)
  [3] =>
  int(110)
}
array(4) {
  [0] =>
  string(3) "map"
  [1] =>
  string(7) "integer"
  [2] =>
  string(7) "integer"
  [3] =>
  string(7) "integer"
}
```

After:

```
array(4) {
  'map index: 0' =>
  array(1) {
    'NaPingSchd' =>
    int(2)
  }
  'integer index: 1' =>
  int(60)
  'integer index: 2' =>
  int(43200)
  'integer index: 3' =>
  int(110)
}
```
