### PR TITLE
Allow current timestamp default to be specified for DateTimeTz type.

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2238,7 +2238,7 @@ abstract class AbstractPlatform
             if (isset($field['type'])) {
                 if (in_array((string)$field['type'], array("Integer", "BigInteger", "SmallInteger"))) {
                     $default = " DEFAULT ".$field['default'];
-                } elseif ((string)$field['type'] == 'DateTime' && $field['default'] == $this->getCurrentTimestampSQL()) {
+                } elseif (((string)$field['type'] == 'DateTime' || (string)$field['type'] == 'DateTimeTz') && $field['default'] == $this->getCurrentTimestampSQL()) {
                     $default = " DEFAULT ".$this->getCurrentTimestampSQL();
                 } elseif ((string)$field['type'] == 'Time' && $field['default'] == $this->getCurrentTimeSQL()) {
                     $default = " DEFAULT ".$this->getCurrentTimeSQL();

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2238,7 +2238,7 @@ abstract class AbstractPlatform
             if (isset($field['type'])) {
                 if (in_array((string)$field['type'], array("Integer", "BigInteger", "SmallInteger"))) {
                     $default = " DEFAULT ".$field['default'];
-                } elseif (((string)$field['type'] == 'DateTime' || (string)$field['type'] == 'DateTimeTz') && $field['default'] == $this->getCurrentTimestampSQL()) {
+                } elseif (in_array((string)$field['type'], array('DateTime', 'DateTimeTz')) && $field['default'] == $this->getCurrentTimestampSQL()) {
                     $default = " DEFAULT ".$this->getCurrentTimestampSQL();
                 } elseif ((string)$field['type'] == 'Time' && $field['default'] == $this->getCurrentTimeSQL()) {
                     $default = " DEFAULT ".$this->getCurrentTimeSQL();
@@ -2584,7 +2584,7 @@ abstract class AbstractPlatform
 
         return $item;
     }
-    
+
     /**
      * Some platforms have boolean literals that needs to be correctly converted
      *

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1458,7 +1458,7 @@ class SQLServerPlatform extends AbstractPlatform
             return " DEFAULT " . $field['default'];
         }
 
-        if ((string) $field['type'] == 'DateTime' && $field['default'] == $this->getCurrentTimestampSQL()) {
+        if (in_array((string) $field['type'], array('DateTime', 'DateTimeTz')) && $field['default'] == $this->getCurrentTimestampSQL()) {
             return " DEFAULT " . $this->getCurrentTimestampSQL();
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -419,6 +419,29 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
         $this->markTestSkipped('Platform does not support Column comments.');
     }
 
+    public function testGetDefaultValueDeclarationSQL()
+    {
+        // timestamps on datetime types should not be quoted
+        foreach (array('datetime', 'datetimetz') as $type) {
+
+            $field = array(
+                'type' => Type::getType($type),
+                'default' => $this->_platform->getCurrentTimestampSQL()
+            );
+
+            $this->assertEquals(' DEFAULT ' . $this->_platform->getCurrentTimestampSQL(), $this->_platform->getDefaultValueDeclarationSQL($field));
+
+        }
+
+        // non-timestamp value will get single quotes
+        $field = array(
+            'type' => 'string',
+            'default' => 'non_timestamp'
+        );
+
+        $this->assertEquals(" DEFAULT 'non_timestamp'", $this->_platform->getDefaultValueDeclarationSQL($field));
+    }
+
     /**
      * @group DBAL-45
      */

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -421,6 +421,17 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 
     public function testGetDefaultValueDeclarationSQL()
     {
+        // non-timestamp value will get single quotes
+        $field = array(
+            'type' => 'string',
+            'default' => 'non_timestamp'
+        );
+
+        $this->assertEquals(" DEFAULT 'non_timestamp'", $this->_platform->getDefaultValueDeclarationSQL($field));
+    }
+
+    public function testGetDefaultValueDeclarationSQLDateTime()
+    {
         // timestamps on datetime types should not be quoted
         foreach (array('datetime', 'datetimetz') as $type) {
 
@@ -432,14 +443,6 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
             $this->assertEquals(' DEFAULT ' . $this->_platform->getCurrentTimestampSQL(), $this->_platform->getDefaultValueDeclarationSQL($field));
 
         }
-
-        // non-timestamp value will get single quotes
-        $field = array(
-            'type' => 'string',
-            'default' => 'non_timestamp'
-        );
-
-        $this->assertEquals(" DEFAULT 'non_timestamp'", $this->_platform->getDefaultValueDeclarationSQL($field));
     }
 
     /**


### PR DESCRIPTION
Currently there is no way to specify a current timestamp as a default when using the `DateTimeTz` type, as it will always be quoted by the system. For example, the generated schema would have:

`DEFAULT 'NOW()'`

Instead of the correct:

`DEFAULT NOW()`

This simple fix allows `DateTimeTz` to behave just as `DateTime` in this regard.
