### PR TITLE
Update index name quoting in MySQL table creation

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1617,10 +1617,7 @@ abstract class AbstractPlatform
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $name => $definition) {
-                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL(
-                        $definition->getQuotedName($this),
-                        $definition
-                    );
+                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($name, $definition);
             }
         }
 
@@ -1630,7 +1627,7 @@ abstract class AbstractPlatform
 
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach ($options['indexes'] as $index => $definition) {
-                $columnListSql .= ', ' . $this->getIndexDeclarationSQL($definition->getQuotedName($this), $definition);
+                $columnListSql .= ', ' . $this->getIndexDeclarationSQL($index, $definition);
             }
         }
 

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2308,12 +2308,13 @@ abstract class AbstractPlatform
     public function getUniqueConstraintDeclarationSQL($name, Index $index)
     {
         $columns = $index->getQuotedColumns($this);
+        $name = new Identifier($name);
 
         if (count($columns) === 0) {
             throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
         }
 
-        return 'CONSTRAINT ' . $index->getQuotedName($this) . ' UNIQUE ('
+        return 'CONSTRAINT ' . $name->getQuotedName($this) . ' UNIQUE ('
              . $this->getIndexFieldDeclarationListSQL($columns)
              . ')' . $this->getPartialIndexSQL($index);
     }
@@ -2332,12 +2333,13 @@ abstract class AbstractPlatform
     public function getIndexDeclarationSQL($name, Index $index)
     {
         $columns = $index->getQuotedColumns($this);
+        $name = new Identifier($name);
 
         if (count($columns) === 0) {
             throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
         }
 
-        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $index->getQuotedName($this) . ' ('
+        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $name->getQuotedName($this) . ' ('
             . $this->getIndexFieldDeclarationListSQL($columns)
             . ')' . $this->getPartialIndexSQL($index);
     }

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1617,7 +1617,10 @@ abstract class AbstractPlatform
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $name => $definition) {
-                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($name, $definition);
+                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL(
+                        $definition->getQuotedName($this),
+                        $definition
+                    );
             }
         }
 
@@ -1627,7 +1630,7 @@ abstract class AbstractPlatform
 
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach ($options['indexes'] as $index => $definition) {
-                $columnListSql .= ', ' . $this->getIndexDeclarationSQL($index, $definition);
+                $columnListSql .= ', ' . $this->getIndexDeclarationSQL($definition->getQuotedName($this), $definition);
             }
         }
 
@@ -2313,7 +2316,7 @@ abstract class AbstractPlatform
             throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
         }
 
-        return 'CONSTRAINT ' . $name . ' UNIQUE ('
+        return 'CONSTRAINT ' . $index->getQuotedName($this) . ' UNIQUE ('
              . $this->getIndexFieldDeclarationListSQL($columns)
              . ')' . $this->getPartialIndexSQL($index);
     }
@@ -2337,7 +2340,7 @@ abstract class AbstractPlatform
             throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
         }
 
-        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $name . ' ('
+        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $index->getQuotedName($this) . ' ('
             . $this->getIndexFieldDeclarationListSQL($columns)
             . ')' . $this->getPartialIndexSQL($index);
     }

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -392,14 +392,14 @@ class MySqlPlatform extends AbstractPlatform
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $index => $definition) {
-                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($index, $definition);
+                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition->getQuotedName($this), $definition);
             }
         }
 
         // add all indexes
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach ($options['indexes'] as $index => $definition) {
-                $queryFields .= ', ' . $this->getIndexDeclarationSQL($index, $definition);
+                $queryFields .= ', ' . $this->getIndexDeclarationSQL($definition->getQuotedName($this), $definition);
             }
         }
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -392,14 +392,14 @@ class MySqlPlatform extends AbstractPlatform
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $index => $definition) {
-                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition->getQuotedName($this), $definition);
+                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($index, $definition);
             }
         }
 
         // add all indexes
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach ($options['indexes'] as $index => $definition) {
-                $queryFields .= ', ' . $this->getIndexDeclarationSQL($definition->getQuotedName($this), $definition);
+                $queryFields .= ', ' . $this->getIndexDeclarationSQL($index, $definition);
             }
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -26,6 +26,20 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $this->assertEquals('CREATE TABLE Foo (Bar INT NOT NULL) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB', array_shift($sql));
     }
 
+    public function testReservedKeywordInIndexGeneratedTableSql()
+    {
+        $table = new Table("Foo");
+        $table->addColumn("user_name", "string");
+        $table->addColumn("last_login", "date");
+        $table->addIndex(array('user_name', 'last_login'), 'key');
+
+        $sql = $this->_platform->getCreateTableSQL($table);
+        $this->assertEquals(
+            'CREATE TABLE Foo (user_name VARCHAR(255) NOT NULL, last_login DATE NOT NULL, INDEX `key` (user_name, last_login)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB',
+            array_shift($sql)
+        );
+    }
+
     public function getGenerateTableSql()
     {
         return 'CREATE TABLE test (id INT AUTO_INCREMENT NOT NULL, test VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB';


### PR DESCRIPTION
When creating a table that includes an index named with a reserved keyword the index name isn't quoted. When creating the index specifically the name is quote. This bring the table generation SQL inline with the index generation.
