### PR TITLE
Support for database URLs

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -21,12 +21,102 @@ You can get a DBAL Connection through the
     );
     $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
 
+Or, using the simpler URL form:
+
+.. code-block:: php
+
+    <?php
+    $config = new \Doctrine\DBAL\Configuration();
+    //..
+    $connectionParams = array(
+        'url' => 'mysql://user:secret@localhost/mydb',
+    );
+    $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
+
 The ``DriverManager`` returns an instance of
 ``Doctrine\DBAL\Connection`` which is a wrapper around the
 underlying driver connection (which is often a PDO instance).
 
 The following sections describe the available connection parameters
 in detail.
+
+Connecting using a URL
+~~~~~~~~~~~~~~~~~~~~~~
+
+The easiest way to specify commonly used connection parameters is
+using a database URL. The scheme is used to specify a driver, the
+user and password in the URL encode user and password for the
+connection, followed by the host and port parts (the "authority").
+The path after the authority part represents the name of the
+database, sans the leading slash. Any query parameters are used as
+additional connection parameters.
+
+The scheme names representing the drivers are either the regular
+driver names (see below) with any underscores in their name replaced
+with a hyphen (to make them legal in URL scheme names), or one of the
+following simplified driver names that serve as aliases:
+
+-  ``db2``: alias for ``ibm_db2``
+-  ``mssql``: alias for ``pdo_sqlsrv``
+-  ``mysql``/``mysql2``: alias for ``pdo_mysql``
+-  ``pgsql``/``postgres``/``postgresql``: alias for ``pdo_pgsql``
+-  ``sqlite``/``sqlite3``: alias for ``pdo_sqlite``
+
+For example, to connect to a "foo" MySQL DB using the ``pdo_mysql``
+driver on localhost port 4486 with the charset set to UTF-8, you
+would use the following URL::
+
+    mysql://localhost:4486/foo?charset=UTF-8
+
+This is identical to the following connection string using the
+full driver name::
+
+    pdo-mysql://localhost:4486/foo?charset=UTF-8
+
+If you wanted to use the ``drizzle_pdo__mysql`` driver instead::
+
+    drizzle-pdo-mysql://localhost:4486/foo?charset=UTF-8
+
+In the two last example above, mind the dashes instead of the
+underscores in the URL schemes.
+
+For connecting to an SQLite database, the authority portion of the
+URL is obviously irrelevant and thus can be omitted. The path part
+of the URL is, like for all other drivers, stripped of its leading
+slash, resulting in a relative file name for the database::
+
+    sqlite:///somedb.sqlite
+
+This would access ``somedb.sqlite`` in the current working directory
+and is identical to the following::
+
+    sqlite://ignored:ignored@ignored:1234/somedb.sqlite
+
+To specify an absolute file path, e.g. ``/usr/local/var/db.sqlite``,
+simply use that as the database name, which results in two leading
+slashes for the path part of the URL, and four slashes in total after
+the URL scheme name and its following colon::
+
+    sqlite:////usr/local/var/db.sqlite
+
+Which is, again, identical to supplying ignored user/pass/authority::
+
+    sqlite://notused:inthis@case//usr/local/var/db.sqlite
+
+To connect to an in-memory SQLite instance, use ``:memory::`` as the
+database name::
+
+    sqlite:///:memory:
+
+.. note::
+
+    Any information extracted from the URL overwrites existing values
+    for the parameter in question, but the rest of the information
+    is merged together. You could, for example, have a URL without
+    the ``charset`` setting in the query string, and then add a
+    ``charset`` connection parameter next to ``url``, to provide a
+    default value in case the URL doesn't contain a charset value.
+
 
 Driver
 ~~~~~~

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -230,7 +230,7 @@ final class DriverManager
         }
         
         // (pdo_)?sqlite3?:///... => (pdo_)?sqlite3?://localhost/... or else the URL will be invalid
