### PR TITLE
[DBAL-1013] Fix table diff's new name if it is not set

### DIFF
--- a/lib/Doctrine/DBAL/Schema/TableDiff.php
+++ b/lib/Doctrine/DBAL/Schema/TableDiff.php
@@ -155,10 +155,10 @@ class TableDiff
     }
 
     /**
-     * @return \Doctrine\DBAL\Schema\Identifier
+     * @return \Doctrine\DBAL\Schema\Identifier|false
      */
     public function getNewName()
     {
-        return new Identifier($this->newName);
+        return $this->newName ? new Identifier($this->newName) : $this->newName;
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/TableDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableDiffTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Identifier;
+use Doctrine\DBAL\Schema\TableDiff;
+
+class TableDiffTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @group DBAL-1013
+     */
+    public function testReturnsName()
+    {
+        $tableDiff = new TableDiff('foo');
+
+        $this->assertEquals(new Identifier('foo'), $tableDiff->getName());
+    }
+
+    /**
+     * @group DBAL-1013
+     */
+    public function testReturnsNewName()
+    {
+        $tableDiff = new TableDiff('foo');
+
+        $this->assertFalse($tableDiff->getNewName());
+
+        $tableDiff->newName = 'bar';
+
+        $this->assertEquals(new Identifier('bar'), $tableDiff->getNewName());
+    }
+}


### PR DESCRIPTION
The `TableDiff` should not wrap `TableDiff::$newName` into an `Identifier` if it is not set.
