### PR TITLE
Fixed type and initialization value of $_nestTransactionsWithSavepoints

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -142,9 +142,9 @@ class Connection implements DriverConnection
     /**
      * If nested transactions should use savepoints.
      *
-     * @var integer
+     * @var boolean
      */
-    private $_nestTransactionsWithSavepoints;
+    private $_nestTransactionsWithSavepoints = false;
 
     /**
      * The parameters used during creation of the Connection instance.
@@ -1130,7 +1130,7 @@ class Connection implements DriverConnection
             throw ConnectionException::savepointsNotSupported();
         }
 
-        $this->_nestTransactionsWithSavepoints = $nestTransactionsWithSavepoints;
+        $this->_nestTransactionsWithSavepoints = (bool) $nestTransactionsWithSavepoints;
     }
 
     /**


### PR DESCRIPTION
`Connection::$_nestTransactionsWithSavepoints` is definitely a `boolean` and not an `integer`, and the rest of the code assumes it's `false` by default, whereas it's actually `null` right now. Which still works as `null` evaluates as `false`, but is not clean.
