### PR TITLE
Allow PHP 7 + `pdo_pgsql` failures on Travis-CI again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,14 +97,6 @@ matrix:
       addons:
         mariadb: 10.1
   allow_failures:
-    - php: 7.0
-      env: DB=pgsql POSTGRESQL_VERSION=9.1 # not fully working yet
-    - php: 7.0
-      env: DB=pgsql POSTGRESQL_VERSION=9.2 # not fully working yet
-    - php: 7.0
-      env: DB=pgsql POSTGRESQL_VERSION=9.3 # not fully working yet
-    - php: 7.0
-      env: DB=pgsql POSTGRESQL_VERSION=9.4 # not fully working yet
     - php: hhvm
   exclude:
     - php: hhvm


### PR DESCRIPTION
Now that the issue was solved in #2279 we can allow failures again. /cc @Ocramius 
