### PR TITLE
added backtrace to query logging

### DIFF
--- a/lib/Doctrine/DBAL/Logging/DebugStack.php
+++ b/lib/Doctrine/DBAL/Logging/DebugStack.php
@@ -62,7 +62,7 @@ class DebugStack implements SQLLogger
     {
         if ($this->enabled) {
             $this->start = microtime(true);
-            $this->queries[++$this->currentQuery] = array('sql' => $sql, 'params' => $params, 'types' => $types, 'executionMS' => 0);
+            $this->queries[++$this->currentQuery] = array('sql' => $sql, 'params' => $params, 'types' => $types, 'executionMS' => 0, 'stacktrace' => debug_backtrace(true));
         }
     }
 

--- a/tests/Doctrine/Tests/DBAL/Logging/DebugStackTest.php
+++ b/tests/Doctrine/Tests/DBAL/Logging/DebugStackTest.php
@@ -19,17 +19,14 @@ class DebugStackTest extends \Doctrine\Tests\DbalTestCase
     public function testLoggedQuery()
     {
         $this->logger->startQuery('SELECT column FROM table');
-        $this->assertEquals(
-            array(
-                1 => array(
-                    'sql' => 'SELECT column FROM table',
-                    'params' => null,
-                    'types' => null,
-                    'executionMS' => 0,
-                ),
-            ),
-            $this->logger->queries
-        );
+        $this->assertTrue(is_array($this->logger->queries));
+        $this->assertTrue(is_array($this->logger->queries[1]));
+        $this->assertEquals('SELECT column FROM table', $this->logger->queries[1]['sql']);
+        $this->assertNull($this->logger->queries[1]['params']);
+        $this->assertNull($this->logger->queries[1]['types']);
+        $this->assertEquals(0, $this->logger->queries[1]['executionMS']);
+        $this->assertTrue(is_array($this->logger->queries[1]['stacktrace']));
+        $this->assertNotEmpty($this->logger->queries[1]['stacktrace']);
 
         $this->logger->stopQuery();
         $this->assertGreaterThan(0, $this->logger->queries[1]['executionMS']);


### PR DESCRIPTION
I've added a stacktrace to each logged query to be able to display it later on. This can help to find out why a query has been executed.
This one is needed for pull request https://github.com/doctrine/DoctrineBundle/pull/275 in doctrine/doctrineBundle.
