### PR TITLE
Could not retrieve columns for a table with quotes on PostgreSQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -348,7 +348,7 @@ class PostgreSqlPlatform extends AbstractPlatform
         } else {
             $schema = "ANY(string_to_array((select replace(replace(setting,'\"\$user\"',user),' ','') from pg_catalog.pg_settings where name = 'search_path'),','))";
         }
-        $whereClause .= "$classAlias.relname = '" . $table . "' AND $namespaceAlias.nspname = $schema";
+        $whereClause .= "quote_ident($classAlias.relname) = '" . $table . "' AND $namespaceAlias.nspname = $schema";
 
         return $whereClause;
     }


### PR DESCRIPTION
If a table "user" exists in database, then it was not possible to retrieve
existing columns from that database, because we used to compare unquoted
table name with quoted table name. This lead to schema that were out of sync
and could never be validated.
