### PR TITLE
template1 as default database for PostgreSQL

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -89,6 +89,9 @@ class Driver extends AbstractPostgreSQLDriver
         if (isset($params['dbname'])) {
             $dsn .= 'dbname=' . $params['dbname'] . ' ';
         }
+        else {
+            $dsn .= 'dbname=template1' . ' ';
+        }
 
         if (isset($params['sslmode'])) {
             $dsn .= 'sslmode=' . $params['sslmode'] . ' ';


### PR DESCRIPTION
Fixes (including but not limited to) https://github.com/doctrine/DoctrineBundle/issues/402 by connecting by default to 'template1' instead of the database with the same name as the user (PostgreSQL default in case of no dbname).
