### PR TITLE
Fix issue with  zero date for DateTime Type

### DIFF
--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -49,8 +49,12 @@ class DateTimeType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        return ($value !== null)
-            ? $value->format($platform->getDateTimeFormatString()) : null;
+        if($value === null) {
+            return null;
+        }
+
+        $value = $value->format($platform->getDateTimeFormatString());
+        return $value === '-0001-11-30 00:00:00' ? '0000-00-00 00:00:00' : $value;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/DateTimeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTimeTest.php
@@ -60,4 +60,14 @@ class DateTimeTest extends \Doctrine\Tests\DbalTestCase
 
         $this->assertEquals('1985-09-01 10:10:10', $actual->format('Y-m-d H:i:s'));
     }
+
+    public function testConvertZeroDateTimeToDatabaseValue()
+    {
+        $value = '0000-00-00 00:00:00';
+        $date = new \DateTime($value);
+
+        $result = $this->_type->convertToDatabaseValue($date, $this->_platform);
+
+        $this->assertEquals($value, $result);
+    }
 }


### PR DESCRIPTION
Fix PHP issue with  zero date for DateTime Type,
when PHP return `-0001-11-30 00:00:00` for `0000-00-00 00:00:00` value
