### PR TITLE
Enable PostGIS extension for PostgreSQL tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
 
 before_script:
   - sh -c "if [ '$DB' = 'pgsql' ]; then sudo service postgresql stop; sudo service postgresql start $POSTGRESQL_VERSION; fi"
+  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create extension postgis;' -U postgres; fi"
 
 script: ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
   - DB=pgsql POSTGRESQL_VERSION=9.1
   - DB=pgsql POSTGRESQL_VERSION=9.2
   - DB=pgsql POSTGRESQL_VERSION=9.3
+  - DB=pgsql POSTGRESQL_VERSION=9.1 ENABLE_POSTGIS=true
+  - DB=pgsql POSTGRESQL_VERSION=9.2 ENABLE_POSTGIS=true
+  - DB=pgsql POSTGRESQL_VERSION=9.3 ENABLE_POSTGIS=true
   - DB=sqlite
   - DB=mysqli
 
@@ -24,7 +27,7 @@ install:
 
 before_script:
   - sh -c "if [ '$DB' = 'pgsql' ]; then sudo service postgresql stop; sudo service postgresql start $POSTGRESQL_VERSION; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create extension postgis;' -U postgres; fi"
+  - sh -c "if [ '$ENABLE_POSTGIS' = true ]; then psql -c 'create extension postgis;' -U postgres; fi"
 
 script: ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml
 
@@ -36,6 +39,12 @@ matrix:
         env: DB=pgsql POSTGRESQL_VERSION=9.2
       - php: hhvm
         env: DB=pgsql POSTGRESQL_VERSION=9.3
+      - php: hhvm
+        env: DB=pgsql POSTGRESQL_VERSION=9.1 ENABLE_POSTGIS=true
+      - php: hhvm
+        env: DB=pgsql POSTGRESQL_VERSION=9.2 ENABLE_POSTGIS=true
+      - php: hhvm
+        env: DB=pgsql POSTGRESQL_VERSION=9.3 ENABLE_POSTGIS=true
       - php: hhvm
         env: DB=sqlite
       - php: hhvm
@@ -54,3 +63,15 @@ matrix:
         env: DB=pgsql POSTGRESQL_VERSION=9.2 # driver currently unsupported by HHVM
       - php: hhvm-nightly
         env: DB=pgsql POSTGRESQL_VERSION=9.3 # driver currently unsupported by HHVM
+      - php: hhvm
+        env: DB=pgsql POSTGRESQL_VERSION=9.1 ENABLE_POSTGIS=true # driver currently unsupported by HHVM
+      - php: hhvm
+        env: DB=pgsql POSTGRESQL_VERSION=9.2 ENABLE_POSTGIS=true # driver currently unsupported by HHVM
+      - php: hhvm
+        env: DB=pgsql POSTGRESQL_VERSION=9.3 ENABLE_POSTGIS=true # driver currently unsupported by HHVM
+      - php: hhvm-nightly
+        env: DB=pgsql POSTGRESQL_VERSION=9.1 ENABLE_POSTGIS=true # driver currently unsupported by HHVM
+      - php: hhvm-nightly
+        env: DB=pgsql POSTGRESQL_VERSION=9.2 ENABLE_POSTGIS=true # driver currently unsupported by HHVM
+      - php: hhvm-nightly
+        env: DB=pgsql POSTGRESQL_VERSION=9.3 ENABLE_POSTGIS=true # driver currently unsupported by HHVM


### PR DESCRIPTION
This is more like a proposal. Since PostGIS is one of the most popular extensions of PostgreSQL, it might be a good idea to enable it on Travis and make sure DBAL works with it.

At the moment, DBAL's Schema Tool does not work with PostGIS because it cannot handle some VIEWS added by PostGIS.

See: https://travis-ci.org/jsor/dbal/jobs/40528527

This requires #725 to be merged to fix the failing tests.
