### PR TITLE
Backporting a fix to allow connection without dbname

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -43,9 +43,10 @@ class MysqliConnection implements Connection
     {
         $port = isset($params['port']) ? $params['port'] : ini_get('mysqli.default_port');
         $socket = isset($params['unix_socket']) ? $params['unix_socket'] : ini_get('mysqli.default_socket');
+        $dbname = isset($params['dbname']) ? $params['dbname'] : null;
 
         $this->_conn = mysqli_init();
-        if ( ! $this->_conn->real_connect($params['host'], $username, $password, $params['dbname'], $port, $socket)) {
+        if ( ! $this->_conn->real_connect($params['host'], $username, $password, $dbname, $port, $socket)) {
             throw new MysqliException($this->_conn->connect_error, $this->_conn->connect_errno);
         }
 


### PR DESCRIPTION
The fix is already in master at
https://github.com/doctrine/dbal/commit/387eb5457498781e24716286a2511f5d030d63fb
but because it has not been backported the functionnality is still broken
for symfony 2.5 for instance.
