### PR TITLE
backport bugfix to avoid fatal error in array_merge during generating the table creation SQL

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -64,7 +64,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
 
         $this->createTableQueries[$namespace] = array_merge(
             $this->createTableQueries[$namespace],
-            $this->platform->getCreateTableSQL($table)
+            (array) $this->platform->getCreateTableSQL($table)
         );
     }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Schema\Visitor;
+
+use \Doctrine\DBAL\Schema\Visitor\CreateSchemaSqlCollector;
+
+class CreateSchemaSqlCollectorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Doctrine\DBAL\Platforms\AbstractPlatform|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $platformMock;
+
+    /**
+     * @var \Doctrine\DBAL\Schema\Visitor\CreateSchemaSqlCollector
+     */
+    private $visitor;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->platformMock = $this->getMockBuilder('Doctrine\DBAL\Platforms\AbstractPlatform')
+            ->setMethods(
+                array(
+                    'getCreateForeignKeySQL',
+                    'getCreateSchemaSQL',
+                    'getCreateSequenceSQL',
+                    'getCreateTableSQL',
+                    'supportsForeignKeyConstraints',
+                    'supportsSchemas'
+                )
+            )
+            ->getMockForAbstractClass();
+        $this->visitor = new CreateSchemaSqlCollector($this->platformMock);
+
+        foreach (array('getCreateSchemaSQL', 'getCreateTableSQL', 'getCreateForeignKeySQL', 'getCreateSequenceSQL') as $method) {
+            $this->platformMock->expects($this->any())
+                ->method($method)
+                ->will($this->returnValue('foo'));
+        }
+    }
+
+    public function testAcceptsTable()
+    {
+        $table = $this->createTableMock();
+
+        $this->visitor->acceptTable($table);
+
+        $this->assertSame(array('foo'), $this->visitor->getQueries());
+    }
+
+    public function testAcceptsSequences()
+    {
+        $sequence = $this->createSequenceMock();
+
+        $this->visitor->acceptSequence($sequence);
+
+        $this->assertSame(array('foo'), $this->visitor->getQueries());
+    }
+
+    public function testResetsQueries()
+    {
+        foreach (array('supportsSchemas', 'supportsForeignKeys') as $method) {
+            $this->platformMock->expects($this->any())
+                ->method($method)
+                ->will($this->returnValue(true));
+        }
+
+        $table = $this->createTableMock();
+        $foreignKey = $this->createForeignKeyConstraintMock();
+        $sequence = $this->createSequenceMock();
+
+        $this->visitor->acceptTable($table);
+        $this->visitor->acceptForeignKey($table, $foreignKey);
+        $this->visitor->acceptSequence($sequence);
+
+        $this->assertNotEmpty($this->visitor->getQueries());
+
+        $this->visitor->resetQueries();
+
+        $this->assertEmpty($this->visitor->getQueries());
+    }
+
+    /**
+     * @return \Doctrine\DBAL\Schema\ForeignKeyConstraint|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createForeignKeyConstraintMock()
+    {
+        return $this->getMockBuilder('Doctrine\DBAL\Schema\ForeignKeyConstraint')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @return \Doctrine\DBAL\Schema\Sequence|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createSequenceMock()
+    {
+        return $this->getMockBuilder('Doctrine\DBAL\Schema\Sequence')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @return \Doctrine\DBAL\Schema\Table|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createTableMock()
+    {
+        return $this->getMockBuilder('Doctrine\DBAL\Schema\Table')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}


### PR DESCRIPTION
2.5 includes this fix in 1c9fe8df . this pull request is just to backport the bugfix without further changes.

i verified on https://github.com/jackalope/jackalope-doctrine-dbal/pull/258 that this change indeed fixes the issue - but i don't know how to write a test for this.
