### PR TITLE
Fix reverse engineering quoted table names on PostgreSQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -21,6 +21,7 @@ namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\BinaryType;
@@ -300,6 +301,9 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getListTableConstraintsSQL($table)
     {
+        $table = new Identifier($table);
+        $table = $table->getName();
+
         return "SELECT
                     quote_ident(relname) as relname
                 FROM
@@ -347,7 +351,9 @@ class PostgreSqlPlatform extends AbstractPlatform
         } else {
             $schema = "ANY(string_to_array((select replace(replace(setting,'\"\$user\"',user),' ','') from pg_catalog.pg_settings where name = 'search_path'),','))";
         }
-        $whereClause .= "$classAlias.relname = '" . $table . "' AND $namespaceAlias.nspname = $schema";
+
+        $table = new Identifier($table);
+        $whereClause .= "$classAlias.relname = '" . $table->getName() . "' AND $namespaceAlias.nspname = $schema";
 
         return $whereClause;
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -301,6 +301,24 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertInstanceOf('Doctrine\DBAL\Types\BlobType', $table->getColumn('column_binary')->getType());
         $this->assertFalse($table->getColumn('column_binary')->getFixed());
     }
+
+    public function testListQuotedTable()
+    {
+        $offlineTable = new Schema\Table('user');
+        $offlineTable->addColumn('id', 'integer');
+        $offlineTable->addColumn('username', 'string', array('unique' => true));
+        $offlineTable->addColumn('fk', 'integer');
+        $offlineTable->setPrimaryKey(array('id'));
+        $offlineTable->addForeignKeyConstraint($offlineTable, array('fk'), array('id'));
+
+        $this->_sm->dropAndCreateTable($offlineTable);
+
+        $onlineTable = $this->_sm->listTableDetails('"user"');
+
+        $comparator = new Schema\Comparator();
+
+        $this->assertFalse($comparator->diffTable($offlineTable, $onlineTable));
+    }
 }
 
 class MoneyType extends Type


### PR DESCRIPTION
Commit https://github.com/doctrine/dbal/commit/83fe296de44ef3e2f04f2342021f656a797787ec introduced a bug with reverse engineering table details for tables with names requiring quotation (reserved keyword, non-identifier characters, case-folded) on PostgreSQL.
`PostgreSqlPlatform::getListTablesSQL()` fetches table names quoted if necessary with `quote_ident(tablename)` which in turn causes other `getListTable*SQL($table)` to fail retrieving results if the table name is quoted. Those methods always have to use unquoted table names in their statements.

See https://github.com/ZF-Commons/ZfcUserDoctrineORM/issues/77 for more details.
