### PR TITLE
[DBAL-1001] Fix NULL / NOT NULL clause for column alterations in Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -685,7 +685,7 @@ LEFT JOIN user_cons_columns r_cols
                 $columnInfo = $column->toArray();
 
                 if ( ! $columnDiff->hasChanged('notnull')) {
-                    $columnInfo['notnull'] = false;
+                    unset($columnInfo['notnull']);
                 }
 
                 $fields[] = $column->getQuotedName($this) . $this->getColumnDeclarationSQL('', $columnInfo);
@@ -751,7 +751,11 @@ LEFT JOIN user_cons_columns r_cols
         } else {
             $default = $this->getDefaultValueDeclarationSQL($field);
 
-            $notnull = empty($field['notnull']) ? ' NULL' : ' NOT NULL';
+            $notnull = '';
+
+            if (isset($field['notnull'])) {
+                $notnull = $field['notnull'] ? ' NOT NULL' : ' NULL';
+            }
 
             $unique = (isset($field['unique']) && $field['unique']) ?
                 ' ' . $this->getUniqueFieldDeclarationSQL() : '';

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -61,6 +61,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     /**
      * @group DBAL-472
+     * @group DBAL-1001
      */
     public function testAlterTableColumnNotNull()
     {
@@ -70,6 +71,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $table->addColumn('id', 'integer');
         $table->addColumn('foo', 'integer');
+        $table->addColumn('bar', 'string');
         $table->setPrimaryKey(array('id'));
 
         $this->_sm->dropAndCreateTable($table);
@@ -78,9 +80,11 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertTrue($columns['id']->getNotnull());
         $this->assertTrue($columns['foo']->getNotnull());
+        $this->assertTrue($columns['bar']->getNotnull());
 
         $diffTable = clone $table;
         $diffTable->changeColumn('foo', array('notnull' => false));
+        $diffTable->changeColumn('bar', array('length' => 1024));
 
         $this->_sm->alterTable($comparator->diffTable($table, $diffTable));
 
@@ -88,6 +92,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertTrue($columns['id']->getNotnull());
         $this->assertFalse($columns['foo']->getNotnull());
+        $this->assertTrue($columns['bar']->getNotnull());
     }
 
     public function testListDatabases()

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -310,6 +310,10 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    /**
+     * @group DBAL-472
+     * @group DBAL-1001
+     */
     public function testAlterTableNotNULL()
     {
         $tableDiff = new \Doctrine\DBAL\Schema\TableDiff('mytable');
@@ -333,7 +337,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         );
 
         $expectedSql = array(
-            "ALTER TABLE mytable MODIFY (foo VARCHAR2(255) DEFAULT 'bla' NULL, baz VARCHAR2(255) DEFAULT 'bla' NOT NULL, metar VARCHAR2(2000) DEFAULT NULL NULL)",
+            "ALTER TABLE mytable MODIFY (foo VARCHAR2(255) DEFAULT 'bla', baz VARCHAR2(255) DEFAULT 'bla' NOT NULL, metar VARCHAR2(2000) DEFAULT NULL NULL)",
 	);
         $this->assertEquals($expectedSql, $this->_platform->getAlterTableSQL($tableDiff));
     }


### PR DESCRIPTION
Due to commit https://github.com/doctrine/dbal/commit/0782e9251a1df353ba589d32effbf75f646ca78f altering a column in Oracle now always appends a `NULL` / `NOT NULL` clause to the column alteration SQL which is wrong if the nullable status has not changed.
During column alteration the clause must only be appended if the nullable status really has changed.
See also: https://github.com/doctrine/dbal/pull/676#issuecomment-57643477
