### PR TITLE
Performance improvement on BlobType

### DIFF
--- a/lib/Doctrine/DBAL/Types/BinaryType.php
+++ b/lib/Doctrine/DBAL/Types/BinaryType.php
@@ -47,7 +47,10 @@ class BinaryType extends Type
         }
 
         if (is_string($value)) {
-            $value = fopen('data://text/plain;base64,' . base64_encode($value), 'r');
+            $fp = fopen('php://temp', 'rb+');
+            fwrite($fp, $value);
+            fseek($fp, 0);
+            $value = $fp;
         }
 
         if ( ! is_resource($value)) {

--- a/lib/Doctrine/DBAL/Types/BlobType.php
+++ b/lib/Doctrine/DBAL/Types/BlobType.php
@@ -46,7 +46,10 @@ class BlobType extends Type
         }
 
         if (is_string($value)) {
-            $value = fopen('data://text/plain;base64,' . base64_encode($value), 'r');
+            $fp = fopen('php://temp', 'rb+');
+            fwrite($fp, $value);
+            fseek($fp, 0);
+            $value = $fp;
         }
 
         if ( ! is_resource($value)) {

--- a/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
@@ -9,18 +9,60 @@ require_once __DIR__ . '/../../TestInit.php';
 
 class BlobTest extends \Doctrine\Tests\DbalTestCase
 {
-    protected
-        $_platform,
-        $_type;
+    /**
+     * @var \Doctrine\Tests\DBAL\Mocks\MockPlatform
+     */
+    protected $platform;
 
+    /**
+     * @var \Doctrine\DBAL\Types\BlobType
+     */
+    protected $type;
+
+    /**
+     * {@inheritdoc}
+     */
     protected function setUp()
     {
-        $this->_platform = new \Doctrine\Tests\DBAL\Mocks\MockPlatform();
-        $this->_type = Type::getType('blob');
+        $this->platform = new \Doctrine\Tests\DBAL\Mocks\MockPlatform();
+        $this->type = Type::getType('blob');
     }
 
     public function testBlobNullConvertsToPHPValue()
     {
-        $this->assertNull($this->_type->convertToPHPValue(null, $this->_platform));
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testBinaryStringConvertsToPHPValue()
+    {
+        $databaseValue = $this->getBinaryString();
+        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
+
+        $this->assertInternalType('resource', $phpValue);
+        $this->assertSame($databaseValue, stream_get_contents($phpValue));
+    }
+
+    public function testBinaryResourceConvertsToPHPValue()
+    {
+        $databaseValue = fopen('data://text/plain;base64,' . base64_encode($this->getBinaryString()), 'r');
+        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
+
+        $this->assertSame($databaseValue, $phpValue);
+    }
+
+    /**
+     * Creates a binary string containing all possible byte values.
+     *
+     * @return string
+     */
+    private function getBinaryString()
+    {
+        $string = '';
+
+        for ($i = 0; $i < 256; $i++) {
+            $string .= chr($i);
+        }
+
+        return $string;
     }
 }


### PR DESCRIPTION
I noticed that the `string` to `resource` conversion code in `BlobType` uses a quite inefficient technique.
This PR improves its performance with a simple change involving the `php://temp` stream.

Quick benchmark of the two approaches, converting a 10MB string:

```
$value = str_repeat('x', 10 * 1024 * 1024);

$t = microtime(true);
$fp = fopen('data://text/plain;base64,' . base64_encode($value), 'r');
printf("%.3fs\n", microtime(true) - $t);

$t = microtime(true);
$fp = fopen('php://temp', 'rb+');
fwrite($fp, $value);
fseek($fp, 0);
printf("%.3fs\n", microtime(true) - $t);
```

Results on my laptop:

```
0.090s
0.008s
```

A tenfold improvement!
