### PR TITLE
Problem with drop database on PostgreSQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,4 @@ before_script:
   - sh -c "if [ '$DB' = 'mysqli' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi"
   - composer --prefer-source --dev install
 
-script: phpunit --configuration tests/travis/$DB.travis.xml
-
+script: vendor/phpunit/phpunit/composer/bin/phpunit --configuration tests/travis/$DB.travis.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ before_script:
   - sh -c "if [ '$DB' = 'mysqli' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi"
   - composer --prefer-source --dev install
 
-script: vendor/phpunit/phpunit/composer/bin/phpunit --configuration tests/travis/$DB.travis.xml
+script: ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml

--- a/build.properties
+++ b/build.properties
@@ -1,10 +1,3 @@
-# Project Name
-project.name=DoctrineDBAL
-
-# Dependency minimum versions
-dependencies.common=2.0.1
-dependencies.sfconsole=2.0.0
-
 # Version class and file
-project.version_class = Doctrine\DBAL\Version
+project.version_class = Doctrine\\DBAL\\Version
 project.version_file = lib/Doctrine/DBAL/Version.php

--- a/build.xml
+++ b/build.xml
@@ -1,91 +1,101 @@
 <?xml version="1.0"?>
 <project name="DoctrineDBAL" default="build" basedir=".">
-    <taskdef classname="phing.tasks.ext.d51PearPkg2Task" name="d51pearpkg2" />
-    <import file="${project.basedir}/lib/vendor/doctrine-build-common/packaging.xml" />
-
     <property file="build.properties" />
 
-    <!--
-        Fileset for artifacts shared across all distributed packages.
-    -->
-    <fileset id="shared-artifacts" dir=".">
-        <include name="LICENSE"/>
-    </fileset>
-
-    <!--
-        Fileset for command line scripts
-    -->
-    <fileset id="bin-scripts" dir="./bin">
-        <include name="doctrine-dbal"/>
-        <include name="doctrine-dbal.php"/>
-    </fileset>
-
-    <!--
-        Fileset for the sources of the Doctrine Common dependency.
-    -->
-    <fileset id="common-sources" dir="./lib/vendor/doctrine-common/lib">
-        <include name="Doctrine/Common/**"/>
-    </fileset>
-
-    <!--
-        Fileset for the sources of the Doctrine DBAL package.
-    -->
-    <fileset id="dbal-sources" dir="./lib">
-        <include name="Doctrine/DBAL/**"/>
-    </fileset>
-
-    <!--
-      Fileset for source of the Symfony YAML and Console components.
-    -->
-    <fileset id="external-sources" dir="./lib/vendor">
-        <include name="Symfony/Component**"/>
-    </fileset>
-
-    <target name="copy-files" depends="prepare">
-        <echo msg="Checking for ${version} in ${project.version_file}" />
-        <exec command="grep '${version}' ${project.basedir}/${project.version_file}" checkreturn="true"/>
-        <copy todir="${build.dir}/${project.name}-${version}">
-            <fileset refid="shared-artifacts"/>
-        </copy>
-        <copy todir="${build.dir}/${project.name}-${version}">
-            <fileset refid="common-sources"/>
-            <fileset refid="dbal-sources"/>
-        </copy>
-        <copy todir="${build.dir}/${project.name}-${version}/Doctrine">
-            <fileset refid="external-sources"/>
-        </copy>
-        <copy todir="${build.dir}/${project.name}-${version}/bin">
-            <fileset refid="bin-scripts"/>
-        </copy>
+    <target name="php">
+        <exec executable="which" outputproperty="php_executable">
+            <arg value="php" />
+        </exec>
     </target>
 
-    <target name="define-pear-package" depends="copy-files">
-        <d51pearpkg2 baseinstalldir="/" dir="${build.dir}/${project.name}-${version}">
-            <name>${project.name}</name>
-            <summary>Doctrine Database Abstraction Layer</summary>
-            <channel>pear.doctrine-project.org</channel>
-            <description>The Doctrine DBAL package is the database abstraction layer used to power the ORM package.</description>
-            <lead user="jwage" name="Jonathan H. Wage" email="jonwage@gmail.com" />
-            <lead user="guilhermeblanco" name="Guilherme Blanco" email="guilhermeblanco@gmail.com" />
-            <lead user="romanb" name="Roman Borschel" email="roman@code-factory.org" />
-            <lead user="beberlei" name="Benjamin Eberlei" email="kontakt@beberlei.de" />
-            <license>LGPL</license>
-            <version release="${pear.version}" api="${pear.version}" />
-            <stability release="${pear.stability}" api="${pear.stability}" />
-            <notes>-</notes>
-            <dependencies>
-                <php minimum_version="5.3.2" />
-                <pear minimum_version="1.6.0" recommended_version="1.6.1" />
-                <package name="DoctrineCommon" channel="pear.doctrine-project.org" minimum_version="${dependencies.common}" />
-                <package name="Console" channel="pear.symfony.com" minimum_version="${dependencies.sfconsole}" />
-            </dependencies>
-            <dirroles key="bin">script</dirroles>
-            <ignore>Doctrine/Common/</ignore>
-            <ignore>Doctrine/Symfony/</ignore>
-            <release>
-                <install as="doctrine-dbal" name="bin/doctrine-dbal" />
-                <install as="doctrine-dbal.php" name="bin/doctrine-dbal.php" />
-            </release>
-        </d51pearpkg2>
+    <target name="prepare">
+        <mkdir dir="build" />
     </target>
+
+    <target name="build" depends="check-git-checkout-clean,prepare,php,composer">
+        <exec executable="${php_executable}">
+            <arg value="build/composer.phar" />
+            <arg value="archive" />
+            <arg value="--dir=build" />
+        </exec>
+    </target>
+
+    <target name="composer" depends="php,composer-check,composer-download">
+        <exec executable="${php_executable}">
+            <arg value="build/composer.phar" />
+            <arg value="install" />
+        </exec>
+    </target>
+
+    <target name="composer-check" depends="prepare">
+        <available file="build/composer.phar" property="composer.present"/>
+    </target>
+
+    <target name="composer-download" unless="composer.present">
+        <exec executable="wget">
+            <arg value="-Obuild/composer.phar" />
+            <arg value="http://getcomposer.org/composer.phar" />
+        </exec>
+    </target>
+
+    <target name="make-release" depends="check-git-checkout-clean,prepare,php">
+        <replace file="${project.version_file}" token="-DEV" value="" failOnNoReplacements="true" />
+        <exec executable="${php_executable}" outputproperty="doctrine.current_version" failonerror="true">
+            <arg value="-r" />
+            <arg value="require_once '${project.version_file}';echo ${project.version_class}::VERSION;" />
+        </exec>
+        <exec executable="${php_executable}" outputproperty="doctrine.next_version" failonerror="true">
+            <arg value="-r" />
+            <arg value="$parts = explode('.', str_ireplace(array('-DEV', '-ALPHA', '-BETA'), '', '${doctrine.current_version}'));
+                if (count($parts) != 3) {
+                    throw new \InvalidArgumentException('Version is assumed in format x.y.z, ${doctrine.current_version} given');
+                }
+                $parts[2]++;
+                echo implode('.', $parts);
+            " />
+        </exec>
+
+        <git-commit file="${project.version_file}" message="Release ${doctrine.current_version}" />
+        <git-tag version="${doctrine.current_version}" />
+        <replace file="${project.version_file}" token="${doctrine.current_version}" value="${doctrine.next_version}-DEV" />
+        <git-commit file="${project.version_file}" message="Bump version to ${doctrine.next_version}" />
+    </target>
+
+    <target name="check-git-checkout-clean">
+        <exec executable="git" failonerror="true">
+            <arg value="diff-index" />
+            <arg value="--quiet" />
+            <arg value="HEAD" />
+        </exec>
+    </target>
+
+    <macrodef name="git-commit">
+        <attribute name="file" default="NOT SET"/>
+        <attribute name="message" default="NOT SET"/>
+
+        <sequential>
+            <exec executable="git">
+                <arg value="add" />
+                <arg value="@{file}" />
+            </exec>
+            <exec executable="git">
+                <arg value="commit" />
+                <arg value="-m" />
+                <arg value="@{message}" />
+            </exec>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="git-tag">
+        <attribute name="version" default="NOT SET" />
+
+        <sequential>
+            <exec executable="git">
+                <arg value="tag" />
+                <arg value="-m" />
+                <arg value="v@{version}" />
+                <arg value="v@{version}" />
+            </exec>
+        </sequential>
+    </macrodef>
 </project>

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,6 @@
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."
     },
-    "suggest": {
-        "symfony/console": "Allows use of the command line interface"
-    },
     "autoload": {
         "psr-0": { "Doctrine\\DBAL\\": "lib/" }
     },

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": "2.4.*@beta"
+        "doctrine/common": "~2.4"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
-        "symfony/console": "2.*"
+        "symfony/console": "~2.0"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -27,11 +27,6 @@
     },
     "autoload": {
         "psr-0": { "Doctrine\\DBAL\\": "lib/" }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.5.x-dev"
-        }
     },
     "archive": {
         "exclude": ["!vendor", "tests", "*phpunit.xml", ".travis.yml", "build.xml", "build.properties", "composer.phar"]

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,10 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.4.x-dev"
+            "dev-master": "2.5.x-dev"
         }
+    },
+    "archive": {
+        "exclude": ["!vendor", "tests", "*phpunit.xml", ".travis.yml", "build.xml", "build.properties", "composer.phar"]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -3,20 +3,20 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "66538e950918bed1d8ce86aa828ca12c",
+    "hash": "ce376b1731cb063432716dedd975ee25",
     "packages": [
         {
             "name": "doctrine/annotations",
-            "version": "v1.1.1",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "v1.1.1"
+                "reference": "40db0c96985aab2822edbc4848b3bd2429e02670"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/v1.1.1",
-                "reference": "v1.1.1",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/40db0c96985aab2822edbc4848b3bd2429e02670",
+                "reference": "40db0c96985aab2822edbc4848b3bd2429e02670",
                 "shasum": ""
             },
             "require": {
@@ -63,7 +63,7 @@
                 {
                     "name": "Johannes Schmitt",
                     "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
+                    "homepage": "http://jmsyst.com",
                     "role": "Developer of wrapped JMSSerializerBundle"
                 }
             ],
@@ -74,26 +74,34 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2013-04-20 08:30:17"
+            "time": "2013-06-16 21:33:03"
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.0",
+            "version": "v1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "v1.0"
+                "reference": "2c9761ff1d13e188d5f7378066c1ce2882d7a336"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/doctrine/cache/archive/v1.0.zip",
-                "reference": "v1.0",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/2c9761ff1d13e188d5f7378066c1ce2882d7a336",
+                "reference": "2c9761ff1d13e188d5f7378066c1ce2882d7a336",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "Doctrine\\Common\\Cache\\": "lib/"
@@ -123,9 +131,9 @@
                     "email": "kontakt@beberlei.de"
                 },
                 {
-                    "name": "Johannes Schmitt",
+                    "name": "Johannes M. Schmitt",
                     "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
+                    "homepage": "http://jmsyst.com",
                     "role": "Developer of wrapped JMSSerializerBundle"
                 }
             ],
@@ -135,7 +143,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2013-01-10 22:43:46"
+            "time": "2013-08-07 16:04:25"
         },
         {
             "name": "doctrine/collections",
@@ -206,16 +214,16 @@
         },
         {
             "name": "doctrine/common",
-            "version": "2.4.0-RC2",
+            "version": "v2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "2.4.0-RC2"
+                "reference": "ceb18cf9b0230f3ea208b6238130fd415abda0a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/2.4.0-RC2",
-                "reference": "2.4.0-RC2",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/ceb18cf9b0230f3ea208b6238130fd415abda0a7",
+                "reference": "ceb18cf9b0230f3ea208b6238130fd415abda0a7",
                 "shasum": ""
             },
             "require": {
@@ -263,7 +271,7 @@
                 {
                     "name": "Johannes Schmitt",
                     "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
+                    "homepage": "http://jmsyst.com",
                     "role": "Developer of wrapped JMSSerializerBundle"
                 }
             ],
@@ -276,7 +284,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2013-05-09 21:35:24"
+            "time": "2013-09-07 10:20:34"
         },
         {
             "name": "doctrine/inflector",
@@ -397,16 +405,16 @@
     "packages-dev": [
         {
             "name": "phpunit/php-code-coverage",
-            "version": "1.2.9",
+            "version": "1.2.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "1.2.9"
+                "reference": "0e9958c459d675fb497d8dc5001c91d335734e48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/1.2.9",
-                "reference": "1.2.9",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/0e9958c459d675fb497d8dc5001c91d335734e48",
+                "reference": "0e9958c459d675fb497d8dc5001c91d335734e48",
                 "shasum": ""
             },
             "require": {
@@ -415,11 +423,19 @@
                 "phpunit/php-text-template": ">=1.1.1@stable",
                 "phpunit/php-token-stream": ">=1.1.3@stable"
             },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*@dev"
+            },
             "suggest": {
                 "ext-dom": "*",
                 "ext-xdebug": ">=2.0.5"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "PHP/"
@@ -446,7 +462,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2013-02-26 18:55:56"
+            "time": "2013-07-06 06:26:16"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -539,16 +555,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
-                "url": "git://github.com/sebastianbergmann/php-timer.git",
-                "reference": "1.0.4"
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/sebastianbergmann/php-timer/zipball/1.0.4",
-                "reference": "1.0.4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
                 "shasum": ""
             },
             "require": {
@@ -575,24 +591,24 @@
                 }
             ],
             "description": "Utility class for timing",
