### PR TITLE
Added flags support for mysqli::real_connect in Mysqli driver.

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -29,14 +29,14 @@ use Doctrine\DBAL\Driver\PingableConnection;
 class MysqliConnection implements Connection, PingableConnection
 {
     /**
+     * Name of the option to set connection flags
+     */
+    const OPTION_FLAGS = 'flags';
+
+    /**
      * @var \mysqli
      */
     private $_conn;
-
-    /**
-     * @var string
-     */
-    private $flagsOptionName = 'flags';
 
     /**
      * @param array  $params
@@ -51,7 +51,7 @@ class MysqliConnection implements Connection, PingableConnection
         $port = isset($params['port']) ? $params['port'] : ini_get('mysqli.default_port');
         $socket = isset($params['unix_socket']) ? $params['unix_socket'] : ini_get('mysqli.default_socket');
 
-        $flags = isset($driverOptions[$this->flagsOptionName]) ? $driverOptions[$this->flagsOptionName] : null;
+        $flags = isset($driverOptions[static::OPTION_FLAGS]) ? $driverOptions[static::OPTION_FLAGS] : null;
 
         $this->_conn = mysqli_init();
 
@@ -197,7 +197,7 @@ class MysqliConnection implements Connection, PingableConnection
 
         foreach ($driverOptions as $option => $value) {
 
-            if ($option === $this->flagsOptionName) {
+            if ($option === static::OPTION_FLAGS) {
                 continue;
             }
 


### PR DESCRIPTION
This is necessary if you want to set connection options like compression or SSL encryption.

Recently I wanted to use DBAL with Mysqli driver and I noticed that there is no possibility to enable connection compression, which is done in mysqli by setting flags to mysqli::real_connect. DBAL Mysqli driver lacks support for setting any flag, so I decided to propose my change to add such possibility. 

With my changes you can set flags in that way:

``` php
$connectionParams = array(
    'dbname' => 'mydb',
    'user' => 'user',
    'password' => 'secret',
    'host' => 'localhost',
    'driverClass' => 'Doctrine\DBAL\Driver\Mysqli\Driver',
    'driverOptions' => array(
        'flags' => MYSQLI_CLIENT_COMPRESS
    )
);
```
