### PR TITLE
Add PDO-based dblib driver

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDODblib/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDODblib/Connection.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver\PDODblib;
+
+use Doctrine\DBAL\Driver\PDOConnection;
+
+/**
+ * Dblib Connection implementation.
+ *
+ * @since 2.0
+ */
+class Connection extends PDOConnection implements \Doctrine\DBAL\Driver\Connection
+{
+    /**
+     * @override
+     */
+    public function quote($value, $type=\PDO::PARAM_STR)
+    {
+        $val = parent::quote($value, $type);
+
+        // Fix for a driver version terminating all values with null byte
+        if (strpos($val, "\0") !== false) {
+            $val = substr($val, 0, -1);
+        }
+
+        return $val;
+    }
+
+    /**
+     * @override
+     */
+    public function getServerVersion()
+    {
+        // Driver does not support getAttribute()
+        return null;
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/PDODblib/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDODblib/Driver.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver\PDODblib;
+
+use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
+
+/**
+ * The PDO-based Dblib driver.
+ *
+ * @since 2.0
+ */
+class Driver extends AbstractSQLServerDriver
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
+    {
+        return new Connection(
+            $this->_constructPdoDsn($params),
+            $username,
+            $password,
+            $driverOptions
+        );
+    }
+
+    /**
+     * Constructs the Sqlsrv PDO DSN.
+     *
+     * @param array $params
+     *
+     * @return string The DSN.
+     */
+    private function _constructPdoDsn(array $params)
+    {
+        $dsn = 'dblib:host=';
+
+        if (isset($params['host'])) {
+            $dsn .= $params['host'];
+        }
+
+        if (isset($params['port']) && !empty($params['port'])) {
+            $dsn .= ',' . $params['port'];
+        }
+
+        if (isset($params['dbname'])) {
+            $dsn .= ';dbname=' .  $params['dbname'];
+        }
+
+        if (isset($params['MultipleActiveResultSets'])) {
+            $dsn .= '; MultipleActiveResultSets=' . ($params['MultipleActiveResultSets'] ? 'true' : 'false');
+        }
+
+        return $dsn;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'pdo_dblib';
+    }
+}

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -45,6 +45,7 @@ final class DriverManager
          'oci8'               => 'Doctrine\DBAL\Driver\OCI8\Driver',
          'ibm_db2'            => 'Doctrine\DBAL\Driver\IBMDB2\DB2Driver',
          'pdo_sqlsrv'         => 'Doctrine\DBAL\Driver\PDOSqlsrv\Driver',
+         'pdo_dblib'          => 'Doctrine\DBAL\Driver\PDODblib\Driver',
          'mysqli'             => 'Doctrine\DBAL\Driver\Mysqli\Driver',
          'drizzle_pdo_mysql'  => 'Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver',
          'sqlanywhere'        => 'Doctrine\DBAL\Driver\SQLAnywhere\Driver',
@@ -56,6 +57,7 @@ final class DriverManager
      */
     private static $driverSchemeAliases = array(
         'db2'        => 'ibm_db2',
+        'dblib'      => 'pdo_dblib',
         'mssql'      => 'pdo_sqlsrv',
         'mysql'      => 'pdo_mysql',
         'mysql2'     => 'pdo_mysql', // Amazon RDS, for some weird reason


### PR DESCRIPTION
This driver may be necessary if you are trying to connect to a MS SQL Server
database from Linux based OS. The pdo-sqlsrv driver is only supported when PHP
itself is running on a Windows machine.

This driver enables access to SQL Server via the [freetds](http://www.freetds.org/) library.
