### PR TITLE
Fix failing unit tests on OracleDB

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -262,7 +262,7 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $table->setPrimaryKey(array('id'));
 
         try {
-            $this->_conn->getSchemaManager()->dropTable($table);
+            $this->_conn->getSchemaManager()->dropTable($table->getQuotedName($platform));
         } catch(\Exception $e) { }
 
         foreach ($platform->getCreateTableSQL($table) as $sql) {


### PR DESCRIPTION
fixes #2250 

getDropAutoincrementSql cannot take a Table object - only string is allowed

@Ocramius here we go - alternative approach for https://github.com/doctrine/dbal/pull/2251
