### PR TITLE
[DBAL-1051] Quote index name in inline index declaration SQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1617,10 +1617,7 @@ abstract class AbstractPlatform
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $name => $definition) {
-                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL(
-                        $definition->getQuotedName($this),
-                        $definition
-                    );
+                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($name, $definition);
             }
         }
 
@@ -1630,7 +1627,7 @@ abstract class AbstractPlatform
 
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach ($options['indexes'] as $index => $definition) {
-                $columnListSql .= ', ' . $this->getIndexDeclarationSQL($definition->getQuotedName($this), $definition);
+                $columnListSql .= ', ' . $this->getIndexDeclarationSQL($index, $definition);
             }
         }
 

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2308,12 +2308,13 @@ abstract class AbstractPlatform
     public function getUniqueConstraintDeclarationSQL($name, Index $index)
     {
         $columns = $index->getQuotedColumns($this);
+        $name = new Identifier($name);
 
         if (count($columns) === 0) {
             throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
         }
 
-        return 'CONSTRAINT ' . $index->getQuotedName($this) . ' UNIQUE ('
+        return 'CONSTRAINT ' . $name->getQuotedName($this) . ' UNIQUE ('
              . $this->getIndexFieldDeclarationListSQL($columns)
              . ')' . $this->getPartialIndexSQL($index);
     }
@@ -2332,12 +2333,13 @@ abstract class AbstractPlatform
     public function getIndexDeclarationSQL($name, Index $index)
     {
         $columns = $index->getQuotedColumns($this);
+        $name = new Identifier($name);
 
         if (count($columns) === 0) {
             throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
         }
 
-        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $index->getQuotedName($this) . ' ('
+        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $name->getQuotedName($this) . ' ('
             . $this->getIndexFieldDeclarationListSQL($columns)
             . ')' . $this->getPartialIndexSQL($index);
     }

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1617,7 +1617,10 @@ abstract class AbstractPlatform
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $name => $definition) {
-                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($name, $definition);
+                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL(
+                        $definition->getQuotedName($this),
+                        $definition
+                    );
             }
         }
 
@@ -1627,7 +1630,7 @@ abstract class AbstractPlatform
 
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach ($options['indexes'] as $index => $definition) {
-                $columnListSql .= ', ' . $this->getIndexDeclarationSQL($index, $definition);
+                $columnListSql .= ', ' . $this->getIndexDeclarationSQL($definition->getQuotedName($this), $definition);
             }
         }
 
@@ -2313,7 +2316,7 @@ abstract class AbstractPlatform
             throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
         }
 
-        return 'CONSTRAINT ' . $name . ' UNIQUE ('
+        return 'CONSTRAINT ' . $index->getQuotedName($this) . ' UNIQUE ('
              . $this->getIndexFieldDeclarationListSQL($columns)
              . ')' . $this->getPartialIndexSQL($index);
     }
@@ -2337,7 +2340,7 @@ abstract class AbstractPlatform
             throw new \InvalidArgumentException("Incomplete definition. 'columns' required.");
         }
 
-        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $name . ' ('
+        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $index->getQuotedName($this) . ' ('
             . $this->getIndexFieldDeclarationListSQL($columns)
             . ')' . $this->getPartialIndexSQL($index);
     }

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Identifier;
@@ -438,7 +439,8 @@ class DB2Platform extends AbstractPlatform
      */
     public function getIndexDeclarationSQL($name, Index $index)
     {
-        return $this->getUniqueConstraintDeclarationSQL($name, $index);
+        // Index declaration in statements like CREATE TABLE is not supported.
+        throw DBALException::notSupported(__METHOD__);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -392,14 +392,14 @@ class MySqlPlatform extends AbstractPlatform
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $index => $definition) {
-                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($index, $definition);
+                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition->getQuotedName($this), $definition);
             }
         }
 
         // add all indexes
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach ($options['indexes'] as $index => $definition) {
-                $queryFields .= ', ' . $this->getIndexDeclarationSQL($index, $definition);
+                $queryFields .= ', ' . $this->getIndexDeclarationSQL($definition->getQuotedName($this), $definition);
             }
         }
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -392,14 +392,14 @@ class MySqlPlatform extends AbstractPlatform
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $index => $definition) {
-                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition->getQuotedName($this), $definition);
+                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($index, $definition);
             }
         }
 
         // add all indexes
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach ($options['indexes'] as $index => $definition) {
-                $queryFields .= ', ' . $this->getIndexDeclarationSQL($definition->getQuotedName($this), $definition);
+                $queryFields .= ', ' . $this->getIndexDeclarationSQL($index, $definition);
             }
         }
 

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -1358,7 +1358,8 @@ class SQLAnywherePlatform extends AbstractPlatform
         $flags = '';
 
         if ( ! empty($name)) {
-            $sql .= 'CONSTRAINT ' . $name . ' ';
+            $name = new Identifier($name);
+            $sql .= 'CONSTRAINT ' . $name->getQuotedName($this) . ' ';
         }
 
         if ($constraint->hasFlag('clustered')) {

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -26,20 +26,6 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $this->assertEquals('CREATE TABLE Foo (Bar INT NOT NULL) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB', array_shift($sql));
     }
 
