### PR TITLE
Fix for bad profiling data, showing an indefinitely long query

### DIFF
--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -164,6 +164,9 @@ class Statement implements \IteratorAggregate, DriverStatement
         try {
             $stmt = $this->stmt->execute($params);
         } catch (\Exception $ex) {
+            if ($logger) {
+                $logger->stopQuery();
+            }
             throw DBALException::driverExceptionDuringQuery(
                 $this->conn->getDriver(),
                 $ex,


### PR DESCRIPTION
This fix solves a problem where a failed transaction generates inaccurate profiling data.

In Symfony's "Timeline" profiler view, the bug makes it appear as if Symfony is taking a lot of time to process something, up until the very end of the request.
