### PR TITLE
Prevent result cache key collisions when sharing caches across different connections

### DIFF
--- a/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
+++ b/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
@@ -88,17 +88,22 @@ class QueryCacheProfile
     }
 
     /**
-     * Generates the real cache key from query, params and types.
+     * Generates the real cache key from query, params, types and connection parameters.
      *
      * @param string $query
      * @param array  $params
      * @param array  $types
+     * @param array  $connectionParams
      *
      * @return array
      */
-    public function generateCacheKeys($query, $params, $types)
+    public function generateCacheKeys($query, $params, $types, $connectionParams = array())
     {
-        $realCacheKey = $query . "-" . serialize($params) . "-" . serialize($types);
+        $realCacheKey = 'query=' . $query .
+            '&params=' . serialize($params) .
+            '&types=' . serialize($types) .
+            (!empty($connectionParams) ? serialize($connectionParams) : '');
+
         // should the key be automatically generated using the inputs or is the cache key set?
         if ($this->cacheKey === null) {
             $cacheKey = sha1($realCacheKey);

--- a/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
+++ b/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
@@ -97,7 +97,7 @@ class QueryCacheProfile
      *
      * @return array
      */
-    public function generateCacheKeys($query, $params, $types, $connectionParams = array())
+    public function generateCacheKeys($query, $params, $types, array $connectionParams = array())
     {
         $realCacheKey = 'query=' . $query .
             '&params=' . serialize($params) .

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -873,7 +873,7 @@ class Connection implements DriverConnection
             throw CacheException::noResultDriverConfigured();
         }
 
-        list($cacheKey, $realKey) = $qcp->generateCacheKeys($query, $params, $types);
+        list($cacheKey, $realKey) = $qcp->generateCacheKeys($query, $params, $types, $this->getParams());
 
         // fetch the row pointers entry
         if ($data = $resultCache->fetch($cacheKey)) {

--- a/tests/Doctrine/Tests/DBAL/Cache/QueryCacheProfileTest.php
+++ b/tests/Doctrine/Tests/DBAL/Cache/QueryCacheProfileTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Cache;
+
+require_once __DIR__ . '/../../TestInit.php';
+
+use Doctrine\DBAL\Cache\QueryCacheProfile;
+use Doctrine\Tests\DbalTestCase;
+
+class QueryCacheProfileTest extends DbalTestCase
+{
+    const LIFETIME = 3600;
+    const CACHE_KEY = 'user_specified_cache_key';
+
+    /** @var QueryCacheProfile */
+    private $queryCacheProfile;
+
+    protected function setUp()
+    {
+        $this->queryCacheProfile = new QueryCacheProfile(self::LIFETIME, self::CACHE_KEY);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_use_the_given_cache_key_if_present()
+    {
+        $query  = 'SELECT * FROM foo WHERE bar = ?';
+        $params = array(666);
+        $types  = array(\PDO::PARAM_INT);
+
+        $connectionParams = array(
+            'dbname' => 'database_name',
+            'user' => 'database_user',
+            'password' => 'database_password',
+            'host' => 'database_host',
+            'driver' => 'database_driver'
+        );
+
+        $expectedRealCacheKey = 'query=SELECT * FROM foo WHERE bar = ?&params=a:1:{i:0;i:666;}&types=a:1:{i:0;'
+            . 'i:1;}a:5:{s:6:"dbname";s:13:"database_name";s:4:"user";s:13:"database_user";s:8:"password";s:17:"'
+            . 'database_password";s:4:"host";s:13:"database_host";s:6:"driver";s:15:"database_driver";}';
+
+        $cacheKeysResult = $this->queryCacheProfile->generateCacheKeys($query, $params, $types, $connectionParams);
+
+        $this->assertEquals(self::CACHE_KEY, $cacheKeysResult[0], 'The returned cached key should match the given one');
+        $this->assertEquals($expectedRealCacheKey, $cacheKeysResult[1]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_an_automatic_key_if_no_key_has_been_specified()
+    {
+        $query  = 'SELECT * FROM foo WHERE bar = ?';
+        $params = array(666);
+        $types  = array(\PDO::PARAM_INT);
+
+        $connectionParams = array(
+            'dbname' => 'database_name',
+            'user' => 'database_user',
+            'password' => 'database_password',
+            'host' => 'database_host',
+            'driver' => 'database_driver'
+        );
+
+        $expectedRealCacheKey = 'query=SELECT * FROM foo WHERE bar = ?&params=a:1:{i:0;i:666;}&types=a:1:{i:0;'
+            . 'i:1;}a:5:{s:6:"dbname";s:13:"database_name";s:4:"user";s:13:"database_user";s:8:"password";s:17:"'
+            . 'database_password";s:4:"host";s:13:"database_host";s:6:"driver";s:15:"database_driver";}';
+
+        $this->queryCacheProfile = $this->queryCacheProfile->setCacheKey(null);
+
+        $cacheKeysResult = $this->queryCacheProfile->generateCacheKeys($query, $params, $types, $connectionParams);
+
+        $this->assertEquals('8f74136f51719d57f4da9b6d2ba955b42189bb81', $cacheKeysResult[0]);
+        $this->assertEquals($expectedRealCacheKey, $cacheKeysResult[1]);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Cache/QueryCacheProfileTest.php
+++ b/tests/Doctrine/Tests/DBAL/Cache/QueryCacheProfileTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Cache;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\Tests\DbalTestCase;
 
@@ -41,7 +39,7 @@ class QueryCacheProfileTest extends DbalTestCase
             $connectionParams
         );
 
-        $this->assertEquals(self::CACHE_KEY, $generatedKeys[0], 'The returned cached key should match the given one');
+        $this->assertEquals(self::CACHE_KEY, $generatedKeys[0], 'The returned cache key should match the given one');
     }
 
     public function testShouldGenerateAnAutomaticKeyIfNoKeyHasBeenGiven()
@@ -65,6 +63,12 @@ class QueryCacheProfileTest extends DbalTestCase
             $params,
             $types,
             $connectionParams
+        );
+
+        $this->assertNotEquals(
+            self::CACHE_KEY,
+            $generatedKeys[0],
+            'The returned cache key should be generated automatically'
         );
 
         $this->assertNotEmpty($generatedKeys[0], 'The generated cache key should not be empty');

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -487,8 +487,9 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
     {
         $resultCacheDriverMock = $this->getMock('Doctrine\Common\Cache\Cache');
 
-        $resultCacheDriverMock->expects($this->any())
+        $resultCacheDriverMock->expects($this->atLeastOnce())
             ->method('fetch')
+            ->with('cacheKey')
             ->will($this->returnValue(array('realKey' => array())));
 
         $query = 'SELECT * FROM foo WHERE bar = ?';
@@ -512,8 +513,8 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
             $this->getMock('Doctrine\DBAL\Driver')
         );
 
-        $result = $conn->executeCacheQuery($query, $params, $types, $queryCacheProfileMock);
-
-        $this->assertInstanceOf('Doctrine\DBAL\Cache\ArrayStatement', $result);
+        $this->assertInstanceOf('Doctrine\DBAL\Cache\ArrayStatement',
+            $conn->executeCacheQuery($query, $params, $types, $queryCacheProfileMock)
+        );
     }
 }

--- a/tests/travis/mysql.travis.xml
+++ b/tests/travis/mysql.travis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit>
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
     <php>
         <var name="db_type" value="pdo_mysql"/>
         <var name="db_host" value="localhost" />

--- a/tests/travis/mysqli.travis.xml
+++ b/tests/travis/mysqli.travis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit>
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
     <php>
         <var name="db_type" value="mysqli"/>
         <var name="db_host" value="localhost" />

--- a/tests/travis/pgsql.travis.xml
+++ b/tests/travis/pgsql.travis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit>
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
     <php>
         <var name="db_type" value="pdo_pgsql"/>
         <var name="db_host" value="localhost" />

--- a/tests/travis/sqlite.travis.xml
+++ b/tests/travis/sqlite.travis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit>
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
     <testsuites>
         <testsuite name="Doctrine DBAL Test Suite">
             <directory>./../Doctrine/Tests/DBAL</directory>


### PR DESCRIPTION
There's an issue when using the default cache key generation for the result cache and using the same cache system across different connections as the generated key will be the same regardless of the connection used.

We can solve this just by using the connection params in the key generation. This issue is quite similar to the one fixed in [#1075](https://github.com/doctrine/doctrine2/pull/1075).
