### PR TITLE
Fix when finding arrays of binary strings

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -245,10 +245,11 @@ SQL injection possibilities if not handled carefully.
 Doctrine DBAL implements a very powerful parsing process that will make this kind of prepared
 statement possible natively in the binding type system.
 The parsing necessarily comes with a performance overhead, but only if you really use a list of parameters.
-There are two special binding types that describe a list of integers or strings:
+There are three special binding types that describe a list of integers, strings, or binary strings:
 
 -   ``\Doctrine\DBAL\Connection::PARAM_INT_ARRAY``
 -   ``\Doctrine\DBAL\Connection::PARAM_STR_ARRAY``
+-   ``\Doctrine\DBAL\Connection::PARAM_LOB_ARRAY``
 
 Using one of this constants as a type you can activate the SQLParser inside Doctrine that rewrites
 the SQL and flattens the specified values into the set of parameters. Consider our previous example:

--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -245,7 +245,7 @@ SQL injection possibilities if not handled carefully.
 Doctrine DBAL implements a very powerful parsing process that will make this kind of prepared
 statement possible natively in the binding type system.
 The parsing necessarily comes with a performance overhead, but only if you really use a list of parameters.
-There are three special binding types that describe a list of integers, strings, or binary strings:
+There are three special binding types that describe a list of integers, strings, or large objects (binary strings):
 
 -   ``\Doctrine\DBAL\Connection::PARAM_INT_ARRAY``
 -   ``\Doctrine\DBAL\Connection::PARAM_STR_ARRAY``

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -84,6 +84,13 @@ class Connection implements DriverConnection
     const PARAM_STR_ARRAY = 102;
 
     /**
+     * Represents an array of binary strings to be expanded by Doctrine SQL parsing.
+     *
+     * @var integer
+     */
+    const PARAM_LOB_ARRAY = 103;
+
+    /**
      * Offset by which PARAM_* constants are detected as arrays of the param type.
      *
      * @var integer

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -84,7 +84,7 @@ class Connection implements DriverConnection
     const PARAM_STR_ARRAY = 102;
 
     /**
-     * Represents an array of binary strings to be expanded by Doctrine SQL parsing.
+     * Represents an array of large objects to be expanded by Doctrine SQL parsing.
      *
      * @var integer
      */

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -89,11 +89,6 @@ class SQLParserUtils
         $isPositional   = is_int(key($params));
         $arrayPositions = array();
         $bindIndex      = -1;
