### PR TITLE
[DBAL-1217] Fix retrieving the database name connected to for SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
@@ -78,7 +78,11 @@ abstract class AbstractSQLServerDriver implements Driver, VersionAwarePlatformDr
     {
         $params = $conn->getParams();
 
-        return $params['dbname'];
+        if (isset($params['dbname'])) {
+            return $params['dbname'];
+        }
+
+        return $conn->query('SELECT DB_NAME()')->fetchColumn();
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/Driver.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/Driver.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\PDOSqlsrv;
+
+use Doctrine\DBAL\Driver\PDOSqlsrv\Driver;
+use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+
+class DriverTest extends AbstractDriverTest
+{
+    protected function setUp()
+    {
+        if (! extension_loaded('pdo_sqlsrv')) {
+            $this->markTestSkipped('pdo_sqlsrv is not installed.');
+        }
+
+        parent::setUp();
+
+        if (! $this->_conn->getDriver() instanceof Driver) {
+            $this->markTestSkipped('pdo_sqlsrv only test.');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createDriver()
+    {
+        return new Driver();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDatabaseNameForConnectionWithoutDatabaseNameParameter()
+    {
+        return 'master';
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/Driver.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/Driver.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\SQLSrv;
+
+use Doctrine\DBAL\Driver\SQLSrv\Driver;
+use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+
+class DriverTest extends AbstractDriverTest
+{
+    protected function setUp()
+    {
+        if (! extension_loaded('sqlsrv')) {
+            $this->markTestSkipped('sqlsrv is not installed.');
+        }
+
+        parent::setUp();
+
+        if (! $this->_conn->getDriver() instanceof Driver) {
+            $this->markTestSkipped('sqlsrv only test.');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createDriver()
+    {
+        return new Driver();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDatabaseNameForConnectionWithoutDatabaseNameParameter()
+    {
+        return 'master';
+    }
+}


### PR DESCRIPTION
When connecting to SQL Server without `dbname` parameter set, the underlying driver emits a `undefined index "dbname"` when trying to retrieve the database name connected to via `Doctrine\DBAL\Driver::getDatabase()`.
This PR implements the "live" retrieval of the current database as seen in other drivers already.
