### PR TITLE
Fix creating database on PostgreSQL with active connections on "template1" database

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -417,7 +417,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getCreateDatabaseSQL($name)
     {
-        return 'CREATE DATABASE ' . $name;
+        return 'CREATE DATABASE ' . $name . ' TEMPLATE template0';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -130,7 +130,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
 
     public function testGeneratesDDLSnippets()
     {
-        $this->assertEquals('CREATE DATABASE foobar', $this->_platform->getCreateDatabaseSQL('foobar'));
+        $this->assertEquals('CREATE DATABASE foobar TEMPLATE template0', $this->_platform->getCreateDatabaseSQL('foobar'));
         $this->assertEquals('DROP DATABASE foobar', $this->_platform->getDropDatabaseSQL('foobar'));
         $this->assertEquals('DROP TABLE foobar', $this->_platform->getDropTableSQL('foobar'));
     }


### PR DESCRIPTION
Fixes:

```
Exception: [Doctrine\DBAL\Exception\DriverException] An exception occurred while executing 'CREATE DATABASE test_drop_database':

SQLSTATE[55006]: Object in use: 7 ERROR:  source database "template1" is being accessed by other users

DETAIL:  There are 19 other sessions using the database.
```

The problem here is that if we want to create a database in PostgreSQL, we temporarily connect to `template1` database in order to be able to create a database safely. Now if there are other active connections on `template1` already, PostgreSQL refuses to create the database as it internally just uses `template1` as a template for the database to be created.
To come around this problem we can use `template0` as the template database when creating database. `template0` doesn't accept connections in a default server setup, so we know this won't issue any errors. If I understood correctly there is no noticeable difference between `template0` and `template1` so it doesn't matter for us which template to use for creating new databases. By default when omitting the `TEMPLATE <template_database>` expression in the `CREATE DATABASE` statement, PostgreSQL uses `template1`.
There is a pretty good explanation of this in the [documentation](http://www.postgresql.org/docs/9.1/static/manage-ag-templatedbs.html).

To sum up in a default database setup we can be sure to have the following environment:
- `template0` database which is protected (cannot be dropped) and **does not** accept connections
- `template1` database which is protected (cannot be dropped) and **does** accept connections
- `postgres` database which is **not** protected (can be dropped)
