### PR TITLE
[DBAL-1016] Fix explicitly quoted table identifiers in ALTER TABLE statements

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2016,7 +2016,7 @@ abstract class AbstractPlatform
      */
     protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff)
     {
-        $tableName = $diff->getName()->getQuotedName($this);
+        $tableName = $diff->getName($this)->getQuotedName($this);
 
         $sql = array();
         if ($this->supportsForeignKeyConstraints()) {
@@ -2047,7 +2047,7 @@ abstract class AbstractPlatform
     {
         $tableName = (false !== $diff->newName)
             ? $diff->getNewName()->getQuotedName($this)
-            : $diff->getName()->getQuotedName($this);
+            : $diff->getName($this)->getQuotedName($this);
 
         $sql = array();
 

--- a/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
@@ -549,7 +549,7 @@ class DrizzlePlatform extends AbstractPlatform
 
         if ( ! $this->onSchemaAlterTable($diff, $tableSql)) {
             if (count($queryParts) > 0) {
-                $sql[] = 'ALTER TABLE ' . $diff->getName()->getQuotedName($this) . ' ' . implode(", ", $queryParts);
+                $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ' . implode(", ", $queryParts);
             }
             $sql = array_merge(
                 $this->getPreAlterTableIndexForeignKeySQL($diff),

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -593,7 +593,7 @@ class MySqlPlatform extends AbstractPlatform
 
         if ( ! $this->onSchemaAlterTable($diff, $tableSql)) {
             if (count($queryParts) > 0) {
-                $sql[] = 'ALTER TABLE ' . $diff->getName()->getQuotedName($this) . ' ' . implode(", ", $queryParts);
+                $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ' . implode(", ", $queryParts);
             }
             $sql = array_merge(
                 $this->getPreAlterTableIndexForeignKeySQL($diff),
@@ -611,7 +611,7 @@ class MySqlPlatform extends AbstractPlatform
     protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff)
     {
         $sql = array();
-        $table = $diff->getName()->getQuotedName($this);
+        $table = $diff->getName($this)->getQuotedName($this);
 
         foreach ($diff->removedIndexes as $remKey => $remIndex) {
             // Dropping primary keys requires to unset autoincrement attribute on the particular column first.

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -702,7 +702,7 @@ LEFT JOIN user_cons_columns r_cols
         }
 
         if (count($fields)) {
-            $sql[] = 'ALTER TABLE ' . $diff->getName()->getQuotedName($this) . ' ADD (' . implode(', ', $fields) . ')';
+            $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ADD (' . implode(', ', $fields) . ')';
         }
 
         $fields = array();
@@ -749,7 +749,7 @@ LEFT JOIN user_cons_columns r_cols
         }
 
         if (count($fields)) {
-            $sql[] = 'ALTER TABLE ' . $diff->getName()->getQuotedName($this) . ' MODIFY (' . implode(', ', $fields) . ')';
+            $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' MODIFY (' . implode(', ', $fields) . ')';
         }
 
         foreach ($diff->renamedColumns as $oldColumnName => $column) {
@@ -759,7 +759,7 @@ LEFT JOIN user_cons_columns r_cols
 
             $oldColumnName = new Identifier($oldColumnName);
 
-            $sql[] = 'ALTER TABLE ' . $diff->getName()->getQuotedName($this) .
+            $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) .
                 ' RENAME COLUMN ' . $oldColumnName->getQuotedName($this) .' TO ' . $column->getQuotedName($this);
         }
 
@@ -773,17 +773,23 @@ LEFT JOIN user_cons_columns r_cols
         }
 
         if (count($fields)) {
-            $sql[] = 'ALTER TABLE ' . $diff->getName()->getQuotedName($this) . ' DROP (' . implode(', ', $fields).')';
+            $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' DROP (' . implode(', ', $fields).')';
         }
 
         $tableSql = array();
 
         if ( ! $this->onSchemaAlterTable($diff, $tableSql)) {
+            $sql = array_merge($sql, $commentsSQL);
+
             if ($diff->newName !== false) {
-                $sql[] = 'ALTER TABLE ' . $diff->getName()->getQuotedName($this) . ' RENAME TO ' . $diff->getNewName()->getQuotedName($this);
+                $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' RENAME TO ' . $diff->getNewName()->getQuotedName($this);
             }
 
-            $sql = array_merge($sql, $this->_getAlterTableIndexForeignKeySQL($diff), $commentsSQL);
+            $sql = array_merge(
+                $this->getPreAlterTableIndexForeignKeySQL($diff),
+                $sql,
+                $this->getPostAlterTableIndexForeignKeySQL($diff)
+            );
         }
 
         return array_merge($sql, $tableSql, $columnSql);

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -185,21 +185,27 @@ class SQLAnywherePlatform extends AbstractPlatform
                 continue;
             }
 
-            $sql[] = $this->getAlterTableClause($diff->getName()) . ' ' .
+            $sql[] = $this->getAlterTableClause($diff->getName($this)) . ' ' .
                 $this->getAlterTableRenameColumnClause($oldColumnName, $column);
         }
 
         if ( ! $this->onSchemaAlterTable($diff, $tableSql)) {
             if ( ! empty($alterClauses)) {
-                $sql[] = $this->getAlterTableClause($diff->getName()) . ' ' . implode(", ", $alterClauses);
+                $sql[] = $this->getAlterTableClause($diff->getName($this)) . ' ' . implode(", ", $alterClauses);
             }
 
+            $sql = array_merge($sql, $commentsSQL);
+
             if ($diff->newName !== false) {
-                $sql[] = $this->getAlterTableClause($diff->getName()) . ' ' .
+                $sql[] = $this->getAlterTableClause($diff->getName($this)) . ' ' .
                     $this->getAlterTableRenameTableClause($diff->getNewName());
             }
 
-            $sql = array_merge($sql, $this->_getAlterTableIndexForeignKeySQL($diff), $commentsSQL);
+            $sql = array_merge(
+                $this->getPreAlterTableIndexForeignKeySQL($diff),
+                $sql,
+                $this->getPostAlterTableIndexForeignKeySQL($diff)
+            );
         }
 
         return array_merge($sql, $tableSql, $columnSql);

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -645,13 +645,13 @@ class SqlitePlatform extends AbstractPlatform
         }
 
         $sql = array();
-        $tableName = $diff->newName ?: $diff->name;
+        $tableName = $diff->newName ? $diff->getNewName(): $diff->getName($this);
         foreach ($this->getIndexesInAlteredTable($diff) as $index) {
             if ($index->isPrimary()) {
                 continue;
             }
 
-            $sql[] = $this->getCreateIndexSQL($index, $tableName);
+            $sql[] = $this->getCreateIndexSQL($index, $tableName->getQuotedName($this));
         }
 
         return $sql;
@@ -836,7 +836,7 @@ class SqlitePlatform extends AbstractPlatform
         if ( ! $this->onSchemaAlterTable($diff, $tableSql)) {
             $dataTable = new Table('__temp__'.$table->getName());
 
-            $newTable = new Table($table->getName(), $columns, $this->getPrimaryIndexInAlteredTable($diff), $this->getForeignKeysInAlteredTable($diff), 0, $table->getOptions());
+            $newTable = new Table($table->getQuotedName($this), $columns, $this->getPrimaryIndexInAlteredTable($diff), $this->getForeignKeysInAlteredTable($diff), 0, $table->getOptions());
             $newTable->addOption('alter', true);
 
             $sql = $this->getPreAlterTableIndexForeignKeySQL($diff);
@@ -849,7 +849,7 @@ class SqlitePlatform extends AbstractPlatform
             $sql[] = $this->getDropTableSQL($dataTable);
 
             if ($diff->newName && $diff->newName != $diff->name) {
-                $renamedTable = new Identifier($diff->newName);
+                $renamedTable = $diff->getNewName();
                 $sql[] = 'ALTER TABLE '.$newTable->getQuotedName($this).' RENAME TO '.$renamedTable->getQuotedName($this);
             }
 

--- a/lib/Doctrine/DBAL/Schema/TableDiff.php
+++ b/lib/Doctrine/DBAL/Schema/TableDiff.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
 /**
  * Table Diff.
  *
@@ -147,11 +149,15 @@ class TableDiff
     }
 
     /**
+     * @param AbstractPlatform $platform The platform to use for retrieving this table diff's name.
+     *
      * @return \Doctrine\DBAL\Schema\Identifier
      */
-    public function getName()
+    public function getName(AbstractPlatform $platform)
     {
-        return new Identifier($this->name);
+        return new Identifier(
+            $this->fromTable instanceof Table ? $this->fromTable->getQuotedName($platform) : $this->name
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -614,4 +614,19 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             "ALTER TABLE foo CHANGE bar baz INT DEFAULT 666 NOT NULL COMMENT 'rename test'",
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesTableIdentifiersInAlterTableSQL()
+    {
+        return array(
+            'ALTER TABLE `foo` DROP FOREIGN KEY fk1',
+            'ALTER TABLE `foo` DROP FOREIGN KEY fk2',
+            'ALTER TABLE `foo` RENAME TO `table`, ADD bloo INT NOT NULL, DROP baz, CHANGE bar bar INT DEFAULT NULL, ' .
+            'CHANGE id war INT NOT NULL',
+            'ALTER TABLE `table` ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
+            'ALTER TABLE `table` ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -6,6 +6,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Events;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
@@ -985,4 +986,46 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
      * @return array
      */
     abstract public function getAlterTableRenameColumnSQL();
+
+    /**
+     * @group DBAL-1016
+     */
+    public function testQuotesTableIdentifiersInAlterTableSQL()
+    {
+        $table = new Table('"foo"');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('fk', 'integer');
+        $table->addColumn('fk2', 'integer');
+        $table->addColumn('fk3', 'integer');
+        $table->addColumn('bar', 'integer');
+        $table->addColumn('baz', 'integer');
+        $table->addForeignKeyConstraint('fk_table', array('fk'), array('id'), array(), 'fk1');
+        $table->addForeignKeyConstraint('fk_table', array('fk2'), array('id'), array(), 'fk2');
+
+        $tableDiff = new TableDiff('"foo"');
+        $tableDiff->fromTable = $table;
+        $tableDiff->newName = 'table';
+        $tableDiff->addedColumns['bloo'] = new Column('bloo', Type::getType('integer'));
+        $tableDiff->changedColumns['bar'] = new ColumnDiff(
+            'bar',
+            new Column('bar', Type::getType('integer'), array('notnull' => false)),
+            array('notnull'),
+            $table->getColumn('bar')
+        );
+        $tableDiff->renamedColumns['id'] = new Column('war', Type::getType('integer'));
+        $tableDiff->removedColumns['baz'] = new Column('baz', Type::getType('integer'));
+        $tableDiff->addedForeignKeys[] = new ForeignKeyConstraint(array('fk3'), 'fk_table', array('id'), 'fk_add');
+        $tableDiff->changedForeignKeys[] = new ForeignKeyConstraint(array('fk2'), 'fk_table2', array('id'), 'fk2');
+        $tableDiff->removedForeignKeys[] = new ForeignKeyConstraint(array('fk'), 'fk_table', array('id'), 'fk1');
+
+        $this->assertSame(
+            $this->getQuotesTableIdentifiersInAlterTableSQL(),
+            $this->_platform->getAlterTableSQL($tableDiff)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    abstract protected function getQuotesTableIdentifiersInAlterTableSQL();
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -682,4 +682,24 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
             'ALTER TABLE foo RENAME COLUMN bar TO baz',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesTableIdentifiersInAlterTableSQL()
+    {
+        return array(
+            'ALTER TABLE "foo" DROP CONSTRAINT fk1',
+            'ALTER TABLE "foo" DROP CONSTRAINT fk2',
+            'ALTER TABLE "foo" ADD bloo INT NOT NULL',
+            'ALTER TABLE "foo" DROP baz',
+            'ALTER TABLE "foo" ALTER bar DROP NOT NULL',
+            'ALTER TABLE "foo" RENAME COLUMN id TO war',
+            'ALTER TABLE "foo" RENAME TO "table"',
+            'ALTER TABLE "table" ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id) NOT DEFERRABLE ' .
+            'INITIALLY IMMEDIATE',
+            'ALTER TABLE "table" ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id) NOT DEFERRABLE ' .
+            'INITIALLY IMMEDIATE',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1137,4 +1137,26 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
             'ALTER TABLE foo ADD CONSTRAINT DF_8C736521_78240498 DEFAULT 666 FOR baz',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesTableIdentifiersInAlterTableSQL()
+    {
+        return array(
+            'ALTER TABLE [foo] DROP CONSTRAINT fk1',
+            'ALTER TABLE [foo] DROP CONSTRAINT fk2',
+            "sp_RENAME '[foo].id', 'war', 'COLUMN'",
+            'ALTER TABLE [foo] ADD bloo INT NOT NULL',
+            'ALTER TABLE [foo] DROP COLUMN baz',
+            'ALTER TABLE [foo] ALTER COLUMN bar INT',
+            "sp_RENAME '[foo]', 'table'",
+            "DECLARE @sql NVARCHAR(MAX) = N''; " .
+            "SELECT @sql += N'EXEC sp_rename N''' + dc.name + ''', N''' + REPLACE(dc.name, '8C736521', 'F6298F46') + ''', " .
+            "''OBJECT'';' FROM sys.default_constraints dc JOIN sys.tables tbl ON dc.parent_object_id = tbl.object_id " .
+            "WHERE tbl.name = 'table';EXEC sp_executesql @sql",
+            'ALTER TABLE [table] ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
+            'ALTER TABLE [table] ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -481,4 +481,21 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE foo RENAME COLUMN bar TO baz',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesTableIdentifiersInAlterTableSQL()
+    {
+        return array(
+            'ALTER TABLE "foo" DROP FOREIGN KEY fk1',
+            'ALTER TABLE "foo" DROP FOREIGN KEY fk2',
+            'ALTER TABLE "foo" ADD COLUMN bloo INTEGER NOT NULL WITH DEFAULT DROP COLUMN baz ' .
+            'ALTER bar bar INTEGER DEFAULT NULL RENAME COLUMN id TO war',
+            'CALL SYSPROC.ADMIN_CMD (\'REORG TABLE "foo"\')',
+            'RENAME TABLE "foo" TO "table"',
+            'ALTER TABLE "table" ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
+            'ALTER TABLE "table" ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -549,4 +549,22 @@ class OraclePlatformTest extends AbstractPlatformTestCase
             ),
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesTableIdentifiersInAlterTableSQL()
+    {
+        return array(
+            'ALTER TABLE "foo" DROP CONSTRAINT fk1',
+            'ALTER TABLE "foo" DROP CONSTRAINT fk2',
+            'ALTER TABLE "foo" ADD (bloo NUMBER(10) NOT NULL)',
+            'ALTER TABLE "foo" MODIFY (bar NUMBER(10) DEFAULT NULL NULL)',
+            'ALTER TABLE "foo" RENAME COLUMN id TO war',
+            'ALTER TABLE "foo" DROP (baz)',
+            'ALTER TABLE "foo" RENAME TO "table"',
+            'ALTER TABLE "table" ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
+            'ALTER TABLE "table" ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -873,4 +873,20 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE foo RENAME bar TO baz',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesTableIdentifiersInAlterTableSQL()
+    {
+        return array(
+            'ALTER TABLE "foo" DROP FOREIGN KEY fk1',
+            'ALTER TABLE "foo" DROP FOREIGN KEY fk2',
+            'ALTER TABLE "foo" RENAME id TO war',
+            'ALTER TABLE "foo" ADD bloo INT NOT NULL, DROP baz, ALTER bar INT DEFAULT NULL',
+            'ALTER TABLE "foo" RENAME "table"',
+            'ALTER TABLE "table" ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
+            'ALTER TABLE "table" ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -498,8 +498,8 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'CREATE TABLE "table" (id INTEGER NOT NULL, PRIMARY KEY(id))',
             'INSERT INTO "table" (id) SELECT id FROM __temp__table',
             'DROP TABLE __temp__table',
-            'CREATE INDEX "select" ON table (id)',
-            'CREATE INDEX "bar" ON table (id)',
+            'CREATE INDEX "select" ON "table" (id)',
+            'CREATE INDEX "bar" ON "table" (id)',
         );
     }
 
@@ -572,6 +572,28 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'CREATE TABLE foo (baz INTEGER DEFAULT 666 NOT NULL)',
             'INSERT INTO foo (baz) SELECT bar FROM __temp__foo',
             'DROP TABLE __temp__foo',
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesTableIdentifiersInAlterTableSQL()
+    {
+        return array(
+            'DROP INDEX IDX_8C736521A81E660E',
+            'DROP INDEX IDX_8C736521FDC58D6C',
+            'CREATE TEMPORARY TABLE __temp__foo AS SELECT fk, fk2, id, fk3, bar FROM "foo"',
+            'DROP TABLE "foo"',
+            'CREATE TABLE "foo" (fk2 INTEGER NOT NULL, fk3 INTEGER NOT NULL, fk INTEGER NOT NULL, war INTEGER NOT NULL, ' .
+            'bar INTEGER DEFAULT NULL, bloo INTEGER NOT NULL, ' .
+            'CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id) NOT DEFERRABLE INITIALLY IMMEDIATE, ' .
+            'CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id) NOT DEFERRABLE INITIALLY IMMEDIATE)',
+            'INSERT INTO "foo" (fk, fk2, war, fk3, bar) SELECT fk, fk2, id, fk3, bar FROM __temp__foo',
+            'DROP TABLE __temp__foo',
+            'ALTER TABLE "foo" RENAME TO "table"',
+            'CREATE INDEX IDX_8C736521A81E660E ON "table" (fk)',
+            'CREATE INDEX IDX_8C736521FDC58D6C ON "table" (fk2)',
         );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/TableDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableDiffTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
 class TableDiffTest extends \PHPUnit_Framework_TestCase
 {
@@ -14,7 +15,28 @@ class TableDiffTest extends \PHPUnit_Framework_TestCase
     {
         $tableDiff = new TableDiff('foo');
 
-        $this->assertEquals(new Identifier('foo'), $tableDiff->getName());
+        $this->assertEquals(new Identifier('foo'), $tableDiff->getName(new MockPlatform()));
+    }
+
+    /**
+     * @group DBAL-1016
+     */
+    public function testPrefersNameFromTableObject()
+    {
+        $platformMock = new MockPlatform();
+        $tableMock = $this->getMockBuilder('Doctrine\DBAL\Schema\Table')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $tableDiff = new TableDiff('foo');
+        $tableDiff->fromTable = $tableMock;
+
+        $tableMock->expects($this->once())
+            ->method('getQuotedName')
+            ->with($platformMock)
+            ->will($this->returnValue('foo'));
+
+        $this->assertEquals(new Identifier('foo'), $tableDiff->getName($platformMock));
     }
 
     /**


### PR DESCRIPTION
Another improvement to the neverending quotation issues.
This patch fixes explicitly quoted table identifiers in `ALTER TABLE` statements.
Additionally some minor fixes had to be applied such as misc fixing of foreign key constraint statements order in the sequence of statements necessary to alter a table.
