### PR TITLE
fix client_encoding setting to support pgbouncer

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -83,7 +83,7 @@ class Driver extends AbstractPostgreSQLDriver
         }
 
         if (isset($params['charset'])) {
-            $dsn .= "options='--client_encoding=" . $params['charset'] . "'";
+            $dsn .= 'client_encoding=' . $params['charset'] . ' ';
         }
 
         if (isset($params['sslmode'])) {


### PR DESCRIPTION
The current release doesn't allow connecting to pgbouncer when specifying the charset due to the lack of support for the 'options' parameter. The fix is to use the client_encoding option directly instead of passing it through the options parameter.

This exact same bug was fixed in node.js's PG driver the exact same way.

https://github.com/brianc/node-postgres/pull/356

I've confirmed this fix works with pgbouncer.
