### PR TITLE
SchemaManager quoting fixes

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -824,7 +824,7 @@ class SQLServerPlatform extends AbstractPlatform
         END AS name
 FROM sysobjects t
 LEFT JOIN sys.schemas s ON s.schema_id = uid
-LEFT JOIN sys.database_principals p ON p.principal_id = s.principal_id
+CROSS JOIN sys.database_principals p
 WHERE t.type = 'U'
     AND t.NAME != 'sysdiagrams'
     AND t.category != 2

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -817,19 +817,14 @@ class SQLServerPlatform extends AbstractPlatform
         // Category 2 must be ignored as it is "MS SQL Server 'pseudo-system' object[s]" for replication
         // Table names are returned with the schema name IF and only if the schema
         // is not the default schema for the user accessing the database.
-        return "SELECT CASE 
-        WHEN s.NAME <> p.default_schema_name
-            THEN '[' + s.NAME + '].[' + t.NAME + ']'
-        ELSE t.NAME
-        END AS name
+        return "SELECT t.NAME AS table_name,
+        s.NAME AS schema_name
 FROM sysobjects t
 LEFT JOIN sys.schemas s ON s.schema_id = uid
-CROSS JOIN sys.database_principals p
 WHERE t.type = 'U'
     AND t.NAME != 'sysdiagrams'
     AND t.category != 2
-    AND p.principal_id = DATABASE_PRINCIPAL_ID()
-ORDER BY t.NAME";
+ORDER BY s.NAME, t.NAME";
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -311,7 +311,7 @@ class SQLServerPlatform extends AbstractPlatform
      * Returns the SQL snippet for declaring a default constraint.
      *
      * @param string $table  Name of the table to return the default constraint declaration for.
-     * @param array  $column Column definition.
+     * @param array  $column Column definition. Note: The column name in the column definition should be quoted.
      *
      * @return string
      *

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -323,13 +323,12 @@ class SQLServerPlatform extends AbstractPlatform
             throw new \InvalidArgumentException("Incomplete column definition. 'default' required.");
         }
 
-        $columnName = new Identifier($column['name']);
-
+        //Table and column name are already quoted.
         return
             ' CONSTRAINT ' .
             $this->generateDefaultConstraintName($table, $column['name']) .
             $this->getDefaultValueDeclarationSQL($column) .
-            ' FOR ' . $columnName->getQuotedName($this);
+            ' FOR ' . $column['name'];
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/AbstractAsset.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractAsset.php
@@ -59,15 +59,24 @@ abstract class AbstractAsset
      */
     protected function _setName($name)
     {
+        if (strpos($name, ".") !== false) {
+            $parts = explode(".", $name);
+            $schema = $parts[0];
+
+            if ($this->isIdentifierQuoted($schema)) {
+                $this->_quoted = true;
+                $schema = $this->trimQuotes($schema);
+            }
+
+            $this->_namespace = $schema;
+            $name = $parts[1];
+        }
+
         if ($this->isIdentifierQuoted($name)) {
             $this->_quoted = true;
             $name = $this->trimQuotes($name);
         }
-        if (strpos($name, ".") !== false) {
-            $parts = explode(".", $name);
-            $this->_namespace = $parts[0];
-            $name = $parts[1];
-        }
+
         $this->_name = $name;
     }
 
@@ -167,7 +176,8 @@ abstract class AbstractAsset
      */
     protected function trimQuotes($identifier)
     {
-        return str_replace(array('`', '"', '[', ']'), '', $identifier);
+        //TODO need to "unquote" the identifier.
+        return trim($identifier, "`\"[]");
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -179,9 +179,11 @@ class SQLServerSchemaManager extends AbstractSchemaManager
     protected function _getPortableTableDefinition($table)
     {
         $defaultSchema = $this->getDefaultSchemaName();
+
         if ($table['schema_name'] == $defaultSchema) {
             return $this->quoteIncomingIdentifier($table['table_name']);
         }
+        
         return $this->quoteIncomingIdentifier($table['schema_name']) . '.' . $this->quoteIncomingIdentifier($table['table_name']);
     }
 

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -183,7 +183,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
         if ($table['schema_name'] == $defaultSchema) {
             return $this->quoteIncomingIdentifier($table['table_name']);
         }
-        
+
         return $this->quoteIncomingIdentifier($table['schema_name']) . '.' . $this->quoteIncomingIdentifier($table['table_name']);
     }
 
