### PR TITLE
Fixed Configuration::getSQLLogger() return type

### DIFF
--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -57,7 +57,7 @@ class Configuration
     /**
      * Gets the SQL logger that is used.
      *
-     * @return \Doctrine\DBAL\Logging\SQLLogger
+     * @return \Doctrine\DBAL\Logging\SQLLogger|null
      */
     public function getSQLLogger()
     {


### PR DESCRIPTION
`getSQLLogger()` can return `null`, this was omitted.
