### PR TITLE
Drop PHP 5.3 from Travis-CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,6 @@ script: ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml
 
 matrix:
   include:
-    - php: 5.3
-      env: DB=mariadb
-      addons:
-        mariadb: 5.5
     - php: 5.4
       env: DB=mariadb
       addons:
@@ -54,10 +50,6 @@ matrix:
       addons:
         mariadb: 5.5
 
-    - php: 5.3
-      env: DB=mariadb
-      addons:
-        mariadb: 10.0
     - php: 5.4
       env: DB=mariadb
       addons:
@@ -79,10 +71,6 @@ matrix:
       addons:
         mariadb: 10.0
 
-    - php: 5.3
-      env: DB=mariadb
-      addons:
-        mariadb: 10.1
     - php: 5.4
       env: DB=mariadb
       addons:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.4",
         "doctrine/common": "~2.4"
     },
     "require-dev": {

--- a/docs/en/reference/security.rst
+++ b/docs/en/reference/security.rst
@@ -155,20 +155,3 @@ the ``Connection#quote`` method:
 
 This method is only available for SQL, not for DQL. For DQL it is always encouraged to use prepared
 statements not only for security, but also for caching reasons.
-
-Non-ASCII compatible Charsets in MySQL
---------------------------------------
-
-Up until PHP 5.3.6 PDO has a security problem when using non ascii compatible charsets. Even if specifying
-the charset using "SET NAMES", emulated prepared statements and ``PDO#quote`` could not reliably escape
-values, opening up to potential SQL injections. If you are running PHP 5.3.6 you can solve this issue
-by passing the driver option "charset" to Doctrine PDO MySQL driver. Using SET NAMES does not suffice!
-
-.. code-block::
-
-    <?php    
-    $conn = DriverManager::getConnection(array(
-        'driver' => 'pdo_mysql',
-        'charset' => 'UTF8',
-    ));
-


### PR DESCRIPTION
Drops php 5.3 from travis build matrix and updates composer.json to require php >= 5.4
