### PR TITLE
Add tsvector type support in PostgreSQL Platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -1077,6 +1077,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             'char'          => 'string',
             'bpchar'        => 'string',
             'inet'          => 'string',
+            'tsvector'      => 'string',
             'date'          => 'date',
             'datetime'      => 'datetime',
             'timestamp'     => 'datetime',


### PR DESCRIPTION
Just one simple string. Maybe add this to code?
