### PR TITLE
Fixed single quote in comments

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1589,7 +1589,9 @@ abstract class AbstractPlatform
      */
     public function getCommentOnColumnSQL($tableName, $columnName, $comment)
     {
-        return "COMMENT ON COLUMN " . $tableName . "." . $columnName . " IS '" . $comment . "'";
+        $comment = $this->quoteStringLiteral($comment);
+
+        return "COMMENT ON COLUMN " . $tableName . "." . $columnName . " IS " . $comment;
     }
 
     /**
@@ -2198,7 +2200,7 @@ abstract class AbstractPlatform
         }
 
         if ($this->supportsInlineColumnComments() && isset($field['comment']) && $field['comment']) {
-            $columnDef .= " COMMENT '" . $field['comment'] . "'";
+            $columnDef .= " COMMENT " . $this->quoteStringLiteral($field['comment']);
         }
 
         return $name . ' ' . $columnDef;
@@ -3458,5 +3460,29 @@ abstract class AbstractPlatform
     protected function getReservedKeywordsClass()
     {
         throw DBALException::notSupported(__METHOD__);
+    }
+
+    /**
+     * Quotes a literal string
+     *
+     * @param string $str The literal string to be quoted.
+     *
+     * @return string The quoted literal string.
+     */
+    public function quoteStringLiteral($str)
+    {
+        $c = $this->getStringLiteralQuoteCharacter();
+
+        return $c . str_replace($c, $c . $c, $str) . $c;
+    }
+
+    /**
+     * Gets the character used for string literal quoting.
+     *
+     * @return string
+     */
+    public function getStringLiteralQuoteCharacter()
+    {
+        return "'";
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
@@ -275,7 +275,7 @@ class DrizzlePlatform extends AbstractPlatform
         if (isset($options['comment'])) {
             $comment = trim($options['comment'], " '");
 
-            $tableOptions[] = sprintf("COMMENT = '%s' ", str_replace("'", "''", $comment));
+            $tableOptions[] = sprintf("COMMENT = %s ", $this->quoteStringLiteral($comment));
         }
 
         // Row format

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -494,7 +494,7 @@ class MySqlPlatform extends AbstractPlatform
         if (isset($options['comment'])) {
             $comment = trim($options['comment'], " '");
 
-            $tableOptions[] = sprintf("COMMENT = '%s' ", str_replace("'", "''", $comment));
+            $tableOptions[] = sprintf("COMMENT = %s ", $this->quoteStringLiteral($comment));
         }
 
         // Row format

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -598,7 +598,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getCommentOnColumnSQL($tableName, $columnName, $comment)
     {
-        $comment = $comment === null ? 'NULL' : "'$comment'";
+        $comment = $comment === null ? 'NULL' : $this->quoteStringLiteral($comment);
 
         return "COMMENT ON COLUMN $tableName.$columnName IS $comment";
     }

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -357,7 +357,7 @@ class SQLAnywherePlatform extends AbstractPlatform
      */
     public function getCommentOnColumnSQL($tableName, $columnName, $comment)
     {
-        $comment = $comment === null ? 'NULL' : "'$comment'";
+        $comment = $comment === null ? 'NULL' : $this->quoteStringLiteral($comment);
 
         return "COMMENT ON COLUMN $tableName.$columnName IS $comment";
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -869,4 +869,22 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
             $this->_sm->listTableForeignKeys($defaultSchemaName . '.' . $primaryTableName)
         );
     }
+
+    public function testCommentStringsAreQuoted()
+    {
+        if ( ! $this->_conn->getDatabasePlatform()->supportsInlineColumnComments() &&
+            ! $this->_conn->getDatabasePlatform()->supportsCommentOnStatement() &&
+            $this->_conn->getDatabasePlatform()->getName() != 'mssql') {
+            $this->markTestSkipped('Database does not support column comments.');
+        }
+
+        $table = new Table('my_table');
+        $table->addColumn('id', 'integer', array('comment' => "It's a comment with a quote"));
+        $table->setPrimaryKey(array('id'));
+
+        $this->_sm->createTable($table);
+
+        $columns = $this->_sm->listTableColumns("my_table");
+        $this->assertEquals("It's a comment with a quote", $columns['id']->getComment());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -821,4 +821,25 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
             'CREATE INDEX "bar" ON "schema"."table" (id)',
         );
     }
+
+    public function testGetCommentOnColumnSQL()
+    {
+        $this->assertEquals(
+            "COMMENT ON COLUMN mytable.id IS 'This is a comment'",
+            $this->_platform->getCommentOnColumnSQL('mytable', 'id', 'This is a comment')
+        );
+
+        $this->assertEquals(
+            "COMMENT ON COLUMN mytable.id IS 'It''s a quote !'",
+            $this->_platform->getCommentOnColumnSQL('mytable', 'id', "It's a quote !")
+        );
+    }
+
+    public function testQuoteStringLiteral()
+    {
+        $c = $this->_platform->getStringLiteralQuoteCharacter();
+        $this->assertEquals($c . 'No quote' . $c, $this->_platform->quoteStringLiteral('No quote'));
+        $this->assertEquals($c . 'It' . $c . $c . 's a quote' . $c, $this->_platform->quoteStringLiteral('It' . $c . 's a quote'));
+        $this->assertEquals($c . $c . $c . $c, $this->_platform->quoteStringLiteral($c));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -669,4 +669,12 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
             'ALTER INDEX "schema"."foo" RENAME TO "bar"',
         );
     }
+
+    public function testGetNullCommentOnColumnSQL()
+    {
+        $this->assertEquals(
+            "COMMENT ON COLUMN mytable.id IS NULL",
+            $this->_platform->getCommentOnColumnSQL('mytable', 'id', null)
+        );
+    }
 }


### PR DESCRIPTION
This is a little fix on unescaped singlequotes in column comments.

I only tested on Postgresql.
The changes in AbstractPlatform.php and SQLAnywherePlatform.php are not tested but the quote string escaping is pretty standard... i guess.
