### PR TITLE
Fix test failures on Windows due to differing newlines

### DIFF
--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -131,9 +131,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testDriverExceptionIsWrapped($method)
     {
-        $this->setExpectedException('Doctrine\DBAL\DBALException', "An exception occurred while executing 'MUUHAAAAHAAAA':
-
-SQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
+        $this->setExpectedException('Doctrine\DBAL\DBALException', "An exception occurred while executing 'MUUHAAAAHAAAA':\n\nSQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
 
         $con = \Doctrine\DBAL\DriverManager::getConnection(array(
             'driver' => 'pdo_sqlite',

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -38,13 +38,7 @@ class SQLParserUtilsTest extends \Doctrine\Tests\DbalTestCase
             array('SELECT "Doctrine\DBAL?" FROM foo WHERE bar = ?', true, array(45)), // Ticket DBAL-558
             array('SELECT `Doctrine\DBAL?` FROM foo WHERE bar = ?', true, array(45)), // Ticket DBAL-558
             array('SELECT [Doctrine\DBAL?] FROM foo WHERE bar = ?', true, array(45)), // Ticket DBAL-558
-            array(
-<<<'SQLDATA'
-SELECT * FROM foo WHERE bar = 'it\'s a trap? \\' OR bar = ?
-AND baz = "\"quote\" me on it? \\" OR baz = ?
-SQLDATA
-                , true, array(58, 104)
-            ),
+            array("SELECT * FROM FOO WHERE bar = 'it\\'s a trap? \\\\' OR bar = ?\nAND baz = \"\\\"quote\\\" me on it? \\\\\" OR baz = ?", true, array(58, 104)),
             array('SELECT * FROM foo WHERE foo = ? AND bar = ?', true, array(1 => 42, 0 => 30)), // explicit keys
 
             // named


### PR DESCRIPTION
Some tests were failing on windows due to differing newlines. 

The tests which were failing used inline newlines in the comparison string, which evaluate to \r\n on Windows and \n on *nix.

The tests have been changed to use explicit newlines "\n".

Failure messages:

```
E:\wwwroot\dbal>vendor\bin\phpunit -c nodb.xml --filter "(testGetPlaceholderPositions|testDriverExceptionIsWrapped)" tests\Doctrine\Tests\DBAL
PHPUnit 4.0.20 by Sebastian Bergmann.

Configuration read from E:\wwwroot\dbal\nodb.xml

FFFFF.....................F............

Time: 2.8 seconds, Memory: 33.25Mb

There were 6 failures:

1) Doctrine\Tests\DBAL\ConnectionTest::testDriverExceptionIsWrapped with data set #0 ('exec')
Failed asserting that exception message 'An exception occurred while executing 'MUUHAAAAHAAAA':

SQLSTATE[HY000]: General error: 1 near "MUUHAAAAHAAAA": syntax error' contains 'An exception occurred while executing 'MUUHAAAAHAAAA':

SQLSTATE[HY000]: General error: 1 near "MUUHAAAAHAAAA"'.

2) Doctrine\Tests\DBAL\ConnectionTest::testDriverExceptionIsWrapped with data set #1 ('query')
Failed asserting that exception message 'An exception occurred while executing 'MUUHAAAAHAAAA':

SQLSTATE[HY000]: General error: 1 near "MUUHAAAAHAAAA": syntax error' contains 'An exception occurred while executing 'MUUHAAAAHAAAA':

SQLSTATE[HY000]: General error: 1 near "MUUHAAAAHAAAA"'.

3) Doctrine\Tests\DBAL\ConnectionTest::testDriverExceptionIsWrapped with data set #2 ('executeQuery')
Failed asserting that exception message 'An exception occurred while executing 'MUUHAAAAHAAAA':

SQLSTATE[HY000]: General error: 1 near "MUUHAAAAHAAAA": syntax error' contains 'An exception occurred while executing 'MUUHAAAAHAAAA':

SQLSTATE[HY000]: General error: 1 near "MUUHAAAAHAAAA"'.

4) Doctrine\Tests\DBAL\ConnectionTest::testDriverExceptionIsWrapped with data set #3 ('executeUpdate')
Failed asserting that exception message 'An exception occurred while executing 'MUUHAAAAHAAAA':

SQLSTATE[HY000]: General error: 1 near "MUUHAAAAHAAAA": syntax error' contains 'An exception occurred while executing 'MUUHAAAAHAAAA':

SQLSTATE[HY000]: General error: 1 near "MUUHAAAAHAAAA"'.

5) Doctrine\Tests\DBAL\ConnectionTest::testDriverExceptionIsWrapped with data set #4 ('prepare')
Failed asserting that exception message 'An exception occurred while executing 'MUUHAAAAHAAAA':

SQLSTATE[HY000]: General error: 1 near "MUUHAAAAHAAAA": syntax error' contains 'An exception occurred while executing 'MUUHAAAAHAAAA':

SQLSTATE[HY000]: General error: 1 near "MUUHAAAAHAAAA"'.

6) Doctrine\Tests\DBAL\SQLParserUtilsTest::testGetPlaceholderPositions with data set #21 ('SELECT * FROM foo WHERE bar = \'it\\\'s a trap? \\\\\' OR bar = ?
AND baz = "\\"quote\\" me on it? \\\\" OR baz = ?', true, array(58, 104))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     0 => 58
-    1 => 104
+    1 => 105
 )

E:\wwwroot\dbal\tests\Doctrine\Tests\DBAL\SQLParserUtilsTest.php:71

FAILURES!
Tests: 39, Assertions: 44, Failures: 6.
```
