### PR TITLE
add `DateInterval` type

### DIFF
--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -289,6 +289,15 @@ without date, time and timezone information, you should consider using this type
 Values retrieved from the database are always converted to PHP's ``\DateTime`` object
 or ``null`` if no data is present.
 
+dateinterval
+^^^^^^^^^^^^
+
+Maps and converts date and time difference data without timezone information.
+If you know that the data to be stored is the difference between two date and time values,
+you should consider using this type.
+Values retrieved from the database are always converted to PHP's ``\DateInterval`` object
+or ``null`` if no data is present.
+
 .. note::
 
     See the `Known Vendor Issue <./known-vendor-issues>`_ section

--- a/lib/Doctrine/DBAL/Types/DateIntervalType.php
+++ b/lib/Doctrine/DBAL/Types/DateIntervalType.php
@@ -9,8 +9,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class DateIntervalType extends Type
 {
-    const DATEINTERVAL_PATTERN = '#(?P<date>\d{4}-\d{2}-\d{2}).(?P<time>\d{2}:\d{2}:\d{2})#';
-
     /**
      * {@inheritdoc}
      */
@@ -35,9 +33,10 @@ class DateIntervalType extends Type
         $spec = null;
         if ($value !== null) {
             /** @var \DateInterval $value */
-            $spec = str_pad($value->y, 4, '0', STR_PAD_LEFT) . '-'
+            $spec = 'P'
+                . str_pad($value->y, 4, '0', STR_PAD_LEFT) . '-'
                 . $value->format('%M') . '-'
-                . $value->format('%D') . ' '
+                . $value->format('%D') . 'T'
                 . $value->format('%H') . ':'
                 . $value->format('%I') . ':'
                 . $value->format('%S')
@@ -56,11 +55,8 @@ class DateIntervalType extends Type
             return $value;
         }
 
-        if (preg_match(self::DATEINTERVAL_PATTERN, $value, $parts) !== 1) {
-            throw ConversionException::conversionFailedFormat($value, $this->getName(), 'Y-m-d H:i:s');
-        }
         try {
-            $interval = new \DateInterval('P' . $parts['date'] . 'T' . $parts['time']);
+            $interval = new \DateInterval($value);
         } catch (\Exception $e) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), 'PY-m-dTH:i:s');
 

--- a/lib/Doctrine/DBAL/Types/DateIntervalType.php
+++ b/lib/Doctrine/DBAL/Types/DateIntervalType.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Doctrine\DBAL\Types;
+
+/**
+ * 
+ */
+class DateIntervalType 
+{
+
+}

--- a/lib/Doctrine/DBAL/Types/DateIntervalType.php
+++ b/lib/Doctrine/DBAL/Types/DateIntervalType.php
@@ -10,8 +10,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class DateIntervalType extends Type
 {
-    const DATEINTERVAL_PATTERN = '#(?P<date>\d{4}-\d{2}-\d{2}).(?P<time>\d{2}:\d{2}:\d{2})#';
-
     /**
      * {@inheritdoc}
      */
@@ -33,19 +31,8 @@ class DateIntervalType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        $spec = null;
-        if ($value !== null) {
-            /** @var \DateInterval $value */
-            $spec = str_pad($value->y, 4, '0', STR_PAD_LEFT) . '-'
-                . $value->format('%M') . '-'
-                . $value->format('%D') . ' '
-                . $value->format('%H') . ':'
-                . $value->format('%I') . ':'
-                . $value->format('%S')
-            ;
-        }
-
-        return $spec;
+        return ($value !== null)
+            ? $value->format('P%yY%mM%dDT%hH%iM%sS') : null;
     }
 
     /**
@@ -57,13 +44,10 @@ class DateIntervalType extends Type
             return $value;
         }
 
-        if (preg_match(self::DATEINTERVAL_PATTERN, $value, $parts) !== 1) {
-            throw ConversionException::conversionFailedFormat($value, $this->getName(), 'Y-m-d H:i:s');
-        }
         try {
-            $interval = new \DateInterval('P' . $parts['date'] . 'T' . $parts['time']);
+            $interval = new \DateInterval($value);
         } catch (\Exception $e) {
-            throw ConversionException::conversionFailedFormat($value, $this->getName(), 'PY-m-dTH:i:s');
+            throw ConversionException::conversionFailedFormat($value, $this->getName(), 'PxYxMxDTxHxMxS');
 
         }
 

--- a/lib/Doctrine/DBAL/Types/DateIntervalType.php
+++ b/lib/Doctrine/DBAL/Types/DateIntervalType.php
@@ -22,6 +22,9 @@ class DateIntervalType extends Type
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
+        $fieldDeclaration['length'] = 20;
+        $fieldDeclaration['fixed']  = true;
+
         return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
     }
 

--- a/lib/Doctrine/DBAL/Types/DateIntervalType.php
+++ b/lib/Doctrine/DBAL/Types/DateIntervalType.php
@@ -3,10 +3,54 @@
 
 namespace Doctrine\DBAL\Types;
 
-/**
- * 
- */
-class DateIntervalType 
-{
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
+/**
+ * Type that maps interval string to a PHP DateInterval Object.
+ */
+class DateIntervalType extends Type
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return Type::DATEINTERVAL;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return ($value !== null)
+            ? $value->format('P%yY%mM%dDT%hH%iM%sS') : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if ($value === null || $value instanceof \DateInterval) {
+            return $value;
+        }
+
+        try {
+            $interval = new \DateInterval($value);
+        } catch (\Exception $e) {
+            throw ConversionException::conversionFailedFormat($value, $this->getName(), 'PxYxMxDTxHxMxS');
+
+        }
+
+        return $interval;
+    }
 }

