### PR TITLE
Add LockMode::OPTIMISTIC_FORCE_INCREMENT

### DIFF
--- a/lib/Doctrine/DBAL/LockMode.php
+++ b/lib/Doctrine/DBAL/LockMode.php
@@ -33,6 +33,7 @@ class LockMode
     const OPTIMISTIC = 1;
     const PESSIMISTIC_READ = 2;
     const PESSIMISTIC_WRITE = 4;
+    const OPTIMISTIC_FORCE_INCREMENT = 5;
 
     /**
      * Private constructor. This class cannot be instantiated.

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -225,6 +225,7 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
             array(true, ''),
             array(LockMode::NONE, ' WITH (NOLOCK)'),
             array(LockMode::OPTIMISTIC, ''),
+            array(LockMode::OPTIMISTIC_FORCE_INCREMENT, ''),
             array(LockMode::PESSIMISTIC_READ, ' WITH (UPDLOCK)'),
             array(LockMode::PESSIMISTIC_WRITE, ' WITH (XLOCK)'),
         );

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -32,6 +32,7 @@ class SQLServerPlatformTest extends AbstractSQLServerPlatformTestCase
             array(true, ''),
             array(LockMode::NONE, ' WITH (NOLOCK)'),
             array(LockMode::OPTIMISTIC, ''),
+            array(LockMode::OPTIMISTIC_FORCE_INCREMENT, ''),
             array(LockMode::PESSIMISTIC_READ, ' WITH (HOLDLOCK, ROWLOCK)'),
             array(LockMode::PESSIMISTIC_WRITE, ' WITH (UPDLOCK, ROWLOCK)'),
         );


### PR DESCRIPTION
These changes are to support doctrine/doctrine2#1456

On the DBAL level, `OPTIMISTIC` and `OPTIMISTIC_FORCE_INCREMENT` should be equivalent almost all the time. The difference between them occurs in higher levels of abstraction.