-    public function testReservedKeywordInIndexGeneratedTableSql()
-    {
-        $table = new Table("Foo");
-        $table->addColumn("user_name", "string");
-        $table->addColumn("last_login", "date");
-        $table->addIndex(array('user_name', 'last_login'), 'key');
-
-        $sql = $this->_platform->getCreateTableSQL($table);
-        $this->assertEquals(
-            'CREATE TABLE Foo (user_name VARCHAR(255) NOT NULL, last_login DATE NOT NULL, INDEX `key` (user_name, last_login)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB',
-            array_shift($sql)
-        );
-    }
-
     public function getGenerateTableSql()
     {
         return 'CREATE TABLE test (id INT AUTO_INCREMENT NOT NULL, test VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB';
@@ -654,5 +640,21 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             "COMMENT ON COLUMN `Foo`.`BAR` IS 'comment'",
             "COMMENT ON COLUMN `select`.`from` IS 'comment'",
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL()
+    {
+        return 'CONSTRAINT `select` UNIQUE (foo)';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL()
+    {
+        return 'INDEX `select` (foo)';
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -26,6 +26,20 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $this->assertEquals('CREATE TABLE Foo (Bar INT NOT NULL) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB', array_shift($sql));
     }
 
+    public function testReservedKeywordInIndexGeneratedTableSql()
+    {
+        $table = new Table("Foo");
+        $table->addColumn("user_name", "string");
+        $table->addColumn("last_login", "date");
+        $table->addIndex(array('user_name', 'last_login'), 'key');
+
+        $sql = $this->_platform->getCreateTableSQL($table);
+        $this->assertEquals(
+            'CREATE TABLE Foo (user_name VARCHAR(255) NOT NULL, last_login DATE NOT NULL, INDEX `key` (user_name, last_login)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB',
+            array_shift($sql)
+        );
+    }
+
     public function getGenerateTableSql()
     {
         return 'CREATE TABLE test (id INT AUTO_INCREMENT NOT NULL, test VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB';

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -739,4 +739,20 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
             $this->_platform->getAlterTableSQL($tableDiff)
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL()
+    {
+        return 'CONSTRAINT "select" UNIQUE (foo)';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL()
+    {
+        return 'INDEX "select" (foo)';
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1186,4 +1186,20 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
             array('CaScAdE', 'CASCADE'),
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL()
+    {
+        return 'CONSTRAINT [select] UNIQUE (foo) WHERE foo IS NOT NULL';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL()
+    {
+        return 'INDEX [select] (foo)';
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -615,4 +615,28 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             ),
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL()
+    {
+        return 'CONSTRAINT "select" UNIQUE (foo)';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL()
+    {
+        return ''; // not supported by this platform
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function supportsInlineIndexDeclaration()
+    {
+        return false;
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -642,4 +642,20 @@ EOD;
 
         $this->assertEquals($createTriggerStatement, $sql[3]);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL()
+    {
+        return 'CONSTRAINT "select" UNIQUE (foo)';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL()
+    {
+        return 'INDEX "select" (foo)';
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -817,11 +817,6 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
         );
     }
 
-    public function testGeneratesPartialIndexesSqlOnlyWhenSupportingPartialIndexes()
-    {
-        $this->markTestSkipped('Index declaration in statements like CREATE TABLE is not supported.');
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -931,5 +926,29 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
             array('SET DEFAULT', 'SET DEFAULT'),
             array('CaScAdE', 'CASCADE'),
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL()
+    {
+        return 'CONSTRAINT "select" UNIQUE (foo)';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL()
+    {
+        return ''; // not supported by this platform
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function supportsInlineIndexDeclaration()
+    {
+        return false;
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -608,4 +608,20 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'COMMENT ON COLUMN "select"."from" IS \'comment\'',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL()
+    {
+        return 'CONSTRAINT "select" UNIQUE (foo)';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL()
+    {
+        return 'INDEX "select" (foo)';
+    }
 }


### PR DESCRIPTION
Supersedes #730 
- Improved test case
- Fixed quoting for SQL Anywhere
- Throw exception in DB2 platform for unsupported inline index declarations
