### PR TITLE
Add close() method in MasterSlaveConnection.php

### DIFF
--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -284,6 +284,17 @@ class MasterSlaveConnection extends Connection
     /**
      * {@inheritDoc}
      */
+    public function close()
+    {
+        unset($this->connections['master']);
+        unset($this->connections['slave']);
+
+        parent::close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function update($tableName, array $data, array $identifier, array $types = array())
     {
         $this->connect('master');


### PR DESCRIPTION
MasterSlaveConnection would use parent::close() to close connection, and it would close master connection, but slave connection.

That will increase the sqlite connections, and occur the "too many open files" error when I run our test.
