### PR TITLE
Cleanup travis database creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,7 @@ install:
   - composer update --prefer-source
 
 before_script:
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests;' -U postgres; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests_tmp;' -U postgres; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests;' -U postgres; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests_tmp;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then sudo service postgresql stop; sudo service postgresql start $POSTGRESQL_VERSION; fi"
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi"
-  - sh -c "if [ '$DB' = 'mysqli' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi"
 
 script: ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml
 

--- a/tests/travis/mysql.travis.xml
+++ b/tests/travis/mysql.travis.xml
@@ -12,7 +12,6 @@
         <var name="tmpdb_host" value="localhost" />
         <var name="tmpdb_username" value="travis" />
         <var name="tmpdb_password" value="" />
-        <var name="tmpdb_name" value="doctrine_tests_tmp" />
         <var name="tmpdb_port" value="3306"/>
     </php>
 

--- a/tests/travis/mysqli.travis.xml
+++ b/tests/travis/mysqli.travis.xml
@@ -12,7 +12,6 @@
         <var name="tmpdb_host" value="localhost" />
         <var name="tmpdb_username" value="travis" />
         <var name="tmpdb_password" value="" />
-        <var name="tmpdb_name" value="doctrine_tests_tmp" />
         <var name="tmpdb_port" value="3306"/>
     </php>
 


### PR DESCRIPTION
Remove database creation from Travis build script because it is actually done by DBAL test suite already. Moreover it avoids creating temp databases which are useless and not even used by PostgreSQL currently.
