### PR TITLE
[DBAL-1218] Fix retrieving the database name connected to for SQL Anywhere

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
@@ -116,7 +116,11 @@ abstract class AbstractSQLAnywhereDriver implements Driver, ExceptionConverterDr
     {
         $params = $conn->getParams();
 
-        return $params['dbname'];
+        if (isset($params['dbname'])) {
+            return $params['dbname'];
+        }
+
+        return $conn->query('SELECT DB_NAME()')->fetchColumn();
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/AbstractDriverTest.php
@@ -12,7 +12,7 @@ abstract class AbstractDriverTest extends DbalFunctionalTestCase
      *
      * @var \Doctrine\DBAL\Driver
      */
-    private $driver;
+    protected $driver;
 
     protected function setUp()
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\SQLAnywhere\Driver;
+use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+
+class DriverTest extends AbstractDriverTest
+{
+    protected function setUp()
+    {
+        if (! extension_loaded('sqlanywhere')) {
+            $this->markTestSkipped('sqlanywhere is not installed.');
+        }
+
+        parent::setUp();
+
+        if (! $this->_conn->getDriver() instanceof Driver) {
+            $this->markTestSkipped('sqlanywhere only test.');
+        }
+    }
+
+    public function testReturnsDatabaseNameWithoutDatabaseNameParameter()
+    {
+        $params = $this->_conn->getParams();
+        unset($params['dbname']);
+
+        $connection = new Connection(
+            $params,
+            $this->_conn->getDriver(),
+            $this->_conn->getConfiguration(),
+            $this->_conn->getEventManager()
+        );
+
+        // SQL Anywhere has no "default" database. The name of the default database
+        // is defined on server startup and therefore can be arbitrary.
+        $this->assertInternalType('string', $this->driver->getDatabase($connection));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createDriver()
+    {
+        return new Driver();
+    }
+}


### PR DESCRIPTION
When connecting to SQL Anywhere without `dbname` parameter set, the underlying driver emits a `undefined index "dbname"` when trying to retrieve the database name connected to via `Doctrine\DBAL\Driver::getDatabase()`.
This PR implements the "live" retrieval of the current database as seen in other drivers already.
