### PR TITLE
Preserve quotation of old column name in ColumnDiff

### DIFF
--- a/lib/Doctrine/DBAL/Schema/ColumnDiff.php
+++ b/lib/Doctrine/DBAL/Schema/ColumnDiff.php
@@ -77,6 +77,8 @@ class ColumnDiff
      */
     public function getOldColumnName()
     {
-        return new Identifier($this->oldColumnName);
+        $quote = $this->fromColumn && $this->fromColumn->isQuoted();
+
+        return new Identifier($this->oldColumnName, $quote);
     }
 }

--- a/lib/Doctrine/DBAL/Schema/Identifier.php
+++ b/lib/Doctrine/DBAL/Schema/Identifier.php
@@ -35,9 +35,14 @@ class Identifier extends AbstractAsset
      * Constructor.
      *
      * @param string $identifier Identifier name to wrap.
+     * @param bool   $quote      Whether to force quoting the given identifier.
      */
-    public function __construct($identifier)
+    public function __construct($identifier, $quote = false)
     {
         $this->_setName($identifier);
+
+        if ($quote && ! $this->_quoted) {
+            $this->_setName('"' . $this->getName() . '"');
+        }
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/ColumnDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ColumnDiffTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Types\Type;
+
+class ColumnDiffTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @group DBAL-1255
+     */
+    public function testPreservesOldColumnNameQuotation()
+    {
+        $fromColumn = new Column('"foo"', Type::getType(Type::INTEGER));
+        $toColumn = new Column('bar', Type::getType(Type::INTEGER));
+
+        $columnDiff = new ColumnDiff('"foo"', $toColumn, array());
+        $this->assertTrue($columnDiff->getOldColumnName()->isQuoted());
+
+        $columnDiff = new ColumnDiff('"foo"', $toColumn, array(), $fromColumn);
+        $this->assertTrue($columnDiff->getOldColumnName()->isQuoted());
+
+        $columnDiff = new ColumnDiff('foo', $toColumn, array(), $fromColumn);
+        $this->assertTrue($columnDiff->getOldColumnName()->isQuoted());
+    }
+}


### PR DESCRIPTION
fixes #1206

Takes over #875 with a correct solution.
