### PR TITLE
Added SET and ENUM types for MySQL and fix issue with schema update tool

### DIFF
--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -233,6 +233,38 @@ or ``null`` if no data is present.
     bit data type if necessary to ensure the least possible data storage
     requirements are met.
 
+enum
+^^^^
+
+Maps and convert enum type
+An ENUM value must be one of those listed in the column definition, or the internal
+numeric equivalent thereof.
+You can specify allowed values in ``values`` in ``options`` @Column annotation
+For example:
+
+.. code-block:: php
+
+    /**
+     * @Column(name="filed", type="enum", options={"values"="'value1','value2'"})
+     */
+    private $field;
+
+set type
+^^^^^^^^
+
+Maps and converts set data.
+A SET is a string object that can have zero or more values, each of which
+must be chosen from a list of permitted values specified when the table is created.
+You can specify allowed values in ``values`` in ``options`` @Column annotation
+For example:
+
+.. code-block:: php
+
+    /**
+     * @Column(name="another_filed", type="set", options={"values"="'value1','value2'"})
+     */
+    private $anotherField;
+
 Date and time types
 ~~~~~~~~~~~~~~~~~~~
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -956,7 +956,8 @@ class MySqlPlatform extends AbstractPlatform
             'tinyblob'      => 'blob',
             'binary'        => 'binary',
             'varbinary'     => 'binary',
-            'set'           => 'simple_array',
+            'set'           => 'set',
+            'enum'          => 'enum'
         );
     }
 

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -122,6 +122,7 @@ class MySqlSchemaManager extends AbstractSchemaManager
 
         $scale = null;
         $precision = null;
+        $values = null;
 
         $type = $this->_platform->getDoctrineTypeMapping($dbType);
 
@@ -174,6 +175,11 @@ class MySqlSchemaManager extends AbstractSchemaManager
             case 'year':
                 $length = null;
                 break;
+            case 'enum':
+            case 'set':
+                strtok($tableColumn['type'],'()');
+                $values = strtok('()');
+                break;
         }
 
         $length = ((int) $length == 0) ? null : (int) $length;
@@ -195,6 +201,10 @@ class MySqlSchemaManager extends AbstractSchemaManager
         if ($scale !== null && $precision !== null) {
             $options['scale'] = $scale;
             $options['precision'] = $precision;
+        }
+
+        if ($values) {
+            $options['customSchemaOptions'] = array('values' => $values);
         }
 
         $column = new Column($tableColumn['field'], Type::getType($type), $options);

--- a/lib/Doctrine/DBAL/Types/EnumType.php
+++ b/lib/Doctrine/DBAL/Types/EnumType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+class EnumType extends Type
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return self::ENUM;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        if (!isset($fieldDeclaration['values'])) {
+            throw new \Exception("Option 'values' in 'options' parameter missing for enum type");
+        }
+
+        return 'ENUM(' . $fieldDeclaration['values'] . ')';
+    }
+}

--- a/lib/Doctrine/DBAL/Types/SetType.php
+++ b/lib/Doctrine/DBAL/Types/SetType.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+class SetType extends Type
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return self::SET;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        if (!isset($fieldDeclaration['values'])) {
+            throw new \Exception("Option 'values' in 'options' parameter missing for set type");
+        }
+
+        return 'SET(' . $fieldDeclaration['values'] . ')';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return (array)explode(',', $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return join(',', (array)$value);
+    }
+}

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -52,6 +52,8 @@ abstract class Type
     const BLOB = 'blob';
     const FLOAT = 'float';
     const GUID = 'guid';
+    const SET = 'set';
+    const ENUM = 'enum';
 
     /**
      * Map of already instantiated type objects. One instance per type (flyweight).
@@ -85,6 +87,8 @@ abstract class Type
         self::BINARY => 'Doctrine\DBAL\Types\BinaryType',
         self::BLOB => 'Doctrine\DBAL\Types\BlobType',
         self::GUID => 'Doctrine\DBAL\Types\GuidType',
+        self::SET => 'Doctrine\DBAL\Types\SetType',
+        self::ENUM => 'Doctrine\DBAL\Types\EnumType',
     );
 
     /**


### PR DESCRIPTION
Set and Enum data types are one of the most popular. However, addition of these data types in the project creates a problem when updating of the database structure.
