### PR TITLE
[DBAL-1025] Allow connecting without database name for sqlanywhere driver

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -47,17 +47,13 @@ class Driver extends AbstractSQLAnywhereDriver
             throw new SQLAnywhereException("Missing 'server' in configuration for sqlanywhere driver.");
         }
 
-        if ( ! isset($params['dbname'])) {
-            throw new SQLAnywhereException("Missing 'dbname' in configuration for sqlanywhere driver.");
-        }
-
         try {
             return new SQLAnywhereConnection(
                 $this->buildDsn(
                     $params['host'],
                     isset($params['port']) ? $params['port'] : null,
                     $params['server'],
-                    $params['dbname'],
+                    isset($params['dbname']) ? $params['dbname'] : null,
                     $username,
                     $password,
                     $driverOptions

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\ConnectionException;
+use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Types\Type;
 
 require_once __DIR__ . '/../../TestInit.php';
@@ -222,5 +223,26 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         $this->assertTrue($this->_conn->ping());
         $this->assertTrue($this->_conn->isConnected());
+    }
+
+    /**
+     * @group DBAL-1025
+     */
+    public function testConnectWithoutExplicitDatabaseName()
+    {
+        if (in_array($this->_conn->getDatabasePlatform()->getName(), array('oracle', 'db2'), true)) {
+            $this->markTestSkipped('Platform does not support connecting without database name.');
+        }
+
+        $params = $this->_conn->getParams();
+        unset($params['dbname']);
+
+        $connection = DriverManager::getConnection(
+            $params,
+            $this->_conn->getConfiguration(),
+            $this->_conn->getEventManager()
+        );
+
+        $this->assertTrue($connection->connect());
     }
 }


### PR DESCRIPTION
It should be possible to connect without a `dbname` connection parameter on capable platforms so that operations like `CREATE DATABASE` can be performed.
This PR removes the constraint for `sqlanywhere` driver and adds a functional test for capable platforms.
