### PR TITLE
[DBAL-474] Fix filtering sequence names on PostgreSQL

### DIFF
--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -260,6 +260,32 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritdoc}
      */
+    protected function _getPortableSequencesList($sequences)
+    {
+        $sequenceDefinitions = array();
+
+        foreach ($sequences as $sequence) {
+            if ($sequence['schemaname'] != 'public') {
+                $sequenceName = $sequence['schemaname'] . "." . $sequence['relname'];
+            } else {
+                $sequenceName = $sequence['relname'];
+            }
+
+            $sequenceDefinitions[$sequenceName] = $sequence;
+        }
+
+        $list = array();
+
+        foreach ($this->filterAssetNames(array_keys($sequenceDefinitions)) as $sequenceName) {
+            $list[] = $this->_getPortableSequenceDefinition($sequenceDefinitions[$sequenceName]);
+        }
+
+        return $list;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function _getPortableSequenceDefinition($sequence)
     {
         if ($sequence['schemaname'] != 'public') {

--- a/tests/Doctrine/Tests/DBAL/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/PostgreSQLSchemaManagerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Schema;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Schema\PostgreSqlSchemaManager;
+use Doctrine\DBAL\Schema\Sequence;
+use Doctrine\Tests\DBAL\Mocks;
+
+class PostgreSQLSchemaManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Doctrine\DBAL\Schema\PostgreSQLSchemaManager
+     */
+    private $schemaManager;
+
+    /**
+     * @var \Doctrine\DBAL\Connection|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $connection;
+
+    protected function setUp()
+    {
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $platform = $this->getMock('Doctrine\DBAL\Platforms\PostgreSqlPlatform');
+        $this->connection = $this->getMock(
+            'Doctrine\DBAL\Connection',
+            array(),
+            array(array('platform' => $platform), $driverMock)
+        );
+        $this->schemaManager = new PostgreSqlSchemaManager($this->connection, $platform);
+    }
+
+    /**
+     * @group DBAL-474
+     */
+    public function testFiltersSequences()
+    {
+        $configuration = new Configuration();
+        $configuration->setFilterSchemaAssetsExpression('/^schema/');
+
+        $sequences = array(
+            array('relname' => 'foo', 'schemaname' => 'schema'),
+            array('relname' => 'bar', 'schemaname' => 'schema'),
+            array('relname' => 'baz', 'schemaname' => ''),
+            array('relname' => 'bloo', 'schemaname' => 'bloo_schema'),
+        );
+
+        $this->connection->expects($this->any())
+            ->method('getConfiguration')
+            ->will($this->returnValue($configuration));
+
+        $this->connection->expects($this->at(0))
+            ->method('fetchAll')
+            ->will($this->returnValue($sequences));
+
+        $this->connection->expects($this->at(1))
+            ->method('fetchAll')
+            ->will($this->returnValue(array(array('min_value' => 1, 'increment_by' => 1))));
+
+        $this->connection->expects($this->at(2))
+            ->method('fetchAll')
+            ->will($this->returnValue(array(array('min_value' => 2, 'increment_by' => 2))));
+
+        $this->connection->expects($this->exactly(3))
+            ->method('fetchAll');
+
+        $this->assertEquals(
+            array(
+                new Sequence('schema.foo', 2, 2),
+                new Sequence('schema.bar', 1, 1),
+            ),
+            $this->schemaManager->listSequences('database')
+        );
+    }
+}


### PR DESCRIPTION
The PostgreSQL schema manager has to filter sequence names before actually creating `Sequence` objects to avoid errors on accessing sequence database objects where the user has not enough privileges for.
The reason for this is that retrieving sequence attributes other than the sequence name requires accessing the particular sequence database object directly which requires the connected user to have enough privileges. This might not always be the case if for example a particular user can only access certain schemas but not others.
This patch might not be the best solution but a good compromise IMO. Changing the `AbstractSchemaManager` to filter sequence names before creating `Sequence` objects might affect other platforms and could also perhaps break BC. Furthermore this issue is completely PostgreSQL specific as it is the only currently supported platform not having a sequence's attributes stored directly in the system catalogs (AFAIK).
