### PR TITLE
[DBAL-939] Fix reverse engineering boolean type columns on DB2

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -25,6 +25,7 @@ use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Types\Type;
 
 class DB2Platform extends AbstractPlatform
 {
@@ -75,6 +76,20 @@ class DB2Platform extends AbstractPlatform
             'real'          => 'float',
             'timestamp'     => 'datetime',
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCommentedDoctrineType(Type $doctrineType)
+    {
+        if ($doctrineType->getName() === Type::BOOLEAN) {
+            // We require a commented boolean type in order to distinguish between boolean and smallint
+            // as both (have to) map to the same native type.
+            return true;
+        }
+
+        return parent::isCommentedDoctrineType($doctrineType);
     }
 
     /**
@@ -267,6 +282,7 @@ class DB2Platform extends AbstractPlatform
                  c.scale,
                  c.identity,
                  tc.type AS tabconsttype,
+                 c.remarks AS comment,
                  k.colseq,
                  CASE
                  WHEN c.generated = 'D' THEN 1
@@ -407,6 +423,14 @@ class DB2Platform extends AbstractPlatform
     public function supportsReleaseSavepoints()
     {
         return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsCommentOnStatement()
+    {
+        return true;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
@@ -65,6 +65,11 @@ class DB2SchemaManager extends AbstractSchemaManager
 
         $type = $this->_platform->getDoctrineTypeMapping($tableColumn['typename']);
 
+        if (isset($tableColumn['comment'])) {
+            $type = $this->extractDoctrineTypeFromComment($tableColumn['comment'], $type);
+            $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);
+        }
+
         switch (strtolower($tableColumn['typename'])) {
             case 'varchar':
                 $length = $tableColumn['length'];
@@ -94,6 +99,9 @@ class DB2SchemaManager extends AbstractSchemaManager
             'notnull'       => (bool) ($tableColumn['nulls'] == 'N'),
             'scale'         => null,
             'precision'     => null,
+            'comment'       => isset($tableColumn['comment']) && $tableColumn['comment'] !== ''
+                ? $tableColumn['comment']
+                : null,
             'platformOptions' => array(),
         );
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/Db2SchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/Db2SchemaManagerTest.php
@@ -2,7 +2,27 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
+use Doctrine\DBAL\Schema\Table;
+
 class Db2SchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
+    /**
+     * @group DBAL-939
+     */
+    public function testGetBooleanColumn()
+    {
+        $table = new Table('boolean_column_test');
+        $table->addColumn('bool', 'boolean');
+        $table->addColumn('bool_commented', 'boolean', array('comment' => "That's a comment"));
 
+        $this->_sm->createTable($table);
+
+        $columns = $this->_sm->listTableColumns('boolean_column_test');
+
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BooleanType', $columns['bool']->getType());
+        $this->assertInstanceOf('Doctrine\DBAL\Types\BooleanType', $columns['bool_commented']->getType());
+
+        $this->assertNull($columns['bool']->getComment());
+        $this->assertSame("That's a comment", $columns['bool_commented']->getComment());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -107,6 +107,34 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
         $this->_platform->registerDoctrineTypeMapping('foo', 'bar');
     }
 
+    /**
+     * @group DBAL-939
+     *
+     * @dataProvider getIsCommentedDoctrineType
+     */
+    public function testIsCommentedDoctrineType(Type $type, $commented)
+    {
+        $this->assertSame($commented, $this->_platform->isCommentedDoctrineType($type));
+    }
+
+    public function getIsCommentedDoctrineType()
+    {
+        $this->setUp();
+
+        $data = array();
+
+        foreach (Type::getTypesMap() as $typeName => $className) {
+            $type = Type::getType($typeName);
+
+            $data[$typeName] = array(
+                $type,
+                $type->requiresSQLCommentHint($this->_platform),
+            );
+        }
+
+        return $data;
+    }
+
     public function testCreateWithNoColumns()
     {
         $table = new Table('test');
@@ -649,6 +677,19 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     protected function supportsInlineIndexDeclaration()
     {
         return true;
+    }
+
+    public function testSupportsCommentOnStatement()
+    {
+        $this->assertSame($this->supportsCommentOnStatement(), $this->_platform->supportsCommentOnStatement());
+    }
+
+    /**
+     * @return bool
+     */
+    protected function supportsCommentOnStatement()
+    {
+        return false;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -227,6 +227,14 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
         $this->assertTrue($this->_platform->supportsSequences());
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function supportsCommentOnStatement()
+    {
+        return true;
+    }
+
     public function testModifyLimitQuery()
     {
         $sql = $this->_platform->modifyLimitQuery('SELECT * FROM user', 10, 0);

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -115,6 +115,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     {
         return array(
             "CREATE TABLE test (id INTEGER NOT NULL, PRIMARY KEY(id))",
+            "COMMENT ON COLUMN test.id IS 'This is a comment'",
         );
     }
 
@@ -134,6 +135,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     {
         return array(
             'CREATE TABLE test (id INTEGER NOT NULL, "data" CLOB(1M) NOT NULL, PRIMARY KEY(id))',
+            'COMMENT ON COLUMN test."data" IS \'(DC2Type:array)\'',
         );
     }
 
@@ -283,6 +285,15 @@ class DB2PlatformTest extends AbstractPlatformTestCase
 
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('timestamp'));
         $this->assertSame('datetime', $this->_platform->getDoctrineTypeMapping('timestamp'));
+    }
+
+    public function getIsCommentedDoctrineType()
+    {
+        $data = parent::getIsCommentedDoctrineType();
+
+        $data[Type::BOOLEAN] = array(Type::getType(Type::BOOLEAN), true);
+
+        return $data;
     }
 
     public function testGeneratesDDLSnippets()
@@ -646,6 +657,14 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     protected function supportsInlineIndexDeclaration()
     {
         return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function supportsCommentOnStatement()
+    {
+        return true;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -187,6 +187,14 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         $this->assertTrue($this->_platform->supportsSavepoints());
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function supportsCommentOnStatement()
+    {
+        return true;
+    }
+
     public function getGenerateIndexSql()
     {
         return 'CREATE INDEX my_idx ON mytable (user_name, last_login)';


### PR DESCRIPTION
- fixes platform's COMMENT ON statement support
- implements reverse engineering for column comments
- marks boolean column type commented for distinction

fixes #2182

Fixing the original issue required fixing the partially implemented `COMMENT ON` statement support first. By fixing this issue, some missing tests have been added for all platforms, too.

This also adds support for reverse engineering custom types as a side effect.
