### PR TITLE
Json_Array: Convert database null to PHP null instead of empty array

### DIFF
--- a/lib/Doctrine/DBAL/Types/JsonArrayType.php
+++ b/lib/Doctrine/DBAL/Types/JsonArrayType.php
@@ -55,7 +55,7 @@ class JsonArrayType extends Type
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         if ($value === null) {
-            return array();
+            return null;
         }
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;

--- a/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
@@ -45,7 +45,7 @@ class JsonArrayTest extends \Doctrine\Tests\DbalTestCase
 
     public function testJsonNullConvertsToPHPValue()
     {
-        $this->assertSame(array(), $this->type->convertToPHPValue(null, $this->platform));
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
     public function testJsonStringConvertsToPHPValue()


### PR DESCRIPTION
Related to https://github.com/doctrine/doctrine2/pull/968.
