### PR TITLE
MasterSlaveConnection::close() should reset connections array

### DIFF
--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -290,6 +290,9 @@ class MasterSlaveConnection extends Connection
         unset($this->connections['slave']);
 
         parent::close();
+
+        $this->_conn = null;
+        $this->connections = array('master' => null, 'slave' => null);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -126,4 +126,17 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
         $conn->connect('slave');
         $this->assertFalse($conn->isConnectedToMaster());
     }
+
+    public function testMasterSlaveConnectionCloseAndReconnect()
+    {
+        $conn = $this->createMasterSlaveConnection();
+        $conn->connect('master');
+        $this->assertTrue($conn->isConnectedToMaster());
+
+        $conn->close();
+        $this->assertFalse($conn->isConnectedToMaster());
+
+        $conn->connect('master');
+        $this->assertTrue($conn->isConnectedToMaster());
+    }
 }


### PR DESCRIPTION
When calling MasterSlaveConnection::close() the connections array should be restored to the default value.
Otherwise a subsequent call to the connect method will fire a PHP Notice because of undefined index in MasterSlaveConnection.php on line 165.
