### PR TITLE
json_array columns should return null for null values

### DIFF
--- a/lib/Doctrine/DBAL/Types/JsonArrayType.php
+++ b/lib/Doctrine/DBAL/Types/JsonArrayType.php
@@ -54,10 +54,6 @@ class JsonArrayType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null) {
-            return array();
-        }
-
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
 
         return json_decode($value, true);

--- a/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
@@ -45,7 +45,7 @@ class JsonArrayTest extends \Doctrine\Tests\DbalTestCase
 
     public function testJsonNullConvertsToPHPValue()
     {
-        $this->assertSame(array(), $this->type->convertToPHPValue(null, $this->platform));
+        $this->assertSame(null, $this->type->convertToPHPValue(null, $this->platform));
     }
 
     public function testJsonStringConvertsToPHPValue()


### PR DESCRIPTION
I guess this is a BC-break, but it fixes [DBAL-446](http://www.doctrine-project.org/jira/browse/DBAL-446).
