### PR TITLE
DBAL-1122 Cleanup PHPUnit test suite bootstrap

### DIFF
--- a/tests/Doctrine/Tests/DBAL/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConfigurationTest.php
@@ -22,8 +22,6 @@ namespace Doctrine\Tests\DBAL;
 use Doctrine\DBAL\Configuration;
 use Doctrine\Tests\DbalTestCase;
 
-require_once __DIR__ . '/../TestInit.php';
-
 /**
  * Unit tests for the configuration container.
  *

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL;
 
-require_once __DIR__ . '/../TestInit.php';
-
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class OCI8StatementTest extends \Doctrine\Tests\DbalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL;
 
-require_once __DIR__ . '/../TestInit.php';
-
 class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
 {
     /**
@@ -114,7 +112,7 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
         $conn = \Doctrine\DBAL\DriverManager::getConnection($options);
         $this->assertInstanceOf('Doctrine\DBAL\Driver\PDOMySql\Driver', $conn->getDriver());
     }
-    
+
     /**
      * @dataProvider databaseUrls
      */
@@ -123,13 +121,13 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
         $options = is_array($url) ? $url : array(
             'url' => $url,
         );
-        
+
         if ($expected === false) {
             $this->setExpectedException('Doctrine\DBAL\DBALException');
         }
-        
+
         $conn = \Doctrine\DBAL\DriverManager::getConnection($options);
-        
+
         $params = $conn->getParams();
         foreach ($expected as $key => $value) {
             if ($key == 'driver') {
@@ -139,7 +137,7 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
             }
         }
     }
