### PR TITLE
Correct SQL Anywhere driver default port to 2638

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -81,7 +81,7 @@ class Driver extends AbstractSQLAnywhereDriver
      * Build the connection string for given connection parameters and driver options.
      *
      * @param string  $host          Host address to connect to.
-     * @param integer $port          Port to use for the connection (default to SQL Anywhere standard port 2683).
+     * @param integer $port          Port to use for the connection (default to SQL Anywhere standard port 2638).
      * @param string  $server        Database server name on the host to connect to.
      *                               SQL Anywhere allows multiple database server instances on the same host,
      *                               therefore specifying the server instance name to use is mandatory.
@@ -94,7 +94,7 @@ class Driver extends AbstractSQLAnywhereDriver
      */
     private function buildDsn($host, $port, $server, $dbname, $username = null, $password = null, array $driverOptions = array())
     {
-        $port = $port ?: 2683;
+        $port = $port ?: 2638;
 
         return
             'LINKS=tcpip(HOST=' . $host . ';PORT=' . $port . ';DoBroadcast=Direct)' .


### PR DESCRIPTION
It looks like this was a simple typo. 

References:
SQLA16 - http://dcx.sybase.com/index.html#sa160/en/dbadmin/serverport-network-conparm.html
SQLA12 - http://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.help.sqlanywhere.11.0.1/dbadmin_en11/serverport-network-conparm.html

It probably wasn't noticed immediately due to the fact SQL Anywhere drivers cache database server address information in a file on disk (sasrv.ini). Once the cache is populated with the database name, it's possible to connect successfully even if the port you were specifying in your code was incorrect (like 2683). 

http://dcx.sybase.com/1201/en/dbadmin/servernamecaching.html
