### PR TITLE
Check for foreign table name on removed tables foreign key

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -116,6 +116,10 @@ class Comparator
                     $localTableName = strtolower($foreignKey->getLocalTableName());
                     if (isset($diff->changedTables[$localTableName])) {
                         foreach ($diff->changedTables[$localTableName]->removedForeignKeys as $key => $removedForeignKey) {
+                            //We check if the key is from the removed table if not we skip
+                            if($tableName !== strtolower($removedForeignKey->getForeignTableName())) {
+                                continue;
+                            }
                             unset($diff->changedTables[$localTableName]->removedForeignKeys[$key]);
                         }
                     }


### PR DESCRIPTION
According to the comment

// deleting duplicated foreign keys present on both on the orphanedForeignKey
// and the removedForeignKeys from changedTables

A check must be had on the $removedForeignKey so it does point on the removed table. Currently it does unset all keys removal even the one pointing on other table.

This should probably be added to a previous version since it's a bug fix but I don't know the exact flow you are following for this.