-    
+
     public function databaseUrls()
     {
         return array(

--- a/tests/Doctrine/Tests/DBAL/Events/MysqlSessionInitTest.php
+++ b/tests/Doctrine/Tests/DBAL/Events/MysqlSessionInitTest.php
@@ -7,8 +7,6 @@ use Doctrine\DBAL\Event\Listeners\MysqlSessionInit;
 use Doctrine\DBAL\Events;
 use Doctrine\Tests\DbalTestCase;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class MysqlSessionInitTest extends DbalTestCase
 {
     public function testPostConnect()

--- a/tests/Doctrine/Tests/DBAL/Events/OracleSessionInitTest.php
+++ b/tests/Doctrine/Tests/DBAL/Events/OracleSessionInitTest.php
@@ -7,8 +7,6 @@ use Doctrine\DBAL\Event\Listeners\OracleSessionInit;
 use Doctrine\DBAL\Events;
 use Doctrine\Tests\DbalTestCase;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class OracleSessionInitTest extends DbalTestCase
 {
     public function testPostConnect()

--- a/tests/Doctrine/Tests/DBAL/Events/SQLSessionInitTest.php
+++ b/tests/Doctrine/Tests/DBAL/Events/SQLSessionInitTest.php
@@ -7,8 +7,6 @@ use Doctrine\DBAL\Event\Listeners\SQLSessionInit;
 use Doctrine\DBAL\Events;
 use Doctrine\Tests\DbalTestCase;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group DBAL-169
  */

--- a/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Functional;
 use Doctrine\DBAL\Types\Type;
 use PDO;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group DBAL-6
  */

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -6,8 +6,6 @@ use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Types\Type;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -7,8 +7,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use PDO;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
     static private $generated = false;

--- a/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Functional;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
     private static $tableCreated = false;

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -5,9 +5,6 @@ namespace Doctrine\Tests\DBAL\Functional\Ticket;
 use Doctrine\DBAL\Connection;
 use PDO;
 
-require_once __DIR__ . '/../../TestInit.php';
-
-
 /**
  * @group DDC-1372
  */

--- a/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
@@ -7,8 +7,6 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Portability\Connection as ConnectionPortability;
 use PDO;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group DBAL-56
  */

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\DBAL\Functional;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use PDO;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group DDC-217
  */
@@ -64,7 +62,7 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
         $this->assertCacheNonCacheSelectSameFetchModeAreEqual($expectedResult, \PDO::FETCH_BOTH);
     }
-	
+
     public function testFetchColumn()
     {
         $expectedResult = array();

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/Db2SchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/Db2SchemaManagerTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class Db2SchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/DrizzleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/DrizzleSchemaManagerTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\DBAL\Functional\Schema;
 
 use Doctrine\DBAL\Schema\Table;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DrizzleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
     public function testListTableWithBinary()

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -8,8 +8,6 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Functional\Schema;
 use Doctrine\DBAL\Schema;
 use Doctrine\Tests\TestUtil;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -6,8 +6,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Types\Type;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
     public function tearDown()

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -11,8 +11,6 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTestCase
 {
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\DBAL\Functional\Schema;
 
 use Doctrine\DBAL\Schema;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\Types\Type;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class TypeConversionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
     static private $typeCounter = 0;

--- a/tests/Doctrine/Tests/DBAL/Logging/DebugStackTest.php
+++ b/tests/Doctrine/Tests/DBAL/Logging/DebugStackTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Logging;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class DebugStackTest extends \Doctrine\Tests\DbalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -9,8 +9,6 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class OraclePlatformTest extends AbstractPlatformTestCase
 {
     static public function dataValidIdentifiers()

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -9,8 +9,6 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class SqlitePlatformTest extends AbstractPlatformTestCase
 {
     public function createPlatform()

--- a/tests/Doctrine/Tests/DBAL/Portability/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Portability/StatementTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Portability;
 use Doctrine\DBAL\Portability\Connection;
 use Doctrine\DBAL\Portability\Statement;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class StatementTest extends \Doctrine\Tests\DbalTestCase
 {
     /**

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\DBAL\Query\Expression;
 
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DBAL-12
  */

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Query\Expression;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DBAL-12
  */

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Query;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group DBAL-12
  */

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\SQLParserUtils;
 
-require_once __DIR__ . '/../TestInit.php';
-
 /**
  * @group DBAL-78
  * @group DDC-1372

--- a/tests/Doctrine/Tests/DBAL/Schema/ColumnTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ColumnTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Schema;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Types\Type;
 

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -19,8 +19,6 @@
 
 namespace Doctrine\Tests\DBAL\Schema;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;

--- a/tests/Doctrine/Tests/DBAL/Schema/IndexTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/IndexTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Schema;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 use Doctrine\DBAL\Schema\Index;
 
 class IndexTest extends \PHPUnit_Framework_TestCase

--- a/tests/Doctrine/Tests/DBAL/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Platforms/MySQLSchemaTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Schema\Platforms;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 use Doctrine\DBAL\Schema\Table;
 
 class MySQLSchemaTest extends \PHPUnit_Framework_TestCase

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Schema;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Schema;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Schema\Visitor;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 use Doctrine\DBAL\Schema\Schema;
 
 class SchemaSqlCollectorTest extends \PHPUnit_Framework_TestCase

--- a/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ArrayTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class BinaryTest extends \Doctrine\Tests\DbalTestCase
 {
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class BlobTest extends \Doctrine\Tests\DbalTestCase
 {
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/BooleanTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BooleanTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class BooleanTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/Types/DateTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class DateTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/Types/DateTimeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTimeTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class DateTimeTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/Types/DateTimeTzTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTimeTzTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class DateTimeTzTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/Types/DecimalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DecimalTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class DecimalTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/Types/FloatTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/FloatTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class FloatTest extends \Doctrine\Tests\DbalTestCase
 {
     protected $_platform, $_type;

--- a/tests/Doctrine/Tests/DBAL/Types/IntegerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/IntegerTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class IntegerTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class JsonArrayTest extends \Doctrine\Tests\DbalTestCase
 {
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ObjectTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/Types/SmallIntTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/SmallIntTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class SmallIntTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/Types/StringTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/StringTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class StringTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/Types/TimeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/TimeTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class TimeTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/Types/VarDateTimeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/VarDateTimeTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class VarDateTimeTest extends \Doctrine\Tests\DbalTestCase
 {
     protected

--- a/tests/Doctrine/Tests/DBAL/UtilTest.php
+++ b/tests/Doctrine/Tests/DBAL/UtilTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\DBAL;
 
-require_once __DIR__ . '/../TestInit.php';
-
 class UtilTest extends \Doctrine\Tests\DbalTestCase
 {
     static public function dataConvertPositionalToNamedParameters()

--- a/tests/travis/mysql.travis.xml
+++ b/tests/travis/mysql.travis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit>
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
     <php>
         <var name="db_type" value="pdo_mysql"/>
         <var name="db_host" value="localhost" />

--- a/tests/travis/mysql.travis.xml
+++ b/tests/travis/mysql.travis.xml
@@ -17,7 +17,7 @@
 
     <testsuites>
         <testsuite name="Doctrine DBAL Test Suite">
-            <directory>./../Doctrine/Tests/DBAL</directory>
+            <directory>../Doctrine/Tests/DBAL</directory>
         </testsuite>
     </testsuites>
     <groups>

--- a/tests/travis/mysqli.travis.xml
+++ b/tests/travis/mysqli.travis.xml
@@ -17,7 +17,7 @@
 
     <testsuites>
         <testsuite name="Doctrine DBAL Test Suite">
-            <directory>./../Doctrine/Tests/DBAL</directory>
+            <directory>../Doctrine/Tests/DBAL</directory>
         </testsuite>
     </testsuites>
     <groups>

--- a/tests/travis/mysqli.travis.xml
+++ b/tests/travis/mysqli.travis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit>
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
     <php>
         <var name="db_type" value="mysqli"/>
         <var name="db_host" value="localhost" />

--- a/tests/travis/pgsql.travis.xml
+++ b/tests/travis/pgsql.travis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit>
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
     <php>
         <var name="db_type" value="pdo_pgsql"/>
         <var name="db_host" value="localhost" />

--- a/tests/travis/pgsql.travis.xml
+++ b/tests/travis/pgsql.travis.xml
@@ -16,7 +16,7 @@
     </php>
     <testsuites>
         <testsuite name="Doctrine DBAL Test Suite">
-            <directory>./../Doctrine/Tests/DBAL</directory>
+            <directory>../Doctrine/Tests/DBAL</directory>
         </testsuite>
     </testsuites>
     <groups>

--- a/tests/travis/sqlite.travis.xml
+++ b/tests/travis/sqlite.travis.xml
@@ -2,7 +2,7 @@
 <phpunit bootstrap="../Doctrine/Tests/TestInit.php">
     <testsuites>
         <testsuite name="Doctrine DBAL Test Suite">
-            <directory>./../Doctrine/Tests/DBAL</directory>
+            <directory>../Doctrine/Tests/DBAL</directory>
         </testsuite>
     </testsuites>
     <groups>

--- a/tests/travis/sqlite.travis.xml
+++ b/tests/travis/sqlite.travis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit>
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
     <testsuites>
         <testsuite name="Doctrine DBAL Test Suite">
             <directory>./../Doctrine/Tests/DBAL</directory>


### PR DESCRIPTION
Removes `require_once` statements leftovers in PHPUnit test classes in favour of properly bootstrapping via PHPUnit config files.
