### PR TITLE
Fix integer 0 default value reverse engineering on SQL Anywhere

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SQLAnywhereSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLAnywhereSchemaManager.php
@@ -109,7 +109,7 @@ class SQLAnywhereSchemaManager extends AbstractSchemaManager
         $fixed                  = false;
         $default                = null;
 
-        if ($tableColumn['default']) {
+        if (null !== $tableColumn['default']) {
             // Strip quotes from default value.
             $default = preg_replace(array("/^'(.*)'$/", "/''/"), array("$1", "'"), $tableColumn['default']);
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -726,6 +726,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $table->addColumn('column4', 'string', array('default' => 0));
         $table->addColumn('column5', 'string', array('default' => ''));
         $table->addColumn('column6', 'string', array('default' => 'def'));
+        $table->addColumn('column7', 'integer', array('default' => 0));
         $table->setPrimaryKey(array('id'));
 
         $this->_sm->dropAndCreateTable($table);
@@ -739,6 +740,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->assertSame('0', $columns['column4']->getDefault());
         $this->assertSame('', $columns['column5']->getDefault());
         $this->assertSame('def', $columns['column6']->getDefault());
+        $this->assertSame('0', $columns['column7']->getDefault());
 
         $diffTable = clone $table;
 
@@ -748,6 +750,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $diffTable->changeColumn('column4', array('default' => null));
         $diffTable->changeColumn('column5', array('default' => false));
         $diffTable->changeColumn('column6', array('default' => 666));
+        $diffTable->changeColumn('column7', array('default' => null));
 
         $comparator = new Comparator();
 
@@ -761,6 +764,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->assertNull($columns['column4']->getDefault());
         $this->assertSame('', $columns['column5']->getDefault());
         $this->assertSame('666', $columns['column6']->getDefault());
+        $this->assertNull($columns['column7']->getDefault());
     }
 
     public function testListTableWithBinary()


### PR DESCRIPTION
If an integer column was created with a default value of `0`, SQL Anywhere reverse engineers the default value to `null`. This is fixed by this PR.
