### PR TITLE
Fix: property access is not allowed yet

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -57,7 +57,12 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
         if ( ! $this->_conn->real_connect($params['host'], $username, $password, $params['dbname'], $port, $socket)) {
             set_error_handler($previousHandler);
 
-            throw new MysqliException($this->_conn->connect_error, $this->_conn->sqlstate, $this->_conn->connect_errno);
+            $sqlState = 'HY000';
+            if (@$this->_conn->sqlstate) {
+                $sqlState = $this->_conn->sqlstate;
+            }
+
+            throw new MysqliException($this->_conn->connect_error, $sqlState, $this->_conn->connect_errno);
         }
 
         set_error_handler($previousHandler);


### PR DESCRIPTION
Fixes the warning emitted by mysqli when sqlstate is not set (yet?).
http://git.php.net/?p=php-src.git;a=blob;f=ext/mysqli/mysqli_prop.c;h=2d36336372b75922bd8fbf40c5c9054a5230c8a0;hb=HEAD#l36

Warning masks actual connection error.

Related:
http://www.doctrine-project.org/jira/browse/DBAL-911