-        $relevantArrayTypes = array(
-            Connection::PARAM_INT_ARRAY,
-            Connection::PARAM_STR_ARRAY,
-            Connection::PARAM_LOB_ARRAY,
-        );
 
         if ($isPositional) {
             ksort($params);
@@ -103,7 +98,9 @@ class SQLParserUtils
         foreach ($types as $name => $type) {
             ++$bindIndex;
 
-            if (!in_array($type, $relevantArrayTypes)) {
+            if ($type !== Connection::PARAM_INT_ARRAY
+                && $type !== Connection::PARAM_STR_ARRAY
+                && $type !== Connection::PARAM_LOB_ARRAY) {
                 continue;
             }
 

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -89,6 +89,11 @@ class SQLParserUtils
         $isPositional   = is_int(key($params));
         $arrayPositions = array();
         $bindIndex      = -1;
+        $relevantArrayTypes = array(
+            Connection::PARAM_INT_ARRAY,
+            Connection::PARAM_STR_ARRAY,
+            Connection::PARAM_LOB_ARRAY,
+        );
 
         if ($isPositional) {
             ksort($params);
@@ -98,7 +103,7 @@ class SQLParserUtils
         foreach ($types as $name => $type) {
             ++$bindIndex;
 
-            if ($type !== Connection::PARAM_INT_ARRAY && $type !== Connection::PARAM_STR_ARRAY) {
+            if (!in_array($type, $relevantArrayTypes)) {
                 continue;
             }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -21,6 +21,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
             $table->addColumn('test_int', 'integer');
             $table->addColumn('test_string', 'string');
             $table->addColumn('test_datetime', 'datetime', array('notnull' => false));
+            $table->addColumn('test_binary', 'binary', array('notnull' => false));
             $table->setPrimaryKey(array('test_int'));
 
             $sm = $this->_conn->getSchemaManager();
@@ -441,11 +442,11 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals(array(array(100), array(101), array(102), array(103), array(104)), $data);
 
         $stmt = $this->_conn->executeQuery('SELECT test_int FROM fetch_table WHERE test_binary IN (?)',
-            array(array($binaryValue)), array(Connection::PARAM_LOB_ARRAY));
+            array(array($binaryValue)), array(Connection::PARAM_STR_ARRAY));
 
         $data = $stmt->fetchAll(PDO::FETCH_NUM);
-        $this->assertEquals(5, count($data));
-        $this->assertEquals(array(array(100), array(101), array(102), array(103), array(104)), $data);
+        $this->assertEquals(10, count($data));
+        $this->assertEquals(array(array(100), array(101), array(102), array(103), array(104), array(105), array(106), array(107), array(108), array(109)), $data);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -27,7 +27,11 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
             $sm = $this->_conn->getSchemaManager();
             $sm->createTable($table);
 
-            $this->_conn->insert('fetch_table', array('test_int' => 1, 'test_string' => 'foo', 'test_datetime' => '2010-01-01 10:10:10'));
+            $this->_conn->insert('fetch_table', array(
+                'test_int'      => 1,
+                'test_string'   => 'foo',
+                'test_datetime' => '2010-01-01 10:10:10'
+            ));
             self::$generated = true;
         }
     }
@@ -424,7 +428,11 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
                     'test_string'   => 'foo' . $i,
                     'test_datetime' => '2010-01-01 10:10:10',
                     'test_binary'   => $binaryValue
-                ));
+                ),
+                array(
+                    'test_binary' => PDO::PARAM_LOB
+                )
+            );
         }
 
         $stmt = $this->_conn->executeQuery('SELECT test_int FROM fetch_table WHERE test_int IN (?)',
@@ -442,7 +450,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals(array(array(100), array(101), array(102), array(103), array(104)), $data);
 
         $stmt = $this->_conn->executeQuery('SELECT test_int FROM fetch_table WHERE test_binary IN (?)',
-            array(array($binaryValue)), array(Connection::PARAM_STR_ARRAY));
+            array(array($binaryValue)), array(Connection::PARAM_LOB_ARRAY));
 
         $data = $stmt->fetchAll(PDO::FETCH_NUM);
         $this->assertEquals(10, count($data));

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -415,8 +415,15 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
      */
     public function testNativeArrayListSupport()
     {
+        $binaryValue = pack("nvc*", 0x1234, 0x5678, 65, 66);
+
         for ($i = 100; $i < 110; $i++) {
-            $this->_conn->insert('fetch_table', array('test_int' => $i, 'test_string' => 'foo' . $i, 'test_datetime' => '2010-01-01 10:10:10'));
+            $this->_conn->insert('fetch_table', array(
+                    'test_int'      => $i,
+                    'test_string'   => 'foo' . $i,
+                    'test_datetime' => '2010-01-01 10:10:10',
+                    'test_binary'   => $binaryValue
+                ));
         }
 
         $stmt = $this->_conn->executeQuery('SELECT test_int FROM fetch_table WHERE test_int IN (?)',
@@ -428,6 +435,13 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $stmt = $this->_conn->executeQuery('SELECT test_int FROM fetch_table WHERE test_string IN (?)',
             array(array('foo100', 'foo101', 'foo102', 'foo103', 'foo104')), array(Connection::PARAM_STR_ARRAY));
+
+        $data = $stmt->fetchAll(PDO::FETCH_NUM);
+        $this->assertEquals(5, count($data));
+        $this->assertEquals(array(array(100), array(101), array(102), array(103), array(104)), $data);
+
+        $stmt = $this->_conn->executeQuery('SELECT test_int FROM fetch_table WHERE test_binary IN (?)',
+            array(array($binaryValue)), array(Connection::PARAM_LOB_ARRAY));
 
         $data = $stmt->fetchAll(PDO::FETCH_NUM);
         $this->assertEquals(5, count($data));

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -52,6 +52,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('bar'=>PDO::PARAM_INT,'baz'=>Connection::PARAM_LOB_ARRAY),
                 array(
                     array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
+                    array('id'=>5,'foo'=>2,'bar'=>1,'baz'=>$binaryData),
                 )
             ),
 

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -177,6 +177,10 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $result = $stmt->fetchAll(\PDO::FETCH_ASSOC);
 
         foreach ($result as $k => $v) {
+            if(is_resource($v)){
+                $v = stream_get_contents($v);
+                $result[$k] = $v;
+            }
             $result[$k] = array_change_key_case($v, CASE_LOWER);
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -178,8 +178,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         foreach ($result as $k => $v) {
             if(is_resource($v["baz"])){
-                $binaryContents = stream_get_contents($v["baz"]);
-                $result[$k]["baz"] = $binaryContents;
+                $v["baz"] = stream_get_contents($v["baz"]);
             }
             $result[$k] = array_change_key_case($v, CASE_LOWER);
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -11,6 +11,16 @@ use PDO;
 class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
 
+    /**
+     * @var string
+     */
+    private $binaryData;
+
+    /**
+     * @var string
+     */
+    private $otherBinary;
+
     public function ticketProvider()
     {
         return array(
@@ -19,9 +29,18 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('foo'=>1,'bar'=> array(1, 2, 3)),
                 array('foo'=>PDO::PARAM_INT,'bar'=> Connection::PARAM_INT_ARRAY,),
                 array(
-                    array('id'=>1,'foo'=>1,'bar'=>1),
-                    array('id'=>2,'foo'=>1,'bar'=>2),
-                    array('id'=>3,'foo'=>1,'bar'=>3),
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
+                )
+            ),
+
+            array(
+                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar IN (:bar) AND f.baz = :baz',
+                array('foo'=>1,'bar'=> array(1, 2, 3),'baz'=>$this->otherBinary),
+                array('foo'=>PDO::PARAM_INT,'bar'=>Connection::PARAM_INT_ARRAY,PDO::PARAM_LOB),
+                array(
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
                 )
             ),
 
@@ -30,9 +49,19 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('foo'=>1,'bar'=> array(1, 2, 3)),
                 array('bar'=> Connection::PARAM_INT_ARRAY,'foo'=>PDO::PARAM_INT),
                 array(
-                    array('id'=>1,'foo'=>1,'bar'=>1),
-                    array('id'=>2,'foo'=>1,'bar'=>2),
-                    array('id'=>3,'foo'=>1,'bar'=>3),
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
+                )
+            ),
+
+            array(
+                'SELECT * FROM ddc1372_foobar f WHERE f.bar = :bar AND f.baz IN (:baz)',
+                array('bar'=>1,'baz'=> array($this->binaryData, $this->otherBinary)),
+                array('bar'=>Connection::PARAM_INT_ARRAY,'baz'=>Connection::PARAM_LOB_ARRAY),
+                array(
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
+                    array('id'=>5,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
                 )
             ),
 
@@ -41,9 +70,9 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('foo'=>1,'bar'=> array(1, 2, 3)),
                 array('bar'=> Connection::PARAM_INT_ARRAY,'foo'=>PDO::PARAM_INT),
                 array(
-                    array('id'=>1,'foo'=>1,'bar'=>1),
-                    array('id'=>2,'foo'=>1,'bar'=>2),
-                    array('id'=>3,'foo'=>1,'bar'=>3),
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
                 )
             ),
 
@@ -52,9 +81,9 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('foo'=>1,'bar'=> array('1', '2', '3')),
                 array('bar'=> Connection::PARAM_STR_ARRAY,'foo'=>PDO::PARAM_INT),
                 array(
-                    array('id'=>1,'foo'=>1,'bar'=>1),
-                    array('id'=>2,'foo'=>1,'bar'=>2),
-                    array('id'=>3,'foo'=>1,'bar'=>3),
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
                 )
             ),
 
@@ -63,10 +92,10 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('foo'=>array('1'),'bar'=> array(1, 2, 3,4)),
                 array('bar'=> Connection::PARAM_STR_ARRAY,'foo'=>Connection::PARAM_INT_ARRAY),
                 array(
-                    array('id'=>1,'foo'=>1,'bar'=>1),
-                    array('id'=>2,'foo'=>1,'bar'=>2),
-                    array('id'=>3,'foo'=>1,'bar'=>3),
-                    array('id'=>4,'foo'=>1,'bar'=>4),
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
+                    array('id'=>4,'foo'=>1,'bar'=>4,'baz'=>$this->otherBinary),
                 )
             ),
 
@@ -75,7 +104,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('foo'=>1,'bar'=> 2),
                 array('bar'=>PDO::PARAM_INT,'foo'=>PDO::PARAM_INT),
                 array(
-                    array('id'=>2,'foo'=>1,'bar'=>2),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
                 )
             ),
 
