### PR TITLE
Quote table and constraint names in drop foreign key / drop constraint SQL

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -154,7 +154,7 @@ class SchemaDiff
 
         if ($platform->supportsForeignKeyConstraints() && $saveMode == false) {
             foreach ($this->orphanedForeignKeys as $orphanedForeignKey) {
-                $sql[] = $platform->getDropForeignKeySQL($orphanedForeignKey, $orphanedForeignKey->getLocalTableName());
+                $sql[] = $platform->getDropForeignKeySQL($orphanedForeignKey, $orphanedForeignKey->getLocalTable());
             }
         }
 


### PR DESCRIPTION
On the MySQLPlatform::getDropForeignKeySQL table name will not be escaped if the name is passed instead of the object table itself.

Since the getLocalTableName use the localTable property the object is always available, there is no reason not to use it.
