### PR TITLE
return result from Doctrine\DBAL\Connection::transactional()

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1093,7 +1093,7 @@ class Connection implements DriverConnection
      *
      * @param \Closure $func The function to execute transactionally.
      *
-     * @return void
+     * @return mixed The value returned by $func
      *
      * @throws \Exception
      */
@@ -1101,8 +1101,9 @@ class Connection implements DriverConnection
     {
         $this->beginTransaction();
         try {
-            $func($this);
+            $res = $func($this);
             $this->commit();
+            return $res;
         } catch (Exception $e) {
             $this->rollBack();
             throw $e;

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -209,6 +209,14 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         });
     }
 
+    public function testTransactionalReturnValue()
+    {
+        $res = $this->_conn->transactional(function($conn) {
+            return 42;
+        });
+        $this->assertEquals(42, $res);
+    }
+
     /**
      * Tests that the quote function accepts DBAL and PDO types.
      */


### PR DESCRIPTION
otherwise we have to import a variable from the parent scope into the closure scope like that

``` php
$conn->transactional(function(Connection $conn) use ($res) {
    $res = ...
});
// use $res here
```

instead with the PR it can be written this way:

``` php
$res = $conn->transactional(function(Connection $conn) {
    return ...;
});
// use $res here
```
