### PR TITLE
[DBAL-1058] Fix database and namespace introspection for SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1028,7 +1028,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getListDatabasesSQL()
     {
-        return 'SELECT * FROM SYS.DATABASES';
+        return 'SELECT * FROM sys.databases';
     }
 
     /**
@@ -1036,7 +1036,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getListNamespacesSQL()
     {
-        return "SELECT name FROM SYS.SCHEMAS WHERE name NOT IN('guest', 'INFORMATION_SCHEMA', 'sys')";
+        return "SELECT name FROM sys.schemas WHERE name NOT IN('guest', 'INFORMATION_SCHEMA', 'sys')";
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -95,6 +95,29 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->assertContains('test_create_database', $databases);
     }
 
+    /**
+     * @group DBAL-1058
+     */
+    public function testListNamespaceNames()
+    {
+        if (!$this->_sm->getDatabasePlatform()->supportsSchemas()) {
+            $this->markTestSkipped('Platform does not support schemas.');
+        }
+
+        // Currently dropping schemas is not supported, so we have to workaround here.
+        $namespaces = $this->_sm->listNamespaceNames();
+        $namespaces = array_map('strtolower', $namespaces);
+
+        if (!in_array('test_create_schema', $namespaces)) {
+            $this->_conn->executeUpdate($this->_sm->getDatabasePlatform()->getCreateSchemaSQL('test_create_schema'));
+
+            $namespaces = $this->_sm->listNamespaceNames();
+            $namespaces = array_map('strtolower', $namespaces);
+        }
+
+        $this->assertContains('test_create_schema', $namespaces);
+    }
+
     public function testListTables()
     {
         $this->createTestTable('list_tables_test');

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -81,7 +81,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     {
         $dropDatabaseExpectation = 'DROP DATABASE foobar';
 
-        $this->assertEquals('SELECT * FROM SYS.DATABASES', $this->_platform->getListDatabasesSQL());
+        $this->assertEquals('SELECT * FROM sys.databases', $this->_platform->getListDatabasesSQL());
         $this->assertEquals('CREATE DATABASE foobar', $this->_platform->getCreateDatabaseSQL('foobar'));
         $this->assertEquals($dropDatabaseExpectation, $this->_platform->getDropDatabaseSQL('foobar'));
         $this->assertEquals('DROP TABLE foobar', $this->_platform->getDropTableSQL('foobar'));


### PR DESCRIPTION
It looks like some SQL Server versions / setups need system tables to be queried lowercased otherwise causing errors.
