### PR TITLE
[DBAL-1029] Fix foreign key referential action SQL on SQL Server and SQL Anywhere

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -652,17 +652,12 @@ class SQLAnywherePlatform extends AbstractPlatform
      */
     public function getForeignKeyReferentialActionSQL($action)
     {
-        $action = strtoupper($action);
-
-        switch ($action) {
-            case 'CASCADE':
-            case 'SET NULL':
-            case 'SET DEFAULT':
-            case 'RESTRICT':
-                return $action;
-            default:
-                throw new \InvalidArgumentException('Invalid foreign key action: ' . $action);
+        // NO ACTION is not supported, therefore falling back to RESTRICT.
+        if (strtoupper($action) === 'NO ACTION') {
+            return 'RESTRICT';
         }
+
+        return parent::getForeignKeyReferentialActionSQL($action);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1394,6 +1394,19 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getForeignKeyReferentialActionSQL($action)
+    {
+        // RESTRICT is not supported, therefore falling back to NO ACTION.
+        if (strtoupper($action) === 'RESTRICT') {
+            return 'NO ACTION';
+        }
+
+        return parent::getForeignKeyReferentialActionSQL($action);
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function appendLockHint($fromClause, $lockMode)

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -58,6 +58,31 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
         $this->assertEquals(str_repeat($c, 4), $this->_platform->quoteSingleIdentifier($c));
     }
 
+    /**
+     * @group DBAL-1029
+     *
+     * @dataProvider getReturnsForeignKeyReferentialActionSQL
+     */
+    public function testReturnsForeignKeyReferentialActionSQL($action, $expectedSQL)
+    {
+        $this->assertSame($expectedSQL, $this->_platform->getForeignKeyReferentialActionSQL($action));
+    }
+
+    /**
+     * @return array
+     */
+    public function getReturnsForeignKeyReferentialActionSQL()
+    {
+        return array(
+            array('CASCADE', 'CASCADE'),
+            array('SET NULL', 'SET NULL'),
+            array('NO ACTION', 'NO ACTION'),
+            array('RESTRICT', 'RESTRICT'),
+            array('SET DEFAULT', 'SET DEFAULT'),
+            array('CaScAdE', 'CASCADE'),
+        );
+    }
+
     public function testGetInvalidtForeignKeyReferentialActionSQL()
     {
         $this->setExpectedException('InvalidArgumentException');

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1171,4 +1171,19 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
             "COMMENT ON COLUMN [select].[from] IS 'comment'",
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReturnsForeignKeyReferentialActionSQL()
+    {
+        return array(
+            array('CASCADE', 'CASCADE'),
+            array('SET NULL', 'SET NULL'),
+            array('NO ACTION', 'NO ACTION'),
+            array('RESTRICT', 'NO ACTION'),
+            array('SET DEFAULT', 'SET DEFAULT'),
+            array('CaScAdE', 'CASCADE'),
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -411,12 +411,6 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
         $this->_platform->getForeignKeyMatchCLauseSQL(3);
     }
 
-    public function testCannotGenerateNoActionForeignKeyReferentialActionClauseSQL()
-    {
-        $this->setExpectedException('\InvalidArgumentException');
-        $this->_platform->getForeignKeyReferentialActionSQL('no action');
-    }
-
     public function testCannotGenerateForeignKeyConstraintSQLWithEmptyLocalColumns()
     {
         $this->setExpectedException('\InvalidArgumentException');
@@ -921,6 +915,21 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
                 'COMMENT ON COLUMN "foo"."bar" IS \'baz\'',
             ),
             $this->_platform->getAlterTableSQL($tableDiff)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReturnsForeignKeyReferentialActionSQL()
+    {
+        return array(
+            array('CASCADE', 'CASCADE'),
+            array('SET NULL', 'SET NULL'),
+            array('NO ACTION', 'RESTRICT'),
+            array('RESTRICT', 'RESTRICT'),
+            array('SET DEFAULT', 'SET DEFAULT'),
+            array('CaScAdE', 'CASCADE'),
         );
     }
 }


### PR DESCRIPTION
SQL Server does not support `RESTRICT` as referential action in foreign keys and should therefore fall back to `NO ACTION`.
SQL Anywhere does not support `NO ACTION` as referential action in foreign keys and should therefore fall back to `RESTRICT`.
I think falling back here is legit as the only difference is that `NO ACTION` is a deferred check that is executed at the end of the statement, while `RESTRICT` checks immediately.
