### PR TITLE
Change MySQL defaults from broken utf8 to fixed utf8mb4

### DIFF
--- a/docs/en/reference/security.rst
+++ b/docs/en/reference/security.rst
@@ -169,6 +169,6 @@ by passing the driver option "charset" to Doctrine PDO MySQL driver. Using SET N
     <?php    
     $conn = DriverManager::getConnection(array(
         'driver' => 'pdo_mysql',
-        'charset' => 'UTF8',
+        'charset' => 'utf8mb4',  // May need 'utf8' for MySQL < 5.5.3
     ));
 

--- a/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
@@ -53,7 +53,7 @@ class MysqlSessionInit implements EventSubscriber
      * @param string         $charset   The charset.
      * @param string|boolean $collation The collation, or FALSE if no collation.
      */
-    public function __construct($charset = 'utf8', $collation = false)
+    public function __construct($charset = 'utf8mb4', $collation = false)
     {
         $this->_charset = $charset;
         $this->_collation = $collation;

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -476,14 +476,14 @@ class MySqlPlatform extends AbstractPlatform
 
         // Charset
         if ( ! isset($options['charset'])) {
-            $options['charset'] = 'utf8';
+            $options['charset'] = 'utf8mb4';
         }
 
         $tableOptions[] = sprintf('DEFAULT CHARACTER SET %s', $options['charset']);
 
         // Collate
         if ( ! isset($options['collate'])) {
-            $options['collate'] = 'utf8_unicode_ci';
+            $options['collate'] = 'utf8mb4_unicode_ci';
         }
 
         $tableOptions[] = sprintf('COLLATE %s', $options['collate']);


### PR DESCRIPTION
This is a conservative echo of https://github.com/doctrine/dbal/pull/317 .

Essentially MySQL's `uft8` character set is broken and does not support full UTF-8, and a better alternative, `utf8mb4` has existed for about five years now. When a 4-byte UTF-8 character comes in for a `utf8` table, by default MySQL will _truncate_ the string and log a warning. 

Insofar as Doctrine has any default configuration values for MySQL, I think `utf8mb4` is a better, safer choice. If anybody is running MySQL <5.5.3 and has problems, they should have a fairly easy time figuring out what's going wrong due to how distinctive the string is. (The other way around, searching for `utf8`, is not.)
