### PR TITLE
Fix test case on OracleDB

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
@@ -103,7 +103,7 @@ class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->_conn->insert('modify_limit_table', array('test_int' => 3));
         $this->_conn->insert('modify_limit_table', array('test_int' => 4));
 
-        $sql = "SELECT *, (SELECT COUNT(*) FROM modify_limit_table) AS cnt FROM modify_limit_table";
+        $sql = "SELECT modify_limit_table.*, (SELECT COUNT(*) FROM modify_limit_table) AS cnt FROM modify_limit_table";
 
         $this->assertLimitResult(array(4, 3, 2, 1), $sql, 10, 0, false);
         $this->assertLimitResult(array(4, 3), $sql, 2, 0, false);


### PR DESCRIPTION
fixes #2252 

Looks like Oracle needs a table reference in the outer `SELECT` statement here.
Tested locally with Oracle and it works now.
