### PR TITLE
Add native JSON type support for MySQL >=5.7.8

### DIFF
--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -35,6 +35,7 @@ MySQL
 
 -  ``MySqlPlatform`` for version 5.0 and above.
 -  ``MySQL57Platform`` for version 5.7 and above.
+-  ``MySQL578Platform`` for version 5.7.8 and above.
 
 Oracle
 ^^^^^^

--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -22,6 +22,7 @@ namespace Doctrine\DBAL\Driver;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQL578Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\MySqlSchemaManager;
@@ -135,6 +136,10 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
         $minorVersion = isset($versionParts['minor']) ? $versionParts['minor'] : 0;
         $patchVersion = isset($versionParts['patch']) ? $versionParts['patch'] : 0;
         $version      = $majorVersion . '.' . $minorVersion . '.' . $patchVersion;
+
+        if (version_compare($version, '5.7.8', '>=')) {
+            return new MySQL578Platform();
+        }
 
         if (version_compare($version, '5.7', '>=')) {
             return new MySQL57Platform();

--- a/lib/Doctrine/DBAL/Platforms/Keywords/MySQL578Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/MySQL578Keywords.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Platforms\Keywords;
+
+/**
+ * MySQL 5.7.8 reserved keywords list.
+ *
+ * @author İsmail BASKIN <ismailbaskin1@gmail.com>
+ * @link   www.doctrine-project.org
+ * @since  2.6
+ */
+class MySQL578Keywords extends MySQL57Keywords
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'MySQL578';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/keywords.html
+     */
+    protected function getKeywords()
+    {
+        $parentKeywords = array_diff(parent::getKeywords(), array(
+            'NONBLOCKING',
+        ));
+
+        return array_merge($parentKeywords, array(
+            'GENERATED',
+            'OPTIMIZER_COSTS',
+            'STORED',
+            'VIRTUAL'
+        ));
+    }
+}

--- a/lib/Doctrine/DBAL/Platforms/MySQL578Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL578Platform.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Platforms;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MySQL >=5.7.8 database platform.
+ * Extends for json support >=5.7.8 version
+ *
+ * @author İsmail BASKIN <ismailbaskin1@gmail.com>
+ * @link   www.doctrine-project.org
+ * @since  2.5
+ */
+class MySQL578Platform extends MySQL57Platform
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function initializeDoctrineTypeMappings()
+    {
+        parent::initializeDoctrineTypeMappings();
+        $this->doctrineTypeMapping['json'] = 'json_array';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasNativeJsonType()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJsonTypeDeclarationSQL(array $field)
+    {
+        return 'JSON';
+    }
+}

--- a/lib/Doctrine/DBAL/Platforms/MySQL578Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL578Platform.php
@@ -53,4 +53,12 @@ class MySQL578Platform extends MySQL57Platform
     {
         return 'JSON';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getReservedKeywordsClass()
+    {
+        return 'Doctrine\DBAL\Platforms\Keywords\MySQL578Keywords';
+    }
 }

--- a/lib/Doctrine/DBAL/Platforms/MySQL578Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL578Platform.php
@@ -25,7 +25,7 @@ namespace Doctrine\DBAL\Platforms;
  *
  * @author İsmail BASKIN <ismailbaskin1@gmail.com>
  * @link   www.doctrine-project.org
- * @since  2.5
+ * @since  2.6
  */
 class MySQL578Platform extends MySQL57Platform
 {

--- a/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
@@ -33,6 +33,7 @@ class ReservedWordsCommand extends Command
     private $keywordListClasses = array(
         'mysql'         => 'Doctrine\DBAL\Platforms\Keywords\MySQLKeywords',
         'mysql57'       => 'Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords',
+        'mysql578'       => 'Doctrine\DBAL\Platforms\Keywords\MySQL578Keywords',
         'sqlserver'     => 'Doctrine\DBAL\Platforms\Keywords\SQLServerKeywords',
         'sqlserver2005' => 'Doctrine\DBAL\Platforms\Keywords\SQLServer2005Keywords',
         'sqlserver2008' => 'Doctrine\DBAL\Platforms\Keywords\SQLServer2008Keywords',

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
@@ -59,6 +59,7 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
             array('5.7', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
             array('5.7.0', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
             array('5.7.1', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
+            array('5.7.8', 'Doctrine\DBAL\Platforms\MySQL578Platform'),
             array('6', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
             array('10.0.15-MariaDB-1~wheezy', 'Doctrine\DBAL\Platforms\MySqlPlatform'),
             array('10.1.2a-MariaDB-a1~lenny-log', 'Doctrine\DBAL\Platforms\MySqlPlatform'),

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
@@ -60,7 +60,7 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
             array('5.7.0', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
             array('5.7.1', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
             array('5.7.8', 'Doctrine\DBAL\Platforms\MySQL578Platform'),
-            array('6', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
+            array('6', 'Doctrine\DBAL\Platforms\MySQL578Platform'),
             array('10.0.15-MariaDB-1~wheezy', 'Doctrine\DBAL\Platforms\MySqlPlatform'),
             array('10.1.2a-MariaDB-a1~lenny-log', 'Doctrine\DBAL\Platforms\MySqlPlatform'),
             array('5.5.40-MariaDB-1~wheezy', 'Doctrine\DBAL\Platforms\MySqlPlatform'),

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySQL578PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySQL578PlatformTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Platforms;
+
+use Doctrine\DBAL\Platforms\MySQL578Platform;
+
+class MySQL578PlatformTest extends MySQL57PlatformTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createPlatform()
+    {
+        return new MySQL578Platform();
+    }
+
+    /**
+     * @group DBAL-553
+     */
+    public function testHasNativeJsonType()
+    {
+        $this->assertTrue($this->_platform->hasNativeJsonType());
+    }
+
+    /**
+     * @group DBAL-553
+     */
+    public function testReturnsJsonTypeDeclarationSQL()
+    {
+        $this->assertSame('JSON', $this->_platform->getJsonTypeDeclarationSQL(array()));
+    }
+
+    /**
+     * @group DBAL-553
+     */
+    public function testInitializesJsonTypeMapping()
+    {
+        $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('json'));
+        $this->assertEquals('json_array', $this->_platform->getDoctrineTypeMapping('json'));
+    }
+}


### PR DESCRIPTION
> As of MySQL 5.7.8, MySQL supports a native JSON data type that enables efficient access to data in  JSON (JavaScript Object Notation) documents. The JSON data type provides these advantages over storing JSON-format strings in a string column:

http://dev.mysql.com/doc/refman/5.7/en/json.html