-        $url = preg_replace('#^((?:pdo_)?sqlite3?):///#', '$1://localhost/', $url);
+        $url = preg_replace('#^((?:pdo_)?sqlite3?):///#', '$1://localhost/', $params['url']);
         
         $url = parse_url($url);
         

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -57,7 +57,6 @@ final class DriverManager
     private static $_driverSchemeAliases = array(
         'db2'        => 'ibm_db2',
         'mssql'      => 'pdo_sqlsrv',
-        'pdo_mssql'  => 'pdo_sqlsrv',
         'mysql'      => 'pdo_mysql',
         'mysql2'     => 'pdo_mysql', // Amazon RDS, for some weird reason
         'postgres'   => 'pdo_pgsql',

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -226,7 +226,7 @@ final class DriverManager
     private static function _parseDatabaseUrl(array $params)
     {
         if (!isset($params['url'])) {
-            return;
+            return $params;
         }
         
         // (pdo_)?sqlite3?:///... => (pdo_)?sqlite3?://localhost/... or else the URL will be invalid
@@ -272,5 +272,7 @@ final class DriverManager
             parse_str($url['query'], $query); // simply ingest query as extra params, e.g. charset or sslmode
             $params = array_merge($params, $query); // parse_str wipes existing array elements
         }
+        
+        return $params;
     }
 }

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -234,7 +234,7 @@ final class DriverManager
         
         $url = parse_url($params['url']);
         
