### PR TITLE
DBAL-1106 Improve schema introspection performance on Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -419,15 +419,33 @@ class OraclePlatform extends AbstractPlatform
     {
         $table = $this->normalizeIdentifier($table);
 
-        return "SELECT uind.index_name AS name, " .
-             "       uind.index_type AS type, " .
-             "       decode( uind.uniqueness, 'NONUNIQUE', 0, 'UNIQUE', 1 ) AS is_unique, " .
-             "       uind_col.column_name AS column_name, " .
-             "       uind_col.column_position AS column_pos, " .
-             "       (SELECT ucon.constraint_type FROM user_constraints ucon WHERE ucon.constraint_name = uind.index_name) AS is_primary ".
-             "FROM user_indexes uind, user_ind_columns uind_col " .
-             "WHERE uind.index_name = uind_col.index_name AND uind_col.table_name = '" . $table->getName() . "' " .
-             "ORDER BY uind_col.column_position ASC";
+        return "SELECT uind_col.index_name AS name,
+                       (
+                           SELECT uind.index_type
+                           FROM   user_indexes uind
+                           WHERE  uind.index_name = uind_col.index_name
+                       ) AS type,
+                       decode(
+                           (
+                               SELECT uind.uniqueness
+                               FROM   user_indexes uind
+                               WHERE  uind.index_name = uind_col.index_name
+                           ),
+                           'NONUNIQUE',
+                           0,
+                           'UNIQUE',
+                           1
+                       ) AS is_unique,
+                       uind_col.column_name AS column_name,
+                       uind_col.column_position AS column_pos,
+                       (
+                           SELECT ucon.constraint_type
+                           FROM   user_constraints ucon
+                           WHERE  ucon.constraint_name = uind_col.index_name
+                       ) AS is_primary
+             FROM      user_ind_columns uind_col
+             WHERE     uind_col.table_name = '" . $table->getName() . "'
+             ORDER BY  uind_col.column_position ASC";
     }
 
     /**
@@ -594,23 +612,26 @@ END;';
 
         return "SELECT alc.constraint_name,
           alc.DELETE_RULE,
-          alc.search_condition,
           cols.column_name \"local_column\",
           cols.position,
-          r_alc.table_name \"references_table\",
-          r_cols.column_name \"foreign_column\"
+          (
+              SELECT r_cols.table_name
+              FROM   user_cons_columns r_cols
+              WHERE  alc.r_constraint_name = r_cols.constraint_name
+              AND    r_cols.position = cols.position
+          ) AS \"references_table\",
+          (
+              SELECT r_cols.column_name
+              FROM   user_cons_columns r_cols
+              WHERE  alc.r_constraint_name = r_cols.constraint_name
+              AND    r_cols.position = cols.position
+          ) AS \"foreign_column\"
      FROM user_cons_columns cols
-LEFT JOIN user_constraints alc
+     JOIN user_constraints alc
        ON alc.constraint_name = cols.constraint_name
-LEFT JOIN user_constraints r_alc
-       ON alc.r_constraint_name = r_alc.constraint_name
-LEFT JOIN user_cons_columns r_cols
-       ON r_alc.constraint_name = r_cols.constraint_name
-      AND cols.position = r_cols.position
-    WHERE alc.constraint_name = cols.constraint_name
       AND alc.constraint_type = 'R'
       AND alc.table_name = '" . $table->getName() . "'
- ORDER BY alc.constraint_name ASC, cols.position ASC";
+    ORDER BY cols.constraint_name ASC, cols.position ASC";
     }
 
     /**
@@ -641,9 +662,16 @@ LEFT JOIN user_cons_columns r_cols
             $ownerCondition = "AND c.owner = '" . $database->getName() . "'";
         }
 
-        return "SELECT c.*, d.comments FROM $tabColumnsTableName c ".
-               "INNER JOIN " . $colCommentsTableName . " d ON d.TABLE_NAME = c.TABLE_NAME AND d.COLUMN_NAME = c.COLUMN_NAME ".
-               "WHERE c.table_name = '" . $table->getName() . "' ".$ownerCondition." ORDER BY c.column_name";
+        return "SELECT   c.*,
+                         (
+                             SELECT d.comments
+                             FROM   $colCommentsTableName d
+                             WHERE  d.TABLE_NAME = c.TABLE_NAME
+                             AND    d.COLUMN_NAME = c.COLUMN_NAME
+                         ) AS comments
+                FROM     $tabColumnsTableName c
+                WHERE    c.table_name = '" . $table->getName() . "' $ownerCondition
+                ORDER BY c.column_name";
     }
 
     /**


### PR DESCRIPTION
This PR improves the overall schema introspection performance on Oracle by optimizing some of the `getList*()` method SQL queries in the platform.
Unfortunately Oracle system views are rather slow, especially when joining tables. Using subqueries can improve the execution time a lot.

**Improved queries**

(the times have been measured using an exemplary query from the functional test suite)

`getListTableForeignKeysSQL()`: Down from `~2.33s` to `~0.68s` per query
`getListTableColumnsSQL()`: Down from `~0.49s` to `~0.14s` per query
`getListTableIndexesSQL()`: Down from `~0.5s` to `~0.25s` per query

Overall improvement of `OracleSchemaManagerTest` from `~100s` to `~37.5s`.

I was quite impressed by the performance improvements :)
