### PR TITLE
Condition is changed to avoid

### DIFF
--- a/lib/Doctrine/DBAL/Types/DateType.php
+++ b/lib/Doctrine/DBAL/Types/DateType.php
@@ -49,7 +49,7 @@ class DateType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        return ($value !== null)
+        return (is_object($value))
             ? $value->format($platform->getDateFormatString()) : null;
     }
 


### PR DESCRIPTION
 PHP Fatal error:  Call to a member function format() on a non-object in /var/www/up.local/vendor/doctrine/dbal/lib/Doctrine/DBAL/Types/DateType.php on line 53

when called from

 /var/www/up.local/vendor/doctrine/dbal/lib/Doctrine/DBAL/Statement.php:114

and $value == FALSE.

Signed-off-by: Aleksei Sitnikov alsi.0669@gmail.com
