### PR TITLE
Exclude tables with table_type of VIEW

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -264,7 +264,8 @@ class PostgreSqlPlatform extends AbstractPlatform
                 WHERE  table_schema NOT LIKE 'pg_%'
                 AND    table_schema != 'information_schema'
                 AND    table_name != 'geometry_columns'
-                AND    table_name != 'spatial_ref_sys'";
+                AND    table_name != 'spatial_ref_sys'
+                AND    table_type != 'VIEW'";
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -319,6 +319,30 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertFalse($comparator->diffTable($offlineTable, $onlineTable));
     }
+
+    public function testListTablesExcludesViews()
+    {
+        $this->createTestTable('list_tables_excludes_views');
+
+        $name = "list_tables_excludes_views_test_view";
+        $sql = "SELECT * from list_tables_excludes_views";
+
+        $view = new Schema\View($name, $sql);
+
+        $this->_sm->dropAndCreateView($view);
+
+        $tables = $this->_sm->listTables();
+
+        $foundTable = false;
+        foreach ($tables as $table) {
+            $this->assertInstanceOf('Doctrine\DBAL\Schema\Table', $table, 'No Table instance was found in tables array.');
+            if (strtolower($table->getName()) == 'list_tables_excludes_views_test_view') {
+                $foundTable = true;
+            }
+        }
+
+        $this->assertFalse($foundTable, 'View "list_tables_excludes_views_test_view" must not be found in table list');
+    }
 }
 
 class MoneyType extends Type


### PR DESCRIPTION
This excludes views registered by PostGIS 2.x like geography_columns, geometry_columns, raster_columns and raster_overviews.

The table_name != 'geometry_columns' is kept for PostGIS 1.5 compatibility. The type changed to VIEW in PostGIS 2.0.

Failing tests: https://travis-ci.org/jsor/dbal/builds/40528525 (See #724)
