### PR TITLE
Fix uses Statement::setFetchMode function in class Connection

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -186,7 +186,7 @@ class Connection implements DriverConnection
     /**
      * @var integer
      */
-    protected $defaultFetchMode = PDO::FETCH_ASSOC;
+    protected $defaultFetchMode = [PDO::FETCH_ASSOC];
 
     /**
      * Initializes a new instance of the Connection class.
@@ -492,9 +492,9 @@ class Connection implements DriverConnection
      *
      * @return void
      */
-    public function setFetchMode($fetchMode)
+    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
-        $this->defaultFetchMode = $fetchMode;
+        $this->defaultFetchMode = [$fetchMode, $arg2, $arg3];
     }
 
     /**
@@ -781,7 +781,7 @@ class Connection implements DriverConnection
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $statement);
         }
 
-        $stmt->setFetchMode($this->defaultFetchMode);
+        call_user_func_array([$stmt, 'setFetchMode'], $this->defaultFetchMode);
 
         return $stmt;
     }
@@ -832,7 +832,7 @@ class Connection implements DriverConnection
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));
         }
 
-        $stmt->setFetchMode($this->defaultFetchMode);
+        call_user_func_array([$stmt, 'setFetchMode'], $this->defaultFetchMode);
 
         if ($logger) {
             $logger->stopQuery();
@@ -876,7 +876,7 @@ class Connection implements DriverConnection
             $stmt = new ResultCacheStatement($this->executeQuery($query, $params, $types), $resultCache, $cacheKey, $realKey, $qcp->getLifetime());
         }
 
-        $stmt->setFetchMode($this->defaultFetchMode);
+        call_user_func_array([$stmt, 'setFetchMode'], $this->defaultFetchMode);
 
         return $stmt;
     }
@@ -941,7 +941,7 @@ class Connection implements DriverConnection
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $args[0]);
         }
 
-        $statement->setFetchMode($this->defaultFetchMode);
+        call_user_func_array([$statement, 'setFetchMode'], $this->defaultFetchMode);
 
         if ($logger) {
             $logger->stopQuery();

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -489,7 +489,9 @@ class Connection implements DriverConnection
      * Sets the fetch mode.
      *
      * @param integer $fetchMode
-     *
+     * @param mixed $arg2
+     * @param mixed $arg3
+     * 
      * @return void
      */
     public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)


### PR DESCRIPTION
I have a problem because interface function Connection::setFetchMode doesnt match PDOStatement::setFetchMode. Through Connection::setFetchMode I can send only first param to function PDOStatement::setFetchMode. 
With this fix in Connection class, function Statement::setFetchMode used with call_user_func_array and this allow send more than one argument.
With this fix, I can use native PDO::FETCH_COLUMN like this:
        $conn = $this->get('database_connection');
        $conn->setFetchMode(\PDO::FETCH_COLUMN, 0);
        $result = $conn->fetchAll("SELECT ..........");
and get full result array.
With function Connection::fetchColumn, I can take only the first row in result array.
