### PR TITLE
`SqlConsoleCommand` should show results of queries containing `RETURNING`

### DIFF
--- a/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
@@ -48,7 +48,8 @@ class RunSqlCommand extends Command
         ->setDescription('Executes arbitrary SQL directly from the command line.')
         ->setDefinition(array(
             new InputArgument('sql', InputArgument::REQUIRED, 'The SQL statement to execute.'),
-            new InputOption('depth', null, InputOption::VALUE_REQUIRED, 'Dumping depth of result set.', 7)
+            new InputOption('depth', null, InputOption::VALUE_REQUIRED, 'Dumping depth of result set.', 7),
+            new InputOption('fetch-result', null, InputOption::VALUE_NONE, 'Forces fetching the result.'),
         ))
         ->setHelp(<<<EOT
 Executes arbitrary SQL directly from the command line.
@@ -73,7 +74,7 @@ EOT
             throw new \LogicException("Option 'depth' must contains an integer value");
         }
 
-        if (stripos($sql, 'select') === 0) {
+        if (stripos($sql, 'select') === 0 || $input->getOption('fetch-result')) {
             $resultSet = $conn->fetchAll($sql);
         } else {
             $resultSet = $conn->executeUpdate($sql);

--- a/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
@@ -106,4 +106,18 @@ class RunSqlCommandTest extends \PHPUnit_Framework_TestCase
             ->expects($this->exactly(1))
             ->method('fetchAll');
     }
+
+    public function testStatementsWithFetchResultPrintsResult()
+    {
+        $this->expectConnectionFetchAll();
+
+        $this->commandTester->execute(array(
+            'command' => $this->command->getName(),
+            'sql' => '"WITH bar as (SELECT 1) SELECT * FROM bar',
+            '--fetch-result' => true,
+        ));
+
+        $this->assertRegExp('@int.*1.*@', $this->commandTester->getDisplay());
+        $this->assertRegExp('@array.*1.*@', $this->commandTester->getDisplay());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Tools\Console;
+
+use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
+use Doctrine\DBAL\Tools\Console\ConsoleRunner;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class RunSqlCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var CommandTester */
+    private $commandTester;
+    /** @var RunSqlCommand */
+    private $command;
+
+    private $connectionMock;
+
+    protected function setUp()
+    {
+        $application = new Application();
+        $application->add(new RunSqlCommand());
+
+        $this->command = $application->find('dbal:run-sql');
+        $this->commandTester = new CommandTester($this->command);
+
+        $this->connectionMock = $this->getMock('\Doctrine\DBAL\Connection', array(), array(), '', false);
+        $this->connectionMock->method('fetchAll')
+            ->willReturn(array(array(1)));
+        $this->connectionMock->method('executeUpdate')
+            ->willReturn(42);
+
+        $helperSet = ConsoleRunner::createHelperSet($this->connectionMock);
+        $this->command->setHelperSet($helperSet);
+    }
+
+    public function testMissingSqlArgument()
+    {
+        try {
+            $this->commandTester->execute(array(
+                'command' => $this->command->getName(),
+                'sql' => null,
+            ));
+            $this->fail('Expected a runtime exception when omitting sql argument');
+        } catch (\RuntimeException $e) {
+            $this->assertContains("Argument 'SQL", $e->getMessage());
+        }
+    }
+
+    public function testIncorrectDepthOption()
+    {
+        try {
+            $this->commandTester->execute(array(
+                'command' => $this->command->getName(),
+                'sql' => 'SELECT 1',
+                '--depth' => 'string',
+            ));
+            $this->fail('Expected a logic exception when executing with a stringy depth');
+        } catch (\LogicException $e) {
+            $this->assertContains("Option 'depth'", $e->getMessage());
+        }
+    }
+
+    public function testSelectStatementsPrintsResult()
+    {
+        $this->expectConnectionFetchAll();
+
+        $this->commandTester->execute(array(
+            'command' => $this->command->getName(),
+            'sql' => 'SELECT 1',
+        ));
+
+        $this->assertRegExp('@int.*1.*@', $this->commandTester->getDisplay());
+        $this->assertRegExp('@array.*1.*@', $this->commandTester->getDisplay());
+    }
+
+    public function testUpdateStatementsPrintsAffectedLines()
+    {
+        $this->expectConnectionExecuteUpdate();
+
+        $this->commandTester->execute(array(
+            'command' => $this->command->getName(),
+            'sql' => 'UPDATE foo SET bar = 42',
+        ));
+
+        $this->assertRegExp('@int.*42.*@', $this->commandTester->getDisplay());
+        $this->assertNotRegExp('@array.*1.*@', $this->commandTester->getDisplay());
+    }
+
+    private function expectConnectionExecuteUpdate()
+    {
+        $this->connectionMock
+            ->expects($this->exactly(1))
+            ->method('executeUpdate');
+        $this->connectionMock
+            ->expects($this->exactly(0))
+            ->method('fetchAll');
+    }
+
+    private function expectConnectionFetchAll()
+    {
+        $this->connectionMock
+            ->expects($this->exactly(0))
+            ->method('executeUpdate');
+        $this->connectionMock
+            ->expects($this->exactly(1))
+            ->method('fetchAll');
+    }
+}


### PR DESCRIPTION
PostgreSQL supports returning values after they are inserted or updated which is especially handy if one wants to get the value of an used sequence. (See http://www.postgresql.org/docs/9.4/static/sql-insert.html) Those returned values are currently omitted but could be displayed.

Currently (with symfony):

```
vagrant@packer-parallels-iso:/vagrant⟫ app/console doctrine:query:sql "INSERT INTO account (id) VALUES (uuid_generate_v4()) RETURNING id"
int 0
```

After the patch the output is the following:

```
array (size=1)
  0 =>
    array (size=1)
      'id' => string 'ad7a7c8f-72fd-48b9-b216-568ac204649d' (length=36)
```

Looking directly for 'returning' is a bit direct in my eyes but as there is no sql parser present, there is no other easy way to do so. If someone has a better implementation or any suggestion, feel free to comment :)
