### PR TITLE
Add failing unit test related to DBAL-1063

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -94,7 +94,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertTrue($indexes['s_index']->hasFlag('spatial'));
     }
 
-    public function testDuplicateIndexFromExistingDatabase()
+    public function testReadDuplicateIndexFromExistingDatabase()
     {
         $this->_conn->executeQuery(<<<EOS
 CREATE TABLE duplicate_index (
@@ -111,6 +111,26 @@ EOS
         $this->assertCount(3, $indexes);
         $table = $this->_sm->listTableDetails('duplicate_index');
         $this->assertCount(3, $table->getIndexes());
+    }
+
+    public function testMergeDuplicateIndexes()
+    {
+        $this->_conn->executeQuery(<<<EOS
+CREATE TABLE merge_duplicate_index (
+    id int(11) NOT NULL AUTO_INCREMENT,
+    test VARCHAR(80) NOT NULL,
+    PRIMARY KEY (id),
+    KEY text_idx (test),
+    KEY duplicate (test)
+)
+EOS
+        );
+        $tableFetched = $this->_sm->listTableDetails('merge_duplicate_index');
+        $tableNew = clone $tableFetched;
+        $tableNew->dropIndex('text_idx');
+        $tableNew->addIndex(array('test'), 'duplicate');
+        $comparator = new Comparator;
+        $this->_sm->alterTable($comparator->diffTable($tableFetched, $tableNew));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -94,6 +94,25 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertTrue($indexes['s_index']->hasFlag('spatial'));
     }
 
+    public function testDuplicateIndexFromExistingDatabase()
+    {
+        $this->_conn->executeQuery(<<<EOS
+CREATE TABLE duplicate_index (
+    id int(11) NOT NULL AUTO_INCREMENT,
+    test VARCHAR(80) NOT NULL,
+    PRIMARY KEY (id),
+    KEY text_idx (test),
+    KEY duplicate (test)
+)
+EOS
+        );
+
+        $indexes = $this->_sm->listTableIndexes('duplicate_index');
+        $this->assertCount(3, $indexes);
+        $table = $this->_sm->listTableDetails('duplicate_index');
+        $this->assertCount(3, $table->getIndexes());
+    }
+
     /**
      * @group DBAL-400
      */


### PR DESCRIPTION
I am not 100% sure, but I think the behavior exposed by this test is one of the factors in DBAL-1063. But even if it wasn't, it is still very confusing that `Table::getIndexes` doesn't return the same thing as `SchemaManager::listTableIndexes` when they are both called on the same table.

I've written the test against the MySQL SM, but I suspect the same might happen with other platforms as well
