### PR TITLE
[DBAL-1024] Add more foreign key constraint violation error codes

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -56,6 +56,7 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
             case '1217':
             case '1451':
             case '1452':
+            case '1701':
                 return new Exception\ForeignKeyConstraintViolationException($message, $exception);
 
             case '1062':

--- a/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
@@ -67,6 +67,8 @@ abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
             case '1400':
                 return new Exception\NotNullConstraintViolationException($message, $exception);
 
+            case '2266':
+            case '2291':
             case '2292':
                 return new Exception\ForeignKeyConstraintViolationException($message, $exception);
         }
@@ -129,7 +131,7 @@ abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
             if (isset($params['service']) && $params['service'] == true) {
                 $service = 'SERVICE_NAME=' . $serviceName;
             }
-            
+
             if (isset($params['instancename']) && ! empty($params['instancename'])) {
                 $instance = '(INSTANCE_NAME = ' . $params['instancename'] . ')';
             }

--- a/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
@@ -45,6 +45,14 @@ abstract class AbstractPostgreSQLDriver implements Driver, ExceptionConverterDri
     public function convertException($message, DriverException $exception)
     {
         switch ($exception->getSQLState()) {
+            case '0A000':
+                // Foreign key constraint violations during a TRUNCATE operation
+                // are considered "feature not supported" in PostgreSQL.
+                if (strpos($exception->getMessage(), 'truncate') !== false) {
+                    return new Exception\ForeignKeyConstraintViolationException($message, $exception);
+                }
+
+                break;
             case '23502':
                 return new Exception\NotNullConstraintViolationException($message, $exception);
 
@@ -76,6 +84,7 @@ abstract class AbstractPostgreSQLDriver implements Driver, ExceptionConverterDri
                 if (strpos($exception->getMessage(), 'SQLSTATE[08006]') !== false) {
                     return new Exception\ConnectionException($message, $exception);
                 }
+
                 break;
         }
 

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
@@ -55,6 +55,7 @@ abstract class AbstractSQLAnywhereDriver implements Driver, ExceptionConverterDr
             case '-193':
             case '-196':
                 return new Exception\UniqueConstraintViolationException($message, $exception);
+            case '-194':
             case '-198':
                 return new Exception\ForeignKeyConstraintViolationException($message, $exception);
             case '-144':

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -151,7 +151,10 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
      */
     public function exec($statement)
     {
-        $this->_conn->query($statement);
+        if (false === $this->_conn->query($statement)) {
+            throw new MysqliException($this->_conn->error, $this->_conn->sqlstate, $this->_conn->errno);
+        }
+
         return $this->_conn->affected_rows;
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -2,10 +2,11 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
+use Doctrine\DBAL\Schema\Table;
 
 class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -54,33 +55,74 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
     }
 
-    public function testForeignKeyContraintViolationException()
+    public function testForeignKeyContraintViolationExceptionOnInsert()
     {
         if ( ! $this->_conn->getDatabasePlatform()->supportsForeignKeyConstraints()) {
             $this->markTestSkipped("Only fails on platforms with foreign key constraints.");
         }
 
-        $schema = new \Doctrine\DBAL\Schema\Schema();
+        $this->setUpForeignKeyConstraintViolationExceptionTest();
 
-        $table = $schema->createTable("constraint_error_table");
-        $table->addColumn('id', 'integer', array());
-        $table->setPrimaryKey(array('id'));
+        $this->_conn->insert("constraint_error_table", array('id' => 1));
+        $this->_conn->insert("owning_table", array('id' => 1, 'constraint_id' => 1));
 
-        $owningTable = $schema->createTable("owning_table");
-        $owningTable->addColumn('id', 'integer', array());
-        $owningTable->addColumn('constraint_id', 'integer', array());
-        $owningTable->setPrimaryKey(array('id'));
-        $owningTable->addForeignKeyConstraint($table, array('constraint_id'), array('id'));
+        $this->setExpectedException('\Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException');
+        $this->_conn->insert('owning_table', array('id' => 2, 'constraint_id' => 2));
 
-        foreach ($schema->toSql($this->_conn->getDatabasePlatform()) as $sql) {
-            $this->_conn->executeQuery($sql);
+        $this->tearDownForeignKeyConstraintViolationExceptionTest();
+    }
+
+    public function testForeignKeyContraintViolationExceptionOnUpdate()
+    {
+        if ( ! $this->_conn->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            $this->markTestSkipped("Only fails on platforms with foreign key constraints.");
         }
+
+        $this->setUpForeignKeyConstraintViolationExceptionTest();
+
+        $this->_conn->insert("constraint_error_table", array('id' => 1));
+        $this->_conn->insert("owning_table", array('id' => 1, 'constraint_id' => 1));
+
+        $this->setExpectedException('\Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException');
+        $this->_conn->update('constraint_error_table', array('id' => 2), array('id' => 1));
+
+        $this->tearDownForeignKeyConstraintViolationExceptionTest();
+    }
+
+    public function testForeignKeyContraintViolationExceptionOnDelete()
+    {
+        if ( ! $this->_conn->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            $this->markTestSkipped("Only fails on platforms with foreign key constraints.");
+        }
+
+        $this->setUpForeignKeyConstraintViolationExceptionTest();
 
         $this->_conn->insert("constraint_error_table", array('id' => 1));
         $this->_conn->insert("owning_table", array('id' => 1, 'constraint_id' => 1));
 
         $this->setExpectedException('\Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException');
         $this->_conn->delete('constraint_error_table', array('id' => 1));
+
+        $this->tearDownForeignKeyConstraintViolationExceptionTest();
+    }
+
+    public function testForeignKeyContraintViolationExceptionOnTruncate()
+    {
+        $platform = $this->_conn->getDatabasePlatform();
+
+        if ( ! $platform->supportsForeignKeyConstraints()) {
+            $this->markTestSkipped("Only fails on platforms with foreign key constraints.");
+        }
+
+        $this->setUpForeignKeyConstraintViolationExceptionTest();
+
+        $this->_conn->insert("constraint_error_table", array('id' => 1));
+        $this->_conn->insert("owning_table", array('id' => 1, 'constraint_id' => 1));
+
+        $this->setExpectedException('\Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException');
+        $this->_conn->executeUpdate($platform->getTruncateTableSQL('constraint_error_table'));
+
+        $this->tearDownForeignKeyConstraintViolationExceptionTest();
     }
 
     public function testNotNullConstraintViolationException()
@@ -249,5 +291,30 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
             array(array('host' => 'localnope')),
         );
     }
