### PR TITLE
Fix escaping of column name for specific alter table case

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -510,7 +510,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             }
 
             if ($columnDiff->hasChanged('length')) {
-                $query = 'ALTER ' . $column->getName() . ' TYPE ' . $column->getType()->getSqlDeclaration($column->toArray(), $this);
+                $query = 'ALTER ' . $oldColumnName . ' TYPE ' . $column->getType()->getSqlDeclaration($column->toArray(), $this);
                 $sql[] = 'ALTER TABLE ' . $diff->getName()->getQuotedName($this) . ' ' . $query;
             }
         }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -580,4 +580,20 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             "CHANGE quoted3 `baz` INT NOT NULL COMMENT 'Quoted 3'"
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotedAlterTableChangeColumnLengthSQL()
+    {
+        return array(
+            "ALTER TABLE mytable " .
+            "CHANGE unquoted1 unquoted1 VARCHAR(255) NOT NULL COMMENT 'Unquoted 1', " .
+            "CHANGE unquoted2 unquoted2 VARCHAR(255) NOT NULL COMMENT 'Unquoted 2', " .
+            "CHANGE unquoted3 unquoted3 VARCHAR(255) NOT NULL COMMENT 'Unquoted 3', " .
+            "CHANGE `create` `create` VARCHAR(255) NOT NULL COMMENT 'Reserved keyword 1', " .
+            "CHANGE `table` `table` VARCHAR(255) NOT NULL COMMENT 'Reserved keyword 2', " .
+            "CHANGE `select` `select` VARCHAR(255) NOT NULL COMMENT 'Reserved keyword 3'"
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -718,6 +718,48 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     abstract protected function getQuotedAlterTableRenameColumnSQL();
 
     /**
+     * @group DBAL-835
+     */
+    public function testQuotesAlterTableChangeColumnLength()
+    {
+        $fromTable = new Table('mytable');
+
+        $fromTable->addColumn('unquoted1', 'string', array('comment' => 'Unquoted 1', 'length' => 10));
+        $fromTable->addColumn('unquoted2', 'string', array('comment' => 'Unquoted 2', 'length' => 10));
+        $fromTable->addColumn('unquoted3', 'string', array('comment' => 'Unquoted 3', 'length' => 10));
+
+        $fromTable->addColumn('create', 'string', array('comment' => 'Reserved keyword 1', 'length' => 10));
+        $fromTable->addColumn('table', 'string', array('comment' => 'Reserved keyword 2', 'length' => 10));
+        $fromTable->addColumn('select', 'string', array('comment' => 'Reserved keyword 3', 'length' => 10));
+
+        $toTable = new Table('mytable');
+
+        $toTable->addColumn('unquoted1', 'string', array('comment' => 'Unquoted 1', 'length' => 255));
+        $toTable->addColumn('unquoted2', 'string', array('comment' => 'Unquoted 2', 'length' => 255));
+        $toTable->addColumn('unquoted3', 'string', array('comment' => 'Unquoted 3', 'length' => 255));
+
+        $toTable->addColumn('create', 'string', array('comment' => 'Reserved keyword 1', 'length' => 255));
+        $toTable->addColumn('table', 'string', array('comment' => 'Reserved keyword 2', 'length' => 255));
+        $toTable->addColumn('select', 'string', array('comment' => 'Reserved keyword 3', 'length' => 255));
+
+        $comparator = new Comparator();
+
+        $this->assertEquals(
+            $this->getQuotedAlterTableChangeColumnLengthSQL(),
+            $this->_platform->getAlterTableSQL($comparator->diffTable($fromTable, $toTable))
+        );
+    }
+
+    /**
+     * Returns SQL statements for {@link testQuotesAlterTableChangeColumnLength}.
+     *
+     * @return array
+     *
+     * @group DBAL-835
+     */
+    abstract protected function getQuotedAlterTableChangeColumnLengthSQL();
+
+    /**
      * @group DBAL-807
      */
     public function testAlterTableRenameIndexInSchema()

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -635,6 +635,21 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getQuotedAlterTableChangeColumnLengthSQL()
+    {
+        return array(
+            'ALTER TABLE mytable ALTER unquoted1 TYPE VARCHAR(255)',
+            'ALTER TABLE mytable ALTER unquoted2 TYPE VARCHAR(255)',
+            'ALTER TABLE mytable ALTER unquoted3 TYPE VARCHAR(255)',
+            'ALTER TABLE mytable ALTER "create" TYPE VARCHAR(255)',
+            'ALTER TABLE mytable ALTER "table" TYPE VARCHAR(255)',
+            'ALTER TABLE mytable ALTER "select" TYPE VARCHAR(255)',
+        );
+    }
+
+    /**
      * @group DBAL-807
      */
     protected function getAlterTableRenameIndexInSchemaSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -883,6 +883,14 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getQuotedAlterTableChangeColumnLengthSQL()
+    {
+        $this->markTestIncomplete('Not implemented yet');
+    }
+
+    /**
      * @group DBAL-807
      */
     protected function getAlterTableRenameIndexInSchemaSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -436,6 +436,14 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getQuotedAlterTableChangeColumnLengthSQL()
+    {
+        $this->markTestIncomplete('Not implemented yet');
+    }
+
+    /**
      * @group DBAL-807
      */
     protected function getAlterTableRenameIndexInSchemaSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -457,6 +457,14 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getQuotedAlterTableChangeColumnLengthSQL()
+    {
+        $this->markTestIncomplete('Not implemented yet');
+    }
+
+    /**
      * @group DBAL-807
      */
     protected function getAlterTableRenameIndexInSchemaSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -847,6 +847,14 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getQuotedAlterTableChangeColumnLengthSQL()
+    {
+        $this->markTestIncomplete('Not implemented yet');
+    }
+
+    /**
      * @group DBAL-807
      */
     protected function getAlterTableRenameIndexInSchemaSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -495,6 +495,20 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'INSERT INTO mytable (unquoted, "where", "foo", reserved_keyword, "from", "bar", quoted, "and", "baz") SELECT unquoted1, unquoted2, unquoted3, "create", "table", "select", "quoted1", "quoted2", "quoted3" FROM __temp__mytable',
             'DROP TABLE __temp__mytable',
         );
+	}
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotedAlterTableChangeColumnLengthSQL()
+    {
+        return array(
+            'CREATE TEMPORARY TABLE __temp__mytable AS SELECT unquoted1, unquoted2, unquoted3, "create", "table", "select" FROM mytable',
+            'DROP TABLE mytable',
+            'CREATE TABLE mytable (unquoted1 VARCHAR(255) NOT NULL, unquoted2 VARCHAR(255) NOT NULL, unquoted3 VARCHAR(255) NOT NULL, "create" VARCHAR(255) NOT NULL, "table" VARCHAR(255) NOT NULL, "select" VARCHAR(255) NOT NULL)',
+            'INSERT INTO mytable (unquoted1, unquoted2, unquoted3, "create", "table", "select") SELECT unquoted1, unquoted2, unquoted3, "create", "table", "select" FROM __temp__mytable',
+            'DROP TABLE __temp__mytable',
+        );
     }
 
     /**


### PR DESCRIPTION
When changing the length of a field, the column name needs to be escaped
properly.

Happens for example when changing the length of a column called "User" on a table.