-            "homepage": "http://www.phpunit.de/",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
             "keywords": [
                 "timer"
             ],
-            "time": "2012-10-11 04:45:58"
+            "time": "2013-08-02 07:42:54"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.1.5",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
-                "url": "git://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1.1.5"
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "31babf400e5b5868573bf49a000a3519d3978233"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/sebastianbergmann/php-token-stream/zipball/1.1.5",
-                "reference": "1.1.5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/31babf400e5b5868573bf49a000a3519d3978233",
+                "reference": "31babf400e5b5868573bf49a000a3519d3978233",
                 "shasum": ""
             },
             "require": {
@@ -600,6 +616,11 @@
                 "php": ">=5.3.3"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "PHP/"
@@ -620,24 +641,24 @@
                 }
             ],
             "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "http://www.phpunit.de/",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2012-10-11 04:47:14"
+            "time": "2013-08-04 05:57:48"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "3.7.19",
+            "version": "3.7.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3.7.19"
+                "reference": "af7b77ccb5c64458bdfca95665d29558d1df7d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3.7.19",
-                "reference": "3.7.19",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/af7b77ccb5c64458bdfca95665d29558d1df7d08",
+                "reference": "af7b77ccb5c64458bdfca95665d29558d1df7d08",
                 "shasum": ""
             },
             "require": {
@@ -646,12 +667,12 @@
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "php": ">=5.3.3",
-                "phpunit/php-code-coverage": ">=1.2.1,<1.3.0",
+                "phpunit/php-code-coverage": "~1.2.1",
                 "phpunit/php-file-iterator": ">=1.3.1",
                 "phpunit/php-text-template": ">=1.1.1",
-                "phpunit/php-timer": ">=1.0.2,<1.1.0",
-                "phpunit/phpunit-mock-objects": ">=1.2.0,<1.3.0",
-                "symfony/yaml": ">=2.0.0,<2.3.0"
+                "phpunit/php-timer": ">=1.0.4",
+                "phpunit/phpunit-mock-objects": "~1.2.0",
+                "symfony/yaml": "~2.0"
             },
             "require-dev": {
                 "pear-pear/pear": "1.9.4"
@@ -698,7 +719,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2013-03-25 11:45:06"
+            "time": "2013-08-09 06:58:24"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -751,26 +772,32 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.2.1",
+            "version": "v2.3.4",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "v2.2.1"
+                "reference": "db78f8ff7fc9e28d25ff9a0bf6ddf9f0e35fbbe3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/v2.2.1",
-                "reference": "v2.2.1",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/db78f8ff7fc9e28d25ff9a0bf6ddf9f0e35fbbe3",
+                "reference": "db78f8ff7fc9e28d25ff9a0bf6ddf9f0e35fbbe3",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "symfony/event-dispatcher": "~2.1"
+            },
+            "suggest": {
+                "symfony/event-dispatcher": ""
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -794,21 +821,21 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
-            "time": "2013-03-19 20:48:08"
+            "time": "2013-08-17 16:34:49"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.2.1",
+            "version": "v2.3.4",
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "v2.2.1"
+                "reference": "5a279f1b5f5e1045a6c432354d9ea727ff3a9847"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/v2.2.1",
-                "reference": "v2.2.1",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/5a279f1b5f5e1045a6c432354d9ea727ff3a9847",
+                "reference": "5a279f1b5f5e1045a6c432354d9ea727ff3a9847",
                 "shasum": ""
             },
             "require": {
@@ -817,7 +844,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -841,16 +868,16 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2013-03-23 07:49:54"
+            "time": "2013-08-24 15:26:22"
         }
     ],
     "aliases": [
 
     ],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "doctrine/common": 10
-    },
+    "stability-flags": [
+
+    ],
     "platform": {
         "php": ">=5.3.2"
     },

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -135,6 +135,8 @@ pdo\_oci / oci8
 -  ``host`` (string): Hostname of the database to connect to.
 -  ``port`` (integer): Port of the database to connect to.
 -  ``dbname`` (string): Name of the database/schema to connect to.
+-  ``pooled`` (boolean): Whether to enable database resident
+   connection pooling.
 -  ``charset`` (string): The charset used when connecting to the
    database.
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -548,15 +548,16 @@ class Connection implements DriverConnection
     {
         $this->connect();
 
-        if ( ! is_int(key($types))) {
-            $types = $this->extractTypeValues($data, $types);
+        if (empty($data)) {
+            return $this->executeUpdate('INSERT INTO ' . $tableName . ' ()' . ' VALUES ()');
         }
 
-        $query = 'INSERT INTO ' . $tableName
-               . ' (' . implode(', ', array_keys($data)) . ')'
-               . ' VALUES (' . implode(', ', array_fill(0, count($data), '?')) . ')';
-
-        return $this->executeUpdate($query, array_values($data), $types);
+        return $this->executeUpdate(
+            'INSERT INTO ' . $tableName . ' (' . implode(', ', array_keys($data)) . ')' .
+            ' VALUES (' . implode(', ', array_fill(0, count($data), '?')) . ')',
+            array_values($data),
+            is_int(key($types)) ? $types : $this->extractTypeValues($data, $types)
+        );
     }
 
     /**

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -283,6 +283,17 @@ class MasterSlaveConnection extends Connection
     /**
      * {@inheritDoc}
      */
+    public function close()
+    {
+        unset($this->connections['master']);
+        unset($this->connections['slave']);
+
+        parent::close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function update($tableName, array $data, array $identifier, array $types = array())
     {
         $this->connect('master');

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -163,11 +163,12 @@ class MasterSlaveConnection extends Connection
         }
 
         if ($this->connections[$connectionName]) {
-            if ($forceMasterAsSlave) {
-                $this->connections['slave'] = $this->_conn = $this->connections['master'];
-            } else {
-                $this->_conn = $this->connections[$connectionName];
+            $this->_conn = $this->connections[$connectionName];
+
+            if ($forceMasterAsSlave && ! $this->keepSlave) {
+                $this->connections['slave'] = $this->_conn;
             }
+
             return false;
         }
 

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -43,9 +43,10 @@ class MysqliConnection implements Connection
     {
         $port = isset($params['port']) ? $params['port'] : ini_get('mysqli.default_port');
         $socket = isset($params['unix_socket']) ? $params['unix_socket'] : ini_get('mysqli.default_socket');
+        $dbname = isset($params['dbname']) ? $params['dbname'] : null;
 
         $this->_conn = mysqli_init();
-        if ( ! $this->_conn->real_connect($params['host'], $username, $password, $params['dbname'], $port, $socket)) {
+        if ( ! $this->_conn->real_connect($params['host'], $username, $password, $dbname, $port, $socket)) {
             throw new MysqliException($this->_conn->connect_error, $this->_conn->connect_errno);
         }
 

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -166,6 +166,11 @@ class MysqliStatement implements \IteratorAggregate, Statement
             throw new MysqliException($this->_stmt->error, $this->_stmt->errno);
         }
 
+        // We have a result.
+        if (false !== $this->_columnNames) {
+            $this->_stmt->store_result();
+        }
+
         if (null === $this->_columnNames) {
             $meta = $this->_stmt->result_metadata();
             if (false !== $meta) {
@@ -189,11 +194,6 @@ class MysqliStatement implements \IteratorAggregate, Statement
             } else {
                 $this->_columnNames = false;
             }
-        }
-
-        // We have a result.
-        if (false !== $this->_columnNames) {
-            $this->_stmt->store_result();
         }
 
         return true;

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -166,14 +166,12 @@ class MysqliStatement implements \IteratorAggregate, Statement
             throw new MysqliException($this->_stmt->error, $this->_stmt->errno);
         }
 
-        // We have a result.
-        if (false !== $this->_columnNames) {
-            $this->_stmt->store_result();
-        }
-
         if (null === $this->_columnNames) {
             $meta = $this->_stmt->result_metadata();
             if (false !== $meta) {
+                // We have a result.
+                $this->_stmt->store_result();
+
                 $columnNames = array();
                 foreach ($meta->fetch_fields() as $col) {
                     $columnNames[] = $col->name;

--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -64,15 +64,18 @@ class Driver implements \Doctrine\DBAL\Driver
                 $dsn .= '(PORT=1521)';
             }
 
+            $database = 'SID=' . $params['dbname'];
+            $pooled   = '';
+
             if (isset($params['service']) && $params['service'] == true) {
-                $dsn .= '))(CONNECT_DATA=(SERVICE_NAME=' . $params['dbname'] . '))';
-            } else {
-                $dsn .= '))(CONNECT_DATA=(SID=' . $params['dbname'] . '))';
+                $database = 'SERVICE_NAME=' . $params['dbname'];
             }
+
             if (isset($params['pooled']) && $params['pooled'] == true) {
-                $dsn .= '(SERVER=POOLED)';
+                $pooled = '(SERVER=POOLED)';
             }
-            $dsn .= ')';
+
+            $dsn .= '))(CONNECT_DATA=(' . $database . ')' . $pooled . '))';
         } else {
             $dsn .= $params['dbname'];
         }

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -58,7 +58,6 @@ class OCI8Statement implements \IteratorAggregate, Statement
         PDO::FETCH_BOTH => OCI_BOTH,
         PDO::FETCH_ASSOC => OCI_ASSOC,
         PDO::FETCH_NUM => OCI_NUM,
-        PDO::PARAM_LOB => OCI_B_BLOB,
         PDO::FETCH_COLUMN => OCI_NUM,
     );
 

--- a/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
@@ -53,10 +53,11 @@ class Driver implements \Doctrine\DBAL\Driver
      */
     private function _constructPdoDsn(array $params)
     {
-        $dsn = 'oci:';
+        $dsn = 'oci:dbname=';
+
         if (isset($params['host']) && $params['host'] != '') {
-            $dsn .= 'dbname=(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)' .
-                   '(HOST=' . $params['host'] . ')';
+            $dsn .= '(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)' .
+                '(HOST=' . $params['host'] . ')';
 
             if (isset($params['port'])) {
                 $dsn .= '(PORT=' . $params['port'] . ')';
@@ -64,13 +65,20 @@ class Driver implements \Doctrine\DBAL\Driver
                 $dsn .= '(PORT=1521)';
             }
 
+            $database = 'SID=' . $params['dbname'];
+            $pooled   = '';
+
             if (isset($params['service']) && $params['service'] == true) {
-                $dsn .= '))(CONNECT_DATA=(SERVICE_NAME=' . $params['dbname'] . ')))';
-            } else {
-                $dsn .= '))(CONNECT_DATA=(SID=' . $params['dbname'] . ')))';
+                $database = 'SERVICE_NAME=' . $params['dbname'];
             }
+
+            if (isset($params['pooled']) && $params['pooled'] == true) {
+                $pooled = '(SERVER=POOLED)';
+            }
+
+            $dsn .= '))(CONNECT_DATA=(' . $database . ')' . $pooled . '))';
         } else {
-            $dsn .= 'dbname=' . $params['dbname'];
+            $dsn .= $params['dbname'];
         }
 
         if (isset($params['charset'])) {

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -45,6 +45,10 @@ class SQLSrvConnection implements \Doctrine\DBAL\Driver\Connection
      */
     public function __construct($serverName, $connectionOptions)
     {
+        if ( ! sqlsrv_configure('WarningsReturnAsErrors', 0)) {
+            throw SQLSrvException::fromSqlSrvErrors();
+        }
+
         $this->conn = sqlsrv_connect($serverName, $connectionOptions);
         if ( ! $this->conn) {
             throw SQLSrvException::fromSqlSrvErrors();

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1227,7 +1227,7 @@ abstract class AbstractPlatform
                     $options['primary']       = $index->getQuotedColumns($this);
                     $options['primary_index'] = $index;
                 } else {
-                    $options['indexes'][$index->getName()] = $index;
+                    $options['indexes'][$index->getQuotedName($this)] = $index;
                 }
             }
         }

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1284,7 +1284,7 @@ abstract class AbstractPlatform
         if ($this->supportsCommentOnStatement()) {
             foreach ($table->getColumns() as $column) {
                 if ($this->getColumnComment($column)) {
-                    $sql[] = $this->getCommentOnColumnSQL($tableName, $column->getName(), $this->getColumnComment($column));
+                    $sql[] = $this->getCommentOnColumnSQL($tableName, $column->getQuotedName($this), $this->getColumnComment($column));
                 }
             }
         }

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1038,8 +1038,9 @@ abstract class AbstractPlatform
     /**
      * Honors that some SQL vendors such as MsSql use table hints for locking instead of the ANSI SQL FOR UPDATE specification.
      *
-     * @param string  $fromClause
-     * @param integer $lockMode
+     * @param string       $fromClause The FROM clause to append the hint for the given lock mode to.
+     * @param integer|null $lockMode   One of the Doctrine\DBAL\LockMode::* constants. If null is given, nothing will
+     *                                 be appended to the FROM clause.
      *
      * @return string
      */

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2214,27 +2214,58 @@ abstract class AbstractPlatform
     }
 
     /**
-     * Some platforms need the boolean values to be converted.
+     * Note: if the input is not a boolean the original input might be returned.
      *
-     * The default conversion in this implementation converts to integers (false => 0, true => 1).
+     * There are two contexts when converting booleans: Literals and Prepared Statements.
+     * This method should handle the literal case
      *
-     * @param mixed $item
-     *
-     * @return mixed
+     * @param mixed $item A boolean or an array of them.
+     * @return mixed A boolean database value or an array of them.
      */
     public function convertBooleans($item)
     {
         if (is_array($item)) {
             foreach ($item as $k => $value) {
                 if (is_bool($value)) {
-                    $item[$k] = (int) $value;
+                    $item[$k] = (int)$value;
                 }
             }
-        } else if (is_bool($item)) {
-            $item = (int) $item;
+        } else {
+            if (is_bool($item)) {
+                $item = (int)$item;
+            }
         }
 
         return $item;
+    }
+
+
+    /**
+     * Some platforms have boolean literals that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into bool "(bool)$item"
+     *
+     * @param mixed $item
+     *
+     * @return bool|null
+     */
+    public function convertFromBoolean($item)
+    {
+        return null === $item ? null : (bool)$item;
+    }
+
+    /**
+     * This method should handle the prepared statements case. When there is no
+     * distinction, it's OK to use the same method.
+     *
+     * Note: if the input is not a boolean the original input might be returned.
+     *
+     * @param mixed $item A boolean or an array of them.
+     * @return mixed A boolean database value or an array of them.
+     */
+    public function convertBooleansToDatabaseValue($item)
+    {
+        return $this->convertBooleans($item);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2227,13 +2227,11 @@ abstract class AbstractPlatform
         if (is_array($item)) {
             foreach ($item as $k => $value) {
                 if (is_bool($value)) {
-                    $item[$k] = (int)$value;
+                    $item[$k] = (int) $value;
                 }
             }
-        } else {
-            if (is_bool($item)) {
-                $item = (int)$item;
-            }
+        } elseif (is_bool($item)) {
+            $item = (int) $item;
         }
 
         return $item;

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -391,7 +391,7 @@ class DB2Platform extends AbstractPlatform
 
             /* @var $columnDiff \Doctrine\DBAL\Schema\ColumnDiff */
             $column = $columnDiff->column;
-            $queryParts[] =  'ALTER ' . ($columnDiff->oldColumnName) . ' '
+            $queryParts[] =  'ALTER ' . ($columnDiff->getOldColumnName()->getQuotedName($this)) . ' '
                     . $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray());
         }
 

--- a/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
@@ -410,7 +410,7 @@ class DrizzlePlatform extends AbstractPlatform
             $column = $columnDiff->column;
             $columnArray = $column->toArray();
             $columnArray['comment'] = $this->getColumnComment($column);
-            $queryParts[] =  'CHANGE ' . ($columnDiff->oldColumnName) . ' '
+            $queryParts[] =  'CHANGE ' . ($columnDiff->getOldColumnName()->getQuotedName($this)) . ' '
                     . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnArray);
         }
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -557,7 +557,7 @@ class MySqlPlatform extends AbstractPlatform
             $column = $columnDiff->column;
             $columnArray = $column->toArray();
             $columnArray['comment'] = $this->getColumnComment($column);
