### PR TITLE
Fixed problem when having subqueries in where clause.

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1190,7 +1190,7 @@ class SQLServerPlatform extends AbstractPlatform
         $format  = 'SELECT * FROM (%s) AS doctrine_tbl WHERE doctrine_rownum BETWEEN %d AND %d ORDER BY doctrine_rownum';
 
         // Pattern to match "main" SELECT ... FROM clause (including nested parentheses in select list).
-        $selectFromPattern = '/^(\s*SELECT\s+(?:(.*)(?![^(]*\))))\sFROM\s/i';
+        $selectFromPattern = '/^(\s*SELECT\s+(?:(.*?)(?![^(]*\))))\sFROM\s/i';
 
         if ( ! $orderBy) {
             //Replace only "main" FROM with OVER to prevent changing FROM also in subqueries.


### PR DESCRIPTION
Hello,

I had some problems when using a query like

``` sql
SELECT a, b, c FROM t1 WHERE (SELECT COUNT(*) FROM t2 WHERE t1.a = t2.a) > 0
```

because the FROM in the WHERE-clause got matched as the "main" FROM. Changing part of the regex to non-greedy seems to fix the problem (without affecting SELECT ... FROM subqueries in the SELECT-part.
