### PR TITLE
[DBAL-1011] Fix column comments containing string literal chars on SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -719,10 +719,10 @@ class SQLServerPlatform extends AbstractPlatform
         $level2Name = null
     ) {
         return "EXEC sp_addextendedproperty " .
-            "N'" . $name . "', N'" . $value . "', " .
-            "N'" . $level0Type . "', " . $level0Name . ', ' .
-            "N'" . $level1Type . "', " . $level1Name . ', ' .
-            "N'" . $level2Type . "', " . $level2Name;
+            "N" . $this->quoteStringLiteral($name) . ", N" . $this->quoteStringLiteral($value) . ", " .
+            "N" . $this->quoteStringLiteral($level0Type) . ", " . $level0Name . ', ' .
+            "N" . $this->quoteStringLiteral($level1Type) . ", " . $level1Name . ', ' .
+            "N" . $this->quoteStringLiteral($level2Type) . ", " . $level2Name;
     }
 
     /**
@@ -750,10 +750,10 @@ class SQLServerPlatform extends AbstractPlatform
         $level2Name = null
     ) {
         return "EXEC sp_dropextendedproperty " .
-        "N'" . $name . "', " .
-        "N'" . $level0Type . "', " . $level0Name . ', ' .
-        "N'" . $level1Type . "', " . $level1Name . ', ' .
-        "N'" . $level2Type . "', " . $level2Name;
+            "N" . $this->quoteStringLiteral($name) . ", " .
+            "N" . $this->quoteStringLiteral($level0Type) . ", " . $level0Name . ', ' .
+            "N" . $this->quoteStringLiteral($level1Type) . ", " . $level1Name . ', ' .
+            "N" . $this->quoteStringLiteral($level2Type) . ", " . $level2Name;
     }
 
     /**
@@ -783,10 +783,10 @@ class SQLServerPlatform extends AbstractPlatform
         $level2Name = null
     ) {
         return "EXEC sp_updateextendedproperty " .
-        "N'" . $name . "', N'" . $value . "', " .
-        "N'" . $level0Type . "', " . $level0Name . ', ' .
-        "N'" . $level1Type . "', " . $level1Name . ', ' .
-        "N'" . $level2Type . "', " . $level2Name;
+        "N" . $this->quoteStringLiteral($name) . ", N" . $this->quoteStringLiteral($value) . ", " .
+        "N" . $this->quoteStringLiteral($level0Type) . ", " . $level0Name . ', ' .
+        "N" . $this->quoteStringLiteral($level1Type) . ", " . $level1Name . ', ' .
+        "N" . $this->quoteStringLiteral($level2Type) . ", " . $level2Name;
     }
 
     /**


### PR DESCRIPTION
When trying to create or update a column with a comment containing the string literal quote character `'`, SQL generation is invalid and fails on execution. This patch now quotes the particular comment to come around this issue.
