### PR TITLE
allow nested functions as second parameter to DATE_* functions

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -128,11 +128,17 @@ class SqlitePlatform extends AbstractPlatform
      */
     protected function getDateArithmeticIntervalExpression($date, $operator, $interval, $unit)
     {
+        // uses getConcatExpression to allow nested expressions as interval
         switch ($unit) {
             case self::DATE_INTERVAL_UNIT_SECOND:
             case self::DATE_INTERVAL_UNIT_MINUTE:
             case self::DATE_INTERVAL_UNIT_HOUR:
-                return "DATETIME(" . $date . ",'" . $operator . $interval . " " . $unit . "')";
+                return "DATETIME(" . $date . "," .
+                    $this->getConcatExpression(
+                        "'" . $operator . "'",
+                        "(" . $interval . ")",
+                        "' " . $unit . "'") .
+                    ")";
 
             default:
                 switch ($unit) {
@@ -147,7 +153,12 @@ class SqlitePlatform extends AbstractPlatform
                         break;
                 }
 
-                return "DATE(" . $date . ",'" . $operator . $interval . " " . $unit . "')";
+                return "DATE(" . $date . "," .
+                    $this->getConcatExpression(
+                        "'" . $operator . "'",
+                        "(" . $interval . ")",
+                        "' " . $unit . "'") .
+                    ")";
         }
     }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -36,6 +36,26 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $this->assertEquals('RLIKE', $this->_platform->getRegexpExpression(), 'Regular expression operator is not correct');
         $this->assertEquals('SUBSTR(column, 5, LENGTH(column))', $this->_platform->getSubstringExpression('column', 5), 'Substring expression without length is not correct');
         $this->assertEquals('SUBSTR(column, 0, 5)', $this->_platform->getSubstringExpression('column', 0, 5), 'Substring expression with length is not correct');
+        // date assertions
+        $this->assertEquals("DATE('1987/05/02','+' || (4) || ' DAY')", $this->_platform->getDateAddDaysExpression("'1987/05/02'", 4));
+        $this->assertEquals("DATETIME('1987/05/02','+' || (12) || ' HOUR')", $this->_platform->getDateAddHourExpression("'1987/05/02'", 12));
+        $this->assertEquals("DATETIME('1987/05/02','+' || (2) || ' MINUTE')", $this->_platform->getDateAddMinutesExpression("'1987/05/02'", 2));
+        $this->assertEquals("DATE('1987/05/02','+' || (102) || ' MONTH')", $this->_platform->getDateAddMonthExpression("'1987/05/02'", 102));
+        $this->assertEquals("DATE('1987/05/02','+' || (15) || ' MONTH')", $this->_platform->getDateAddQuartersExpression("'1987/05/02'", 5));
+        $this->assertEquals("DATETIME('1987/05/02','+' || (1) || ' SECOND')", $this->_platform->getDateAddSecondsExpression("'1987/05/02'", 1));
+        $this->assertEquals("DATE('1987/05/02','+' || (21) || ' DAY')", $this->_platform->getDateAddWeeksExpression("'1987/05/02'", 3));
+        $this->assertEquals("DATE('1987/05/02','+' || (10) || ' YEAR')", $this->_platform->getDateAddYearsExpression("'1987/05/02'", 10));
+        $this->assertEquals("ROUND(JULIANDAY('1987/05/02')-JULIANDAY('1987/04/01'))", $this->_platform->getDateDiffExpression("'1987/05/02'", "'1987/04/01'"));
+        $this->assertEquals("DATE('1987/05/02','-' || (4) || ' DAY')", $this->_platform->getDateSubDaysExpression("'1987/05/02'", 4));
+        $this->assertEquals("DATETIME('1987/05/02','-' || (12) || ' HOUR')", $this->_platform->getDateSubHourExpression("'1987/05/02'", 12));
+        $this->assertEquals("DATETIME('1987/05/02','-' || (2) || ' MINUTE')", $this->_platform->getDateSubMinutesExpression("'1987/05/02'", 2));
+        $this->assertEquals("DATE('1987/05/02','-' || (102) || ' MONTH')", $this->_platform->getDateSubMonthExpression("'1987/05/02'", 102));
+        $this->assertEquals("DATE('1987/05/02','-' || (15) || ' MONTH')", $this->_platform->getDateSubQuartersExpression("'1987/05/02'", 5));
+        $this->assertEquals("DATETIME('1987/05/02','-' || (1) || ' SECOND')", $this->_platform->getDateSubSecondsExpression("'1987/05/02'", 1));
+        $this->assertEquals("DATE('1987/05/02','-' || (21) || ' DAY')", $this->_platform->getDateSubWeeksExpression("'1987/05/02'", 3));
+        $this->assertEquals("DATE('1987/05/02','-' || (10) || ' YEAR')", $this->_platform->getDateSubYearsExpression("'1987/05/02'", 10));
+        // date operation with nested expression (coalesce)
+        $this->assertEquals("DATE('1987/05/02','-' || (COALESCE(column1, 10)) || ' YEAR')", $this->_platform->getDateSubYearsExpression("'1987/05/02'", "COALESCE(column1, 10)"));
     }
 
     public function testGeneratesTransactionCommands()

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -36,6 +36,26 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $this->assertEquals('RLIKE', $this->_platform->getRegexpExpression(), 'Regular expression operator is not correct');
         $this->assertEquals('SUBSTR(column, 5, LENGTH(column))', $this->_platform->getSubstringExpression('column', 5), 'Substring expression without length is not correct');
         $this->assertEquals('SUBSTR(column, 0, 5)', $this->_platform->getSubstringExpression('column', 0, 5), 'Substring expression with length is not correct');
