### PR TITLE
Update MysqliStatement to support PDO::FETCH_OBJ

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -261,6 +261,14 @@ class MysqliStatement implements \IteratorAggregate, Statement
                 $ret = array_combine($this->_columnNames, $values);
                 $ret += $values;
                 return $ret;
+                
+            case PDO::FETCH_OBJ:
+                $assoc = array_combine($this->_columnNames, $values);
+                $ret = new \stdClass();
+                foreach ($assoc as $column => $value) {
+                    $ret->$column = $value;
+                }
+                return $ret;
 
             default:
                 throw new MysqliException("Unknown fetch type '{$fetchMode}'");


### PR DESCRIPTION
Return a simple stdClass object if that fetch type is requested.
