### PR TITLE
convertToDatabaseValueSQL with $columnName

### DIFF
--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -291,10 +291,11 @@ abstract class Type
      *
      * @param string                                    $sqlExpr
      * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     * @param string                                    $columnName
      *
      * @return string
      */
-    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform)
+    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform, $columnName = null)
     {
         return $sqlExpr;
     }


### PR DESCRIPTION
## Goal:

I want to be able to atomically increment a property such that `$stock->setQuantityDelta(2);` will render into an SQL such as `UPDATE stock SET quantity = quantity+? WHERE id = ?;`.

I would like to accomplish this without using `DQL` every time it is necessary hence I implemented a custom Doctrine2 type which can accomplish this -- with support from this PR.
## Changes:

Added a new `$columnName` parameter to `\Doctrine\DBAL\Types\Type::convertToDatabaseValueSQL` which would be passed by `\Doctrine\ORM\Persisters\BasicEntityPersister::updateTable` ([PR](https://github.com/doctrine/doctrine2/pull/1434)) and used by the concrete type instance (ex.: **@mihai-stancu/doctrine-types-extra**:`\MS\Doctrine\DBAL\Types\DeltaType`).
