### PR TITLE
[DBAL-1779] Fix string column type declarations with whitespace on SQLite

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -269,7 +269,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     protected function _getPortableTableColumnDefinition($tableColumn)
     {
         $parts = explode('(', $tableColumn['type']);
-        $tableColumn['type'] = $parts[0];
+        $tableColumn['type'] = trim($parts[0]);
         if (isset($parts[1])) {
             $length = trim($parts[1], ')');
             $tableColumn['length'] = $length;


### PR DESCRIPTION
When introspecting column types from a table in SQLite that has not been created by Doctrine and contains whitespaces in the DDL, DBAL fails to introspect the column types correctly.

**Works**

``` sql
CREATE TABLE dbal_1779 (
    foo VARCHAR(64),
    bar TEXT(100)
)
```

**Does not work**

``` sql
CREATE TABLE dbal_1779 (
    foo VARCHAR (64) ,
    bar TEXT (100)
)
```

fixes #1339
closes/supersedes #921
