### PR TITLE
Add test for schema diffing on a table with a renamed foreign key column referencing a renamed table

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -1232,4 +1232,44 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
             array('0', 'foo', false),
         );
     }
+
+    public function testForeignKeyRemovalWithRenamedLocalColumn()
+    {
+        $fromSchema = new Schema( array(
+            'table1' => new Table('table1',
+                array(
+                    'id' => new Column('id', Type::getType('integer')),
+                )),
+            'table2' => new Table('table2',
+                array(
+                    'id' => new Column('id', Type::getType('integer')),
+                    'id_table1' => new Column('id_table1', Type::getType('integer'))
+                ),
+                array(),
+                array(
+                    new ForeignKeyConstraint(array('id_table1'), 'table1', array('id'), 'fk_table2_table1')
+                ))
+        ));
+        $toSchema = new Schema( array(
+            'table2' => new Table('table2',
+                array(
+                    'id' => new Column('id', Type::getType('integer')),
+                    'id_table3' => new Column('id_table3', Type::getType('integer'))
+                ),
+                array(),
+                array(
+                    new ForeignKeyConstraint(array('id_table3'), 'table3', array('id'), 'fk_table2_table3')
+                )),
+            'table3' => new Table('table3',
+                array(
+                    'id' => new Column('id', Type::getType('integer'))
+                ))
+        ));
+        $actual = Comparator::compareSchemas($fromSchema, $toSchema);
+        $this->assertArrayHasKey("table2", $actual->changedTables);
+        $this->assertCount(1, $actual->orphanedForeignKeys);
+        $this->assertEquals("fk_table2_table1", $actual->orphanedForeignKeys[0]->getName());
+        $this->assertCount(1, $actual->changedTables['table2']->addedForeignKeys, "FK to table3 should be added.");
+        $this->assertEquals("table3", $actual->changedTables['table2']->addedForeignKeys[0]->getForeignTableName());
+    }
 }


### PR DESCRIPTION
~~In situations where SQL is generated with SchemaDiff::toSaveSql, foreign keys for columns that have been renamed or removed were not being dropped if the referenced table was orphaned.~~

This PR adds a test to ensure that when a table should be renamed, and the FK columns referencing it should also be renamed, the FKs are properly removed and readded. This PR formerly fixed an issue where this was not successful, but it has since been fixed upstream, so this PR has just been pared back to the added test.
