### PR TITLE
Fix: SQLite offset with no limit support

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -660,6 +660,18 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    protected function doModifyLimitQuery($query, $limit, $offset)
+    {
+        if (null === $limit && null !== $offset) {
+            return $query . ' LIMIT -1 OFFSET ' . $offset;
+        }
+
+        return parent::doModifyLimitQuery($query, $limit, $offset);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getBlobTypeDeclarationSQL(array $field)
     {
         return 'BLOB';

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -288,6 +288,12 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $this->assertEquals('SELECT * FROM user LIMIT 10', $sql);
     }
 
+    public function testModifyLimitQueryWithOffsetAndEmptyLimit()
+    {
+        $sql = $this->_platform->modifyLimitQuery('SELECT * FROM user', null, 10);
+        $this->assertEquals('SELECT * FROM user LIMIT -1 OFFSET 10', $sql);
+    }
+
     public function getGenerateAlterTableSql()
     {
         return array(


### PR DESCRIPTION
Required for doctrine/doctrine2#1280

This just slipped through.

Should be merged into 2.4, 2.5 and 2.6
