### PR TITLE
Fix DateTimeTz type compatibility on SQL Anywhere versions < 12

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -538,6 +538,14 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
+    public function getDateTimeTzFormatString()
+    {
+        return $this->getDateTimeFormatString();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getDateTypeDeclarationSQL(array $fieldDeclaration)
     {
         return 'DATE';

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -592,6 +592,14 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
         $this->_platform->getRegexpExpression();
     }
 
+    public function testHasCorrectDateTimeTzFormatString()
+    {
+        // Date time type with timezone is not supported before version 12.
+        // For versions before we have to ensure that the date time with timezone format
+        // equals the normal date time format so that it corresponds to the declaration SQL equality (datetimetz -> datetime).
+        $this->assertEquals($this->_platform->getDateTimeFormatString(), $this->_platform->getDateTimeTzFormatString());
+    }
+
     public function testHasCorrectDefaultTransactionIsolationLevel()
     {
         $this->assertEquals(


### PR DESCRIPTION
SQL Anywhere versions < 12 do not support a native date time with timezone type. Therefore the fallback strategy is to use the normal date time type. However the format of the date time tz type declaration has to correspond to the normal date time type declaration, too then.

`getDateTimeTzTypeDeclarationSQL()` -> `getDateTimeTypeDeclarationSQL()`
`getDateTimeTzFormatString()` -> `getDateTimeFormatString()`

I thought about changing that in the `AbstractPlatform` but I am not sure if that might break assumptions in userland code and therefore BC. So I left the implementation SQL Anywhere specific.
