### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "doctrine/common": ">=2.4,<2.6-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*",
-        "symfony/console": "2.*"
+        "phpunit/phpunit": "~4",
+        "symfony/console": "~2.3|~3.0"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0
