### PR TITLE
Do not TRIM() parentheses around partial indexes conditions

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -343,7 +343,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     {
         return "SELECT quote_ident(relname) as relname, pg_index.indisunique, pg_index.indisprimary,
                        pg_index.indkey, pg_index.indrelid,
-                       TRIM(BOTH '()' FROM pg_get_expr(indpred, indrelid)) AS where
+                       pg_get_expr(indpred, indrelid) AS where
                  FROM pg_class, pg_index
                  WHERE oid IN (
                     SELECT indexrelid

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -343,6 +343,25 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertFalse($foundTable, 'View "list_tables_excludes_views_test_view" must not be found in table list');
     }
+
+    public function testPartialIndexes()
+    {
+        $offlineTable = new Schema\Table('person');
+        $offlineTable->addColumn('id', 'integer');
+        $offlineTable->addColumn('name', 'string');
+        $offlineTable->addColumn('email', 'string');
+        $offlineTable->addUniqueIndex(array('id', 'name'), 'simple_partial_index', array('where' => '(id IS NULL)'));
+        $offlineTable->addIndex(array('id', 'name'), 'complex_partial_index', array('where' => '(((id IS NOT NULL) AND (name IS NULL)) AND (email IS NULL))'));
+
+        $this->_sm->dropAndCreateTable($offlineTable);
+
+        $onlineTable = $this->_sm->listTableDetails('person');
+
+        $comparator = new Schema\Comparator();
+
+        $this->assertFalse($comparator->diffTable($offlineTable, $onlineTable));
+    }
+
 }
 
 class MoneyType extends Type


### PR DESCRIPTION
Because PostgreSQL will return the expression with a lot of
parentheses we cannot TRIM() them easily. It is easier and more
correct to adapt to what PostgreSQL returns. That means the declaration
of partial indexes must be updated as follow:

Before:
`options={"where": "other_id IS NULL"}`

After:
`options={"where": "(other_id IS NULL)"}`

And fore more complexe conditions, that would be:
`options={"where": "(((id IS NOT NULL) AND (other_id IS NULL)) AND (name IS NULL))"}`
