### PR TITLE
Fix quoted integers as default value.

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2241,7 +2241,7 @@ abstract class AbstractPlatform
         if (isset($field['default'])) {
             $default = " DEFAULT '".$field['default']."'";
             if (isset($field['type'])) {
-                if (in_array((string) $field['type'], array("Integer", "BigInteger", "SmallInteger"))) {
+                if (in_array((string) $field['type'], array("Integer", "BigInt", "SmallInt"))) {
                     $default = " DEFAULT ".$field['default'];
                 } elseif (in_array((string) $field['type'], array('DateTime', 'DateTimeTz')) && $field['default'] == $this->getCurrentTimestampSQL()) {
                     $default = " DEFAULT ".$this->getCurrentTimestampSQL();

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1454,7 +1454,7 @@ class SQLServerPlatform extends AbstractPlatform
             return " DEFAULT '" . $field['default'] . "'";
         }
 
-        if (in_array((string) $field['type'], array('Integer', 'BigInteger', 'SmallInteger'))) {
+        if (in_array((string) $field['type'], array('Integer', 'BigInt', 'SmallInt'))) {
             return " DEFAULT " . $field['default'];
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -469,7 +469,6 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     public function testGetDefaultValueDeclarationSQLForIntegerTypes()
     {
         foreach(array('bigint', 'integer', 'smallint') as $type) {
-
             $field = array(
                 'type'    => Type::getType($type),
                 'default' => 1
@@ -479,7 +478,6 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
                 ' DEFAULT 1',
                 $this->_platform->getDefaultValueDeclarationSQL($field)
             );
-
         }
     }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -466,6 +466,23 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
         }
     }
 
+    public function testGetDefaultValueDeclarationSQLForIntegerTypes()
+    {
+        foreach(array('bigint', 'integer', 'smallint') as $type) {
+
+            $field = array(
+                'type'    => Type::getType($type),
+                'default' => 1
+            );
+
+            $this->assertEquals(
+                ' DEFAULT 1',
+                $this->_platform->getDefaultValueDeclarationSQL($field)
+            );
+
+        }
+    }
+
     /**
      * @group DBAL-45
      */


### PR DESCRIPTION
The comparison names for the bigint and smallint types in the sql declaration for default values are misspelled and the values are returned quoted unlike the integer type that is returned unquoted.
