### PR TITLE
Add missing args to fetchAll/fetch

### DIFF
--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -61,13 +61,15 @@ interface ResultStatement extends \Traversable
      * @param integer|null $fetchMode Controls how the next row will be returned to the caller.
      *                                The value must be one of the PDO::FETCH_* constants,
      *                                defaulting to PDO::FETCH_BOTH.
+     * @param mixed        $arg2
+     * @param mixed        $arg3
      *
      * @return mixed The return value of this method on success depends on the fetch mode. In all cases, FALSE is
      *               returned on failure.
      *
      * @see PDO::FETCH_* constants.
      */
-    public function fetch($fetchMode = null);
+    public function fetch($fetchMode = null, $arg2 = null, $arg3 = null);
 
     /**
      * Returns an array containing all of the result set rows.
@@ -75,12 +77,14 @@ interface ResultStatement extends \Traversable
      * @param integer|null $fetchMode Controls how the next row will be returned to the caller.
      *                                The value must be one of the PDO::FETCH_* constants,
      *                                defaulting to PDO::FETCH_BOTH.
+     * @param mixed        $arg2
+     * @param mixed        $arg3
      *
      * @return array
      *
      * @see PDO::FETCH_* constants.
      */
-    public function fetchAll($fetchMode = null);
+    public function fetchAll($fetchMode = null, $arg2 = null, $arg3 = null);
 
     /**
      * Returns a single column from the next row of a result set or FALSE if there are no more rows.

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -262,9 +262,9 @@ class QueryBuilder
      *         ->setParameter(':user_id', 1);
      * </code>
      *
-     * @param string|integer $key   The parameter position or name.
-     * @param mixed          $value The parameter value.
-     * @param string|null    $type  One of the PDO::PARAM_* constants.
+     * @param string|integer         $key   The parameter position or name.
+     * @param mixed                  $value The parameter value.
+     * @param string|integer|null    $type  One of the PDO::PARAM_* constants.
      *
      * @return \Doctrine\DBAL\Query\QueryBuilder This QueryBuilder instance.
      */


### PR DESCRIPTION
Without this stuff static analysis with tools like phan fails on `$statement->fetchAll(PDO::FETCH_CLASS, 'classname');` for example with `PhanParamTooMany Call with 2 arg(s) to \Doctrine\DBAL\Driver\resultstatement::fetchall() which only takes 1 arg(s)`

The second commit is similar, allowing ints for QueryBuilder::setParameter (`PhanTypeMismatchArgument Argument 3 (type) is int but \Doctrine\DBAL\Query\querybuilder::setparameter() takes null|string)` because all the `PDO::FETCH_*` are ints.
