### PR TITLE
unit test to create constraint on forced lowercase table in oracle

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -467,9 +467,12 @@ class OraclePlatform extends AbstractPlatform
      */
     public function getCreateAutoincrementSql($name, $table, $start = 1)
     {
-        $table = strtoupper($table);
-        $name = strtoupper($name);
-
+        if ($table[0] !== '"') {
+            $table = strtoupper($table);
+        }
+        if ($name[0] !== '"') {
+            $name = strtoupper($name);
+        }
         $sql   = array();
 
         $indexName  = $table . '_AI_PK';
@@ -490,6 +493,10 @@ END;';
         $sql[] = $this->getCreateSequenceSQL($sequence);
 
         $triggerName  = $table . '_AI_PK';
+        if ($table[0] === '"') {
+            $triggerName  = '"' . trim($table, '"') . '_AI_PK"';
+        }
+
         $sql[] = 'CREATE TRIGGER ' . $triggerName . '
    BEFORE INSERT
    ON ' . $table . '
@@ -576,7 +583,11 @@ LEFT JOIN user_cons_columns r_cols
      */
     public function getListTableColumnsSQL($table, $database = null)
     {
-        $table = strtoupper($table);
+        if ($table[0] !== '"') {
+            $table = strtoupper($table);
+        } else {
+            $table = trim($table, '"');
+        }
 
         $tabColumnsTableName = "user_tab_columns";
         $colCommentsTableName = "user_col_comments";
@@ -791,6 +802,19 @@ LEFT JOIN user_cons_columns r_cols
      */
     public function getIdentitySequenceName($tableName, $columnName)
     {
+        $quotingRequired = false;
+        if ($tableName[0] === '"') {
+            $tableName  = trim($tableName, '"');
+            $quotingRequired = true;
+        }
+        if ($columnName[0] === '"') {
+            $columnName  = trim($columnName, '"');
+            $quotingRequired = true;
+        }
+
+        if ($quotingRequired) {
+            return '"' . $tableName . '_' . $columnName . '_SEQ"';
+        }
         return $tableName . '_' . $columnName . '_SEQ';
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -102,4 +102,21 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertContains('c##test_create_database', $databases);
     }
+
+    public function testConstraintOnLowercase()
+    {
+        // the identifiers will be quoted before in order to force lowercase names
+        $tableName = $this->_sm->getDatabasePlatform()->quoteIdentifier('oc_storages');
+        $column1 = $this->_sm->getDatabasePlatform()->quoteIdentifier('id');
+        $column2 = $this->_sm->getDatabasePlatform()->quoteIdentifier('numeric_id');
+
+        $table = new Schema\Table($tableName);
+        $table->addColumn($column1, 'string', array('length' => 64));
+        $table->addColumn($column2, 'integer', array('notnull' => true, 'autoincrement' => true));
+
+        $table->setPrimaryKey(array($column1));
+
+        $this->_sm->dropAndCreateTable($table);
+
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -114,9 +114,10 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn($column1, 'string', array('length' => 64));
         $table->addColumn($column2, 'integer', array('notnull' => true, 'autoincrement' => true));
 
-        $table->setPrimaryKey(array($column1));
-
         $this->_sm->dropAndCreateTable($table);
+
+        $columns = $this->_sm->listTableColumns($tableName);
+        $this->assertEquals(2, count($columns));
 
     }
 }


### PR DESCRIPTION
This might be crazy - but this was working in the 2.3.x code basis.

On master as well as 2.4.2 following error is throws:

```
Exception : [Doctrine\DBAL\Exception\TableNotFoundException] An exception occurred while executing 'DECLARE
  constraints_Count NUMBER;
BEGIN
  SELECT COUNT(CONSTRAINT_NAME) INTO constraints_Count FROM USER_CONSTRAINTS WHERE TABLE_NAME = '"OC_STORAGES"' AND CONSTRAINT_TYPE = 'P';
  IF constraints_Count = 0 OR constraints_Count = '' THEN
    EXECUTE IMMEDIATE 'ALTER TABLE "OC_STORAGES" ADD CONSTRAINT "OC_STORAGES_AI_PK" PRIMARY KEY ("NUMERIC_ID")';
  END IF;
END;':

ORA-00942: table or view does not exist
ORA-06512: at line 6

With queries:
6. SQL: 'DECLARE
  constraints_Count NUMBER;
BEGIN
  SELECT COUNT(CONSTRAINT_NAME) INTO constraints_Count FROM USER_CONSTRAINTS WHERE TABLE_NAME = '"OC_STORAGES"' AND CONSTRAINT_TYPE = 'P';
  IF constraints_Count = 0 OR constraints_Count = '' THEN
    EXECUTE IMMEDIATE 'ALTER TABLE "OC_STORAGES" ADD CONSTRAINT "OC_STORAGES_AI_PK" PRIMARY KEY ("NUMERIC_ID")';
  END IF;
END;' Params: 
5. SQL: 'CREATE TABLE "oc_storages" ("id" VARCHAR2(64) NOT NULL, "numeric_id" NUMBER(10) NOT NULL, PRIMARY KEY("id"))' Params: 
4. SQL: 'DROP TABLE "oc_storages"' Params: 
3. SQL: 'DROP TRIGGER "OC_STORAGES"_AI_PK' Params: 
2. SQL: 'ALTER SESSION SET NLS_TIME_FORMAT = 'HH24:MI:SS' NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS' NLS_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH24:MI:SS' NLS_TIMESTAMP_TZ_FORMAT = 'YYYY-MM-DD HH24:MI:SS TZH:TZM' NLS_NUMERIC_CHARACTERS = '.,'' Params: 

Trace:
/home/deepdiver/Development/ownCloud/dbal/lib/Doctrine/DBAL/DBALException.php:116
/home/deepdiver/Development/ownCloud/dbal/lib/Doctrine/DBAL/Connection.php:988
/home/deepdiver/Development/ownCloud/dbal/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php:971
/home/deepdiver/Development/ownCloud/dbal/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php:429
/home/deepdiver/Development/ownCloud/dbal/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php:569
/home/deepdiver/Development/ownCloud/dbal/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php:118

#0 /home/deepdiver/Development/ownCloud/dbal/vendor/phpunit/phpunit/PHPUnit/Framework/TestCase.php(946): Doctrine\Tests\DbalFunctionalTestCase->onNotSuccessfulTest(Object(Doctrine\DBAL\Exception\TableNotFoundException))
#1 /home/deepdiver/Development/ownCloud/dbal/vendor/phpunit/phpunit/PHPUnit/Framework/TestResult.php(648): PHPUnit_Framework_TestCase->runBare()
#2 /home/deepdiver/Development/ownCloud/dbal/vendor/phpunit/phpunit/PHPUnit/Framework/TestCase.php(776): PHPUnit_Framework_TestResult->run(Object(Doctrine\Tests\DBAL\Functional\Schema\OracleSchemaManagerTest))
#3 /home/deepdiver/Development/ownCloud/dbal/vendor/phpunit/phpunit/PHPUnit/Framework/TestSuite.php(775): PHPUnit_Framework_TestCase->run(Object(PHPUnit_Framework_TestResult))
#4 /home/deepdiver/Development/ownCloud/dbal/vendor/phpunit/phpunit/PHPUnit/Framework/TestSuite.php(745): PHPUnit_Framework_TestSuite->runTest(Object(Doctrine\Tests\DBAL\Functional\Schema\OracleSchemaManagerTest), Object(PHPUnit_Framework_TestResult))
#5 /home/deepdiver/Development/ownCloud/dbal/vendor/phpunit/phpunit/PHPUnit/TextUI/TestRunner.php(349): PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult), '/::testConstrai...', Array, Array, false)
#6 /usr/share/php/PHPUnit/TextUI/Command.php(176): PHPUnit_TextUI_TestRunner->doRun(Object(PHPUnit_Framework_TestSuite), Array)
#7 /tmp/ide-phpunit.php(268): PHPUnit_TextUI_Command->run(Array, true)
#8 /tmp/ide-phpunit.php(506): IDE_Base_PHPUnit_TextUI_Command::main()
#9 {main}
```
