### PR TITLE
Fixed closing a connection

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -597,7 +597,7 @@ class Connection implements DriverConnection
      */
     public function close()
     {
-        unset($this->_conn);
+        $this->_conn = null;
 
         $this->_isConnected = false;
     }


### PR DESCRIPTION
The inner connection should be unreferenced, but the property should not be removed from the object

Refs https://github.com/doctrine/dbal/pull/685
