### PR TITLE
BlobType without fopen & allow_url_fopen

### DIFF
--- a/lib/Doctrine/DBAL/Types/BlobType.php
+++ b/lib/Doctrine/DBAL/Types/BlobType.php
@@ -46,7 +46,7 @@ class BlobType extends Type
         }
 
         if (is_string($value)) {
-            $fp = fopen('php://temp', 'rb+');
+            $fp = tmpfile();
             fwrite($fp, $value);
             fseek($fp, 0);
             $value = $fp;


### PR DESCRIPTION
The allow_url_fopen parameter  is disabled in many host providers by security. This commit introduces a small change to avoid the use of fopen function that this is affected by this parameter.
