### PR TITLE
[WIP] [DBAL-218] Add bulk insert query

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -595,6 +595,16 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Returns the maximum number of rows that can be inserted in a single INSERT statement.
+     *
+     * @return integer
+     */
+    public function getInsertMaxRows()
+    {
+        return 0;
+    }
+
+    /**
      * Gets all SQL wildcard characters of the platform.
      *
      * @return array

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1112,6 +1112,14 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getInsertMaxRows()
+    {
+        return 1000;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getClobTypeDeclarationSQL(array $field)

--- a/lib/Doctrine/DBAL/Query/BulkInsertQuery.php
+++ b/lib/Doctrine/DBAL/Query/BulkInsertQuery.php
@@ -1,0 +1,271 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Identifier;
+
+/**
+ * Provides functionality to generate and execute bulk INSERT statements.
+ *
+ * Intended for row based inserts, not from SELECT statements.
+ *
+ * @author Steve Müller <st.mueller@dzh-online.de>
+ * @link   www.doctrine-project.org
+ * @since  2.5
+ */
+class BulkInsertQuery
+{
+    /**
+     * @var array
+     */
+    private $columns;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var Identifier
+     */
+    private $table;
+
+    /**
+     * @var array
+     */
+    private $parameters = array();
+
+    /**
+     * @var array
+     */
+    private $types = array();
+
+    /**
+     * @var array
+     */
+    private $values = array();
+
+    /**
+     * Constructor.
+     *
+     * @param Connection $connection The connection to use for query execution.
+     * @param string     $table      The name of the table to insert rows into.
+     * @param array      $columns    The names of the columns to insert values into.
+     *                               Can be left empty to allow arbitrary table row inserts
+     *                               based on the table's column order.
+     */
+    public function __construct(Connection $connection, $table, array $columns = array())
+    {
+        $this->connection = $connection;
+        $this->table = new Identifier($table);
+        $this->columns = $columns;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return $this->getSQL();
+    }
+
+    /**
+     * Adds a set of values to the bulk insert query to be inserted as a row into the specified table.
+     *
+     * @param array $values The set of values to be inserted as a row into the table.
+     *                      If no columns have been specified for insertion, this can be
+     *                      an arbitrary list of values to be inserted into the table.
+     *                      Otherwise the values' keys have to match either one of the
+     *                      specified column names or indexes.
+     * @param array $types  The types for the given values to bind to the query.
+     *                      If no columns have been specified for insertion, the types'
+     *                      keys will be matched against the given values' keys.
+     *                      Otherwise the types' keys will be matched against the
+     *                      specified column names and indexes.
+     *                      Non-matching keys will be discarded, missing keys will not
+     *                      be bound to a specific type.
+     *
+     * @throws \InvalidArgumentException if columns were specified for this query
+     *                                   and either no value for one of the specified
+     *                                   columns is given or multiple values are given
+     *                                   for a single column (named and indexed) or
+     *                                   multiple types are given for a single column
+     *                                   (named and indexed).
+     *
+     * @todo add support for expressions.
+     */
+    public function addValues(array $values, array $types = array())
+    {
+        $valueSet = array();
+
+        if (empty($this->columns)) {
+            foreach ($values as $index => $value) {
+                $this->parameters[] = $value; // todo: allow expressions.
+                $this->types[] = isset($types[$index]) ? $types[$index] : null;
+                $valueSet[] = '?'; // todo: allow expressions.
+            }
+
+            $this->values[] = $valueSet;
+
+            return;
+        }
+
+        foreach ($this->columns as $index => $column) {
+            $namedValue = isset($values[$column]) || array_key_exists($column, $values);
+            $positionalValue = isset($values[$index]) || array_key_exists($index, $values);
+
+            if ( ! $namedValue && ! $positionalValue) {
+                throw new \InvalidArgumentException(
+                    sprintf('No value specified for column %s (index %d).', $column, $index)
+                );
+            }
+
+            if ($namedValue && $positionalValue && $values[$column] !== $values[$index]) {
+                throw new \InvalidArgumentException(
+                    sprintf('Multiple values specified for column %s (index %d).', $column, $index)
+                );
+            }
+
+            $this->parameters[] = $namedValue ? $values[$column] : $values[$index]; // todo: allow expressions.
+            $valueSet[] = '?'; // todo: allow expressions.
+
+            $namedType = isset($types[$column]);
+            $positionalType = isset($types[$index]);
+
+            if ($namedType && $positionalType && $types[$column] !== $types[$index]) {
+                throw new \InvalidArgumentException(
+                    sprintf('Multiple types specified for column %s (index %d).', $column, $index)
+                );
+            }
+
+            if ($namedType) {
+                $this->types[] = $types[$column];
+
+                continue;
+            }
+
+            if ($positionalType) {
+                $this->types[] = $types[$index];
+
+                continue;
+            }
+
+            $this->types[] = null;
+        }
+
+        $this->values[] = $valueSet;
+    }
+
+    /**
+     * Executes this INSERT query using the bound parameters and their types.
+     *
+     * @return integer The number of affected rows.
+     *
+     * @throws \LogicException if this query contains more rows than acceptable
+     *                         for a single INSERT statement by the underlying platform.
+     */
+    public function execute()
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $insertMaxRows = $platform->getInsertMaxRows();
+
+        if ($insertMaxRows > 0 && count($this->values) > $insertMaxRows) {
+            throw new \LogicException(
+                sprintf(
+                    'You can only insert %d rows in a single INSERT statement with platform "%s".',
+                    $insertMaxRows,
+                    $platform->getName()
+                )
+            );
+        }
+
+        return $this->connection->executeUpdate($this->getSQL(), $this->parameters, $this->types);
+    }
+
+    /**
+     * Returns the parameters for this INSERT query being constructed indexed by parameter index.
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * Returns the parameter types for this INSERT query being constructed indexed by parameter index.
+     *
+     * @return array
+     */
+    public function getParameterTypes()
+    {
+        return $this->types;
+    }
+
+    /**
+     * Returns the SQL formed by the current specifications of this INSERT query.
+     *
+     * @return string
+     *
+     * @throws \LogicException if no values have been specified yet.
+     */
+    public function getSQL()
+    {
+        if (empty($this->values)) {
+            throw new \LogicException('You need to add at least one set of values before generating the SQL.');
+        }
+
+        $platform = $this->connection->getDatabasePlatform();
+        $columnList = '';
+
+        if (! empty($this->columns)) {
+            $columnList = sprintf(
+                ' (%s)',
+                implode(
+                    ', ',
+                    array_map(
+                        function ($column) use ($platform) {
+                            $column = new Identifier($column);
+
+                            return $column->getQuotedName($platform);
+                        },
+                        $this->columns
+                    )
+                )
+            );
+        }
+
+        return sprintf(
+            'INSERT INTO %s%s VALUES (%s)',
+            $this->table->getQuotedName($platform),
+            $columnList,
+            implode(
+                '), (',
+                array_map(
+                    function (array $valueSet) {
+                        return implode(', ', $valueSet);
+                    },
+                    $this->values
+                )
+            )
+        );
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Mocks/KeywordsMock.php
+++ b/tests/Doctrine/Tests/DBAL/Mocks/KeywordsMock.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Mocks;
+
+use Doctrine\DBAL\Platforms\Keywords\KeywordList;
+
+class KeywordsMock extends KeywordList
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'mock';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getKeywords()
+    {
+        return array(
+            'RESERVED'
+        );
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Mocks/MockPlatform.php
+++ b/tests/Doctrine/Tests/DBAL/Mocks/MockPlatform.php
@@ -63,4 +63,20 @@ class MockPlatform extends AbstractPlatform
     {
 
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInsertMaxRows()
+    {
+        return 10;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getReservedKeywordsClass()
+    {
+        return 'Doctrine\Tests\DBAL\Mocks\KeywordsMock';
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Query/BulkInsertQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/BulkInsertQueryTest.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Query;
+
+use Doctrine\DBAL\Query\BulkInsertQuery;
+use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+
+/**
+ * @group DBAL-218
+ */
+class BulkInsertQueryTest extends \Doctrine\Tests\DbalTestCase
+{
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    protected $connection;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->connection = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->connection->expects($this->any())
+            ->method('getDatabasePlatform')
+            ->will($this->returnValue(new MockPlatform()));
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage You need to add at least one set of values before generating the SQL.
+     */
+    public function testGetSQLWithoutSpecifiedValuesThrowsException()
+    {
+        $query = new BulkInsertQuery($this->connection, 'foo');
+
+        $query->getSQL();
+    }
+
+    public function testEmptyInsertWithoutColumnSpecification()
+    {
+        $query = new BulkInsertQuery($this->connection, 'foo');
+
+        $query->addValues(array());
+
+        $this->assertSame("INSERT INTO foo VALUES ()", (string) $query);
+        $this->assertSame(array(), $query->getParameters());
+        $this->assertSame(array(), $query->getParameterTypes());
+
+        $query = new BulkInsertQuery($this->connection, 'foo');
+
+        $query->addValues(array(), array(\PDO::PARAM_BOOL));
+
+        $this->assertSame("INSERT INTO foo VALUES ()", (string) $query);
+        $this->assertSame(array(), $query->getParameters());
+        $this->assertSame(array(), $query->getParameterTypes());
+    }
+
+    public function testSingleInsertWithoutColumnSpecification()
+    {
+        $query = new BulkInsertQuery($this->connection, 'foo');
+
+        $query->addValues(array('bar', 'baz', 'named' => 'bloo'));
+
+        $this->assertSame("INSERT INTO foo VALUES (?, ?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz', 'bloo'), $query->getParameters());
+        $this->assertSame(array(null, null, null), $query->getParameterTypes());
+
+        $query = new BulkInsertQuery($this->connection, 'foo');
+
+        $query->addValues(
+            array('bar', 'baz', 'named' => 'bloo'),
+            array('named' => \PDO::PARAM_BOOL, null, \PDO::PARAM_INT)
+        );
+
+        $this->assertSame("INSERT INTO foo VALUES (?, ?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz', 'bloo'), $query->getParameters());
+        $this->assertSame(array(null, \PDO::PARAM_INT, \PDO::PARAM_BOOL), $query->getParameterTypes());
+    }
+
+    public function testMultiInsertWithoutColumnSpecification()
+    {
+        $query = new BulkInsertQuery($this->connection, 'foo');
+
+        $query->addValues(array());
+        $query->addValues(array('bar', 'baz'));
+        $query->addValues(array('bar', 'baz', 'bloo'));
+        $query->addValues(array('bar', 'baz', 'named' => 'bloo'));
+
+        $this->assertSame("INSERT INTO foo VALUES (), (?, ?), (?, ?, ?), (?, ?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz', 'bar', 'baz', 'bloo', 'bar', 'baz', 'bloo'), $query->getParameters());
+        $this->assertSame(array(null, null, null, null, null, null, null, null), $query->getParameterTypes());
+
+        $query = new BulkInsertQuery($this->connection, 'foo');
+
+        $query->addValues(array(), array(\PDO::PARAM_INT));
+        $query->addValues(array('bar', 'baz'), array(1 => \PDO::PARAM_BOOL));
+        $query->addValues(array('bar', 'baz', 'bloo'), array(\PDO::PARAM_INT, null, \PDO::PARAM_BOOL));
+        $query->addValues(
+            array('bar', 'baz', 'named' => 'bloo'),
+            array('named' => \PDO::PARAM_INT, null, \PDO::PARAM_BOOL)
+        );
+
+        $this->assertSame("INSERT INTO foo VALUES (), (?, ?), (?, ?, ?), (?, ?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz', 'bar', 'baz', 'bloo', 'bar', 'baz', 'bloo'), $query->getParameters());
+        $this->assertSame(
+            array(null, \PDO::PARAM_BOOL, \PDO::PARAM_INT, null, \PDO::PARAM_BOOL, null, \PDO::PARAM_BOOL, \PDO::PARAM_INT),
+            $query->getParameterTypes()
+        );
+    }
+
+    public function testSingleInsertWithColumnSpecificationAndPositionalTypeValues()
+    {
+        $query = new BulkInsertQuery($this->connection, 'foo', array('bar', 'baz'));
+
+        $query->addValues(array('bar', 'baz'));
+
+        $this->assertSame("INSERT INTO foo (bar, baz) VALUES (?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz'), $query->getParameters());
+        $this->assertSame(array(null, null), $query->getParameterTypes());
+
+        $query = new BulkInsertQuery($this->connection, 'foo', array('bar', 'baz'));
+
+        $query->addValues(array('bar', 'baz'), array(1 => \PDO::PARAM_BOOL));
+
+        $this->assertSame("INSERT INTO foo (bar, baz) VALUES (?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz'), $query->getParameters());
+        $this->assertSame(array(null, \PDO::PARAM_BOOL), $query->getParameterTypes());
+    }
+
+    public function testSingleInsertWithColumnSpecificationAndNamedTypeValues()
+    {
+        $query = new BulkInsertQuery($this->connection, 'foo', array('bar', 'baz'));
+
+        $query->addValues(array('baz' => 'baz', 'bar' => 'bar'));
+
+        $this->assertSame("INSERT INTO foo (bar, baz) VALUES (?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz'), $query->getParameters());
+        $this->assertSame(array(null, null), $query->getParameterTypes());
+
+        $query = new BulkInsertQuery($this->connection, 'foo', array('bar', 'baz'));
+
+        $query->addValues(array('baz' => 'baz', 'bar' => 'bar'), array(null, \PDO::PARAM_INT));
+
+        $this->assertSame("INSERT INTO foo (bar, baz) VALUES (?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz'), $query->getParameters());
+        $this->assertSame(array(null, \PDO::PARAM_INT), $query->getParameterTypes());
+    }
+
+    public function testSingleInsertWithColumnSpecificationAndMixedTypeValues()
+    {
+        $query = new BulkInsertQuery($this->connection, 'foo', array('bar', 'baz'));
+
+        $query->addValues(array(1 => 'baz', 'bar' => 'bar'));
+
+        $this->assertSame("INSERT INTO foo (bar, baz) VALUES (?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz'), $query->getParameters());
+        $this->assertSame(array(null, null), $query->getParameterTypes());
+
+        $query = new BulkInsertQuery($this->connection, 'foo', array('bar', 'baz'));
+
+        $query->addValues(array(1 => 'baz', 'bar' => 'bar'), array(\PDO::PARAM_INT, \PDO::PARAM_BOOL));
+
+        $this->assertSame("INSERT INTO foo (bar, baz) VALUES (?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz'), $query->getParameters());
+        $this->assertSame(array(\PDO::PARAM_INT, \PDO::PARAM_BOOL), $query->getParameterTypes());
+    }
+
+    public function testMultiInsertWithColumnSpecification()
+    {
+        $query = new BulkInsertQuery($this->connection, 'foo', array('bar', 'baz'));
+
+        $query->addValues(array('bar', 'baz'));
+        $query->addValues(array(1 => 'baz', 'bar' => 'bar'));
+        $query->addValues(array('bar', 'baz' => 'baz'));
+        $query->addValues(array('bar' => 'bar', 'baz' => 'baz'));
+
+        $this->assertSame("INSERT INTO foo (bar, baz) VALUES (?, ?), (?, ?), (?, ?), (?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz', 'bar', 'baz', 'bar', 'baz', 'bar', 'baz'), $query->getParameters());
+        $this->assertSame(array(null, null, null, null, null, null, null, null), $query->getParameterTypes());
+
+        $query = new BulkInsertQuery($this->connection, 'foo', array('bar', 'baz'));
+
+        $query->addValues(array('bar', 'baz'), array('baz' => \PDO::PARAM_BOOL, 'bar' => \PDO::PARAM_INT));
+        $query->addValues(array(1 => 'baz', 'bar' => 'bar'), array(1 => \PDO::PARAM_BOOL, 'bar' => \PDO::PARAM_INT));
+        $query->addValues(array('bar', 'baz' => 'baz'), array(null, null));
+        $query->addValues(
+            array('bar' => 'bar', 'baz' => 'baz'),
+            array('bar' => \PDO::PARAM_INT, 'baz' => \PDO::PARAM_BOOL)
+        );
+
+        $this->assertSame("INSERT INTO foo (bar, baz) VALUES (?, ?), (?, ?), (?, ?), (?, ?)", (string) $query);
+        $this->assertSame(array('bar', 'baz', 'bar', 'baz', 'bar', 'baz', 'bar', 'baz'), $query->getParameters());
+        $this->assertSame(
+            array(\PDO::PARAM_INT, \PDO::PARAM_BOOL, \PDO::PARAM_INT, \PDO::PARAM_BOOL, null, null, \PDO::PARAM_INT, \PDO::PARAM_BOOL),
+            $query->getParameterTypes()
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage No value specified for column bar (index 0).
+     */
+    public function testEmptyInsertWithColumnSpecificationThrowsException()
+    {
+        $query = new BulkInsertQuery($this->connection, 'foo', array('bar', 'baz'));
+
+        $query->addValues(array());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Multiple values specified for column baz (index 1).
+     */
+    public function testInsertWithColumnSpecificationAndMultipleValuesForColumnThrowsException()
+    {
+        $query = new BulkInsertQuery($this->connection, 'foo', array('bar', 'baz'));
+
+        $query->addValues(array('bar', 'baz', 'baz' => 666));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Multiple types specified for column baz (index 1).
+     */
+    public function testInsertWithColumnSpecificationAndMultipleTypesForColumnThrowsException()
+    {
+        $query = new BulkInsertQuery($this->connection, 'foo', array('bar', 'baz'));
+
+        $query->addValues(array('bar', 'baz'), array(\PDO::PARAM_INT, \PDO::PARAM_INT, 'baz' => \PDO::PARAM_STR));
+    }
+
+    public function testExecuteWithMaxInsertRowsPerStatementExceededThrowsException()
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $insertMaxRows = $platform->getInsertMaxRows();
+
+        $this->setExpectedException(
+            '\LogicException',
+            sprintf(
+                'You can only insert %d rows in a single INSERT statement with platform "%s".',
+                $insertMaxRows,
+                $platform->getName()
+            )
+        );
+
+        $query = new BulkInsertQuery($this->connection, 'foo');
+
+        for ($i = 0; $i <= $insertMaxRows; $i++) {
+            $query->addValues(array());
+        }
+
+        $query->execute();
+    }
+}


### PR DESCRIPTION
This is an approach to make use of database vendors' bulk row insert query syntax.
As the nature of bulk inserts usually is to insert a LOT of rows into a table (primarily from an external source), the implementation tries to focus on good performance and low memory consumption. It is NOT intended for `INSERT INTO ... SELECT ...` statement queries.

TODO:
- Add an "executor" class that encapsulates the `BulkInsertQuery` object, adds options like bulk size and internally automatically evaluates the underlying platform's limits for a single `INSERT` statement and splits queries accordingly.
- Evaluate platforms' max insert rows per `INSERT` statement and implement in platforms.
- Add unit tests for quoted identifiers.
- Add functional tests.

Future additions:
- Add support for expressions.
- Query builder (if there will be more bulk insert queries like `INSERT INTO ... SELECT ...`)?

Open for discussion. Ideas welcome!
