### PR TITLE
Allow usage of getNowExpression() value in default

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2253,6 +2253,8 @@ abstract class AbstractPlatform
                     $default = " DEFAULT ".$field['default'];
                 } elseif (in_array((string) $field['type'], array('DateTime', 'DateTimeTz')) && $field['default'] == $this->getCurrentTimestampSQL()) {
                     $default = " DEFAULT ".$this->getCurrentTimestampSQL();
+                } elseif (in_array((string) $field['type'], array('DateTime', 'DateTimeTz')) && $field['default'] == $this->getNowExpression()) {
+                    $default = " DEFAULT ".$this->getNowExpression();
                 } elseif ((string) $field['type'] == 'Time' && $field['default'] == $this->getCurrentTimeSQL()) {
                     $default = " DEFAULT ".$this->getCurrentTimeSQL();
                 } elseif ((string) $field['type'] == 'Date' && $field['default'] == $this->getCurrentDateSQL()) {

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1489,6 +1489,10 @@ class SQLServerPlatform extends AbstractPlatform
             return " DEFAULT " . $this->getCurrentTimestampSQL();
         }
 
+        if (in_array((string) $field['type'], array('DateTime', 'DateTimeTz')) && $field['default'] == $this->getNowExpression()) {
+            return " DEFAULT " . $this->getNowExpression();
+        }
+
         if ((string) $field['type'] == 'Boolean') {
             return " DEFAULT '" . $this->convertBooleans($field['default']) . "'";
         }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -495,6 +495,13 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 
             $this->assertEquals(' DEFAULT ' . $this->_platform->getCurrentTimestampSQL(), $this->_platform->getDefaultValueDeclarationSQL($field));
 
+
+            $field = array(
+                'type' => Type::getType($type),
+                'default' => $this->_platform->getNowExpression()
+            );
+
+            $this->assertEquals(' DEFAULT ' . $this->_platform->getNowExpression(), $this->_platform->getDefaultValueDeclarationSQL($field));
         }
     }
 


### PR DESCRIPTION
This update allow the usage of the `AbstractPlatform::getNowExpression()` return value for the default.
