### PR TITLE
#1234 On OracleDB, a "Table has no primary key" error is raised when the index and the constraint name don't match

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -441,7 +441,7 @@ class OraclePlatform extends AbstractPlatform
                        (
                            SELECT ucon.constraint_type
                            FROM   user_constraints ucon
-                           WHERE  ucon.constraint_name = uind_col.index_name
+                           WHERE  ucon.index_name = uind_col.index_name
                        ) AS is_primary
              FROM      user_ind_columns uind_col
              WHERE     uind_col.table_name = '" . $table->getName() . "'


### PR DESCRIPTION
When reverse-engineering oracle database, "Table has no primary key" error is triggered. That is caused by a mistake in index selection from database.
