### PR TITLE
Store the parameters of the chosen connection when using Master/Slave.

### DIFF
--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -435,5 +435,14 @@ class MasterSlaveConnection extends Connection
     {
         return isset($this->chosenParams['password']) ? $this->chosenParams['password'] : null ;
     }
-    
+
+    /**
+     * Gets the name of the database this Connection is connected to.
+     *
+     * @return string
+     */
+    public function getDatabase()
+    {
+        return isset($this->chosenParams['dbname']) ? $this->chosenParams['dbname'] : null ;
+    }
 }

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -98,6 +98,14 @@ class MasterSlaveConnection extends Connection
     protected $keepSlave = false;
 
     /**
+     * This property holds the parameters of the chosen connection.
+     * It can store the master params or any slave params at any time.
+     *
+     * @var array
+     */
+    private $chosenParams = array();
+
+    /**
      * Creates Master Slave Connection.
      *
      * @param array                              $params
@@ -225,10 +233,10 @@ class MasterSlaveConnection extends Connection
     protected function chooseConnectionConfiguration($connectionName, $params)
     {
         if ($connectionName === 'master') {
-            return $params['master'];
+            return $this->chosenParams = $params['master'];
         }
 
-        return $params['slaves'][array_rand($params['slaves'])];
+        return $this->chosenParams = $params['slaves'][array_rand($params['slaves'])];
     }
 
     /**
@@ -387,4 +395,45 @@ class MasterSlaveConnection extends Connection
 
         return parent::prepare($statement);
     }
+
+    /**
+     * Gets the hostname of the currently connected database.
+     *
+     * @return string|null
+     */
+    public function getHost()
+    {
+        return isset($this->chosenParams['host']) ? $this->chosenParams['host'] : null ;
+    }
+
+    /**
+     * Gets the port of the currently connected database.
+     *
+     * @return mixed
+     */
+    public function getPort()
+    {
+        return isset($this->chosenParams['port']) ? $this->chosenParams['port'] : null ;
+    }
+
+    /**
+     * Gets the username used by the current connection.
+     *
+     * @return string|null
+     */
+    public function getUsername()
+    {
+        return isset($this->chosenParams['user']) ? $this->chosenParams['user'] : null ;
+    }
+
+    /**
+     * Gets the password used by the current connection.
+     *
+     * @return string|null
+     */
+    public function getPassword()
+    {
+        return isset($this->chosenParams['password']) ? $this->chosenParams['password'] : null ;
+    }
+    
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,14 +24,22 @@
 >
   <php>
     <!-- "Real" test database -->
+
     <!-- Uncomment, otherwise SQLite runs
     <var name="db_type" value="pdo_mysql"/>
-    <var name="db_host" value="localhost" />
+    <var name="db_host" value="127.0.0.1" />
     <var name="db_username" value="root" />
     <var name="db_password" value="" />
     <var name="db_name" value="doctrine_tests" />
     <var name="db_port" value="3306"/>
+
+    <var name="slave_db_host" value="127.0.0.2" />
+    <var name="slave_db_username" value="root" />
+    <var name="slave_db_password" value="" />
+    <var name="slave_db_name" value="doctrine_tests" />
+    <var name="slave_db_port" value="3306"/>
     -->
+
     <!--<var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit">-->
     
     <!-- Database for temporary connections (i.e. to drop/create the main database) -->

--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -160,6 +160,7 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
                 $conn->getPort(),
                 $conn->getUsername(),
                 $conn->getPassword(),
+                $conn->getDatabase(),
             );
 
             $that->assertSame($params, $expected);
@@ -170,6 +171,7 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
             $GLOBALS['db_port'],
             $GLOBALS['db_username'],
             $GLOBALS['db_password'],
+            $GLOBALS['db_name'],
         );
 
         $expectedSlave = array(
@@ -177,6 +179,7 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
             $GLOBALS['slave_db_port'],
             $GLOBALS['slave_db_username'],
             $GLOBALS['slave_db_password'],
+            $GLOBALS['slave_db_name'],
         );
 
         $conn = $this->createMasterSlaveConnection();

--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -171,5 +171,6 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
 
         $test('master', $this, $expected);
         $test('slave', $this, $expected);
+        $test(null, $this, $expected);
     }
 }

--- a/tests/travis/mysql.travis.xml
+++ b/tests/travis/mysql.travis.xml
@@ -2,11 +2,17 @@
 <phpunit>
     <php>
         <var name="db_type" value="pdo_mysql"/>
-        <var name="db_host" value="localhost" />
+        <var name="db_host" value="127.0.0.1" />
         <var name="db_username" value="travis" />
         <var name="db_password" value="" />
         <var name="db_name" value="doctrine_tests" />
         <var name="db_port" value="3306"/>
+
+        <var name="slave_db_host" value="127.0.0.2" />
+        <var name="slave_db_username" value="travis" />
+        <var name="slave_db_password" value="" />
+        <var name="slave_db_name" value="doctrine_tests" />
+        <var name="slave_db_port" value="3306"/>
 
         <var name="tmpdb_type" value="pdo_mysql"/>
         <var name="tmpdb_host" value="localhost" />

--- a/tests/travis/mysqli.travis.xml
+++ b/tests/travis/mysqli.travis.xml
@@ -2,11 +2,17 @@
 <phpunit>
     <php>
         <var name="db_type" value="mysqli"/>
-        <var name="db_host" value="localhost" />
+        <var name="db_host" value="127.0.0.1" />
         <var name="db_username" value="travis" />
         <var name="db_password" value="" />
         <var name="db_name" value="doctrine_tests" />
         <var name="db_port" value="3306"/>
+
+        <var name="slave_db_host" value="127.0.0.2" />
+        <var name="slave_db_username" value="travis" />
+        <var name="slave_db_password" value="" />
+        <var name="slave_db_name" value="doctrine_tests" />
+        <var name="slave_db_port" value="3306"/>
 
         <var name="tmpdb_type" value="mysqli"/>
         <var name="tmpdb_host" value="localhost" />

--- a/tests/travis/pgsql.travis.xml
+++ b/tests/travis/pgsql.travis.xml
@@ -2,11 +2,17 @@
 <phpunit>
     <php>
         <var name="db_type" value="pdo_pgsql"/>
-        <var name="db_host" value="localhost" />
+        <var name="db_host" value="127.0.0.1" />
         <var name="db_username" value="postgres" />
         <var name="db_password" value="" />
         <var name="db_name" value="doctrine_tests" />
         <var name="db_port" value="5432"/>
+
+        <var name="slave_db_host" value="127.0.0.2" />
+        <var name="slave_db_username" value="postgres" />
+        <var name="slave_db_password" value="" />
+        <var name="slave_db_name" value="doctrine_tests" />
+        <var name="slave_db_port" value="5432"/>
 
         <var name="tmpdb_type" value="pdo_pgsql"/>
         <var name="tmpdb_host" value="localhost" />


### PR DESCRIPTION
When using the MasterSlaveConnection, the internal parameters array has a different structure than the usual Connection. This can cause the following methods to fail: getHost(), getPort(), getUsername() and getPassword().

I changed the MasterSlaveConnection so that it stores the parameters of the chosen connection in a private property. With this change, the methods that used to fail can now retrieve the configuration for the actual chosen connection, which is, in my opinion, clearly the expected behavior.

I chose to create a new private property in MasterSlaveConnection instead of inherit the $_params from Connection in order to not cause any confusion by having two different array structures in the same variable at different situations.

I also expanded the tests for this case.
