### PR TITLE
Fix truncate on MySQL >= 5.5

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -947,4 +947,14 @@ class MySqlPlatform extends AbstractPlatform
 
         return 'LONGBLOB';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTruncateTableSQL($tableName, $cascade = false)
+    {
+        return 'SET FOREIGN_KEY_CHECKS=0;'
+            . parent::getTruncateTableSQL($tableName, $cascade) . ';'
+            . 'SET FOREIGN_KEY_CHECKS=1';
+    }
 }


### PR DESCRIPTION
When truncating tables on MySQL >= 5.5, an error is thrown:

``` mysql
SQLSTATE[42000]: Syntax error or access violation: 
1701 Cannot truncate a table referenced in a foreign key constraint ...
```

It turns out that with MySQL 5.5.7, `TRUNCATE` behaviour has changed. From the [MySQL docs](http://dev.mysql.com/doc/refman/5.5/en/truncate-table.html):

> TRUNCATE TABLE fails for an InnoDB table if there are any FOREIGN KEY constraints from other tables that reference the table. Foreign key constraints between columns of the same table are permitted.

This PR disables foreign key checks just before, and re-enables them just after, truncate.

As I encountered this issue using doctrine/data-fixtures, I originally submitted a fix there: https://github.com/doctrine/data-fixtures/pull/127. However, as @deeky666 pointed out, the DBAL is a better place for the fix.
