### PR TITLE
Oracle DateTime sql declaration changed to DATE from TIMESTAMP

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -294,7 +294,7 @@ class OraclePlatform extends AbstractPlatform
      */
     public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration)
     {
-        return 'TIMESTAMP(0)';
+        return 'DATE';
     }
 
     /**


### PR DESCRIPTION
SQL declaration of DateTime doctrine type is DATE, not TIMESTAMP. Oracle stores date and time in one type DATE.

_getDateTypeDeclarationSQL_ returns DATE, _getTimeTypeDeclarationSQL_ returns DATE types for Oracle. It is justified to return DATE type for _getDateTimeTypeDeclarationSQL_.
