### PR TITLE
Add SQL Anywhere builds to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,29 @@ php:
   - hhvm
 
 env:
-  - DB=mysql
-  - DB=pgsql POSTGRESQL_VERSION=9.1
-  - DB=pgsql POSTGRESQL_VERSION=9.2
-  - DB=pgsql POSTGRESQL_VERSION=9.3
-  - DB=pgsql POSTGRESQL_VERSION=9.4
-  - DB=sqlite
-  - DB=mysqli
+  global:
+    # $SQLANYWHERE_12_GDRIVE_ID
+    - secure: "TaIWN0OTS1fGCdvpDpRIX/svYb3pjwBqISeN6KMspqn8QB2bkqRWn+A1s9lAZw/1Ou27Qep2sRvo3lYBEssz2ZC84/qlt520bga5P/DRBLzJWjNowFh1c8jti6WiAHCnhoEO+HoUa/4ZFdeNA71RSL+8Fb8slKjC/InrwrYTmQo="
+    # $SQLANYWHERE_16_GDRIVE_ID
+    - secure: "jMGH+6QisWj5XDLq5seTdJjQa8IXqqjjggufVOM0iqK3yqsCm/3D+XgXiREOABvV2iWhbR2j0jvrOGqYTaCX2mp/HSj4w86zFl+IDrsC7IcozoaJg2I4fBYn56jBEsk/wsMpGKBdH7TW1bMWyvJ1+3MCUVsEzTHYdpauVydv7Ek="
+    - LD_LIBRARY_PATH=`pwd`/sqlanywhere/lib64
+    - SQLANY16=`pwd`/sqlanywhere
+  matrix:
+    - DB=mysql
+    - DB=pgsql POSTGRESQL_VERSION=9.1
+    - DB=pgsql POSTGRESQL_VERSION=9.2
+    - DB=pgsql POSTGRESQL_VERSION=9.3
+    - DB=pgsql POSTGRESQL_VERSION=9.4
+    - DB=sqlite
+    - DB=mysqli
+    - DB=sqlanywhere SQLANYWHERE_GDRIVE_ID=$SQLANYWHERE_12_GDRIVE_ID
+    - DB=sqlanywhere SQLANYWHERE_GDRIVE_ID=$SQLANYWHERE_16_GDRIVE_ID
 
 before_install:
   - composer self-update
 
 install:
+  - if [ $DB = 'sqlanywhere' ]; then ./tests/travis/install_sqlanywhere.sh; fi
   - composer update --prefer-source
 
 before_script:
@@ -41,6 +52,14 @@ matrix:
       env: DB=pgsql POSTGRESQL_VERSION=9.3 # driver currently unsupported by HHVM
     - php: hhvm
       env: DB=pgsql POSTGRESQL_VERSION=9.4 # driver currently unsupported by HHVM
+    - php: hhvm
+      env: DB=sqlanywhere SQLANYWHERE_GDRIVE_ID=$SQLANYWHERE_12_GDRIVE_ID # driver currently unsupported by HHVM
+    - php: hhvm
+      env: DB=sqlanywhere SQLANYWHERE_GDRIVE_ID=$SQLANYWHERE_16_GDRIVE_ID # driver currently unsupported by HHVM
+    - php: 7.0
+      env: DB=sqlanywhere SQLANYWHERE_GDRIVE_ID=$SQLANYWHERE_12_GDRIVE_ID # driver currently unsupported by PHP 7.0
+    - php: 7.0
+      env: DB=sqlanywhere SQLANYWHERE_GDRIVE_ID=$SQLANYWHERE_16_GDRIVE_ID # driver currently unsupported by PHP 7.0
 
 addons:
   postgresql: '9.4'

--- a/tests/travis/install_sqlanywhere.sh
+++ b/tests/travis/install_sqlanywhere.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+wget -qO- "https://drive.google.com/uc?export=download&id=$SQLANYWHERE_GDRIVE_ID" | tar xz # SQL Anywhere server
+wget -qO- "https://drive.google.com/uc?export=download&id=0BxDG3LHQ2MkLS1oxaUQzTy1Jczg" | tar xz # PHP extensions
+
+echo "extension = `pwd`/php_sqlanywhere/sqlanywhere_$(phpenv version-name).so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
+cd sqlanywhere
+
+./bin64/dbspawn ./bin64/dbsrv -x tcpip{DOBROADCAST=NO} demo.db

--- a/tests/travis/sqlanywhere.travis.xml
+++ b/tests/travis/sqlanywhere.travis.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
+    <php>
+        <var name="db_type" value="sqlanywhere"/>
+        <var name="db_host" value="127.0.0.1" />
+        <var name="db_username" value="DBA" />
+        <var name="db_password" value="sql" />
+        <var name="db_name" value="doctrine_tests" />
+        <var name="db_port" value=""/>
+
+        <var name="tmpdb_type" value="sqlanywhere"/>
+        <var name="tmpdb_host" value="127.0.0.1" />
+        <var name="tmpdb_username" value="DBA" />
+        <var name="tmpdb_password" value="sql" />
+        <var name="tmpdb_port" value=""/>
+    </php>
+    <testsuites>
+        <testsuite name="Doctrine DBAL Test Suite">
+            <directory>../Doctrine/Tests/DBAL</directory>
+        </testsuite>
+    </testsuites>
+    <groups>
+        <exclude>
+            <group>performance</group>
+            <group>locking_functional</group>
+        </exclude>
+    </groups>
+</phpunit>


### PR DESCRIPTION
This is an attempt to enable functional testing for SQL Anywhere 12 + 16 on Travis.
It uses precompiled `sqlanywhere` PHP extensions for 5.3, 5.4, 5.5 and 5.6. Server-wise it uses preinstalled, lightweight packages (around 15 MB). This allows for a fast environment setup.
The packages reside on my Google Drive account, the URLs for the server packages are secured by Travis encryption.
The only downside of using secured environment variables is, that builds won't work on forks because of different SSH keys but that is a fair trade-off IMO.

/cc @zeroedin-bill @Ocramius @beberlei thoughts?
