### PR TITLE
[DBAL-843] Fix reverse engineering LOB type column types in MySQL

### DIFF
--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Types\Type;
 
 /**
@@ -146,16 +147,30 @@ class MySqlSchemaManager extends AbstractSchemaManager
                     $length = null;
                 }
                 break;
+            case 'tinytext':
+                $length = MySqlPlatform::LENGTH_LIMIT_TINYTEXT;
+                break;
+            case 'text':
+                $length = MySqlPlatform::LENGTH_LIMIT_TEXT;
+                break;
+            case 'mediumtext':
+                $length = MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT;
+                break;
+            case 'tinyblob':
+                $length = MySqlPlatform::LENGTH_LIMIT_TINYBLOB;
+                break;
+            case 'blob':
+                $length = MySqlPlatform::LENGTH_LIMIT_BLOB;
+                break;
+            case 'mediumblob':
+                $length = MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB;
+                break;
             case 'tinyint':
             case 'smallint':
             case 'mediumint':
             case 'int':
             case 'integer':
             case 'bigint':
-            case 'tinyblob':
-            case 'mediumblob':
-            case 'longblob':
-            case 'blob':
             case 'year':
                 $length = null;
                 break;


### PR DESCRIPTION
This PR fixes reverse engineering the length of `TextType` / `BlobType` columns in MySQL which is important for proper SQL generation of distinct native `TINYTEXT`, `TEXT`, `MEDIUMTEXT`, `LONGTEXT`, `TINYBLOB`, `BLOB`, `MEDIUMBLOB` and `LONGBLOB` types.
