### PR TITLE
Fix removing autoincrement column from a primary key

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -659,7 +659,8 @@ class MySqlPlatform extends AbstractPlatform
             // Dropping primary keys requires to unset autoincrement attribute on the particular column first
             if ($chgIndex->isPrimary() && $diff->fromTable instanceof Table) {
 
-                foreach ($diff->fromTable->getIndex($chgIndex->getName())->getColumns() as $columnName) {
+                // when chgIndex->isPrimary we can be sure fromTable->hasPrimaryKey is true
+                foreach ($diff->fromTable->getPrimaryKeyColumns() as $columnName) {
                     $column = $diff->fromTable->getColumn($columnName);
 
                     if ($column->getAutoincrement() === true && in_array($columnName, $chgIndex->getColumns()) === false) {

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -654,6 +654,24 @@ class MySqlPlatform extends AbstractPlatform
             }
         }
 
+        // handle columns that are removed from changed indexes
+        foreach ($diff->changedIndexes as $chgKey => $chgIndex) {
+            // Dropping primary keys requires to unset autoincrement attribute on the particular column first
+            if ($chgIndex->isPrimary() && $diff->fromTable instanceof Table) {
+
+                foreach ($diff->fromTable->getIndex($chgIndex->getName())->getColumns() as $columnName) {
+                    $column = $diff->fromTable->getColumn($columnName);
+
+                    if ($column->getAutoincrement() === true && in_array($columnName, $chgIndex->getColumns()) === false) {
+                        $column->setAutoincrement(false);
+
+                        $sql[] = 'ALTER TABLE ' . $table . ' MODIFY ' .
+                            $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray());
+                    }
+                }
+            }
+        }
+
         $engine = 'INNODB';
 
         if ($diff->fromTable instanceof Table && $diff->fromTable->hasOption('engine')) {

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -625,6 +625,9 @@ class MySqlPlatform extends AbstractPlatform
 
                         $sql[] = 'ALTER TABLE ' . $table . ' MODIFY ' .
                             $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray());
+
+                        // original autoincrement information might be needed later on by other parts of the table alteration
+                        $column->setAutoincrement(true);
                     }
                 }
             }
@@ -668,6 +671,9 @@ class MySqlPlatform extends AbstractPlatform
 
                         $sql[] = 'ALTER TABLE ' . $table . ' MODIFY ' .
                             $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray());
+
+                        // original autoincrement information might be needed later on by other parts of the table alteration
+                        $column->setAutoincrement(true);
                     }
                 }
             }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -329,6 +329,32 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     /**
      * @group DBAL-464
      */
+    public function testAlterPrimaryKeyWithAutoincrementColumn()
+    {
+        $table = new Table("drop_primary_key");
+        $table->addColumn('id', 'integer', array('primary' => true, 'autoincrement' => true));
+        $table->addColumn('foo', 'integer');
+        $table->setPrimaryKey(array('id'));
+
+        $comparator = new Comparator();
+        $diffTable = clone $table;
+
+        $diffTable->dropPrimaryKey();
+        $diffTable->setPrimaryKey(array('foo'));
+
+        $this->assertEquals(
+            array(
+                'ALTER TABLE drop_primary_key MODIFY id INT NOT NULL',
+                'ALTER TABLE drop_primary_key DROP PRIMARY KEY',
+                'ALTER TABLE drop_primary_key ADD PRIMARY KEY (foo)'
+            ),
+            $this->_platform->getAlterTableSQL($comparator->diffTable($table, $diffTable))
+        );
+    }
+
+    /**
+     * @group DBAL-464
+     */
     public function testDropPrimaryKeyWithAutoincrementColumn()
     {
         $table = new Table("drop_primary_key");

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -332,7 +332,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testAlterPrimaryKeyWithAutoincrementColumn()
     {
         $table = new Table("drop_primary_key");
-        $table->addColumn('id', 'integer', array('primary' => true, 'autoincrement' => true));
+        $table->addColumn('id', 'integer', array('autoincrement' => true));
         $table->addColumn('foo', 'integer');
         $table->setPrimaryKey(array('id'));
 
@@ -358,8 +358,8 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testDropPrimaryKeyWithAutoincrementColumn()
     {
         $table = new Table("drop_primary_key");
-        $table->addColumn('id', 'integer', array('primary' => true, 'autoincrement' => true));
-        $table->addColumn('foo', 'integer', array('primary' => true));
+        $table->addColumn('id', 'integer', array('autoincrement' => true));
+        $table->addColumn('foo', 'integer');
         $table->addColumn('bar', 'integer');
         $table->setPrimaryKey(array('id', 'foo'));
 


### PR DESCRIPTION
https://github.com/doctrine/dbal/pull/430 is only a partial fix for DBAL-464. This adds treating autoincrement columns that get removed when altering a primary key.
