### PR TITLE
Add Mysql per-column charset support

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -1080,4 +1080,12 @@ class MySqlPlatform extends AbstractPlatform
 
         return 'LONGBLOB';
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getColumnCharsetDeclarationSQL($charset)
+    {
+        return 'CHARACTER SET ' . $charset;
+    }
 }

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -199,6 +199,10 @@ class MySqlSchemaManager extends AbstractSchemaManager
 
         $column = new Column($tableColumn['field'], Type::getType($type), $options);
 
+        if (isset($tableColumn['characterset'])) {
+            $column->setPlatformOption('charset', $tableColumn['characterset']);
+        }
+
         if (isset($tableColumn['collation'])) {
             $column->setPlatformOption('collation', $tableColumn['collation']);
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -199,6 +199,25 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertEquals('utf8_general_ci', $columns['bar']->getPlatformOption('collation'));
     }
 
+    public function testColumnCharset()
+    {
+        $table = new Table('test_charset');
+        $table->addOption('collate', $collation = 'latin1_swedish_ci');
+        $table->addOption('charset', 'latin1');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('text', 'text');
+        $table->addColumn('foo', 'text')->setPlatformOption('charset', 'latin1');
+        $table->addColumn('bar', 'text')->setPlatformOption('charset', 'utf8');
+        $this->_sm->dropAndCreateTable($table);
+
+        $columns = $this->_sm->listTableColumns('test_charset');
+
+        $this->assertArrayNotHasKey('charset', $columns['id']->getPlatformOptions());
+        $this->assertEquals('latin1', $columns['text']->getPlatformOption('charset'));
+        $this->assertEquals('latin1', $columns['foo']->getPlatformOption('charset'));
+        $this->assertEquals('utf8', $columns['bar']->getPlatformOption('charset'));
+    }
+
     /**
      * @group DBAL-843
      */

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -10,4 +10,12 @@ class MySqlPlatformTest extends AbstractMySQLPlatformTestCase
     {
         return new MysqlPlatform;
     }
+
+    public function testColumnCharsetDeclarationSQL()
+    {
+        $this->assertEquals(
+            'CHARACTER SET utf8',
+            $this->_platform->getColumnCharsetDeclarationSQL('utf8')
+        );
+    }
 }


### PR DESCRIPTION
Actually with MySQL we can define a collation per column, but the charset seems not supported, whereas specified in the documentation : http://doctrine-dbal.readthedocs.org/en/latest/reference/schema-representation.html#vendor-specific-options

I've added the `CHARACTER SET ***` sql declation for the MySQL platform.

Use case with Doctrine/ORM : 

``` php
/**
 * @Column(name="foo", type="text", options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4"})
 **/
```

Linked PR : #850 
