### PR TITLE
Added field specific options for converting data between PHP and DB

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1417,28 +1417,30 @@ class Connection implements DriverConnection
      * Converts a given value to its database representation according to the conversion
      * rules of a specific DBAL mapping type.
      *
-     * @param mixed  $value The value to convert.
-     * @param string $type  The name of the DBAL mapping type.
+     * @param mixed  $value   The value to convert.
+     * @param string $type    The name of the DBAL mapping type.
+     * @param array  $options Configuration options for the type.
      *
      * @return mixed The converted value.
      */
-    public function convertToDatabaseValue($value, $type)
+    public function convertToDatabaseValue($value, $type, array $options = array())
     {
-        return Type::getType($type)->convertToDatabaseValue($value, $this->getDatabasePlatform());
+        return Type::getType($type)->convertToDatabaseValue($value, $this->getDatabasePlatform(), $options);
     }
 
     /**
      * Converts a given value to its PHP representation according to the conversion
      * rules of a specific DBAL mapping type.
      *
-     * @param mixed  $value The value to convert.
-     * @param string $type  The name of the DBAL mapping type.
+     * @param mixed  $value   The value to convert.
+     * @param string $type    The name of the DBAL mapping type.
+     * @param array  $options Configuration options for the type.
      *
      * @return mixed The converted type.
      */
