### PR TITLE
Remove HHVM-nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
 
 env:
   - DB=mysql
@@ -33,20 +32,6 @@ matrix:
   allow_failures:
     - php: 7.0
     - php: hhvm
-      env: DB=pgsql POSTGRESQL_VERSION=9.1
-    - php: hhvm
-      env: DB=pgsql POSTGRESQL_VERSION=9.2
-    - php: hhvm
-      env: DB=pgsql POSTGRESQL_VERSION=9.3
-    - php: hhvm
-      env: DB=pgsql POSTGRESQL_VERSION=9.4
-    - php: hhvm
-      env: DB=sqlite
-    - php: hhvm
-      env: DB=mysql
-    - php: hhvm
-      env: DB=mysqli
-    - php: hhvm-nightly
   exclude:
     - php: hhvm
       env: DB=pgsql POSTGRESQL_VERSION=9.1 # driver currently unsupported by HHVM
@@ -55,14 +40,6 @@ matrix:
     - php: hhvm
       env: DB=pgsql POSTGRESQL_VERSION=9.3 # driver currently unsupported by HHVM
     - php: hhvm
-      env: DB=pgsql POSTGRESQL_VERSION=9.4 # driver currently unsupported by HHVM
-    - php: hhvm-nightly
-      env: DB=pgsql POSTGRESQL_VERSION=9.1 # driver currently unsupported by HHVM
-    - php: hhvm-nightly
-      env: DB=pgsql POSTGRESQL_VERSION=9.2 # driver currently unsupported by HHVM
-    - php: hhvm-nightly
-      env: DB=pgsql POSTGRESQL_VERSION=9.3 # driver currently unsupported by HHVM
-    - php: hhvm-nightly
       env: DB=pgsql POSTGRESQL_VERSION=9.4 # driver currently unsupported by HHVM
 
 addons:


### PR DESCRIPTION
This is similar to https://github.com/doctrine/doctrine2/pull/1401

This also simplies the allowed failures for HHVM
