### PR TITLE
Take care about mariadb platform

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -127,6 +127,10 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
             );
         }
 
+        if (false !== stripos($version, 'mariadb')) {
+            return $this->getDatabasePlatform();
+        }
+
         $majorVersion = $versionParts['major'];
         $minorVersion = isset($versionParts['minor']) ? $versionParts['minor'] : 0;
         $patchVersion = isset($versionParts['patch']) ? $versionParts['patch'] : 0;

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
@@ -60,6 +60,9 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
             array('5.7.0', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
             array('5.7.1', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
             array('6', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
+            array('10.0.15-MariaDB-1~wheezy', 'Doctrine\DBAL\Platforms\MySqlPlatform'),
+            array('10.1.2a-MariaDB-a1~lenny-log', 'Doctrine\DBAL\Platforms\MySqlPlatform'),
+            array('5.5.40-MariaDB-1~wheezy', 'Doctrine\DBAL\Platforms\MySqlPlatform'),
         );
     }
 


### PR DESCRIPTION
Hi,
After upgrading to DBAL 2.5, I got an issue where I could not rename index while migrating because of MariaDB [versioning](http://en.wikipedia.org/wiki/MariaDB#Versioning) which outputs `10.0.15-MariaDB-1~wheezy` as server version.

Because 10.x > 5.7 it loads new features from mysql 5.7 which are not available in mariadb ..
