### PR TITLE
[DBAL-1115] Fix quoted identifiers for database creation SQL on SQL Anywhere

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -405,7 +405,9 @@ class SQLAnywherePlatform extends AbstractPlatform
      */
     public function getCreateDatabaseSQL($database)
     {
-        return "CREATE DATABASE '$database'";
+        $database = new Identifier($database);
+
+        return "CREATE DATABASE '" . $database->getName() . "'";
     }
 
     /**
@@ -537,7 +539,9 @@ class SQLAnywherePlatform extends AbstractPlatform
      */
     public function getDropDatabaseSQL($database)
     {
-        return "DROP DATABASE '$database'";
+        $database = new Identifier($database);
+
+        return "DROP DATABASE '" . $database->getName() . "'";
     }
 
     /**
@@ -1025,7 +1029,9 @@ class SQLAnywherePlatform extends AbstractPlatform
      */
     public function getStartDatabaseSQL($database)
     {
-        return "START DATABASE '$database' AUTOSTOP OFF";
+        $database = new Identifier($database);
+
+        return "START DATABASE '" . $database->getName() . "' AUTOSTOP OFF";
     }
 
     /**
@@ -1042,7 +1048,9 @@ class SQLAnywherePlatform extends AbstractPlatform
      */
     public function getStopDatabaseSQL($database)
     {
-        return 'STOP DATABASE "' . $database . '" UNCONDITIONALLY';
+        $database = new Identifier($database);
+
+        return 'STOP DATABASE "' . $database->getName() . '" UNCONDITIONALLY';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -301,10 +301,18 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     public function testGeneratesDDLSnippets()
     {
         $this->assertEquals("CREATE DATABASE 'foobar'", $this->_platform->getCreateDatabaseSQL('foobar'));
+        $this->assertEquals("CREATE DATABASE 'foobar'", $this->_platform->getCreateDatabaseSQL('"foobar"'));
+        $this->assertEquals("CREATE DATABASE 'create'", $this->_platform->getCreateDatabaseSQL('create'));
         $this->assertEquals("DROP DATABASE 'foobar'", $this->_platform->getDropDatabaseSQL('foobar'));
+        $this->assertEquals("DROP DATABASE 'foobar'", $this->_platform->getDropDatabaseSQL('"foobar"'));
+        $this->assertEquals("DROP DATABASE 'create'", $this->_platform->getDropDatabaseSQL('create'));
         $this->assertEquals('CREATE GLOBAL TEMPORARY TABLE', $this->_platform->getCreateTemporaryTableSnippetSQL());
         $this->assertEquals("START DATABASE 'foobar' AUTOSTOP OFF", $this->_platform->getStartDatabaseSQL('foobar'));
+        $this->assertEquals("START DATABASE 'foobar' AUTOSTOP OFF", $this->_platform->getStartDatabaseSQL('"foobar"'));
+        $this->assertEquals("START DATABASE 'create' AUTOSTOP OFF", $this->_platform->getStartDatabaseSQL('create'));
         $this->assertEquals('STOP DATABASE "foobar" UNCONDITIONALLY', $this->_platform->getStopDatabaseSQL('foobar'));
+        $this->assertEquals('STOP DATABASE "foobar" UNCONDITIONALLY', $this->_platform->getStopDatabaseSQL('"foobar"'));
+        $this->assertEquals('STOP DATABASE "create" UNCONDITIONALLY', $this->_platform->getStopDatabaseSQL('create'));
         $this->assertEquals('TRUNCATE TABLE foobar', $this->_platform->getTruncateTableSQL('foobar'));
         $this->assertEquals('TRUNCATE TABLE foobar', $this->_platform->getTruncateTableSQL('foobar'), true);
 


### PR DESCRIPTION
In SQL Anywhere the statements `CREATE DATABASE`, `DROP DATABASE`, `START DATABASE`, `STOP DATABASE` always take unquoted identifiers.
This PR ensures given identifiers are always passed unquoted to the generated SQL.
This issue was discovered by using DoctrineBundle's `database:create` and `database:drop` commands which always quote the database identifiers.

``` bash
$ php app/console doctrine:database:create
Could not create database for connection named "symfony"
An exception occurred while executing 'START DATABASE '"symfony"' AUTOSTOP OFF':

SQLSTATE [00000] [-82] Angegebene Datenbank konnte nicht gestartet werden: Illegal character in database alias.
```
