### PR TITLE
[DBAL-669] Make schema visit namespaces

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -21,6 +21,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Visitor\CreateSchemaSqlCollector;
 use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
+use Doctrine\DBAL\Schema\Visitor\NamespaceVisitor;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
@@ -477,9 +478,16 @@ class Schema extends AbstractAsset
     {
         $visitor->acceptSchema($this);
 
+        if ($visitor instanceof NamespaceVisitor) {
+            foreach ($this->namespaces as $namespace) {
+                $visitor->acceptNamespace($namespace);
+            }
+        }
+
         foreach ($this->_tables as $table) {
             $table->visit($visitor);
         }
+
         foreach ($this->_sequences as $sequence) {
             $sequence->visit($visitor);
         }


### PR DESCRIPTION
This PR is a followup to https://github.com/doctrine/dbal/pull/444 and fixes schema not visiting namespaces.
Because of this issue the ORM test suite is [currently failing](https://travis-ci.org/doctrine/doctrine2/jobs/32975659). The schema tool is not creating the namespaces before actually creating the namespace prefixed tables, therefore one test case is failing in ORM.
With this PR now the `CreateSchemaSqlCollector` is also generating the appropriate namespace creation SQL.
