### PR TITLE
[DBAL-1062] Fix renaming indexes used by foreign key constraints

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\TableDiff;
 
 /**
  * Provides the behavior, features and SQL dialect of the MySQL 5.7 database platform.
@@ -30,6 +31,22 @@ use Doctrine\DBAL\Schema\Index;
  */
 class MySQL57Platform extends MySqlPlatform
 {
+    /**
+     * {@inheritdoc}
+     */
+    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    {
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    {
+        return array();
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -986,6 +986,12 @@ class SqlitePlatform extends AbstractPlatform
         $columnNames = $this->getColumnNamesInAlteredTable($diff);
 
         foreach ($indexes as $key => $index) {
+            foreach ($diff->renamedIndexes as $oldIndexName => $renamedIndex) {
+                if (strtolower($key) === strtolower($oldIndexName)) {
+                    unset($indexes[$key]);
+                }
+            }
+
             $changed = false;
             $indexColumns = array();
             foreach ($index->getColumns() as $columnName) {

--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -363,4 +363,27 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
 
         return false;
     }
+
+    /**
+     * Checks whether this foreign key constraint intersects the given index columns.
+     *
+     * Returns `true` if at least one of this foreign key's local columns
+     * matches one of the given index's columns, `false` otherwise.
+     *
+     * @param Index $index The index to be checked against.
+     *
+     * @return boolean
+     */
+    public function intersectsIndexColumns(Index $index)
+    {
+        foreach ($index->getColumns() as $indexColumn) {
+            foreach ($this->_localColumnNames as $localColumn) {
+                if (strtolower($indexColumn) === strtolower($localColumn->getName())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -667,4 +667,17 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             'ALTER TABLE mytable CHANGE name name CHAR(2) NOT NULL',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL()
+    {
+        return array(
+            'ALTER TABLE mytable DROP FOREIGN KEY fk_foo',
+            'DROP INDEX idx_foo ON mytable',
+            'CREATE INDEX idx_foo_renamed ON mytable (foo)',
+            'ALTER TABLE mytable ADD CONSTRAINT fk_foo FOREIGN KEY (foo) REFERENCES foreign_table (id)',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -765,4 +765,14 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
             'ALTER TABLE mytable ALTER name TYPE CHAR(2)',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL()
+    {
+        return array(
+            'ALTER INDEX idx_foo RENAME TO idx_foo_renamed',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1212,4 +1212,14 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
             'ALTER TABLE mytable ALTER COLUMN name NCHAR(2) NOT NULL',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL()
+    {
+        return array(
+            "EXEC sp_RENAME N'mytable.idx_foo', N'idx_foo_renamed', N'INDEX'",
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -650,4 +650,14 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             'CALL SYSPROC.ADMIN_CMD (\'REORG TABLE mytable\')',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL()
+    {
+        return array(
+            'RENAME INDEX idx_foo TO idx_foo_renamed',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
@@ -55,4 +55,14 @@ class MySQL57PlatformTest extends AbstractMySQLPlatformTestCase
             'ALTER TABLE `schema`.`table` RENAME INDEX `foo` TO `bar`',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL()
+    {
+        return array(
+            'ALTER TABLE mytable RENAME INDEX idx_foo TO idx_foo_renamed',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -668,4 +668,14 @@ EOD;
             'ALTER TABLE mytable MODIFY (name CHAR(2) DEFAULT NULL)',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL()
+    {
+        return array(
+            'ALTER INDEX idx_foo RENAME TO idx_foo_renamed',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -961,4 +961,14 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE mytable ALTER name CHAR(2) NOT NULL',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL()
+    {
+        return array(
+            'ALTER INDEX idx_foo ON mytable RENAME TO idx_foo_renamed',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -638,4 +638,22 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'DROP TABLE __temp__mytable',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL()
+    {
+        return array(
+            'DROP INDEX idx_foo',
+            'DROP INDEX idx_bar',
+            'CREATE TEMPORARY TABLE __temp__mytable AS SELECT foo, bar, baz FROM mytable',
+            'DROP TABLE mytable',
+            'CREATE TABLE mytable (foo INTEGER NOT NULL, bar INTEGER NOT NULL, baz INTEGER NOT NULL, CONSTRAINT fk_foo FOREIGN KEY (foo) REFERENCES foreign_table (id) NOT DEFERRABLE INITIALLY IMMEDIATE, CONSTRAINT fk_bar FOREIGN KEY (bar) REFERENCES foreign_table (id) NOT DEFERRABLE INITIALLY IMMEDIATE)',
+            'INSERT INTO mytable (foo, bar, baz) SELECT foo, bar, baz FROM __temp__mytable',
+            'DROP TABLE __temp__mytable',
+            'CREATE INDEX idx_bar ON mytable (bar)',
+            'CREATE INDEX idx_foo_renamed ON mytable (foo)',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ForeignKeyConstraintTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+
+class ForeignKeyConstraintTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @group DBAL-1062
+     *
+     * @dataProvider getIntersectsIndexColumnsData
+     */
+    public function testIntersectsIndexColumns(array $indexColumns, $expectedResult)
+    {
+        $foreignKey = new ForeignKeyConstraint(array('foo', 'bar'), 'foreign_table', array('fk_foo', 'fk_bar'));
+
+        $index = $this->getMockBuilder('Doctrine\DBAL\Schema\Index')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $index->expects($this->once())
+            ->method('getColumns')
+            ->will($this->returnValue($indexColumns));
+
+        $this->assertSame($expectedResult, $foreignKey->intersectsIndexColumns($index));
+    }
+
+    /**
+     * @return array
+     */
+    public function getIntersectsIndexColumnsData()
+    {
+        return array(
+            array(array('baz'), false),
+            array(array('baz', 'bloo'), false),
+
+            array(array('foo'), true),
+            array(array('bar'), true),
+
+            array(array('foo', 'bar'), true),
+            array(array('bar', 'foo'), true),
+
+            array(array('foo', 'baz'), true),
+            array(array('baz', 'foo'), true),
+
+            array(array('bar', 'baz'), true),
+            array(array('baz', 'bar'), true),
+
+            array(array('foo', 'bloo', 'baz'), true),
+            array(array('bloo', 'foo', 'baz'), true),
+            array(array('bloo', 'baz', 'foo'), true),
+
+            array(array('FOO'), true),
+        );
+    }
+}


### PR DESCRIPTION
Platforms that do not support a SQL syntax for natively renaming indexes need to drop and recreate indexes to perform a rename.
Platforms like MySQL < 5.7 deny dropping indexes used by foreign key constraints. In this case foreign key constraints have to be dropped before dropping indexes and have to be recreated after the particular index(es) have been recreated.
This is a major issue right now for people trying to upgrade to DBAL 2.5.
