### PR TITLE
Add deprecated annotation to renameColumn method

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -328,6 +328,8 @@ class Table extends AbstractAsset
     /**
      * Renames a Column.
      *
+     * @deprecated Please use a manual SQL ALTER TABLE query to rename a column.
+     *
      * @param string $oldColumnName
      * @param string $newColumnName
      *


### PR DESCRIPTION
I added the deprecated annotation to warn a dev that the method isn't working anymore. This will allow a dev to spot the deprecated method before he actually attempts to use it.

![screen shot 2015-02-10 at 09 55 50](https://cloud.githubusercontent.com/assets/594614/6124164/646f5f8e-b10b-11e4-9098-e1cb999d720d.png)

Should there be some comment added or perhaps a referring to the exception message?
