### PR TITLE
Strip leading slash of databasename from URL

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -231,8 +231,15 @@ final class DriverManager
         
         // (pdo_)?sqlite3?:///... => (pdo_)?sqlite3?://localhost/... or else the URL will be invalid
         $url = preg_replace('#^((?:pdo_)?sqlite3?):///#', '$1://localhost/', $params['url']);
-        
-        $url = parse_url($url);
+
+        // PHP<5.4.8 doesn't parse schemeless urls properly
+        if (strpos($url, '//') === 0 && version_compare(PHP_VERSION, '5.4.8') < 0) {
+            $url = parse_url("fake:$url");
+            unset($url['scheme']);
+        } else {
+            $url = parse_url($url);
+        }
+
         
         if ($url === false) {
             throw new DBALException('Malformed parameter "url".');

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -259,10 +259,10 @@ final class DriverManager
         }
         
         if (isset($url['path'])) {
-            if (!isset($url['scheme']) || (strpos($url['scheme'], 'sqlite') !== false && $url['path'] == ':memory:')) {
-                $params['dbname'] = $url['path']; // if the URL was just "sqlite::memory:", which parses to scheme and path only
-            } else {
+            if (isset($params['driverClass']) || (isset($params['driver']) && (strpos($params['driver'], 'sqlite') === false || $url['path'] !== ':memory:'))) {
                 $params['dbname'] = substr($url['path'], 1); // strip the leading slash from the URL
+            } else {
+                $params['dbname'] = $url['path']; // if the URL was just "sqlite::memory:", which parses to scheme and path only
             }
         }
         

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -197,6 +197,14 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
                 'drizzle-pdo-mysql://foo:bar@localhost/baz',
                 array('user' => 'foo', 'password' => 'bar', 'host' => 'localhost', 'dbname' => 'baz', 'driver' => 'Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver'),
             ),
+            'custom schema with custom driverClass does not get the leading slash trimmed from path' => array(
+                    array('url' => '//foo:bar@localhost/baz', 'driverClass' => 'Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver'),
+                    array('user' => 'foo', 'password' => 'bar', 'host' => 'localhost', 'dbname' => 'baz', 'driverClass' => 'Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver'),
+            ),
+            'Specifying driver separate from URL works' => array(
+                    array('url' => '//foo:bar@localhost/baz', 'driver' => 'pdo_mysql'),
+                    array('user' => 'foo', 'password' => 'bar', 'host' => 'localhost', 'dbname' => 'baz', 'driver' => 'Doctrine\DBAL\Driver\PDOMySQL\Driver'),
+            ),
         );
     }
 }


### PR DESCRIPTION
This is actuall the commit for [DBAL-1234](http://www.doctrine-project.org/jira/browse/DBAL-1234)

When using a custom driver via `driverClass` in all (some?) cases one cannot set
the scheme properly. In the earlier implementation when the scheme is missing the
`DriverManager` leaves the leading slash in the path, because it silently assumes,
that this is a SQLite-connection. With custom drivers this leads to invalid database
names.

Additionally this takes care, that if one specifies the driver via configuration key
`driver`, but the connection with scheme-less URL it ends up in an invalid database
name too    

```
driver: pdo_mysql
url: //user:pass@localhost/database
```

Another solution is to introduce a special `custom`-scheme, that doesn't point to a driver, but declares, that `driverClass` is required

```
custom://foo:bar@localhost:123/my_db
```

However, this would not take care of the other use-case,
