### PR TITLE
Always store dates in UTC

### DIFF
--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -49,8 +49,12 @@ class DateTimeType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        return ($value !== null)
-            ? $value->format($platform->getDateTimeFormatString()) : null;
+        if ($value === null) { return null; }
+
+        $copy = clone $value;
+        $copy->setTimezone(new \DateTimeZone('UTC'));
+
+        return $copy->format($platform->getDateTimeFormatString());
     }
 
     /**
@@ -62,15 +66,17 @@ class DateTimeType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat($platform->getDateTimeFormatString(), $value);
+        $val = \DateTime::createFromFormat($platform->getDateTimeFormatString(), $value, new \DateTimeZone('UTC'));
 
         if ( ! $val) {
-            $val = date_create($value);
+            $val = date_create($value, new \DateTimeZone('UTC'));
         }
 
         if ( ! $val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateTimeFormatString());
         }
+
+        $val->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
         return $val;
     }

--- a/lib/Doctrine/DBAL/Types/DateType.php
+++ b/lib/Doctrine/DBAL/Types/DateType.php
@@ -49,8 +49,12 @@ class DateType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        return ($value !== null)
-            ? $value->format($platform->getDateFormatString()) : null;
+        if ($value === null) { return null; }
+
+        $copy = clone $value;
+        $copy->setTimezone(new \DateTimeZone('UTC'));
+
+        return $copy->format($platform->getDateFormatString());
     }
 
     /**
@@ -62,10 +66,12 @@ class DateType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat('!'.$platform->getDateFormatString(), $value);
+        $val = \DateTime::createFromFormat('!'.$platform->getDateFormatString(), $value, new \DateTimeZone('UTC'));
         if ( ! $val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateFormatString());
         }
+
+        $val->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
         return $val;
     }


### PR DESCRIPTION
This PQ will make sure that the dates saved in the database (without indication of timezone) is always stored in the UTC timezone.

I was doing development on my machine in Sweden when I noticed that when I created a `DateTime`, stored it in the db and then retrieved it again, the time was off by two hours. This is because a created the `DateTime` object with the UTC timezone. Doctrine then saved it straight to the database (by using `$date->format(...)`) and thus the information about which timezone it was in was lost. When doctrine then fetched the value, it used `DateTime::createFromFormat(...)` to create a `DateTime` for me. The problem is that since the timezone wasn't saved anywhere, it assumed that it was a Swedish date, and thus it removed two hours.

I believe that the correct way of doing it is to store the dates in the db as UTC. Then it will always work no matter what the default timezone is, even if I later decide to change it.

`date_default_timezone_set('UTC')` is not the answer. If I use it, I need to make sure that every `DateTime` that I pass to doctrine always has the timezone set to `UTC`. Since the `DateTime` can come from any number of sources (e.g. third party library) it could easily introduce hard to detect bugs. It will also output every date in the UTC timezone which may not be what I want if I'm developing a localised site (e.g. small page for a local Swedish business).
