### PR TITLE
[DBAL-1137] Fix infinite recursion on non-unique table/join alias in QueryBuilder

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1308,9 +1308,9 @@ class QueryBuilder
         $sql = '';
 
         if (isset($this->sqlParts['join'][$fromAlias])) {
-			if (array_key_exists($join['joinAlias'], $knownAliases)) {
-				throw QueryException::aliasNotUnique($join['joinAlias']);
-			}
+            if (array_key_exists($join['joinAlias'], $knownAliases)) {
+                throw QueryException::notUniqueAlias($join['joinAlias'], $knownAliases);
+            }
             foreach ($this->sqlParts['join'][$fromAlias] as $join) {
                 $sql .= ' ' . strtoupper($join['joinType'])
                     . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1308,10 +1308,10 @@ class QueryBuilder
         $sql = '';
 
         if (isset($this->sqlParts['join'][$fromAlias])) {
-            if (array_key_exists($join['joinAlias'], $knownAliases)) {
-                throw QueryException::notUniqueAlias($join['joinAlias'], $knownAliases);
-            }
             foreach ($this->sqlParts['join'][$fromAlias] as $join) {
+                if (array_key_exists($join['joinAlias'], $knownAliases)) {
+                    throw QueryException::notUniqueAlias($join['joinAlias'], $knownAliases);
+                }
                 $sql .= ' ' . strtoupper($join['joinType'])
                     . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']
                     . ' ON ' . ((string) $join['joinCondition']);

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1308,6 +1308,9 @@ class QueryBuilder
         $sql = '';
 
         if (isset($this->sqlParts['join'][$fromAlias])) {
+			if (array_key_exists($join['joinAlias'], $knownAliases)) {
+				throw QueryException::aliasNotUnique($join['joinAlias']);
+			}
             foreach ($this->sqlParts['join'][$fromAlias] as $join) {
                 $sql .= ' ' . strtoupper($join['joinType'])
                     . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']

--- a/lib/Doctrine/DBAL/Query/QueryException.php
+++ b/lib/Doctrine/DBAL/Query/QueryException.php
@@ -38,4 +38,17 @@ class QueryException extends DBALException
             "any FROM or JOIN clause table. The currently registered " .
             "aliases are: " . implode(", ", $registeredAliases) . ".");
     }
+    
+    /**
+     * @param string $alias
+     * @param array  $registeredAliases
+     *
+     * @return \Doctrine\DBAL\Query\QueryException
+     */
+    static public function notUniqueAlias($alias, $registeredAliases)
+    {
+        return new self("The given alias '" . $alias . "' is not unique " .
+            "in FROM and JOIN clause table. The currently registered " .
+            "aliases are: " . implode(", ", $registeredAliases) . ".");
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Query;
 
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Query\QueryException;
 
 /**
  * @group DBAL-12

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -880,7 +880,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
         $this->setExpectedException('QueryException');
         $this->assertEquals(
             'dumb string',
-            $qb->getSQL(),
+            $qb->getSQL()
         );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -863,4 +863,24 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
 
         $this->assertSame(array('name' => \PDO::PARAM_STR, 'isActive' => \PDO::PARAM_BOOL), $qb->getParameterTypes());
     }
+
+    /**
+     * @group DBAL-790
+     */
+    public function testSelectWithJoinsWithNotUniqueAliases()
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('a.id, b.id')
+            ->from('table_a', 'a')
+            ->join('a', 'table_b', 'b', 'a.fk_b = b.id')
+            ->join('a', 'table_b', 'b', 'a.fk_b = b.id')
+            ->join('b', 'table_a', 'a', 'a.fk_b = b.id');
+
+        $this->setExpectedException('QueryException');
+        $this->assertEquals(
+            'dumb string',
+            $qb->getSQL(),
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -4,7 +4,6 @@ namespace Doctrine\Tests\DBAL\Query;
 
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\DBAL\Query\QueryException;
 
 /**
  * @group DBAL-12
@@ -878,7 +877,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
             ->join('a', 'table_b', 'b', 'a.fk_b = b.id')
             ->join('b', 'table_a', 'a', 'a.fk_b = b.id');
 
-        $this->setExpectedException('QueryException');
+        $this->setExpectedException('Doctrine\DBAL\Query\QueryException');
         $this->assertEquals(
             'dumb string',
             $qb->getSQL()


### PR DESCRIPTION
What do you guys think about this solution? I found this problem when got not unique join alias - getSQLForJoins went for infinite recursion and apache crashed without promt..
