### PR TITLE
Adds helper selection method to QueryBuilder

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -251,6 +251,30 @@ class QueryBuilder
         return $sql;
     }
 
+	/**
+	 * @param string[] $columnNames
+	 * @param string   $tableName
+	 * @param array    $criteria [$columnName (string) => $columnValue (mixed)]
+	 *
+	 * @return self
+	 */
+	public function selectFromWhere(array $columnNames, $tableName, array $criteria)
+	{
+		$wherePredicates = array();
+
+		foreach ($criteria as $columnName => $columnValue) {
+			$wherePredicates[] = 't.' . $columnName . ' = :' . $columnName;
+			$this->setParameter(':' . $columnName, $columnValue);
+		}
+
+		$this
+			->select(array_map(function( $columnName ) { return 't.' . $columnName; }, $columnNames))
+			->from($tableName, 't')
+			->where($wherePredicates);
+
+		return $this;
+	}
+
     /**
      * Sets a query parameter for the query being constructed.
      *


### PR DESCRIPTION
This is a draft; it has not been tested, not even manually.
It is meant for conceptual review

In my application I have a place where I get the table name, columns to select, and array with `[ field => required value ]`. There appears to be no convenient way to feed this to DBAL. This commit contains pretty much what I was doing in my app.
