### PR TITLE
Override methods for sharding connection

### DIFF
--- a/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
@@ -129,6 +129,64 @@ class PoolingShardConnection extends Connection
     }
 
     /**
+     * Get active shard id.
+     * 
+     * @return integer
+     */
+    public function getActiveShardId()
+    {
+        return $this->activeShardId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParams()
+    {
+        return $this->activeShardId ? $this->connections[$this->activeShardId] : parent::getParams();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHost()
+    {
+        $params = $this->getParams();
+
+        return isset($params['host']) ? $params['host'] : parent::getHost();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPort()
+    {
+        $params = $this->getParams();
+
+        return isset($params['port']) ? $params['port'] : parent::getPort();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUsername()
+    {
+        $params = $this->getParams();
+
+        return isset($params['user']) ? $params['user'] : parent::getUsername();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPassword()
+    {
+        $params = $this->getParams();
+
+        return isset($params['password']) ? $params['password'] : parent::getPassword();
+    }
+
+    /**
      * Connects to a given shard.
      *
      * @param mixed $shardId

--- a/lib/Doctrine/DBAL/Sharding/PoolingShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardManager.php
@@ -18,6 +18,7 @@
  */
 
 namespace Doctrine\DBAL\Sharding;
+use Doctrine\DBAL\Sharding\ShardChoser\ShardChoser;
 
 /**
  * Shard Manager for the Connection Pooling Shard Strategy
@@ -27,12 +28,12 @@ namespace Doctrine\DBAL\Sharding;
 class PoolingShardManager implements ShardManager
 {
     /**
-     * @var \Doctrine\DBAL\Sharding\PoolingShardConnection
+     * @var PoolingShardConnection
      */
     private $conn;
 
     /**
-     * @var \Doctrine\DBAL\Sharding\ShardChoser\ShardChoser
+     * @var ShardChoser
      */
     private $choser;
 
@@ -42,7 +43,7 @@ class PoolingShardManager implements ShardManager
     private $currentDistributionValue;
 
     /**
-     * @param \Doctrine\DBAL\Sharding\PoolingShardConnection $conn
+     * @param PoolingShardConnection $conn
      */
     public function __construct(PoolingShardConnection $conn)
     {

--- a/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardConnectionTest.php
@@ -20,6 +20,7 @@
 namespace Doctrine\Tests\DBAL\Sharding;
 
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser;
 
 class PoolingShardConnectionTest extends \PHPUnit_Framework_TestCase
 {
@@ -177,6 +178,118 @@ class PoolingShardConnectionTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('Doctrine\DBAL\Sharding\ShardingException', 'Cannot switch shard when transaction is active.');
         $conn->connect(1);
+    }
+
+    public function testGetParamsOverride()
+    {
+        $conn = DriverManager::getConnection(array(
+            'wrapperClass' => 'Doctrine\DBAL\Sharding\PoolingShardConnection',
+            'driver' => 'pdo_sqlite',
+            'global' => array('memory' => true),
+            'shards' => array(
+                array('id' => 1, 'memory' => true),
+            ),
+            'shardChoser' => 'Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser',
+        ));
+
+        $this->assertEquals(array(
+            'wrapperClass' => 'Doctrine\DBAL\Sharding\PoolingShardConnection',
+            'driver' => 'pdo_sqlite',
+            'global' => array('memory' => true),
+            'shards' => array(
+                array('id' => 1, 'memory' => true),
+            ),
+            'shardChoser' => new MultiTenantShardChoser(),
+        ), $conn->getParams());
+
+        $conn->connect(1);
+        $this->assertEquals(array(
+            'wrapperClass' => 'Doctrine\DBAL\Sharding\PoolingShardConnection',
+            'driver' => 'pdo_sqlite',
+            'global' => array('memory' => true),
+            'shards' => array(
+                array('id' => 1, 'memory' => true),
+            ),
+            'shardChoser' => new MultiTenantShardChoser(),
+            'id' => 1,
+            'memory' => true,
+        ), $conn->getParams());
+    }
+
+    public function testGetHostOverride()
+    {
+        $conn = DriverManager::getConnection(array(
+            'wrapperClass' => 'Doctrine\DBAL\Sharding\PoolingShardConnection',
+            'driver' => 'pdo_sqlite',
+            'host' => 'localhost',
+            'global' => array('memory' => true),
+            'shards' => array(
+                array('id' => 1, 'memory' => true, 'host' => 'foo'),
+            ),
+            'shardChoser' => 'Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser',
+        ));
+
+        $this->assertEquals('localhost', $conn->getHost());
+
+        $conn->connect(1);
+        $this->assertEquals('foo', $conn->getHost());
+    }
+
+    public function testGetPortOverride()
+    {
+        $conn = DriverManager::getConnection(array(
+            'wrapperClass' => 'Doctrine\DBAL\Sharding\PoolingShardConnection',
+            'driver' => 'pdo_sqlite',
+            'port' => 3306,
+            'global' => array('memory' => true),
+            'shards' => array(
+                array('id' => 1, 'memory' => true, 'port' => 3307),
+            ),
+            'shardChoser' => 'Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser',
+        ));
+
+        $this->assertEquals(3306, $conn->getPort());
+
+        $conn->connect(1);
+        $this->assertEquals(3307, $conn->getPort());
+    }
+
+    public function testGetUsernameOverride()
+    {
+        $conn = DriverManager::getConnection(array(
+            'wrapperClass' => 'Doctrine\DBAL\Sharding\PoolingShardConnection',
+            'driver' => 'pdo_sqlite',
+            'user' => 'foo',
+            'global' => array('memory' => true),
+            'shards' => array(
+                array('id' => 1, 'memory' => true, 'user' => 'bar'),
+            ),
+            'shardChoser' => 'Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser',
+        ));
+
+        $this->assertEquals('foo', $conn->getUsername());
+
+        $conn->connect(1);
+        $this->assertEquals('bar', $conn->getUsername());
+    }
+
+    public function testGetPasswordOverride()
+    {
+        $conn = DriverManager::getConnection(array(
+            'wrapperClass' => 'Doctrine\DBAL\Sharding\PoolingShardConnection',
+            'driver' => 'pdo_sqlite',
+            'password' => 'foo',
+            'global' => array('memory' => true),
+            'shards' => array(
+                array('id' => 1, 'memory' => true, 'password' => 'bar'),
+            ),
+            'shardChoser' => 'Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser',
+        ));
+
+        $this->assertEquals('foo', $conn->getPassword());
+
+        $conn->connect(1);
+        $this->assertEquals('bar', $conn->getPassword());
     }
 }
 


### PR DESCRIPTION
Required by https://github.com/doctrine/DoctrineBundle/pull/455
- [x] Override `getHost`, `getUsername`, `getPassword`, `getPort` & `getParams` methods on [PoolingShardConnection](http://www.doctrine-project.org/api/dbal/2.4/class-Doctrine.DBAL.Sharding.PoolingShardConnection.html)
- [x] Add unit tests
