### PR TITLE
Foreign key checks on MySQL >= 5.5.7 for TRUNCATE

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/ConfigurablePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/ConfigurablePlatform.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Platforms;
+
+/**
+ * Interface ConfigurablePlatform
+ *
+ * This interface provides a way to inject the connection parameters into the platform.
+ */
+interface ConfigurablePlatform
+{
+    /**
+     * This method will be called in the Connection to pass the Connection parameters if the Platform
+     * implements this interface
+     *
+     * @param array $connectionParams
+     *
+     * @return void
+     */
+    public function setConnectionParams(array $connectionParams);
+}


### PR DESCRIPTION
- Added `ConfigurablePlatform` interface to set the connection
  parameters to the Platform
- Connection is now setting the parameters to the Platform if it
  implements `ConfigurablePlatform`
- `MySQLPlatform::getTruncateSql()` now checks for a new param
  `disable_fk_checks`, if it is true and the version is affected, it
  automatically adds the required SQL.

Additional solution to https://github.com/doctrine/dbal/pull/549

Also see https://github.com/doctrine/data-fixtures/pull/127
