### PR TITLE
Introduce a Transaction object (replaced with #634)

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -126,25 +126,11 @@ class Connection implements DriverConnection
     private $autoCommit = true;
 
     /**
-     * The transaction nesting level.
-     *
-     * @var integer
-     */
-    private $_transactionNestingLevel = 0;
-
-    /**
      * The currently active transaction isolation level.
      *
      * @var integer
      */
     private $_transactionIsolationLevel;
-
-    /**
-     * If nested transactions should use savepoints.
-     *
-     * @var boolean
-     */
-    private $_nestTransactionsWithSavepoints = false;
 
     /**
      * The parameters used during creation of the Connection instance.
@@ -176,16 +162,14 @@ class Connection implements DriverConnection
     protected $_driver;
 
     /**
-     * Flag that indicates whether the current transaction is marked for rollback only.
-     *
-     * @var boolean
-     */
-    private $_isRollbackOnly = false;
-
-    /**
      * @var integer
      */
     protected $defaultFetchMode = PDO::FETCH_ASSOC;
+
+    /**
+     * @var \Doctrine\DBAL\TransactionManager
+     */
+    protected $transactionManager;
 
     /**
      * Initializes a new instance of the Connection class.
@@ -223,6 +207,8 @@ class Connection implements DriverConnection
         $this->_expr = new Query\Expression\ExpressionBuilder($this);
 
         $this->autoCommit = $config->getAutoCommit();
+
+        $this->transactionManager = new TransactionManager($this);
     }
 
     /**
@@ -313,6 +299,14 @@ class Connection implements DriverConnection
     public function getEventManager()
     {
         return $this->_eventManager;
+    }
+
+    /**
+     * @return \Doctrine\DBAL\TransactionManager
+     */
+    public function getTransactionManager()
+    {
+        return $this->transactionManager;
     }
 
     /**
@@ -476,8 +470,8 @@ class Connection implements DriverConnection
         $this->autoCommit = $autoCommit;
 
         // Commit all currently active transactions if any when switching auto-commit mode.
-        if (true === $this->_isConnected && 0 !== $this->_transactionNestingLevel) {
-            $this->commitAll();
+        if ($this->_isConnected && $this->transactionManager->isTransactionActive()) {
+            $this->transactionManager->getTopLevelTransaction()->commit();
         }
     }
 
@@ -552,11 +546,13 @@ class Connection implements DriverConnection
     /**
      * Checks whether a transaction is currently active.
      *
+     * @deprecated use getTransactionManager()->isTransactionActive()
+     *
      * @return boolean TRUE if a transaction is currently active, FALSE otherwise.
      */
     public function isTransactionActive()
     {
-        return $this->_transactionNestingLevel > 0;
+        return $this->transactionManager->isTransactionActive();
     }
 
     /**
@@ -1035,11 +1031,13 @@ class Connection implements DriverConnection
     /**
      * Returns the current transaction nesting level.
      *
+     * @deprecated Use getTransactionManager()->getTransactionNestingLevel()
+     *
      * @return integer The nesting level. A value of 0 means there's no active transaction.
      */
     public function getTransactionNestingLevel()
     {
-        return $this->_transactionNestingLevel;
+        return $this->transactionManager->getTransactionNestingLevel();
     }
 
     /**
@@ -1114,6 +1112,8 @@ class Connection implements DriverConnection
     /**
      * Sets if nested transactions should use savepoints.
      *
+     * @deprecated Use getTransactionManager()->setNestTransactionsWithSavepoints()
+     *
      * @param boolean $nestTransactionsWithSavepoints
      *
      * @return void
@@ -1122,72 +1122,47 @@ class Connection implements DriverConnection
      */
     public function setNestTransactionsWithSavepoints($nestTransactionsWithSavepoints)
     {
-        if ($this->_transactionNestingLevel > 0) {
-            throw ConnectionException::mayNotAlterNestedTransactionWithSavepointsInTransaction();
-        }
-
-        if ( ! $this->getDatabasePlatform()->supportsSavepoints()) {
-            throw ConnectionException::savepointsNotSupported();
-        }
-
-        $this->_nestTransactionsWithSavepoints = (bool) $nestTransactionsWithSavepoints;
+        $this->transactionManager->setNestTransactionsWithSavepoints($nestTransactionsWithSavepoints);
     }
 
     /**
      * Gets if nested transactions should use savepoints.
      *
+     * @deprecated Use getTransactionManager()->getNestTransactionsWithSavepoints()
+     *
      * @return boolean
      */
     public function getNestTransactionsWithSavepoints()
     {
-        return $this->_nestTransactionsWithSavepoints;
+        return $this->transactionManager->getNestTransactionsWithSavepoints();
     }
 
     /**
-     * Returns the savepoint name to use for nested transactions are false if they are not supported
-     * "savepointFormat" parameter is not set
+     * Begins a transaction and returns the associated Transaction instance.
      *
-     * @return mixed A string with the savepoint name or false.
+     * @return \Doctrine\DBAL\Transaction
      */
-    protected function _getNestedTransactionSavePointName()
+    public function createTransaction()
     {
-        return 'DOCTRINE2_SAVEPOINT_'.$this->_transactionNestingLevel;
+        return $this->transactionManager->createTransaction();
     }
 
     /**
      * Starts a transaction by suspending auto-commit mode.
      *
+     * @deprecated Use createTransaction()
+     *
      * @return void
      */
     public function beginTransaction()
     {
-        $this->connect();
-
-        ++$this->_transactionNestingLevel;
-
-        $logger = $this->_config->getSQLLogger();
-
-        if ($this->_transactionNestingLevel == 1) {
-            if ($logger) {
-                $logger->startQuery('"START TRANSACTION"');
-            }
-            $this->_conn->beginTransaction();
-            if ($logger) {
-                $logger->stopQuery();
-            }
-        } elseif ($this->_nestTransactionsWithSavepoints) {
-            if ($logger) {
-                $logger->startQuery('"SAVEPOINT"');
-            }
-            $this->createSavepoint($this->_getNestedTransactionSavePointName());
-            if ($logger) {
-                $logger->stopQuery();
-            }
-        }
+        $this->createTransaction();
     }
 
     /**
      * Commits the current transaction.
+     *
+     * @deprecated Use Transaction::commit()
      *
      * @return void
      *
@@ -1196,58 +1171,7 @@ class Connection implements DriverConnection
      */
     public function commit()
     {
-        if ($this->_transactionNestingLevel == 0) {
-            throw ConnectionException::noActiveTransaction();
-        }
-        if ($this->_isRollbackOnly) {
-            throw ConnectionException::commitFailedRollbackOnly();
-        }
-
-        $this->connect();
-
-        $logger = $this->_config->getSQLLogger();
-
-        if ($this->_transactionNestingLevel == 1) {
-            if ($logger) {
-                $logger->startQuery('"COMMIT"');
-            }
-            $this->_conn->commit();
-            if ($logger) {
-                $logger->stopQuery();
-            }
-        } elseif ($this->_nestTransactionsWithSavepoints) {
-            if ($logger) {
-                $logger->startQuery('"RELEASE SAVEPOINT"');
-            }
-            $this->releaseSavepoint($this->_getNestedTransactionSavePointName());
-            if ($logger) {
-                $logger->stopQuery();
-            }
-        }
-
-        --$this->_transactionNestingLevel;
-
-        if (false === $this->autoCommit && 0 === $this->_transactionNestingLevel) {
-            $this->beginTransaction();
-        }
-    }
-
-    /**
-     * Commits all current nesting transactions.
-     */
-    private function commitAll()
-    {
-        while (0 !== $this->_transactionNestingLevel) {
-            if (false === $this->autoCommit && 1 === $this->_transactionNestingLevel) {
-                // When in no auto-commit mode, the last nesting commit immediately starts a new transaction.
-                // Therefore we need to do the final commit here and then leave to avoid an infinite loop.
-                $this->commit();
-
-                return;
-            }
-
-            $this->commit();
-        }
+        $this->transactionManager->getCurrentTransaction()->commit();
     }
 
     /**
@@ -1256,45 +1180,15 @@ class Connection implements DriverConnection
      * This method can be listened with onPreTransactionRollback and onTransactionRollback
      * eventlistener methods.
      *
+     * @deprecated Use Transaction::rollback()
+     *
+     * @return void
+     *
      * @throws \Doctrine\DBAL\ConnectionException If the rollback operation failed.
      */
     public function rollBack()
     {
-        if ($this->_transactionNestingLevel == 0) {
-            throw ConnectionException::noActiveTransaction();
-        }
-
-        $this->connect();
-
-        $logger = $this->_config->getSQLLogger();
-
-        if ($this->_transactionNestingLevel == 1) {
-            if ($logger) {
-                $logger->startQuery('"ROLLBACK"');
-            }
-            $this->_transactionNestingLevel = 0;
-            $this->_conn->rollback();
-            $this->_isRollbackOnly = false;
-            if ($logger) {
-                $logger->stopQuery();
-            }
-
-            if (false === $this->autoCommit) {
-                $this->beginTransaction();
-            }
-        } elseif ($this->_nestTransactionsWithSavepoints) {
-            if ($logger) {
-                $logger->startQuery('"ROLLBACK TO SAVEPOINT"');
-            }
-            $this->rollbackSavepoint($this->_getNestedTransactionSavePointName());
-            --$this->_transactionNestingLevel;
-            if ($logger) {
-                $logger->stopQuery();
-            }
-        } else {
-            $this->_isRollbackOnly = true;
-            --$this->_transactionNestingLevel;
-        }
+        $this->transactionManager->getCurrentTransaction()->rollback();
     }
 
     /**
@@ -1384,20 +1278,21 @@ class Connection implements DriverConnection
      * Marks the current transaction so that the only possible
      * outcome for the transaction to be rolled back.
      *
+     * @deprecated Use Transaction::setRollbackOnly()
+     *
      * @return void
      *
      * @throws \Doctrine\DBAL\ConnectionException If no transaction is active.
      */
     public function setRollbackOnly()
     {
-        if ($this->_transactionNestingLevel == 0) {
-            throw ConnectionException::noActiveTransaction();
-        }
-        $this->_isRollbackOnly = true;
+        $this->transactionManager->getTopLevelTransaction()->setRollbackOnly();
     }
 
     /**
      * Checks whether the current transaction is marked for rollback only.
+     *
+     * @deprecated use Transaction::isRollbackOnly()
      *
      * @return boolean
      *
@@ -1405,11 +1300,7 @@ class Connection implements DriverConnection
      */
     public function isRollbackOnly()
     {
-        if ($this->_transactionNestingLevel == 0) {
-            throw ConnectionException::noActiveTransaction();
-        }
-
-        return $this->_isRollbackOnly;
+        return $this->transactionManager->getTopLevelTransaction()->isRollbackOnly();
     }
 
     /**

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -169,7 +169,7 @@ class Connection implements DriverConnection
     /**
      * @var \Doctrine\DBAL\TransactionManager
      */
-    protected $transactionManager;
+    private $transactionManager;
 
     /**
      * Initializes a new instance of the Connection class.

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1286,7 +1286,7 @@ class Connection implements DriverConnection
      */
     public function setRollbackOnly()
     {
-        $this->transactionManager->getTopLevelTransaction()->setRollbackOnly();
+        $this->transactionManager->getCurrentTransaction()->setRollbackOnly();
     }
 
     /**
@@ -1300,7 +1300,7 @@ class Connection implements DriverConnection
      */
     public function isRollbackOnly()
     {
-        return $this->transactionManager->getTopLevelTransaction()->isRollbackOnly();
+        return $this->transactionManager->getCurrentTransaction()->isRollbackOnly();
     }
 
     /**

--- a/lib/Doctrine/DBAL/ConnectionException.php
+++ b/lib/Doctrine/DBAL/ConnectionException.php
@@ -45,6 +45,25 @@ class ConnectionException extends DBALException
     /**
      * @return \Doctrine\DBAL\ConnectionException
      */
+    public static function transactionNotActive()
+    {
+        return new self("This transaction is not active, and cannot be committed or rolled back.");
+    }
+
+    /**
+     * @return \Doctrine\DBAL\ConnectionException
+     */
+    public static function staleTransaction()
+    {
+        return new self(
+            "This transaction is not managed by this transaction manager, " .
+            "it has probably already been committed or rolled back, or belongs to another transaction manager."
+        );
+    }
+
+    /**
+     * @return \Doctrine\DBAL\ConnectionException
+     */
     public static function savepointsNotSupported()
     {
         return new self("Savepoints are not supported by this driver.");

--- a/lib/Doctrine/DBAL/Transaction.php
+++ b/lib/Doctrine/DBAL/Transaction.php
@@ -27,6 +27,16 @@ class Transaction
     private $isRollbackOnly = false;
 
     /**
+     * @var boolean
+     */
+    private $wasCommitted = false;
+
+    /**
+     * @var boolean
+     */
+    private $wasRolledBack = false;
+
+    /**
      * @param TransactionManager $transactionManager
      */
     public function __construct(TransactionManager $transactionManager)
@@ -50,6 +60,7 @@ class Transaction
         }
 
         $this->isActive = false;
+        $this->wasCommitted = true;
 
         $this->transactionManager->commitTransaction($this);
     }
