### PR TITLE
Remove Unknown database type enum error.

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -1005,6 +1005,7 @@ class MySqlPlatform extends AbstractPlatform
             'binary'        => 'binary',
             'varbinary'     => 'binary',
             'set'           => 'simple_array',
+            'enum'          => 'string'  
         );
     }
 


### PR DESCRIPTION
This PR fixes the following error whenever columns are to be renamed in database migrations:

```
Unknown database type enum requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it.
```
