### PR TITLE
DBAL-1302 Avoid rewrapping `Docrine\DBAL\Exception\DriverException` with nested drivers

### DIFF
--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -19,7 +19,8 @@
 
 namespace Doctrine\DBAL;
 
-use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 
 class DBALException extends \Exception
@@ -112,11 +113,7 @@ class DBALException extends \Exception
         }
         $msg .= ":\n\n".$driverEx->getMessage();
 
-        if ($driver instanceof ExceptionConverterDriver && $driverEx instanceof DriverException) {
-            return $driver->convertException($msg, $driverEx);
-        }
-
-        return new self($msg, 0, $driverEx);
+        return static::wrapException($driver, $driverEx, $msg);
     }
 
     /**
@@ -127,9 +124,21 @@ class DBALException extends \Exception
      */
     public static function driverException(Driver $driver, \Exception $driverEx)
     {
-        $msg = "An exception occurred in driver: " . $driverEx->getMessage();
+        return static::wrapException($driver, $driverEx, "An exception occurred in driver: " . $driverEx->getMessage());
+    }
 
-        if ($driver instanceof ExceptionConverterDriver && $driverEx instanceof DriverException) {
+    /**
+     * @param \Doctrine\DBAL\Driver     $driver
+     * @param \Exception $driverEx
+     *
+     * @return \Doctrine\DBAL\DBALException
+     */
+    private static function wrapException(Driver $driver, \Exception $driverEx, $msg)
+    {
+        if ($driverEx instanceof Exception\DriverException) {
+            return $driverEx;
+        }
+        if ($driver instanceof ExceptionConverterDriver && $driverEx instanceof Driver\DriverException) {
             return $driver->convertException($msg, $driverEx);
         }
 

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL;
 
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception\DriverException;
 
 class DBALExceptionTest extends \Doctrine\Tests\DbalTestCase
 {
@@ -11,5 +12,13 @@ class DBALExceptionTest extends \Doctrine\Tests\DbalTestCase
         $driver = $this->getMock('\Doctrine\DBAL\Driver');
         $e = DBALException::driverExceptionDuringQuery($driver, new \Exception, '', array('ABC', chr(128)));
         $this->assertContains('with params ["ABC", "\x80"]', $e->getMessage());
+    }
+
+    public function testAvoidOverWrappingOnDriverException()
+    {
+        $driver = $this->getMock('\Doctrine\DBAL\Driver');
+        $ex = new DriverException('', $this->getMock('\Doctrine\DBAL\Driver\DriverException'));
+        $e = DBALException::driverExceptionDuringQuery($driver, $ex, '');
+        $this->assertSame($ex, $e);
     }
 }


### PR DESCRIPTION
fixes [DBAL-1302](http://www.doctrine-project.org/jira/browse/DBAL-1302)