@@ -84,7 +113,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('arg'=>'1'),
                 array('arg'=>PDO::PARAM_STR),
                 array(
-                    array('id'=>5,'foo'=>2,'bar'=>1),
+                    array('id'=>5,'foo'=>2,'bar'=>1,'baz'=>$this->binaryData),
                 )
             ),
 
@@ -93,8 +122,8 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('arg'=>array(1, 2)),
                 array('arg'=>Connection::PARAM_INT_ARRAY),
                 array(
-                    array('id'=>3,'foo'=>1,'bar'=>3),
-                    array('id'=>4,'foo'=>1,'bar'=>4),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
+                    array('id'=>4,'foo'=>1,'bar'=>4,'baz'=>$this->otherBinary),
                 )
             ),
 
@@ -113,29 +142,29 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 $table->addColumn('bar','string');
                 $table->addColumn('baz','binary');
                 $table->setPrimaryKey(array('id'));
-                $binaryData  = pack("nvc*", 0x1234, 0x5678, 65, 66);
-                $otherBinary = pack("nvc*", 0x1234, 0x5678, 64, 67, 68);
+                $this->binaryData  = pack("nvc*", 0x1234, 0x5678, 65, 66);
+                $this->otherBinary = pack("nvc*", 0x1234, 0x5678, 64, 67, 68);
 
                 $sm = $this->_conn->getSchemaManager();
                 $sm->createTable($table);
 
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 1, 'foo'   => 1,  'bar'   => 1, 'baz' => $binaryData
+                        'id'    => 1, 'foo'   => 1,  'bar'   => 1, 'baz' => $this->binaryData
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 2, 'foo'   => 1,  'bar'   => 2, 'baz' => $otherBinary
+                        'id'    => 2, 'foo'   => 1,  'bar'   => 2, 'baz' => $this->otherBinary
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 3, 'foo'   => 1,  'bar'   => 3, 'baz' => $binaryData
+                        'id'    => 3, 'foo'   => 1,  'bar'   => 3, 'baz' => $this->binaryData
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 4, 'foo'   => 1,  'bar'   => 4, 'baz' => $otherBinary
+                        'id'    => 4, 'foo'   => 1,  'bar'   => 4, 'baz' => $this->otherBinary
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 5, 'foo'   => 2,  'bar'   => 1, 'baz' => $binaryData
+                        'id'    => 5, 'foo'   => 2,  'bar'   => 1, 'baz' => $this->binaryData
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 6, 'foo'   => 2,  'bar'   => 2, 'baz' => $otherBinary
+                        'id'    => 6, 'foo'   => 2,  'bar'   => 2, 'baz' => $this->otherBinary
                 ));
             } catch(\Exception $e) {
                 $this->fail($e->getMessage());

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -177,9 +177,9 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $result = $stmt->fetchAll(\PDO::FETCH_ASSOC);
 
         foreach ($result as $k => $v) {
-            if(is_resource($v)){
-                $v = stream_get_contents($v);
-                $result[$k] = $v;
+            if(is_resource($v["baz"])){
+                $binaryContents = stream_get_contents($v["baz"]);
+                $result[$k]["baz"] = $binaryContents;
             }
             $result[$k] = array_change_key_case($v, CASE_LOWER);
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -50,7 +50,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.bar = :bar AND f.baz IN (:baz)',
                 array('bar'=>1,'baz'=> array($binaryData, $otherBinary)),
-                array('bar'=>Connection::PARAM_INT_ARRAY,'baz'=>Connection::PARAM_LOB_ARRAY),
+                array('bar'=>PDO::PARAM_INT,'baz'=>Connection::PARAM_LOB_ARRAY),
                 array(
                     array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
                     array('id'=>5,'foo'=>1,'bar'=>1,'baz'=>$binaryData),

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -27,9 +27,9 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
             ),
 
             array(
-                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar IN (:bar) AND BINARY f.baz = :baz',
+                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar IN (:bar) AND f.baz = :baz',
                 array('foo' => 1,'bar' => array(1, 2, 3), 'baz' => $otherBinary),
-                array('foo'=>PDO::PARAM_INT,'bar'=>Connection::PARAM_INT_ARRAY, 'baz'=>PDO::PARAM_LOB),
+                array('foo'=>PDO::PARAM_INT,'bar'=>Connection::PARAM_INT_ARRAY, 'baz'=>PDO::PARAM_STR),
                 array(
                     array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$otherBinary),
                 )
@@ -47,9 +47,9 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
             ),
 
             array(
-                'SELECT * FROM ddc1372_foobar f WHERE f.bar = :bar AND BINARY f.baz IN (:baz)',
+                'SELECT * FROM ddc1372_foobar f WHERE f.bar = :bar AND f.baz IN (:baz)',
                 array('bar'=>1,'baz'=> array($binaryData, $otherBinary)),
-                array('bar'=>PDO::PARAM_INT,'baz'=>Connection::PARAM_LOB_ARRAY),
+                array('bar'=>PDO::PARAM_INT,'baz'=>Connection::PARAM_STR_ARRAY),
                 array(
                     array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
                     array('id'=>5,'foo'=>2,'bar'=>1,'baz'=>$binaryData),

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -29,7 +29,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar IN (:bar) AND f.baz = :baz',
                 array('foo' => 1,'bar' => array(1, 2, 3), 'baz' => $otherBinary),
-                array('foo'=>PDO::PARAM_INT,'bar'=>Connection::PARAM_INT_ARRAY, 'baz'=>PDO::PARAM_STR),
+                array('foo'=>PDO::PARAM_INT,'bar'=>Connection::PARAM_INT_ARRAY, 'baz'=>PDO::PARAM_LOB),
                 array(
                     array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$otherBinary),
                 )
@@ -49,7 +49,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.bar = :bar AND f.baz IN (:baz)',
                 array('bar'=>1,'baz'=> array($binaryData, $otherBinary)),
-                array('bar'=>PDO::PARAM_INT,'baz'=>Connection::PARAM_STR_ARRAY),
+                array('bar'=>PDO::PARAM_INT,'baz'=>Connection::PARAM_LOB_ARRAY),
                 array(
                     array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
                     array('id'=>5,'foo'=>2,'bar'=>1,'baz'=>$binaryData),
@@ -142,22 +142,22 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
                 $this->_conn->insert('ddc1372_foobar', array(
                         'id'    => 1, 'foo'   => 1,  'bar'   => 1, 'baz' => $binaryData
-                ));
+                ), array('baz' => PDO::PARAM_LOB));
                 $this->_conn->insert('ddc1372_foobar', array(
                         'id'    => 2, 'foo'   => 1,  'bar'   => 2, 'baz' => $otherBinary
-                ));
+                ), array('baz' => PDO::PARAM_LOB));
                 $this->_conn->insert('ddc1372_foobar', array(
                         'id'    => 3, 'foo'   => 1,  'bar'   => 3, 'baz' => $binaryData
-                ));
+                ), array('baz' => PDO::PARAM_LOB));
                 $this->_conn->insert('ddc1372_foobar', array(
                         'id'    => 4, 'foo'   => 1,  'bar'   => 4, 'baz' => $otherBinary
-                ));
+                ), array('baz' => PDO::PARAM_LOB));
                 $this->_conn->insert('ddc1372_foobar', array(
                         'id'    => 5, 'foo'   => 2,  'bar'   => 1, 'baz' => $binaryData
-                ));
+                ), array('baz' => PDO::PARAM_LOB));
                 $this->_conn->insert('ddc1372_foobar', array(
                         'id'    => 6, 'foo'   => 2,  'bar'   => 2, 'baz' => $otherBinary
-                ));
+                ), array('baz' => PDO::PARAM_LOB));
             } catch(\Exception $e) {
                 $this->fail($e->getMessage());
             }

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -52,7 +52,6 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('bar'=>PDO::PARAM_INT,'baz'=>Connection::PARAM_LOB_ARRAY),
                 array(
                     array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
-                    array('id'=>5,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
                 )
             ),
 

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -111,29 +111,31 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 $table->addColumn('id', 'integer');
                 $table->addColumn('foo','string');
                 $table->addColumn('bar','string');
