### PR TITLE
ORACLE, (INSTANCE_NAME = XXXXX)

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -193,6 +193,10 @@ pdo\_oci / oci8
    connection pooling.
 -  ``charset`` (string): The charset used when connecting to the
    database.
+-  ``instancename´´ (string): Optional parameter, complete whether to
+   add the INSTANCE_NAME parameter in the connection. It is generally used
+   to connect to an Oracle RAC server to select the name of a particular instance.   
+
 
 pdo\_sqlsrv / sqlsrv
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -193,7 +193,7 @@ pdo\_oci / oci8
    connection pooling.
 -  ``charset`` (string): The charset used when connecting to the
    database.
--  ``instancename´´ (string): Optional parameter, complete whether to
+-  ``instancename`` (string): Optional parameter, complete whether to
    add the INSTANCE_NAME parameter in the connection. It is generally used
    to connect to an Oracle RAC server to select the name of a particular instance.   
 

--- a/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
@@ -130,8 +130,8 @@ abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
                 $service = 'SERVICE_NAME=' . $serviceName;
             }
             
-            if (isset($params['instance_name']) && ! empty($params['instance_name'])) {
-                $instance = '(INSTANCE_NAME = ' . $params['instance_name'] . ')';
+            if (isset($params['instancename']) && ! empty($params['instancename'])) {
+                $instance = '(INSTANCE_NAME = ' . $params['instancename'] . ')';
             }
 
             if (isset($params['pooled']) && $params['pooled'] == true) {

--- a/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
@@ -124,9 +124,14 @@ abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
 
             $service = 'SID=' . $serviceName;
             $pooled  = '';
+            $instance = '';
 
             if (isset($params['service']) && $params['service'] == true) {
                 $service = 'SERVICE_NAME=' . $serviceName;
+            }
+            
+            if (isset($params['instance_name']) && ! empty($params['instance_name'])) {
+                $instance = '(INSTANCE_NAME = ' . $params['instance_name'] . ')';
             }
 
             if (isset($params['pooled']) && $params['pooled'] == true) {
@@ -135,7 +140,7 @@ abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
 
             return '(DESCRIPTION=' .
                      '(ADDRESS=(PROTOCOL=TCP)(HOST=' . $params['host'] . ')(PORT=' . $params['port'] . '))' .
-                     '(CONNECT_DATA=(' . $service . ')' . $pooled . '))';
+                     '(CONNECT_DATA=(' . $service . ')' . $instance . $pooled . '))';
 
         }
 


### PR DESCRIPTION
Hello, first sorry for my English. 
I need to put in the ORACLE Connection string to the parameter: (INSTANCE_NAME = XXXXX) 

I was reading the source code at github and the latest version does not include this possibility in the method getEasyConnectString. 

Could add to the next version an element in the array of parameters, eg $params['instance_name'] and concatenating that value to the Connection string? 

Thank you, greetings 
Facundo Panizza
