### PR TITLE
Fix undefined notices within MasterSlaveConnection

### DIFF
--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -151,7 +151,7 @@ class MasterSlaveConnection extends Connection
         // If we have a connection open, and this is not an explicit connection
         // change request, then abort right here, because we are already done.
         // This prevents writes to the slave in case of "keepSlave" option enabled.
-        if ($this->_conn && !$requestedConnectionChange) {
+        if (isset($this->_conn) && $this->_conn && !$requestedConnectionChange) {
             return false;
         }
 
@@ -162,7 +162,7 @@ class MasterSlaveConnection extends Connection
             $forceMasterAsSlave = true;
         }
 
-        if ($this->connections[$connectionName]) {
+        if (isset($this->connections[$connectionName]) && $this->connections[$connectionName]) {
             $this->_conn = $this->connections[$connectionName];
 
             if ($forceMasterAsSlave && ! $this->keepSlave) {


### PR DESCRIPTION
To fix the following notice-level errors:

Notice: Undefined property: Doctrine\DBAL\Connections\MasterSlaveConnection::$_conn in vendor/doctrine/dbal/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php line 154
Notice: Undefined index: slave in vendor/doctrine/dbal/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php line 165
