### PR TITLE
Correct minor formatting glitches in the transactions documentation

### DIFF
--- a/docs/en/reference/transactions.rst
+++ b/docs/en/reference/transactions.rst
@@ -60,9 +60,9 @@ transactions, or rather propagating transaction control up the call
 stack. For that purpose, the ``Connection`` class keeps an internal
 counter that represents the nesting level and is
 increased/decreased as ``beginTransaction()``, ``commit()`` and
- ``rollBack()`` are invoked. ``beginTransaction()`` increases the
+``rollBack()`` are invoked. ``beginTransaction()`` increases the
 nesting level whilst
- ``commit()`` and ``rollBack()`` decrease the nesting level. The nesting level starts at 0. Whenever the nesting level transitions from 0 to 1, ``beginTransaction()`` is invoked on the underlying driver connection and whenever the nesting level transitions from 1 to 0, ``commit()`` or ``rollBack()`` is invoked on the underlying driver, depending on whether the transition was caused by ``Connection#commit()`` or ``Connection#rollBack()``.
+``commit()`` and ``rollBack()`` decrease the nesting level. The nesting level starts at 0. Whenever the nesting level transitions from 0 to 1, ``beginTransaction()`` is invoked on the underlying driver connection and whenever the nesting level transitions from 1 to 0, ``commit()`` or ``rollBack()`` is invoked on the underlying driver, depending on whether the transition was caused by ``Connection#commit()`` or ``Connection#rollBack()``.
 
 What this means is that transaction control is basically passed to
 code higher up in the call stack and the inner transaction block is


### PR DESCRIPTION
The first paragraph of section 6.1 has some minor formatting errors (see http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/transactions.html#transaction-nesting)
Removing a couple of spaces fixes the problem.
