### PR TITLE
Fix `DISTINCT` queries with `LIMIT` and no `ORDER` on SQLServer 2012

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -120,9 +120,17 @@ class SQLServer2012Platform extends SQLServer2008Platform
         if ($orderByPos === false
             || substr_count($query, "(", $orderByPos) - substr_count($query, ")", $orderByPos)
         ) {
-            // In another DBMS, we could do ORDER BY 0, but SQL Server gets angry if you use constant expressions in
-            // the order by list.
-            $query .= " ORDER BY (SELECT 0)";
+            if (strtoupper(substr($query, 0, 15)) == 'SELECT DISTINCT') {
+                // SQL Server won't let us order by a non-selected column in a DISTINCT query,
+                // so we have to do this madness. This says, select 0 as column one, and order
+                // by column one.
+                $query = 'SELECT DISTINCT 0,' . substr($query, 15);
+                $query .= " ORDER BY 1";
+            } else {
+                // In another DBMS, we could do ORDER BY 0, but SQL Server gets angry if you use constant expressions in
+                // the order by list.
+                $query .= " ORDER BY (SELECT 0)";
+            }
         }
 
         if ($offset === null) {

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -120,7 +120,7 @@ class SQLServer2012Platform extends SQLServer2008Platform
         if ($orderByPos === false
             || substr_count($query, "(", $orderByPos) - substr_count($query, ")", $orderByPos)
         ) {
-            if (strtoupper(substr($query, 0, 15)) == 'SELECT DISTINCT') {
+            if (stripos($query, 'SELECT DISTINCT') === 0) {
                 // SQL Server won't let us order by a non-selected column in a DISTINCT query,
                 // so we have to do this madness. This says, order by the first column in the
                 // result. SQL Server's docs say that a nonordered query's result order is non-

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -122,13 +122,14 @@ class SQLServer2012Platform extends SQLServer2008Platform
         ) {
             if (strtoupper(substr($query, 0, 15)) == 'SELECT DISTINCT') {
                 // SQL Server won't let us order by a non-selected column in a DISTINCT query,
-                // so we have to do this madness. This says, select 0 as column one, and order
-                // by column one.
-                $query = 'SELECT DISTINCT 0,' . substr($query, 15);
+                // so we have to do this madness. This says, order by the first column in the
+                // result. SQL Server's docs say that a nonordered query's result order is non-
+                // deterministic anyway, so this won't do anything that a bunch of update and
+                // deletes to the table wouldn't do anyway.
                 $query .= " ORDER BY 1";
             } else {
-                // In another DBMS, we could do ORDER BY 0, but SQL Server gets angry if you use constant expressions in
-                // the order by list.
+                // In another DBMS, we could do ORDER BY 0, but SQL Server gets angry if you
+                // use constant expressions in the order by list.
                 $query .= " ORDER BY (SELECT 0)";
             }
         }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -247,7 +247,7 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
     {
         $sql = $this->_platform->modifyLimitQuery("SELECT DISTINCT id_0 FROM (SELECT k0_.id AS id_0 FROM key_measure k0_ WHERE (k0_.id_zone in(2))) dctrn_result", 10);
 
-        $expected = "SELECT DISTINCT 0, id_0 FROM (SELECT k0_.id AS id_0 FROM key_measure k0_ WHERE (k0_.id_zone in(2))) dctrn_result ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY";
+        $expected = "SELECT DISTINCT id_0 FROM (SELECT k0_.id AS id_0 FROM key_measure k0_ WHERE (k0_.id_zone in(2))) dctrn_result ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY";
 
         $this->assertEquals($sql, $expected);
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -247,7 +247,7 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
     {
         $sql = $this->_platform->modifyLimitQuery("SELECT DISTINCT id_0 FROM (SELECT k0_.id AS id_0 FROM key_measure k0_ WHERE (k0_.id_zone in(2))) dctrn_result", 10);
 
-        $expected = "SELECT DISTINCT id_0 FROM (SELECT k0_.id AS id_0 FROM key_measure k0_ WHERE (k0_.id_zone in(2))) dctrn_result ORDER BY (SELECT 0) OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY";
+        $expected = "SELECT DISTINCT 0, id_0 FROM (SELECT k0_.id AS id_0 FROM key_measure k0_ WHERE (k0_.id_zone in(2))) dctrn_result ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY";
 
         $this->assertEquals($sql, $expected);
     }


### PR DESCRIPTION
On SQLServer2012Platform, doModifyLimitQuery adds a do-nothing ORDER BY clause, because this is required in order to use OFFSET...FETCH NEXT N ROWS ONLY.

DISTINCT queries run via the paginator without an ORDER BY clause on SQL Server 2012 were failing with this error:

```
ORDER BY items must appear in the select list if SELECT DISTINCT is specified.
```

This PR fixes the error by adding 0 to the select list and changing the generated ORDER BY clause to read ORDER BY 1.

So a query that would have been generated as:

``` sql
SELECT DISTINCT id_0
FROM (
    SELECT p0_.id AS id_0
        ,p0_.preference_code AS preference_code_1
        ,p0_.id_zone AS id_zone_2
    FROM preference p0_
    WHERE (p0_.id_zone IN (2))
    ) dctrn_result
ORDER BY (SELECT 0) 
OFFSET 0 ROWS FETCH NEXT 30 ROWS ONLY
```

Will now be generated as:

``` sql
SELECT DISTINCT 0, id_0
FROM (
    SELECT p0_.id AS id_0
        ,p0_.preference_code AS preference_code_1
        ,p0_.id_zone AS id_zone_2
    FROM preference p0_
    WHERE (p0_.id_zone IN (2))
    ) dctrn_result
ORDER BY 1
OFFSET 0 ROWS FETCH NEXT 30 ROWS ONLY
```
