### PR TITLE
[WIP] Add native JSON type to Mysql 5.7 platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
@@ -34,6 +34,14 @@ class MySQL57Platform extends MySqlPlatform
     /**
      * {@inheritdoc}
      */
+    public function hasNativeJsonType()
+    {
+        return true;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
     public function getJsonTypeDeclarationSQL(array $field)
     {
         return 'JSON';

--- a/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
@@ -34,6 +34,14 @@ class MySQL57Platform extends MySqlPlatform
     /**
      * {@inheritdoc}
      */
+    public function getJsonTypeDeclarationSQL(array $field)
+    {
+        return 'JSON';
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
     protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
     {
         return array();

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
@@ -7,6 +7,29 @@ use Doctrine\DBAL\Platforms\MySQL57Platform;
 class MySQL57PlatformTest extends AbstractMySQLPlatformTestCase
 {
     /**
+     * @group DBAL-553
+     */
+    public function hasNativeJsonType()
+    {
+        $this->assertTrue($this->_platform->hasNativeJsonType());
+    }
+    /**
+     * @group DBAL-553
+     */
+    public function testReturnsJsonTypeDeclarationSQL()
+    {
+        $column = array(
+            'length'  => 666,
+            'notnull' => true,
+            'type'    => Type::getType('json_array'),
+        );
+        $this->assertSame(
+            'JSON',
+            $this->_platform->getJsonTypeDeclarationSQL($column)
+        );
+    }
+    
+    /**
      * {@inheritdoc}
      */
     public function createPlatform()

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 
+use Doctrine\DBAL\Types\Type;
+
 class MySQL57PlatformTest extends AbstractMySQLPlatformTestCase
 {
     /**


### PR DESCRIPTION
Mysql 5.7 supports JSON as a native type https://dev.mysql.com/doc/refman/5.7/en/json.html
