### PR TITLE
Fixed the installation of HHVM nightly on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - DB=mysqli
 
 before_script:
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' = 'hhvm' ]; then sudo apt-get remove hhvm; sudo apt-get autoremove; sudo apt-get update; sudo apt-get install hhvm-nightly; fi"
+  - sh -c "if [ '$TRAVIS_PHP_VERSION' = 'hhvm' ]; then sudo apt-get remove --auto-remove hhvm; sudo apt-get update; sudo apt-get install -y --force-yes hhvm-nightly; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests_tmp;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests;' -U postgres; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - DB=mysqli
 
 before_script:
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' = 'hhvm' ]; then sudo apt-get remove hhvm; sudo apt-get update; sudo apt-get install hhvm-nightly; fi"
+  - sh -c "if [ '$TRAVIS_PHP_VERSION' = 'hhvm' ]; then sudo apt-get remove hhvm; sudo apt-get autoremove; sudo apt-get update; sudo apt-get install hhvm-nightly; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests_tmp;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests;' -U postgres; fi"


### PR DESCRIPTION
This is an attempt to fix the installation of HHVM nightly on Travis, which is failing because of dependency versions: https://travis-ci.org/doctrine/dbal/jobs/23685468

Once Travis updates its VM, we will get HHVM 3.0.1 by default, and so no need to reinstall HHVM, but the process of deploying the new versions seems staled: https://github.com/travis-ci/travis-ci/issues/2126