@@ -66,6 +77,7 @@ class Transaction
         }
 
         $this->isActive = false;
+        $this->wasRolledBack = true;
 
         $this->transactionManager->rollbackTransaction($this);
     }
@@ -85,10 +97,14 @@ class Transaction
      *
      * @return void
      *
-     * @throws \Doctrine\DBAL\ConnectionException If no transaction is active.
+     * @throws \Doctrine\DBAL\ConnectionException If the transaction is not active.
      */
     public function setRollbackOnly()
     {
+        if (! $this->isActive) {
+            throw ConnectionException::transactionNotActive();
+        }
+
         $this->isRollbackOnly = true;
     }
 
@@ -100,5 +116,21 @@ class Transaction
     public function isRollbackOnly()
     {
         return $this->isRollbackOnly;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function wasCommitted()
+    {
+        return $this->wasCommitted;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function wasRolledBack()
+    {
+        return $this->wasRolledBack;
     }
 }

--- a/lib/Doctrine/DBAL/Transaction.php
+++ b/lib/Doctrine/DBAL/Transaction.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Doctrine\DBAL;
+
+/**
+ * The transaction object.
+ */
+class Transaction
+{
+    /**
+     * @var \Doctrine\DBAL\TransactionManager
+     */
+    private $transactionManager;
+
+    /**
+     * Indicates whether this transaction is active, and can be committed or rolled back.
+     *
+     * @var boolean
+     */
+    private $isActive = true;
+
+    /**
+     * Indicates whether this transaction is marked for rollback only.
+     *
+     * @var boolean
+     */
+    private $isRollbackOnly = false;
+
+    /**
+     * @param TransactionManager $transactionManager
+     */
+    public function __construct(TransactionManager $transactionManager)
+    {
+        $this->transactionManager = $transactionManager;
+    }
+
+    /**
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\ConnectionException If this transaction is not active or marked as rollback only.
+     */
+    public function commit()
+    {
+        if (! $this->isActive) {
+            throw ConnectionException::transactionNotActive();
+        }
+
+        if ($this->isRollbackOnly) {
+            throw ConnectionException::commitFailedRollbackOnly();
+        }
+
+        $this->isActive = false;
+
+        $this->transactionManager->commitTransaction($this);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\ConnectionException If this transaction is not active.
+     */
+    public function rollback()
+    {
+        if (! $this->isActive) {
+            throw ConnectionException::transactionNotActive();
+        }
+
+        $this->isActive = false;
+
+        $this->transactionManager->rollbackTransaction($this);
+    }
+
+    /**
+     * Returns whether this transaction is still active.
+     *
+     * @return boolean
+     */
+    public function isActive()
+    {
+        return $this->isActive;
+    }
+
+    /**
+     * Marks the current transaction so that the only possible outcome for the transaction to be rolled back.
+     *
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\ConnectionException If no transaction is active.
+     */
+    public function setRollbackOnly()
+    {
+        $this->isRollbackOnly = true;
+    }
+
+    /**
+     * Returns whether this transaction is marked for rollback only.
+     *
+     * @return boolean
+     */
+    public function isRollbackOnly()
+    {
+        return $this->isRollbackOnly;
+    }
+}

--- a/lib/Doctrine/DBAL/Transaction.php
+++ b/lib/Doctrine/DBAL/Transaction.php
@@ -8,6 +8,8 @@ namespace Doctrine\DBAL;
 class Transaction
 {
     /**
+     * The transaction manager that created this transaction object.
+     *
      * @var \Doctrine\DBAL\TransactionManager
      */
     private $transactionManager;
@@ -27,16 +29,22 @@ class Transaction
     private $isRollbackOnly = false;
 
     /**
+     * Indicates whether this transaction was committed.
+     *
      * @var boolean
      */
     private $wasCommitted = false;
 
     /**
+     * Indicates whether this transaction was rolled back.
+     *
      * @var boolean
      */
     private $wasRolledBack = false;
 
     /**
+     * Class constructor.
+     *
      * @param TransactionManager $transactionManager
      */
     public function __construct(TransactionManager $transactionManager)
@@ -45,6 +53,8 @@ class Transaction
     }
 
     /**
+     * Commits this transaction.
+     *
      * @return void
      *
      * @throws \Doctrine\DBAL\ConnectionException If this transaction is not active or marked as rollback only.
@@ -66,6 +76,8 @@ class Transaction
     }
 
     /**
+     * Rolls back this transaction.
+     *
      * @return void
      *
      * @throws \Doctrine\DBAL\ConnectionException If this transaction is not active.
@@ -97,7 +109,7 @@ class Transaction
      *
      * @return void
      *
-     * @throws \Doctrine\DBAL\ConnectionException If the transaction is not active.
+     * @throws \Doctrine\DBAL\ConnectionException If this transaction is not active.
      */
     public function setRollbackOnly()
     {
@@ -119,6 +131,8 @@ class Transaction
     }
 
     /**
+     * Returns whether this transaction was committed.
+     *
      * @return boolean
      */
     public function wasCommitted()
@@ -127,6 +141,8 @@ class Transaction
     }
 
     /**
+     * Returns whether this transaction was rolled back.
+     *
      * @return boolean
      */
     public function wasRolledBack()

--- a/lib/Doctrine/DBAL/TransactionManager.php
+++ b/lib/Doctrine/DBAL/TransactionManager.php
@@ -184,11 +184,11 @@ class TransactionManager
     }
 
     /**
-     * @return bool
+     * @return boolean
      */
     public function isTransactionActive()
     {
-        return (bool) $this->activeTransactions;
+        return ! empty($this->activeTransactions);
     }
 
     /**

--- a/lib/Doctrine/DBAL/TransactionManager.php
+++ b/lib/Doctrine/DBAL/TransactionManager.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Doctrine\DBAL;
+
+/**
+ * Manages transactions.
+ */
+class TransactionManager
+{
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    private $connection;
+
+    /**
+     * @var \Doctrine\DBAL\Transaction[]
+     */
+    private $activeTransactions = array();
+
+    /**
+     * Whether nested transactions should use savepoints.
+     *
+     * @var boolean
+     */
+    private $nestTransactionsWithSavepoints = false;
+
+    /**
+     * @param \Doctrine\DBAL\Connection $connection
+     */
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @return \Doctrine\DBAL\Transaction
+     */
+    public function createTransaction()
+    {
+        $this->connection->connect();
+
+        $transaction = new Transaction($this);
+        $this->activeTransactions[] = $transaction;
+
+        $logger = $this->connection->getConfiguration()->getSQLLogger();
+
+        if (count($this->activeTransactions) === 1) {
+            $logger && $logger->startQuery('"START TRANSACTION"');
+            $this->connection->getWrappedConnection()->beginTransaction();
+            $logger && $logger->stopQuery();
+        } elseif ($this->nestTransactionsWithSavepoints) {
+            $logger && $logger->startQuery('"SAVEPOINT"');
+            $this->connection->createSavepoint($this->getNestedTransactionSavePointName());
+            $logger && $logger->stopQuery();
+        }
+
+        return $transaction;
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Transaction $transaction
+     *
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\ConnectionException If the transaction is stale, or belongs to another manager.
+     */
+    public function commitTransaction(Transaction $transaction)
+    {
+        if ($transaction->isActive()) {
+            // Transaction::commit() has to be called first, and in turn call this method.
+            $transaction->commit();
+
+            return;
+        }
+
+        $nestedTransaction = $this->getNestedTransaction($transaction);
+
+        if ($nestedTransaction) {
+            $nestedTransaction->commit();
+        }
+
+        $logger = $this->connection->getConfiguration()->getSQLLogger();
+
+        if (count($this->activeTransactions) === 1) {
+            $logger && $logger->startQuery('"COMMIT"');
+            $this->connection->getWrappedConnection()->commit();
+            $logger && $logger->stopQuery();
+        } elseif ($this->nestTransactionsWithSavepoints) {
+            $logger && $logger->startQuery('"RELEASE SAVEPOINT"');
+            $this->connection->releaseSavepoint($this->getNestedTransactionSavePointName());
+            $logger && $logger->stopQuery();
+        }
+
+        array_pop($this->activeTransactions);
+
+        if (! $this->connection->isAutoCommit() && ! $this->activeTransactions) {
+            $this->createTransaction();
+        }
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Transaction $transaction
+     *
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\ConnectionException
+     */
+    public function rollbackTransaction(Transaction $transaction)
+    {
+        if ($transaction->isActive()) {
+            // Transaction::rollback() has to be called first, and in turn call this method.
+            $transaction->rollback();
+
+            return;
+        }
+
+        $nestedTransaction = $this->getNestedTransaction($transaction);
+
+        if ($nestedTransaction) {
+            $nestedTransaction->rollback();
+        }
+
+        $logger = $this->connection->getConfiguration()->getSQLLogger();
+
+        if (count($this->activeTransactions) === 1) {
+            $logger && $logger->startQuery('"ROLLBACK"');
+            $this->connection->getWrappedConnection()->rollBack();
+            $logger && $logger->stopQuery();
+
+            if (! $this->connection->isAutoCommit()) {
+                $this->createTransaction();
+            }
+        } elseif ($this->nestTransactionsWithSavepoints) {
+            $logger && $logger->startQuery('"ROLLBACK TO SAVEPOINT"');
+            $this->connection->rollbackSavepoint($this->getNestedTransactionSavePointName());
+            $logger && $logger->stopQuery();
+        } else {
+            $this->getTopLevelTransaction()->setRollbackOnly();
+        }
+
+        array_pop($this->activeTransactions);
+    }
+
+    /**
+     * Sets whether nested transactions should use savepoints.
+     *
+     * @param boolean $nestTransactionsWithSavepoints
+     *
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\ConnectionException If a transaction is active, or savepoints are not supported.
+     */
+    public function setNestTransactionsWithSavepoints($nestTransactionsWithSavepoints)
+    {
+        if ($this->activeTransactions) {
+            throw ConnectionException::mayNotAlterNestedTransactionWithSavepointsInTransaction();
+        }
+
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            throw ConnectionException::savepointsNotSupported();
+        }
+
+        $this->nestTransactionsWithSavepoints = (bool) $nestTransactionsWithSavepoints;
+    }
+
+    /**
+     * Returns whether nested transactions should use savepoints.
+     *
+     * @return boolean
+     */
+    public function getNestTransactionsWithSavepoints()
+    {
+        return $this->nestTransactionsWithSavepoints;
+    }
+
+    /**
+     * Returns the current transaction nesting level.
+     *
+     * @return integer The nesting level. A value of 0 means there's no active transaction.
+     */
+    public function getTransactionNestingLevel()
+    {
+        return count($this->activeTransactions);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTransactionActive()
+    {
+        return (bool) $this->activeTransactions;
+    }
+
+    /**
+     * Returns the top-level active transaction, i.e. the first transaction started.
+     *
+     * @return \Doctrine\DBAL\Transaction
+     *
+     * @throws \Doctrine\DBAL\ConnectionException If there is no active transaction.
+     */
+    public function getTopLevelTransaction()
+    {
+        if (! $this->activeTransactions) {
+            throw ConnectionException::noActiveTransaction();
+        }
+
+        return reset($this->activeTransactions);
+    }
+
+    /**
+     * Returns the current transaction, i.e. the last transaction started.
+     *
+     * @return \Doctrine\DBAL\Transaction
+     *
+     * @throws \Doctrine\DBAL\ConnectionException If there is no active transaction.
+     */
+    public function getCurrentTransaction()
+    {
+        if (! $this->activeTransactions) {
+            throw ConnectionException::noActiveTransaction();
+        }
+
+        return end($this->activeTransactions);
+    }
+
+    /**
+     * Returns the savepoint name to use for nested transactions.
+     *
+     * @return string
+     */
+    private function getNestedTransactionSavePointName()
+    {
+        return 'DOCTRINE2_SAVEPOINT_' . count($this->activeTransactions);
+    }
+
+    /**
+     * Returns the nested transaction one level below the given one, if any.
+     *
+     * @param \Doctrine\DBAL\Transaction $transaction
+     *
+     * @return \Doctrine\DBAL\Transaction|null The nested transaction, or null if none.
+     *
+     * @throws \Doctrine\DBAL\ConnectionException If the given transaction is stale, or belongs to another manager.
+     */
+    private function getNestedTransaction(Transaction $transaction)
+    {
+        $transactionIndex = array_search($transaction, $this->activeTransactions, true);
+
+        if ($transactionIndex === false) {
+            throw ConnectionException::staleTransaction();
+        }
+
+        if (++$transactionIndex === count($this->activeTransactions)) {
+            return null;
+        }
+
+        return $this->activeTransactions[$transactionIndex];
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/TransactionManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TransactionManagerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional;
+
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+/**
+ * Functional tests for the transaction manager.
+ */
+class TransactionManagerTest extends DbalFunctionalTestCase
+{
+    /**
+     * @var \Doctrine\DBAL\TransactionManager
+     */
+    private $transactionManager;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->transactionManager = $this->_conn->getTransactionManager();
+    }
+
+    public function testGetNestTransactionsWithSavepointsIsFalseByDefault()
+    {
+        $this->assertFalse($this->transactionManager->getNestTransactionsWithSavepoints());
+    }
+
+    public function testSetNestTransactionsWithSavepoints()
+    {
+        $this->transactionManager->setNestTransactionsWithSavepoints(true);
+        $this->assertTrue($this->transactionManager->getNestTransactionsWithSavepoints());
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\ConnectionException
+     */
+    public function testCallingGetCurrentTransactionWhileNotInTransactionThrowsException()
+    {
+        $this->transactionManager->getCurrentTransaction();
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\ConnectionException
+     */
+    public function testCallingGetTopLevelTransactionWhileNotInTransactionThrowsException()
+    {
+        $this->transactionManager->getTopLevelTransaction();
+    }
+
+    public function testTransactionNesting()
+    {
+        $this->assertTransactionNestingLevel(0);
+
+        $transaction1 = $this->transactionManager->createTransaction();
+
+        $this->assertSame($transaction1, $this->transactionManager->getTopLevelTransaction());
+        $this->assertSame($transaction1, $this->transactionManager->getCurrentTransaction());
+
+        $this->assertTransactionNestingLevel(1);
+
+        $transaction2 = $this->transactionManager->createTransaction();
+
+        $this->assertSame($transaction1, $this->transactionManager->getTopLevelTransaction());
+        $this->assertSame($transaction2, $this->transactionManager->getCurrentTransaction());
+
+        $this->assertTransactionNestingLevel(2);
+
+        $transaction2->rollback();
+
+        $this->assertSame($transaction1, $this->transactionManager->getTopLevelTransaction());
+        $this->assertSame($transaction1, $this->transactionManager->getCurrentTransaction());
+
+        $this->assertTransactionNestingLevel(1);
+
+        $transaction1->commit();
+
+        $this->assertTransactionNestingLevel(0);
+    }
+
+    public function testCommittingTopLevelTransactionCommitsNestedTransactions()
+    {
+        $transaction1 = $this->transactionManager->createTransaction();
+        $transaction2 = $this->transactionManager->createTransaction();
+        $transaction3 = $this->transactionManager->createTransaction();
+
+        $transaction1->commit();
+
+        $this->assertTrue($transaction2->wasCommitted());
+        $this->assertTrue($transaction3->wasCommitted());
+    }
+
+    public function testRollingBackTopLevelTransactionRollsBackNestedTransactions()
+    {
+        $transaction1 = $this->transactionManager->createTransaction();
+        $transaction2 = $this->transactionManager->createTransaction();
+        $transaction3 = $this->transactionManager->createTransaction();
+
+        $transaction1->rollback();
+
+        $this->assertTrue($transaction2->wasRolledBack());
+        $this->assertTrue($transaction3->wasRolledBack());
+    }
+
+    /**
+     * @param integer $expected
+     */
+    private function assertTransactionNestingLevel($expected)
+    {
+        $this->assertSame($expected, $this->transactionManager->getTransactionNestingLevel());
+        $this->assertSame($expected !== 0, $this->transactionManager->isTransactionActive());
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Mocks/TransactionManagerMock.php
+++ b/tests/Doctrine/Tests/DBAL/Mocks/TransactionManagerMock.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Mocks;
+
+use Doctrine\DBAL\TransactionManager;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+/**
+ * The transaction manager mock is actually generated dynamically by PHPUnit,
+ * but this class allows type-hinting both TransactionManager and MockObject at the same time
+ * for IDE code inspection and completion to work properly.
+ */
+abstract class TransactionManagerMock extends TransactionManager implements MockObject
+{
+}

--- a/tests/Doctrine/Tests/DBAL/TransactionTest.php
+++ b/tests/Doctrine/Tests/DBAL/TransactionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Doctrine\Tests\DBAL;
+
+use Doctrine\DBAL\Transaction;
+use Doctrine\Tests\DbalTestCase;
+
+/**
+ * Unit tests for the transaction object.
+ */
+class TransactionTest extends DbalTestCase
+{
+    /**
+     * The transaction manager mock.
+     *
+     * @var \Doctrine\Tests\DBAL\Mocks\TransactionManagerMock
+     */
+    private $transactionManager;
+
+    /**
+     * A Transaction instance built on the transaction manager mock.
+     *
+     * @var \Doctrine\DBAL\Transaction
+     */
+    private $transaction;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->transactionManager = $this->getMock('Doctrine\DBAL\TransactionManager', array(), array(), '', false);
+        $this->transaction = new Transaction($this->transactionManager);
+    }
+
+    public function testTransactionDefaults()
+    {
+        $this->assertTrue($this->transaction->isActive());
+        $this->assertFalse($this->transaction->wasCommitted());
+        $this->assertFalse($this->transaction->wasRolledBack());
+        $this->assertFalse($this->transaction->isRollbackOnly());
+    }
+
+    public function testCommit()
+    {
+        $this->transactionManager->expects($this->once())->method('commitTransaction');
+
+        $this->transaction->commit();
+
+        $this->assertFalse($this->transaction->isActive());
+        $this->assertTrue($this->transaction->wasCommitted());
+        $this->assertFalse($this->transaction->wasRolledBack());
+    }
+
+    public function testRollback()
+    {
+        $this->transactionManager->expects($this->once())->method('rollbackTransaction');
+
+        $this->transaction->rollback();
+
+        $this->assertFalse($this->transaction->isActive());
+        $this->assertTrue($this->transaction->wasRolledBack());
+        $this->assertFalse($this->transaction->wasCommitted());
+    }
+
+    public function testSetRollbackOnly()
+    {
+        $this->transaction->setRollbackOnly();
+        $this->assertTrue($this->transaction->isRollbackOnly());
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\ConnectionException
+     */
+    public function testCommittingInactiveTransactionThrowsException()
+    {
+        $this->transaction->commit();
+        $this->transaction->commit();
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\ConnectionException
+     */
+    public function testCommittingRollbackOnlyTransactionThrowsException()
+    {
+        $this->transaction->setRollbackOnly();
+        $this->transaction->commit();
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\ConnectionException
+     */
+    public function testRollingBackInactiveTransactionThrowsException()
+    {
+        $this->transaction->rollback();
+        $this->transaction->rollback();
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\ConnectionException
+     */
+    public function testMarkingInactiveTransactionAsRollbackOnlyThrowsException()
+    {
+        $this->transaction->commit();
+        $this->transaction->setRollbackOnly();
+    }
+}


### PR DESCRIPTION
This is a first draft on the idea of a Transaction object, as suggested by @guilhermeblanco and @beberlei in doctrine/doctrine2#949.

This makes the following changes to `Connection`:
- **Adds** the following methods:
  - `createTransaction()` : begins a transaction and returns the associated `Transaction` object
  - `getTransactionManager()` : returns the `TransactionManager`
- **Deprecates** `beginTransaction()` in favour of `createTransaction()`
- **Deprecates** the following methods, in favour of their counterparts on `Transaction`:
  - `commit()`
  - `rollBack()`
  - `setRollbackOnly()`
  - `isRollbackOnly()`
- **Deprecates** the following methods, in favour of their counterparts on `TransactionManager`:
  - `isTransactionActive()`
  - `getTransactionNestingLevel()`
  - `setNestTransactionsWithSavepoints()`
  - `getNestTransactionsWithSavepoints()`

The new way of dealing with transactions is then:

```
$transaction = $connection->createTransaction();
$transaction->commit();
```

It also automatically propagates `commit()` and `rollback()` to nested transactions:

```
$transaction1 = $connection->createTransaction();
$transaction2 = $connection->createTransaction();
$transaction1->commit(); // will commit $transaction2 then $transaction1
```

Overall, it's not a complicated change, does not introduce any BC break, and passes all existing tests.

I'm looking forward to hearing what you think!