+                $table->addColumn('baz','binary');
                 $table->setPrimaryKey(array('id'));
-
+                $binaryData  = pack("nvc*", 0x1234, 0x5678, 65, 66);
+                $otherBinary = pack("nvc*", 0x1234, 0x5678, 64, 67, 68);
 
                 $sm = $this->_conn->getSchemaManager();
                 $sm->createTable($table);
 
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 1, 'foo'   => 1,  'bar'   => 1
+                        'id'    => 1, 'foo'   => 1,  'bar'   => 1, 'baz' => $binaryData
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 2, 'foo'   => 1,  'bar'   => 2
+                        'id'    => 2, 'foo'   => 1,  'bar'   => 2, 'baz' => $otherBinary
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 3, 'foo'   => 1,  'bar'   => 3
+                        'id'    => 3, 'foo'   => 1,  'bar'   => 3, 'baz' => $binaryData
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 4, 'foo'   => 1,  'bar'   => 4
+                        'id'    => 4, 'foo'   => 1,  'bar'   => 4, 'baz' => $otherBinary
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 5, 'foo'   => 2,  'bar'   => 1
+                        'id'    => 5, 'foo'   => 2,  'bar'   => 1, 'baz' => $binaryData
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 6, 'foo'   => 2,  'bar'   => 2
+                        'id'    => 6, 'foo'   => 2,  'bar'   => 2, 'baz' => $otherBinary
                 ));
             } catch(\Exception $e) {
                 $this->fail($e->getMessage());

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -11,36 +11,28 @@ use PDO;
 class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
 
-    /**
-     * @var string
-     */
-    private $binaryData;
-
-    /**
-     * @var string
-     */
-    private $otherBinary;
-
     public function ticketProvider()
     {
+        $binaryData  = pack("nvc*", 0x1234, 0x5678, 65, 66);
+        $otherBinary = pack("nvc*", 0x1234, 0x5678, 64, 67, 68);
         return array(
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar IN (:bar)',
                 array('foo'=>1,'bar'=> array(1, 2, 3)),
                 array('foo'=>PDO::PARAM_INT,'bar'=> Connection::PARAM_INT_ARRAY,),
                 array(
-                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
-                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
-                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$otherBinary),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$binaryData),
                 )
             ),
 
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar IN (:bar) AND f.baz = :baz',
-                array('foo'=>1,'bar'=> array(1, 2, 3),'baz'=>$this->otherBinary),
+                array('foo'=>1,'bar'=> array(1, 2, 3),'baz'=>$otherBinary),
                 array('foo'=>PDO::PARAM_INT,'bar'=>Connection::PARAM_INT_ARRAY,PDO::PARAM_LOB),
                 array(
-                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$otherBinary),
                 )
             ),
 