-}
 
+    private function setUpForeignKeyConstraintViolationExceptionTest()
+    {
+        $schemaManager = $this->_conn->getSchemaManager();
+
+        $table = new Table("constraint_error_table");
+        $table->addColumn('id', 'integer', array());
+        $table->setPrimaryKey(array('id'));
+
+        $owningTable = new Table("owning_table");
+        $owningTable->addColumn('id', 'integer', array());
+        $owningTable->addColumn('constraint_id', 'integer', array());
+        $owningTable->setPrimaryKey(array('id'));
+        $owningTable->addForeignKeyConstraint($table, array('constraint_id'), array('id'));
+
+        $schemaManager->createTable($table);
+        $schemaManager->createTable($owningTable);
+    }
+
+    private function tearDownForeignKeyConstraintViolationExceptionTest()
+    {
+        $schemaManager = $this->_conn->getSchemaManager();
+
+        $schemaManager->dropTable('owning_table');
+        $schemaManager->dropTable('constraint_error_table');
+    }
+}


### PR DESCRIPTION
Driver exception conversion was missing some error codes for foreign key constraint violations. Currently only foreign key constraint violations for `DELETE` statements are tested. Foreign key constraint violations can also occur for `INSERT`, `UPDATE` and `TRUNCATE` write operations where some platforms provide dedicated error codes for.
