### PR TITLE
[DBAL-1220] Fix dropping database with active connection on PostgreSQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSQL92Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSQL92Platform.php
@@ -72,4 +72,12 @@ class PostgreSQL92Platform extends PostgreSQL91Platform
         parent::initializeDoctrineTypeMappings();
         $this->doctrineTypeMapping['json'] = 'json_array';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCloseActiveDatabaseConnectionsSQL($database)
+    {
+        return "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$database'";
+    }
 }

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -421,6 +421,34 @@ class PostgreSqlPlatform extends AbstractPlatform
     }
 
     /**
+     * Returns the SQL statement for disallowing new connections on the given database.
+     *
+     * This is useful to force DROP DATABASE operations which could fail because of active connections.
+     *
+     * @param string $database The name of the database to disallow new connections for.
+     *
+     * @return string
+     */
+    public function getDisallowDatabaseConnectionsSQL($database)
+    {
+        return "UPDATE pg_database SET datallowconn = 'false' WHERE datname = '$database'";
+    }
+
+    /**
+     * Returns the SQL statement for closing currently active connections on the given database.
+     *
+     * This is useful to force DROP DATABASE operations which could fail because of active connections.
+     *
+     * @param string $database The name of the database to close currently active connections for.
+     *
+     * @return string
+     */
+    public function getCloseActiveDatabaseConnectionsSQL($database)
+    {
+        return "SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE datname = '$database'";
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getAdvancedForeignKeyOptionsSQL(\Doctrine\DBAL\Schema\ForeignKeyConstraint $foreignKey)

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -41,6 +41,36 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
     }
 
     /**
+     * @group DBAL-1220
+     */
+    public function testDropsDatabaseWithActiveConnections()
+    {
+        if (! $this->_sm->getDatabasePlatform()->supportsCreateDropDatabase()) {
+            $this->markTestSkipped('Cannot drop Database client side with this Driver.');
+        }
+
+        $this->_sm->dropAndCreateDatabase('test_drop_database');
+
+        $this->assertContains('test_drop_database', $this->_sm->listDatabases());
+
+        $params = $this->_conn->getParams();
+        $params['dbname'] = 'test_drop_database';
+
+        $user = isset($params['user']) ? $params['user'] : null;
+        $password = isset($params['password']) ? $params['password'] : null;
+
+        $connection = $this->_conn->getDriver()->connect($params, $user, $password);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Driver\Connection', $connection);
+
+        $this->_sm->dropDatabase('test_drop_database');
+
+        $this->assertNotContains('test_drop_database', $this->_sm->listDatabases());
+
+        unset($connection);
+    }
+
+    /**
      * @group DBAL-195
      */
     public function testDropAndCreateSequence()

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -792,4 +792,26 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('tsvector'));
         $this->assertEquals('text', $this->_platform->getDoctrineTypeMapping('tsvector'));
     }
+
+    /**
+     * @group DBAL-1220
+     */
+    public function testReturnsDisallowDatabaseConnectionsSQL()
+    {
+        $this->assertSame(
+            "UPDATE pg_database SET datallowconn = 'false' WHERE datname = 'foo'",
+            $this->_platform->getDisallowDatabaseConnectionsSQL('foo')
+        );
+    }
+
+    /**
+     * @group DBAL-1220
+     */
+    public function testReturnsCloseActiveDatabaseConnectionsSQL()
+    {
+        $this->assertSame(
+            "SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE datname = 'foo'",
+            $this->_platform->getCloseActiveDatabaseConnectionsSQL('foo')
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL92PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL92PlatformTest.php
@@ -56,4 +56,15 @@ class PostgreSQL92PlatformTest extends AbstractPostgreSqlPlatformTestCase
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('json'));
         $this->assertEquals('json_array', $this->_platform->getDoctrineTypeMapping('json'));
     }
+
+    /**
+     * @group DBAL-1220
+     */
+    public function testReturnsCloseActiveDatabaseConnectionsSQL()
+    {
+        $this->assertSame(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'foo'",
+            $this->_platform->getCloseActiveDatabaseConnectionsSQL('foo')
+        );
+    }
 }


### PR DESCRIPTION
PostgreSQL fails to drop a database if there are active connections using that particular database.
This PR closes all active connections before dropping the database if dropping the database failed before.
