### PR TITLE
Lower case "order by" keyword causes wrong LIMIT query on SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1150,7 +1150,7 @@ class SQLServerPlatform extends AbstractPlatform
         $start   = $offset + 1;
         $end     = $offset + $limit;
         $orderBy = stristr($query, 'ORDER BY');
-        $query   = preg_replace('/\s+ORDER\s+BY\s+([^\)]*)/', '', $query); //Remove ORDER BY from $query
+        $query   = preg_replace('/\s+ORDER\s+BY\s+([^\)]*)/i', '', $query); //Remove ORDER BY from $query
         $format  = 'SELECT * FROM (%s) AS doctrine_tbl WHERE doctrine_rownum BETWEEN %d AND %d';
 
         // Pattern to match "main" SELECT ... FROM clause (including nested parentheses in select list).
@@ -1169,7 +1169,7 @@ class SQLServerPlatform extends AbstractPlatform
         }
 
         //Clear ORDER BY
-        $orderBy        = preg_replace('/ORDER\s+BY\s+([^\)]*)(.*)/', '$1', $orderBy);
+        $orderBy        = preg_replace('/ORDER\s+BY\s+([^\)]*)(.*)/i', '$1', $orderBy);
         $orderByParts   = explode(',', $orderBy);
         $orderbyColumns = array();
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -190,6 +190,12 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         $sql = $this->_platform->modifyLimitQuery('SELECT * FROM user ORDER BY username ASC', 10);
         $this->assertEquals('SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY username ASC) AS doctrine_rownum FROM user) AS doctrine_tbl WHERE doctrine_rownum BETWEEN 1 AND 10', $sql);
     }
+    
+    public function testModifyLimitQueryWithLowercaseOrderBy()
+    {
+        $sql = $this->_platform->modifyLimitQuery('SELECT * FROM user order by username', 10);
+        $this->assertEquals('SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY username) AS doctrine_rownum FROM user) AS doctrine_tbl WHERE doctrine_rownum BETWEEN 1 AND 10', $sql);
+    }
 
     public function testModifyLimitQueryWithDescOrderBy()
     {


### PR DESCRIPTION
`SQLServerPlatform::modifyLimitQuery('SELECT * FROM user order by username')` (lowercase order by)
returns
`SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY order) AS doctrine_rownum FROM user order by username) AS doctrine_tbl WHERE doctrine_rownum BETWEEN 1 AND 10`
instead of
`SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY username) AS doctrine_rownum FROM user) AS doctrine_tbl WHERE doctrine_rownum BETWEEN 1 AND 10`
