### PR TITLE
Treat SQLite Connection URLs Differently in DriverManager

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -258,10 +258,16 @@ final class DriverManager
         }
         
         if (isset($url['path'])) {
-            if (!isset($url['scheme']) || (strpos($url['scheme'], 'sqlite') !== false && $url['path'] == ':memory:')) {
-                $params['dbname'] = $url['path']; // if the URL was just "sqlite::memory:", which parses to scheme and path only
+            if (isset($url['scheme']) && strpos($url['scheme'], 'sqlite') !== false) {
+                // sqlite::memory: OR :sqlite:///:memory:
+                if (':memory:' === $url['path'] || substr($url['path'], 1) === ':memory:') {
+                    $params['memory'] = true;
+                    $params['dbname'] = ':memory:';
+                } else {
+                    $params['dbname'] = $params['path'] = substr($url['path'], 1);
+                }
             } else {
-                $params['dbname'] = substr($url['path'], 1); // strip the leading slash from the URL
+                $params['dbname'] = ltrim($url['path'], '/'); // strip the leading slash from the URL
             }
         }
         

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -153,27 +153,27 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
             ),
             'sqlite relative URL with host' => array(
                 'sqlite://localhost/foo/dbname.sqlite',
-                array('dbname' => 'foo/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('dbname' => 'foo/dbname.sqlite', 'path' => 'foo/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'sqlite absolute URL with host' => array(
                 'sqlite://localhost//tmp/dbname.sqlite',
-                array('dbname' => '/tmp/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('dbname' => '/tmp/dbname.sqlite', 'path' => '/tmp/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'sqlite relative URL without host' => array(
                 'sqlite:///foo/dbname.sqlite',
-                array('dbname' => 'foo/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('dbname' => 'foo/dbname.sqlite', 'path' => 'foo/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'sqlite absolute URL without host' => array(
                 'sqlite:////tmp/dbname.sqlite',
-                array('dbname' => '/tmp/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('dbname' => '/tmp/dbname.sqlite', 'path' => '/tmp/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'sqlite memory' => array(
                 'sqlite:///:memory:',
-                array('dbname' => ':memory:', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('dbname' => ':memory:', 'memory' => true, 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'sqlite memory with host' => array(
                 'sqlite://localhost/:memory:',
-                array('dbname' => ':memory:', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('dbname' => ':memory:', 'memory' => true, 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'params parsed from URL override individual params' => array(
                 array('url' => 'mysql://foo:bar@localhost/baz', 'password' => 'lulz'),


### PR DESCRIPTION
In addition to setting `dbname`, which is ignored by the SQLite Driver, set the
`path` and `memory` params based on the database URL.

See http://www.doctrine-project.org/jira/browse/DBAL-1164

Not sure if this is a good solution, but it seemed more okay (less risky to BC) than changing the driver itself.
