### PR TITLE
Allow testing against `doctrine/common` `2.6`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.4,<2.6-dev"
+        "doctrine/common": "~2.4"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
By forbidding 2.6-dev, dbal 2.5 is untestable, because when composer tries to resolve deps to their highest, it has two choices:
- doctrine/common@dev-master + dbal@2.4
- or doctrine/common@2.5 + dbal@dev-master

and it chooses the first option.
