### PR TITLE
Define composer test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi"
   - sh -c "if [ '$DB' = 'mysqli' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi"
 
-script: ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml
+script: composer test
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
         {"name": "Benjamin Eberlei", "email": "kontakt@beberlei.de"},
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
+    "scripts": {
+        "test": "phpunit --configuration tests/travis/$DB.travis.xml"
+    },
     "require": {
         "php": ">=5.3.2",
         "doctrine/common": ">=2.4,<2.6-dev"


### PR DESCRIPTION
The composer test script is an easy and convenient way to define your unit
testing scripts. It makes testing your library as easy as just running
`composer test`.

For more information about the `scripts` field check out [the manual](https://getcomposer.org/doc/articles/scripts.md) and [this blog post](http://maxgfeller.com/blog/2014/07/22/composer-test/).
