### PR TITLE
Debug-infos if connection-query without params fails

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -833,6 +833,9 @@ class Connection implements DriverConnection
                 }
             } else {
                 $stmt = $this->_conn->query($query);
+                if (!$stmt) {
+                    throw new DBALException(var_export($this->_conn->errorInfo(), true));
+                }
             }
         } catch (\Exception $ex) {
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -485,11 +485,15 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
 
     public function testExecuteQueryInvalidQuery()
     {
+        $errorMsg = array('some connection error');
+
         $driver  = $this->getMock('Doctrine\DBAL\Driver');
         $pdoMock = $this->getMock('Doctrine\DBAL\Driver\Connection');
+        $pdoMock->method('errorInfo')
+                ->willReturn($errorMsg);
         $conn = new Connection(array('pdo' => $pdoMock), $driver);
 
-        $this->setExpectedException('Doctrine\DBAL\DBALException');
+        $this->setExpectedException('Doctrine\DBAL\DBALException', $errorMsg);
 
         $conn->executeQuery(null);
     }

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -482,4 +482,16 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
         $this->setExpectedException('Doctrine\DBAL\Exception\InvalidArgumentException');
         $conn->delete('kittens', array());
     }
+    
+    public function testExecuteQueryInvalidQuery()
+    {
+        $driver  = $this->getMock('Doctrine\DBAL\Driver');
+        $pdoMock = $this->getMock('Doctrine\DBAL\Driver\Connection');
+        $conn = new Connection(array('pdo' => $pdoMock), $driver);
+
+        $this->setExpectedException('Doctrine\DBAL\DBALException');
+
+        $query = 'Some invalid SQL.';
+        $conn->executeQuery($query);
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -482,7 +482,7 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
         $this->setExpectedException('Doctrine\DBAL\Exception\InvalidArgumentException');
         $conn->delete('kittens', array());
     }
-    
+
     public function testExecuteQueryInvalidQuery()
     {
         $driver  = $this->getMock('Doctrine\DBAL\Driver');
@@ -491,7 +491,6 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
 
         $this->setExpectedException('Doctrine\DBAL\DBALException');
 
-        $query = 'Some invalid SQL.';
-        $conn->executeQuery($query);
+        $conn->executeQuery(null);
     }
 }


### PR DESCRIPTION
When a query without params is executed against internal connection, and it fails, cancel execution by throwing an exception with additional informations.
Fixed: db-stmt ("$stmt" in executeQuery()) can become a non-object in case of query-error, leading to a PHP Fatal Error when fetchMode is set on it.
