### PR TITLE
Fix SQL queries numbering in test failure output

### DIFF
--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -51,7 +51,7 @@ class DbalFunctionalTestCase extends DbalTestCase
             $i = count($this->_sqlLoggerStack->queries);
             foreach (array_reverse($this->_sqlLoggerStack->queries) as $query) {
                 $params = array_map(function($p) { if (is_object($p)) return get_class($p); else return "'".$p."'"; }, $query['params'] ?: array());
-                $queries .= ($i+1).". SQL: '".$query['sql']."' Params: ".implode(", ", $params).PHP_EOL;
+                $queries .= $i.". SQL: '".$query['sql']."' Params: ".implode(", ", $params).PHP_EOL;
                 $i--;
             }
 


### PR DESCRIPTION
For example if the DebugStack SQL logger contains 3 queries, then we want an output like this:

```
3. <query 3>
2. <query 2>
1. <query 1>
```

not like that:

```
4. <query 3>
3. <query 2>
2. <query 1>
```
