### PR TITLE
[DBAL-1028] Fix fetching NULL values via fetchColumn()

### DIFF
--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -262,11 +262,12 @@ class DB2Statement implements \IteratorAggregate, Statement
     public function fetchColumn($columnIndex = 0)
     {
         $row = $this->fetch(\PDO::FETCH_NUM);
-        if ($row && isset($row[$columnIndex])) {
-            return $row[$columnIndex];
+
+        if (false === $row) {
+            return false;
         }
 
-        return false;
+        return isset($row[$columnIndex]) ? $row[$columnIndex] : null;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -289,7 +289,11 @@ class OCI8Statement implements \IteratorAggregate, Statement
     {
         $row = oci_fetch_array($this->_sth, OCI_NUM | OCI_RETURN_NULLS | OCI_RETURN_LOBS);
 
-        return isset($row[$columnIndex]) ? $row[$columnIndex] : false;
+        if (false === $row) {
+            return false;
+        }
+
+        return isset($row[$columnIndex]) ? $row[$columnIndex] : null;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -266,11 +266,11 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
     {
         $row = $this->fetch(PDO::FETCH_NUM);
 
-        if ($row && isset($row[$columnIndex])) {
-            return $row[$columnIndex];
+        if (false === $row) {
+            return false;
         }
 
-        return false;
+        return isset($row[$columnIndex]) ? $row[$columnIndex] : null;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -239,7 +239,9 @@ class SQLSrvStatement implements IteratorAggregate, Statement
         $args = func_get_args();
         $fetchMode = $fetchMode ?: $this->defaultFetchMode;
         if (isset(self::$fetchMap[$fetchMode])) {
-            return sqlsrv_fetch_array($this->stmt, self::$fetchMap[$fetchMode]);
+            $rows = sqlsrv_fetch_array($this->stmt, self::$fetchMap[$fetchMode]);
+
+            return $rows ?: false;
         } elseif ($fetchMode == PDO::FETCH_OBJ || $fetchMode == PDO::FETCH_CLASS) {
             $className = $this->defaultFetchClass;
             $ctorArgs  = $this->defaultFetchClassCtorArgs;
@@ -247,7 +249,10 @@ class SQLSrvStatement implements IteratorAggregate, Statement
                 $className = $args[1];
                 $ctorArgs = (isset($args[2])) ? $args[2] : array();
             }
-            return sqlsrv_fetch_object($this->stmt, $className, $ctorArgs);
+
+            $rows = sqlsrv_fetch_object($this->stmt, $className, $ctorArgs);
+
+            return $rows ?: false;
         }
 
         throw new SQLSrvException("Fetch mode is not supported!");
@@ -287,11 +292,11 @@ class SQLSrvStatement implements IteratorAggregate, Statement
     {
         $row = $this->fetch(PDO::FETCH_NUM);
 
-        if ($row && isset($row[$columnIndex])) {
-            return $row[$columnIndex];
+        if (false === $row) {
+            return false;
         }
 
-        return false;
+        return isset($row[$columnIndex]) ? $row[$columnIndex] : null;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -236,23 +236,23 @@ class SQLSrvStatement implements IteratorAggregate, Statement
      */
     public function fetch($fetchMode = null)
     {
-        $args = func_get_args();
+        $args      = func_get_args();
         $fetchMode = $fetchMode ?: $this->defaultFetchMode;
-        if (isset(self::$fetchMap[$fetchMode])) {
-            $rows = sqlsrv_fetch_array($this->stmt, self::$fetchMap[$fetchMode]);
 
-            return $rows ?: false;
-        } elseif ($fetchMode == PDO::FETCH_OBJ || $fetchMode == PDO::FETCH_CLASS) {
+        if (isset(self::$fetchMap[$fetchMode])) {
+            return sqlsrv_fetch_array($this->stmt, self::$fetchMap[$fetchMode]) ?: false;
+        }
+
+        if ($fetchMode == PDO::FETCH_OBJ || $fetchMode == PDO::FETCH_CLASS) {
             $className = $this->defaultFetchClass;
             $ctorArgs  = $this->defaultFetchClassCtorArgs;
+
             if (count($args) >= 2) {
                 $className = $args[1];
-                $ctorArgs = (isset($args[2])) ? $args[2] : array();
+                $ctorArgs  = (isset($args[2])) ? $args[2] : array();
             }
 
-            $rows = sqlsrv_fetch_object($this->stmt, $className, $ctorArgs);
-
-            return $rows ?: false;
+            return sqlsrv_fetch_object($this->stmt, $className, $ctorArgs) ?: false;
         }
 
         throw new SQLSrvException("Fetch mode is not supported!");

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -767,6 +767,47 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals(array(), $rows);
     }
 
+    /**
+     * @group DBAL-1028
+     */
+    public function testFetchColumnNullValue()
+    {
+        $this->_conn->executeUpdate(
+            'INSERT INTO fetch_table (test_int, test_string) VALUES (?, ?)',
+            array(1, 'foo')
+        );
+
+        $this->assertNull(
+            $this->_conn->fetchColumn('SELECT test_datetime FROM fetch_table WHERE test_int = ?', array(1))
+        );
+    }
+
+    /**
+     * @group DBAL-1028
+     */
+    public function testFetchColumnNonExistingIndex()
+    {
+        if ($this->_conn->getDriver()->getName() === 'pdo_sqlsrv') {
+            $this->markTestSkipped(
+                'Test does not work for pdo_sqlsrv driver as it throws a fatal error for a non-existing column index.'
+            );
+        }
+
+        $this->assertNull(
+            $this->_conn->fetchColumn('SELECT test_int FROM fetch_table WHERE test_int = ?', array(1), 1)
+        );
+    }
+
+    /**
+     * @group DBAL-1028
+     */
+    public function testFetchColumnNoResult()
+    {
+        $this->assertFalse(
+            $this->_conn->fetchColumn('SELECT test_int FROM fetch_table WHERE test_int = ?', array(-1))
+        );
+    }
+
     private function setupFixture()
     {
         $this->_conn->executeQuery('DELETE FROM fetch_table')->execute();


### PR DESCRIPTION
`PDO` drivers return `null` when retrieving a SQL `NULL` value from a column via `Statement::fetchColumn()`.
However all native driver implementations except `mysqli` return `false` which according to the interface should only be returned if no more rows are available or an error occurred. So currently it is not possible to retrieve a SQL `NULL` value via `Statement::fetchColumn()` with those drivers.
This PR fixes this. Additionally if a non-existing column index is requested from the resultset, `PDO` also returns `null` whereas those mentioned native drivers return `false`. This is also fixed.