@@ -311,6 +311,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
      */
     private function isIncomingIdentifierValid($name)
     {
-        return (bool)preg_match('/^(?:[_@#[:alpha:]][$@#_[:alnum:]]*|".*"|\[.*\])$/i', $name);
+        return !($this->_platform->getReservedKeywordsList()->isKeyword($name))
+            && (bool)preg_match('/^(?:[_@#[:alpha:]][$@#_[:alnum:]]*|".*"|\[.*\])$/i', $name);
     }
 }

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -299,7 +299,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
     {
         return $this->isIncomingIdentifierValid($name)
             ? $name
-            : $this->_platform->quoteIdentifier($name);
+            : "`" . $name . "`";
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -389,4 +389,32 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $relatedFk = array_pop($relatedFks);
         $this->assertEquals("nested.schemarelated", $relatedFk->getForeignTableName());
     }
+
+    /**
+     * @param string $name
+     * @dataProvider invalidNamesProvider
+     */
+    public function testTablesWithInvalidNames($name, $expected)
+    {
+        $table = new Table($name);
+        $idColumn = $table->addColumn('id', 'integer');
+        $idColumn->setAutoincrement(true);
+        $otherColumn = $table->addColumn('other', 'integer');
+        $otherColumn->setDefault(1);
+        $this->_sm->createTable($table);
+        $tables = $this->_sm->listTableNames();
+        $this->assertContains($expected, $tables, "The table name should be detected with quotes.");
+    }
+
+    public function invalidNamesProvider()
+    {
+        return [
+            ['`fo]o`', '[fo]]o]'],
+            ['`fo[o`', '[fo[o]'],
+            ['`!foo`', '[!foo]'],
+            ['`drop`', '[drop]'],
+            ['`!`', '[!]'],
+            ['`1foo`', '[1foo]']
+        ];
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -394,7 +394,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
      * @param string $name
      * @dataProvider invalidNamesProvider
      */
-    public function testTablesWithInvalidNames($name, $expected)
+    public function testTablesWithInvalidNames($name)
     {
         $table = new Table($name);
         $idColumn = $table->addColumn('id', 'integer');
@@ -403,18 +403,18 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $otherColumn->setDefault(1);
         $this->_sm->createTable($table);
         $tables = $this->_sm->listTableNames();
-        $this->assertContains($expected, $tables, "The table name should be detected with quotes.");
+        $this->assertContains($name, $tables, "The table name should be detected with quotes.");
     }
 
     public function invalidNamesProvider()
     {
         return [
-            ['`fo]o`', '[fo]]o]'],
-            ['`fo[o`', '[fo[o]'],
-            ['`!foo`', '[!foo]'],
-            ['`drop`', '[drop]'],
-            ['`!`', '[!]'],
-            ['`1foo`', '[1foo]']
+            ['`fo]o`'],
+            ['`fo[o`'],
+            ['`!foo`'],
+            ['`and`'],
+            ['`!`'],
+            ['`1foo`']
         ];
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -355,4 +355,38 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertEquals('colB', $columns[0]);
         $this->assertEquals('colA', $columns[1]);
     }
+
+    /**
+     * @group DBAL-75
+     */
+    public function testTableWithSchema()
+    {
+        $this->_conn->exec('CREATE SCHEMA nested');
+
+        $nestedRelatedTable = new \Doctrine\DBAL\Schema\Table('nested.schemarelated');
+        $column = $nestedRelatedTable->addColumn('id', 'integer');
+        $column->setAutoincrement(true);
+        $nestedRelatedTable->setPrimaryKey(array('id'));
+
+        $nestedSchemaTable = new \Doctrine\DBAL\Schema\Table('nested.schematable');
+        $column = $nestedSchemaTable->addColumn('id', 'integer');
+        $column->setAutoincrement(true);
+        $nestedSchemaTable->setPrimaryKey(array('id'));
+        $nestedSchemaTable->addUnnamedForeignKeyConstraint($nestedRelatedTable, array('id'), array('id'));
+
+        $this->_sm->createTable($nestedRelatedTable);
+        $this->_sm->createTable($nestedSchemaTable);
+
+        $tables = $this->_sm->listTableNames();
+        $this->assertContains('nested.schematable', $tables, "The table should be detected with its non-public schema.");
+
+        $nestedSchemaTable = $this->_sm->listTableDetails('nested.schematable');
+        $this->assertTrue($nestedSchemaTable->hasColumn('id'));
+        $this->assertEquals(array('id'), $nestedSchemaTable->getPrimaryKey()->getColumns());
+
+        $relatedFks = $nestedSchemaTable->getForeignKeys();
+        $this->assertEquals(1, count($relatedFks));
+        $relatedFk = array_pop($relatedFks);
+        $this->assertEquals("nested.schemarelated", $relatedFk->getForeignTableName());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -361,7 +361,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
      */
     public function testTableWithSchema()
     {
-        $this->_conn->exec('CREATE SCHEMA nested');
+        $this->_conn->exec($this->_conn->getDatabasePlatform()->getCreateSchemaSQL('nested'));
 
         $nestedRelatedTable = new \Doctrine\DBAL\Schema\Table('nested.schemarelated');
         $column = $nestedRelatedTable->addColumn('id', 'integer');

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL461Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL461Test.php
@@ -12,10 +12,13 @@ class DBAL461Test extends \PHPUnit_Framework_TestCase
     public function testIssue()
     {
         $conn = $this->getMock('Doctrine\DBAL\Connection', array(), array(), '', false);
-        $platform = $this->getMockForAbstractClass('Doctrine\DBAL\Platforms\AbstractPlatform');
-        $platform->registerDoctrineTypeMapping('numeric', 'decimal');
+        $platformMock = $this->getMock('Doctrine\DBAL\Platforms\SQLServerPlatform');
+        $platformMock->expects($this->exactly(1))
+            ->method('getDoctrineTypeMapping')
+            ->with($this->isType('string'))
+            ->will($this->returnValue('decimal'));
 
-        $schemaManager = new SQLServerSchemaManager($conn, $platform);
+        $schemaManager = new SQLServerSchemaManager($conn, $platformMock);
 
         $reflectionMethod = new \ReflectionMethod($schemaManager, '_getPortableTableColumnDefinition');
         $reflectionMethod->setAccessible(true);

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -386,7 +386,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
      */
     public function testQuoteIdentifier()
     {
-        $this->assertEquals('[fo][o]', $this->_platform->quoteIdentifier('fo]o'));
+        $this->assertEquals('[fo]]o]', $this->_platform->quoteIdentifier('fo]o'));
         $this->assertEquals('[test]', $this->_platform->quoteIdentifier('test'));
         $this->assertEquals('[test].[test]', $this->_platform->quoteIdentifier('test.test'));
     }
@@ -396,7 +396,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
      */
     public function testQuoteSingleIdentifier()
     {
-        $this->assertEquals('[fo][o]', $this->_platform->quoteSingleIdentifier('fo]o'));
+        $this->assertEquals('[fo]]o]', $this->_platform->quoteSingleIdentifier('fo]o'));
         $this->assertEquals('[test]', $this->_platform->quoteSingleIdentifier('test'));
         $this->assertEquals('[test.test]', $this->_platform->quoteSingleIdentifier('test.test'));
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -956,15 +956,16 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
 
     public function getGeneratesIdentifierNamesInDefaultConstraintDeclarationSQL()
     {
+        // Default constraint generation assumes identifiers are already quoted.
         return array(
             // Unquoted identifiers non-reserved keywords.
             array('mytable', array('name' => 'mycolumn', 'default' => 'foo'), " CONSTRAINT DF_6B2BD609_9BADD926 DEFAULT 'foo' FOR mycolumn"),
             // Quoted identifiers non-reserved keywords.
-            array('`mytable`', array('name' => '`mycolumn`', 'default' => 'foo'), " CONSTRAINT DF_6B2BD609_9BADD926 DEFAULT 'foo' FOR [mycolumn]"),
+            array('`mytable`', array('name' => '[mycolumn]', 'default' => 'foo'), " CONSTRAINT DF_6B2BD609_9BADD926 DEFAULT 'foo' FOR [mycolumn]"),
             // Unquoted identifiers reserved keywords.
-            array('table', array('name' => 'select', 'default' => 'foo'), " CONSTRAINT DF_F6298F46_4BF2EAC0 DEFAULT 'foo' FOR [select]"),
+            array('table', array('name' => '[select]', 'default' => 'foo'), " CONSTRAINT DF_F6298F46_4BF2EAC0 DEFAULT 'foo' FOR [select]"),
             // Quoted identifiers reserved keywords.
-            array('`table`', array('name' => '`select`', 'default' => 'foo'), " CONSTRAINT DF_F6298F46_4BF2EAC0 DEFAULT 'foo' FOR [select]"),
+            array('`table`', array('name' => '[select]', 'default' => 'foo'), " CONSTRAINT DF_F6298F46_4BF2EAC0 DEFAULT 'foo' FOR [select]"),
         );
     }
 


### PR DESCRIPTION
The SchemaManager, when used with SQL Server, fails to quote incoming table names and column names that should be quoted. That means that when a table that exists in the database called 'quote-address' needs to be dropped, the drop table statement will fail because the identifer is not marked as quoted when the schema diff is created.

This patch adds a method isValidIdentifier to the AbstractPlatform API - the purpose of this is to check if an identifier is valid to be used in SQL on the platform. 

This is used by a new protected method in AbstractSchemaManager, quoteIncomingIdentifier. This method checks if the passed string literal is a valid identifier using isValidIdentifier. If the identifier is not valid, it quotes it for the platform and returns it. If it is valid, or is already quoted, it returns the identifier unchanged.
