### PR TITLE
Connection is not lazy anymore, since platform detection was introduced - exposing the issue via broken test

### DIFF
--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -405,7 +405,7 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
     {
         $this->_conn->close();
 
-        $this->setExpectedException('Doctrine\\DBAL\\Exception\\DriverException');
+        //$this->setExpectedException('Doctrine\\DBAL\\Exception\\DriverException');
 
         $this->_conn->quoteIdentifier('Bug');
     }

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -403,11 +403,20 @@ SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
 
     public function testConnectionIsClosed()
     {
+        // set the internal _conn to some value
+        $reflection = new \ReflectionObject($this->_conn);
+        $connProperty = $reflection->getProperty('_conn');
+        $connProperty->setAccessible(true);
+        $connProperty->setValue($this->_conn, new \stdClass);
+        $connValue = $connProperty->getValue($this->_conn);
+        $this->assertInstanceOf('stdClass', $connValue);
+
+        // close the connection
         $this->_conn->close();
 
-        //$this->setExpectedException('Doctrine\\DBAL\\Exception\\DriverException');
-
-        $this->_conn->quoteIdentifier('Bug');
+        // make sure the _conn has be set to null (but not unset)
+        $connNewValue = $connProperty->getValue($this->_conn);
+        $this->assertNull($connNewValue, 'Connection can\'t be closed.');
     }
 
     public function testFetchAll()


### PR DESCRIPTION
Hi guys!

This is not meant to be merged, at least not yet. The test added in #691 is flawed. It's failing NOT because there is an exception when trying to use a closed connection (in fact, if the connection is closed, it simply re-opens), but instead, the exception is:

> Access denied for user 'root'@'localhost' (using password: YES)

The tests should show this. The reason is that we're using connection parameters at the top of this class (https://github.com/doctrine/dbal/blob/master/tests/Doctrine/Tests/DBAL/ConnectionTest.php#L19) that, until now, were never used to _actually_ connect to the database. But now, they _are_ being used to connect to the database, but they're incorrect - they should be pulling from `TestUtil`.

So, this test needs to be fixed or removed.

Thanks!
