### PR TITLE
[DBAL-1097] Fix foreign key constraint referential action on Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -675,6 +675,44 @@ LEFT JOIN user_cons_columns r_cols
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
+    {
+        $referentialAction = null;
+
+        if ($foreignKey->hasOption('onDelete')) {
+            $referentialAction = $this->getForeignKeyReferentialActionSQL($foreignKey->getOption('onDelete'));
+        }
+
+        return $referentialAction ? ' ON DELETE ' . $referentialAction : '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getForeignKeyReferentialActionSQL($action)
+    {
+        $action = strtoupper($action);
+
+        switch ($action) {
+            case 'RESTRICT': // RESTRICT is not supported, therefore falling back to NO ACTION.
+            case 'NO ACTION':
+                // NO ACTION cannot be declared explicitly,
+                // therefore returning empty string to indicate to OMIT the referential clause.
+                return '';
+
+            case 'CASCADE':
+            case 'SET NULL':
+                return $action;
+
+            default:
+                // SET DEFAULT is not supported, throw exception instead.
+                throw new \InvalidArgumentException('Invalid foreign key action: ' . $action);
+        }
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getDropDatabaseSQL($database)


### PR DESCRIPTION
Oracle only supports `CASCADE` and `SET NULL` referential actions for foreign key constraints. It also supports `NO ACTION` but it cannot be declared with an explicit `ON DELETE NO ACTION` clause. The complete clause has to be omitted in order to make it work.
This PR fixes supported referential actions and omits the referential clause if either action `NO ACTION` or `RESTRICT` is set for the foreign key constraint to create.
