### PR TITLE
[DBAL-1022] Wrap PDOException in PDOConnection::exec()

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -51,6 +51,18 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
     /**
      * {@inheritdoc}
      */
+    public function exec($statement)
+    {
+        try {
+            return parent::exec($statement);
+        } catch (\PDOException $exception) {
+            throw new PDOException($exception);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getServerVersion()
     {
         return PDO::getAttribute(PDO::ATTR_SERVER_VERSION);
@@ -100,11 +112,7 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
      */
     public function quote($input, $type = \PDO::PARAM_STR)
     {
-        try {
-            return parent::quote($input, $type);
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
-        }
+        return parent::quote($input, $type);
     }
 
     /**
@@ -112,11 +120,7 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
      */
     public function lastInsertId($name = null)
     {
-        try {
-            return parent::lastInsertId($name);
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
-        }
+        return parent::lastInsertId($name);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOConnectionTest.php
@@ -24,7 +24,7 @@ class PDOConnectionTest extends DbalFunctionalTestCase
 
         $this->driverConnection = $this->_conn->getWrappedConnection();
 
-        if ( ! $this->_conn->getWrappedConnection() instanceof PDOConnection) {
+        if ( ! $this->driverConnection instanceof PDOConnection) {
             $this->markTestSkipped('PDO connection only test.');
         }
     }
@@ -32,5 +32,55 @@ class PDOConnectionTest extends DbalFunctionalTestCase
     public function testDoesNotRequireQueryForServerVersion()
     {
         $this->assertFalse($this->driverConnection->requiresQueryForServerVersion());
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\Driver\PDOException
+     */
+    public function testThrowsWrappedExceptionOnConstruct()
+    {
+        new PDOConnection('foo');
+    }
+
+    /**
+     * @group DBAL-1022
+     *
+     * @expectedException \Doctrine\DBAL\Driver\PDOException
+     */
+    public function testThrowsWrappedExceptionOnExec()
+    {
+        $this->driverConnection->exec('foo');
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\Driver\PDOException
+     */
+    public function testThrowsWrappedExceptionOnPrepare()
+    {
+        // Emulated prepared statements have to be disabled for this test
+        // so that PDO actually communicates with the database server to check the query.
+        $this->driverConnection->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);
+
+        $this->driverConnection->prepare('foo');
+
+        // Some PDO adapters like PostgreSQL do not check the query server-side
+        // even though emulated prepared statements are disabled,
+        // so an exception is thrown only eventually.
+        // Skip the test otherwise.
+        $this->markTestSkipped(
+            sprintf(
+                'The PDO adapter %s does not check the query to be prepared server-side, ' .
+                'so no assertions can be made.',
+                $this->_conn->getDriver()->getName()
+            )
+        );
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\Driver\PDOException
+     */
+    public function testThrowsWrappedExceptionOnQuery()
+    {
+        $this->driverConnection->query('foo');
     }
 }


### PR DESCRIPTION
Seems we forgot to wrap `\PDOException` in `PDOConnection::exec()` therefore calls like `PDOConnection::exec('DROP TABLE foo')` are not properly converted to `TableNotFoundException` accordingly. (or similar).
