### PR TITLE
Allow `serverVersion` to be explicitly unspecified (`null`)

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -418,7 +418,7 @@ class Connection implements DriverConnection
         }
 
         // Explicit platform version requested (supersedes auto-detection).
-        if (isset($this->_params['serverVersion'])) {
+        if (array_key_exists('serverVersion', $this->_params)) {
             return $this->_params['serverVersion'];
         }
 

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Events;
 use Doctrine\Tests\Mocks\DriverConnectionMock;
 use Doctrine\Tests\Mocks\DriverMock;
+use Doctrine\Tests\Mocks\VersionAwareDriverMock;
 
 class ConnectionTest extends \Doctrine\Tests\DbalTestCase
 {
@@ -562,5 +563,24 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
             ->will($this->returnValue($platformMock));
 
         $this->assertSame($platformMock, $connection->getDatabasePlatform());
+    }
+
+    public function testNullServerVersionDoesNotTriggerDatabaseConnect()
+    {
+        $driverMock = new VersionAwareDriverMock();
+        $params = $this->params;
+        $params['serverVersion'] = null;
+
+        $connection = $this->getMock(
+            'Doctrine\DBAL\Connection',
+            ['connect'],
+            [$params, $driverMock]
+        );
+
+        $connection->expects($this->never())
+            ->method('connect');
+
+
+        $connection->getDatabasePlatform();
     }
 }

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -573,8 +573,8 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
 
         $connection = $this->getMock(
             'Doctrine\DBAL\Connection',
-            ['connect'],
-            [$params, $driverMock]
+            array('connect'),
+            array($params, $driverMock)
         );
 
         $connection->expects($this->never())

--- a/tests/Doctrine/Tests/Mocks/VersionAwareDriverMock.php
+++ b/tests/Doctrine/Tests/Mocks/VersionAwareDriverMock.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\Tests\Mocks;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\VersionAwarePlatformDriver;
+
+class VersionAwareDriverMock extends DriverMock implements VersionAwarePlatformDriver
+{
+    /**
+     * Factory method for creating the appropriate platform instance for the given version.
+     *
+     * @param string $version The platform/server version string to evaluate. This should be given in the notation
+     *                        the underlying database vendor uses.
+     *
+     * @return \Doctrine\DBAL\Platforms\AbstractPlatform
+     *
+     * @throws DBALException if the given version string could not be evaluated.
+     */
+    public function createDatabasePlatformForVersion($version)
+    {
+        throw new DBALException('PHPUnit');
+    }
+}


### PR DESCRIPTION
Hi,

this PR allows `serverVersion`to be nullable.

We use doctrine/dbal in Integration-Tests and to prevent the unit-tests from connecting to a database, we specify `serverVersion` with something made-up (like `5.6`).

However, i'm not comfortable set `serverVersion` to a made-up server-version to prevent connections from being made, when there even isn't a server to connect to. With this PR merged, we could specify `serverVersion` to be `null` instead of something like `5.6` and still prevent connections from being made. `null` is a valid return value for `getDatabasePlatformVersion()`.
