### PR TITLE
Fixed some broken links in the types documentation

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -327,7 +327,7 @@ returns the affected rows count:
 The ``$types`` variable contains the PDO or Doctrine Type constants
 to perform necessary type conversions between actual input
 parameters and expected database values. See the
-`Types <./types#mapping-matrix>`_ section for more information.
+:ref:`Types <mappingMatrix>` section for more information.
 
 executeQuery()
 ~~~~~~~~~~~~~~
@@ -351,7 +351,7 @@ parameters to the execute method, then returning the statement:
 The ``$types`` variable contains the PDO or Doctrine Type constants
 to perform necessary type conversions between actual input
 parameters and expected database values. See the
-`Types <./types#mapping-matrix>`_ section for more information.
+:ref:`Types <mappingMatrix>` section for more information.
 
 fetchAll()
 ~~~~~~~~~~

--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -300,7 +300,7 @@ or ``null`` if no data is present.
 
 .. note::
 
-    See the `Known Vendor Issue <./known-vendor-issues>`_ section
+    See the Known Vendor Issue :doc:`known-vendor-issues` section
     for details about the different handling of microseconds and
     timezones across all the different vendors.
 
@@ -418,6 +418,8 @@ using deserialization or ``null`` if no data is present.
     the object type will cause deserialization errors on PostgreSQL. A workaround is
     to ``serialize()``/``unserialize()`` and ``base64_encode()``/``base64_decode()`` PHP objects and store
     them into a ``text`` field manually.
+
+.. _mappingMatrix:
 
 Mapping Matrix
 --------------


### PR DESCRIPTION
I tested on the html and pdf versions of the documentation and now its working. I may do the same for the ORM in the near future if you like.
