### PR TITLE
DDC-3863 add a `json` type that doesn't have the flaws of `json_array`

### DIFF
--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -368,6 +368,25 @@ using comma delimited ``explode()`` or ``null`` if no data is present.
     This basically means that every array item other than ``string``
     will loose its type awareness.
 
+json
+^^^^
+
+Maps and converts array data based on PHP's JSON encoding functions.
+If you know that the data to be stored always is in a valid UTF-8
+encoded JSON format string, you should consider using this type.
+Values retrieved from the database are always converted to PHP's ``array`` or 
+``null`` types using PHP's ``json_decode()`` function.
+
+.. note::
+
+    Some vendors have a native JSON type and Doctrine will use it if possible
+    and otherwise silently fall back to the vendor's ``text`` type to ensure
+    the most efficient storage requirements.
+    If the vendor does not have a native JSON type, this type requires a SQL
+    column comment hint so that it can be reverse engineered from the database.
+    Doctrine cannot map back this type properly on vendors not supporting column
+    comments and will fall back to ``text`` type instead.
+
 json_array
 ^^^^^^^^^^
 

--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -390,6 +390,10 @@ Values retrieved from the database are always converted to PHP's ``array`` or
 json_array
 ^^^^^^^^^^
 
+.. warning::
+
+    This type is deprecated since 2.6, you should use ``json`` instead.
+
 Maps and converts array data based on PHP's JSON encoding functions.
 If you know that the data to be stored always is in a valid UTF-8
 encoded JSON format string, you should consider using this type.

--- a/lib/Doctrine/DBAL/Types/ConversionException.php
+++ b/lib/Doctrine/DBAL/Types/ConversionException.php
@@ -99,4 +99,16 @@ class ConversionException extends \Doctrine\DBAL\DBALException
             implode(', ', $possibleTypes)
         ));
     }
+
+    static public function conversionFailedSerialization($value, $format, $error, \Exception $previous = null)
+    {
+        $actualType = is_object($value) ? get_class($value) : gettype($value);
+
+        return new self(sprintf(
+            "Could not convert PHP type '%s' to '%s', as an '%s' error was triggered by the serialization",
+            $actualType,
+            $format,
+            $error
+        ));
+    }
 }

--- a/lib/Doctrine/DBAL/Types/JsonArrayType.php
+++ b/lib/Doctrine/DBAL/Types/JsonArrayType.php
@@ -25,30 +25,11 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  * Array Type which can be used to generate json arrays.
  *
  * @since  2.3
+ * @deprecated Use JsonType instead
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class JsonArrayType extends Type
+class JsonArrayType extends JsonType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
-    {
-        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
-    {
-        if (null === $value) {
-            return null;
-        }
-
-        return json_encode($value);
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/lib/Doctrine/DBAL/Types/JsonType.php
+++ b/lib/Doctrine/DBAL/Types/JsonType.php
@@ -46,7 +46,13 @@ class JsonType extends Type
             return null;
         }
 
-        return json_encode($value);
+        $encoded = json_encode($value);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw ConversionException::conversionFailedSerialization($value, 'json', $this->getLastErrorMessage());
+        }
+
+        return $encoded;
     }
 
     /**
@@ -90,5 +96,45 @@ class JsonType extends Type
          */
         //return ! $platform->hasNativeJsonType();
         return true;
+    }
+
+    /**
+     * Get the latest json error message
+     *
+     * This method declaration has been extracted from symfony's php 5.5 polyfill
+     *
+     * @link https://github.com/symfony/polyfill-php55/blob/master/Php55.php
+     * @link http://nl1.php.net/manual/en/function.json-last-error-msg.php
+     *
+     * @return string
+     */
+    private function getLastErrorMessage()
+    {
+        if (function_exists('json_last_error_msg')) {
+            return json_last_error_msg();
+        }
+
+        switch (json_last_error()) {
+            case JSON_ERROR_NONE:
+                return 'No error';
+
+            case JSON_ERROR_DEPTH:
+                return 'Maximum stack depth exceeded';
+
+            case JSON_ERROR_STATE_MISMATCH:
+                return 'State mismatch (invalid or malformed JSON)';
+
+            case JSON_ERROR_CTRL_CHAR:
+                return 'Control character error, possibly incorrectly encoded';
+
+            case JSON_ERROR_SYNTAX:
+                return 'Syntax error';
+
+            case JSON_ERROR_UTF8:
+                return 'Malformed UTF-8 characters, possibly incorrectly encoded';
+
+            default:
+                return 'Unknown error';
+        }
     }
 }

