### PR TITLE
Fixed simple_array type if array is empty

### DIFF
--- a/lib/Doctrine/DBAL/Types/SimpleArrayType.php
+++ b/lib/Doctrine/DBAL/Types/SimpleArrayType.php
@@ -44,9 +44,8 @@ class SimpleArrayType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        if (!$value) {
-            return null;
-        }
+        if ($value === null) return null;
+        if (!$value) return '';
 
         return implode(',', $value);
     }
@@ -56,9 +55,8 @@ class SimpleArrayType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null) {
-            return array();
-        }
+        if ($value === null) return null;
+        if (!$value) return array();
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
 


### PR DESCRIPTION
I'm using `"doctrine/orm": v2.5.0` and have `simple_array` type.
If I persist the class where the property with type `simple_array` is empty `array()` the query fails.

```
[Doctrine\DBAL\Exception\NotNullConstraintViolationException]                                                                                
  An exception occurred while executing 'INSERT INTO option (value, indicators) VALUES (?, ?)' with params ["Y", null]:  
  SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'question_id' cannot be null
```

``` php
class Option
{
    /**
     * @Column(type="simple_array")
     */
    public $indicators = array();
}
```

Found the problem in `/lib/Doctrine/DBAL/Types/JsonArrayType.php` line 38
https://github.com/doctrine/dbal/pull/143/files#diff-505f8625ef2628cdf37564b6bb499bdcR40

This PR allow pesisting empty arrays.
