### PR TITLE
Use shorter table names, as OracleDB allows max 30 characters

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1101,24 +1101,24 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
             $this->markTestSkipped('This test is only supported on platforms that have foreign keys.');
         }
 
-        $primaryTable = new Table('test_list_index_implicit_primary');
+        $primaryTable = new Table('test_list_index_impl_primary');
         $primaryTable->addColumn('id', 'integer');
         $primaryTable->setPrimaryKey(array('id'));
 
-        $foreignTable = new Table('test_list_index_implicit_foreign');
+        $foreignTable = new Table('test_list_index_impl_foreign');
         $foreignTable->addColumn('fk1', 'integer');
         $foreignTable->addColumn('fk2', 'integer');
         $foreignTable->addIndex(array('fk1'), 'explicit_fk1_idx');
-        $foreignTable->addForeignKeyConstraint('test_list_index_implicit_primary', array('fk1'), array('id'));
-        $foreignTable->addForeignKeyConstraint('test_list_index_implicit_primary', array('fk2'), array('id'));
+        $foreignTable->addForeignKeyConstraint('test_list_index_impl_primary', array('fk1'), array('id'));
+        $foreignTable->addForeignKeyConstraint('test_list_index_impl_primary', array('fk2'), array('id'));
 
         $this->_sm->dropAndCreateTable($primaryTable);
         $this->_sm->dropAndCreateTable($foreignTable);
 
-        $indexes = $this->_sm->listTableIndexes('test_list_index_implicit_foreign');
+        $indexes = $this->_sm->listTableIndexes('test_list_index_impl_foreign');
 
         $this->assertCount(2, $indexes);
         $this->assertArrayHasKey('explicit_fk1_idx', $indexes);
-        $this->assertArrayHasKey('idx_6d88c7b4fdc58d6c', $indexes);
+        $this->assertArrayHasKey('idx_3d6c147fdc58d6c', $indexes);
     }
 }


### PR DESCRIPTION
http://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements008.htm#sthref723
