### PR TITLE
Add enum type to mysql platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -952,6 +952,7 @@ class MySqlPlatform extends AbstractPlatform
             'text'          => 'text',
             'varchar'       => 'string',
             'string'        => 'string',
+            'enum'          => 'string',
             'char'          => 'string',
             'date'          => 'date',
             'datetime'      => 'datetime',


### PR DESCRIPTION
Added enum type to mysql platform, because doctrine-migrations could not generate database schema with enum fields in table.