--- a/lib/Doctrine/DBAL/Types/DateIntervalType.php
+++ b/lib/Doctrine/DBAL/Types/DateIntervalType.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class DateIntervalType extends Type
 {
+    const DATEINTERVAL_PATTERN = '#(?P<date>\d{4}-\d{2}-\d{2}).(?P<time>\d{2}:\d{2}:\d{2})#';
+
     /**
      * {@inheritdoc}
      */
@@ -31,8 +33,19 @@ class DateIntervalType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        return ($value !== null)
-            ? $value->format('P%yY%mM%dDT%hH%iM%sS') : null;
+        $spec = null;
+        if ($value !== null) {
+            /** @var \DateInterval $value */
+            $spec = str_pad($value->y, 4, '0', STR_PAD_LEFT) . '-'
+                . $value->format('%M') . '-'
+                . $value->format('%D') . ' '
+                . $value->format('%H') . ':'
+                . $value->format('%I') . ':'
+                . $value->format('%S')
+            ;
+        }
+
+        return $spec;
     }
 
     /**
@@ -44,10 +57,13 @@ class DateIntervalType extends Type
             return $value;
         }
 
+        if (preg_match(self::DATEINTERVAL_PATTERN, $value, $parts) !== 1) {
+            throw ConversionException::conversionFailedFormat($value, $this->getName(), 'Y-m-d H:i:s');
+        }
         try {
-            $interval = new \DateInterval($value);
+            $interval = new \DateInterval('P' . $parts['date'] . 'T' . $parts['time']);
         } catch (\Exception $e) {
-            throw ConversionException::conversionFailedFormat($value, $this->getName(), 'PxYxMxDTxHxMxS');
+            throw ConversionException::conversionFailedFormat($value, $this->getName(), 'PY-m-dTH:i:s');
 
         }
 

--- a/lib/Doctrine/DBAL/Types/DateIntervalType.php
+++ b/lib/Doctrine/DBAL/Types/DateIntervalType.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -52,6 +52,7 @@ abstract class Type
     const BLOB = 'blob';
     const FLOAT = 'float';
     const GUID = 'guid';
+    const DATEINTERVAL = 'dateinterval';
 
     /**
      * Map of already instantiated type objects. One instance per type (flyweight).
@@ -85,6 +86,7 @@ abstract class Type
         self::BINARY => 'Doctrine\DBAL\Types\BinaryType',
         self::BLOB => 'Doctrine\DBAL\Types\BlobType',
         self::GUID => 'Doctrine\DBAL\Types\GuidType',
+        self::DATEINTERVAL => 'Doctrine\DBAL\Types\DateIntervalType',
     );
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
@@ -19,9 +19,9 @@ class DateIntervalTest  extends \Doctrine\Tests\DbalTestCase
 
     public function testDateIntervalConvertsToDatabaseValue()
     {
-        $interval = new \DateInterval('P2Y1DT1H2M3S');
+        $interval = new \DateInterval('P1DT1H2M3S');
 
-        $expected = '0002-00-01 01:02:03';
+        $expected = $interval->format('P%yY%mM%dDT%hH%iM%sS');
         $actual = $this->_type->convertToDatabaseValue($interval, $this->_platform);
 
         $this->assertEquals($expected, $actual);
@@ -29,9 +29,9 @@ class DateIntervalTest  extends \Doctrine\Tests\DbalTestCase
 
     public function testDateIntervalConvertsToPHPValue()
     {
-        $date = $this->_type->convertToPHPValue('0002-00-01 01:02:03', $this->_platform);
+        $date = $this->_type->convertToPHPValue('P1DT1H2M3S', $this->_platform);
         $this->assertInstanceOf('DateInterval', $date);
-        $this->assertEquals('P2Y0M1DT1H2M3S', $date->format('P%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('P0Y0M1DT1H2M3S', $date->format('P%yY%mM%dDT%hH%iM%sS'));
     }
 
     public function testInvalidDateIntervalFormatConversion()

--- a/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Doctrine\Tests\DBAL\Types;
+
+/**
+ * 
+ */
+class DateIntervalTest 
+{
+
+}

