### PR TITLE
Allow overriding implicit indexes

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -491,6 +491,78 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         $this->assertTrue($table->hasIndex('idx_unique'));
     }
 
+    public function testAddingFulfillingRegularIndexOverridesImplicitForeignKeyConstraintIndex()
+    {
+        $foreignTable = new Table('foreign');
+        $foreignTable->addColumn('id', 'integer');
+
+        $localTable = new Table('local');
+        $localTable->addColumn('id', 'integer');
+        $localTable->addForeignKeyConstraint($foreignTable, array('id'), array('id'));
+
+        $this->assertCount(1, $localTable->getIndexes());
+
+        $localTable->addIndex(array('id'), 'explicit_idx');
+
+        $this->assertCount(1, $localTable->getIndexes());
+        $this->assertTrue($localTable->hasIndex('explicit_idx'));
+    }
+
+    public function testAddingFulfillingUniqueIndexOverridesImplicitForeignKeyConstraintIndex()
+    {
+        $foreignTable = new Table('foreign');
+        $foreignTable->addColumn('id', 'integer');
+
+        $localTable = new Table('local');
+        $localTable->addColumn('id', 'integer');
+        $localTable->addForeignKeyConstraint($foreignTable, array('id'), array('id'));
+
+        $this->assertCount(1, $localTable->getIndexes());
+
+        $localTable->addUniqueIndex(array('id'), 'explicit_idx');
+
+        $this->assertCount(1, $localTable->getIndexes());
+        $this->assertTrue($localTable->hasIndex('explicit_idx'));
+    }
+
+    public function testAddingFulfillingPrimaryKeyOverridesImplicitForeignKeyConstraintIndex()
+    {
+        $foreignTable = new Table('foreign');
+        $foreignTable->addColumn('id', 'integer');
+
+        $localTable = new Table('local');
+        $localTable->addColumn('id', 'integer');
+        $localTable->addForeignKeyConstraint($foreignTable, array('id'), array('id'));
+
+        $this->assertCount(1, $localTable->getIndexes());
+
+        $localTable->setPrimaryKey(array('id'), 'explicit_idx');
+
+        $this->assertCount(1, $localTable->getIndexes());
+        $this->assertTrue($localTable->hasIndex('explicit_idx'));
+    }
+
+    public function testAddingFulfillingExplicitIndexOverridingImplicitForeignKeyConstraintIndexWithSameNameDoesNotThrowException()
+    {
+        $foreignTable = new Table('foreign');
+        $foreignTable->addColumn('id', 'integer');
+
+        $localTable = new Table('local');
+        $localTable->addColumn('id', 'integer');
+        $localTable->addForeignKeyConstraint($foreignTable, array('id'), array('id'));
+
+        $this->assertCount(1, $localTable->getIndexes());
+        $this->assertTrue($localTable->hasIndex('IDX_8BD688E8BF396750'));
+
+        $implicitIndex = $localTable->getIndex('IDX_8BD688E8BF396750');
+
+        $localTable->addIndex(array('id'), 'IDX_8BD688E8BF396750');
+
+        $this->assertCount(1, $localTable->getIndexes());
+        $this->assertTrue($localTable->hasIndex('IDX_8BD688E8BF396750'));
+        $this->assertNotSame($implicitIndex, $localTable->getIndex('IDX_8BD688E8BF396750'));
+    }
+
     /**
      * @group DBAL-64
      */


### PR DESCRIPTION
This is a follow-up patch for the change introduced in https://github.com/doctrine/dbal/pull/764.
It makes the `Table` class act more intelligent when it comes to preferring explicit over implicit indexes.
Currently it is necessary to construct a `Table` instance in a specific order to not have unnecessary duplicate indexes because of foreign keys. If you first add a foreign key and afterwards and explicit index that is fulfilling the implicit one, both indexes are stored. Instead it is more intelligent to replace the implicit by the explicit one if and only if the explicit one fulfills the implicit one.
This should also fix possible issues with how ORM's schema tool constructs a schema. See [here](https://travis-ci.org/doctrine/doctrine2/jobs/46321581#L307) where for a OneToOne relation on a primary key an additional regular index for the foreign key is created.