-    public function convertToPHPValue($value, $type)
+    public function convertToPHPValue($value, $type, array $options = array())
     {
-        return Type::getType($type)->convertToPHPValue($value, $this->getDatabasePlatform());
+        return Type::getType($type)->convertToPHPValue($value, $this->getDatabasePlatform(), $options);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/ArrayType.php
+++ b/lib/Doctrine/DBAL/Types/ArrayType.php
@@ -39,7 +39,7 @@ class ArrayType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform, array $options = array())
     {
         // @todo 3.0 - $value === null check to save real NULL in database
         return serialize($value);
@@ -48,7 +48,7 @@ class ArrayType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         if ($value === null) {
             return null;

--- a/lib/Doctrine/DBAL/Types/BigIntType.php
+++ b/lib/Doctrine/DBAL/Types/BigIntType.php
@@ -56,7 +56,7 @@ class BigIntType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         return (null === $value) ? null : (string) $value;
     }

--- a/lib/Doctrine/DBAL/Types/BinaryType.php
+++ b/lib/Doctrine/DBAL/Types/BinaryType.php
@@ -40,7 +40,7 @@ class BinaryType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         if (null === $value) {
             return null;

--- a/lib/Doctrine/DBAL/Types/BlobType.php
+++ b/lib/Doctrine/DBAL/Types/BlobType.php
@@ -39,7 +39,7 @@ class BlobType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         if (null === $value) {
             return null;

--- a/lib/Doctrine/DBAL/Types/BooleanType.php
+++ b/lib/Doctrine/DBAL/Types/BooleanType.php
@@ -39,7 +39,7 @@ class BooleanType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform, array $options = array())
     {
         return $platform->convertBooleansToDatabaseValue($value);
     }
@@ -47,7 +47,7 @@ class BooleanType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         return $platform->convertFromBoolean($value);
     }

--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -47,7 +47,7 @@ class DateTimeType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform, array $options = array())
     {
         return ($value !== null)
             ? $value->format($platform->getDateTimeFormatString()) : null;
@@ -56,7 +56,7 @@ class DateTimeType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         if ($value === null || $value instanceof \DateTime) {
             return $value;

--- a/lib/Doctrine/DBAL/Types/DateTimeTzType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeTzType.php
@@ -65,7 +65,7 @@ class DateTimeTzType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform, array $options = array())
     {
         return ($value !== null)
             ? $value->format($platform->getDateTimeTzFormatString()) : null;
@@ -74,7 +74,7 @@ class DateTimeTzType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         if ($value === null || $value instanceof \DateTime) {
             return $value;

--- a/lib/Doctrine/DBAL/Types/DateType.php
+++ b/lib/Doctrine/DBAL/Types/DateType.php
@@ -47,7 +47,7 @@ class DateType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform, array $options = array())
     {
         return ($value !== null)
             ? $value->format($platform->getDateFormatString()) : null;
@@ -56,7 +56,7 @@ class DateType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         if ($value === null || $value instanceof \DateTime) {
             return $value;

--- a/lib/Doctrine/DBAL/Types/DecimalType.php
+++ b/lib/Doctrine/DBAL/Types/DecimalType.php
@@ -47,7 +47,7 @@ class DecimalType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         return (null === $value) ? null : $value;
     }

--- a/lib/Doctrine/DBAL/Types/FloatType.php
+++ b/lib/Doctrine/DBAL/Types/FloatType.php
@@ -42,7 +42,7 @@ class FloatType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         return (null === $value) ? null : (double) $value;
     }

--- a/lib/Doctrine/DBAL/Types/IntegerType.php
+++ b/lib/Doctrine/DBAL/Types/IntegerType.php
@@ -48,7 +48,7 @@ class IntegerType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         return (null === $value) ? null : (int) $value;
     }

--- a/lib/Doctrine/DBAL/Types/JsonArrayType.php
+++ b/lib/Doctrine/DBAL/Types/JsonArrayType.php
@@ -40,7 +40,7 @@ class JsonArrayType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform, array $options = array())
     {
         if (null === $value) {
             return null;
@@ -52,7 +52,7 @@ class JsonArrayType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         if ($value === null) {
             return array();

--- a/lib/Doctrine/DBAL/Types/ObjectType.php
+++ b/lib/Doctrine/DBAL/Types/ObjectType.php
@@ -39,7 +39,7 @@ class ObjectType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform, array $options = array())
     {
         return serialize($value);
     }
@@ -47,7 +47,7 @@ class ObjectType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         if ($value === null) {
             return null;

--- a/lib/Doctrine/DBAL/Types/SimpleArrayType.php
+++ b/lib/Doctrine/DBAL/Types/SimpleArrayType.php
@@ -42,7 +42,7 @@ class SimpleArrayType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform, array $options = array())
     {
         if (!$value) {
             return null;
@@ -54,7 +54,7 @@ class SimpleArrayType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         if ($value === null) {
             return array();

--- a/lib/Doctrine/DBAL/Types/SmallIntType.php
+++ b/lib/Doctrine/DBAL/Types/SmallIntType.php
@@ -47,7 +47,7 @@ class SmallIntType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         return (null === $value) ? null : (int) $value;
     }

--- a/lib/Doctrine/DBAL/Types/TextType.php
+++ b/lib/Doctrine/DBAL/Types/TextType.php
@@ -39,7 +39,7 @@ class TextType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         return (is_resource($value)) ? stream_get_contents($value) : $value;
     }

--- a/lib/Doctrine/DBAL/Types/TimeType.php
+++ b/lib/Doctrine/DBAL/Types/TimeType.php
@@ -47,7 +47,7 @@ class TimeType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform, array $options = array())
     {
         return ($value !== null)
             ? $value->format($platform->getTimeFormatString()) : null;
@@ -56,7 +56,7 @@ class TimeType extends Type
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         if ($value === null || $value instanceof \DateTime) {
             return $value;

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -100,10 +100,11 @@ abstract class Type
      *
      * @param mixed                                     $value    The value to convert.
      * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform The currently used database platform.
+     * @param array                                     $options  Field specific options.
      *
      * @return mixed The database representation of the value.
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform, array $options = array())
     {
         return $value;
     }
@@ -114,10 +115,11 @@ abstract class Type
      *
      * @param mixed                                     $value    The value to convert.
      * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform The currently used database platform.
+     * @param array                                     $options  Field specific options.
      *
      * @return mixed The PHP representation of the value.
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         return $value;
     }

--- a/lib/Doctrine/DBAL/Types/VarDateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/VarDateTimeType.php
@@ -40,7 +40,7 @@ class VarDateTimeType extends DateTimeType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = array())
     {
         if ($value === null || $value instanceof \DateTime) {
             return $value;


### PR DESCRIPTION
Added option parameter so field specific data can be passed when converting data for types. This is needed in cases like enum types or more generic types where you want field specific options for conversion.

This would give developers more freedom in creating custom domain-specific types.

Our (simplified) use-case is:

``` php
class EnumType extends Type
{
    const ENUM = 'enum';

    public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
    {
        return 'Enum';
    }

    public function convertToPHPValue($value, AbstractPlatform $platform, array $options = [])
    {
        return (null === $value) ? null : new $options['class']((int) $value);
    }

    public function convertToDatabaseValue($value, AbstractPlatform $platform, array $options = [])
    {
        return $value;
    }

    public function getName()
    {
        return self::ENUM;
    }
}
```

This way you can define a generic Enum and configure the matching type of the enum in the field itself. The end goal is to make use of this change in the ORM as follows:

``` php
class Entity
{
    /**
    * @ORM\Column(
    *     name         = "bar",
    *     type         = "enum",
    *     type_options = {
    *         "class" = "\Foo\Bar\FooBarEnum"
    *     }
    * )
    * @var FooBarEnum
    */
    private $foo;
}
```
