### PR TITLE
Call `detectDatabasePlatform` only once

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -324,7 +324,7 @@ class Connection implements DriverConnection
      */
     public function getDatabasePlatform()
     {
-        if (null == $this->platform) {
+        if (null === $this->platform) {
             $this->detectDatabasePlatform();
         }
 
@@ -359,10 +359,6 @@ class Connection implements DriverConnection
 
         $this->_conn = $this->_driver->connect($this->_params, $user, $password, $driverOptions);
         $this->_isConnected = true;
-
-        if (null === $this->platform) {
-            $this->detectDatabasePlatform();
-        }
 
         if (false === $this->autoCommit) {
             $this->beginTransaction();
@@ -1597,7 +1593,7 @@ class Connection implements DriverConnection
         }
 
         try {
-            $this->query($this->platform->getDummySelectSQL());
+            $this->query($this->getDatabasePlatform()->getDummySelectSQL());
 
             return true;
         } catch (DBALException $e) {


### PR DESCRIPTION
Database platform detection is triggered twice if `Doctrine/DBAL/Connection::getDatabasePlatform()` is called before `Doctrine/DBAL/Connection::connect()`
