### PR TITLE
Add left-over console file to the mapped composer binaries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."
     },
-    "bin": ["bin/doctrine-dbal"],
+    "bin": ["bin/doctrine-dbal", "bin/doctrine-dbal.php"],
     "autoload": {
         "psr-0": { "Doctrine\\DBAL\\": "lib/" }
     },


### PR DESCRIPTION
`bin/doctrine-dbal` includes `bin/doctrine-dbal.php`, but the later is not symlinked to the `vendor/bin` directory of projects as it is not declared in composer.json. This PR declares the file as a vendor binary.
