### PR TITLE
Correcting the doc because mysqli doesn't support named parameter natively

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -102,7 +102,30 @@ class MysqliStatement implements \IteratorAggregate, Statement
     }
 
     /**
-     * {@inheritdoc}
+     * Binds a PHP variable to a corresponding question mark placeholder in the
+     * SQL statement that was use to prepare the statement. Unlike PDOStatement->bindValue(),
+     * the variable is bound as a reference and will only be evaluated at the time
+     * that PDOStatement->execute() is called.
+     *
+     * The named parameter are not natively supported by the mysqli driver, use executeQuery(), fetchAll(),
+     * fetchArray(), fetchColumn(), fetchAssoc() methods to have the named parameter emulated by doctrine.
+     *
+     * Most parameters are input parameters, that is, parameters that are
+     * used in a read-only fashion to build up the query. Some drivers support the invocation
+     * of stored procedures that return data as output parameters, and some also as input/output
+     * parameters that both send in data and are updated to receive it.
+     *
+     * @param mixed        $column   Parameter identifier. For a prepared statement using named placeholders,
+     *                               this will be a parameter name of the form :name. For a prepared statement using
+     *                               question mark placeholders, this will be the 1-indexed position of the parameter.
+     * @param mixed        $variable Name of the PHP variable to bind to the SQL statement parameter.
+     * @param integer|null $type     Explicit data type for the parameter using the PDO::PARAM_* constants. To return
+     *                               an INOUT parameter from a stored procedure, use the bitwise OR operator to set the
+     *                               PDO::PARAM_INPUT_OUTPUT bits for the data_type parameter.
+     * @param integer|null $length   You must specify maxlength when using an OUT bind
+     *                               so that PHP allocates enough memory to hold the returned value.
+     *
+     * @return boolean TRUE on success or FALSE on failure.
      */
     public function bindParam($column, &$variable, $type = null, $length = null)
     {
@@ -123,7 +146,18 @@ class MysqliStatement implements \IteratorAggregate, Statement
     }
 
     /**
-     * {@inheritdoc}
+     * Binds a value to a corresponding positional placeholder in the SQL statement that was used to prepare
+     * the statement.
+     * The named parameter are not natively supported by the mysqli driver, use executeQuery(), fetchAll(),
+     * fetchArray(), fetchColumn(), fetchAssoc() methods to have the named parameter emulated by doctrine.
+     *
+     * @param mixed   $param Parameter identifier. For a prepared statement using named placeholders,
+     *                       this will be a parameter name of the form :name. For a prepared statement
+     *                       using question mark placeholders, this will be the 1-indexed position of the parameter.
+     * @param mixed   $value The value to bind to the parameter.
+     * @param integer $type  Explicit data type for the parameter using the PDO::PARAM_* constants.
+     *
+     * @return boolean TRUE on success or FALSE on failure.
      */
     public function bindValue($param, $value, $type = null)
     {


### PR DESCRIPTION
The documentation incorrectly stated that their use was possible.
