### PR TITLE
Do not generate FROM clause in QueryBuilder if no tables specified

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1107,9 +1107,9 @@ class QueryBuilder
      */
     private function getSQLForSelect()
     {
-        $query = 'SELECT ' . implode(', ', $this->sqlParts['select']) . ' FROM ';
+        $query = 'SELECT ' . implode(', ', $this->sqlParts['select']);
 
-        $query .= implode(', ', $this->getFromClauses())
+        $query .= ($this->sqlParts['from'] ? ' FROM ' . implode(', ', $this->getFromClauses()) : '')
             . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '')
             . ($this->sqlParts['groupBy'] ? ' GROUP BY ' . implode(', ', $this->sqlParts['groupBy']) : '')
             . ($this->sqlParts['having'] !== null ? ' HAVING ' . ((string) $this->sqlParts['having']) : '')

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -23,6 +23,18 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
                    ->will($this->returnValue($expressionBuilder));
     }
 
+    /**
+     * @group DBAL-2291
+     */
+    public function testSimpleSelectWithoutFrom()
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('some_function()');
+
+        $this->assertEquals('SELECT some_function()', (string) $qb);
+    }
+
     public function testSimpleSelect()
     {
         $qb = new QueryBuilder($this->conn);


### PR DESCRIPTION
fixes #2291 

`SELECT` statements without `FROM` clause can be valid and legit in some scenarios. See issue.
