### PR TITLE
fix all sqlite integer types

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -205,7 +205,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getIntegerTypeDeclarationSQL(array $field)
     {
-        return 'INTEGER' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return $this->_getCommonIntegerTypeDeclarationSQL($field);
     }
 
     /**
@@ -213,7 +213,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getBigIntTypeDeclarationSQL(array $field)
     {
-        return 'BIGINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return $this->_getCommonIntegerTypeDeclarationSQL($field);
     }
 
     /**
@@ -221,7 +221,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getTinyIntTypeDeclarationSql(array $field)
     {
-        return 'TINYINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return $this->_getCommonIntegerTypeDeclarationSQL($field);
     }
 
     /**
@@ -229,7 +229,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getSmallIntTypeDeclarationSQL(array $field)
     {
-        return 'SMALLINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return $this->_getCommonIntegerTypeDeclarationSQL($field);
     }
 
     /**
@@ -237,7 +237,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getMediumIntTypeDeclarationSql(array $field)
     {
-        return 'MEDIUMINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return $this->_getCommonIntegerTypeDeclarationSQL($field);
     }
 
     /**
@@ -271,10 +271,10 @@ class SqlitePlatform extends AbstractPlatform
     {
         // sqlite autoincrement is implicit for integer PKs, but not when the field is unsigned
         if ( ! empty($columnDef['autoincrement'])) {
-            return '';
+            return 'INTEGER';
         }
 
-        return ! empty($columnDef['unsigned']) ? ' UNSIGNED' : '';
+        return ! empty($columnDef['unsigned']) ? 'INTEGER UNSIGNED' : 'INTEGER';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -77,24 +77,24 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     public function testGeneratesTypeDeclarationForTinyIntegers()
     {
         $this->assertEquals(
-            'TINYINT',
+            'INTEGER',
             $this->_platform->getTinyIntTypeDeclarationSQL(array())
         );
         $this->assertEquals(
-            'TINYINT',
+            'INTEGER',
             $this->_platform->getTinyIntTypeDeclarationSQL(array('autoincrement' => true))
         );
         $this->assertEquals(
-            'TINYINT',
+            'INTEGER',
             $this->_platform->getTinyIntTypeDeclarationSQL(
                 array('autoincrement' => true, 'primary' => true))
         );
         $this->assertEquals(
-            'TINYINT',
+            'INTEGER',
             $this->_platform->getTinyIntTypeDeclarationSQL(array('unsigned' => false))
         );
         $this->assertEquals(
-            'TINYINT UNSIGNED',
+            'INTEGER UNSIGNED',
             $this->_platform->getTinyIntTypeDeclarationSQL(array('unsigned' => true))
         );
     }
@@ -105,24 +105,24 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     public function testGeneratesTypeDeclarationForSmallIntegers()
     {
         $this->assertEquals(
-            'SMALLINT',
+            'INTEGER',
             $this->_platform->getSmallIntTypeDeclarationSQL(array())
         );
         $this->assertEquals(
-            'SMALLINT',
+            'INTEGER',
             $this->_platform->getSmallIntTypeDeclarationSQL(array('autoincrement' => true))
         );
         $this->assertEquals(
-            'SMALLINT',
+            'INTEGER',
             $this->_platform->getSmallIntTypeDeclarationSQL(
                 array('autoincrement' => true, 'primary' => true))
         );
         $this->assertEquals(
-            'SMALLINT',
+            'INTEGER',
             $this->_platform->getSmallIntTypeDeclarationSQL(array('unsigned' => false))
         );
         $this->assertEquals(
-            'SMALLINT UNSIGNED',
+            'INTEGER UNSIGNED',
             $this->_platform->getSmallIntTypeDeclarationSQL(array('unsigned' => true))
         );
     }
@@ -133,24 +133,24 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     public function testGeneratesTypeDeclarationForMediumIntegers()
     {
         $this->assertEquals(
-            'MEDIUMINT',
+            'INTEGER',
             $this->_platform->getMediumIntTypeDeclarationSQL(array())
         );
         $this->assertEquals(
-            'MEDIUMINT',
+            'INTEGER',
             $this->_platform->getMediumIntTypeDeclarationSQL(array('autoincrement' => true))
         );
         $this->assertEquals(
-            'MEDIUMINT',
+            'INTEGER',
             $this->_platform->getMediumIntTypeDeclarationSQL(
                 array('autoincrement' => true, 'primary' => true))
         );
         $this->assertEquals(
-            'MEDIUMINT',
+            'INTEGER',
             $this->_platform->getMediumIntTypeDeclarationSQL(array('unsigned' => false))
         );
         $this->assertEquals(
-            'MEDIUMINT UNSIGNED',
+            'INTEGER UNSIGNED',
             $this->_platform->getMediumIntTypeDeclarationSQL(array('unsigned' => true))
         );
     }
@@ -186,24 +186,24 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     public function testGeneratesTypeDeclarationForBigIntegers()
     {
         $this->assertEquals(
-            'BIGINT',
+            'INTEGER',
             $this->_platform->getBigIntTypeDeclarationSQL(array())
         );
         $this->assertEquals(
-            'BIGINT',
+            'INTEGER',
             $this->_platform->getBigIntTypeDeclarationSQL(array('autoincrement' => true))
         );
         $this->assertEquals(
-            'BIGINT',
+            'INTEGER',
             $this->_platform->getBigIntTypeDeclarationSQL(
                 array('autoincrement' => true, 'primary' => true))
         );
         $this->assertEquals(
-            'BIGINT',
+            'INTEGER',
             $this->_platform->getBigIntTypeDeclarationSQL(array('unsigned' => false))
         );
         $this->assertEquals(
-            'BIGINT UNSIGNED',
+            'INTEGER UNSIGNED',
             $this->_platform->getBigIntTypeDeclarationSQL(array('unsigned' => true))
         );
     }


### PR DESCRIPTION
The SQLite platform introduced integer types that are not supported. This PR addresses integer issues with SQLite
