### PR TITLE
Stop using template1 as default database for postgres drivers

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -90,9 +90,9 @@ class Driver extends AbstractPostgreSQLDriver
             $dsn .= 'dbname=' . $params['dbname'] . ' ';
         } else {
             // Used for temporary connections to allow operations like dropping the database currently connected to.
-            // Connecting without an explicit database does not work, therefore "template1" database is used
-            // as it is certainly present in every server setup.
-            $dsn .= 'dbname=template1' . ' ';
+            // Connecting without an explicit database does not work, therefore "postgres" database is used
+            // as it is certainly present in every server setup. 
+            $dsn .= 'dbname=postgres' . ' ';
         }
 
         if (isset($params['sslmode'])) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
@@ -33,6 +33,6 @@ class DriverTest extends AbstractDriverTest
      */
     protected function getDatabaseNameForConnectionWithoutDatabaseNameParameter()
     {
-        return 'template1';
+        return 'postgres';
     }
 }


### PR DESCRIPTION
The "postgresql" should be used as the default database and not "template1". Postgresql creates databases by copying an existing database and "template1" is the default if none is specified, if any connection to the template database exists when a "CREATE DATABASE" is issued postgresql is unable to create the new database.

http://www.postgresql.org/docs/9.4/static/manage-ag-templatedbs.html
