### PR TITLE
Add sqlite3 driver (BenMorel)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   - DB=pgsql POSTGRESQL_VERSION=9.3
   - DB=pgsql POSTGRESQL_VERSION=9.4
   - DB=sqlite
+  - DB=sqlite3
   - DB=mysqli
 
 install:

--- a/lib/Doctrine/DBAL/Driver/AbstractDriverException.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractDriverException.php
@@ -48,10 +48,11 @@ abstract class AbstractDriverException extends \Exception implements DriverExcep
      * @param string              $message   The driver error message.
      * @param string|null         $sqlState  The SQLSTATE the driver is in at the time the error occurred, if any.
      * @param integer|string|null $errorCode The driver specific error code if any.
+     * @param \Exception|null     $previous  The previous exception used for the exception chaining. Since 2.6.
      */
-    public function __construct($message, $sqlState = null, $errorCode = null)
+    public function __construct($message, $sqlState = null, $errorCode = null, \Exception $previous = null)
     {
-        parent::__construct($message);
+        parent::__construct($message, 0, $previous);
 
         $this->errorCode = $errorCode;
         $this->sqlState  = $sqlState;

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
@@ -92,7 +92,7 @@ abstract class AbstractSQLiteDriver implements Driver, ExceptionConverterDriver
     {
         $params = $conn->getParams();
 
-        return isset($params['path']) ? $params['path'] : null;
+        return !empty($params['path']) ? $params['path'] : null;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLite3/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/Driver.php
@@ -25,7 +25,9 @@ use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 /**
  * The SQLite3 driver.
  *
- * @since 2.0
+ * @since 2.6
+ * @author Ben Morel <ben@benjaminmorel.com>
+ * @author Bill Schaller <bill@zeroedin.com>
  */
 class Driver extends AbstractSQLiteDriver
 {

--- a/lib/Doctrine/DBAL/Driver/SQLite3/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/Driver.php
@@ -53,7 +53,7 @@ class Driver extends AbstractSQLiteDriver
 
         try {
             $connection = new SQLite3Connection(
-                isset($params['path']) ? $params['path'] : ':memory:',
+                !empty($params['path']) ? $params['path'] : ':memory:',
                 isset($params['flags']) ? $params['flags'] : null,
                 isset($params['encryption_key']) ? $params['encryption_key'] : null
             );

--- a/lib/Doctrine/DBAL/Driver/SQLite3/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/Driver.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver\SQLite3;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
+
+/**
+ * The SQLite3 driver.
+ *
+ * @since 2.0
+ */
+class Driver extends AbstractSQLiteDriver
+{
+    /**
+     * @var array
+     */
+    protected $_userDefinedFunctions = array(
+        'sqrt' => array('callback' => array('Doctrine\DBAL\Platforms\SqlitePlatform', 'udfSqrt'), 'numArgs' => 1),
+        'mod'  => array('callback' => array('Doctrine\DBAL\Platforms\SqlitePlatform', 'udfMod'), 'numArgs' => 2),
+        'locate'  => array('callback' => array('Doctrine\DBAL\Platforms\SqlitePlatform', 'udfLocate'), 'numArgs' => -1),
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
+    {
+        if (isset($driverOptions['userDefinedFunctions'])) {
+            $this->_userDefinedFunctions = array_merge(
+                $this->_userDefinedFunctions, $driverOptions['userDefinedFunctions']);
+            unset($driverOptions['userDefinedFunctions']);
+        }
+
+        try {
+            $connection = new SQLite3Connection(
+                isset($params['path']) ? $params['path'] : ':memory:',
+                isset($params['flags']) ? $params['flags'] : null,
+                isset($params['encryption_key']) ? $params['encryption_key'] : null
+            );
+        } catch (SQLite3Exception $e) {
+            throw DBALException::driverException($this, $e);
+        }
+
+        $sqlite3 = $connection->getSQLite3();
+
+        foreach ($this->_userDefinedFunctions as $fn => $data) {
+            $sqlite3->createFunction($fn, $data['callback'], $data['numArgs']);
+        }
+
+        return $connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sqlite3';
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/SQLite3/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/Driver.php
@@ -26,7 +26,7 @@ use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
  * The SQLite3 driver.
  *
  * @since 2.6
- * @author Ben Morel <ben@benjaminmorel.com>
+ * @author Ben Morel <benjamin.morel@gmail.com>
  * @author Bill Schaller <bill@zeroedin.com>
  */
 class Driver extends AbstractSQLiteDriver

--- a/lib/Doctrine/DBAL/Driver/SQLite3/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/Driver.php
@@ -32,7 +32,7 @@ class Driver extends AbstractSQLiteDriver
     /**
      * @var array
      */
-    protected $_userDefinedFunctions = array(
+    private $userDefinedFunctions = array(
         'sqrt' => array('callback' => array('Doctrine\DBAL\Platforms\SqlitePlatform', 'udfSqrt'), 'numArgs' => 1),
         'mod'  => array('callback' => array('Doctrine\DBAL\Platforms\SqlitePlatform', 'udfMod'), 'numArgs' => 2),
         'locate'  => array('callback' => array('Doctrine\DBAL\Platforms\SqlitePlatform', 'udfLocate'), 'numArgs' => -1),
@@ -44,8 +44,8 @@ class Driver extends AbstractSQLiteDriver
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
     {
         if (isset($driverOptions['userDefinedFunctions'])) {
-            $this->_userDefinedFunctions = array_merge(
-                $this->_userDefinedFunctions, $driverOptions['userDefinedFunctions']);
+            $this->userDefinedFunctions = array_merge(
+                $this->userDefinedFunctions, $driverOptions['userDefinedFunctions']);
             unset($driverOptions['userDefinedFunctions']);
         }
 
@@ -61,7 +61,7 @@ class Driver extends AbstractSQLiteDriver
 
         $sqlite3 = $connection->getSQLite3();
 
-        foreach ($this->_userDefinedFunctions as $fn => $data) {
+        foreach ($this->userDefinedFunctions as $fn => $data) {
             $sqlite3->createFunction($fn, $data['callback'], $data['numArgs']);
         }
 

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Abstract.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Abstract.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver\SQLite3;
+
+/**
+ * Base functionality for SQLite3Connection and SQLite3Statement.
+ */
+abstract class SQLite3Abstract
+{
+    /**
+     * @var \SQLite3
+     */
+    protected $sqlite3;
+
+    /**
+     * Runs code interacting with native SQLite3 objects, and catches errors to throw a proper exception.
+     *
+     * @param \Closure $function A function calling native SQLite3 objects.
+     *
+     * @return mixed The return value of the given function.
+     *
+     * @throws SQLite3Exception If an error occurs.
+     */
+    protected function call(\Closure $function)
+    {
+        // Temporary set the error reporting level to 0 to avoid any warning
+        $errorReportingLevel = error_reporting(0);
+
+        // Call the function containing SQLite3 code to execute
+        $result = $function();
+
+        // Restore the original error reporting level
+        error_reporting($errorReportingLevel);
+
+        $errorCode = $this->sqlite3->lastErrorCode();
+
+        if ($errorCode === 0) {
+            return $result;
+        }
+
+        $errorMessage = $this->sqlite3->lastErrorMsg();
+
+        throw new SQLite3Exception($errorMessage, $errorCode);
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Abstract.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Abstract.php
@@ -23,7 +23,7 @@ namespace Doctrine\DBAL\Driver\SQLite3;
  * Base functionality for SQLite3Connection and SQLite3Statement.
  *
  * @since 2.6
- * @author Ben Morel <ben@benjaminmorel.com>
+ * @author Ben Morel <benjamin.morel@gmail.com>
  * @author Bill Schaller <bill@zeroedin.com>
  */
 abstract class SQLite3Abstract

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Abstract.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Abstract.php
@@ -50,23 +50,4 @@ abstract class SQLite3Abstract
 
         throw new SQLite3Exception($errorMessage, null, $errorCode);
     }
-
-    /**
-     * Wraps an exception thrown by SQLite3 in a SQLite3Exception.
-     *
-     * @param \Exception $driverException
-     * @return SQLite3Exception
-     */
-    protected function wrapDriverException(\Exception $driverException)
-    {
-        $errorMessage = $driverException->getMessage();
-        $errorCode = $driverException->getCode();
-
-        if ($this->sqlite3 instanceof \SQLite3) {
-            $errorMessage = $this->sqlite3->lastErrorMsg();
-            $errorCode = $this->sqlite3->lastErrorCode();
-        }
-
-        return new SQLite3Exception($errorMessage, null, $errorCode, $driverException);
-    }
 }

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Abstract.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Abstract.php
@@ -21,6 +21,10 @@ namespace Doctrine\DBAL\Driver\SQLite3;
 
 /**
  * Base functionality for SQLite3Connection and SQLite3Statement.
+ *
+ * @since 2.6
+ * @author Ben Morel <ben@benjaminmorel.com>
+ * @author Bill Schaller <bill@zeroedin.com>
  */
 abstract class SQLite3Abstract
 {
@@ -44,6 +48,25 @@ abstract class SQLite3Abstract
 
         $errorMessage = $this->sqlite3->lastErrorMsg();
 
-        throw new SQLite3Exception($errorMessage, $errorCode);
+        throw new SQLite3Exception($errorMessage, null, $errorCode);
+    }
+
+    /**
+     * Wraps an exception thrown by SQLite3 in a SQLite3Exception.
+     *
+     * @param \Exception $driverException
+     * @return SQLite3Exception
+     */
+    protected function wrapDriverException(\Exception $driverException)
+    {
+        $errorMessage = $driverException->getMessage();
+        $errorCode = $driverException->getCode();
+
+        if ($this->sqlite3 instanceof \SQLite3) {
+            $errorMessage = $this->sqlite3->lastErrorMsg();
+            $errorCode = $this->sqlite3->lastErrorCode();
+        }
+
+        return new SQLite3Exception($errorMessage, null, $errorCode, $driverException);
     }
 }

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Abstract.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Abstract.php
@@ -30,29 +30,16 @@ abstract class SQLite3Abstract
     protected $sqlite3;
 
     /**
-     * Runs code interacting with native SQLite3 objects, and catches errors to throw a proper exception.
+     * @return void
      *
-     * @param \Closure $function A function calling native SQLite3 objects.
-     *
-     * @return mixed The return value of the given function.
-     *
-     * @throws SQLite3Exception If an error occurs.
+     * @throws SQLite3Exception
      */
-    protected function call(\Closure $function)
+    protected function throwExceptionOnError()
     {
-        // Temporary set the error reporting level to 0 to avoid any warning
-        $errorReportingLevel = error_reporting(0);
-
-        // Call the function containing SQLite3 code to execute
-        $result = $function();
-
-        // Restore the original error reporting level
-        error_reporting($errorReportingLevel);
-
         $errorCode = $this->sqlite3->lastErrorCode();
 
         if ($errorCode === 0) {
-            return $result;
+            return;
         }
 
         $errorMessage = $this->sqlite3->lastErrorMsg();

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
@@ -24,6 +24,10 @@ use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 
 /**
  * SQLite3 implementation of the Connection interface.
+ *
+ * @since 2.6
+ * @author Ben Morel <ben@benjaminmorel.com>
+ * @author Bill Schaller <bill@zeroedin.com>
  */
 class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInfoAwareConnection
 {
@@ -45,7 +49,7 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
                 $this->sqlite3 = new \SQLite3($filename, $flags, $encryption_key);
             }
         } catch (\Exception $e) {
-            throw new SQLite3Exception($e->getMessage(), $e->getCode(), $e);
+            throw $this->wrapDriverException($e);
         }
     }
 
@@ -64,7 +68,11 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function prepare($prepareString)
     {
-        $statement = @ $this->sqlite3->prepare($prepareString);
+        try {
+            $statement = @ $this->sqlite3->prepare($prepareString);
+        } catch (\Exception $e) {
+            throw $this->wrapDriverException($e);
+        }
 
         $this->throwExceptionOnError();
 
@@ -97,7 +105,12 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function exec($statement)
     {
-        @ $this->sqlite3->exec($statement);
+        try {
+            $this->sqlite3->exec($statement);
+        } catch (\Exception $e) {
+            throw $this->wrapDriverException($e);
+        }
+
         $this->throwExceptionOnError();
 
         return $this->sqlite3->changes();
@@ -108,7 +121,11 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function lastInsertId($name = null)
     {
-        return $this->sqlite3->lastInsertRowID();
+        try {
+            return $this->sqlite3->lastInsertRowID();
+        } catch (\Exception $e) {
+            throw $this->wrapDriverException($e);
+        }
     }
 
     /**
@@ -116,7 +133,12 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function beginTransaction()
     {
-        @ $this->sqlite3->exec('BEGIN');
+        try {
+            $this->sqlite3->exec('BEGIN');
+        } catch (\Exception $e) {
+            throw $this->wrapDriverException($e);
+        }
+
         $this->throwExceptionOnError();
 
         return true;
@@ -127,7 +149,12 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function commit()
     {
-        @ $this->sqlite3->exec('COMMIT');
+        try {
+            $this->sqlite3->exec('COMMIT');
+        } catch (\Exception $e) {
+            throw $this->wrapDriverException($e);
+        }
+
         $this->throwExceptionOnError();
 
         return true;
@@ -138,7 +165,12 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function rollBack()
     {
-        @ $this->sqlite3->exec('ROLLBACK');
+        try {
+            $this->sqlite3->exec('ROLLBACK');
+        } catch (\Exception $e) {
+            throw $this->wrapDriverException($e);
+        }
+
         $this->throwExceptionOnError();
 
         return true;

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
@@ -64,9 +64,9 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function prepare($prepareString)
     {
-        $statement = $this->call(function() use ($prepareString) {
-            return $this->sqlite3->prepare($prepareString);
-        });
+        $statement = @ $this->sqlite3->prepare($prepareString);
+
+        $this->throwExceptionOnError();
 
         return new SQLite3Statement($this->sqlite3, $statement);
     }
@@ -97,9 +97,8 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function exec($statement)
     {
-        $this->call(function() use ($statement) {
-            $this->sqlite3->exec($statement);
-        });
+        @ $this->sqlite3->exec($statement);
+        $this->throwExceptionOnError();
 
         return $this->sqlite3->changes();
     }
@@ -117,9 +116,8 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function beginTransaction()
     {
-        $this->call(function() {
-            $this->sqlite3->exec('BEGIN');
-        });
+        @ $this->sqlite3->exec('BEGIN');
+        $this->throwExceptionOnError();
 
         return true;
     }
@@ -129,9 +127,8 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function commit()
     {
-        $this->call(function() {
-            $this->sqlite3->exec('COMMIT');
-        });
+        @ $this->sqlite3->exec('COMMIT');
+        $this->throwExceptionOnError();
 
         return true;
     }
@@ -141,9 +138,8 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function rollBack()
     {
-        $this->call(function() {
-            $this->sqlite3->exec('ROLLBACK');
-        });
+        @ $this->sqlite3->exec('ROLLBACK');
+        $this->throwExceptionOnError();
 
         return true;
     }

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
@@ -51,7 +51,7 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
 
             $this->sqlite3->enableExceptions(true);
         } catch (\Exception $e) {
-            throw $this->wrapDriverException($e);
+            throw SQLite3Exception::fromNativeException($e);
         }
     }
 
@@ -73,7 +73,7 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
         try {
             $statement = @ $this->sqlite3->prepare($prepareString);
         } catch (\Exception $e) {
-            throw $this->wrapDriverException($e);
+            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
         }
 
         $this->throwExceptionOnError();
@@ -110,7 +110,7 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
         try {
             $this->sqlite3->exec($statement);
         } catch (\Exception $e) {
-            throw $this->wrapDriverException($e);
+            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
         }
 
         $this->throwExceptionOnError();
@@ -126,7 +126,7 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
         try {
             return $this->sqlite3->lastInsertRowID();
         } catch (\Exception $e) {
-            throw $this->wrapDriverException($e);
+            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
         }
     }
 
@@ -138,7 +138,7 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
         try {
             $this->sqlite3->exec('BEGIN');
         } catch (\Exception $e) {
-            throw $this->wrapDriverException($e);
+            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
         }
 
         $this->throwExceptionOnError();
@@ -154,7 +154,7 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
         try {
             $this->sqlite3->exec('COMMIT');
         } catch (\Exception $e) {
-            throw $this->wrapDriverException($e);
+            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
         }
 
         $this->throwExceptionOnError();
@@ -170,7 +170,7 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
         try {
             $this->sqlite3->exec('ROLLBACK');
         } catch (\Exception $e) {
-            throw $this->wrapDriverException($e);
+            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
         }
 
         $this->throwExceptionOnError();

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
@@ -1,0 +1,186 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver\SQLite3;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+
+/**
+ * SQLite3 implementation of the Connection interface.
+ */
+class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInfoAwareConnection
+{
+    /**
+     * @param string      $filename
+     * @param int|null    $flags
+     * @param string|null $encryption_key
+     *
+     * @throws SQLite3Exception
+     */
+    public function __construct($filename, $flags = null, $encryption_key = null)
+    {
+        try {
+            if ($flags === null) {
+                $this->sqlite3 = new \SQLite3($filename);
+            } elseif ($encryption_key === null) {
+                $this->sqlite3 = new \SQLite3($filename, $flags);
+            } else {
+                $this->sqlite3 = new \SQLite3($filename, $flags, $encryption_key);
+            }
+        } catch (\Exception $e) {
+            throw new SQLite3Exception($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * Returns the underlying SQLite3 object.
+     *
+     * @return \SQLite3
+     */
+    public function getSQLite3()
+    {
+        return $this->sqlite3;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepare($prepareString)
+    {
+        $statement = $this->call(function() use ($prepareString) {
+            return $this->sqlite3->prepare($prepareString);
+        });
+
+        return new SQLite3Statement($this->sqlite3, $statement);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function query()
+    {
+        $query = func_get_arg(0);
+
+        $statement = $this->prepare($query);
+        $statement->execute();
+
+        return $statement;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function quote($input, $type = \PDO::PARAM_STR)
+    {
+        return "'" . \SQLite3::escapeString($input) . "'";
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function exec($statement)
+    {
+        $this->call(function() use ($statement) {
+            $this->sqlite3->exec($statement);
+        });
+
+        return $this->sqlite3->changes();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lastInsertId($name = null)
+    {
+        return $this->sqlite3->lastInsertRowID();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function beginTransaction()
+    {
+        $this->call(function() {
+            $this->sqlite3->exec('BEGIN');
+        });
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        $this->call(function() {
+            $this->sqlite3->exec('COMMIT');
+        });
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rollBack()
+    {
+        $this->call(function() {
+            $this->sqlite3->exec('ROLLBACK');
+        });
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function errorCode()
+    {
+        return $this->sqlite3->lastErrorCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function errorInfo()
+    {
+        return [
+            null,
+            $this->sqlite3->lastErrorCode(),
+            $this->sqlite3->lastErrorMsg()
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getServerVersion()
+    {
+        return \SQLite3::version()['versionString'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresQueryForServerVersion()
+    {
+        return false;
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
@@ -26,7 +26,7 @@ use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
  * SQLite3 implementation of the Connection interface.
  *
  * @since 2.6
- * @author Ben Morel <ben@benjaminmorel.com>
+ * @author Ben Morel <benjamin.morel@gmail.com>
  * @author Bill Schaller <bill@zeroedin.com>
  */
 class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInfoAwareConnection

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
@@ -48,6 +48,8 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
             } else {
                 $this->sqlite3 = new \SQLite3($filename, $flags, $encryption_key);
             }
+
+            $this->sqlite3->enableExceptions(true);
         } catch (\Exception $e) {
             throw $this->wrapDriverException($e);
         }

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Connection.php
@@ -70,15 +70,7 @@ class SQLite3Connection extends SQLite3Abstract implements Connection, ServerInf
      */
     public function prepare($prepareString)
     {
-        try {
-            $statement = @ $this->sqlite3->prepare($prepareString);
-        } catch (\Exception $e) {
-            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
-        }
-
-        $this->throwExceptionOnError();
-
-        return new SQLite3Statement($this->sqlite3, $statement);
+        return new SQLite3Statement($this->sqlite3, $prepareString);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Exception.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Exception.php
@@ -19,26 +19,15 @@
 
 namespace Doctrine\DBAL\Driver\SQLite3;
 
-use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Driver\AbstractDriverException;
 
 /**
  * Exception thrown by SQLite3Connection.
+ *
+ * @since 2.6
+ * @author Ben Morel <ben@benjaminmorel.com
+ * @author Bill Schaller <bill@zeroedin.com>>
  */
-class SQLite3Exception extends \RuntimeException implements DriverException
+class SQLite3Exception extends AbstractDriverException
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getErrorCode()
-    {
-        return $this->getCode();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLState()
-    {
-        return null;
-    }
 }

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Exception.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Exception.php
@@ -25,7 +25,7 @@ use Doctrine\DBAL\Driver\AbstractDriverException;
  * Exception thrown by SQLite3Connection.
  *
  * @since 2.6
- * @author Ben Morel <ben@benjaminmorel.com
+ * @author Ben Morel <benjamin.morel@gmail.com
  * @author Bill Schaller <bill@zeroedin.com>>
  */
 class SQLite3Exception extends AbstractDriverException

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Exception.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Exception.php
@@ -17,38 +17,28 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\DBAL\Types;
+namespace Doctrine\DBAL\Driver\SQLite3;
 
-use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Driver\DriverException;
 
 /**
- * Type that maps an SQL DECIMAL to a PHP string.
- *
- * @since 2.0
+ * Exception thrown by SQLite3Connection.
  */
-class DecimalType extends Type
+class SQLite3Exception extends \RuntimeException implements DriverException
 {
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getErrorCode()
     {
-        return Type::DECIMAL;
+        return $this->getCode();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLState()
     {
-        return $platform->getDecimalTypeDeclarationSQL($fieldDeclaration);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        return (null === $value) ? null : (string) $value;
+        return null;
     }
 }

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Exception.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Exception.php
@@ -22,7 +22,7 @@ namespace Doctrine\DBAL\Driver\SQLite3;
 use Doctrine\DBAL\Driver\AbstractDriverException;
 
 /**
- * Exception thrown by SQLite3Connection.
+ * SQLite3 driver exception.
  *
  * @since 2.6
  * @author Ben Morel <benjamin.morel@gmail.com

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Exception.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Exception.php
@@ -30,4 +30,23 @@ use Doctrine\DBAL\Driver\AbstractDriverException;
  */
 class SQLite3Exception extends AbstractDriverException
 {
+    /**
+     * Wraps an exception thrown by SQLite3 in a SQLite3Exception.
+     *
+     * @param \Exception $nativeException
+     * @param \SQLite3|null $connection
+     * @return SQLite3Exception
+     */
+    public static function fromNativeException(\Exception $nativeException, \SQLite3 $connection = null)
+    {
+        $errorMessage = $nativeException->getMessage();
+        $errorCode = $nativeException->getCode();
+
+        if ($connection instanceof \SQLite3) {
+            $errorMessage = $connection->lastErrorMsg();
+            $errorCode = $connection->lastErrorCode();
+        }
+
+        return new self($errorMessage, null, $errorCode, $nativeException);
+    }
 }

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
@@ -116,7 +116,7 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
 
             return $this->stmt->bindValue($param, $value, $this->convertType($type));
         } catch (\Exception $e) {
-            throw $this->wrapDriverException($e);
+            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
         }
     }
 
@@ -132,7 +132,7 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
 
             return $this->stmt->bindParam($column, $variable, $this->convertType($type));
         } catch (\Exception $e) {
-            throw $this->wrapDriverException($e);
+            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
         }
     }
 
@@ -176,7 +176,7 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
             $this->result = $result;
             $this->rowCount = $this->sqlite3->changes();
         } catch (\Exception $e) {
-            throw $this->wrapDriverException($e);
+            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
         }
 
         $this->throwExceptionOnError();
@@ -209,7 +209,7 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
             try {
                 return $this->result->numColumns();
             } catch (\Exception $e) {
-                throw $this->wrapDriverException($e);
+                throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
             }
         }
 
@@ -250,7 +250,7 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
         try {
             $result = $this->result->fetchArray($this->convertFetchMode($fetchMode));
         } catch (\Exception $e) {
-            throw $this->wrapDriverException($e);
+            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
         }
 
         if ($result === false) {
@@ -311,7 +311,7 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
                     $rows[] = $row;
                 }
             } catch (\Exception $e) {
-                throw $this->wrapDriverException($e);
+                throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
             }
         }
 

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
@@ -25,7 +25,7 @@ use Doctrine\DBAL\Driver\Statement;
  * SQLite3 implementation of the Statement interface.
  *
  * @since 2.6
- * @author Ben Morel <ben@benjaminmorel.com>
+ * @author Ben Morel <benjamin.morel@gmail.com>
  * @author Bill Schaller <bill@zeroedin.com>
  */
 class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, Statement

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
@@ -137,10 +137,10 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
             }
         }
 
-        $this->call(function() {
-            $this->result = $this->stmt->execute();
-        });
+        $result = @ $this->stmt->execute();
+        $this->throwExceptionOnError();
 
+        $this->result   = $result;
         $this->rowCount = $this->sqlite3->changes();
 
         return true;

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
@@ -184,12 +184,11 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
                 }
             }
 
-            $result = $this->stmt->execute();
+            $this->result = $this->stmt->execute();
 
             $this->lastErrorCode = $this->sqlite3->lastErrorCode();
             $this->lastErrorMessage = $this->sqlite3->lastErrorMsg();
 
-            $this->result = $result;
             $this->rowCount = $this->sqlite3->changes();
         } catch (\Exception $e) {
             throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
@@ -213,7 +212,11 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
      */
     public function closeCursor()
     {
-        return $this->result->finalize();
+        if ($this->result instanceof \SQLite3Stmt) {
+            return $this->result->finalize();
+        }
+        // todo: should this set error message and return false?
+        return true;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
@@ -1,0 +1,344 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver\SQLite3;
+
+use Doctrine\DBAL\Driver\Statement;
+
+/**
+ * SQLite3 implementation of the Statement interface.
+ */
+class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, Statement
+{
+    /**
+     * The SQLite3 statement object.
+     *
+     * @var \SQLite3Stmt
+     */
+    private $stmt;
+
+    /**
+     * The last SQLite3 result object, if the statement has been executed.
+     *
+     * @var \SQLite3Result|null
+     */
+    private $result;
+
+    /**
+     * The number of rows affected by the last execution.
+     *
+     * @var integer
+     */
+    private $rowCount = 0;
+
+    /**
+     * The default fetch mode, one of the \PDO::FETCH_* constants.
+     *
+     * @var integer
+     */
+    private $fetchMode = \PDO::FETCH_BOTH;
+
+    /**
+     * An optional argument for the default fetch mode.
+     *
+     * This argument has a different meaning depending on the value of the fetch_style parameter:
+     *
+     * - PDO::FETCH_COLUMN: the index of the column to return.
+     * - PDO::FETCH_CLASS: the name of the class to instantiate.
+     * - PDO::FETCH_FUNC: the function to call.
+     *
+     * @var integer|string|callable|null
+     */
+    private $fetchArgument;
+
+    /**
+     * The arguments of the class constructor when the fetch_style parameter is PDO::FETCH_CLASS.
+     *
+     * @var array|null
+     */
+    private $fetchCtorArgs;
+
+    /**
+     * Class constructor.
+     *
+     * @param \SQLite3     $sqlite3 The SQLite3 connection object.
+     * @param \SQLite3Stmt $stmt    The SQLite3 statement object.
+     */
+    public function __construct(\SQLite3 $sqlite3, \SQLite3Stmt $stmt)
+    {
+        $this->sqlite3 = $sqlite3;
+        $this->stmt    = $stmt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindValue($param, $value, $type = null)
+    {
+        if ($type === null) {
+            return $this->stmt->bindValue($param, $value);
+        }
+
+        return $this->stmt->bindValue($param, $value, $this->convertType($type));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindParam($column, & $variable, $type = null, $length = null)
+    {
+        if ($type === null) {
+            return $this->stmt->bindParam($column, $variable);
+        }
+
+        return $this->stmt->bindParam($column, $variable, $this->convertType($type));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function errorCode()
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function errorInfo()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($params = null)
+    {
+        if ($params) {
+            foreach ($params as $key => $value) {
+                $this->bindValue(is_int($key) ? $key + 1 : $key, $value);
+            }
+        }
+
+        $this->call(function() {
+            $this->result = $this->stmt->execute();
+        });
+
+        $this->rowCount = $this->sqlite3->changes();
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rowCount()
+    {
+        return $this->rowCount;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function closeCursor()
+    {
+        return $this->result->finalize();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function columnCount()
+    {
+        if ($this->result) {
+            return $this->result->numColumns();
+        }
+
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
+    {
+        $this->fetchMode     = $fetchMode;
+        $this->fetchArgument = $arg2;
+        $this->fetchCtorArgs = $arg3;
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch($fetchMode = null)
+    {
+        if (! $this->result) {
+            return false;
+        }
+
+        if ($fetchMode === null) {
+            $fetchMode = $this->fetchMode;
+            $argument  = $this->fetchArgument;
+            $ctorArgs  = $this->fetchCtorArgs;
+        } else {
+            $args = func_get_args();
+            $argument = isset($args[1]) ? $args[1] : null;
+            $ctorArgs = isset($args[2]) ? $args[2] : null;
+        }
+
+        $result = $this->result->fetchArray($this->convertFetchMode($fetchMode));
+
+        if ($result === false) {
+            return false;
+        }
+
+        if ($fetchMode === \PDO::FETCH_OBJ || $fetchMode === \PDO::FETCH_CLASS) {
+            if ($fetchMode === \PDO::FETCH_OBJ) {
+                $object = new \StdClass();
+            } else {
+                $class = new \ReflectionClass($argument);
+
+                if ($ctorArgs === null) {
+                    $object = $class->newInstance();
+                } else {
+                    $object = $class->newInstanceArgs($ctorArgs);
+                }
+            }
+
+            foreach ($result as $name => $value) {
+                $object->$name = $value;
+            }
+
+            return $object;
+        }
+
+        if ($fetchMode === \PDO::FETCH_COLUMN) {
+            $columnIndex = ($argument === null) ? 0 : (int) $argument;
+
+            if (isset($result[$columnIndex])) {
+                return $result[$columnIndex];
+            }
+
+            return null;
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAll($fetchMode = null)
+    {
+        $rows = [];
+
+        if ($this->result) {
+            $this->result->reset();
+
+            for (;;) {
+                $row = call_user_func_array(array($this, 'fetch'), func_get_args());
+
+                if ($row === false) {
+                    break;
+                }
+
+                $rows[] = $row;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchColumn($columnIndex = 0)
+    {
+        return $this->fetch(\PDO::FETCH_COLUMN, $columnIndex);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->fetchAll());
+    }
+
+    /**
+     * Converts a PDO type constant to a SQLite3 type constant.
+     *
+     * @param integer $type The PDO type.
+     *
+     * @return integer The SQLite3 type.
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function convertType($type)
+    {
+        switch ($type) {
+            case \PDO::PARAM_INT:
+                return SQLITE3_INTEGER;
+
+            case \PDO::PARAM_STR:
+                return SQLITE3_TEXT;
+
+            case \PDO::PARAM_BOOL:
+                return SQLITE3_INTEGER;
+
+            case \PDO::PARAM_LOB:
+                return SQLITE3_BLOB;
+
+            case \PDO::PARAM_NULL:
+                return SQLITE3_NULL;
+        }
+
+        throw new \InvalidArgumentException('Unknown type: ' . $type);
+    }
+
+    /**
+     * Converts a PDO fetch mode constant to a SQLite3 fetch mode constant.
+     *
+     * @param integer $fetchMode The PDO fetch mode.
+     *
+     * @return integer The SQLite3 fetch mode.
+     */
+    private function convertFetchMode($fetchMode)
+    {
+        switch ($fetchMode) {
+            case \PDO::FETCH_NUM:
+            case \PDO::FETCH_COLUMN:
+                return SQLITE3_NUM;
+
+            case \PDO::FETCH_ASSOC:
+            case \PDO::FETCH_OBJ:
+            case \PDO::FETCH_CLASS:
+            case \PDO::FETCH_FUNC:
+                return SQLITE3_ASSOC;
+
+            case \PDO::FETCH_BOTH:
+                return SQLITE3_BOTH;
+        }
+
+        throw new \InvalidArgumentException('Unknown fetch mode: ' . $fetchMode);
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
@@ -48,7 +48,7 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
     private $rowCount = 0;
 
     /**
-     * The default fetch mode, one of the \PDO::FETCH_* constants.
+     * The default fetch mode, one of the PDO::FETCH_* constants.
      *
      * @var integer
      */
@@ -73,6 +73,20 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
      * @var array|null
      */
     private $fetchCtorArgs;
+
+    /**
+     * The error code for the last execution of the statement.
+     *
+     * @var integer
+     */
+    private $lastErrorCode = 0;
+
+    /**
+     * The error message for the last execution of the statement.
+     *
+     * @var string
+     */
+    private $lastErrorMessage = 'not an error';
 
     /**
      * Class constructor.
@@ -115,7 +129,7 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
      */
     public function errorCode()
     {
-        return '';
+        return $this->lastErrorCode;
     }
 
     /**
@@ -123,7 +137,11 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
      */
     public function errorInfo()
     {
-        return [];
+        return [
+            null,
+            $this->lastErrorCode,
+            $this->lastErrorMessage
+        ];
     }
 
     /**
@@ -138,6 +156,10 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
         }
 
         $result = @ $this->stmt->execute();
+
+        $this->lastErrorCode    = $this->sqlite3->lastErrorCode();
+        $this->lastErrorMessage = $this->sqlite3->lastErrorMsg();
+
         $this->throwExceptionOnError();
 
         $this->result   = $result;

--- a/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLite3/SQLite3Statement.php
@@ -31,7 +31,14 @@ use Doctrine\DBAL\Driver\Statement;
 class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, Statement
 {
     /**
-     * The SQLite3 statement object.
+     * The SQL statement.
+     *
+     * @var string
+     */
+    private $sql;
+
+    /**
+     * The SQLite3Stmt object.
      *
      * @var \SQLite3Stmt
      */
@@ -95,13 +102,22 @@ class SQLite3Statement extends SQLite3Abstract implements \IteratorAggregate, St
     /**
      * Class constructor.
      *
-     * @param \SQLite3     $sqlite3 The SQLite3 connection object.
-     * @param \SQLite3Stmt $stmt    The SQLite3 statement object.
+     * @param \SQLite3 $sqlite3 The SQLite3 connection object.
+     * @param string   $sql     The SQL statement to prepare.
+     * @throws SQLite3Exception
      */
-    public function __construct(\SQLite3 $sqlite3, \SQLite3Stmt $stmt)
+    public function __construct(\SQLite3 $sqlite3, $sql)
     {
         $this->sqlite3 = $sqlite3;
-        $this->stmt    = $stmt;
+        $this->sql     = $sql;
+
+        try {
+            $this->stmt = $this->sqlite3->prepare($sql);
+        } catch (\Exception $e) {
+            throw SQLite3Exception::fromNativeException($e, $this->sqlite3);
+        }
+
+        $this->throwExceptionOnError();
     }
 
     /**

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -49,6 +49,7 @@ final class DriverManager
          'drizzle_pdo_mysql'  => 'Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver',
          'sqlanywhere'        => 'Doctrine\DBAL\Driver\SQLAnywhere\Driver',
          'sqlsrv'             => 'Doctrine\DBAL\Driver\SQLSrv\Driver',
+         'sqlite3'            => 'Doctrine\DBAL\Driver\SQLite3\Driver',
     );
 
     /**

--- a/lib/Doctrine/DBAL/Types/DecimalType.php
+++ b/lib/Doctrine/DBAL/Types/DecimalType.php
@@ -49,6 +49,6 @@ class DecimalType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        return (null === $value) ? null : (string) $value;
+        return (null === $value) ? null : $value;
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Driver/SQLite3/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/SQLite3/DriverTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Driver\SQLite3;
+
+use Doctrine\DBAL\Driver\SQLite3\Driver;
+use Doctrine\Tests\DBAL\Driver\AbstractSQLiteDriverTest;
+
+class DriverTest extends AbstractSQLiteDriverTest
+{
+    public function testReturnsName()
+    {
+        $this->assertSame('sqlite3', $this->driver->getName());
+    }
+
+    protected function createDriver()
+    {
+        return new Driver();
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -216,6 +216,10 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
             $this->markTestSkipped('mysqli and sqlsrv actually supports this');
         }
 
+        if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLite3\Driver) {
+            $this->markTestSkipped('Using an object as a parameter makes SQLite3 crash.');
+        }
+
         $datetimeString = '2010-01-01 10:10:10';
         $datetime = new \DateTime($datetimeString);
         $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
@@ -275,6 +279,10 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
             $this->markTestSkipped('mysqli and sqlsrv actually supports this');
         }
 
+        if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLite3\Driver) {
+            $this->markTestSkipped('Using an object as a parameter makes SQLite3 crash.');
+        }
+
         $datetimeString = '2010-01-01 10:10:10';
         $datetime = new \DateTime($datetimeString);
         $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
@@ -313,6 +321,10 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\Mysqli\Driver ||
             $this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLSrv\Driver) {
             $this->markTestSkipped('mysqli and sqlsrv actually supports this');
+        }
+
+        if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLite3\Driver) {
+            $this->markTestSkipped('Using an object as a parameter makes SQLite3 crash.');
         }
 
         $datetimeString = '2010-01-01 10:10:10';
@@ -354,6 +366,10 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\Mysqli\Driver ||
             $this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLSrv\Driver) {
             $this->markTestSkipped('mysqli and sqlsrv actually supports this');
+        }
+
+        if ($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLite3\Driver) {
+            $this->markTestSkipped('Using an object as a parameter makes SQLite3 crash.');
         }
 
         $datetimeString = '2010-01-01 10:10:10';

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLite3/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLite3/DriverTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\SQLite3;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\SQLite3\Driver;
+use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+
+class DriverTest extends AbstractDriverTest
+{
+    protected function setUp()
+    {
+        if (!extension_loaded('sqlite3')) {
+            $this->markTestSkipped('sqlite3 is not loaded.');
+        }
+
+        parent::setUp();
+
+        if (!$this->_conn->getDriver() instanceof Driver) {
+            $this->markTestSkipped('sqlite3 only test.');
+        }
+    }
+
+    protected function createDriver()
+    {
+        return new Driver();
+    }
+
+    public function testConnectsWithoutDatabaseNameParameter()
+    {
+        $this->markTestSkipped("dbname not supported on sqlite");
+    }
+
+    public function testReturnsDatabaseNameWithoutDatabaseNameParameter()
+    {
+        $this->markTestSkipped("dbname not supported on sqlite");
+    }
+
+    public function testConnectsWithoutPathParameter()
+    {
+        $params = $this->_conn->getParams();
+        unset($params['path']);
+
+        $connection = $this->driver->connect($params);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Driver\SQLite3\SQLite3Connection', $connection);
+    }
+
+    public function testConnectsWithBlankPathParameter()
+    {
+        $params = $this->_conn->getParams();
+        $params['path'] = '';
+
+        $connection = $this->driver->connect($params);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Driver\SQLite3\SQLite3Connection', $connection);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLite3/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLite3/DriverTest.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Driver\SQLite3;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\SQLite3\Driver;
+use Doctrine\DBAL\Exception\SyntaxErrorException;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 
 class DriverTest extends AbstractDriverTest
@@ -54,5 +54,27 @@ class DriverTest extends AbstractDriverTest
         $connection = $this->driver->connect($params);
 
         $this->assertInstanceOf('Doctrine\DBAL\Driver\SQLite3\SQLite3Connection', $connection);
+    }
+
+    /**
+     * @expectedException \Doctrine\DBAL\Exception\SyntaxErrorException
+     */
+    public function testSyntaxErrorException()
+    {
+        $this->_conn->query("KWYJIBO!");
+    }
+
+    public function testQueryExceptionIsChainedProperly()
+    {
+        $exception = null;
+        try {
+            $this->_conn->query("KWYJIBO!");
+        } catch (SyntaxErrorException $e) {
+            $exception = $e;
+        }
+
+        $this->assertInstanceOf('Doctrine\DBAL\Exception\SyntaxErrorException', $exception);
+        $this->assertInstanceOf('Doctrine\DBAL\Driver\SQLite3\SQLite3Exception', $exception->getPrevious());
+        $this->assertInstanceOf('Exception', $exception->getPrevious()->getPrevious());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Driver\SQLite3;
 
 class TypeConversionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
@@ -75,6 +76,10 @@ class TypeConversionTest extends \Doctrine\Tests\DbalFunctionalTestCase
      */
     public function testIdempotentDataConversion($type, $originalValue, $expectedPhpType)
     {
+        if ($type == 'decimal' && $this->_conn->getDriver() instanceof SQLite3\Driver) {
+            $this->markTestIncomplete("SQLite3 returns decimal types as true floats if they can be losslessly represented as a float. This is an inconsistency and should possibly be addressed in the DecimalType.");
+        }
+
         $columnName = "test_" . $type;
         $typeInstance = Type::getType($type);
         $insertionValue = $typeInstance->convertToDatabaseValue($originalValue, $this->_conn->getDatabasePlatform());

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -157,6 +157,10 @@ class TestUtil
             $connectionParams['unix_socket'] = $GLOBALS['tmpdb_unix_socket'];
         }
 
+        if (isset($GLOBALS['tmpdb_path'])) {
+            $connectionParams['path'] = $GLOBALS['tmpdb_path'];
+        }
+
         return $connectionParams;
     }
 
@@ -177,6 +181,10 @@ class TestUtil
 
         if (isset($GLOBALS['db_unix_socket'])) {
             $connectionParams['unix_socket'] = $GLOBALS['db_unix_socket'];
+        }
+
+        if (isset($GLOBALS['db_path'])) {
+            $connectionParams['path'] = $GLOBALS['db_path'];
         }
 
         return $connectionParams;

--- a/tests/travis/sqlite3.travis.xml
+++ b/tests/travis/sqlite3.travis.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
+    <php>
+        <var name="db_type" value="sqlite3"/>
+        <var name="tmpdb_type" value="sqlite3"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Doctrine DBAL Test Suite">
+            <directory>../Doctrine/Tests/DBAL</directory>
+        </testsuite>
+    </testsuites>
+    <groups>
+        <exclude>
+            <group>performance</group>
+            <group>locking_functional</group>
+        </exclude>
+    </groups>
+</phpunit>
+

--- a/tests/travis/sqlite3.travis.xml
+++ b/tests/travis/sqlite3.travis.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="../../vendor/autoload.php"
+>
     <php>
+        <var name="error_reporting" value="-1" />
         <var name="db_type" value="sqlite3"/>
         <var name="tmpdb_type" value="sqlite3"/>
     </php>
@@ -17,4 +23,3 @@
         </exclude>
     </groups>
 </phpunit>
-


### PR DESCRIPTION
This PR supplements and closes #840.

I made some changes to the exception handling in the driver. SQLite3 is one of the only non-PDO drivers that throws exceptions instead of errors. The changes I made allow the exceptions thrown by the underlying driver to be chained into the SQLite3Exception.

I also added some phpdoc @ since and @ author annotations.

/ping @BenMorel @deeky666 @stof
## From BenMorel's Original PR #840:

This PR adds an additional driver using the [SQLite3](http://php.net/manual/fr/book.sqlite3.php) class, in addition to the PDO_SQLITE driver.
## Why this driver?

Even though the PDO SQLite driver is already available to interact with SQLite databases, PDO currently has a big limitation: it [does not allow to load SQLite extensions](https://bugs.php.net/bug.php?id=64810).

This functionality is provided by the `SQLite3` class, which becomes your only option if you need to use your PHP application with an SQLite extension such as [SpatiaLite](http://www.gaia-gis.it/gaia-sins/).
