### PR TITLE
Add support string date modifiers for SqlitePlatform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -136,7 +136,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getDateAddHourExpression($date, $hours)
     {
-        return "DATETIME(" . $date . ",'+". $hours . " hour')";
+        return "DATETIME(" . $date . ",'+". $this->prepareDateIntervalParam($hours) . " hour')";
     }
 
     /**
@@ -144,7 +144,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getDateSubHourExpression($date, $hours)
     {
-        return "DATETIME(" . $date . ",'-". $hours . " hour')";
+        return "DATETIME(" . $date . ",'-". $this->prepareDateIntervalParam($hours) . " hour')";
     }
 
     /**
@@ -152,7 +152,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getDateAddDaysExpression($date, $days)
     {
-        return "DATE(" . $date . ",'+". $days . " day')";
+        return "DATE(" . $date . ",'+". $this->prepareDateIntervalParam($days) . " day')";
     }
 
     /**
@@ -160,7 +160,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getDateSubDaysExpression($date, $days)
     {
-        return "DATE(" . $date . ",'-". $days . " day')";
+        return "DATE(" . $date . ",'-". $this->prepareDateIntervalParam($days) . " day')";
     }
 
     /**
@@ -168,7 +168,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getDateAddMonthExpression($date, $months)
     {
-        return "DATE(" . $date . ",'+". $months . " month')";
+        return "DATE(" . $date . ",'+". $this->prepareDateIntervalParam($months) . " month')";
     }
 
     /**
@@ -176,7 +176,12 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getDateSubMonthExpression($date, $months)
     {
-        return "DATE(" . $date . ",'-". $months . " month')";
+        return "DATE(" . $date . ",'-". $this->prepareDateIntervalParam($months) . " month')";
+    }
+
+    protected function prepareDateIntervalParam($param)
+    {
+        return !is_numeric($param) ? "' || ". $param . " || '" : $param;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -405,6 +405,36 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $this->assertEquals($sql, $this->_platform->getAlterTableSQL($diff));
     }
 
+    public function testPrepareDateIntervalStringParamInDateFunctions()
+    {
+        $this->assertEquals(
+            "DATETIME(NOW(),'+' || field || ' hour')",
+            $this->_platform->getDateAddHourExpression("NOW()", "field")
+        );
+        $this->assertEquals(
+            "DATETIME(NOW(),'-' || field || ' hour')",
+            $this->_platform->getDateSubHourExpression("NOW()", "field")
+        );
+
+        $this->assertEquals(
+            "DATE(NOW(),'+' || field || ' day')",
+            $this->_platform->getDateAddDaysExpression("NOW()", "field")
+        );
+        $this->assertEquals(
+            "DATE(NOW(),'-' || field || ' day')",
+            $this->_platform->getDateSubDaysExpression("NOW()", "field")
+        );
+
+        $this->assertEquals(
+            "DATE(NOW(),'+' || field || ' month')",
+            $this->_platform->getDateAddMonthExpression("NOW()", "field")
+        );
+        $this->assertEquals(
+            "DATE(NOW(),'-' || field || ' month')",
+            $this->_platform->getDateSubMonthExpression("NOW()", "field")
+        );
+    }
+
     protected function getQuotedColumnInPrimaryKeySQL()
     {
         return array(


### PR DESCRIPTION
In some cases we need support of non-numeric date(datetime) modifiers. 
For example if we store interval-value-field in the table. Sqlite doesn't support '+field day' modifier. Common solution for this case is concatenate interval to a string: '+' || field || 'day'
