### PR TITLE
Fix DocBlock type hint

### DIFF
--- a/lib/Doctrine/DBAL/Schema/TableDiff.php
+++ b/lib/Doctrine/DBAL/Schema/TableDiff.php
@@ -123,14 +123,14 @@ class TableDiff
     /**
      * Constructs an TableDiff object.
      *
-     * @param string                           $tableName
-     * @param \Doctrine\DBAL\Schema\Column[]   $addedColumns
-     * @param \Doctrine\DBAL\Schema\Column[]   $changedColumns
-     * @param \Doctrine\DBAL\Schema\Column[]   $removedColumns
-     * @param \Doctrine\DBAL\Schema\Index[]    $addedIndexes
-     * @param \Doctrine\DBAL\Schema\Index[]    $changedIndexes
-     * @param \Doctrine\DBAL\Schema\Index[]    $removedIndexes
-     * @param \Doctrine\DBAL\Schema\Table|null $fromTable
+     * @param string                             $tableName
+     * @param \Doctrine\DBAL\Schema\Column[]     $addedColumns
+     * @param \Doctrine\DBAL\Schema\ColumnDiff[] $changedColumns
+     * @param \Doctrine\DBAL\Schema\Column[]     $removedColumns
+     * @param \Doctrine\DBAL\Schema\Index[]      $addedIndexes
+     * @param \Doctrine\DBAL\Schema\Index[]      $changedIndexes
+     * @param \Doctrine\DBAL\Schema\Index[]      $removedIndexes
+     * @param \Doctrine\DBAL\Schema\Table|null   $fromTable
      */
     public function __construct($tableName, $addedColumns = array(),
         $changedColumns = array(), $removedColumns = array(), $addedIndexes = array(),


### PR DESCRIPTION
`$changedColumns` is actually an array of `Doctrine\DBAL\Schema\ColumnDiff` instances.
