### PR TITLE
Handle default values for datetime/datetimetz columns in PostgreSQL

### DIFF
--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -426,6 +426,12 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
             case 'year':
                 $length = null;
                 break;
+            case 'timestamp':
+            case 'timestamptz':
+                if ($tableColumn['default'] === 'now()') {
+                    $tableColumn['default'] = $this->_platform->getCurrentTimestampSQL();
+                }
+                break;
 
             // PostgreSQL 9.4+ only
             case 'jsonb':

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -723,6 +723,14 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getGenerateAlterDefaultSql()
+    {
+        return ["ALTER TABLE test_table CHANGE test_column test_column VARCHAR(255) DEFAULT 'some_value' NOT NULL"];
+    }
+
+    /**
      * @group DBAL-423
      */
     public function testReturnsGuidTypeDeclarationSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -1299,6 +1299,46 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
     }
 
     /**
+     * Verify that setting a string column to have a default value
+     * does generate the correct ALTER statement.
+     */
+    public function testCompareDefaultString()
+    {
+        $oldColumn = new Column('test_column', Type::getType('string'), [
+            'default' => null,
+            'length' => 255,
+        ]);
+
+        $newColumn = new Column('test_column', Type::getType('string'), [
+            'default' => 'some_value',
+            'length' => 255,
+        ]);
+
+        $columnDiff = new ColumnDiff(
+            'test_column',
+            $newColumn,
+            ['default'],
+            $oldColumn
+        );
+
+        $tableDiff            = new TableDiff('test_table');
+        $tableDiff->fromTable = new Table('test_table');
+        $tableDiff->fromTable->addColumn('test_column', 'string');
+        $tableDiff->changedColumns[] = $columnDiff;
+
+        $sql = $this->platform->getAlterTableSQL($tableDiff);
+
+        self::assertEquals($this->getGenerateAlterDefaultSql(), $sql);
+    }
+
+    /**
+     * Return ALTER statement to set a string default.
+     *
+     * @return string
+     */
+    abstract protected function getGenerateAlterDefaultSql();
+
+    /**
      * @group DBAL-423
      */
     public function testReturnsGuidTypeDeclarationSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -789,6 +789,14 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getGenerateAlterDefaultSql()
+    {
+        return ["ALTER TABLE test_table ALTER test_column SET DEFAULT 'some_value'"];
+    }
+
+    /**
      * @group DBAL-423
      */
     public function testReturnsGuidTypeDeclarationSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1115,6 +1115,17 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getGenerateAlterDefaultSql()
+    {
+        return [
+            'ALTER TABLE test_table ALTER COLUMN test_column NVARCHAR(255) NOT NULL',
+            "ALTER TABLE test_table ADD CONSTRAINT DF_FDF7294D_EA8A8050 DEFAULT 'some_value' FOR test_column",
+        ];
+    }
+
+    /**
      * @dataProvider getGeneratesIdentifierNamesInDefaultConstraintDeclarationSQL
      * @group DBAL-830
      */

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -491,6 +491,17 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getGenerateAlterDefaultSql()
+    {
+        return [
+            "ALTER TABLE test_table ALTER COLUMN test_column SET DEFAULT 'some_value'",
+            "CALL SYSPROC.ADMIN_CMD ('REORG TABLE test_table')",
+        ];
+    }
+
+    /**
      * @group DBAL-423
      */
     public function testReturnsGuidTypeDeclarationSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -619,6 +619,14 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getGenerateAlterDefaultSql()
+    {
+        return ["ALTER TABLE test_table MODIFY (test_column VARCHAR2(255) DEFAULT 'some_value')"];
+    }
+
+    /**
      * @group DBAL-423
      */
     public function testReturnsGuidTypeDeclarationSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -865,6 +865,14 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getGenerateAlterDefaultSql()
+    {
+        return ["ALTER TABLE test_table ALTER test_column VARCHAR(255) DEFAULT 'some_value' NOT NULL"];
+    }
+
+    /**
      * @group DBAL-423
      */
     public function testReturnsGuidTypeDeclarationSQL()

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -588,6 +588,20 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getGenerateAlterDefaultSql()
+    {
+        return [
+            'CREATE TEMPORARY TABLE __temp__test_table AS SELECT test_column FROM test_table',
+            'DROP TABLE test_table',
+            "CREATE TABLE test_table (test_column VARCHAR(255) DEFAULT 'some_value' NOT NULL)",
+            'INSERT INTO test_table (test_column) SELECT test_column FROM __temp__test_table',
+            'DROP TABLE __temp__test_table',
+        ];
+    }
+
+    /**
      * @group DBAL-423
      */
     public function testReturnsGuidTypeDeclarationSQL()


### PR DESCRIPTION
(This was originally in #670 but am re-submitting due to a busted merge)

When dealing with legacy schema it would be nice to be able to map default values and not have the schema spit out ALTER statements each time. This works correctly today for basic integer and string columns, but does not handle columns with special types such as boolean or datetime.

For example, the following statement:

`ALTER TABLE test_table ALTER test_column SET DEFAULT CURRENT_TIMESTAMP;`

Results in a column definition like:

`test_column | timestamp with time zone | not null default now()`

However, repeating the same schema generation will result in the same ALTER statement each time, because it will always detect that the default value has changed. The same is true for boolean columns.

This simple change prevents this situation from happening and correctly detects that the column default has not changed. It is specific to PostgreSQL.
