### PR TITLE
Reset date fields to UNIX epoch in TimeType.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade to 2.5
 
+## BC BREAK: time type resets date fields to UNIX epoch
+
+When mapping `time` type field to PHP's `DateTime` instance all unused date fields are 
+reset to UNIX epoch (i.e. 1970-01-01). This might break any logic which relies on comparing 
+`DateTime` instances with date fields set to the current date. 
+
+Use `!` format prefix (see http://php.net/manual/en/datetime.createfromformat.php) for parsing
+time strings to prevent having different date fields when comparing user input and `DateTime` 
+instances as mapped by Doctrine.
+
 ## BC BREAK: Doctrine\DBAL\Schema\Table
 
 The methods ``addIndex()`` and ``addUniqueIndex()`` in ``Doctrine\DBAL\Schema\Table``

--- a/lib/Doctrine/DBAL/Types/TimeType.php
+++ b/lib/Doctrine/DBAL/Types/TimeType.php
@@ -62,7 +62,7 @@ class TimeType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat($platform->getTimeFormatString(), $value);
+        $val = \DateTime::createFromFormat('!' . $platform->getTimeFormatString(), $value);
         if ( ! $val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getTimeFormatString());
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
@@ -59,7 +59,7 @@ class TypeConversionTest extends \Doctrine\Tests\DbalFunctionalTestCase
             array('datetime',   new \DateTime('2010-04-05 10:10:10'), 'DateTime'),
             array('datetimetz', new \DateTime('2010-04-05 10:10:10'), 'DateTime'),
             array('date',       new \DateTime('2010-04-05'), 'DateTime'),
-            array('time',       new \DateTime('10:10:10'), 'DateTime'),
+            array('time',       new \DateTime('1970-01-01 10:10:10'), 'DateTime'),
             array('text',       str_repeat('foo ', 1000), 'string'),
             array('array',      array('foo' => 'bar'), 'array'),
             array('json_array', array('foo' => 'bar'), 'array'),

--- a/tests/Doctrine/Tests/DBAL/Types/TimeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/TimeTest.php
@@ -34,6 +34,13 @@ class TimeTest extends \Doctrine\Tests\DbalTestCase
         );
     }
 
+    public function testDateFieldResetInPHPValue()
+    {
+        $time = $this->_type->convertToPHPValue('01:23:34', $this->_platform);
+        $this->assertEquals('01:23:34', $time->format('H:i:s'));
+        $this->assertEquals('1970-01-01', $time->format('Y-m-d'));
+    }
+
     public function testInvalidTimeFormatConversion()
     {
         $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');


### PR DESCRIPTION
TimeType resets date fields (i.e. unused DateTime object fields) to UNIX
epoch (1970-01-01). This makes TIME field mapping stabe (i.e. same time
will be always mapped to the same DateTime fields).

See DDC-179 (similar issue with DateType). Fixes DBAL-993.
