### PR TITLE
DDC 3863 - Invalid JsonArrayType [master]

### DIFF
--- a/lib/Doctrine/DBAL/Types/JsonArrayType.php
+++ b/lib/Doctrine/DBAL/Types/JsonArrayType.php
@@ -54,7 +54,11 @@ class JsonArrayType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value === '') {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value === '') {
             return array();
         }
 

--- a/lib/Doctrine/DBAL/Types/JsonArrayType.php
+++ b/lib/Doctrine/DBAL/Types/JsonArrayType.php
@@ -63,8 +63,13 @@ class JsonArrayType extends Type
         }
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
+        $val = json_decode($value, true);
 
-        return json_decode($value, true);
+        if ($val === null && json_last_error() !== 0) {
+            throw ConversionException::conversionFailed($value, $this->getName());
+        }
+
+        return $val;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
@@ -43,7 +43,7 @@ class JsonArrayTest extends \Doctrine\Tests\DbalTestCase
 
     public function testJsonNullConvertsToPHPValue()
     {
-        $this->assertSame(array(), $this->type->convertToPHPValue(null, $this->platform));
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
     public function testJsonEmptyStringConvertsToPHPValue()

--- a/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
@@ -69,6 +69,13 @@ class JsonArrayTest extends \Doctrine\Tests\DbalTestCase
         $this->assertSame($value, $phpValue);
     }
 
+    public function testConversionFailure()
+    {
+        error_reporting( (E_ALL | E_STRICT) - \E_NOTICE );
+        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
+        $this->type->convertToPHPValue('{', $this->platform);
+    }
+
     public function testRequiresSQLCommentHint()
     {
         $this->assertTrue($this->type->requiresSQLCommentHint($this->platform));


### PR DESCRIPTION
Master version of the [DDC-3863](http://www.doctrine-project.org/jira/browse/DDC-3863)'s fix. Basically, instead of returning an empty `array()` value if the value is null (or empty), we're returning another null value instead.

If you think this is a valid addition (after some corrections if needed), should I open other PRs for the other supported branches (2.3, 2.4, 2.5) ? But this looks like a BC break, even though the original behaviour is strange compared to the `ArrayType`'s behavior...

Thanks
