### PR TITLE
Fix unique index exception handling for an index on multiple columns in PHP 5.4

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
@@ -42,6 +42,7 @@ abstract class AbstractSQLiteDriver implements Driver, ExceptionConverterDriver
     {
         if (strpos($exception->getMessage(), 'must be unique') !== false ||
             strpos($exception->getMessage(), 'is not unique') !== false ||
+            strpos($exception->getMessage(), 'are not unique') !== false ||
             strpos($exception->getMessage(), 'UNIQUE constraint failed') !== false
         ) {
             return new Exception\UniqueConstraintViolationException($message, $exception);

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLiteDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLiteDriverTest.php
@@ -71,6 +71,7 @@ class AbstractSQLiteDriverTest extends AbstractDriverTest
             self::EXCEPTION_UNIQUE_CONSTRAINT_VIOLATION => array(
                 array(null, null, 'must be unique'),
                 array(null, null, 'is not unique'),
+                array(null, null, 'are not unique'),
             ),
         );
     }


### PR DESCRIPTION
In SQLite under PHP 5.4, when I violate a unique index on multiple columns by creating a duplicate record, the PDO Exception thrown is "SQLSTATE[23000]: Integrity constraint violation: 19 columns X, Y are not unique".  This PDO exception message is not parsed by the AbstractSQLiteDriver and converted to a UniqueConstraintViolationException as expected, and as happens in PHP 5.5, so only a generic DriverException is thrown, making error handling much harder.

This pull request adds "are not unique" as a string that is checked for in the exception handling code.
