### PR TITLE
[2.5] Fix allowed failures for HHVM + MariaDB builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,12 +111,6 @@ matrix:
         mariadb: 10.1
   allow_failures:
       - php: hhvm
-        env: DB=pgsql POSTGRESQL_VERSION=9.1
-      - php: hhvm
-        env: DB=pgsql POSTGRESQL_VERSION=9.2
-      - php: hhvm
-        env: DB=pgsql POSTGRESQL_VERSION=9.3
-      - php: hhvm
         env: DB=sqlite
       - php: hhvm
         env: DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,8 @@ matrix:
         env: DB=mysql
       - php: hhvm
         env: DB=mysqli
+      - php: hhvm
+        env: DB=mariadb
       - php: hhvm-nightly
   exclude:
       - php: hhvm


### PR DESCRIPTION
Allow failures for HHVM + MariaDB builds on Travis as those are currently not succeeding (same as for HHVM + pdo_mysql).
Also removed useless HHVM + pgsql allowed failures (already excluded).
