### PR TITLE
`README.md` nicer badges, cleanup, 2.3 dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Doctrine DBAL
 
+| [Master][Master] | [2.5][2.5] | [2.4][2.4] |
+|:----------------:|:----------:|:----------:|
+| [![Build status][Master image]][Master] | [![Build status][2.5 image]][2.5] | [![Build status][2.4 image]][2.4] |
+
+
 Powerful database abstraction layer with many features for database schema introspection, schema management and PDO abstraction.
 
-* Master: [![Build Status](https://secure.travis-ci.org/doctrine/dbal.png?branch=master)](http://travis-ci.org/doctrine/dbal) [![Dependency Status](https://www.versioneye.com/php/doctrine:dbal/dev-master/badge.png)](https://www.versioneye.com/php/doctrine:dbal/dev-master)
-* 2.5: [![Build Status](https://secure.travis-ci.org/doctrine/dbal.png?branch=2.5)](http://travis-ci.org/doctrine/dbal) [![Dependency Status](https://www.versioneye.com/php/doctrine:dbal/2.5.0/badge.png)](https://www.versioneye.com/php/doctrine:dbal/2.5.0)
-* 2.4: [![Build Status](https://secure.travis-ci.org/doctrine/dbal.png?branch=2.4)](http://travis-ci.org/doctrine/dbal) [![Dependency Status](https://www.versioneye.com/php/doctrine:dbal/2.4.2/badge.png)](https://www.versioneye.com/php/doctrine:dbal/2.4.2)
-* 2.3: [![Build Status](https://secure.travis-ci.org/doctrine/dbal.png?branch=2.3)](http://travis-ci.org/doctrine/dbal) [![Dependency Status](https://www.versioneye.com/php/doctrine:dbal/2.3.4/badge.png)](https://www.versioneye.com/php/doctrine:dbal/2.3.4)
 
 ## More resources:
 
@@ -13,3 +14,11 @@ Powerful database abstraction layer with many features for database schema intro
 * [Documentation](http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/)
 * [Issue Tracker](http://www.doctrine-project.org/jira/browse/DBAL)
 * [Downloads](http://github.com/doctrine/dbal/downloads)
+
+
+  [Master image]: https://img.shields.io/travis/doctrine/dbal/master.svg?style=flat-square
+  [Master]: https://travis-ci.org/doctrine/dbal
+  [2.5 image]: https://img.shields.io/travis/doctrine/dbal/2.5.svg?style=flat-square
+  [2.5]: https://github.com/doctrine/dbal/tree/2.5
+  [2.4 image]: https://img.shields.io/travis/doctrine/dbal/2.4.svg?style=flat-square
+  [2.4]: https://github.com/doctrine/dbal/tree/2.4


### PR DESCRIPTION
Ref https://github.com/doctrine/doctrine2/pull/1362

Is there any reason why coverage is not in here? Would be much more useful than dependency badge.
