### PR TITLE
workaround for travis composer self-update ipv6 timeout issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - DB=mysqli
 
 before_install:
+  - sudo sh -c "echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf"
   - composer self-update
 
 install:


### PR DESCRIPTION
Testing to see if making ipv6 have lower precedence than ipv4 on travis boxes fixes the composer timeout issue.

Workaround from @Seldaek in this issue thread: https://github.com/composer/composer/issues/4142
