### PR TITLE
Allow mysql spatial indexes

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -718,6 +718,8 @@ class MySqlPlatform extends AbstractPlatform
             $type .= 'UNIQUE ';
         } elseif ($index->hasFlag('fulltext')) {
             $type .= 'FULLTEXT ';
+        } elseif ($index->hasFlag('spatial')) {
+            $type .= 'SPATIAL ';
         }
 
         return $type;

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -73,6 +73,8 @@ class MySqlSchemaManager extends AbstractSchemaManager
             }
             if (strpos($v['index_type'], 'FULLTEXT') !== false) {
                 $v['flags'] = array('FULLTEXT');
+            } elseif (strpos($v['index_type'], 'SPATIAL') !== false) {
+                $v['flags'] = array('SPATIAL');
             }
             $tableIndexes[$k] = $v;
         }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -268,6 +268,20 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $this->assertEquals(array('CREATE TABLE fulltext_table (text LONGTEXT NOT NULL, FULLTEXT INDEX fulltext_text (text)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = MyISAM'), $sql);
     }
 
+    public function testCreateTableWithSpatialIndex()
+    {
+        $table = new Table('spatial_table');
+        $table->addOption('engine', 'MyISAM');
+        $table->addColumn('point', 'text'); // This should be a point type
+        $table->addIndex(array('point'), 'spatial_text');
+
+        $index = $table->getIndex('spatial_text');
+        $index->addFlag('spatial');
+
+        $sql = $this->_platform->getCreateTableSQL($table);
+        $this->assertEquals(array('CREATE TABLE spatial_table (point LONGTEXT NOT NULL, SPATIAL INDEX spatial_text (point)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = MyISAM'), $sql);
+    }
+
     public function testClobTypeDeclarationSQL()
     {
         $this->assertEquals('TINYTEXT', $this->_platform->getClobTypeDeclarationSQL(array('length' => 1)));

--- a/tests/Doctrine/Tests/Types/MySqlPointType.php
+++ b/tests/Doctrine/Tests/Types/MySqlPointType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\Tests\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+class MySqlPointType extends Type
+{
+    public function getName()
+    {
+        return 'point';
+    }
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return strtoupper($this->getName());
+    }
+
+    public function getMappedDatabaseTypes(AbstractPlatform $platform)
+    {
+        return array('point');
+    }
+}


### PR DESCRIPTION
Allows spatial indexes via the SPATIAL flag.
http://dev.mysql.com/doc/refman/5.7/en/creating-spatial-indexes.html
