### PR TITLE
Improved failure resilience for array type

### DIFF
--- a/lib/Doctrine/DBAL/Types/ArrayType.php
+++ b/lib/Doctrine/DBAL/Types/ArrayType.php
@@ -57,7 +57,7 @@ class ArrayType extends Type
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
         $val = unserialize($value);
         if ($val === false && $value != 'b:0;') {
-            throw ConversionException::conversionFailed($value, $this->getName());
+            return array();
         }
 
         return $val;


### PR DESCRIPTION
The array type is the only one that throws an error if the value can't be decoded and that causes problems if the database column is empty or invalid. The patch adjusts the behavior to the rest of the implemented types.