-            $queryParts[] =  'CHANGE ' . ($columnDiff->oldColumnName) . ' '
+            $queryParts[] =  'CHANGE ' . ($columnDiff->getOldColumnName()->getQuotedName($this)) . ' '
                     . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnArray);
         }
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -556,6 +556,12 @@ class MySqlPlatform extends AbstractPlatform
                     . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnArray);
         }
 
+        if (isset($diff->addedIndexes['primary'])) {
+            $keyColumns = array_unique(array_values($diff->addedIndexes['primary']->getColumns()));
+            $queryParts[] = 'ADD PRIMARY KEY (' . implode(', ', $keyColumns) . ')';
+            unset($diff->addedIndexes['primary']);
+        }
+
         $sql = array();
         $tableSql = array();
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -118,6 +118,22 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getDateAddHourExpression($date, $hours)
+    {
+        return 'DATE_ADD(' . $date . ', INTERVAL ' . $hours . ' HOUR)';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateSubHourExpression($date, $hours)
+    {
+        return 'DATE_SUB(' . $date . ', INTERVAL ' . $hours . ' HOUR)';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDateAddDaysExpression($date, $days)
     {
         return 'DATE_ADD(' . $date . ', INTERVAL ' . $days . ' DAY)';
@@ -605,13 +621,16 @@ class MySqlPlatform extends AbstractPlatform
             foreach ($diff->addedIndexes as $addKey => $addIndex) {
                 if ($remIndex->getColumns() == $addIndex->getColumns()) {
 
-                    $type = '';
-                    if ($addIndex->isUnique()) {
-                        $type = 'UNIQUE ';
+                    $indexClause = 'INDEX ' . $addIndex->getName();
+
+                    if ($addIndex->isPrimary()) {
+                        $indexClause = 'PRIMARY KEY';
+                    } elseif ($addIndex->isUnique()) {
+                        $indexClause = 'UNIQUE INDEX ' . $addIndex->getName();
                     }
 
                     $query = 'ALTER TABLE ' . $table . ' DROP INDEX ' . $remIndex->getName() . ', ';
-                    $query .= 'ADD ' . $type . 'INDEX ' . $addIndex->getName();
+                    $query .= 'ADD ' . $indexClause;
                     $query .= ' (' . $this->getIndexFieldDeclarationListSQL($addIndex->getQuotedColumns($this)) . ')';
 
                     $sql[] = $query;

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -623,6 +623,15 @@ class MySqlPlatform extends AbstractPlatform
                 }
             }
         }
+        foreach ($diff->changedIndexes as $changedKey => $changedIndex) {
+            if ($changedIndex->isPrimary() && $changedKey != 'PRIMARY') {
+                $index = $diff->changedIndexes[$changedKey];
+                $index = new Index($changedKey, $index->getColumns(), $index->isUnique(), false);
+                $diff->removedIndexes[$changedKey] = $index;
+                $diff->addedIndexes['PRIMARY'] = $diff->changedIndexes[$changedKey];
+                unset($diff->changedIndexes[$changedKey]);
+            }
+        }
 
         $sql = array_merge($sql, parent::getPreAlterTableIndexForeignKeySQL($diff));
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -623,15 +623,6 @@ class MySqlPlatform extends AbstractPlatform
                 }
             }
         }
