### PR TITLE
added support of LOB download

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -230,4 +230,15 @@ class OCI8Connection implements Connection, ServerInfoAwareConnection
     {
         return oci_error($this->dbh);
     }
+
+    /**
+     * Returns the database handler resource.
+     *
+     * @return resource
+     */
+    public function getDBH()
+    {
+      return $this->dbh;
+    }
+    
 }

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -145,10 +145,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
         $column = isset($this->_paramMap[$column]) ? $this->_paramMap[$column] : $column;
 
         if ($type == \PDO::PARAM_LOB) {
-            $lob = oci_new_descriptor($this->_dbh, OCI_D_LOB);
-            $lob->writeTemporary($variable, OCI_TEMP_BLOB);
-
-            return oci_bind_by_name($this->_sth, $column, $lob, -1, OCI_B_BLOB);
+            return oci_bind_by_name($this->_sth, $column, $variable, -1, OCI_B_BLOB);
         } elseif ($length !== null) {
             return oci_bind_by_name($this->_sth, $column, $variable, $length);
         }


### PR DESCRIPTION
OCI8Statement::bindParam() was forcing a LOB upload when passing a parameter of a LOB type. Also, this forced upload is out of concern for OCI8Statement::bindParam().

So I removed it to support LOB download. Now call of oci_new_descriptor() to create a LOB is the responsibility of the controller. To help this call I added OCI8Connection::getDBH() to be able to get the resource to the connection.

File download example:

```
$connection = new \Doctrine\DBAL\Connection(...);
$sql = 'BEGIN APP.PKG_NAME.GET_FILE(:id,:data); END;';
$stmt = $connection->prepare($sql);
$stmt->bindValue('id', $id);

$blob = oci_new_descriptor($connection->getWrappedConnection()->getDBH(), OCI_DTYPE_LOB);
$stmt->bindParam('data', $blob, PDO::PARAM_LOB);

$stmt->execute();
$data = $blob->load();
```

File upload example:

```
$connection = new \Doctrine\DBAL\Connection(...);
$sql = 'BEGIN APP.PKG_NAME.PUT_FILE(:id,:bData); END;';
$stmt = $connection->prepare($sql);
$stmt->bindValue('id', $id);

$blob = oci_new_descriptor($connection->getWrappedConnection()->getDBH(), OCI_DTYPE_LOB);
$blob->writeTemporary($data, OCI_TEMP_BLOB);
$stmt->bindParam('data', $blob, PDO::PARAM_LOB);

$stmt->execute();
```
