### PR TITLE
Update PostgreSqlPlatform.php

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -209,8 +209,10 @@ class PostgreSqlPlatform extends AbstractPlatform
                     c.relname, n.nspname AS schemaname
                 FROM
                    pg_class c, pg_namespace n
-                WHERE relkind = 'S' AND n.oid = c.relnamespace AND
-                    (n.nspname NOT LIKE 'pg_%' AND n.nspname != 'information_schema')";
+                WHERE relkind = 'S' 
+                AND n.oid = c.relnamespace 
+                AND (n.nspname NOT LIKE 'pg_%' AND n.nspname != 'information_schema')
+                AND pg_table_is_visible(oid) is true";
     }
 
     /**
@@ -218,8 +220,17 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getListTablesSQL()
     {
-        return "SELECT quote_ident(tablename) AS table_name, schemaname AS schema_name
-                FROM pg_tables WHERE schemaname NOT LIKE 'pg_%' AND schemaname != 'information_schema' AND tablename != 'geometry_columns' AND tablename != 'spatial_ref_sys'";
+        return "SELECT quote_ident(t.tablename) AS table_name, 
+                t.schemaname AS schema_name
+                FROM pg_tables t,
+                     pg_class c
+                WHERE t.tablename = c.relname
+                AND c.relkind = 'r'
+                AND pg_table_is_visible(c.oid) is true
+                AND t.schemaname NOT LIKE 'pg_%' 
+                AND schemaname != 'information_schema' 
+                AND tablename != 'geometry_columns' 
+                AND tablename != 'spatial_ref_sys'";
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -205,14 +205,11 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getListSequencesSQL($database)
     {
-        return "SELECT
-                    c.relname, n.nspname AS schemaname
-                FROM
-                   pg_class c, pg_namespace n
-                WHERE relkind = 'S' 
-                AND n.oid = c.relnamespace 
-                AND (n.nspname NOT LIKE 'pg_%' AND n.nspname != 'information_schema')
-                AND pg_table_is_visible(c.oid) is true";
+        return "SELECT sequence_name AS relname, 
+                       sequence_schema AS schemaname
+                FROM information_schema.sequences
+                WHERE sequence_schema NOT LIKE 'pg_%' 
+                AND sequence_schema != 'information_schema'";
     }
 
     /**
@@ -220,17 +217,13 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getListTablesSQL()
     {
-        return "SELECT quote_ident(t.tablename) AS table_name, 
-                t.schemaname AS schema_name
-                FROM pg_tables t,
-                     pg_class c
-                WHERE t.tablename = c.relname
-                AND c.relkind = 'r'
-                AND pg_table_is_visible(c.oid) is true
-                AND t.schemaname NOT LIKE 'pg_%' 
-                AND schemaname != 'information_schema' 
-                AND tablename != 'geometry_columns' 
-                AND tablename != 'spatial_ref_sys'";
+        return "SELECT quote_ident(table_name) AS table_name, 
+                       table_schema AS schema_name
+                FROM information_schema.tables
+                WHERE table_schema NOT LIKE 'pg_%' 
+                AND table_schema != 'information_schema' 
+                AND table_name != 'geometry_columns' 
+                AND table_name != 'spatial_ref_sys'";
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -212,7 +212,7 @@ class PostgreSqlPlatform extends AbstractPlatform
                 WHERE relkind = 'S' 
                 AND n.oid = c.relnamespace 
                 AND (n.nspname NOT LIKE 'pg_%' AND n.nspname != 'information_schema')
-                AND pg_table_is_visible(n.oid) is true";
+                AND pg_table_is_visible(c.oid) is true";
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -212,7 +212,7 @@ class PostgreSqlPlatform extends AbstractPlatform
                 WHERE relkind = 'S' 
                 AND n.oid = c.relnamespace 
                 AND (n.nspname NOT LIKE 'pg_%' AND n.nspname != 'information_schema')
-                AND pg_table_is_visible(oid) is true";
+                AND pg_table_is_visible(n.oid) is true";
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -207,9 +207,9 @@ class PostgreSqlPlatform extends AbstractPlatform
     {
         return "SELECT sequence_name AS relname, 
                        sequence_schema AS schemaname
-                FROM information_schema.sequences
-                WHERE sequence_schema NOT LIKE 'pg_%' 
-                AND sequence_schema != 'information_schema'";
+                FROM   information_schema.sequences
+                WHERE  sequence_schema NOT LIKE 'pg_%' 
+                AND    sequence_schema != 'information_schema'";
     }
 
     /**
@@ -219,11 +219,11 @@ class PostgreSqlPlatform extends AbstractPlatform
     {
         return "SELECT quote_ident(table_name) AS table_name, 
                        table_schema AS schema_name
-                FROM information_schema.tables
-                WHERE table_schema NOT LIKE 'pg_%' 
-                AND table_schema != 'information_schema' 
-                AND table_name != 'geometry_columns' 
-                AND table_name != 'spatial_ref_sys'";
+                FROM   information_schema.tables
+                WHERE  table_schema NOT LIKE 'pg_%' 
+                AND    table_schema != 'information_schema' 
+                AND    table_name != 'geometry_columns' 
+                AND    table_name != 'spatial_ref_sys'";
     }
 
     /**


### PR DESCRIPTION
If the database have different schemes, with objects, that the actual logged in user has no rights, the existing statements will collect all objects (sequences and tables) and try to read them in later steps. This will throws exceptions. The reason for that is the fact, that both procedures getListSequencesList() and getListTablesSQL() will receive all known database objects from postgres catalogs. But the actual logged-in user, maby has no read permissions to object inside other scheme-owner. The additional parts inside both sql-statements will reduce the result to only objects that the user are able to see.
