### PR TITLE
Fix driver exception conversion for newer SQLite versions

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
@@ -40,16 +40,17 @@ abstract class AbstractSQLiteDriver implements Driver, ExceptionConverterDriver
      */
     public function convertException($message, DriverException $exception)
     {
-        if (strpos($exception->getMessage(), 'must be unique') !== false) {
+        if (strpos($exception->getMessage(), 'must be unique') !== false ||
+            strpos($exception->getMessage(), 'is not unique') !== false ||
+            strpos($exception->getMessage(), 'UNIQUE constraint failed') !== false
+        ) {
             return new Exception\UniqueConstraintViolationException($message, $exception);
         }
 
-        if (strpos($exception->getMessage(), 'may not be NULL') !== false) {
+        if (strpos($exception->getMessage(), 'may not be NULL') !== false ||
+            strpos($exception->getMessage(), 'NOT NULL constraint failed') !== false
+        ) {
             return new Exception\NotNullConstraintViolationException($message, $exception);
-        }
-
-        if (strpos($exception->getMessage(), 'is not unique') !== false) {
-            return new Exception\UniqueConstraintViolationException($message, $exception);
         }
 
         if (strpos($exception->getMessage(), 'no such table:') !== false) {


### PR DESCRIPTION
As of [PHP 5.5.11](http://www.php.net/ChangeLog-5.php#5.5.11) the internal `libsqlite` has been upgraded to version `3.8.3.1` which seems to change some of the driver exception messages for constraint violations and causes [Travis to fail](https://travis-ci.org/doctrine/dbal/jobs/24234077#L187).
This PR now also matches strings to catch those appropriately.
