### PR TITLE
[Types] Make unknown type exception a bit friendlier

### DIFF
--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Types\Type;
 
 class DBALExceptionTest extends \Doctrine\Tests\DbalTestCase
 {
@@ -20,5 +21,44 @@ class DBALExceptionTest extends \Doctrine\Tests\DbalTestCase
         $ex = new DriverException('', $this->getMock('\Doctrine\DBAL\Driver\DriverException'));
         $e = DBALException::driverExceptionDuringQuery($driver, $ex, '');
         $this->assertSame($ex, $e);
+    }
+
+    /**
+     * @dataProvider getCloseMatchSuggestions
+     */
+    public function testUnknownColumnTypeSuggestsClosestMatch($requestedType, $expectedTypeSuggest)
+    {
+        $exception = DBALException::unknownColumnType($requestedType);
+        $this->assertContains("Did you mean \"$expectedTypeSuggest\"?", $exception->getMessage());
+    }
+    
+    public function getCloseMatchSuggestions()
+    {
+        return array(
+            array('bool', Type::BOOLEAN),
+            array('str', Type::STRING),
+            array('aray', Type::TARRAY),
+            array('tetx', Type::TEXT)
+        );
+    }
+
+    /**
+     * @dataProvider getFarMatches
+     */
+    public function testUnknownColumnTypeIgnoresFarMatches($requestedType)
+    {
+        $exception = DBALException::unknownColumnType($requestedType);
+        $this->assertNotContains("Did you mean", $exception->getMessage());
+    }
+    
+    public function getFarMatches()
+    {
+        return array(
+            array('itgaer'),
+            array('yarra'),
+            array('daetiem'),
+            array('cdeaimal'),
+            array('jasdnviw')
+        );
     }
 }


### PR DESCRIPTION
This adds a suggested type for cases when someone could have badly referenced a mapping type, yet there is a type that's named closely to what the user originally wanted.
