### PR TITLE
fix date format on oracle

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -870,7 +870,7 @@ LEFT JOIN user_cons_columns r_cols
      */
     public function getDateFormatString()
     {
-        return 'Y-m-d 00:00:00';
+        return 'd-M-Y';
     }
 
     /**


### PR DESCRIPTION
The expected format for DATE columns is `01-MAR-14`. See http://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#CNCPT413

It also works with `01-Mar-2014` as this PR uses.

We found the problem when trying something like

```
$this->oci8Con->executeQuery(
    'SELECT * FROM table WHERE datefield > ?',
    array(new \DateTime()),
    array(Type::DATE)
);
```

which was raising an oracle error that the date could not be parsed.

The time format in `getTimeFormatString` is also wrong because according to the above doc, times can only be passed by using `TO_DATE('13-AUG-66 12:56 A.M.','DD-MON-YY HH:MI A.M.')`.
So this requires wrapping the SQL with a TO_DATE function.
