### PR TITLE
bugfix(Jira-1077): Correction for parenthesis misbehavior on querylimit for sql server

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -810,7 +810,7 @@ class SQLServerPlatform extends AbstractPlatform
         $format  = 'SELECT * FROM (%s) AS doctrine_tbl WHERE doctrine_rownum BETWEEN %d AND %d';
 
         // Pattern to match "main" SELECT ... FROM clause (including nested parentheses in select list).
-        $selectFromPattern = '/^(\s*SELECT\s+(?:\((?>[^()]+)|(?:R)*\)|[^(])+)\sFROM\s/i';
+        $selectFromPattern = '/^(\s*SELECT\s+(?:\((?>[^()]+)|(?:R)*\)|[^(])+)\sFROM\s/iU';
 
         if ( ! $orderBy) {
             //Replace only "main" FROM with OVER to prevent changing FROM also in subqueries.

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -235,6 +235,21 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
 
         $this->assertEquals($expected, $actual);
     }
+    
+    /**
+     * 	This test should address a bug on  subrequests containing aggregates
+     * 	Complete description available at http://www.doctrine-project.org/jira/browse/DBAL-1077
+     * 
+     */
+    public function testModifyLimitQueryWithSubSelectContainingAggregate()
+    {
+    	$underTestQuery = 'SELECT son.label AS Name FROM SqlObjectName son WHERE ( SELECT COUNT(eso.identifier) FROM ExtractedSqlObject eso INNER JOIN ProductionDbName pdn ON eso.ref_ProductionDbName_ID = pdn.identifier AND (pdn.label IN (?, ?)) WHERE eso.ref_SqlObjectName_ID = son.identifier) > 0 ORDER BY son.identifier DESC';
+    	$actualModifiedQuery = $this->_platform->modifyLimitQuery($underTestQuery, 1, 0);
+    	
+    	$expectedQuery 						= 'SELECT * FROM (SELECT son.label AS Name, ROW_NUMBER() OVER (ORDER BY son.identifier DESC) AS doctrine_rownum FROM SqlObjectName son WHERE ( SELECT COUNT(eso.identifier) FROM ExtractedSqlObject eso INNER JOIN ProductionDbName pdn ON eso.ref_ProductionDbName_ID = pdn.identifier AND (pdn.label IN (?, ?)) WHERE eso.ref_SqlObjectName_ID = son.identifier) > 0) AS doctrine_tbl WHERE doctrine_rownum BETWEEN 1 AND 1';
+    	//$beforePatchFaultyResult	= 'SELECT * FROM (SELECT son.label AS Name FROM SqlObjectName son WHERE ( SELECT COUNT(eso.identifier), ROW_NUMBER() OVER (ORDER BY son.identifier DESC) AS doctrine_rownum FROM ExtractedSqlObject eso INNER JOIN ProductionDbName pdn ON eso.ref_ProductionDbName_ID = pdn.identifier AND (pdn.label IN (?, ?)) WHERE eso.ref_SqlObjectName_ID = son.identifier) > 0) AS doctrine_tbl WHERE doctrine_rownum BETWEEN 1 AND 1
+    	$this->assertEquals($expectedQuery, $actualModifiedQuery);
+    }
 
     /**
      * @group DDC-1360


### PR DESCRIPTION
bugfix(Jira-1077): Correction for parenthesis misbehavior on querylimit for sql server

Correction added to production code
Test added for automated proof

Environment:
Windows 7/ Git Bash/ Sql Server
Test command line run : "./vendor/bin/phpunit -c ./phpunit.xml --verbose ./tests/Doctrine/Tests/DBAL/platforms/SqlServerPlatformTest.php"

Results:
![jira1077_dbal24_results](https://cloud.githubusercontent.com/assets/10148824/6312030/298f9c02-b96d-11e4-80a6-d1f1e5fcc9ef.PNG)
