### PR TITLE
Fixed correct value in "Doctrine\Tests\DBAL\Schema\Visitor\SchemaSqlCollectorTest"

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -66,10 +66,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
     public function acceptNamespace($namespaceName)
     {
         if ($this->platform->supportsSchemas()) {
-            $this->createNamespaceQueries = array_merge(
-                $this->createNamespaceQueries,
-                (array) $this->platform->getCreateSchemaSQL($namespaceName)
-            );
+            $this->createNamespaceQueries[] = $this->platform->getCreateSchemaSQL($namespaceName);
         }
     }
 
@@ -87,12 +84,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
     public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint)
     {
         if ($this->platform->supportsForeignKeyConstraints()) {
-            $this->createFkConstraintQueries = array_merge(
-                $this->createFkConstraintQueries,
-                (array) $this->platform->getCreateForeignKeySQL(
-                    $fkConstraint, $localTable
-                )
-            );
+            $this->createFkConstraintQueries[] = $this->platform->getCreateForeignKeySQL($fkConstraint, $localTable);
         }
     }
 
@@ -101,10 +93,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
      */
     public function acceptSequence(Sequence $sequence)
     {
-        $this->createSequenceQueries = array_merge(
-            $this->createSequenceQueries,
-            (array) $this->platform->getCreateSequenceSQL($sequence)
-        );
+        $this->createSequenceQueries[] = $this->platform->getCreateSequenceSQL($sequence);
     }
 
     /**
@@ -125,24 +114,11 @@ class CreateSchemaSqlCollector extends AbstractVisitor
      */
     public function getQueries()
     {
-        $sql = array();
-
-        foreach ($this->createNamespaceQueries as $schemaSql) {
-            $sql = array_merge($sql, (array) $schemaSql);
-        }
-
-        foreach ($this->createTableQueries as $schemaSql) {
-            $sql = array_merge($sql, (array) $schemaSql);
-        }
-
-        foreach ($this->createSequenceQueries as $schemaSql) {
-            $sql = array_merge($sql, (array) $schemaSql);
-        }
-
-        foreach ($this->createFkConstraintQueries as $schemaSql) {
-            $sql = array_merge($sql, (array) $schemaSql);
-        }
-
-        return $sql;
+        return array_merge(
+            $this->createNamespaceQueries,
+            $this->createTableQueries,
+            $this->createSequenceQueries,
+            $this->createFkConstraintQueries
+        );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
@@ -17,10 +17,10 @@ class SchemaSqlCollectorTest extends \PHPUnit_Framework_TestCase
                      ->will($this->returnValue(array("foo")));
         $platformMock->expects($this->exactly(1))
                      ->method('getCreateSequenceSql')
-                     ->will($this->returnValue(array("bar")));
+                     ->will($this->returnValue("bar"));
         $platformMock->expects($this->exactly(1))
                      ->method('getCreateForeignKeySql')
-                     ->will($this->returnValue(array("baz")));
+                     ->will($this->returnValue("baz"));
 
         $schema = $this->createFixtureSchema();
 


### PR DESCRIPTION
In the `Doctrine\DBAL\Platforms\AbstractPlatform`, those three methods' return value are `string`
- getCreateSchemaSQL
- getCreateForeignKeySQL
- getCreateSequenceSQL

The `$platformMock` should return string value, not array

I also refactored `Doctrine\DBAL\Schema\Visitor\CreateSchemaSqlCollector`
Since these three methods' return value are string, we can simply add the SQL string into an array with this style `$foo[] = $sql`
