### PR TITLE
convenience method for FULL OUTER JOINs in QueryBuilder

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -706,6 +706,35 @@ class QueryBuilder
     }
 
     /**
+     * Creates and adds a full join to the query.
+     *
+     * <code>
+     *     $qb = $conn->createQueryBuilder()
+     *         ->select('u.name')
+     *         ->from('users', 'u')
+     *         ->fullJoin('u', 'phonenumbers', 'p', 'p.is_primary = 1');
+     * </code>
+     *
+     * @param string $fromAlias The alias that points to a from clause.
+     * @param string $join      The table name to join.
+     * @param string $alias     The alias of the join table.
+     * @param string $condition The condition for the join.
+     *
+     * @return \Doctrine\DBAL\Query\QueryBuilder This QueryBuilder instance.
+     */
+    public function fullJoin($fromAlias, $join, $alias, $condition = null)
+    {
+        return $this->add('join', array(
+            $fromAlias => array(
+                'joinType'      => 'full',
+                'joinTable'     => $join,
+                'joinAlias'     => $alias,
+                'joinCondition' => $condition
+            )
+        ), true);
+    }
+
+    /**
      * Sets a new value for a column in a bulk update query.
      *
      * <code>

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -95,6 +95,18 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
         $this->assertEquals('SELECT u.*, p.* FROM users u RIGHT JOIN phones p ON p.user_id = u.id', (string) $qb);
     }
 
+    public function testSelectWithFullJoin()
+    {
+        $qb   = new QueryBuilder($this->conn);
+        $expr = $qb->expr();
+
+        $qb->select('u.*', 'p.*')
+           ->from('users', 'u')
+           ->fullJoin('u', 'phones', 'p', $expr->eq('p.user_id', 'u.id'));
+
+        $this->assertEquals('SELECT u.*, p.* FROM users u FULL JOIN phones p ON p.user_id = u.id', (string) $qb);
+    }
+
     public function testSelectWithAndWhereConditions()
     {
         $qb   = new QueryBuilder($this->conn);


### PR DESCRIPTION
was working on a project today where I needed a full outer join and found out that the method was missing in the QueryBuilder.
It's a minor change and I have also included a test case.

david
