### PR TITLE
Add test to verify null cast in boolean type

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -788,7 +788,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             $item,
             function ($boolean) {
                 if (null === $boolean) {
-                    return 'NULL';
+                    return null;
                 }
 
                 return true === $boolean ? 'true' : 'false';

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -722,7 +722,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     private function convertSingleBooleanValue($value, $callback)
     {
         if (null === $value) {
-            return $callback(false);
+            return $callback(null);
         }
 
         if (is_bool($value) || is_numeric($value)) {
@@ -786,6 +786,9 @@ class PostgreSqlPlatform extends AbstractPlatform
         return $this->doConvertBooleans(
             $item,
             function ($boolean) {
+                if (is_null($boolean)) {
+                    return 'NULL';
+                }
                 return true === $boolean ? 'true' : 'false';
             }
         );
@@ -803,7 +806,7 @@ class PostgreSqlPlatform extends AbstractPlatform
         return $this->doConvertBooleans(
             $item,
             function ($boolean) {
-                return (int) $boolean;
+                return is_null($boolean) ? null : (int) $boolean;
             }
         );
     }

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -786,7 +786,7 @@ class PostgreSqlPlatform extends AbstractPlatform
         return $this->doConvertBooleans(
             $item,
             function ($boolean) {
-                if (is_null($boolean)) {
+                if (null === $boolean) {
                     return 'NULL';
                 }
                 return true === $boolean ? 'true' : 'false';
@@ -806,7 +806,7 @@ class PostgreSqlPlatform extends AbstractPlatform
         return $this->doConvertBooleans(
             $item,
             function ($boolean) {
-                return is_null($boolean) ? null : (int) $boolean;
+                return null === $boolean ? null : (int) $boolean;
             }
         );
     }

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -789,6 +789,7 @@ class PostgreSqlPlatform extends AbstractPlatform
                 if (null === $boolean) {
                     return 'NULL';
                 }
+
                 return true === $boolean ? 'true' : 'false';
             }
         );

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -788,7 +788,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             $item,
             function ($boolean) {
                 if (null === $boolean) {
-                    return null;
+                    return 'NULL';
                 }
 
                 return true === $boolean ? 'true' : 'false';

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
@@ -117,7 +117,7 @@ class DBAL630Test extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $row = $this->_conn->fetchAssoc('SELECT bool_col FROM dbal630_allow_nulls WHERE id = ?', array($id));
 
-        $this->assertEquals($databaseConvertedValue, $row['bool_col']);
+        $this->assertSame($databaseConvertedValue, $row['bool_col']);
     }
 
     /**
@@ -147,7 +147,7 @@ class DBAL630Test extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $row = $this->_conn->fetchAssoc('SELECT bool_col FROM dbal630_allow_nulls WHERE id = ?', array($id));
 
-        $this->assertEquals($databaseConvertedValue, $row['bool_col']);
+        $this->assertSame($databaseConvertedValue, $row['bool_col']);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
@@ -24,6 +24,7 @@ class DBAL630Test extends \Doctrine\Tests\DbalFunctionalTestCase
 
         try {
             $this->_conn->exec('CREATE TABLE dbal630 (id SERIAL, bool_col BOOLEAN NOT NULL);');
+            $this->_conn->exec('CREATE TABLE dbal630_allow_nulls (id SERIAL, bool_col BOOLEAN);');
         } catch (DBALException $e) {
         }
         $this->running = true;
@@ -88,11 +89,14 @@ class DBAL630Test extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $this->assertFalse($row['bool_col']);
     }
-    
-    public function testBooleanConversionNullParamEmulatedPrepares()
-    {
-        $this->_conn->exec('CREATE TABLE dbal630_allow_nulls (id SERIAL, bool_col BOOLEAN);');
 
+    /**
+     * @dataProvider booleanTypeConversionWithoutPdoTypeProvider
+     */
+    public function testBooleanConversionNullParamEmulatedPrepares(
+        $statementValue,
+        $databaseConvertedValue
+    ) {
         $this->_conn->getWrappedConnection()->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 
         // PDO::PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT is deprecated in php 5.6. PDO::ATTR_EMULATE_PREPARES should
@@ -104,15 +108,73 @@ class DBAL630Test extends \Doctrine\Tests\DbalFunctionalTestCase
         $platform = $this->_conn->getDatabasePlatform();
 
         $stmt = $this->_conn->prepare('INSERT INTO dbal630_allow_nulls (bool_col) VALUES(?)');
-        $stmt->bindValue(1, $platform->convertBooleansToDatabaseValue(null));
+        $stmt->bindValue(1, $platform->convertBooleansToDatabaseValue($statementValue));
         $stmt->execute();
 
-        $id = $this->_conn->lastInsertId('dbal630_id_seq');
+        $id = $this->_conn->lastInsertId('dbal630_allow_nulls_id_seq');
 
         $this->assertNotEmpty($id);
 
         $row = $this->_conn->fetchAssoc('SELECT bool_col FROM dbal630_allow_nulls WHERE id = ?', array($id));
 
-        $this->assertNull($row['bool_col']);
+        $this->assertEquals($databaseConvertedValue, $row['bool_col']);
+    }
+
+    /**
+     * @dataProvider booleanTypeConversionUsingBooleanTypeProvider
+     */
+    public function testBooleanConversionNullParamEmulatedPreparesWithBooleanTypeInBindValue(
+        $statementValue,
+        $databaseConvertedValue
+    ) {
+        $this->_conn->getWrappedConnection()->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+
+        // PDO::PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT is deprecated in php 5.6. PDO::ATTR_EMULATE_PREPARES should
+        // be used instead. so should only it be set when it is supported.
+        if (PHP_VERSION_ID < 50600) {
+            $this->_conn->getWrappedConnection()->setAttribute(PDO::PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT, true);
+        }
+
+        $platform = $this->_conn->getDatabasePlatform();
+
+        $stmt = $this->_conn->prepare('INSERT INTO dbal630_allow_nulls (bool_col) VALUES(?)');
+        $stmt->bindValue(1, $platform->convertBooleansToDatabaseValue($statementValue), PDO::PARAM_BOOL);
+        $stmt->execute();
+
+        $id = $this->_conn->lastInsertId('dbal630_allow_nulls_id_seq');
+
+        $this->assertNotEmpty($id);
+
+        $row = $this->_conn->fetchAssoc('SELECT bool_col FROM dbal630_allow_nulls WHERE id = ?', array($id));
+
+        $this->assertEquals($databaseConvertedValue, $row['bool_col']);
+    }
+
+    /**
+     * Boolean conversion mapping provider
+     * @return array
+     */
+    public function booleanTypeConversionUsingBooleanTypeProvider()
+    {
+        return array(
+            // statement value, database converted value result
+            array(true, true),
+            array(false, false),
+            array(null, false)
+        );
+    }
+
+    /**
+     * Boolean conversion mapping provider
+     * @return array
+     */
+    public function booleanTypeConversionWithoutPdoTypeProvider()
+    {
+        return array(
+            // statement value, database converted value result
+            array(true, true),
+            array(false, false),
+            array(null, null)
+        );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -613,6 +613,8 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
             array('no', 'false', 0, false),
             array('off', 'false', 0, false),
             array('0', 'false', 0, false),
+
+            array(null, 'NULL', null, null)
         );
     }
 


### PR DESCRIPTION
This test verify how null values are casted to boolean values in PostgresPlatform.

NULL values are wrongly casted when flag **useBooleanTrueFalseStrings** is `true`, This issue can be related to #625 
