### PR TITLE
fix diffColumn in text length is different

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -441,7 +441,7 @@ class Comparator
         }
 
         if (($properties1['type'] instanceof Types\StringType && ! $properties1['type'] instanceof Types\GuidType) ||
-            $properties1['type'] instanceof Types\BinaryType
+            $properties1['type'] instanceof Types\TextType || $properties1['type'] instanceof Types\BinaryType
         ) {
             // check if value of length is set at all, default value assumed otherwise.
             $length1 = $properties1['length'] ?: 255;

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -207,6 +207,18 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $c->diffColumn($column1, $column1));
     }
 
+    public function testCompareChangedColumns_ChangeTextLength()
+    {
+        $column1 = new Column('textfield1', Type::getType('text'), array('Length' => 128));
+        $column2 = new Column('textfield1', Type::getType('text'), array('Length' => 65536));
+        $column3 = new Column('textfield1', Type::getType('text'), array('Length' => 65536));
+
+        $c = new Comparator();
+        $this->assertEquals(array('length'), $c->diffColumn($column1, $column2));
+        $this->assertEquals(array(), $c->diffColumn($column1, $column1));
+        $this->assertEquals(array(), $c->diffColumn($column2, $column3));
+    }
+
     public function testCompareChangedColumns_ChangeCustomSchemaOption()
     {
         $column1 = new Column('charfield1', Type::getType('string'));


### PR DESCRIPTION
Because mysql has multiple TEXT types.

```
    $column1 = new Column('clobfield1', Type::getType('text'), array('Length' => 128));
    $column2 = new Column('clobfield1', Type::getType('text'), array('Length' => 65536));

    $platform = new MySqlPlatform();
    var_dump($platform->getClobTypeDeclarationSQL($column1->toArray()));// this is "TINYTEXT"
    var_dump($platform->getClobTypeDeclarationSQL($column2->toArray()));// this is "MEDIUMTEXT"

    $c = new Comparator();
    var_dump($c->diffColumn($column1, $column2));// this is empty!
```