-        foreach ($diff->changedIndexes as $changedKey => $changedIndex) {
-            if ($changedIndex->isPrimary() && $changedKey != 'PRIMARY') {
-                $index = $diff->changedIndexes[$changedKey];
-                $index = new Index($changedKey, $index->getColumns(), $index->isUnique(), false);
-                $diff->removedIndexes[$changedKey] = $index;
-                $diff->addedIndexes['PRIMARY'] = $diff->changedIndexes[$changedKey];
-                unset($diff->changedIndexes[$changedKey]);
-            }
-        }
 
         $sql = array_merge($sql, parent::getPreAlterTableIndexForeignKeySQL($diff));
 

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -568,6 +568,44 @@ LEFT JOIN user_cons_columns r_cols
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
+    {
+        $referentialAction = null;
+
+        if ($foreignKey->hasOption('onDelete')) {
+            $referentialAction = $this->getForeignKeyReferentialActionSQL($foreignKey->getOption('onDelete'));
+        }
+
+        return $referentialAction ? ' ON DELETE ' . $referentialAction : '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getForeignKeyReferentialActionSQL($action)
+    {
+        $action = strtoupper($action);
+
+        switch ($action) {
+            case 'RESTRICT': // RESTRICT is not supported, therefore falling back to NO ACTION.
+            case 'NO ACTION':
+                // NO ACTION cannot be declared explicitly,
+                // therefore returning empty string to indicate to OMIT the referential clause.
+                return '';
+
+            case 'CASCADE':
+            case 'SET NULL':
+                return $action;
+
+            default:
+                // SET DEFAULT is not supported, throw exception instead.
+                throw new \InvalidArgumentException('Invalid foreign key action: ' . $action);
+        }
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getDropDatabaseSQL($database)

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -505,7 +505,8 @@ LEFT JOIN user_cons_columns r_cols
       AND cols.position = r_cols.position
     WHERE alc.constraint_name = cols.constraint_name
       AND alc.constraint_type = 'R'
-      AND alc.table_name = '".$table."'";
+      AND alc.table_name = '".$table."'
+ ORDER BY alc.constraint_name ASC, cols.position ASC";
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -614,7 +614,13 @@ LEFT JOIN user_cons_columns r_cols
              * Do not add query part if only comment has changed
              */
             if ( ! ($columnHasChangedComment && count($columnDiff->changedProperties) === 1)) {
-                $fields[] = $column->getQuotedName($this). ' ' . $this->getColumnDeclarationSQL('', $column->toArray());
+                $columnInfo = $column->toArray();
+
+                if ( ! $columnDiff->hasChanged('notnull')) {
+                    $columnInfo['notnull'] = false;
+                }
+
+                $fields[] = $column->getQuotedName($this) . ' ' . $this->getColumnDeclarationSQL('', $columnInfo);
             }
 
             if ($columnHasChangedComment) {

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -443,7 +443,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             $oldColumnName = $columnDiff->getOldColumnName()->getQuotedName($this);
             $column = $columnDiff->column;
 
-            if ($columnDiff->hasChanged('type') || $columnDiff->hasChanged('precision') || $columnDiff->hasChanged('scale')) {
+            if ($columnDiff->hasChanged('type') || $columnDiff->hasChanged('precision') || $columnDiff->hasChanged('scale') || $columnDiff->hasChanged('fixed')) {
                 $type = $column->getType();
 
                 // here was a server version check before, but DBAL API does not support this anymore.

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -300,7 +300,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             list($schema, $table) = explode(".", $table);
             $schema = "'" . $schema . "'";
         } else {
-            $schema = "ANY(string_to_array((select replace(setting,'\"\$user\"',user) from pg_catalog.pg_settings where name = 'search_path'),','))";
+            $schema = "ANY(string_to_array((select replace(replace(setting,'\"\$user\"',user),' ','') from pg_catalog.pg_settings where name = 'search_path'),','))";
         }
         $whereClause .= "$classAlias.relname = '" . $table . "' AND $namespaceAlias.nspname = $schema";
 

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -430,7 +430,10 @@ class PostgreSqlPlatform extends AbstractPlatform
             }
 
             if ($columnDiff->hasChanged('default')) {
-                $query = 'ALTER ' . $oldColumnName . ' SET ' . $this->getDefaultValueDeclarationSQL($column->toArray());
+                $defaultClause = null === $column->getDefault()
+                    ? ' DROP DEFAULT'
+                    : ' SET' . $this->getDefaultValueDeclarationSQL($column->toArray());
+                $query = 'ALTER ' . $oldColumnName . $defaultClause;
                 $sql[] = 'ALTER TABLE ' . $diff->name . ' ' . $query;
             }
 

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -421,7 +421,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             $oldColumnName = $columnDiff->oldColumnName;
             $column = $columnDiff->column;
 
-            if ($columnDiff->hasChanged('type')) {
+            if ($columnDiff->hasChanged('type') || $columnDiff->hasChanged('precision') || $columnDiff->hasChanged('scale')) {
                 $type = $column->getType();
 
                 // here was a server version check before, but DBAL API does not support this anymore.

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -51,6 +51,28 @@ class PostgreSqlPlatform extends AbstractPlatform
     }
 
     /**
+     * @var array PostgreSQL booleans literals
+     */
+    private $booleanLiterals = array(
+        'true'  => array(
+            't',
+            'true',
+            'y',
+            'yes',
+            'on',
+            '1'
+        ),
+        'false' => array(
+            'f',
+            'false',
+            'n',
+            'no',
+            'off',
+            '0'
+        )
+    );
+
+    /**
      * {@inheritDoc}
      */
     public function getSubstringExpression($value, $from, $length = null)
@@ -574,6 +596,71 @@ class PostgreSqlPlatform extends AbstractPlatform
     }
 
     /**
+     * Converts a single boolean value.
+     *
+     * First converts the value to its native PHP boolean type
+     * and passes it to the given callback function to be reconverted
+     * into any custom representation.
+     *
+     * @param mixed    $value    The value to convert.
+     * @param callable $callback The callback function to use for converting the real boolean value.
+     *
+     * @return mixed
+     */
+    private function convertSingleBooleanValue($value, $callback)
+    {
+        if (null === $value) {
+            return $callback(false);
+        }
+
+        if (is_bool($value) || is_numeric($value)) {
+            return $callback($value ? true : false);
+        }
+
+        if (!is_string($value)) {
+            return $callback(true);
+        }
+
+        /**
+         * Better safe than sorry: http://php.net/in_array#106319
+         */
+        if (in_array(trim(strtolower($value)), $this->booleanLiterals['false'], true)) {
+            return $callback(false);
+        }
+
+        if (in_array(trim(strtolower($value)), $this->booleanLiterals['true'], true)) {
+            return $callback(true);
+        }
+
+        throw new \UnexpectedValueException("Unrecognized boolean literal '${value}'");
+    }
+
+    /**
+     * Converts one or multiple boolean values.
+     *
+     * First converts the value(s) to their native PHP boolean type
+     * and passes them to the given callback function to be reconverted
+     * into any custom representation.
+     *
+     * @param mixed    $item     The value(s) to convert.
+     * @param callable $callback The callback function to use for converting the real boolean value(s).
+     *
+     * @return mixed
+     */
+    private function doConvertBooleans($item, $callback)
+    {
+        if (is_array($item)) {
+            foreach ($item as $key => $value) {
+                $item[$key] = $this->convertSingleBooleanValue($value, $callback);
+            }
+
+            return $item;
+        }
+
+        return $this->convertSingleBooleanValue($item, $callback);
+    }
+
+    /**
      * {@inheritDoc}
      *
      * Postgres wants boolean values converted to the strings 'true'/'false'.
@@ -584,20 +671,43 @@ class PostgreSqlPlatform extends AbstractPlatform
             return parent::convertBooleans($item);
         }
 
-        if (is_array($item)) {
-            foreach ($item as $key => $value) {
-                if (is_bool($value) || is_numeric($item)) {
-                    $item[$key] = ($value) ? 'true' : 'false';
-                }
+        return $this->doConvertBooleans(
+            $item,
+            function ($boolean) {
+                return true === $boolean ? 'true' : 'false';
             }
-        } else {
-           if (is_bool($item) || is_numeric($item)) {
-               $item = ($item) ? 'true' : 'false';
-           }
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function convertBooleansToDatabaseValue($item)
+    {
+        if ( ! $this->useBooleanTrueFalseStrings) {
+            return parent::convertBooleansToDatabaseValue($item);
         }
 
-        return $item;
+        return $this->doConvertBooleans(
+            $item,
+            function ($boolean) {
+                return (int) $boolean;
+            }
+        );
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function convertFromBoolean($item)
+    {
+        if (in_array(strtolower($item), $this->booleanLiterals['false'], true)) {
+            return false;
+        }
+
+        return parent::convertFromBoolean($item);
+    }
+
 
     /**
      * {@inheritDoc}

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -484,7 +484,7 @@ class PostgreSqlPlatform extends AbstractPlatform
                 $sql[] = 'ALTER TABLE ' . $diff->name . ' RENAME TO ' . $diff->newName;
             }
 
-            $sql = array_merge($sql, $this->_getAlterTableIndexForeignKeySQL($diff), $commentsSQL);
+            $sql = array_merge($this->getPreAlterTableIndexForeignKeySQL($diff), $sql, $this->getPostAlterTableIndexForeignKeySQL($diff), $commentsSQL);
         }
 
         return array_merge($sql, $tableSql, $columnSql);

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -418,7 +418,7 @@ class PostgreSqlPlatform extends AbstractPlatform
                 continue;
             }
 
-            $oldColumnName = $columnDiff->oldColumnName;
+            $oldColumnName = $columnDiff->getOldColumnName()->getQuotedName($this);
             $column = $columnDiff->column;
 
             if ($columnDiff->hasChanged('type') || $columnDiff->hasChanged('precision') || $columnDiff->hasChanged('scale')) {

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -708,7 +708,6 @@ class PostgreSqlPlatform extends AbstractPlatform
         return parent::convertFromBoolean($item);
     }
 
-
     /**
      * {@inheritDoc}
      */

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -67,7 +67,14 @@ class SQLServer2012Platform extends SQLServer2008Platform
      */
     public function getListSequencesSQL($database)
     {
-        return 'SELECT seq.name, seq.increment, seq.start_value FROM sys.sequences AS seq';
+        return 'SELECT seq.name,
+                       CAST(
+                           seq.increment AS VARCHAR(MAX)
+                       ) AS increment, -- CAST avoids driver error for sql_variant type
+                       CAST(
+                           seq.start_value AS VARCHAR(MAX)
+                       ) AS start_value -- CAST avoids driver error for sql_variant type
+                FROM   sys.sequences AS seq';
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -675,7 +675,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getListDatabasesSQL()
     {
-        return 'SELECT * FROM SYS.DATABASES';
+        return 'SELECT * FROM sys.databases';
     }
 
     /**
@@ -848,7 +848,7 @@ class SQLServerPlatform extends AbstractPlatform
 
                 $pattern    = sprintf('/%s\.(%s)\s*(AS)?\s*([^,\s\)]*)/i', $column['table'], $column['column']);
                 $overColumn = preg_match($pattern, $query, $matches)
-                    ? ($column['hasTable'] ? $column['table']  . '.' : '') . $column['column'] 
+                    ? ($column['hasTable'] ? $column['table']  . '.' : '') . $column['column']
                     : $column['column'];
 
                 if (isset($column['sort'])) {

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -202,10 +202,8 @@ class SQLServerPlatform extends AbstractPlatform
                 $column['notnull'] = true;
             }
 
-            /**
-             * Build default constraints SQL statements
-             */
-            if ( ! empty($column['default']) || is_numeric($column['default'])) {
+            // Build default constraints SQL statements.
+            if (isset($column['default'])) {
                 $defaultConstraintsSql[] = 'ALTER TABLE ' . $tableName .
                     ' ADD' . $this->getDefaultConstraintDeclarationSQL($tableName, $column);
             }
@@ -276,7 +274,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getDefaultConstraintDeclarationSQL($table, array $column)
     {
-        if (empty($column['default']) && ! is_numeric($column['default'])) {
+        if ( ! isset($column['default'])) {
             throw new \InvalidArgumentException("Incomplete column definition. 'default' required.");
         }
 
@@ -369,7 +367,7 @@ class SQLServerPlatform extends AbstractPlatform
             $columnDef = $column->toArray();
             $queryParts[] = 'ADD ' . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnDef);
 
-            if ( ! empty($columnDef['default']) || is_numeric($columnDef['default'])) {
+            if (isset($columnDef['default'])) {
                 $columnDef['name'] = $column->getQuotedName($this);
                 $queryParts[] = 'ADD' . $this->getDefaultConstraintDeclarationSQL($diff->name, $columnDef);
             }
@@ -400,7 +398,7 @@ class SQLServerPlatform extends AbstractPlatform
              * if default value has changed and another
              * default constraint already exists for the column.
              */
-            if ($columnDefaultHasChanged && ( ! empty($fromColumnDefault) || is_numeric($fromColumnDefault))) {
+            if ($columnDefaultHasChanged && null !== $fromColumnDefault) {
                 $queryParts[] = 'DROP CONSTRAINT ' .
                     $this->generateDefaultConstraintName($diff->name, $columnDiff->oldColumnName);
             }
@@ -408,7 +406,7 @@ class SQLServerPlatform extends AbstractPlatform
             $queryParts[] = 'ALTER COLUMN ' .
                     $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnDef);
 
-            if ($columnDefaultHasChanged && (! empty($columnDef['default']) || is_numeric($columnDef['default']))) {
+            if ($columnDefaultHasChanged && isset($columnDef['default'])) {
                 $columnDef['name'] = $column->getQuotedName($this);
                 $queryParts[] = 'ADD' . $this->getDefaultConstraintDeclarationSQL($diff->name, $columnDef);
             }
@@ -427,7 +425,7 @@ class SQLServerPlatform extends AbstractPlatform
              * Drop existing default constraint for the old column name
              * if column has default value.
              */
-            if ( ! empty($columnDef['default']) || is_numeric($columnDef['default'])) {
+            if (isset($columnDef['default'])) {
                 $queryParts[] = 'DROP CONSTRAINT ' .
                     $this->generateDefaultConstraintName($diff->name, $oldColumnName);
             }
@@ -438,7 +436,7 @@ class SQLServerPlatform extends AbstractPlatform
             /**
              * Readd default constraint for the new column name.
              */
-            if ( ! empty($columnDef['default']) || is_numeric($columnDef['default'])) {
+            if (isset($columnDef['default'])) {
                 $columnDef['name'] = $column->getQuotedName($this);
                 $queryParts[] = 'ADD' . $this->getDefaultConstraintDeclarationSQL($diff->name, $columnDef);
             }

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1012,21 +1012,19 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function appendLockHint($fromClause, $lockMode)
     {
-        switch ($lockMode) {
-            case LockMode::NONE:
-                $lockClause = ' WITH (NOLOCK)';
-                break;
-            case LockMode::PESSIMISTIC_READ:
-                $lockClause = ' WITH (HOLDLOCK, ROWLOCK)';
-                break;
-            case LockMode::PESSIMISTIC_WRITE:
-                $lockClause = ' WITH (UPDLOCK, ROWLOCK)';
-                break;
-            default:
-                $lockClause = '';
-        }
+        switch (true) {
+            case LockMode::NONE === $lockMode:
+                return $fromClause . ' WITH (NOLOCK)';
 
-        return $fromClause . $lockClause;
+            case LockMode::PESSIMISTIC_READ === $lockMode:
+                return $fromClause . ' WITH (HOLDLOCK, ROWLOCK)';
+
+            case LockMode::PESSIMISTIC_WRITE === $lockMode:
+                return $fromClause . ' WITH (UPDLOCK, ROWLOCK)';
+
+            default:
+                return $fromClause;
+        }
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -543,7 +543,6 @@ class SqlitePlatform extends AbstractPlatform
             'decimal'          => 'decimal',
             'numeric'          => 'decimal',
             'blob'             => 'blob',
-            'integer unsigned' => 'integer',
         );
     }
 

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -369,7 +369,7 @@ class SqlitePlatform extends AbstractPlatform
     {
         $table = str_replace('.', '__', $table);
 
-        return "PRAGMA table_info($table)";
+        return "PRAGMA table_info('$table')";
     }
 
     /**
@@ -379,7 +379,7 @@ class SqlitePlatform extends AbstractPlatform
     {
         $table = str_replace('.', '__', $table);
 
-        return "PRAGMA index_list($table)";
+        return "PRAGMA index_list('$table')";
     }
 
     /**
@@ -452,7 +452,7 @@ class SqlitePlatform extends AbstractPlatform
     {
         $tableName = str_replace('.', '__', $tableName);
 
-        return 'DELETE FROM '.$tableName;
+        return 'DELETE FROM ' . $tableName;
     }
 
     /**
@@ -685,7 +685,7 @@ class SqlitePlatform extends AbstractPlatform
     {
         $table = str_replace('.', '__', $table);
 
-        return "PRAGMA foreign_key_list($table)";
+        return "PRAGMA foreign_key_list('$table')";
     }
 
     /**

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -19,8 +19,6 @@
 
 namespace Doctrine\DBAL;
 
-use Doctrine\DBAL\Connection;
-
 /**
  * Utility class that parses sql statements with regard to types and parameters.
  *
@@ -34,9 +32,9 @@ class SQLParserUtils
     const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
 
     // Quote characters within string literals can be preceded by a backslash.
-    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:[^'\\\\]|\\\\'|\\\\\\\\)*'";
-    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:[^"\\\\]|\\\\"|\\\\\\\\)*"';
-    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:[^`\\\\]|\\\\`|\\\\\\\\)*`';
+    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:[^'\\\\]|\\\\'?)*'";
+    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:[^"\\\\]|\\\\"?)*"';
+    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:[^`\\\\]|\\\\`?)*`';
 
     /**
      * Gets an array of the placeholders in an sql statements as keys and their positions in the query string.

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -36,6 +36,7 @@ class SQLParserUtils
     // Quote characters within string literals can be preceded by a backslash.
     const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:[^'\\\\]|\\\\'|\\\\\\\\)*'";
     const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:[^"\\\\]|\\\\"|\\\\\\\\)*"';
+    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:[^`\\\\]|\\\\`|\\\\\\\\)*`';
 
     /**
      * Gets an array of the placeholders in an sql statements as keys and their positions in the query string.
@@ -194,8 +195,10 @@ class SQLParserUtils
      */
     static private function getUnquotedStatementFragments($statement)
     {
-        $literal = self::ESCAPED_SINGLE_QUOTED_TEXT . '|' . self::ESCAPED_DOUBLE_QUOTED_TEXT;
-        preg_match_all("/([^'\"]+)(?:$literal)?/s", $statement, $fragments, PREG_OFFSET_CAPTURE);
+        $literal = self::ESCAPED_SINGLE_QUOTED_TEXT . '|' .
+                   self::ESCAPED_DOUBLE_QUOTED_TEXT . '|' .
+                   self::ESCAPED_BACKTICK_QUOTED_TEXT;
+        preg_match_all("/([^'\"`]+)(?:$literal)?/s", $statement, $fragments, PREG_OFFSET_CAPTURE);
 
         return $fragments[1];
     }

--- a/lib/Doctrine/DBAL/Schema/ColumnDiff.php
+++ b/lib/Doctrine/DBAL/Schema/ColumnDiff.php
@@ -71,4 +71,12 @@ class ColumnDiff
     {
         return in_array($propertyName, $this->changedProperties);
     }
+
+    /**
+     * @return \Doctrine\DBAL\Schema\Identifier
+     */
+    public function getOldColumnName()
+    {
+        return new Identifier($this->oldColumnName);
+    }
 }

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -322,11 +322,11 @@ class Comparator
      */
     public function diffForeignKey(ForeignKeyConstraint $key1, ForeignKeyConstraint $key2)
     {
-        if (array_map('strtolower', $key1->getLocalColumns()) != array_map('strtolower', $key2->getLocalColumns())) {
+        if (array_map('strtolower', $key1->getUnquotedLocalColumns()) != array_map('strtolower', $key2->getUnquotedLocalColumns())) {
             return true;
         }
 
-        if (array_map('strtolower', $key1->getForeignColumns()) != array_map('strtolower', $key2->getForeignColumns())) {
+        if (array_map('strtolower', $key1->getUnquotedForeignColumns()) != array_map('strtolower', $key2->getUnquotedForeignColumns())) {
             return true;
         }
 

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -367,7 +367,15 @@ class Comparator
             $changedProperties[] = 'notnull';
         }
 
-        if ($column1->getDefault() != $column2->getDefault()) {
+        $column1Default = $column1->getDefault();
+        $column2Default = $column2->getDefault();
+
+        if ($column1Default != $column2Default ||
+            // Null values need to be checked additionally as they tell whether to create or drop a default value.
+            // null != 0, null != false, null != '' etc. This affects platform's table alteration SQL generation.
+            (null === $column1Default && null !== $column2Default) ||
+            (null === $column2Default && null !== $column1Default)
+        ) {
             $changedProperties[] = 'default';
         }
 

--- a/lib/Doctrine/DBAL/Schema/DrizzleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DrizzleSchemaManager.php
@@ -41,7 +41,7 @@ class DrizzleSchemaManager extends AbstractSchemaManager
         $options = array(
             'notnull' => !(bool)$tableColumn['IS_NULLABLE'],
             'length' => (int)$tableColumn['CHARACTER_MAXIMUM_LENGTH'],
-            'default' => empty($tableColumn['COLUMN_DEFAULT']) ? null : $tableColumn['COLUMN_DEFAULT'],
+            'default' => isset($tableColumn['COLUMN_DEFAULT']) ? $tableColumn['COLUMN_DEFAULT'] : null,
             'autoincrement' => (bool)$tableColumn['IS_AUTO_INCREMENT'],
             'scale' => (int)$tableColumn['NUMERIC_SCALE'],
             'precision' => (int)$tableColumn['NUMERIC_PRECISION'],

--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -164,6 +164,26 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
     }
 
     /**
+     * Returns unquoted representation of local table column names for comparison with other FK
+     *
+     * @return array
+     */
+    public function getUnquotedLocalColumns()
+    {
+        return array_map(array($this, 'trimQuotes'), $this->getLocalColumns());
+    }
+
+    /**
+     * Returns unquoted representation of foreign table column names for comparison with other FK
+     *
+     * @return array
+     */
+    public function getUnquotedForeignColumns()
+    {
+        return array_map(array($this, 'trimQuotes'), $this->getForeignColumns());
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @see getLocalColumns

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -113,8 +113,14 @@ class OracleSchemaManager extends AbstractSchemaManager
             $tableColumn['column_name'] = '';
         }
 
-        if (stripos($tableColumn['data_default'], 'NULL') !== null) {
+        if ($tableColumn['data_default'] === 'NULL') {
             $tableColumn['data_default'] = null;
+        }
+
+        if (null !== $tableColumn['data_default']) {
+            // Default values returned from database are enclosed in single quotes.
+            // Sometimes trailing spaces are also encountered.
+            $tableColumn['data_default'] = trim(trim($tableColumn['data_default']), "'");
         }
 
         $precision = null;

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -343,6 +343,14 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
                 break;
             case 'bool':
             case 'boolean':
+                if ($tableColumn['default'] === 'true') {
+                    $tableColumn['default'] = true;
+                }
+
+                if ($tableColumn['default'] === 'false') {
+                    $tableColumn['default'] = false;
+                }
+
                 $length = null;
                 break;
             case 'text':

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -130,48 +130,6 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritdoc}
      */
-    public function dropDatabase($database)
-    {
-        $params = $this->_conn->getParams();
-        $params["dbname"] = "postgres";
-        $tmpPlatform = $this->_platform;
-        $tmpConn = $this->_conn;
-
-        $this->_conn = \Doctrine\DBAL\DriverManager::getConnection($params);
-        $this->_platform = $this->_conn->getDatabasePlatform();
-
-        parent::dropDatabase($database);
-
-        $this->_conn->close();
-
-        $this->_platform = $tmpPlatform;
-        $this->_conn = $tmpConn;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createDatabase($database)
-    {
-        $params = $this->_conn->getParams();
-        $params["dbname"] = "postgres";
-        $tmpPlatform = $this->_platform;
-        $tmpConn = $this->_conn;
-
-        $this->_conn = \Doctrine\DBAL\DriverManager::getConnection($params);
-        $this->_platform = $this->_conn->getDatabasePlatform();
-
-        parent::createDatabase($database);
-
-        $this->_conn->close();
-
-        $this->_platform = $tmpPlatform;
-        $this->_conn = $tmpConn;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function _getPortableTriggerDefinition($trigger)
     {
         return $trigger['trigger_name'];

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -236,7 +236,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
     {
         $tableColumn = array_change_key_case($tableColumn, CASE_LOWER);
 
-        if (strtolower($tableColumn['type']) === 'varchar') {
+        if (strtolower($tableColumn['type']) === 'varchar' || strtolower($tableColumn['type']) === 'bpchar') {
             // get length from varchar definition
             $length = preg_replace('~.*\(([0-9]*)\).*~', '$1', $tableColumn['complete_type']);
             $tableColumn['length'] = $length;

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -244,16 +244,22 @@ class SqliteSchemaManager extends AbstractSchemaManager
      */
     protected function _getPortableTableColumnDefinition($tableColumn)
     {
-        $e = explode('(', $tableColumn['type']);
-        $tableColumn['type'] = $e[0];
-        if (isset($e[1])) {
-            $length = trim($e[1], ')');
+        $parts = explode('(', $tableColumn['type']);
+        $tableColumn['type'] = $parts[0];
+        if (isset($parts[1])) {
+            $length = trim($parts[1], ')');
             $tableColumn['length'] = $length;
         }
 
         $dbType = strtolower($tableColumn['type']);
         $length = isset($tableColumn['length']) ? $tableColumn['length'] : null;
-        $unsigned = (boolean) isset($tableColumn['unsigned']) ? $tableColumn['unsigned'] : false;
+        $unsigned = false;
+
+        if (strpos($dbType, ' unsigned') !== false) {
+            $dbType = str_replace(' unsigned', '', $dbType);
+            $unsigned = true;
+        }
+
         $fixed = false;
         $type = $this->_platform->getDoctrineTypeMapping($dbType);
         $default = $tableColumn['dflt_value'];

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -167,7 +167,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $stmt = $this->_conn->executeQuery( "PRAGMA TABLE_INFO ('$tableName')" );
         $indexArray = $stmt->fetchAll(\PDO::FETCH_ASSOC);
         foreach($indexArray as $indexColumnRow) {
-            if($indexColumnRow['pk'] == "1") {
+            if($indexColumnRow['pk'] !== "0") {
                 $indexBuffer[] = array(
                     'key_name' => 'primary',
                     'primary' => true,

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -220,7 +220,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $autoincrementColumn = null;
         $autoincrementCount = 0;
         foreach ($tableColumns as $tableColumn) {
-            if ('1' == $tableColumn['pk']) {
+            if ('0' != $tableColumn['pk']) {
                 $autoincrementCount++;
                 if (null === $autoincrementColumn && 'integer' == strtolower($tableColumn['type'])) {
                     $autoincrementColumn = $tableColumn['name'];

--- a/lib/Doctrine/DBAL/Sharding/PoolingShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardManager.php
@@ -115,7 +115,7 @@ class PoolingShardManager implements ShardManager
         $oldDistribution = $this->getCurrentDistributionValue();
 
         foreach ($shards as $shard) {
-            $this->selectShard($shard['id']);
+            $this->conn->connect($shard['id']);
             foreach ($this->conn->fetchAll($sql, $params, $types) as $row) {
                 $result[] = $row;
             }

--- a/lib/Doctrine/DBAL/Types/BooleanType.php
+++ b/lib/Doctrine/DBAL/Types/BooleanType.php
@@ -41,7 +41,7 @@ class BooleanType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        return $platform->convertBooleans($value);
+        return $platform->convertBooleansToDatabaseValue($value);
     }
 
     /**
@@ -49,7 +49,7 @@ class BooleanType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        return (null === $value) ? null : (bool) $value;
+        return $platform->convertFromBoolean($value);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/JsonArrayType.php
+++ b/lib/Doctrine/DBAL/Types/JsonArrayType.php
@@ -54,7 +54,7 @@ class JsonArrayType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return array();
         }
 

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.4.1';
+    const VERSION = '2.4.2-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.4.0-DEV';
+    const VERSION = '2.4.0';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.4.3-DEV';
+    const VERSION = '2.4.3';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.4.2-DEV';
+    const VERSION = '2.4.2';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.4.1-DEV';
+    const VERSION = '2.4.1';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.4.2';
+    const VERSION = '2.4.3-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.4.3';
+    const VERSION = '2.4.4-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.4.0';
+    const VERSION = '2.4.1-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Events;
-use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Mocks\DriverConnectionMock;
 
 class ConnectionTest extends \Doctrine\Tests\DbalTestCase

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Events;
+use Doctrine\Tests\Mocks\ConnectionMock;
+use Doctrine\Tests\Mocks\DriverConnectionMock;
 
 class ConnectionTest extends \Doctrine\Tests\DbalTestCase
 {
@@ -173,5 +175,25 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
         $logger = new \Doctrine\DBAL\Logging\DebugStack();
         $this->_conn->getConfiguration()->setSQLLogger($logger);
         $this->assertSame($logger, $this->_conn->getConfiguration()->getSQLLogger());
+    }
+
+    public function testEmptyInsert()
+    {
+        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setMethods(array('executeUpdate'))
+            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
+            ->getMock();
+
+        $conn->expects($this->once())
+            ->method('executeUpdate')
+            ->with('INSERT INTO footable () VALUES ()');
+
+        $conn->insert('footable', array());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -102,4 +102,23 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
         $conn->connect('slave');
         $this->assertFalse($conn->isConnectedToMaster());
     }
+
+    /**
+     * @group DBAL-335
+     */
+    public function testKeepSlaveInsertStaysOnMaster()
+    {
+        $conn = $this->createMasterSlaveConnection($keepSlave = true);
+        $conn->connect('slave');
+
+        $conn->insert('master_slave_table', array('test_int' => 30));
+
+        $this->assertTrue($conn->isConnectedToMaster());
+
+        $conn->connect();
+        $this->assertTrue($conn->isConnectedToMaster());
+
+        $conn->connect('slave');
+        $this->assertFalse($conn->isConnectedToMaster());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
@@ -102,6 +102,20 @@ class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertLimitResult(array(2), $sql, 1, 1);
     }
 
+    public function testModifyLimitQuerySubSelect()
+    {
+        $this->_conn->insert('modify_limit_table', array('test_int' => 1));
+        $this->_conn->insert('modify_limit_table', array('test_int' => 2));
+        $this->_conn->insert('modify_limit_table', array('test_int' => 3));
+        $this->_conn->insert('modify_limit_table', array('test_int' => 4));
+
+        $sql = "SELECT *, (SELECT COUNT(*) FROM modify_limit_table) AS cnt FROM modify_limit_table";
+
+        $this->assertLimitResult(array(4, 3, 2, 1), $sql, 10, 0, false);
+        $this->assertLimitResult(array(4, 3), $sql, 2, 0, false);
+        $this->assertLimitResult(array(2, 1), $sql, 2, 2, false);
+    }
+
     public function assertLimitResult($expectedResults, $sql, $limit, $offset, $deterministic = true)
     {
         $p = $this->_conn->getDatabasePlatform();

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -84,5 +84,10 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $comparator = new Comparator();
 
         $this->_sm->alterTable($comparator->diffTable($table, $diffTable));
+
+        $table = $this->_sm->listTableDetails("drop_primary_key");
+
+        $this->assertFalse($table->hasPrimaryKey());
+        $this->assertFalse($table->getColumn('id')->getAutoincrement());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -66,7 +66,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     }
 
     /**
-     * @group 464
+     * @group DBAL-464
      */
     public function testDropPrimaryKeyWithAutoincrementColumn()
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
+use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Schema\Comparator;
 
 class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
@@ -20,7 +20,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableNew = clone $tableFetched;
         $tableNew->setPrimaryKey(array('bar_id', 'foo_id'));
 
-        $comparator = new \Doctrine\DBAL\Schema\Comparator;
+        $comparator = new Comparator;
         $this->_sm->alterTable($comparator->diffTable($tableFetched, $tableNew));
     }
 
@@ -41,7 +41,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->_sm->createTable($table);
         $tableFetched = $this->_sm->listTableDetails("diffbug_routing_translations");
 
-        $comparator = new \Doctrine\DBAL\Schema\Comparator;
+        $comparator = new Comparator;
         $diff = $comparator->diffTable($tableFetched, $table);
 
         $this->assertFalse($diff, "no changes expected.");
@@ -88,5 +88,31 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertFalse($table->hasPrimaryKey());
         $this->assertFalse($table->getColumn('id')->getAutoincrement());
+    }
+
+    /**
+     * @group DBAL-400
+     */
+    public function testAlterTableAddPrimaryKey()
+    {
+        $table = new Table('alter_table_add_pk');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('foo', 'integer');
+        $table->addIndex(array('id'), 'idx_id');
+
+        $this->_sm->createTable($table);
+
+        $comparator = new Comparator();
+        $diffTable  = clone $table;
+
+        $diffTable->dropIndex('idx_id');
+        $diffTable->setPrimaryKey(array('id'));
+
+        $this->_sm->alterTable($comparator->diffTable($table, $diffTable));
+
+        $table = $this->_sm->listTableDetails("alter_table_add_pk");
+
+        $this->assertFalse($table->hasIndex('idx_id'));
+        $this->assertTrue($table->hasPrimaryKey());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -4,8 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Schema;
 
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Schema;
-
-require_once __DIR__ . '/../../../TestInit.php';
+use Doctrine\DBAL\Schema\Comparator;
 
 class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -64,4 +64,25 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertArrayHasKey('f_index', $indexes);
         $this->assertTrue($indexes['f_index']->hasFlag('fulltext'));
     }
+
+    /**
+     * @group 464
+     */
+    public function testDropPrimaryKeyWithAutoincrementColumn()
+    {
+        $table = new Table("drop_primary_key");
+        $table->addColumn('id', 'integer', array('primary' => true, 'autoincrement' => true));
+        $table->addColumn('foo', 'integer', array('primary' => true));
+        $table->setPrimaryKey(array('id', 'foo'));
+
+        $this->_sm->dropAndCreateTable($table);
+
+        $diffTable = clone $table;
+
+        $diffTable->dropPrimaryKey();
+
+        $comparator = new Comparator();
+
+        $this->_sm->alterTable($comparator->diffTable($table, $diffTable));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -261,6 +261,25 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertEquals('foo', $databaseTable->getColumn('def')->getDefault());
     }
+
+    /**
+     * @group DDC-2843
+     */
+    public function testBooleanDefault()
+    {
+        $table = new \Doctrine\DBAL\Schema\Table('ddc2843_bools');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('checked', 'boolean', array('default' => false));
+
+        $this->_sm->createTable($table);
+
+        $databaseTable = $this->_sm->listTableDetails($table->getName());
+
+        $c = new \Doctrine\DBAL\Schema\Comparator();
+        $diff = $c->diffTable($table, $databaseTable);
+
+        $this->assertFalse($diff);
+    }
 }
 
 class MoneyType extends Type

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -479,6 +479,16 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $inferredTable = $this->_sm->listTableDetails('test_autoincrement');
         $this->assertTrue($inferredTable->hasColumn('id'));
         $this->assertTrue($inferredTable->getColumn('id')->getAutoincrement());
+    }
+
+    /**
+     * @group DBAL-792
+     */
+    public function testAutoincrementDetectionMulticolumns()
+    {
+        if (!$this->_sm->getDatabasePlatform()->supportsIdentityColumns()) {
+            $this->markTestSkipped('This test is only supported on platforms that have autoincrement');
+        }
 
         $table = new \Doctrine\DBAL\Schema\Table('test_not_autoincrement');
         $table->setSchemaConfig($this->_sm->createSchemaConfig());

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -195,6 +195,26 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->assertInternalType('array',  $columns['baz3']->getPlatformOptions());
     }
 
+    /**
+     * @group DBAL-1078
+     */
+    public function testListTableColumnsWithFixedStringColumn()
+    {
+        $tableName = 'test_list_table_fixed_string';
+
+        $table = new Table($tableName);
+        $table->addColumn('column_char', 'string', array('fixed' => true, 'length' => 2));
+
+        $this->_sm->createTable($table);
+
+        $columns = $this->_sm->listTableColumns($tableName);
+
+        $this->assertArrayHasKey('column_char', $columns);
+        $this->assertInstanceOf('Doctrine\DBAL\Types\StringType', $columns['column_char']->getType());
+        $this->assertTrue($columns['column_char']->getFixed());
+        $this->assertSame(2, $columns['column_char']->getLength());
+    }
+
     public function testListTableColumnsDispatchEvent()
     {
         $table = $this->createListTableColumns();

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -479,6 +479,18 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $inferredTable = $this->_sm->listTableDetails('test_autoincrement');
         $this->assertTrue($inferredTable->hasColumn('id'));
         $this->assertTrue($inferredTable->getColumn('id')->getAutoincrement());
+
+        $table = new \Doctrine\DBAL\Schema\Table('test_not_autoincrement');
+        $table->setSchemaConfig($this->_sm->createSchemaConfig());
+        $table->addColumn('id', 'integer');
+        $table->addColumn('other_id', 'integer');
+        $table->setPrimaryKey(array('id', 'other_id'));
+
+        $this->_sm->createTable($table);
+
+        $inferredTable = $this->_sm->listTableDetails('test_not_autoincrement');
+        $this->assertTrue($inferredTable->hasColumn('id'));
+        $this->assertFalse($inferredTable->getColumn('id')->getAutoincrement());
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Ticket;
+
+use Doctrine\DBAL\DBALException;
+use PDO;
+
+/**
+ * @group DBAL-630
+ */
+class DBAL630Test extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+    private $running = false;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $platform = $this->_conn->getDatabasePlatform()->getName();
+
+        if (!in_array($platform, array('postgresql'))) {
+            $this->markTestSkipped('Currently restricted to PostgreSQL');
+        }
+
+        try {
+            $this->_conn->exec('CREATE TABLE dbal630 (id SERIAL, bool_col BOOLEAN NOT NULL);');
+        } catch (DBALException $e) {
+        }
+        $this->running = true;
+    }
+
+    protected function tearDown()
+    {
+        if ($this->running) {
+            $this->_conn->getWrappedConnection()->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+
+            // PDO::PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT is deprecated in php 5.6. PDO::ATTR_EMULATE_PREPARES should
+            // be used instead. so should only it be set when it is supported.
+            if (PHP_VERSION_ID < 50600) {
+                $this->_conn->getWrappedConnection()->setAttribute(
+                    PDO::PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT,
+                    false
+                );
+            }
+        }
+    }
+
+    public function testBooleanConversionSqlLiteral()
+    {
+        $this->_conn->executeUpdate('INSERT INTO dbal630 (bool_col) VALUES(false)');
+        $id = $this->_conn->lastInsertId('dbal630_id_seq');
+        $this->assertNotEmpty($id);
+
+        $row = $this->_conn->fetchAssoc('SELECT bool_col FROM dbal630 WHERE id = ?', array($id));
+
+        $this->assertFalse($row['bool_col']);
+    }
+
+    public function testBooleanConversionBoolParamRealPrepares()
+    {
+        $this->_conn->executeUpdate('INSERT INTO dbal630 (bool_col) VALUES(?)', array('false'), array(PDO::PARAM_BOOL));
+        $id = $this->_conn->lastInsertId('dbal630_id_seq');
+        $this->assertNotEmpty($id);
+
+        $row = $this->_conn->fetchAssoc('SELECT bool_col FROM dbal630 WHERE id = ?', array($id));
+
+        $this->assertFalse($row['bool_col']);
+    }
+
+    public function testBooleanConversionBoolParamEmulatedPrepares()
+    {
+        $this->_conn->getWrappedConnection()->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+
+        // PDO::PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT is deprecated in php 5.6. PDO::ATTR_EMULATE_PREPARES should
+        // be used instead. so should only it be set when it is supported.
+        if (PHP_VERSION_ID < 50600) {
+            $this->_conn->getWrappedConnection()->setAttribute(PDO::PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT, true);
+        }
+
+        $platform = $this->_conn->getDatabasePlatform();
+
+        $stmt = $this->_conn->prepare('INSERT INTO dbal630 (bool_col) VALUES(?)');
+        $stmt->bindValue(1, $platform->convertBooleansToDatabaseValue('false'), PDO::PARAM_BOOL);
+        $stmt->execute();
+
+        $id = $this->_conn->lastInsertId('dbal630_id_seq');
+
+        $this->assertNotEmpty($id);
+
+        $row = $this->_conn->fetchAssoc('SELECT bool_col FROM dbal630 WHERE id = ?', array($id));
+
+        $this->assertFalse($row['bool_col']);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL752Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL752Test.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Ticket;
+
+use Doctrine\DBAL\Schema\Table;
+
+/**
+ * @group DBAL-752
+ */
+class DBAL752Test extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $platform = $this->_conn->getDatabasePlatform()->getName();
+
+        if (!in_array($platform, array('sqlite'))) {
+            $this->markTestSkipped('Related to SQLite only');
+        }
+    }
+
+    public function testUnsignedIntegerDetection()
+    {
+        $this->_conn->exec(<<<SQL
+CREATE TABLE dbal752_unsigneds (
+    id  BIGINT UNSIGNED,
+    flag SMALLINT UNSIGNED,
+    masks  INTEGER UNSIGNED
+);
+SQL
+        );
+
+        $schemaManager = $this->_conn->getSchemaManager();
+
+        $fetchedTable = $schemaManager->listTableDetails('dbal752_unsigneds');
+
+        $this->assertEquals('bigint', $fetchedTable->getColumn('id')->getType()->getName());
+        $this->assertEquals('smallint', $fetchedTable->getColumn('flag')->getType()->getName());
+        $this->assertEquals('integer', $fetchedTable->getColumn('masks')->getType()->getName());
+        $this->assertTrue($fetchedTable->getColumn('id')->getUnsigned());
+        $this->assertTrue($fetchedTable->getColumn('flag')->getUnsigned());
+        $this->assertTrue($fetchedTable->getColumn('masks')->getUnsigned());
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -161,7 +161,7 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $sequences = $this->_conn->getSchemaManager()->listSequences();
         $this->assertEquals(1, count(array_filter($sequences, function($sequence) {
-            return $sequence->getName() === 'write_table_id_seq';
+            return strtolower($sequence->getName()) === 'write_table_id_seq';
         })));
 
         $stmt = $this->_conn->query($this->_conn->getDatabasePlatform()->getSequenceNextValSQL('write_table_id_seq'));

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -494,4 +494,24 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
         $sql = $this->_platform->getCreateTableSQL($table, AbstractPlatform::CREATE_FOREIGNKEYS);
         $this->assertEquals($this->getQuotedColumnInForeignKeySQL(), $sql);
     }
+
+    /**
+     * @group DBAL-585
+     */
+    public function testAlterTableChangeQuotedColumn()
+    {
+        $tableDiff = new \Doctrine\DBAL\Schema\TableDiff('mytable');
+        $tableDiff->fromTable = new \Doctrine\DBAL\Schema\Table('mytable');
+        $tableDiff->changedColumns['foo'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'select', new \Doctrine\DBAL\Schema\Column(
+                'select', \Doctrine\DBAL\Types\Type::getType('string')
+            ),
+            array('type')
+        );
+
+        $this->assertContains(
+            $this->_platform->quoteIdentifier('select'),
+            implode(';', $this->_platform->getAlterTableSQL($tableDiff))
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -514,4 +514,35 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
             implode(';', $this->_platform->getAlterTableSQL($tableDiff))
         );
     }
+
+    /**
+     * @group DBAL-1090
+     */
+    public function testAlterStringToFixedString()
+    {
+
+        $table = new Table('mytable');
+        $table->addColumn('name', 'string', array('length' => 2));
+
+        $tableDiff = new TableDiff('mytable');
+        $tableDiff->fromTable = $table;
+
+        $tableDiff->changedColumns['name'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'name', new \Doctrine\DBAL\Schema\Column(
+                'name', \Doctrine\DBAL\Types\Type::getType('string'), array('fixed' => true, 'length' => 2)
+            ),
+            array('fixed')
+        );
+
+        $sql = $this->_platform->getAlterTableSQL($tableDiff);
+
+        $expectedSql = $this->getAlterStringToFixedStringSQL();
+
+        $this->assertEquals($expectedSql, $sql);
+    }
+
+    /**
+     * @return array
+     */
+    abstract protected function getAlterStringToFixedStringSQL();
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -442,6 +442,7 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 
     abstract protected function getQuotedColumnInPrimaryKeySQL();
     abstract protected function getQuotedColumnInIndexSQL();
+    abstract protected function getQuotedNameInIndexSQL();
     abstract protected function getQuotedColumnInForeignKeySQL();
 
     /**
@@ -455,6 +456,16 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 
         $sql = $this->_platform->getCreateTableSQL($table);
         $this->assertEquals($this->getQuotedColumnInIndexSQL(), $sql);
+    }
+
+    public function testQuotedNameInIndexSQL()
+    {
+        $table = new Table('test');
+        $table->addColumn('column1', 'string');
+        $table->addIndex(array('column1'), 'create');
+
+        $sql = $this->_platform->getCreateTableSQL($table);
+        $this->assertEquals($this->getQuotedNameInIndexSQL(), $sql);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -295,4 +295,29 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
         $this->assertEquals('LONGBLOB', $this->_platform->getBlobTypeDeclarationSQL(array('length' => 16777216)));
         $this->assertEquals('LONGBLOB', $this->_platform->getBlobTypeDeclarationSQL(array()));
     }
+
+    /**
+     * @group 464
+     */
+    public function testDropPrimaryKeyWithAutoincrementColumn()
+    {
+        $table = new Table("drop_primary_key");
+        $table->addColumn('id', 'integer', array('primary' => true, 'autoincrement' => true));
+        $table->addColumn('foo', 'integer', array('primary' => true));
+        $table->addColumn('bar', 'integer');
+        $table->setPrimaryKey(array('id', 'foo'));
+
+        $comparator = new Comparator();
+        $diffTable = clone $table;
+
+        $diffTable->dropPrimaryKey();
+
+        $this->assertEquals(
+            array(
+                'ALTER TABLE drop_primary_key MODIFY id INT NOT NULL',
+                'ALTER TABLE drop_primary_key DROP PRIMARY KEY'
+            ),
+            $this->_platform->getAlterTableSQL($comparator->diffTable($table, $diffTable))
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -320,4 +320,27 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
             $this->_platform->getAlterTableSQL($comparator->diffTable($table, $diffTable))
         );
     }
+
+    /**
+     * @group DBAL-586
+     */
+    public function testAddAutoIncrementPrimaryKey()
+    {
+        $keyTable = new Table("foo");
+        $keyTable->addColumn("id", "integer", array('autoincrement' => true));
+        $keyTable->addColumn("baz", "string");
+        $keyTable->setPrimaryKey(array("id"));
+
+        $oldTable = new Table("foo");
+        $oldTable->addColumn("baz", "string");
+
+        $c = new \Doctrine\DBAL\Schema\Comparator;
+        $diff = $c->diffTable($oldTable, $keyTable);
+
+        $sql = $this->_platform->getAlterTableSQL($diff);
+
+        $this->assertEquals(array(
+            "ALTER TABLE foo ADD id INT AUTO_INCREMENT NOT NULL, ADD PRIMARY KEY (id)",
+        ), $sql);
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Index;
-
+use Doctrine\DBAL\Schema\Comparator;
 
 class MySqlPlatformTest extends AbstractPlatformTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -378,4 +378,14 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
             "ALTER TABLE mytable ADD PRIMARY KEY (foo)",
         ), $sql);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAlterStringToFixedStringSQL()
+    {
+        return array(
+            'ALTER TABLE mytable CHANGE name name CHAR(2) NOT NULL',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -3,12 +3,12 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Comparator;
 
 class MySqlPlatformTest extends AbstractPlatformTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -343,4 +343,17 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
             "ALTER TABLE foo ADD id INT AUTO_INCREMENT NOT NULL, ADD PRIMARY KEY (id)",
         ), $sql);
     }
+
+    public function testNamedPrimaryKey()
+    {
+        $diff = new TableDiff('mytable');
+        $diff->changedIndexes['foo_index'] = new Index('foo_index', array('foo'), true, true);
+
+        $sql = $this->_platform->getAlterTableSQL($diff);
+
+        $this->assertEquals(array(
+	    "DROP INDEX foo_index ON mytable",
+            "ALTER TABLE mytable ADD PRIMARY KEY (foo)",
+        ), $sql);
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -248,6 +248,13 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    protected function getQuotedNameInIndexSQL()
+    {
+        return array(
+            'CREATE TABLE test (column1 VARCHAR(255) NOT NULL, INDEX `create` (column1)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB'
+        );
+    }
+
     protected function getQuotedColumnInForeignKeySQL()
     {
         return array(

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -297,7 +297,7 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
     }
 
     /**
-     * @group 464
+     * @group DBAL-464
      */
     public function testDropPrimaryKeyWithAutoincrementColumn()
     {

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -297,6 +297,28 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
     }
 
     /**
+     * @group DBAL-400
+     */
+    public function testAlterTableAddPrimaryKey()
+    {
+        $table = new Table('alter_table_add_pk');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('foo', 'integer');
+        $table->addIndex(array('id'), 'idx_id');
+
+        $comparator = new Comparator();
+        $diffTable  = clone $table;
+
+        $diffTable->dropIndex('idx_id');
+        $diffTable->setPrimaryKey(array('id'));
+
+        $this->assertEquals(
+            array('DROP INDEX idx_id ON alter_table_add_pk', 'ALTER TABLE alter_table_add_pk ADD PRIMARY KEY (id)'),
+            $this->_platform->getAlterTableSQL($comparator->diffTable($table, $diffTable))
+        );
+    }
+
+    /**
      * @group DBAL-464
      */
     public function testDropPrimaryKeyWithAutoincrementColumn()
@@ -352,7 +374,7 @@ class MySqlPlatformTest extends AbstractPlatformTestCase
         $sql = $this->_platform->getAlterTableSQL($diff);
 
         $this->assertEquals(array(
-	    "DROP INDEX foo_index ON mytable",
+	        "ALTER TABLE mytable DROP PRIMARY KEY",
             "ALTER TABLE mytable ADD PRIMARY KEY (foo)",
         ), $sql);
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -308,4 +308,26 @@ class OraclePlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") REFERENCES "foo-bar" ("create", bar, "foo-bar")',
         );
     }
+
+    public function testAlterTableNotNULL()
+    {
+        $tableDiff = new \Doctrine\DBAL\Schema\TableDiff('mytable');
+        $tableDiff->changedColumns['foo'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'foo', new \Doctrine\DBAL\Schema\Column(
+                'foo', \Doctrine\DBAL\Types\Type::getType('string'), array('default' => 'bla', 'notnull' => true)
+            ),
+            array('type')
+        );
+        $tableDiff->changedColumns['bar'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'bar', new \Doctrine\DBAL\Schema\Column(
+                'baz', \Doctrine\DBAL\Types\Type::getType('string'), array('default' => 'bla', 'notnull' => true)
+            ),
+            array('type', 'notnull')
+        );
+
+        $expectedSql = array(
+            "ALTER TABLE mytable MODIFY (foo  VARCHAR2(255) DEFAULT 'bla', baz  VARCHAR2(255) DEFAULT 'bla' NOT NULL)",
+	);
+        $this->assertEquals($expectedSql, $this->_platform->getAlterTableSQL($tableDiff));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -344,6 +344,14 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    protected function getQuotedNameInIndexSQL()
+    {
+        return array(
+            'CREATE TABLE test (column1 VARCHAR2(255) NOT NULL)',
+            'CREATE INDEX "create" ON test (column1)',
+        );
+    }
+
     protected function getQuotedColumnInForeignKeySQL()
     {
         return array(

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -330,4 +330,14 @@ class OraclePlatformTest extends AbstractPlatformTestCase
 	);
         $this->assertEquals($expectedSql, $this->_platform->getAlterTableSQL($tableDiff));
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAlterStringToFixedStringSQL()
+    {
+        return array(
+            'ALTER TABLE mytable MODIFY (name  CHAR(2) DEFAULT NULL)',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -3,6 +3,10 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 
 require_once __DIR__ . '/../../TestInit.php';
@@ -198,6 +202,47 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     public function getGenerateForeignKeySql()
     {
         return 'ALTER TABLE test ADD FOREIGN KEY (fk_name_id) REFERENCES other_table (id)';
+    }
+
+    /**
+     * @group DBAL-1097
+     *
+     * @dataProvider getGeneratesAdvancedForeignKeyOptionsSQLData
+     */
+    public function testGeneratesAdvancedForeignKeyOptionsSQL(array $options, $expectedSql)
+    {
+        $foreignKey = new ForeignKeyConstraint(array('foo'), 'foreign_table', array('bar'), null, $options);
+
+        $this->assertSame($expectedSql, $this->_platform->getAdvancedForeignKeyOptionsSQL($foreignKey));
+    }
+
+    /**
+     * @return array
+     */
+    public function getGeneratesAdvancedForeignKeyOptionsSQLData()
+    {
+        return array(
+            array(array(), ''),
+            array(array('onUpdate' => 'CASCADE'), ''),
+            array(array('onDelete' => 'CASCADE'), ' ON DELETE CASCADE'),
+            array(array('onDelete' => 'NO ACTION'), ''),
+            array(array('onDelete' => 'RESTRICT'), ''),
+            array(array('onUpdate' => 'SET NULL', 'onDelete' => 'SET NULL'), ' ON DELETE SET NULL'),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReturnsForeignKeyReferentialActionSQL()
+    {
+        return array(
+            array('CASCADE', 'CASCADE'),
+            array('SET NULL', 'SET NULL'),
+            array('NO ACTION', ''),
+            array('RESTRICT', ''),
+            array('CaScAdE', 'CASCADE'),
+        );
     }
 
     public function testModifyLimitQuery()

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
 
 class PostgreSqlPlatformTest extends AbstractPlatformTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -284,6 +284,14 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    protected function getQuotedNameInIndexSQL()
+    {
+        return array(
+            'CREATE TABLE test (column1 VARCHAR(255) NOT NULL)',
+            'CREATE INDEX "create" ON test (column1)',
+        );
+    }
+
     protected function getQuotedColumnInForeignKeySQL()
     {
         return array(

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -332,25 +332,25 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
             'dloo1', new \Doctrine\DBAL\Schema\Column(
                 'dloo1', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 16, 'scale' => 6)
             ),
-            array('type')
+            array('precision')
         );
         $tableDiff->changedColumns['dloo2'] = new \Doctrine\DBAL\Schema\ColumnDiff(
             'dloo2', new \Doctrine\DBAL\Schema\Column(
                 'dloo2', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 10, 'scale' => 4)
             ),
-            array('type')
+            array('scale')
         );
         $tableDiff->changedColumns['dloo3'] = new \Doctrine\DBAL\Schema\ColumnDiff(
             'dloo3', new \Doctrine\DBAL\Schema\Column(
                 'dloo3', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 10, 'scale' => 6)
             ),
-            array('type')
+            array()
         );
         $tableDiff->changedColumns['dloo4'] = new \Doctrine\DBAL\Schema\ColumnDiff(
             'dloo4', new \Doctrine\DBAL\Schema\Column(
                 'dloo4', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 16, 'scale' => 8)
             ),
-            array('type')
+            array('precision', 'scale')
         );
 
         $sql = $this->_platform->getAlterTableSQL($tableDiff);

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -33,10 +33,10 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE mytable ADD quota INT DEFAULT NULL',
             'ALTER TABLE mytable DROP foo',
             'ALTER TABLE mytable ALTER bar TYPE VARCHAR(255)',
-            "ALTER TABLE mytable ALTER bar SET  DEFAULT 'def'",
+            "ALTER TABLE mytable ALTER bar SET DEFAULT 'def'",
             'ALTER TABLE mytable ALTER bar SET NOT NULL',
             'ALTER TABLE mytable ALTER bloo TYPE BOOLEAN',
-            "ALTER TABLE mytable ALTER bloo SET  DEFAULT 'false'",
+            "ALTER TABLE mytable ALTER bloo SET DEFAULT 'false'",
             'ALTER TABLE mytable ALTER bloo SET NOT NULL',
             'ALTER TABLE mytable RENAME TO userlist',
         );

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -487,29 +487,11 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
     /**
      * @group DBAL-1090
      */
-    public function testAlterStringToFixedString()
+    protected function getAlterStringToFixedStringSQL()
     {
-
-        $table = new Table('mytable');
-        $table->addColumn('name', 'string', array('length' => 2));
-
-        $tableDiff = new TableDiff('mytable');
-        $tableDiff->fromTable = $table;
-
-        $tableDiff->changedColumns['dloo1'] = new \Doctrine\DBAL\Schema\ColumnDiff(
-            'name', new \Doctrine\DBAL\Schema\Column(
-                'name', \Doctrine\DBAL\Types\Type::getType('string'), array('fixed' => true, 'length' => 2)
-            ),
-            array('fixed')
-        );
-
-        $sql = $this->_platform->getAlterTableSQL($tableDiff);
-
-        $expectedSql = array(
+        return array(
             'ALTER TABLE mytable ALTER name TYPE CHAR(2)',
         );
-
-        $this->assertEquals($expectedSql, $sql);
     }
 }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -332,25 +332,25 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
             'dloo1', new \Doctrine\DBAL\Schema\Column(
                 'dloo1', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 16, 'scale' => 6)
             ),
-            array('type', 'notnull', 'default')
+            array('type')
         );
         $tableDiff->changedColumns['dloo2'] = new \Doctrine\DBAL\Schema\ColumnDiff(
             'dloo2', new \Doctrine\DBAL\Schema\Column(
                 'dloo2', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 10, 'scale' => 4)
             ),
-            array('type', 'notnull', 'default')
+            array('type')
         );
         $tableDiff->changedColumns['dloo3'] = new \Doctrine\DBAL\Schema\ColumnDiff(
             'dloo3', new \Doctrine\DBAL\Schema\Column(
                 'dloo3', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 10, 'scale' => 6)
             ),
-            array('type', 'notnull', 'default')
+            array('type')
         );
         $tableDiff->changedColumns['dloo4'] = new \Doctrine\DBAL\Schema\ColumnDiff(
             'dloo4', new \Doctrine\DBAL\Schema\Column(
                 'dloo4', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 16, 'scale' => 8)
             ),
-            array('type', 'notnull', 'default')
+            array('type')
         );
 
         $sql = $this->_platform->getAlterTableSQL($tableDiff);

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -485,7 +485,7 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
     }
 
     /**
-     * @todo add issue ticket number as phpunit group
+     * @group DBAL-1090
      */
     public function testAlterStringToFixedString()
     {

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -483,5 +483,33 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
 
         $this->assertEquals($expectedSql, $sql);
     }
+
+    /**
+     * @todo add issue ticket number as phpunit group
+     */
+    public function testAlterStringToFixedString()
+    {
+
+        $table = new Table('mytable');
+        $table->addColumn('name', 'string', array('length' => 2));
+
+        $tableDiff = new TableDiff('mytable');
+        $tableDiff->fromTable = $table;
+
+        $tableDiff->changedColumns['dloo1'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'name', new \Doctrine\DBAL\Schema\Column(
+                'name', \Doctrine\DBAL\Types\Type::getType('string'), array('fixed' => true, 'length' => 2)
+            ),
+            array('fixed')
+        );
+
+        $sql = $this->_platform->getAlterTableSQL($tableDiff);
+
+        $expectedSql = array(
+            'ALTER TABLE mytable ALTER name TYPE CHAR(2)',
+        );
+
+        $this->assertEquals($expectedSql, $sql);
+    }
 }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -314,5 +314,52 @@ class PostgreSqlPlatformTest extends AbstractPlatformTestCase
         $this->assertEquals('1', $platform->convertBooleans(true));
         $this->assertEquals('0', $platform->convertBooleans(false));
     }
+
+    public function testAlterDecimalPrecisionScale()
+    {
+        $table = new Table('mytable');
+        $table->addColumn('dfoo1', 'decimal');
+        $table->addColumn('dfoo2', 'decimal', array('precision' => 10, 'scale' => 6));
+        $table->addColumn('dfoo3', 'decimal', array('precision' => 10, 'scale' => 6));
+        $table->addColumn('dfoo4', 'decimal', array('precision' => 10, 'scale' => 6));
+
+        $tableDiff = new TableDiff('mytable');
+        $tableDiff->fromTable = $table;
+
+        $tableDiff->changedColumns['dloo1'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'dloo1', new \Doctrine\DBAL\Schema\Column(
+                'dloo1', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 16, 'scale' => 6)
+            ),
+            array('type', 'notnull', 'default')
+        );
+        $tableDiff->changedColumns['dloo2'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'dloo2', new \Doctrine\DBAL\Schema\Column(
+                'dloo2', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 10, 'scale' => 4)
+            ),
+            array('type', 'notnull', 'default')
+        );
+        $tableDiff->changedColumns['dloo3'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'dloo3', new \Doctrine\DBAL\Schema\Column(
+                'dloo3', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 10, 'scale' => 6)
+            ),
+            array('type', 'notnull', 'default')
+        );
+        $tableDiff->changedColumns['dloo4'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'dloo4', new \Doctrine\DBAL\Schema\Column(
+                'dloo4', \Doctrine\DBAL\Types\Type::getType('decimal'), array('precision' => 16, 'scale' => 8)
+            ),
+            array('type', 'notnull', 'default')
+        );
+
+        $sql = $this->_platform->getAlterTableSQL($tableDiff);
+
+        $expectedSql = array(
+            'ALTER TABLE mytable ALTER dloo1 TYPE NUMERIC(16, 6)',
+            'ALTER TABLE mytable ALTER dloo2 TYPE NUMERIC(10, 4)',
+            'ALTER TABLE mytable ALTER dloo4 TYPE NUMERIC(16, 8)',
+        );
+
+        $this->assertEquals($expectedSql, $sql);
+    }
 }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -33,6 +33,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE mytable ALTER COLUMN baz NVARCHAR(255) NOT NULL',
             "ALTER TABLE mytable ADD CONSTRAINT DF_6B2BD609_78240498 DEFAULT 'def' FOR baz",
             'ALTER TABLE mytable ALTER COLUMN bloo BIT NOT NULL',
+            "ALTER TABLE mytable ADD CONSTRAINT DF_6B2BD609_CECED971 DEFAULT '0' FOR bloo",
             "sp_RENAME 'mytable', 'userlist'",
             "DECLARE @sql NVARCHAR(MAX) = N''; " .
             "SELECT @sql += N'EXEC sp_rename N''' + dc.name + ''', N''' " .

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -84,7 +84,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     {
         $dropDatabaseExpectation = 'DROP DATABASE foobar';
 
-        $this->assertEquals('SELECT * FROM SYS.DATABASES', $this->_platform->getListDatabasesSQL());
+        $this->assertEquals('SELECT * FROM sys.databases', $this->_platform->getListDatabasesSQL());
         $this->assertEquals('CREATE DATABASE foobar', $this->_platform->getCreateDatabaseSQL('foobar'));
         $this->assertEquals($dropDatabaseExpectation, $this->_platform->getDropDatabaseSQL('foobar'));
         $this->assertEquals('DROP TABLE foobar', $this->_platform->getDropTableSQL('foobar'));

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -353,4 +353,12 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE mytable ALTER COLUMN name NCHAR(2) NOT NULL',
         );
     }
+
+    protected function getQuotedNameInIndexSQL()
+    {
+        return array(
+            'CREATE TABLE test (column1 NVARCHAR(255) NOT NULL)',
+            'CREATE INDEX [create] ON test (column1)',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -343,4 +343,14 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
             array(LockMode::PESSIMISTIC_WRITE, ' WITH (UPDLOCK, ROWLOCK)'),
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAlterStringToFixedStringSQL()
+    {
+        return array(
+            'ALTER TABLE mytable ALTER COLUMN name NCHAR(2) NOT NULL',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -302,4 +302,18 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") REFERENCES "foo-bar" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE)',
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAlterStringToFixedStringSQL()
+    {
+        return array(
+            'CREATE TEMPORARY TABLE __temp__mytable AS SELECT name FROM mytable',
+            'DROP TABLE mytable',
+            'CREATE TABLE mytable (name CHAR(2) NOT NULL)',
+            'INSERT INTO mytable (name) SELECT name FROM __temp__mytable',
+            'DROP TABLE __temp__mytable',
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -292,6 +292,14 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    protected function getQuotedNameInIndexSQL()
+    {
+        return array(
+            'CREATE TABLE test (column1 VARCHAR(255) NOT NULL)',
+            'CREATE INDEX "create" ON test (column1)',
+        );
+    }
+
     protected function getQuotedColumnInForeignKeySQL()
     {
         return array(

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -27,9 +27,15 @@ class SQLParserUtilsTest extends \Doctrine\Tests\DbalTestCase
             array('SELECT "?" FROM foo', true, array()),
             array("SELECT '?' FROM foo", true, array()),
             array("SELECT `?` FROM foo", true, array()), // Ticket DBAL-552
+            array("SELECT 'Doctrine\DBAL?' FROM foo", true, array()), // Ticket DBAL-558
+            array('SELECT "Doctrine\DBAL?" FROM foo', true, array()), // Ticket DBAL-558
+            array('SELECT `Doctrine\DBAL?` FROM foo', true, array()), // Ticket DBAL-558
             array('SELECT "?" FROM foo WHERE bar = ?', true, array(32)),
             array("SELECT '?' FROM foo WHERE bar = ?", true, array(32)),
             array("SELECT `?` FROM foo WHERE bar = ?", true, array(32)), // Ticket DBAL-552
+            array("SELECT 'Doctrine\DBAL?' FROM foo WHERE bar = ?", true, array(45)), // Ticket DBAL-558
+            array('SELECT "Doctrine\DBAL?" FROM foo WHERE bar = ?', true, array(45)), // Ticket DBAL-558
+            array('SELECT `Doctrine\DBAL?` FROM foo WHERE bar = ?', true, array(45)), // Ticket DBAL-558
             array(
 <<<'SQLDATA'
 SELECT * FROM foo WHERE bar = 'it\'s a trap? \\' OR bar = ?

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -26,8 +26,10 @@ class SQLParserUtilsTest extends \Doctrine\Tests\DbalTestCase
             array('SELECT ? FROM ?', true, array(7, 14)),
             array('SELECT "?" FROM foo', true, array()),
             array("SELECT '?' FROM foo", true, array()),
+            array("SELECT `?` FROM foo", true, array()), // Ticket DBAL-552
             array('SELECT "?" FROM foo WHERE bar = ?', true, array(32)),
             array("SELECT '?' FROM foo WHERE bar = ?", true, array(32)),
+            array("SELECT `?` FROM foo WHERE bar = ?", true, array(32)), // Ticket DBAL-552
             array(
 <<<'SQLDATA'
 SELECT * FROM foo WHERE bar = 'it\'s a trap? \\' OR bar = ?
@@ -45,7 +47,8 @@ SQLDATA
             array('SELECT @rank := 1', false, array()), // Ticket DBAL-398
             array('SELECT @rank := 1 AS rank, :foo AS foo FROM :bar', false, array(27 => 'foo', 44 => 'bar')), // Ticket DBAL-398
             array('SELECT * FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(30 => 'start_date', 52 =>  'start_date')), // Ticket GH-113
-            array('SELECT foo::date as date FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(46 => 'start_date', 68 =>  'start_date')) // Ticket GH-259
+            array('SELECT foo::date as date FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(46 => 'start_date', 68 =>  'start_date')), // Ticket GH-259
+            array('SELECT `d.ns:col_name` FROM my_table d WHERE `d.date` >= :param1', false, array(57 => 'param1')), // Ticket DBAL-552
         );
     }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -914,6 +914,20 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group DBAL-617
+     */
+    public function testCompareQuotedAndUnquotedForeignKeyColumns()
+    {
+        $fk1 = new ForeignKeyConstraint(array("foo"), "bar", array("baz"), "fk1", array('onDelete' => 'NO ACTION'));
+        $fk2 = new ForeignKeyConstraint(array("`foo`"), "bar", array("`baz`"), "fk1", array('onDelete' => 'NO ACTION'));
+
+        $comparator = new Comparator();
+        $diff = $comparator->diffForeignKey($fk1, $fk2);
+
+        $this->assertFalse($diff);
+    }
+
+    /**
      * @param SchemaDiff $diff
      * @param int $newTableCount
      * @param int $changeTableCount

--- a/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
@@ -36,6 +36,15 @@ class PoolingShardManagerTest extends \PHPUnit_Framework_TestCase
         return $mock;
     }
 
+    private function createStaticShardChoser()
+    {
+        $mock = $this->getMock('Doctrine\DBAL\Sharding\ShardChoser\ShardChoser');
+        $mock->expects($this->any())
+            ->method('pickShard')
+            ->will($this->returnCallback(function($value) { return 1; }));
+        return $mock;
+    }
+
     public function testSelectGlobal()
     {
         $conn = $this->createConnectionMock();
@@ -100,6 +109,36 @@ class PoolingShardManagerTest extends \PHPUnit_Framework_TestCase
              ->will($this->returnValue(array( array('id' => 2) ) ));
 
         $shardManager = new PoolingShardManager($conn, $this->createPassthroughShardChoser());
+        $result = $shardManager->queryAll($sql, $params, $types);
+
+        $this->assertEquals(array(array('id' => 1), array('id' => 2)), $result);
+    }
+
+    public function testQueryAllWithStaticShardChoser()
+    {
+        $sql = "SELECT * FROM table";
+        $params = array(1);
+        $types = array(1);
+
+        $conn = $this->createConnectionMock();
+        $conn->expects($this->at(0))->method('getParams')->will($this->returnValue(
+            array('shards' => array( array('id' => 1), array('id' => 2) ), 'shardChoser' => $this->createStaticShardChoser())
+        ));
+        $conn->expects($this->at(1))->method('getParams')->will($this->returnValue(
+            array('shards' => array( array('id' => 1), array('id' => 2) ), 'shardChoser' => $this->createStaticShardChoser())
+        ));
+        $conn->expects($this->at(2))->method('connect')->with($this->equalTo(1));
+        $conn->expects($this->at(3))
+            ->method('fetchAll')
+            ->with($this->equalTo($sql), $this->equalTo($params), $this->equalTo($types))
+            ->will($this->returnValue(array( array('id' => 1) ) ));
+        $conn->expects($this->at(4))->method('connect')->with($this->equalTo(2));
+        $conn->expects($this->at(5))
+            ->method('fetchAll')
+            ->with($this->equalTo($sql), $this->equalTo($params), $this->equalTo($types))
+            ->will($this->returnValue(array( array('id' => 2) ) ));
+
+        $shardManager = new PoolingShardManager($conn, $this->createStaticShardChoser());
         $result = $shardManager->queryAll($sql, $params, $types);
 
         $this->assertEquals(array(array('id' => 1), array('id' => 2)), $result);

--- a/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Types;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+
+require_once __DIR__ . '/../../TestInit.php';
+
+class JsonArrayTest extends \Doctrine\Tests\DbalTestCase
+{
+    /**
+     * @var \Doctrine\Tests\DBAL\Mocks\MockPlatform
+     */
+    protected $platform;
+
+    /**
+     * @var \Doctrine\DBAL\Types\JsonArrayType
+     */
+    protected $type;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->platform = new MockPlatform();
+        $this->type     = Type::getType('json_array');
+    }
+
+    public function testJsonEmptyStringConvertsToPHPValue()
+    {
+        $this->assertSame(array(), $this->type->convertToPHPValue('', $this->platform));
+    }
+}


### PR DESCRIPTION
Hello,

After upgrading doctrine/dbal from version v2.4.3 to v2.4.4 I couldn't drop database with zero open connections.

Example:

./app/console doctrine:database:drop --force
Could not drop database for connection named "test"
An exception occurred while executing 'DROP DATABASE "test"':

SQLSTATE[55006]: Object in use: 7 ERROR:  cannot drop the currently open database

details:
• PostgreSQL 9.2.4
• PHP 5.5.10

Any suggestions or workarounds for this issue.

Thank you
