### PR TITLE
Fix failin unit test on oracle

### DIFF
--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -318,6 +318,9 @@ class OracleSchemaManager extends AbstractSchemaManager
      */
     public function dropAutoincrement($table)
     {
+        if ($table instanceof Table) {
+            $table = $table->getQuotedName($this->_platform);
+        }
         $sql = $this->_platform->getDropAutoincrementSql($table);
         foreach ($sql as $query) {
             $this->_conn->executeUpdate($query);


### PR DESCRIPTION
fixes #2250 

getDropAutoincrementSql cannot take a Table object - only string is allowed
