### PR TITLE
Fix TRIM expression

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -724,24 +724,31 @@ abstract class AbstractPlatform
      */
     public function getTrimExpression($str, $pos = self::TRIM_UNSPECIFIED, $char = false)
     {
-        $posStr = '';
-        $trimChar = ($char != false) ? $char . ' FROM ' : '';
+        $expression = '';
 
         switch ($pos) {
             case self::TRIM_LEADING:
-                $posStr = 'LEADING '.$trimChar;
+                $expression = 'LEADING ';
                 break;
 
             case self::TRIM_TRAILING:
-                $posStr = 'TRAILING '.$trimChar;
+                $expression = 'TRAILING ';
                 break;
 
             case self::TRIM_BOTH:
-                $posStr = 'BOTH '.$trimChar;
+                $expression = 'BOTH ';
                 break;
         }
 
-        return 'TRIM(' . $posStr . $str . ')';
+        if (false !== $char) {
+            $expression .= $char . ' ';
+        }
+
+        if ($pos || false !== $char) {
+            $expression .= 'FROM ';
+        }
+
+        return 'TRIM(' . $expression . $str . ')';
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -1128,7 +1128,7 @@ class SQLAnywherePlatform extends AbstractPlatform
             }
         }
 
-        $pattern = "'%[^$char]%'";
+        $pattern = "'%[^' + $char + ']%'";
 
         switch ($pos) {
             case self::TRIM_LEADING:

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Functional;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Connection;
 use PDO;
@@ -433,6 +434,63 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $data = $stmt->fetchAll(PDO::FETCH_NUM);
         $this->assertEquals(5, count($data));
         $this->assertEquals(array(array(100), array(101), array(102), array(103), array(104)), $data);
+    }
+
+    /**
+     * @dataProvider getTrimExpressionData
+     */
+    public function testTrimExpression($value, $position, $char, $expectedResult)
+    {
+        $sql = 'SELECT ' .
+            $this->_conn->getDatabasePlatform()->getTrimExpression($value, $position, $char) . ' AS trimmed ' .
+            'FROM fetch_table';
+
+        $row = $this->_conn->fetchAssoc($sql);
+        $row = array_change_key_case($row, CASE_LOWER);
+
+        $this->assertEquals($expectedResult, $row['trimmed']);
+    }
+
+    public function getTrimExpressionData()
+    {
+        return array(
+            array('test_string', AbstractPlatform::TRIM_UNSPECIFIED, false, 'foo'),
+            array('test_string', AbstractPlatform::TRIM_LEADING, false, 'foo'),
+            array('test_string', AbstractPlatform::TRIM_TRAILING, false, 'foo'),
+            array('test_string', AbstractPlatform::TRIM_BOTH, false, 'foo'),
+            array('test_string', AbstractPlatform::TRIM_UNSPECIFIED, "'f'", 'oo'),
+            array('test_string', AbstractPlatform::TRIM_UNSPECIFIED, "'o'", 'f'),
+            array('test_string', AbstractPlatform::TRIM_UNSPECIFIED, "'.'", 'foo'),
+            array('test_string', AbstractPlatform::TRIM_LEADING, "'f'", 'oo'),
+            array('test_string', AbstractPlatform::TRIM_LEADING, "'o'", 'foo'),
+            array('test_string', AbstractPlatform::TRIM_LEADING, "'.'", 'foo'),
+            array('test_string', AbstractPlatform::TRIM_TRAILING, "'f'", 'foo'),
+            array('test_string', AbstractPlatform::TRIM_TRAILING, "'o'", 'f'),
+            array('test_string', AbstractPlatform::TRIM_TRAILING, "'.'", 'foo'),
+            array('test_string', AbstractPlatform::TRIM_BOTH, "'f'", 'oo'),
+            array('test_string', AbstractPlatform::TRIM_BOTH, "'o'", 'f'),
+            array('test_string', AbstractPlatform::TRIM_BOTH, "'.'", 'foo'),
+            array("' foo '", AbstractPlatform::TRIM_UNSPECIFIED, false, 'foo'),
+            array("' foo '", AbstractPlatform::TRIM_LEADING, false, 'foo '),
+            array("' foo '", AbstractPlatform::TRIM_TRAILING, false, ' foo'),
+            array("' foo '", AbstractPlatform::TRIM_BOTH, false, 'foo'),
+            array("' foo '", AbstractPlatform::TRIM_UNSPECIFIED, "'f'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_UNSPECIFIED, "'o'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_UNSPECIFIED, "'.'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_UNSPECIFIED, "' '", 'foo'),
+            array("' foo '", AbstractPlatform::TRIM_LEADING, "'f'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_LEADING, "'o'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_LEADING, "'.'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_LEADING, "' '", 'foo '),
+            array("' foo '", AbstractPlatform::TRIM_TRAILING, "'f'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_TRAILING, "'o'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_TRAILING, "'.'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_TRAILING, "' '", ' foo'),
+            array("' foo '", AbstractPlatform::TRIM_BOTH, "'f'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_BOTH, "'o'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_BOTH, "'.'", ' foo '),
+            array("' foo '", AbstractPlatform::TRIM_BOTH, "' '", 'foo'),
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -568,19 +568,21 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
             $this->_platform->getTrimExpression('column', AbstractPlatform::TRIM_UNSPECIFIED)
         );
         $this->assertEquals(
-            "SUBSTR(column, PATINDEX('%[^c]%', column))",
+            "SUBSTR(column, PATINDEX('%[^' + c + ']%', column))",
             $this->_platform->getTrimExpression('column', AbstractPlatform::TRIM_LEADING, 'c')
         );
         $this->assertEquals(
-            "REVERSE(SUBSTR(REVERSE(column), PATINDEX('%[^c]%', REVERSE(column))))",
+            "REVERSE(SUBSTR(REVERSE(column), PATINDEX('%[^' + c + ']%', REVERSE(column))))",
             $this->_platform->getTrimExpression('column', AbstractPlatform::TRIM_TRAILING, 'c')
         );
         $this->assertEquals(
-            "REVERSE(SUBSTR(REVERSE(SUBSTR(column, PATINDEX('%[^c]%', column))), PATINDEX('%[^c]%', REVERSE(SUBSTR(column, PATINDEX('%[^c]%', column))))))",
+            "REVERSE(SUBSTR(REVERSE(SUBSTR(column, PATINDEX('%[^' + c + ']%', column))), PATINDEX('%[^' + c + ']%', " .
+            "REVERSE(SUBSTR(column, PATINDEX('%[^' + c + ']%', column))))))",
             $this->_platform->getTrimExpression('column', null, 'c')
         );
         $this->assertEquals(
-            "REVERSE(SUBSTR(REVERSE(SUBSTR(column, PATINDEX('%[^c]%', column))), PATINDEX('%[^c]%', REVERSE(SUBSTR(column, PATINDEX('%[^c]%', column))))))",
+            "REVERSE(SUBSTR(REVERSE(SUBSTR(column, PATINDEX('%[^' + c + ']%', column))), PATINDEX('%[^' + c + ']%', " .
+            "REVERSE(SUBSTR(column, PATINDEX('%[^' + c + ']%', column))))))",
             $this->_platform->getTrimExpression('column', AbstractPlatform::TRIM_UNSPECIFIED, 'c')
         );
     }


### PR DESCRIPTION
The `TRIM` expression is broken on SQL Anywhere and while fixing it and writing functional tests for testing the `TRIM` expression on all platforms, I realized that it is seriously broken in `AbstractPlatform`, too.
We have prove now through the tests that it works as expected.
