### PR TITLE
[Oracle] Fix list table columns when using external or OS authentication with Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -655,7 +655,7 @@ END;';
         $colCommentsTableName = "user_col_comments";
         $ownerCondition = '';
 
-        if (null !== $database) {
+        if (null !== $database && '/' !== $database) {
             $database = $this->normalizeIdentifier($database);
             $tabColumnsTableName = "all_tab_columns";
             $colCommentsTableName = "all_col_comments";

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -697,6 +697,60 @@ EOD;
     }
 
     /**
+     * @dataProvider getReturnsGetListTableColumnsSQL
+     * @group DBAL-831
+     */
+    public function testReturnsGetListTableColumnsSQL($database, $expectedSql)
+    {
+        $this->assertEquals($expectedSql, $this->_platform->getListTableColumnsSQL('"test"', $database));
+    }
+
+    public function getReturnsGetListTableColumnsSQL()
+    {
+        return array(
+            array(
+                null,
+                "SELECT   c.*,
+                         (
+                             SELECT d.comments
+                             FROM   user_col_comments d
+                             WHERE  d.TABLE_NAME = c.TABLE_NAME
+                             AND    d.COLUMN_NAME = c.COLUMN_NAME
+                         ) AS comments
+                FROM     user_tab_columns c
+                WHERE    c.table_name = 'test' 
+                ORDER BY c.column_name"
+            ),
+            array(
+                '/',
+                "SELECT   c.*,
+                         (
+                             SELECT d.comments
+                             FROM   user_col_comments d
+                             WHERE  d.TABLE_NAME = c.TABLE_NAME
+                             AND    d.COLUMN_NAME = c.COLUMN_NAME
+                         ) AS comments
+                FROM     user_tab_columns c
+                WHERE    c.table_name = 'test' 
+                ORDER BY c.column_name"
+            ),
+            array(
+                'scott',
+                "SELECT   c.*,
+                         (
+                             SELECT d.comments
+                             FROM   all_col_comments d
+                             WHERE  d.TABLE_NAME = c.TABLE_NAME
+                             AND    d.COLUMN_NAME = c.COLUMN_NAME
+                         ) AS comments
+                FROM     all_tab_columns c
+                WHERE    c.table_name = 'test' AND c.owner = 'SCOTT'
+                ORDER BY c.column_name"
+            ),
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL()


### PR DESCRIPTION
To use an external authentication mechanism, ef. Oracle Wallet you specify "/" us the db user and "" as the host when calling oci_connect. See http://php.net/manual/de/function.oci-connect.php#refsect1-function.oci-connect-parameters

This works as expected until you try to read the table columns with `getListTableColumnsSQL()`.

Since `$database` is "/" the code that should limit the listed columns to the given user actually prevents listing anything because a user "/" never exists.

I did not find a test for `getListTableColumnsSQL()` but am documenting the debug session that lead to this PR at https://github.com/owncloud/core/wiki/%5BWIP%5D-Oracle-Wallet
