### PR TITLE
Fix call on non-object in ping() with PDO wrapper

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1590,7 +1590,7 @@ class Connection implements DriverConnection
         }
 
         try {
-            $this->query($this->platform->getDummySelectSQL());
+            $this->query($this->getDatabasePlatform()->getDummySelectSQL());
 
             return true;
         } catch (DBALException $e) {


### PR DESCRIPTION
Fixes an issue when calling `ping()` where `$this->platform` is null. Happened to me because using the `'pdo'` param bypasses the `connect()` method and the platform is never set without explicitly calling the method.

Not sure if this is the most elegant way to deal with this but it worked enough for my purposes so I figured I should submit a PR.
