### PR TITLE
Make SQLite honor the "memory" option for in-memory db

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -52,9 +52,13 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $params = $this->_conn->getParams();
         $driver = $params['driver'];
         $options = array(
-            'driver' => $driver,
-            'path' => $database
+            'driver' => $driver
         );
+        if(isset($params['memory']) && $params['memory']){
+            $options['memory'] = true;
+        }else{
+            $options['path'] = $database;
+        }
         $conn = \Doctrine\DBAL\DriverManager::getConnection($options);
         $conn->connect();
         $conn->close();

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -18,6 +18,10 @@ class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testCreateAndDropDatabase()
     {
+        $params = $this->_conn->getParams();
+        if(isset($params['memory']) && $params['memory']){
+            $this->markTestSkipped("Cannot test add/drop of Sqlite in-memory databases by looking at files");
+        }
         $path = dirname(__FILE__).'/test_create_and_drop_sqlite_database.sqlite';
 
         $this->_sm->createDatabase($path);


### PR DESCRIPTION
Shouldn't this be the default behavior ?
