### PR TITLE
Pass "path" to pdo-sqlite drivers from DriverManager instead of "dbname"

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -259,10 +259,14 @@ final class DriverManager
         }
         
         if (isset($url['path'])) {
+            $nameKey = isset($url['scheme']) && strpos($url['scheme'], 'sqlite') !== false
+                ? 'path' // pdo_sqlite driver uses 'path' instead of 'dbname' key
+                : 'dbname';
+
             if (!isset($url['scheme']) || (strpos($url['scheme'], 'sqlite') !== false && $url['path'] == ':memory:')) {
-                $params['dbname'] = $url['path']; // if the URL was just "sqlite::memory:", which parses to scheme and path only
+                $params[$nameKey] = $url['path']; // if the URL was just "sqlite::memory:", which parses to scheme and path only
             } else {
-                $params['dbname'] = substr($url['path'], 1); // strip the leading slash from the URL
+                $params[$nameKey] = substr($url['path'], 1); // strip the leading slash from the URL
             }
         }
         

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -151,27 +151,27 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
             ),
             'sqlite relative URL with host' => array(
                 'sqlite://localhost/foo/dbname.sqlite',
-                array('dbname' => 'foo/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('path' => 'foo/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'sqlite absolute URL with host' => array(
                 'sqlite://localhost//tmp/dbname.sqlite',
-                array('dbname' => '/tmp/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('path' => '/tmp/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'sqlite relative URL without host' => array(
                 'sqlite:///foo/dbname.sqlite',
-                array('dbname' => 'foo/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('path' => 'foo/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'sqlite absolute URL without host' => array(
                 'sqlite:////tmp/dbname.sqlite',
-                array('dbname' => '/tmp/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('path' => '/tmp/dbname.sqlite', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'sqlite memory' => array(
                 'sqlite:///:memory:',
-                array('dbname' => ':memory:', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('path' => ':memory:', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'sqlite memory with host' => array(
                 'sqlite://localhost/:memory:',
-                array('dbname' => ':memory:', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
+                array('path' => ':memory:', 'driver' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver'),
             ),
             'params parsed from URL override individual params' => array(
                 array('url' => 'mysql://foo:bar@localhost/baz', 'password' => 'lulz'),


### PR DESCRIPTION
This fixes https://github.com/doctrine/dbal/issues/1106. Any input on the correct way to do this per Doctrine coding standards is welcome.