+        // date assertions
+        $this->assertEquals("DATE('1987-05-02','+' || (4) || ' DAY')", $this->_platform->getDateAddDaysExpression("'1987-05-02'", 4));
+        $this->assertEquals("DATETIME('1987-05-02','+' || (12) || ' HOUR')", $this->_platform->getDateAddHourExpression("'1987-05-02'", 12));
+        $this->assertEquals("DATETIME('1987-05-02','+' || (2) || ' MINUTE')", $this->_platform->getDateAddMinutesExpression("'1987-05-02'", 2));
+        $this->assertEquals("DATE('1987-05-02','+' || (102) || ' MONTH')", $this->_platform->getDateAddMonthExpression("'1987-05-02'", 102));
+        $this->assertEquals("DATE('1987-05-02','+' || (15) || ' MONTH')", $this->_platform->getDateAddQuartersExpression("'1987-05-02'", 5));
+        $this->assertEquals("DATETIME('1987-05-02','+' || (1) || ' SECOND')", $this->_platform->getDateAddSecondsExpression("'1987-05-02'", 1));
+        $this->assertEquals("DATE('1987-05-02','+' || (21) || ' DAY')", $this->_platform->getDateAddWeeksExpression("'1987-05-02'", 3));
+        $this->assertEquals("DATE('1987-05-02','+' || (10) || ' YEAR')", $this->_platform->getDateAddYearsExpression("'1987-05-02'", 10));
+        $this->assertEquals("ROUND(JULIANDAY('1987-05-02')-JULIANDAY('1987-04-01'))", $this->_platform->getDateDiffExpression("'1987-05-02'", "'1987-04-01'"));
+        $this->assertEquals("DATE('1987-05-02','-' || (4) || ' DAY')", $this->_platform->getDateSubDaysExpression("'1987-05-02'", 4));
+        $this->assertEquals("DATETIME('1987-05-02','-' || (12) || ' HOUR')", $this->_platform->getDateSubHourExpression("'1987-05-02'", 12));
+        $this->assertEquals("DATETIME('1987-05-02','-' || (2) || ' MINUTE')", $this->_platform->getDateSubMinutesExpression("'1987-05-02'", 2));
+        $this->assertEquals("DATE('1987-05-02','-' || (102) || ' MONTH')", $this->_platform->getDateSubMonthExpression("'1987-05-02'", 102));
+        $this->assertEquals("DATE('1987-05-02','-' || (15) || ' MONTH')", $this->_platform->getDateSubQuartersExpression("'1987-05-02'", 5));
+        $this->assertEquals("DATETIME('1987-05-02','-' || (1) || ' SECOND')", $this->_platform->getDateSubSecondsExpression("'1987-05-02'", 1));
+        $this->assertEquals("DATE('1987-05-02','-' || (21) || ' DAY')", $this->_platform->getDateSubWeeksExpression("'1987-05-02'", 3));
+        $this->assertEquals("DATE('1987-05-02','-' || (10) || ' YEAR')", $this->_platform->getDateSubYearsExpression("'1987-05-02'", 10));
+        // date operation with nested expression (coalesce)
+        $this->assertEquals("DATE('1987-05-02','-' || (COALESCE(column1, 10)) || ' YEAR')", $this->_platform->getDateSubYearsExpression("'1987-05-02'", "COALESCE(column1, 10)"));
     }
 
     public function testGeneratesTransactionCommands()


### PR DESCRIPTION
Using sqlite as backend you can't pass nested function for the second parameter of DATE_\* functions since it is transformed to a string. I've fixed that concatenating the string expression passed to sqlite DATE and DATETIME function using the getConcatExpression method - does this seem correct?

The DATE_\* functions work fine with nested second parameter in mysql.

I've added assertions similar to other platforms for the date functions.
