### PR TITLE
Add support for Easy Connect string as connection parameter in OracleDB

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -295,9 +295,11 @@ pdo\_oci / oci8
 -  ``instancename`` (string): Optional parameter, complete whether to
    add the INSTANCE_NAME parameter in the connection. It is generally used
    to connect to an Oracle RAC server to select the name of a particular instance.
-
-Complete connection descriptors are also supported. You only need to provide the following parameter, and none of the above:
-- ``connectstring`` (string): Complete Easy Connect connection descriptor, see https://docs.oracle.com/cd/E11882_01/network.112/e41945/naming.htm.
+-  ``connectstring`` (string): Complete Easy Connect connection descriptor,
+   see https://docs.oracle.com/database/121/NETAG/naming.htm. When using this option,
+   you will still need to provide the ``user`` and ``password` parameters, but the other
+   parameters will no longer be used. Note that when using this parameter, the `getHost`
+   and `getPort` methods from `Doctrine\DBAL\Connection` will no longer function as expected.
 
 pdo\_sqlsrv / sqlsrv
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -296,6 +296,8 @@ pdo\_oci / oci8
    add the INSTANCE_NAME parameter in the connection. It is generally used
    to connect to an Oracle RAC server to select the name of a particular instance.
 
+Complete connection descriptors are also supported. You only need to provide the following parameter, and none of the above:
+- ``connectstring`` (string): Complete Easy Connect connection descriptor, see https://docs.oracle.com/cd/E11882_01/network.112/e41945/naming.htm.
 
 pdo\_sqlsrv / sqlsrv
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -297,9 +297,9 @@ pdo\_oci / oci8
    to connect to an Oracle RAC server to select the name of a particular instance.
 -  ``connectstring`` (string): Complete Easy Connect connection descriptor,
    see https://docs.oracle.com/database/121/NETAG/naming.htm. When using this option,
-   you will still need to provide the ``user`` and ``password` parameters, but the other
-   parameters will no longer be used. Note that when using this parameter, the `getHost`
-   and `getPort` methods from `Doctrine\DBAL\Connection` will no longer function as expected.
+   you will still need to provide the ``user`` and ``password`` parameters, but the other
+   parameters will no longer be used. Note that when using this parameter, the ``getHost``
+   and ``getPort`` methods from ``Doctrine\DBAL\Connection`` will no longer function as expected.
 
 pdo\_sqlsrv / sqlsrv
 ^^^^^^^^^^^^^^^^^^^^

--- a/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
@@ -109,11 +109,10 @@ abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
      *
      * @return string
      *
-     * @link https://docs.oracle.com/cd/E11882_01/network.112/e41945/naming.htm
+     * @link https://docs.oracle.com/database/121/NETAG/naming.htm
      */
     protected function getEasyConnectString(array $params)
     {
-
         if ( ! empty($params['connectstring'])) {
             return $params['connectstring'];
         }

--- a/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
@@ -109,10 +109,15 @@ abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
      *
      * @return string
      *
-     * @link http://download.oracle.com/docs/cd/E11882_01/network.112/e10836/naming.htm
+     * @link https://docs.oracle.com/cd/E11882_01/network.112/e41945/naming.htm
      */
     protected function getEasyConnectString(array $params)
     {
+
+        if ( ! empty($params['connectstring'])) {
+            return $params['connectstring'];
+        }
+
         if ( ! empty($params['host'])) {
             if ( ! isset($params['port'])) {
                 $params['port'] = 1521;

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractOracleDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractOracleDriverTest.php
@@ -25,6 +25,25 @@ class AbstractOracleDriverTest extends AbstractDriverTest
         $this->assertSame($params['user'], $this->driver->getDatabase($connection));
     }
 
+    public function testReturnsDatabaseNameWithConnectDescriptor()
+    {
+        $params = array(
+            'user'             => 'foo',
+            'password'         => 'bar',
+            'connectionstring' => '(DESCRIPTION=' .
+                '(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))' .
+                '(CONNECT_DATA=(SERVICE_NAME=baz)))'
+        );
+
+        $connection = $this->getConnectionMock();
+
+        $connection->expects($this->once())
+            ->method('getParams')
+            ->will($this->returnValue($params));
+
+        $this->assertSame($params['user'], $this->driver->getDatabase($connection));
+    }
+
     protected function createDriver()
     {
         return $this->getMockForAbstractClass('Doctrine\DBAL\Driver\AbstractOracleDriver');


### PR DESCRIPTION
As discussed in #2306, the standard for sharing Oracle database parameters is using a connect description. This PR adds support for this with a simple parameter.

I've updated the code, added a line in the doc and added a test (not sure if I did the last one correct). The extra tests pass here.

Note: when merged, I will also add this to the DoctrineBundle, such that it can easily be used in Symfony.
