### PR TITLE
[WIP] Remove PHP 5.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,9 @@
+# Upgrade to 2.6
+
+## PHP Version requirement change
+
+As of version 2.6.0, PHP versions below 5.4.0 will not be supported anymore.
+
 # Upgrade to 2.5
 
 ## BC BREAK: time type resets date fields to UNIX epoch

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.4",
         "doctrine/common": ">=2.4,<2.6-dev"
     },
     "require-dev": {


### PR DESCRIPTION
Just a suggestion for master (2.6). We should move on.
