### PR TITLE
[DBAL-1090] Changing string to fixed string is not recognized in PostgreSQL Platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -500,7 +500,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             $oldColumnName = $columnDiff->getOldColumnName()->getQuotedName($this);
             $column = $columnDiff->column;
 
-            if ($columnDiff->hasChanged('type') || $columnDiff->hasChanged('precision') || $columnDiff->hasChanged('scale')) {
+            if ($columnDiff->hasChanged('type') || $columnDiff->hasChanged('precision') || $columnDiff->hasChanged('scale') || $columnDiff->hasChanged('fixed')) {
                 $type = $column->getType();
 
                 // here was a server version check before, but DBAL API does not support this anymore.

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -657,4 +657,14 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         return 'INDEX `select` (foo)';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAlterStringToFixedStringSQL()
+    {
+        return array(
+            'ALTER TABLE mytable CHANGE name name CHAR(2) NOT NULL',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -1128,4 +1128,35 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
      * @return array
      */
     abstract protected function getQuotesTableIdentifiersInAlterTableSQL();
+
+    /**
+     * @group DBAL-1090
+     */
+    public function testAlterStringToFixedString()
+    {
+
+        $table = new Table('mytable');
+        $table->addColumn('name', 'string', array('length' => 2));
+
+        $tableDiff = new TableDiff('mytable');
+        $tableDiff->fromTable = $table;
+
+        $tableDiff->changedColumns['name'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'name', new \Doctrine\DBAL\Schema\Column(
+                'name', \Doctrine\DBAL\Types\Type::getType('string'), array('fixed' => true, 'length' => 2)
+            ),
+            array('fixed')
+        );
+
+        $sql = $this->_platform->getAlterTableSQL($tableDiff);
+
+        $expectedSql = $this->getAlterStringToFixedStringSQL();
+
+        $this->assertEquals($expectedSql, $sql);
+    }
+
+    /**
+     * @return array
+     */
+    abstract protected function getAlterStringToFixedStringSQL();
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -757,30 +757,12 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     }
 
     /**
-     * @group DBAL-1090
+     * {@inheritdoc}
      */
-    public function testAlterStringToFixedString()
+    protected function getAlterStringToFixedStringSQL()
     {
-
-        $table = new Table('mytable');
-        $table->addColumn('name', 'string', array('length' => 2));
-
-        $tableDiff = new TableDiff('mytable');
-        $tableDiff->fromTable = $table;
-
-        $tableDiff->changedColumns['dloo1'] = new \Doctrine\DBAL\Schema\ColumnDiff(
-            'name', new \Doctrine\DBAL\Schema\Column(
-                'name', \Doctrine\DBAL\Types\Type::getType('string'), array('fixed' => true, 'length' => 2)
-            ),
-            array('fixed')
-        );
-
-        $sql = $this->_platform->getAlterTableSQL($tableDiff);
-
-        $expectedSql = array(
+        return array(
             'ALTER TABLE mytable ALTER name TYPE CHAR(2)',
         );
-
-        $this->assertEquals($expectedSql, $sql);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -755,4 +755,32 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     {
         return 'INDEX "select" (foo)';
     }
+
+    /**
+     * @todo add issue ticket number as phpunit group
+     */
+    public function testAlterStringToFixedString()
+    {
+
+        $table = new Table('mytable');
+        $table->addColumn('name', 'string', array('length' => 2));
+
+        $tableDiff = new TableDiff('mytable');
+        $tableDiff->fromTable = $table;
+
+        $tableDiff->changedColumns['dloo1'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'name', new \Doctrine\DBAL\Schema\Column(
+                'name', \Doctrine\DBAL\Types\Type::getType('string'), array('fixed' => true, 'length' => 2)
+            ),
+            array('fixed')
+        );
+
+        $sql = $this->_platform->getAlterTableSQL($tableDiff);
+
+        $expectedSql = array(
+            'ALTER TABLE mytable ALTER name TYPE CHAR(2)',
+        );
+
+        $this->assertEquals($expectedSql, $sql);
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -757,7 +757,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     }
 
     /**
-     * @todo add issue ticket number as phpunit group
+     * @group DBAL-1090
      */
     public function testAlterStringToFixedString()
     {

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1202,4 +1202,14 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     {
         return 'INDEX [select] (foo)';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAlterStringToFixedStringSQL()
+    {
+        return array(
+            'ALTER TABLE mytable ALTER COLUMN name NCHAR(2) NOT NULL',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -639,4 +639,15 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     {
         return false;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAlterStringToFixedStringSQL()
+    {
+        return array(
+            'ALTER TABLE mytable ALTER COLUMN name SET DATA TYPE CHAR(2)',
+            'CALL SYSPROC.ADMIN_CMD (\'REORG TABLE mytable\')',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -658,4 +658,14 @@ EOD;
     {
         return 'INDEX "select" (foo)';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAlterStringToFixedStringSQL()
+    {
+        return array(
+            'ALTER TABLE mytable MODIFY (name CHAR(2) DEFAULT NULL)',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -951,4 +951,14 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     {
         return false;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAlterStringToFixedStringSQL()
+    {
+        return array(
+            'ALTER TABLE mytable ALTER name CHAR(2) NOT NULL',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -624,4 +624,18 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     {
         return 'INDEX "select" (foo)';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAlterStringToFixedStringSQL()
+    {
+        return array(
+            'CREATE TEMPORARY TABLE __temp__mytable AS SELECT name FROM mytable',
+            'DROP TABLE mytable',
+            'CREATE TABLE mytable (name CHAR(2) NOT NULL)',
+            'INSERT INTO mytable (name) SELECT name FROM __temp__mytable',
+            'DROP TABLE __temp__mytable',
+        );
+    }
 }


### PR DESCRIPTION
The following change of an entity using PostgreSQL is not recognized by Doctrine DBAL:
from

``` php
    /**
     * @ORM\Column(type="string", name="name", length=2)
     */
    public $name;
```

to

``` php
    /**
     * @ORM\Column(type="string", name="name", length=2, options={"fixed"=true})
     */
    public $name;
```

A schema-update should change the column from `character varying(2)` to `character(2)` but instead acts like no changes were made on the column.

With this PR, I've extended the `PostgreSqlPlatform` to detect changes of the fixed option of a column.
