### PR TITLE
[DBAL-834] Fix order by with aggregate function(s) for limit/offset queries on SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1149,7 +1149,10 @@ class SQLServerPlatform extends AbstractPlatform
         $start   = $offset + 1;
         $end     = $offset + $limit;
         $orderBy = stristr($query, 'ORDER BY');
-        $query   = preg_replace('/\s+ORDER\s+BY\s+([^\)]*)/i', '', $query); //Remove ORDER BY from $query
+
+        //Remove ORDER BY from $query (including nested parentheses in order by list).
+        $query = preg_replace('/\s+ORDER\s+BY\s+([^()]+|\((?:(?:(?>[^()]+)|(?R))*)\))+/i', '', $query);
+
         $format  = 'SELECT * FROM (%s) AS doctrine_tbl WHERE doctrine_rownum BETWEEN %d AND %d';
 
         // Pattern to match "main" SELECT ... FROM clause (including nested parentheses in select list).
@@ -1168,7 +1171,7 @@ class SQLServerPlatform extends AbstractPlatform
         }
 
         //Clear ORDER BY
-        $orderBy        = preg_replace('/ORDER\s+BY\s+([^\)]*)(.*)/i', '$1', $orderBy);
+        $orderBy        = preg_replace('/ORDER\s+BY\s+(.*)/i', '$1', $orderBy);
         $orderByParts   = explode(',', $orderBy);
         $orderbyColumns = array();
 
@@ -1190,7 +1193,6 @@ class SQLServerPlatform extends AbstractPlatform
         //Find alias for each colum used in ORDER BY
         if ( ! empty($orderbyColumns)) {
             foreach ($orderbyColumns as $column) {
-
                 $pattern    = sprintf('/%s\.%s\s+(?:AS\s+)?([^,\s)]+)/i', $column['table'], $column['column']);
 
                 if ($isWrapped) {

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -331,6 +331,35 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     }
 
     /**
+     * @group DBAL-834
+     */
+    public function testModifyLimitQueryWithAggregateFunctionInOrderByClause()
+    {
+        $sql = $this->_platform->modifyLimitQuery(
+            "SELECT " .
+            "MAX(heading_id) aliased, " .
+            "code " .
+            "FROM operator_model_operator " .
+            "GROUP BY code " .
+            "ORDER BY MAX(heading_id) DESC",
+            1,
+            0
+        );
+
+        $this->assertEquals(
+            "SELECT * FROM (" .
+            "SELECT " .
+            "MAX(heading_id) aliased, " .
+            "code, " .
+            "ROW_NUMBER() OVER (ORDER BY MAX(heading_id) DESC) AS doctrine_rownum " .
+            "FROM operator_model_operator " .
+            "GROUP BY code" .
+            ") AS doctrine_tbl WHERE doctrine_rownum BETWEEN 1 AND 1",
+            $sql
+        );
+    }
+
+    /**
      * @group DDC-1360
      */
     public function testQuoteIdentifier()


### PR DESCRIPTION
When modifying a query with limit/offset clauses on SQL Server, using aggregate functions, the platform generates wrong SQL.
See http://www.doctrine-project.org/jira/browse/DBAL-834
