### PR TITLE
fix incorrect ordering of columns in clustered indexes on sql server

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -893,7 +893,7 @@ class SQLServerPlatform extends AbstractPlatform
                 JOIN sys.index_columns AS idxcol ON idx.object_id = idxcol.object_id AND idx.index_id = idxcol.index_id
                 JOIN sys.columns AS col ON idxcol.object_id = col.object_id AND idxcol.column_id = col.column_id
                 WHERE " . $this->getTableWhereClause($table, 'scm.name', 'tbl.name') . "
-                ORDER BY idx.index_id ASC, idxcol.index_column_id ASC";
+                ORDER BY idx.index_id ASC, idxcol.key_ordinal ASC";
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -329,4 +329,30 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertNull($columns['added_commented_type']->getComment());
         $this->assertEquals('666', $columns['added_commented_type_with_comment']->getComment());
     }
+
+    public function testPkOrdering()
+    {
+        // SQL Server stores index column information in a system table with two
+        // columns that almost always have the same value: index_column_id and key_ordinal.
+        // The only situation when the two values doesn't match up is when a clustered index
+        // is declared that references columns in a different order from which they are
+        // declared in the table. In that case, key_ordinal != index_column_id.
+        // key_ordinal holds the index ordering. index_column_id is just a unique identifier
+        // for index columns within the given index.
+        $table = new Table('sqlsrv_pk_ordering');
+        $table->addColumn('colA', 'integer', array('notnull' => true));
+        $table->addColumn('colB', 'integer', array('notnull' => true));
+        $table->setPrimaryKey(['colB', 'colA']);
+        $this->_sm->createTable($table);
+
+        $indexes = $this->_sm->listTableIndexes('sqlsrv_pk_ordering');
+
+        $this->assertCount(1, $indexes);
+
+        $firstIndex = current($indexes);
+        $columns = $firstIndex->getColumns();
+        $this->assertCount(2, $columns);
+        $this->assertEquals('colB', $columns[0]);
+        $this->assertEquals('colA', $columns[1]);
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -342,7 +342,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table = new Table('sqlsrv_pk_ordering');
         $table->addColumn('colA', 'integer', array('notnull' => true));
         $table->addColumn('colB', 'integer', array('notnull' => true));
-        $table->setPrimaryKey(['colB', 'colA']);
+        $table->setPrimaryKey(array('colB', 'colA'));
         $this->_sm->createTable($table);
 
         $indexes = $this->_sm->listTableIndexes('sqlsrv_pk_ordering');


### PR DESCRIPTION
When schema information is fetched from SQL server, the getListTableIndexesSQL was fetching index columns ordered by sys.index_columns.index_column_id. This was incorrect, because that column is simply a unique id for the column within the index. The column ordering information is actually in the key_ordinal column.

This PR changes SQLServerPlatform to generate a resultset ordered by key_ordinal instead of index_column_id.

This was causing schema diffs on tables with composite primary keys to try to drop and re-create the indexes every time the diff is run. 

So this solves index churn in schema diffs on SQL server.
