### PR TITLE
Fix return type of `Table::renameColumn()` and mark it as deprecated

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -331,7 +331,7 @@ class Table extends AbstractAsset
      * @param string $oldColumnName
      * @param string $newColumnName
      *
-     * @return self
+     * @deprecated
      *
      * @throws DBALException
      */


### PR DESCRIPTION
What do you think, I should use `@deprecated` or `@internal` here?
