### PR TITLE
[DBAL-1104] Add support for object hydration in oci8 driver

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -243,11 +243,19 @@ class OCI8Statement implements \IteratorAggregate, Statement
     public function fetch($fetchMode = null)
     {
         $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
-        if ( ! isset(self::$fetchModeMap[$fetchMode])) {
+
+        if (PDO::FETCH_OBJ == $fetchMode) {
+            return oci_fetch_object($this->_sth);
+        }
+
+        if (! isset(self::$fetchModeMap[$fetchMode])) {
             throw new \InvalidArgumentException("Invalid fetch style: " . $fetchMode);
         }
 
-        return oci_fetch_array($this->_sth, self::$fetchModeMap[$fetchMode] | OCI_RETURN_NULLS | OCI_RETURN_LOBS);
+        return oci_fetch_array(
+            $this->_sth,
+            self::$fetchModeMap[$fetchMode] | OCI_RETURN_NULLS | OCI_RETURN_LOBS
+        );
     }
 
     /**
@@ -256,11 +264,21 @@ class OCI8Statement implements \IteratorAggregate, Statement
     public function fetchAll($fetchMode = null)
     {
         $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
+
+        $result = array();
+
+        if (PDO::FETCH_OBJ == $fetchMode) {
+            while ($row = $this->fetch($fetchMode)) {
+                $result[] = $row;
+            }
+
+            return $result;
+        }
+
         if ( ! isset(self::$fetchModeMap[$fetchMode])) {
             throw new \InvalidArgumentException("Invalid fetch style: " . $fetchMode);
         }
 
-        $result = array();
         if (self::$fetchModeMap[$fetchMode] === OCI_BOTH) {
             while ($row = $this->fetch($fetchMode)) {
                 $result[] = $row;

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -646,12 +646,6 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
      */
     public function testFetchAllStyleObject()
     {
-        $driverName = $this->_conn->getDriver()->getName();
-
-        if (in_array($driverName, array('oci8'), true)) {
-            $this->markTestSkipped(sprintf('Driver "%s" does not support hydrating data to an object.', $driverName));
-        }
-
         $this->setupFixture();
 
         $sql = 'SELECT test_int, test_string, test_datetime FROM fetch_table';


### PR DESCRIPTION
Adds support for fetching data into `\stdClass` objects in `oci8` driver.
