### PR TITLE
Fix `DateInterval` database value truncation (string overflow)

### DIFF
--- a/lib/Doctrine/DBAL/Types/DateIntervalType.php
+++ b/lib/Doctrine/DBAL/Types/DateIntervalType.php
@@ -22,7 +22,7 @@ class DateIntervalType extends Type
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        $fieldDeclaration['length'] = 20;
+        $fieldDeclaration['length'] = 255;
         $fieldDeclaration['fixed']  = true;
 
         return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
@@ -38,9 +38,8 @@ class DateIntervalType extends Type
         }
 
         if ($value instanceof \DateInterval) {
-            return 'P'
-                . str_pad($value->y, 4, '0', STR_PAD_LEFT) . '-'
-                . $value->format('%M-%DT%H:%I:%S');
+            /** @var \DateInterval $value */
+            return $value->format('P%YY%MM%DDT%HH%IM%SS');
         }
 
         throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateInterval']);
@@ -58,10 +57,10 @@ class DateIntervalType extends Type
         try {
             return new \DateInterval($value);
         } catch (\Exception $exception) {
-            throw ConversionException::conversionFailedFormat($value, $this->getName(), 'PY-m-dTH:i:s', $exception);
+            throw ConversionException::conversionFailedFormat($value, $this->getName(), 'P%YY%MM%DDT%HH%IM%SS', $exception);
         }
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/lib/Doctrine/DBAL/Types/DateIntervalType.php
+++ b/lib/Doctrine/DBAL/Types/DateIntervalType.php
@@ -38,7 +38,6 @@ class DateIntervalType extends Type
         }
 
         if ($value instanceof \DateInterval) {
-            /** @var \DateInterval $value */
             return $value->format('P%YY%MM%DDT%HH%IM%SS');
         }
 

--- a/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
@@ -32,7 +32,7 @@ class DateIntervalTest  extends \Doctrine\Tests\DbalTestCase
     {
         $interval = new \DateInterval('P2Y1DT1H2M3S');
 
-        $expected = 'P0002-00-01T01:02:03';
+        $expected = 'P02Y00M01DT01H02M03S';
         $actual = $this->type->convertToDatabaseValue($interval, $this->platform);
 
         $this->assertEquals($expected, $actual);
@@ -40,9 +40,9 @@ class DateIntervalTest  extends \Doctrine\Tests\DbalTestCase
 
     public function testDateIntervalConvertsToPHPValue()
     {
-        $date = $this->type->convertToPHPValue('P0002-00-01T01:02:03', $this->platform);
+        $date = $this->type->convertToPHPValue('P02Y00M01DT01H02M03S', $this->platform);
         $this->assertInstanceOf('DateInterval', $date);
-        $this->assertEquals('P2Y0M1DT1H2M3S', $date->format('P%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('P02Y00M01DT01H02M03S', $date->format('P%YY%MM%DDT%HH%IM%SS'));
     }
 
     public function testInvalidDateIntervalFormatConversion()


### PR DESCRIPTION
`DateIntervalType` now stores data in `P%YY%MM%DDT%HH%IM%SS` format as `%M-%DT%H:%I:%S` brings a lot of problems with large intervals, i.e.: `P100DT500M`
