### PR TITLE
Fixes issue (DBAL-1057) use default platform when not connected

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL;
 
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use PDO;
 use Closure;
@@ -429,7 +430,12 @@ class Connection implements DriverConnection
         // cause an error in our application when determining the platform
         // version is not mission-critical
         if (null === $this->_conn) {
-            return null;
+            try {
+                $this->connect();
+            } catch (DriverException $e) {
+                // i.e. connection params are invalid or db doesn't exist
+                return null;
+            }
         }
 
         // Automatic platform version detection.

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -424,9 +424,12 @@ class Connection implements DriverConnection
             return $this->_params['serverVersion'];
         }
 
-        // If not connected, we need to connect now to determine the platform version.
+        // If not connected, we can't figure out the server version. If
+        // we try to connect, it may fail (e.g. no database), which would
+        // cause an error in our application when determining the platform
+        // version is not mission-critical
         if (null === $this->_conn) {
-            $this->connect();
+            return null;
         }
 
         // Automatic platform version detection.

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -403,15 +403,6 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
         $this->assertSame($result, $conn->fetchColumn($statement, $params, $column, $types));
     }
 
-    public function testConnectionIsClosed()
-    {
-        $this->_conn->close();
-
-        $this->setExpectedException('Doctrine\\DBAL\\Exception\\DriverException');
-
-        $this->_conn->quoteIdentifier('Bug');
-    }
-
     public function testGetPlatformVersionDoesNotFailOnBadConnection()
     {
         // the connection uses bogus connection requirements, so connecting

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -412,6 +412,14 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
         $this->_conn->quoteIdentifier('Bug');
     }
 
+    public function testGetPlatformVersionDoesNotFailOnBadConnection()
+    {
+        // the connection uses bogus connection requirements, so connecting
+        // *will* fail. We should be able to call this without connection
+        // and causing that exception
+        $this->_conn->getDatabasePlatform();
+    }
+
     public function testFetchAll()
     {
         $statement = 'SELECT * FROM foo WHERE bar = ?';


### PR DESCRIPTION
Hi guys!

This is a fix for http://www.doctrine-project.org/jira/browse/DBAL-1057. It leaves the ability to set the platform and platform version from sha: 3176f51d1426022d305c6531a9b9bc93a868bddd, but does not try to connect if we're not already connected. This is consistent with the previous behavior (again see the linked sha) - before there was never a connection made to determine the platform.

The alternate solution is to connect, but surround this by a try-catch (`PDOException`, `DriverException`, `Exception`?) and return `null`. in case we have some situation where the database isn't created or the connection information is wrong.

I know this issue is causing a lot of problems around my world (I ran into myself yesterday), so thanks in advance for the attention.

Thanks!