-        if($url === false) {
+        if ($url === false) {
             throw new DBALException('Malformed parameter "url".');
         }
         

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -54,7 +54,7 @@ final class DriverManager
     /**
      * List of URL schemes from a database URL and their mappings to driver.
      */
-    private static $_driverSchemeAliases = array(
+    private static $driverSchemeAliases = array(
         'db2'        => 'ibm_db2',
         'mssql'      => 'pdo_sqlsrv',
         'mysql'      => 'pdo_mysql',
@@ -239,8 +239,8 @@ final class DriverManager
         
         if (isset($url['scheme'])) {
             $url['scheme'] = str_replace('-', '_', $url['scheme']); // URL schemes must not contain underscores, but dashes are ok
-            if (isset(self::$_driverSchemeAliases[$url['scheme']])) {
-                $params['driver'] = self::$_driverSchemeAliases[$url['scheme']]; // use alias
+            if (isset(self::$driverSchemeAliases[$url['scheme']])) {
+                $params['driver'] = self::$driverSchemeAliases[$url['scheme']]; // use alias
             } else {
                 $params['driver'] = $url['scheme']; // let's see what checkParams() says about it later
             }

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -141,7 +141,7 @@ final class DriverManager
             $eventManager = new EventManager();
         }
 
-        $params = self::AMQPChanneltabaseUrl($params);
+        $params = self::parseDatabaseUrl($params);
         
         // check for existing pdo object
         if (isset($params['pdo']) && ! $params['pdo'] instanceof \PDO) {

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -232,7 +232,7 @@ final class DriverManager
         // (pdo_)?sqlite3?:///... => (pdo_)?sqlite3?://localhost/... or else the URL will be invalid
         $url = preg_replace('#^((?:pdo_)?sqlite3?):///#', '$1://localhost/', $url);
         
-        $url = parse_url($params['url']);
+        $url = parse_url($url);
         
         if ($url === false) {
             throw new DBALException('Malformed parameter "url".');

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -141,7 +141,7 @@ final class DriverManager
             $eventManager = new EventManager();
         }
 
-        $params = self::_parseDatabaseUrl($params);
+        $params = self::AMQPChanneltabaseUrl($params);
         
         // check for existing pdo object
         if (isset($params['pdo']) && ! $params['pdo'] instanceof \PDO) {
@@ -222,7 +222,7 @@ final class DriverManager
      *              URL extracted into indidivual parameter parts.
      *
      */
-    private static function _parseDatabaseUrl(array $params)
+    private static function parseDatabaseUrl(array $params)
     {
         if (!isset($params['url'])) {
             return $params;

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -238,6 +238,7 @@ final class DriverManager
         }
         
         if (isset($url['scheme'])) {
+            $url['scheme'] = str_replace('-', '_', $url['scheme']); // URL schemes must not contain underscores, but dashes are ok
             if (isset(self::$_driverSchemeAliases[$url['scheme']])) {
                 $params['driver'] = self::$_driverSchemeAliases[$url['scheme']]; // use alias
             } else {

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -238,11 +238,9 @@ final class DriverManager
         }
         
         if (isset($url['scheme'])) {
-            $url['scheme'] = str_replace('-', '_', $url['scheme']); // URL schemes must not contain underscores, but dashes are ok
-            if (isset(self::$driverSchemeAliases[$url['scheme']])) {
-                $params['driver'] = self::$driverSchemeAliases[$url['scheme']]; // use alias
-            } else {
-                $params['driver'] = $url['scheme']; // let's see what checkParams() says about it later
+            $params['driver'] = str_replace('-', '_', $url['scheme']); // URL schemes must not contain underscores, but dashes are ok
+            if (isset(self::$driverSchemeAliases[$params['driver']])) {
+                $params['driver'] = self::$driverSchemeAliases[$params['driver']]; // use alias like "postgres", else we just let checkParams decide later if the driver exists (for literal "pdo-pgsql" etc)
             }
         }
         

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -125,7 +125,7 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
         );
         
         if ($expected === false) {
-            $this->setExpectedException('\Doctrine\DBAL\DBALException');
+            $this->setExpectedException('Doctrine\DBAL\DBALException');
         }
         
         $conn = \Doctrine\DBAL\DriverManager::getConnection($options);

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -130,10 +130,6 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
         
         $conn = \Doctrine\DBAL\DriverManager::getConnection($options);
         
-        if ($expected === false) {
-            return;
-        }
-        
         $params = $conn->getParams();
         foreach ($expected as $key => $value) {
             if ($key == 'driver') {

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -199,6 +199,10 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
                 'drizzle_pdo_mysql://foo:bar@localhost/baz',
                 false,
             ),
+            'simple URL with fallthrough scheme containing dashes works' => array(
+                'drizzle-pdo-mysql://foo:bar@localhost/baz',
+                array('user' => 'foo', 'password' => 'bar', 'host' => 'localhost', 'dbname' => 'baz', 'driver' => 'Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver'),
+            ),
         );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -175,6 +175,10 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
                 'sqlite:///:memory:',
                 array('dbname' => ':memory:', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
+            'sqlite memory with host' => array(
+                'sqlite://localhost/:memory:',
+                array('dbname' => ':memory:', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+            ),
             'params parsed from URL override individual params' => array(
                 array('url' => 'mysql://foo:bar@localhost/baz', 'password' => 'lulz'),
                 array('user' => 'foo', 'password' => 'bar', 'host' => 'localhost', 'dbname' => 'baz', 'driver' => 'Doctrine\DBAL\Driver\PDOMySQL\Driver'),
@@ -186,6 +190,14 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
             'query params from URL are used as extra params' => array(
                 'url' => 'mysql://foo:bar@localhost/dbname?charset=UTF-8',
                 array('charset' => 'UTF-8'),
+            ),
+            'simple URL with fallthrough scheme not defined in map' => array(
+                'sqlsrv://foo:bar@localhost/baz',
+                array('user' => 'foo', 'password' => 'bar', 'host' => 'localhost', 'dbname' => 'baz', 'driver' => 'Doctrine\DBAL\Driver\SQLSrv\Driver'),
+            ),
+            'simple URL with fallthrough scheme containing underscores fails' => array(
+                'drizzle_pdo_mysql://foo:bar@localhost/baz',
+                false,
             ),
         );
     }


### PR DESCRIPTION
With a bunch of tests.

Of note:
1. in the case of information present in both URL and "normal" parameters, I'm currently giving priority to the information from the URL; IMO this makes more sense than vice versa (base info would be defined in params, and each developer or environment has a URL that may or may not override that base info, such as charset)
2. the syntax for SQLite is `sqlite:///relativepath.db` or `sqlite://ignoredhost/relativepath.db` for relative, and `sqlite:////tmp/absolutepath.db` or `sqlite://ignoredhost//tmp/absolutepath.db` for absolute paths to the database file (I went back and forth on this, but this way is easier and more consistent; https://github.com/kennethreitz/dj-database-url does the same)
3. extra query params are simply "copied" into `$params` verbatim; makes sense IMO especially considering point number 1
4. the URL/driver mappings may need some review
