### PR TITLE
Fix parameter list expansion by making SQLParserUtils platform aware

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -812,7 +812,12 @@ class Connection implements DriverConnection
 
         try {
             if ($params) {
-                list($query, $params, $types) = SQLParserUtils::expandListParameters($query, $params, $types);
+                list($query, $params, $types) = SQLParserUtils::expandListParameters(
+                    $query,
+                    $params,
+                    $types,
+                    $this->getDatabasePlatform()
+                );
 
                 $stmt = $this->_conn->prepare($query);
                 if ($types) {
@@ -971,7 +976,12 @@ class Connection implements DriverConnection
 
         try {
             if ($params) {
-                list($query, $params, $types) = SQLParserUtils::expandListParameters($query, $params, $types);
+                list($query, $params, $types) = SQLParserUtils::expandListParameters(
+                    $query,
+                    $params,
+                    $types,
+                    $this->getDatabasePlatform()
+                );
 
                 $stmt = $this->_conn->prepare($query);
                 if ($types) {


### PR DESCRIPTION
fixes #2295

@Ocramius @zeroedin-bill Ideas about how to test this properly without having to completely rewrite `Doctrine\Tests\DBAL\SQLParserUtilsTest` are welcome. Also I don't see a reasonable way how to test the changes in the connection as `SQLParserUtils` is called statically.

@maryo also please test if that fixes your problem if you have time to.
