### PR TITLE
add `sslrootcert` connection option to the `pdo_pgsql` driver

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -254,6 +254,11 @@ pdo\_pgsql
    a SSL TCP/IP connection will be negotiated with the server.
    See the list of available modes:
    `http://www.postgresql.org/docs/9.1/static/libpq-connect.html#LIBPQ-CONNECT-SSLMODE`
+-  ``sslrootcert`` (string): specifies the name of a file containing
+   SSL certificate authority (CA) certificate(s). If the file exists,
+   the server's certificate will be verified to be signed by one of these
+   authorities.
+   See http://www.postgresql.org/docs/9.0/static/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT
 
 PostgreSQL behaves differently with regard to booleans when you use
 ``PDO::ATTR_EMULATE_PREPARES`` or not. To switch from using ``'true'``

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -99,6 +99,10 @@ class Driver extends AbstractPostgreSQLDriver
             $dsn .= 'sslmode=' . $params['sslmode'] . ' ';
         }
 
+        if (isset($params['sslrootcert'])) {
+            $dsn .= 'sslrootcert=' . $params['sslrootcert'] . ' ';
+        }
+
         return $dsn;
     }
 


### PR DESCRIPTION
Right now it is pretty hard to trust certificates for a server with doctrine. Postgres requires you to put the `root.crt` in the home directory for a user which becomes messy rather quickly.
