### PR TITLE
bugfix(Jira1077): Correction for parenthesis misbehavior on querylimit for sqlserver

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1190,7 +1190,7 @@ class SQLServerPlatform extends AbstractPlatform
         $format  = 'SELECT * FROM (%s) AS doctrine_tbl WHERE doctrine_rownum BETWEEN %d AND %d ORDER BY doctrine_rownum';
 
         // Pattern to match "main" SELECT ... FROM clause (including nested parentheses in select list).
-        $selectFromPattern = '/^(\s*SELECT\s+(?:(.*)(?![^(]*\))))\sFROM\s/i';
+        $selectFromPattern = '/^(\s*SELECT\s+(?:(.*)(?![^(]*\))))\sFROM\s/iU';
 
         if ( ! $orderBy) {
             //Replace only "main" FROM with OVER to prevent changing FROM also in subqueries.

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -385,6 +385,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
      * This test should address a bug on subrequests containing aggregates
      * Complete description available at http://www.doctrine-project.org/jira/browse/DBAL-1077
      *
+     *@Overriden in SQLServer2012PlatformTest for specific new T-SQL language features implemented
      */
     public function testModifyLimitQueryWithSubSelectContainingAggregate()
     {

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -285,7 +285,7 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
     	$underTestQuery = 'SELECT son.label AS Name FROM SqlObjectName son WHERE ( SELECT COUNT(eso.identifier) FROM ExtractedSqlObject eso INNER JOIN ProductionDbName pdn ON eso.ref_ProductionDbName_ID = pdn.identifier AND (pdn.label IN (?, ?)) WHERE eso.ref_SqlObjectName_ID = son.identifier) > 0 ORDER BY son.identifier DESC';
     	$actualModifiedQuery = $this->_platform->modifyLimitQuery($underTestQuery, 1, 0);
     	
-    	$expectedQuery 						= 'SELECT son.label AS Name FROM SqlObjectName son WHERE ( SELECT COUNT(eso.identifier) FROM ExtractedSqlObject eso INNER JOIN ProductionDbName pdn ON eso.ref_ProductionDbName_ID = pdn.identifier AND (pdn.label IN (?, ?)) WHERE eso.ref_SqlObjectName_ID = son.identifier) > 0 ORDER BY son.identifier DESC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLLY';
+    	$expectedQuery 						= 'SELECT son.label AS Name FROM SqlObjectName son WHERE ( SELECT COUNT(eso.identifier) FROM ExtractedSqlObject eso INNER JOIN ProductionDbName pdn ON eso.ref_ProductionDbName_ID = pdn.identifier AND (pdn.label IN (?, ?)) WHERE eso.ref_SqlObjectName_ID = son.identifier) > 0 ORDER BY son.identifier DESC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY';
     	//$beforePatchFaultyResult 	= 'N/A result was correct';
     	$this->assertEquals($expectedQuery, $actualModifiedQuery);
     }


### PR DESCRIPTION
bugfix(Jira1077): Correction for parenthesis misbehavior on querylimit for sqlserver

Correction added to production code
Test added for automated proof

Environment:
Windows 7/ Git Bash/ Sql Server
Test command line run : "./vendor/bin/phpunit -c ./sqlsrv.phpunit.xml --verbose ./tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php"

Results:
![jira1077_dbalmaster_results](https://cloud.githubusercontent.com/assets/10148824/6312055/9d79743a-b96d-11e4-8842-5b9c649431a5.PNG)