@@ -49,19 +41,19 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('foo'=>1,'bar'=> array(1, 2, 3)),
                 array('bar'=> Connection::PARAM_INT_ARRAY,'foo'=>PDO::PARAM_INT),
                 array(
-                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
-                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
-                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$otherBinary),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$binaryData),
                 )
             ),
 
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.bar = :bar AND f.baz IN (:baz)',
-                array('bar'=>1,'baz'=> array($this->binaryData, $this->otherBinary)),
+                array('bar'=>1,'baz'=> array($binaryData, $otherBinary)),
                 array('bar'=>Connection::PARAM_INT_ARRAY,'baz'=>Connection::PARAM_LOB_ARRAY),
                 array(
-                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
-                    array('id'=>5,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
+                    array('id'=>5,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
                 )
             ),
 
@@ -70,9 +62,9 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('foo'=>1,'bar'=> array(1, 2, 3)),
                 array('bar'=> Connection::PARAM_INT_ARRAY,'foo'=>PDO::PARAM_INT),
                 array(
-                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
-                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
-                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$otherBinary),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$binaryData),
                 )
             ),
 
@@ -81,9 +73,9 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('foo'=>1,'bar'=> array('1', '2', '3')),
                 array('bar'=> Connection::PARAM_STR_ARRAY,'foo'=>PDO::PARAM_INT),
                 array(
-                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
-                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
-                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$otherBinary),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$binaryData),
                 )
             ),
 
