### PR TITLE
#2260 - loosening doctrine/common requirement: allowing 2.6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.4,<2.6-dev"
+        "doctrine/common": ">=2.4,<2.7-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
Alternate fix to #2260