--- a/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
@@ -19,9 +19,9 @@ class DateIntervalTest  extends \Doctrine\Tests\DbalTestCase
 
     public function testDateIntervalConvertsToDatabaseValue()
     {
-        $interval = new \DateInterval('P1DT1H2M3S');
+        $interval = new \DateInterval('P2Y1DT1H2M3S');
 
-        $expected = $interval->format('P%yY%mM%dDT%hH%iM%sS');
+        $expected = '0002-00-01 01:02:03';
         $actual = $this->_type->convertToDatabaseValue($interval, $this->_platform);
 
         $this->assertEquals($expected, $actual);
@@ -29,9 +29,9 @@ class DateIntervalTest  extends \Doctrine\Tests\DbalTestCase
 
     public function testDateIntervalConvertsToPHPValue()
     {
-        $date = $this->_type->convertToPHPValue('P1DT1H2M3S', $this->_platform);
+        $date = $this->_type->convertToPHPValue('0002-00-01 01:02:03', $this->_platform);
         $this->assertInstanceOf('DateInterval', $date);
-        $this->assertEquals('P0Y0M1DT1H2M3S', $date->format('P%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('P2Y0M1DT1H2M3S', $date->format('P%yY%mM%dDT%hH%iM%sS'));
     }
 
     public function testInvalidDateIntervalFormatConversion()

--- a/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
@@ -20,7 +20,6 @@ class DateIntervalTest  extends \Doctrine\Tests\DbalTestCase
     public function testDateIntervalConvertsToDatabaseValue()
     {
         $interval = new \DateInterval('P2Y1DT1H2M3S');
-
         $expected = '0002-00-01 01:02:03';
         $actual = $this->_type->convertToDatabaseValue($interval, $this->_platform);
 

--- a/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
@@ -21,7 +21,7 @@ class DateIntervalTest  extends \Doctrine\Tests\DbalTestCase
     {
         $interval = new \DateInterval('P2Y1DT1H2M3S');
 
-        $expected = '0002-00-01 01:02:03';
+        $expected = 'P0002-00-01T01:02:03';
         $actual = $this->_type->convertToDatabaseValue($interval, $this->_platform);
 
         $this->assertEquals($expected, $actual);
@@ -29,7 +29,7 @@ class DateIntervalTest  extends \Doctrine\Tests\DbalTestCase
 
     public function testDateIntervalConvertsToPHPValue()
     {
-        $date = $this->_type->convertToPHPValue('0002-00-01 01:02:03', $this->_platform);
+        $date = $this->_type->convertToPHPValue('P0002-00-01T01:02:03', $this->_platform);
         $this->assertInstanceOf('DateInterval', $date);
         $this->assertEquals('P2Y0M1DT1H2M3S', $date->format('P%yY%mM%dDT%hH%iM%sS'));
     }

--- a/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
@@ -1,12 +1,47 @@
 <?php
 
-
 namespace Doctrine\Tests\DBAL\Types;
 
-/**
- * 
- */
-class DateIntervalTest 
-{
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 
+class DateIntervalTest  extends \Doctrine\Tests\DbalTestCase
+{
+    protected
+        $_platform,
+        $_type;
+
+    protected function setUp()
+    {
+        $this->_platform = new MockPlatform();
+        $this->_type = Type::getType('dateinterval');
+    }
+
+    public function testDateIntervalConvertsToDatabaseValue()
+    {
+        $interval = new \DateInterval('P1DT1H2M3S');
+
+        $expected = $interval->format('P%yY%mM%dDT%hH%iM%sS');
+        $actual = $this->_type->convertToDatabaseValue($interval, $this->_platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testDateIntervalConvertsToPHPValue()
+    {
+        $date = $this->_type->convertToPHPValue('P1DT1H2M3S', $this->_platform);
+        $this->assertInstanceOf('DateInterval', $date);
+        $this->assertEquals('P0Y0M1DT1H2M3S', $date->format('P%yY%mM%dDT%hH%iM%sS'));
+    }
+
+    public function testInvalidDateIntervalFormatConversion()
+    {
+        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
+        $this->_type->convertToPHPValue('abcdefg', $this->_platform);
+    }
+
+    public function testDateIntervalNullConversion()
+    {
+        $this->assertNull($this->_type->convertToPHPValue(null, $this->_platform));
+    }
 }


### PR DESCRIPTION
Added DateInterval Type to store/receive PHP DateInterval objects.
Internally DateInterval is converted to string to store in VARCHAR field.
For maximum performance full DateInterval format is used when converting to database value.
