### PR TITLE
Fixing the command when option is CURRENT_SCHEMA

### DIFF
--- a/lib/Doctrine/DBAL/Event/Listeners/OracleSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/OracleSessionInit.php
@@ -69,7 +69,11 @@ class OracleSessionInit implements EventSubscriber
             array_change_key_case($this->_defaultSessionVars, \CASE_UPPER);
             $vars = array();
             foreach ($this->_defaultSessionVars as $option => $value) {
-                $vars[] = $option." = '".$value."'";
+                if($option === 'CURRENT_SCHEMA') {
+                    $vars[] = $option . " = " . $value;
+                } else {
+                    $vars[] = $option . " = '" . $value . "'";
+                }
             }
             $sql = "ALTER SESSION SET ".implode(" ", $vars);
             $args->getConnection()->executeUpdate($sql);


### PR DESCRIPTION
The schema's name in the alter session command must be unquoted.
https://docs.oracle.com/cd/B28359_01/server.111/b28310/general009.htm