@@ -92,10 +84,10 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('foo'=>array('1'),'bar'=> array(1, 2, 3,4)),
                 array('bar'=> Connection::PARAM_STR_ARRAY,'foo'=>Connection::PARAM_INT_ARRAY),
                 array(
-                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$this->binaryData),
-                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
-                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
-                    array('id'=>4,'foo'=>1,'bar'=>4,'baz'=>$this->otherBinary),
+                    array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$otherBinary),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$binaryData),
+                    array('id'=>4,'foo'=>1,'bar'=>4,'baz'=>$otherBinary),
                 )
             ),
 
@@ -104,7 +96,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('foo'=>1,'bar'=> 2),
                 array('bar'=>PDO::PARAM_INT,'foo'=>PDO::PARAM_INT),
                 array(
-                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$this->otherBinary),
+                    array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$otherBinary),
                 )
             ),
 
@@ -113,7 +105,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('arg'=>'1'),
                 array('arg'=>PDO::PARAM_STR),
                 array(
-                    array('id'=>5,'foo'=>2,'bar'=>1,'baz'=>$this->binaryData),
+                    array('id'=>5,'foo'=>2,'bar'=>1,'baz'=>$binaryData),
                 )
             ),
 
@@ -122,8 +114,8 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 array('arg'=>array(1, 2)),
                 array('arg'=>Connection::PARAM_INT_ARRAY),
                 array(
-                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$this->binaryData),
-                    array('id'=>4,'foo'=>1,'bar'=>4,'baz'=>$this->otherBinary),
+                    array('id'=>3,'foo'=>1,'bar'=>3,'baz'=>$binaryData),
+                    array('id'=>4,'foo'=>1,'bar'=>4,'baz'=>$otherBinary),
                 )
             ),
 
