### PR TITLE
Prevent Connection from maintaining a second reference to an injected PDO object.

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -206,6 +206,7 @@ class Connection implements DriverConnection
         if (isset($params['pdo'])) {
             $this->_conn = $params['pdo'];
             $this->_isConnected = true;
+            unset($this->_params['pdo']);
         }
 
         // Create default config and event manager if none given

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -435,4 +435,26 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
 
         $this->assertSame($result, $conn->fetchAll($statement, $params, $types));
     }
+
+    public function testConnectionDoesNotMaintainTwoReferencesToExternalPDO()
+    {
+        $params['pdo'] = new \stdClass();
+
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+
+        $conn = new Connection($params, $driverMock);
+
+        $this->assertArrayNotHasKey('pdo', $conn->getParams(), "Connection is maintaining additional reference to the PDO connection");
+    }
+
+    public function testPassingExternalPDOMeansConnectionIsConnected()
+    {
+        $params['pdo'] = new \stdClass();
+
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+
+        $conn = new Connection($params, $driverMock);
+
+        $this->assertTrue($conn->isConnected(), "Connection is not connected after passing external PDO");
+    }
 }


### PR DESCRIPTION
Previously, if a developer explicitly closed the Connection, only the _conn reference was destroyed, but the _params['pdo'] reference remained and kept the PDO connection alive. By unsetting the _params reference, we maintain only the _conn reference, exactly as if the PDO connection is generated internally.