--- a/lib/Doctrine/DBAL/Types/JsonType.php
+++ b/lib/Doctrine/DBAL/Types/JsonType.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * Type generating json objects values
+ *
+ * @since  2.6
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+class JsonType extends Type
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        return json_encode($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_resource($value)) {
+            $value = stream_get_contents($value);
+        }
+
+        $val = json_decode($value, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw ConversionException::conversionFailed($value, $this->getName());
+        }
+
+        return $val;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return Type::JSON;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        /*
+         * should be switched back to the platform detection at 3.0, when
+         * JsonArrayType will be dropped
+         */
+        //return ! $platform->hasNativeJsonType();
+        return true;
+    }
+}

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -36,6 +36,7 @@ abstract class Type
     const TARRAY = 'array';
     const SIMPLE_ARRAY = 'simple_array';
     const JSON_ARRAY = 'json_array';
+    const JSON = 'json';
     const BIGINT = 'bigint';
     const BOOLEAN = 'boolean';
     const DATETIME = 'datetime';
@@ -70,6 +71,7 @@ abstract class Type
         self::TARRAY => 'Doctrine\DBAL\Types\ArrayType',
         self::SIMPLE_ARRAY => 'Doctrine\DBAL\Types\SimpleArrayType',
         self::JSON_ARRAY => 'Doctrine\DBAL\Types\JsonArrayType',
+        self::JSON => 'Doctrine\DBAL\Types\JsonType',
         self::OBJECT => 'Doctrine\DBAL\Types\ObjectType',
         self::BOOLEAN => 'Doctrine\DBAL\Types\BooleanType',
         self::INTEGER => 'Doctrine\DBAL\Types\IntegerType',

--- a/tests/Doctrine/Tests/DBAL/Types/JsonTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Types;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+
+class JsonTest extends \Doctrine\Tests\DbalTestCase
+{
+    /**
+     * @var \Doctrine\Tests\DBAL\Mocks\MockPlatform
+     */
+    protected $platform;
+
+    /**
+     * @var \Doctrine\DBAL\Types\JsonType
+     */
+    protected $type;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->platform = new MockPlatform();
+        $this->type     = Type::getType('json');
+    }
+
+    public function testReturnsBindingType()
+    {
+        $this->assertSame(\PDO::PARAM_STR, $this->type->getBindingType());
+    }
+
+    public function testReturnsName()
+    {
+        $this->assertSame(Type::JSON, $this->type->getName());
+    }
+
+    public function testReturnsSQLDeclaration()
+    {
+        $this->assertSame('DUMMYJSON', $this->type->getSQLDeclaration(array(), $this->platform));
+    }
+
+    public function testJsonNullConvertsToPHPValue()
+    {
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testJsonEmptyStringConvertsToPHPValue()
+    {
+        $this->assertNull($this->type->convertToPHPValue('', $this->platform));
+    }
+
+    public function testJsonStringConvertsToPHPValue()
+    {
+        $value         = array('foo' => 'bar', 'bar' => 'foo');
+        $databaseValue = json_encode($value);
+        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
+
+        $this->assertEquals($value, $phpValue);
+    }
+
+    /** @dataProvider providerFailure */
+    public function testConversionFailure($data)
+    {
+        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
+        $this->type->convertToPHPValue($data, $this->platform);
+    }
+
+    public function providerFailure()
+    {
+        return array(array('a'), array('{'));
+    }
+
+    public function testJsonResourceConvertsToPHPValue()
+    {
+        $value         = array('foo' => 'bar', 'bar' => 'foo');
+        $databaseValue = fopen('data://text/plain;base64,' . base64_encode(json_encode($value)), 'r');
+        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
+
+        $this->assertSame($value, $phpValue);
+    }
+
+    public function testRequiresSQLCommentHint()
+    {
+        $this->assertTrue($this->type->requiresSQLCommentHint($this->platform));
+    }
+}


### PR DESCRIPTION
As discussed in #891, the `JsonArrayType` was deprecated in favor of a new `JsonType`. :}
