### PR TITLE
rehashed charset implementation to support old versions of postgresql

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -53,7 +53,10 @@ class Driver extends AbstractPostgreSQLDriver
                 $pdo->setAttribute(PDO::PGSQL_ATTR_DISABLE_PREPARES, true);
             }
 
-            /* define charset via SET NAMES to avoid inconsistent DSN support */
+            /* defining client_encoding via SET NAMES to avoid inconsistent DSN support
+             * - the 'client_encoding' connection param only works with postgres >= 9.1
+             * - also, padding client_encoding via the 'options' param breaks pgbouncer support
+             */
             if (isset($params['charset'])) {
               $pdo->query('SET NAMES \''.$params['charset'].'\'');
             }

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -53,6 +53,11 @@ class Driver extends AbstractPostgreSQLDriver
                 $pdo->setAttribute(PDO::PGSQL_ATTR_DISABLE_PREPARES, true);
             }
 
+            /* define charset via SET NAMES to avoid inconsistent DSN support */
+            if (isset($params['charset'])) {
+              $pdo->query('SET NAMES \''.$params['charset'].'\'');
+            }
+
             return $pdo;
         } catch (PDOException $e) {
             throw DBALException::driverException($this, $e);
@@ -80,10 +85,6 @@ class Driver extends AbstractPostgreSQLDriver
 
         if (isset($params['dbname'])) {
             $dsn .= 'dbname=' . $params['dbname'] . ' ';
-        }
-
-        if (isset($params['charset'])) {
-            $dsn .= 'client_encoding=' . $params['charset'] . ' ';
         }
 
         if (isset($params['sslmode'])) {

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -55,7 +55,7 @@ class Driver extends AbstractPostgreSQLDriver
 
             /* defining client_encoding via SET NAMES to avoid inconsistent DSN support
              * - the 'client_encoding' connection param only works with postgres >= 9.1
-             * - also, padding client_encoding via the 'options' param breaks pgbouncer support
+             * - passing client_encoding via the 'options' param breaks pgbouncer support
              */
             if (isset($params['charset'])) {
               $pdo->query('SET NAMES \''.$params['charset'].'\'');


### PR DESCRIPTION
My previous client_encoding fix turned out not to work on older postgres versions -- BUT, the options param isn't supported by pgbouncer at all. SO, because there isn't consistent behavior with setting the character set via DSN - this change utilizes `SET NAMES`. I used SET NAMES since that is SQL standard and supported by PG.

I confirmed `SET NAMES` is supported all the way back to the older doc PG has, 7.1: http://www.postgresql.org/docs/7.1/static/multibyte.html
