### PR TITLE
Allow use own exceptions in 3d-side db-connectors.

### DIFF
--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -112,7 +112,7 @@ class DBALException extends \Exception
         }
         $msg .= ":\n\n".$driverEx->getMessage();
 
-        if ($driver instanceof ExceptionConverterDriver && $driverEx instanceof DriverException) {
+        if ($driver instanceof ExceptionConverterDriver) {
             return $driver->convertException($msg, $driverEx);
         }
 
@@ -129,7 +129,7 @@ class DBALException extends \Exception
     {
         $msg = "An exception occured in driver: " . $driverEx->getMessage();
 
-        if ($driver instanceof ExceptionConverterDriver && $driverEx instanceof DriverException) {
+        if ($driver instanceof ExceptionConverterDriver) {
             return $driver->convertException($msg, $driverEx);
         }
 

--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -42,7 +42,7 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
      * @link http://dev.mysql.com/doc/refman/5.7/en/error-messages-client.html
      * @link http://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
      */
-    public function convertException($message, DriverException $exception)
+    public function convertException($message, \Exception $exception)
     {
         switch ($exception->getErrorCode()) {
             case '1050':

--- a/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
@@ -36,7 +36,7 @@ abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
     /**
      * {@inheritdoc}
      */
-    public function convertException($message, DriverException $exception)
+    public function convertException($message, \Exception $exception)
     {
         switch ($exception->getErrorCode()) {
             case '1':

--- a/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
@@ -42,7 +42,7 @@ abstract class AbstractPostgreSQLDriver implements Driver, ExceptionConverterDri
      *
      * @link http://www.postgresql.org/docs/9.3/static/errcodes-appendix.html
      */
-    public function convertException($message, DriverException $exception)
+    public function convertException($message, \Exception $exception)
     {
         switch ($exception->getSQLState()) {
             case '0A000':

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
@@ -43,7 +43,7 @@ abstract class AbstractSQLAnywhereDriver implements Driver, ExceptionConverterDr
      *
      * @link http://dcx.sybase.com/index.html#sa160/en/saerrors/sqlerror.html
      */
-    public function convertException($message, DriverException $exception)
+    public function convertException($message, \Exception $exception)
     {
         switch ($exception->getErrorCode()) {
             case '-100':

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
@@ -38,7 +38,7 @@ abstract class AbstractSQLiteDriver implements Driver, ExceptionConverterDriver
      *
      * @link http://www.sqlite.org/c3ref/c_abort.html
      */
-    public function convertException($message, DriverException $exception)
+    public function convertException($message, \Exception $exception)
     {
         if (strpos($exception->getMessage(), 'must be unique') !== false ||
             strpos($exception->getMessage(), 'is not unique') !== false ||

--- a/lib/Doctrine/DBAL/Driver/ExceptionConverterDriver.php
+++ b/lib/Doctrine/DBAL/Driver/ExceptionConverterDriver.php
@@ -40,5 +40,5 @@ interface ExceptionConverterDriver
      *
      * @return \Doctrine\DBAL\Exception\DriverException An instance of one of the DriverException subclasses.
      */
-    public function convertException($message, DriverException $exception);
+    public function convertException($message,\Exception $exception);
 }

--- a/lib/Doctrine/DBAL/Exception/DriverException.php
+++ b/lib/Doctrine/DBAL/Exception/DriverException.php
@@ -43,7 +43,7 @@ class DriverException extends DBALException
      * @param string                                $message         The exception message.
      * @param \Doctrine\DBAL\Driver\DriverException $driverException The DBAL driver exception to chain.
      */
-    public function __construct($message, \Doctrine\DBAL\Driver\DriverException $driverException)
+    public function __construct($message, \Exception $driverException)
     {
         $exception = null;
 


### PR DESCRIPTION
DBALException::driverExceptionDuringQuery wrap exceptions from our db-connector into self because our exceptions not inherited from DriverException. We use external db-connector (it is standalone project with minimal dependencies) and cannot inherit it's exceptions from DriverException.
