### PR TITLE
Removed non-phpdoc @internal tags

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -804,8 +804,6 @@ class Connection implements DriverConnection
      * @return \Doctrine\DBAL\Driver\Statement The executed statement.
      *
      * @throws \Doctrine\DBAL\DBALException
-     *
-     * @internal PERF: Directly prepares a driver statement, not a wrapper.
      */
     public function executeQuery($query, array $params = array(), $types = array(), QueryCacheProfile $qcp = null)
     {
@@ -969,8 +967,6 @@ class Connection implements DriverConnection
      * @return integer The number of affected rows.
      *
      * @throws \Doctrine\DBAL\DBALException
-     *
-     * @internal PERF: Directly prepares a driver statement, not a wrapper.
      */
     public function executeUpdate($query, array $params = array(), array $types = array())
     {


### PR DESCRIPTION
Removed 2 @internal phpdoc tags as they were about old internal api usage and these methods are public api as @beberlei & @Ocramius confirmed on irc #doctrine

> ocramius: the @internal are old comments that were used to tell information about internal API usage
> ocramius: they are not the @internal of phpdoc, so you are welcome to send a PR to fix that
