### PR TITLE
[DBAL-1063] Allow defining duplicate indexes on a table

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,13 +1,32 @@
+# Upgrade to 2.5.1
+
+## MINOR BC BREAK: Doctrine\DBAL\Schema\Table
+
+When adding indexes to ``Doctrine\DBAL\Schema\Table`` via ``addIndex()`` or ``addUniqueIndex()``,
+duplicate indexes are not silently ignored/dropped anymore (based on semantics, not naming!).
+Duplicate indexes are considered indexes that pass ``isFullfilledBy()`` or ``overrules()``
+in ``Doctrine\DBAL\Schema\Index``.
+This is required to make the index renaming feature introduced in 2.5.0 work properly and avoid
+issues in the ORM schema tool / DBAL schema manager which pretends users from updating
+their schemas and migrate to DBAL 2.5.*.
+Additionally it offers more flexibility in declaring indexes for the user and potentially fixes
+related issues in the ORM.
+With this change, the responsibility to decide which index is a "duplicate" is completely deferred
+to the user.
+Please also note that adding foreign key constraints to a table via ``addForeignKeyConstraint()``,
+``addUnnamedForeignKeyConstraint()`` or ``addNamedForeignKeyConstraint()`` now first checks if an
+appropriate index is already present and avoids adding an additional auto-generated one eventually.
+
 # Upgrade to 2.5
 
 ## BC BREAK: time type resets date fields to UNIX epoch
 
