### PR TITLE
PostgreSQL needs explicitly closed connection in functional test

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -244,5 +244,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         );
 
         $this->assertTrue($connection->connect());
+
+        $connection->close();
     }
 }


### PR DESCRIPTION
The test `Doctrine\Tests\DBAL\Functional\ConnectionTest::testConnectWithoutExplicitDatabaseName` prevents further tests in the suite from being run as the connection hangs around in PostgreSQL. 

After this particular test, when the next `DROP DATABASE` is run, the log shows:

> 2015-01-03 00:21:28 PST ERROR:  database "doctrine_tests" is being accessed by other users
> 2015-01-03 00:21:28 PST DETAIL:  There is 1 other session using the database.
> 2015-01-03 00:21:28 PST STATEMENT:  DROP DATABASE doctrine_tests

And the next functional test to be run produces something like:

> 1) Doctrine\Tests\DBAL\Functional\ConnectionTest::testPingDoesTriggersConnect
> Doctrine\DBAL\Exception\DriverException: An exception occurred while executing 'CREATE DATABASE doctrine_tests':
> 
> SQLSTATE[42P04]: Duplicate database: 7 ERROR:  database "doctrine_tests" already exists
> 
> ...

This is with the following:
- Debian Linux
- PHP 5.5.9
- PostgreSQL 9.3.5
- PHPUnit 4.0.20
- Process Isolation = off

Turning process isolation on does resolve the issue, but I assume that shouldn't be required. This doesn't seem to affect Travis.
