### PR TITLE
updated PDO_SQLSRV connection to use driverOptions in prepare-function

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -29,13 +29,13 @@ use Doctrine\DBAL\Driver\PDOConnection;
 class Connection extends PDOConnection implements \Doctrine\DBAL\Driver\Connection
 {
     /**
-	 * The driver options for PDO::prepare as documented in
-	 * http://msdn.microsoft.com/en-us/library/ff628176.aspx
-	 *
+     * The driver options for PDO::prepare as documented in
+     * http://msdn.microsoft.com/en-us/library/ff628176.aspx
+     *
      * @var array
      */
     protected $driverOptions;
-	
+    
     /**
      * @override
      */

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -29,6 +29,23 @@ use Doctrine\DBAL\Driver\PDOConnection;
 class Connection extends PDOConnection implements \Doctrine\DBAL\Driver\Connection
 {
     /**
+	 * The driver options for PDO::prepare as documented in
+	 * http://msdn.microsoft.com/en-us/library/ff628176.aspx
+	 *
+     * @var array
+     */
+    protected $driverOptions;
+	
+    /**
+     * @override
+     */
+    public function __construct($dsn, $user = null, $password = null, array $options = null)
+    {
+        $this->driverOptions = $options;
+        parent::__construct($dsn, $user, $password, $options);
+    }
+	
+    /**
      * @override
      */
     public function quote($value, $type=\PDO::PARAM_STR)
@@ -41,5 +58,17 @@ class Connection extends PDOConnection implements \Doctrine\DBAL\Driver\Connecti
         }
 
         return $val;
+    }
+	
+    /**
+     * @override
+     */
+    public function prepare($prepareString, $driverOptions = array())
+    {
+        if(!is_null($this->driverOptions)) {
+            return parent::prepare($prepareString, $this->driverOptions);
+        } else {
+            return parent::prepare($prepareString);
+        }        
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/ConnectionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\PDOSqlsrv;
+
+use Doctrine\DBAL\Driver\PDOSqlsrv\Connection;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+class ConnectionTest extends DbalFunctionalTestCase
+{
+    /**
+     * The pdo_sqlsrv driver connection mock under test.
+     *
+     * @var \Doctrine\DBAL\Driver\PDOSqlsrv\Connection|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $driverConnection;
+
+    public function setUp()
+    {
+        if ( ! extension_loaded('pdo_sqlsrv')) {
+            $this->markTestSkipped('pdo_sqlsrv is not installed.');
+        }
+        
+        parent::setUp();
+        
+        $this->driverConnection = $this->_conn->getWrappedConnection();
+        
+        if ( !($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\PDOSqlsrv\Driver)) {
+            $this->markTestSkipped('PDOSqlsrv only test.');
+        }
+    }
+    
+    public function testPrepareWithDriverOptions()
+    {
+        $sql = 'SELECT name, colour, calories FROM fruit WHERE calories < :calories AND colour = :colour';
+        $pdoStatement = $this->driverConnection->prepare($sql, array(PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL));
+        
+        $this->assertEquals($pdoStatement->getAttribute(PDO::ATTR_CURSOR), PDO::CURSOR_SCROLL);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/ConnectionTest.php
@@ -8,9 +8,9 @@ use Doctrine\Tests\DbalFunctionalTestCase;
 class ConnectionTest extends DbalFunctionalTestCase
 {
     /**
-     * The pdo_sqlsrv driver connection mock under test.
+     * The pdo_sqlsrv driver connection under test.
      *
-     * @var \Doctrine\DBAL\Driver\PDOSqlsrv\Connection|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Doctrine\DBAL\Driver\PDOConnection
      */
     private $driverConnection;
 


### PR DESCRIPTION
it seems that the `PDO::prepare` `$driver_options` param was never used.
in order to use the `PDOStatement::rowCount` function, the connection to an sql-server has to be established with the following params:

```
$connectionParams = array(
    'host' => $cfgHostName,
    'port' => $cfgPort,
    'dbname' => $cfgDatabase,
    'user' => $cfgUser,
    'password' => $cfgPassword,
    'driver' => 'pdo_sqlsrv',
    'driverOptions' => array(
        PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL
    )
);
```

the `driverOptions`-array is essential.
see http://msdn.microsoft.com/en-us/library/ff628176.aspx and http://at2.php.net/manual/de/pdo.prepare.php

with the follwing commit, the driver options are used by the PDO_SQLSRV prepared statements.
maybe there's a better way to implement this. please share your opinion on this fix.
