### PR TITLE
deleted invalid target for quantifier

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1176,7 +1176,7 @@ class SQLServerPlatform extends AbstractPlatform
         $format  = 'SELECT * FROM (%s) AS doctrine_tbl WHERE doctrine_rownum BETWEEN %d AND %d';
 
         // Pattern to match "main" SELECT ... FROM clause (including nested parentheses in select list).
-        $selectFromPattern = '/^(\s*SELECT\s+(?:\((?>[^()]+)|(?:R)*\)|[^(])+)\sFROM\s/i';
+        $selectFromPattern = '/^(\s*SELECT\s+(?:\((>[^()]+)|(?:R)*\)|[^(])+)\sFROM\s/i';
 
         if ( ! $orderBy) {
             //Replace only "main" FROM with OVER to prevent changing FROM also in subqueries.


### PR DESCRIPTION
according to regexr.com the `?` quantifier is invalid in this context (see diff):
`/^(\s*SELECT\s+(?:\((?>[^()]+)|(?:R)*\)|[^(])+)\sFROM\s/i`
http://www.regexr.com/

test query:

```
SELECT a.agreement_id, c.name as client, rp.name as roaming_partner, rp.active as active, te.name as technology, a.changedate as changedate, a.client_id as client_id, sv.value_text as status FROM rtd_agreement a, rtd_client c, rtd_client_user cu, rtd_user u, rtd_technology te, rtd_roaming_partner rp, rtd_agreement_state ast, rtd_state s, rtd_state_values sv WHERE (a.technology_id = te.technology_id) AND (a.roaming_partner_id = rp.roaming_partner_id) AND (a.client_id = c.client_id) AND (c.client_id = cu.client_id) AND (cu.user_id = u.user_id) AND (u.username = ?) AND (a.client_id IN (?)) AND (ast.agreement_id = a.agreement_id) AND (ast.state_id = s.state_id) AND (ast.state_id = sv.state_id) AND (ast.state_value = sv.state_value) AND (s.type = ?) AND (exists (select ast.agreement_id from rtd_agreement_state ast, rtd_state s where ast.agreement_id = a.agreement_id and ast.state_id = s.state_id and s.type = ? and ast.state_value = ?))
```

applying the current regex to this query results in `NULL`.
this only happens when i add a `(exists (select ...))` where-clause.
with the `?` quantifier removed, the regex works just fine.
please have a look at this.