@@ -133,7 +125,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-
+        
         if (!$this->_conn->getSchemaManager()->tablesExist("ddc1372_foobar")) {
             try {
                 $table = new \Doctrine\DBAL\Schema\Table("ddc1372_foobar");
@@ -142,29 +134,30 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 $table->addColumn('bar','string');
                 $table->addColumn('baz','binary');
                 $table->setPrimaryKey(array('id'));
-                $this->binaryData  = pack("nvc*", 0x1234, 0x5678, 65, 66);
-                $this->otherBinary = pack("nvc*", 0x1234, 0x5678, 64, 67, 68);
-
+                
                 $sm = $this->_conn->getSchemaManager();
                 $sm->createTable($table);
 
+                $binaryData  = pack("nvc*", 0x1234, 0x5678, 65, 66);
+                $otherBinary = pack("nvc*", 0x1234, 0x5678, 64, 67, 68);
+
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 1, 'foo'   => 1,  'bar'   => 1, 'baz' => $this->binaryData
+                        'id'    => 1, 'foo'   => 1,  'bar'   => 1, 'baz' => $binaryData
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 2, 'foo'   => 1,  'bar'   => 2, 'baz' => $this->otherBinary
+                        'id'    => 2, 'foo'   => 1,  'bar'   => 2, 'baz' => $otherBinary
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 3, 'foo'   => 1,  'bar'   => 3, 'baz' => $this->binaryData
+                        'id'    => 3, 'foo'   => 1,  'bar'   => 3, 'baz' => $binaryData
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 4, 'foo'   => 1,  'bar'   => 4, 'baz' => $this->otherBinary
+                        'id'    => 4, 'foo'   => 1,  'bar'   => 4, 'baz' => $otherBinary
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 5, 'foo'   => 2,  'bar'   => 1, 'baz' => $this->binaryData
+                        'id'    => 5, 'foo'   => 2,  'bar'   => 1, 'baz' => $binaryData
                 ));
                 $this->_conn->insert('ddc1372_foobar', array(
-                        'id'    => 6, 'foo'   => 2,  'bar'   => 2, 'baz' => $this->otherBinary
+                        'id'    => 6, 'foo'   => 2,  'bar'   => 2, 'baz' => $otherBinary
                 ));
             } catch(\Exception $e) {
                 $this->fail($e->getMessage());

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -10,7 +10,6 @@ use PDO;
  */
 class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
-
     public function ticketProvider()
     {
         $binaryData  = pack("nvc*", 0x1234, 0x5678, 65, 66);
@@ -19,7 +18,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
             array(
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar IN (:bar)',
                 array('foo'=>1,'bar'=> array(1, 2, 3)),
-                array('foo'=>PDO::PARAM_INT,'bar'=> Connection::PARAM_INT_ARRAY,),
+                array('foo'=>PDO::PARAM_INT,'bar'=> Connection::PARAM_INT_ARRAY),
                 array(
                     array('id'=>1,'foo'=>1,'bar'=>1,'baz'=>$binaryData),
                     array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$otherBinary),
@@ -28,9 +27,9 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
             ),
 
             array(
-                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar IN (:bar) AND f.baz = :baz',
-                array('foo'=>1,'bar'=> array(1, 2, 3),'baz'=>$otherBinary),
-                array('foo'=>PDO::PARAM_INT,'bar'=>Connection::PARAM_INT_ARRAY,PDO::PARAM_LOB),
+                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar IN (:bar) AND BINARY f.baz = :baz',
+                array('foo' => 1,'bar' => array(1, 2, 3), 'baz' => $otherBinary),
+                array('foo'=>PDO::PARAM_INT,'bar'=>Connection::PARAM_INT_ARRAY, 'baz'=>PDO::PARAM_LOB),
                 array(
                     array('id'=>2,'foo'=>1,'bar'=>2,'baz'=>$otherBinary),
                 )
@@ -48,7 +47,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
             ),
 
             array(
-                'SELECT * FROM ddc1372_foobar f WHERE f.bar = :bar AND f.baz IN (:baz)',
+                'SELECT * FROM ddc1372_foobar f WHERE f.bar = :bar AND BINARY f.baz IN (:baz)',
                 array('bar'=>1,'baz'=> array($binaryData, $otherBinary)),
                 array('bar'=>PDO::PARAM_INT,'baz'=>Connection::PARAM_LOB_ARRAY),
                 array(
@@ -125,7 +124,7 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        
+
         if (!$this->_conn->getSchemaManager()->tablesExist("ddc1372_foobar")) {
             try {
                 $table = new \Doctrine\DBAL\Schema\Table("ddc1372_foobar");

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -223,7 +223,7 @@ SQLDATA
             array(
                 "SELECT * FROM Foo WHERE foo IN (:foo)",
                 array('foo'=>array($binaryData, $binaryData, $binaryData)),
-                array('foo'=>Connection::PARAM_INT_ARRAY),
+                array('foo'=>Connection::PARAM_LOB_ARRAY),
                 'SELECT * FROM Foo WHERE foo IN (?, ?, ?)',
                 array($binaryData, $binaryData, $binaryData),
                 array(\PDO::PARAM_LOB, \PDO::PARAM_LOB, \PDO::PARAM_LOB)
@@ -261,7 +261,7 @@ SQLDATA
                 array('b'=>array(4, 5),'a'=>array(1, 2, 3), 'c'=>array($binaryData)),
                 array('a'=>Connection::PARAM_INT_ARRAY, 'b'=>Connection::PARAM_INT_ARRAY, 'c'=>Connection::PARAM_LOB_ARRAY),
                 'SELECT * FROM Foo WHERE foo IN (?, ?, ?, ?, ?, ?)',
-                array(1, 2, 3, 4, 5),
+                array(1, 2, 3, 4, 5, $binaryData),
                 array(\PDO::PARAM_INT, \PDO::PARAM_INT, \PDO::PARAM_INT, \PDO::PARAM_INT, \PDO::PARAM_INT, \PDO::PARAM_LOB)
             ),
             //  Named parameters : With the same name arg type string

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -402,6 +402,7 @@ SQLDATA
 
     public function dataQueryWithMissingParameters()
     {
+        $binaryData = pack("nvc*", 0x1234, 0x5678, 65, 66);
         return array(
             array(
                 "SELECT * FROM foo WHERE bar = :param",
@@ -432,6 +433,11 @@ SQLDATA
                 "SELECT * FROM foo WHERE bar = :param",
                 array('bar' => 'value'),
                 array('bar' => Connection::PARAM_INT_ARRAY),
+            ),
+             array(
+                "SELECT * FROM foo WHERE bar = :param",
+                array('bar' => $binaryData),
+                array('bar' => Connection::PARAM_LOB_ARRAY),
             ),
         );
     }


### PR DESCRIPTION
## What the problem was

When using the ORM findBy() method to select data in a binary column (compared against an array of binary strings), I would get exceptions. Code example:

``` php
    /**
     * @param string[] $email_addresses Encrypted email addresses
     * @return \Project\Entity\EmailAddresses[]
     */
    public function retrieveEmailAddressEntities(array $email_addresses){
        return $this->repository->findBy(['EmailAddress' => $email_addresses]);
    }
```

When I would only search for one binary string, however, everything would work correctly. I noticed I was getting a PHP Notice for array to string conversion in my error log:

```
PHP Notice:  Array to string conversion in/var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php on line 91
```

In my MySQL table, the column is a varbinary(255) and the ORM entity was marked as type "binary".
## How I fixed

I noticed that the `$type` in `SQLParserUtils::expandListParameters` was marking the type as 103. When this method was checking array types, it was not checking for binary strings. By simply adding the extra check for type 103 in this method, everything started working properly. Line comments below.
## Extra

This worked to fix it for me and I haven't noticed any side effects of this, however I have not extensively tested all features. If there are any problems with this please let me know.
## Specific file commit comments:

Connection.php 
- Added constant PARAM_LOB_ARRAY for binary

SQLParserUtils.php
- Added check to see if the array type is binary
- Changed the way that the foreach checked if the type was not equal to int, string, or binary
