### PR TITLE
Map `tsvector` type as `text` in PostgreSQL Platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -1071,6 +1071,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             'bool'          => 'boolean',
             'boolean'       => 'boolean',
             'text'          => 'text',
+            'tsvector'      => 'text',
             'varchar'       => 'string',
             'interval'      => 'string',
             '_varchar'      => 'string',

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -15,4 +15,11 @@ class PostgreSqlPlatformTest extends AbstractPostgreSqlPlatformTestCase
     {
         $this->assertTrue($this->_platform->supportsPartialIndexes());
     }
+
+    public function testInitializesTsvectorTypeMapping()
+    {
+        $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('tsvector'));
+        $this->assertEquals('text', $this->_platform->getDoctrineTypeMapping('tsvector'));
+    }
+
 }


### PR DESCRIPTION
This conversation continued from this request: https://github.com/doctrine/dbal/pull/795

I created test case and changed field type to "text". Test passes)