-When mapping `time` type field to PHP's `DateTime` instance all unused date fields are 
-reset to UNIX epoch (i.e. 1970-01-01). This might break any logic which relies on comparing 
-`DateTime` instances with date fields set to the current date. 
+When mapping `time` type field to PHP's `DateTime` instance all unused date fields are
+reset to UNIX epoch (i.e. 1970-01-01). This might break any logic which relies on comparing
+`DateTime` instances with date fields set to the current date.
 
 Use `!` format prefix (see http://php.net/manual/en/datetime.createfromformat.php) for parsing
-time strings to prevent having different date fields when comparing user input and `DateTime` 
+time strings to prevent having different date fields when comparing user input and `DateTime`
 instances as mapped by Doctrine.
 
 ## BC BREAK: Doctrine\DBAL\Schema\Table

--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -354,19 +354,6 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
     /**
      * @group DBAL-50
      */
-    public function testAddIndexTwice_IgnoreSecond()
-    {
-        $table = new Table("foo.bar");
-        $table->addColumn('baz', 'integer', array());
-        $table->addIndex(array('baz'));
-        $table->addIndex(array('baz'));
-
-        $this->assertEquals(1, count($table->getIndexes()));
-    }
-
-    /**
-     * @group DBAL-50
-     */
     public function testAddForeignKeyIndexImplicitly()
     {
         $table = new Table("foo");
@@ -386,9 +373,56 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
     }
 
     /**
-     * @group DBAL-50
+     * @group DBAL-1063
      */
-    public function testOverruleIndex()
+    public function testAddForeignKeyDoesNotCreateDuplicateIndex()
+    {
+        $table = new Table('foo');
+        $table->addColumn('bar', 'integer');
+        $table->addIndex(array('bar'), 'bar_idx');
+
+        $foreignTable = new Table('bar');
+        $foreignTable->addColumn('foo', 'integer');
+
+        $table->addForeignKeyConstraint($foreignTable, array('bar'), array('foo'));
+
+        $this->assertCount(1, $table->getIndexes());
+        $this->assertTrue($table->hasIndex('bar_idx'));
+        $this->assertSame(array('bar'), $table->getIndex('bar_idx')->getColumns());
+    }
+
+    /**
+     * @group DBAL-1063
+     */
+    public function testAddForeignKeyAddsImplicitIndexIfIndexColumnsDoNotSpan()
+    {
+        $table = new Table('foo');
+        $table->addColumn('bar', 'integer');
+        $table->addColumn('baz', 'string');
+        $table->addColumn('bloo', 'string');
+        $table->addIndex(array('baz', 'bar'), 'composite_idx');
+        $table->addIndex(array('bar', 'baz', 'bloo'), 'full_idx');
+
+        $foreignTable = new Table('bar');
+        $foreignTable->addColumn('foo', 'integer');
+        $foreignTable->addColumn('baz', 'string');
+
+        $table->addForeignKeyConstraint($foreignTable, array('bar', 'baz'), array('foo', 'baz'));
+
+        $this->assertCount(3, $table->getIndexes());
+        $this->assertTrue($table->hasIndex('composite_idx'));
+        $this->assertTrue($table->hasIndex('full_idx'));
+        $this->assertTrue($table->hasIndex('idx_8c73652176ff8caa78240498'));
+        $this->assertSame(array('baz', 'bar'), $table->getIndex('composite_idx')->getColumns());
+        $this->assertSame(array('bar', 'baz', 'bloo'), $table->getIndex('full_idx')->getColumns());
+        $this->assertSame(array('bar', 'baz'), $table->getIndex('idx_8c73652176ff8caa78240498')->getColumns());
+    }
+
+    /**
+     * @group DBAL-50
+     * @group DBAL-1063
+     */
+    public function testOverrulingIndexDoesNotDropOverruledIndex()
     {
         $table = new Table("bar");
         $table->addColumn('baz', 'integer', array());
@@ -399,23 +433,62 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         $index = current($indexes);
 
         $table->addUniqueIndex(array('baz'));
-        $this->assertEquals(1, count($table->getIndexes()));
-        $this->assertFalse($table->hasIndex($index->getName()));
+        $this->assertEquals(2, count($table->getIndexes()));
+        $this->assertTrue($table->hasIndex($index->getName()));
     }
 
-    public function testPrimaryKeyOverrulesUniqueIndex()
+    /**
+     * @group DBAL-1063
+     */
+    public function testAllowsAddingDuplicateIndexesBasedOnColumns()
+    {
+        $table = new Table('foo');
+        $table->addColumn('bar', 'integer');
+        $table->addIndex(array('bar'), 'bar_idx');
+        $table->addIndex(array('bar'), 'duplicate_idx');
+
+        $this->assertCount(2, $table->getIndexes());
+        $this->assertTrue($table->hasIndex('bar_idx'));
+        $this->assertTrue($table->hasIndex('duplicate_idx'));
+        $this->assertSame(array('bar'), $table->getIndex('bar_idx')->getColumns());
+        $this->assertSame(array('bar'), $table->getIndex('duplicate_idx')->getColumns());
+    }
+
+    /**
+     * @group DBAL-1063
+     */
+    public function testAllowsAddingFulfillingIndexesBasedOnColumns()
+    {
+        $table = new Table('foo');
+        $table->addColumn('bar', 'integer');
+        $table->addColumn('baz', 'string');
+        $table->addIndex(array('bar'), 'bar_idx');
+        $table->addIndex(array('bar', 'baz'), 'fulfilling_idx');
+
+        $this->assertCount(2, $table->getIndexes());
+        $this->assertTrue($table->hasIndex('bar_idx'));
+        $this->assertTrue($table->hasIndex('fulfilling_idx'));
+        $this->assertSame(array('bar'), $table->getIndex('bar_idx')->getColumns());
+        $this->assertSame(array('bar', 'baz'), $table->getIndex('fulfilling_idx')->getColumns());
+    }
+
+    /**
+     * @group DBAL-50
+     * @group DBAL-1063
+     */
+    public function testPrimaryKeyOverrulingUniqueIndexDoesNotDropUniqueIndex()
     {
         $table = new Table("bar");
         $table->addColumn('baz', 'integer', array());
-        $table->addUniqueIndex(array('baz'));
+        $table->addUniqueIndex(array('baz'), 'idx_unique');
 
         $table->setPrimaryKey(array('baz'));
 
         $indexes = $table->getIndexes();
-        $this->assertEquals(1, count($indexes), "Table should only contain the primary key table index, not the unique one anymore, because it was overruled.");
+        $this->assertEquals(2, count($indexes), "Table should only contain both the primary key table index and the unique one, even though it was overruled.");
 
-        $index = current($indexes);
-        $this->assertTrue($index->isPrimary());
+        $this->assertTrue($table->hasPrimaryKey());
+        $this->assertTrue($table->hasIndex('idx_unique'));
     }
 
     /**


### PR DESCRIPTION
This PR removes silent dropping of "duplicate" indexes on a table if two indexes fulfill each other or one overrules the other.
This is necessary to make detection of renamed indexes work properly (introduced in 2.5). Currently there are situations where false positive index renamings are detected because of race conditions.

**Example**

An ORM entity contains an association which adds a foreign key constraint to the underlying table. Foreign key constraints always create implicit indexes on the particular columns.
The entity also contains a mapping for a custom named index fulfilling the foreign key column(s).
The ORM schema tool first adds the foreign key constraint to the table, implicitly creating an index. Afterwards it adds the custom named index which is dropped silently by the table instance because it is considered a "duplicate".
So the table instance created by the schema now contains the auto generated index but not the custom named one.
When using the schema tool to update the schema, the DBAL schema manager is utilized to create the "online" schema. The schema manager detects two indexes in the database, the auto generated one and the custom named one (manually created by the user).
When the schema manger creates the table instance it eventually adds the custom named index first which results in the auto generated index being dropped silently.
When comparing both "offline" and "online" schema, the comparator detects an index rename which actually is none.
This leads to failing `DROP INDEX` and `CREATE INDEX` SQL.

Besides this issue "duplicate" indexes are totally legit and DBAL should not decide whether or not to create an index. This should be user responsibility.

This implementation is much more transparent and less error prone and opens up more flexibility for the user to define indexes on tables.

/cc @flack @Ocramius @beberlei 
