### PR TITLE
Fix issue where schema diffs on sql server try and fail to drop nonexistent indexes

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -192,7 +192,7 @@ class SQLServerPlatform extends AbstractPlatform
 
         return "IF EXISTS (SELECT * FROM sysobjects WHERE name = '$index')
                     ALTER TABLE " . $table . " DROP CONSTRAINT " . $index . "
-                ELSE
+                ELSE IF EXISTS (SELECT name FROM sysindexes WHERE name = '$index')
                     DROP INDEX " . $index . " ON " . $table;
     }
 


### PR DESCRIPTION
When running a schema diff on SQL Server, the diff generated includes commands to drop indexes that don't exist. This doesn't fix that problem.

This patch works around the problem by changing sql generated like this:

``` sql
IF EXISTS (SELECT * FROM sysobjects WHERE name = 'IDX_1234567890')
  ALTER TABLE sometable DROP CONSTRAINT IDX_1234567890
ELSE
  DROP INDEX IDX_1234567890 ON sometable
```

to this:

``` sql
IF EXISTS (SELECT * FROM sysobjects WHERE name = 'IDX_1234567890')
  ALTER TABLE sometable DROP CONSTRAINT IDX_1234567890
ELSE IF EXISTS (SELECT name FROM sysindexes WHERE name = 'IDX_1234567890')
  DROP INDEX IDX_1234567890 ON sometable
```

Checking for the existence of the index to be dropped before trying to drop it.

The root of the problem, however, is that when the "from" schema is hydrated from schema-details via Table::__construct, a unique index is added for @JoinColumns that are flagged as unique. This also happens for joined table inheritance child tables.
