### PR TITLE
Generating a ColumnDiff led to unquoted Columns for Postgres

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.6.x-dev"
+            "dev-master": "2.6.x-dev",
+            "dev-patch-1": "~2.5"
         }
     },
     "archive": {

--- a/lib/Doctrine/DBAL/Schema/ColumnDiff.php
+++ b/lib/Doctrine/DBAL/Schema/ColumnDiff.php
@@ -77,6 +77,10 @@ class ColumnDiff
      */
     public function getOldColumnName()
     {
-        return new Identifier($this->oldColumnName);
+        if ($this->column->isQuoted()) {
+            return new Identifier('"' . $this->oldColumnName . '"');
+        } else {
+            return new Identifier($this->oldColumnName);
+        }
     }
 }

--- a/lib/Doctrine/DBAL/Schema/ColumnDiff.php
+++ b/lib/Doctrine/DBAL/Schema/ColumnDiff.php
@@ -79,8 +79,7 @@ class ColumnDiff
     {
         if ($this->column->isQuoted()) {
             return new Identifier('"' . $this->oldColumnName . '"');
-        } else {
-            return new Identifier($this->oldColumnName);
         }
+        return new Identifier($this->oldColumnName);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/ColumnDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ColumnDiffTest.php
@@ -9,31 +9,54 @@ use Doctrine\DBAL\Types\Type;
 
 class ColumnDiffTest extends \PHPUnit_Framework_TestCase
 {
-    public function testColumnDiffQuotationForOldAndNewName()
+    public function testColumnDiffQuotationForOldAndNewNameSqlite()
     {
-        $comparator = new Comparator();
+        list($columnA, $columnB, $diff) = $this->getColumnDiff();
 
-        $string = Type::getType('string');
-        $columnA = new Column("`bar`", $string, array());
-        $columnB = new Column("`foo`", $string, array());
-
-        $diff = new ColumnDiff($columnA->getName(), $columnB, $comparator->diffColumn($columnA, $columnB));
-
-
-        $mysqlPlatform = new \Doctrine\DBAL\Platforms\MySqlPlatform();
         $sqlitePlatform = new \Doctrine\DBAL\Platforms\SqlitePlatform();
 
         $this->assertEquals($columnA->getName(), $diff->getOldColumnName()->getName());
-        $this->assertEquals($columnA->getQuotedName($mysqlPlatform), $diff->getOldColumnName()->getQuotedName($mysqlPlatform));
         $this->assertEquals($columnA->getQuotedName($sqlitePlatform), $diff->getOldColumnName()->getQuotedName($sqlitePlatform));
 
         $this->assertEquals($columnB->getName(), $diff->column->getName());
-        $this->assertEquals($columnB->getQuotedName($mysqlPlatform), $diff->column->getQuotedName($mysqlPlatform));
         $this->assertEquals($columnB->getQuotedName($sqlitePlatform), $diff->column->getQuotedName($sqlitePlatform));
+    }
 
-        $columnA = new Column("[bar]", $string);
-        $columnB = new Column("[foo]", $string);
-        $diff = new ColumnDiff($columnA->getName(), $columnB, $comparator->diffColumn($columnA, $columnB));
+    public function testColumnDiffQuotationForOldAndNewNameMySql()
+    {
+        list($columnA, $columnB, $diff) = $this->getColumnDiff();
+
+        $mysqlPlatform = new \Doctrine\DBAL\Platforms\MySqlPlatform();
+
+        $this->assertEquals($columnA->getName(), $diff->getOldColumnName()->getName());
+        $this->assertEquals($columnA->getQuotedName($mysqlPlatform), $diff->getOldColumnName()->getQuotedName($mysqlPlatform));
+
+        $this->assertEquals($columnB->getName(), $diff->column->getName());
+        $this->assertEquals($columnB->getQuotedName($mysqlPlatform), $diff->column->getQuotedName($mysqlPlatform));
+    }
+
+    public function testColumnDiffQuotationForOldAndNewNamePostgreSql()
+    {
+        list($columnA, $columnB, $diff) = $this->getColumnDiff();
+
+        $pgPlatform = new \Doctrine\DBAL\Platforms\PostgreSqlPlatform();
+        $pg91Platform = new \Doctrine\DBAL\Platforms\PostgreSQL91Platform();
+        $pg92Platform = new \Doctrine\DBAL\Platforms\PostgreSQL92Platform();
+
+        $this->assertEquals($columnA->getName(), $diff->getOldColumnName()->getName());
+        $this->assertEquals($columnA->getQuotedName($pgPlatform), $diff->getOldColumnName()->getQuotedName($pgPlatform));
+        $this->assertEquals($columnA->getQuotedName($pg91Platform), $diff->getOldColumnName()->getQuotedName($pg91Platform));
+        $this->assertEquals($columnA->getQuotedName($pg92Platform), $diff->getOldColumnName()->getQuotedName($pg92Platform));
+
+        $this->assertEquals($columnB->getName(), $diff->column->getName());
+        $this->assertEquals($columnB->getQuotedName($pgPlatform), $diff->column->getQuotedName($pgPlatform));
+        $this->assertEquals($columnB->getQuotedName($pg91Platform), $diff->column->getQuotedName($pg91Platform));
+        $this->assertEquals($columnB->getQuotedName($pg92Platform), $diff->column->getQuotedName($pg92Platform));
+    }
+
+    public function testColumnDiffQuotationForOldAndNewNameSqlServer()
+    {
+        list($columnA, $columnB, $diff) = $this->getColumnDiff("[", "]");
 
         $sqlServerPlatform = new \Doctrine\DBAL\Platforms\SQLServerPlatform();
 
@@ -44,4 +67,24 @@ class ColumnDiffTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($columnB->getQuotedName($sqlServerPlatform), $diff->column->getQuotedName($sqlServerPlatform));
     }
 
+    /**
+     * @param string $left
+     * @param string $right
+     * @return array
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    private function getColumnDiff($left = "`", $right = "`")
+    {
+        $comparator = new Comparator();
+
+        $string = Type::getType('string');
+        $columnA = new Column("${left}bar${right}", $string, array());
+        $columnB = new Column("${left}foo${right}", $string, array());
+
+        return array(
+            $columnA,
+            $columnB,
+            new ColumnDiff($columnA->getName(), $columnB, $comparator->diffColumn($columnA, $columnB))
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/ColumnDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ColumnDiffTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Types\Type;
+
+class ColumnDiffTest extends \PHPUnit_Framework_TestCase
+{
+    public function testColumnDiffQuotationForOldAndNewName()
+    {
+        $comparator = new Comparator();
+
+        $string = Type::getType('string');
+        $columnA = new Column("`bar`", $string, array());
+        $columnB = new Column("`foo`", $string, array());
+
+        $diff = new ColumnDiff($columnA->getName(), $columnB, $comparator->diffColumn($columnA, $columnB));
+
+
+        $mysqlPlatform = new \Doctrine\DBAL\Platforms\MySqlPlatform();
+        $sqlitePlatform = new \Doctrine\DBAL\Platforms\SqlitePlatform();
+
+        $this->assertEquals($columnA->getName(), $diff->getOldColumnName()->getName());
+        $this->assertEquals($columnA->getQuotedName($mysqlPlatform), $diff->getOldColumnName()->getQuotedName($mysqlPlatform));
+        $this->assertEquals($columnA->getQuotedName($sqlitePlatform), $diff->getOldColumnName()->getQuotedName($sqlitePlatform));
+
+        $this->assertEquals($columnB->getName(), $diff->column->getName());
+        $this->assertEquals($columnB->getQuotedName($mysqlPlatform), $diff->column->getQuotedName($mysqlPlatform));
+        $this->assertEquals($columnB->getQuotedName($sqlitePlatform), $diff->column->getQuotedName($sqlitePlatform));
+
+        $columnA = new Column("[bar]", $string);
+        $columnB = new Column("[foo]", $string);
+        $diff = new ColumnDiff($columnA->getName(), $columnB, $comparator->diffColumn($columnA, $columnB));
+
+        $sqlServerPlatform = new \Doctrine\DBAL\Platforms\SQLServerPlatform();
+
+        $this->assertEquals($columnA->getName(), $diff->getOldColumnName()->getName());
+        $this->assertEquals($columnA->getQuotedName($sqlServerPlatform), $diff->getOldColumnName()->getQuotedName($sqlServerPlatform));
+
+        $this->assertEquals($columnB->getName(), $diff->column->getName());
+        $this->assertEquals($columnB->getQuotedName($sqlServerPlatform), $diff->column->getQuotedName($sqlServerPlatform));
+    }
+
+}


### PR DESCRIPTION
Postgres needs (or understands) quoted column-names all the Time, especially if one is using mix cased column names.
While generating Diffs, the old column name got no quotation.
