### PR TITLE
Fix usage of PDO::PGSQL_ATTR_DISABLE_PREPARES for edge case pdo_pgsql setups

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -45,7 +45,7 @@ class Driver extends AbstractPostgreSQLDriver
                 $driverOptions
             );
 
-            if (PHP_VERSION_ID >= 50600
+            if (defined('PDO::PGSQL_ATTR_DISABLE_PREPARES')
                 && (! isset($driverOptions[PDO::PGSQL_ATTR_DISABLE_PREPARES])
                     || true === $driverOptions[PDO::PGSQL_ATTR_DISABLE_PREPARES]
                 )

--- a/tests/Doctrine/Tests/DBAL/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDOPgSql/DriverTest.php
@@ -107,7 +107,7 @@ class DriverTest extends AbstractPostgreSQLDriverTest
      */
     private function skipWhenNotUsingPhp56AndPdoPgsql()
     {
-        if (PHP_VERSION_ID < 50600) {
+        if (! defined('PDO::PGSQL_ATTR_DISABLE_PREPARES')) {
             $this->markTestSkipped('Test requires PHP 5.6+');
         }
 


### PR DESCRIPTION
The constant `PDO::PGSQL_ATTR_DISABLE_PREPARES` is available since PHP 5.6.0, however this is only true if the extension is installed/built from the PHP core sources. Looks like in rare situations it is possible to run PHP 5.6 with a heavily outdated `pdo_pgsql` extension (coming from PECL?!?). In this case DBAL crashes.
This PR makes the check for the constant's availability more robust to also work in those setups.

fixes #2249
