### PR TITLE
Ignore pseudo-system objects in table list

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -813,7 +813,8 @@ class SQLServerPlatform extends AbstractPlatform
     public function getListTablesSQL()
     {
         // "sysdiagrams" table must be ignored as it's internal SQL Server table for Database Diagrams
-        return "SELECT name FROM sysobjects WHERE type = 'U' AND name != 'sysdiagrams' ORDER BY name";
+        // Category 2 must be ignored as it is "MS SQL Server 'pseudo-system' object[s]" for replication
+        return "SELECT name FROM sysobjects WHERE type = 'U' AND name != 'sysdiagrams' AND category != 2 ORDER BY name";
     }
 
     /**


### PR DESCRIPTION
These objects are created by turning on replication and they have column types (sysname, xml) that are not supported by Doctrine. 

According to Microsoft's support, these are "'pseudo-system' object[s]" that appear in the User Table type instead of the System Table type.

https://social.msdn.microsoft.com/Forums/sqlserver/en-US/135ec547-2214-4da3-bd42-5c458759e144/sysobjectscategory

This issue is very similar to http://www.doctrine-project.org/jira/browse/DBAL-114 so I handled it in the same section of the code as the fix for that issue.
