### PR TITLE
Documentation and code styling fixes

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1104,7 +1104,7 @@ class Connection implements DriverConnection
             $func($this);
             $this->commit();
         } catch (Exception $e) {
-            $this->rollback();
+            $this->rollBack();
             throw $e;
         }
     }
@@ -1268,7 +1268,7 @@ class Connection implements DriverConnection
                 $logger->startQuery('"ROLLBACK"');
             }
             $this->_transactionNestingLevel = 0;
-            $this->_conn->rollback();
+            $this->_conn->rollBack();
             $this->_isRollbackOnly = false;
             if ($logger) {
                 $logger->stopQuery();

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -29,7 +29,7 @@ use Doctrine\DBAL\Driver\PDOConnection;
 class Connection extends PDOConnection implements \Doctrine\DBAL\Driver\Connection
 {
     /**
-     * @override
+     * {@inheritDoc}
      */
     public function quote($value, $type=\PDO::PARAM_STR)
     {

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -218,9 +218,10 @@ final class DriverManager
      *
      * @param array $params The list of parameters.
      *
-     * @param array A modified list of parameters with info from a database
-     *              URL extracted into indidivual parameter parts.
+     * @return array A modified list of parameters with info from a database
+     *               URL extracted into indidivual parameter parts.
      *
+     * @throws DBALException
      */
     private static function parseDatabaseUrl(array $params)
     {

--- a/lib/Doctrine/DBAL/Id/TableGenerator.php
+++ b/lib/Doctrine/DBAL/Id/TableGenerator.php
@@ -156,7 +156,7 @@ class TableGenerator
             $this->conn->commit();
 
         } catch (\Exception $e) {
-            $this->conn->rollback();
+            $this->conn->rollBack();
             throw new \Doctrine\DBAL\DBALException("Error occurred while generating ID with TableGenerator, aborted generation: " . $e->getMessage(), 0, $e);
         }
 

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -20,7 +20,6 @@
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -49,6 +49,12 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * Adds MySQL-specific LIMIT clause to the query
      * 18446744073709551615 is 2^64-1 maximum of unsigned BIGINT the biggest limit possible
+     *
+     * @param string  $query
+     * @param integer $limit
+     * @param integer $offset
+     *
+     * @return string
      */
     protected function doModifyLimitQuery($query, $limit, $offset)
     {
@@ -346,6 +352,9 @@ class MySqlPlatform extends AbstractPlatform
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getListTablesSQL()
     {
         return "SHOW FULL TABLES WHERE Table_type = 'BASE TABLE'";

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -517,7 +517,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             }
 
             if ($columnDiff->hasChanged('notnull')) {
-                $query = 'ALTER ' . $oldColumnName . ' ' . ($column->getNotNull() ? 'SET' : 'DROP') . ' NOT NULL';
+                $query = 'ALTER ' . $oldColumnName . ' ' . ($column->getNotnull() ? 'SET' : 'DROP') . ' NOT NULL';
                 $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ' . $query;
             }
 

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1302,6 +1302,8 @@ class QueryBuilder
      * @param array  $knownAliases
      *
      * @return string
+     *
+     * @throws QueryException
      */
     private function getSQLForJoins($fromAlias, array &$knownAliases)
     {

--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -313,6 +313,8 @@ class Schema extends AbstractAsset
      * @param string $namespaceName The name of the namespace to create.
      *
      * @return \Doctrine\DBAL\Schema\Schema This schema instance.
+     *
+     * @throws SchemaException
      */
     public function createNamespace($namespaceName)
     {

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -418,6 +418,12 @@ class SqliteSchemaManager extends AbstractSchemaManager
         return $tableDiff;
     }
 
+    /**
+     * @param string $column
+     * @param string $sql
+     *
+     * @return string|false
+     */
     private function parseColumnCollationFromSQL($column, $sql)
     {
         if (preg_match(


### PR DESCRIPTION
This fixes:
- incorrect / incomplete / missing PHPdoc
- wrong case for method names
- unused imports
