### PR TITLE
Type json_array is not consistent with NULL values

### DIFF
--- a/lib/Doctrine/DBAL/Types/JsonArrayType.php
+++ b/lib/Doctrine/DBAL/Types/JsonArrayType.php
@@ -54,7 +54,7 @@ class JsonArrayType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return array();
         }
 

--- a/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
@@ -48,6 +48,11 @@ class JsonArrayTest extends \Doctrine\Tests\DbalTestCase
         $this->assertSame(array(), $this->type->convertToPHPValue(null, $this->platform));
     }
 
+    public function testJsonEmptyStringConvertsToPHPValue()
+    {
+        $this->assertSame(array(), $this->type->convertToPHPValue('', $this->platform));
+    }
+
     public function testJsonStringConvertsToPHPValue()
     {
         $value         = array('foo' => 'bar', 'bar' => 'foo');


### PR DESCRIPTION
Fields of type json_array are created as "TEXT NOT NULL", because they are not nullable by default.

If you have an existing table, and you add this field, all existing records will get an empty string as the value of the field and not NULL.
If you try to store a NULL value in that field, the database will convert it to an empty string.

The "convertToPHPValue" method for that type only checks for NULL when it converts NULL to array(), it does not check for an empty string.

The test must be changed to also test for the empty string, or else it behaves differently for when the column is set as nullable or not. And for the most common case, when the default vaule of letting the column be not nullable is used, this "feature" of converting blank values to empty arrays is not working.
