### PR TITLE
MySQL getListTableForeignKeysSQL: use current database if null passed

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -191,6 +191,8 @@ class MySqlPlatform extends AbstractPlatform
 
         if ($database) {
             $sql .= " AND k.table_schema = '$database' /*!50116 AND c.constraint_schema = '$database' */";
+        } else {
+            $sql .= " AND k.table_schema = DATABASE() /*!50116 AND c.constraint_schema = DATABASE() */";
         }
 
         $sql .= " AND k.`REFERENCED_COLUMN_NAME` is not NULL";

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -189,12 +189,9 @@ class MySqlPlatform extends AbstractPlatform
                "  c.constraint_name = k.constraint_name AND ".
                "  c.table_name = '$table' */ WHERE k.table_name = '$table'";
 
-        if ($database) {
-            $sql .= " AND k.table_schema = '$database' /*!50116 AND c.constraint_schema = '$database' */";
-        } else {
-            $sql .= " AND k.table_schema = DATABASE() /*!50116 AND c.constraint_schema = DATABASE() */";
-        }
+        $databaseNameSql = null === $database ? "'$database'" : 'DATABASE()';
 
+        $sql .= " AND k.table_schema = $databaseNameSql /*!50116 AND c.constraint_schema = $databaseNameSql */";
         $sql .= " AND k.`REFERENCED_COLUMN_NAME` is not NULL";
 
         return $sql;


### PR DESCRIPTION
In line with the behavior of `getListTableIndexesSQL()` the foreign key function should select only foreign keys from the current database if no database name is specified. Otherwise it returns foreign keys of all tables in any database with the given name. This can especially lead to issues if you install different versions of the same schema into multiple databases on the same server.

This function is always called with `$database = null` in the following chain, which leads to SQL errors when trying to setup/delete a schema in tests on a mysql server that contains another copy of the schema in another database:

```
Doctrine\ORM\Tools\SchemaTool::dropDatabase()
Doctrine\ORM\Tools\SchemaTool::getDropDatabaseSQL()
Doctrine\DBAL\Schema\AbstractSchemaManager::createSchema()
Doctrine\DBAL\Schema\AbstractSchemaManager::listTables()
Doctrine\DBAL\Schema\AbstractSchemaManager::listTableDetails($tableName)
Doctrine\DBAL\Schema\AbstractSchemaManager::listTableForeignKeys($table, null)
Doctrine\DBAL\Platforms\MySqlPlatform::getListTableForeignKeysSQL($table, null)
```

I think the `$database` parameter would ideally be required, and an exception should be thrown if it is null. The AbstractSchemaManager should be modified to consistently pass the database name to the platform in all its calls. But for now this workaround corrects the issue for foreign keys.
