### PR TITLE
Revert the addition of the wrong `bin` script to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."
     },
-    "bin": ["bin/doctrine-dbal", "bin/doctrine-dbal.php"],
+    "bin": ["bin/doctrine-dbal"],
     "autoload": {
         "psr-0": { "Doctrine\\DBAL\\": "lib/" }
     },


### PR DESCRIPTION
The bin/doctrine-dbal.php file is not an executable file. Adding them as a bin in composer.json means that any composer install will trigger changes in the source when using symlinks because of the chmod. This makes things a pain when installing from source.
Thus, there is no valid reason to add it. It is absolutely not necessary when using a composer install. The issue requesting it previously is actually an issue in Laravel which replaces the proxy file/symlink generated by Composer with a copy of the original file, which of course cannot work because of paths used in require. But copying a second file does not help for that (unless in very specific cases). It only moves the issue until the next require call.
