### PR TITLE
WIP Parameter names are normalized to not contain colons

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,15 @@
+## MINOR BC BREAK: Doctrine\DBAL\Query\QueryBuilder
+
+When using ``Doctrine\DBAL\Query\QueryBuilder``, the names of parameters are no longer stored
+with leading colons (``:``), hence the methods ``getParameters()`` and ``getParameterTypes()``
+always return array keys without colons. For back compatibility, parameter names can still be
+given, and accessed individually, with or without a leading colon.
+
+Parameter names are now limited to ``[a-zA-Z0-9_]`` and may not being with a digit. Invalid names
+now throw ``Doctrine\DBAL\Query\QueryException``.
+
+Positional parameters (with integer keys) are not affected.
+
 # Upgrade to 2.5.1
 
 ## MINOR BC BREAK: Doctrine\DBAL\Schema\Table

--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -355,3 +355,30 @@ in your query as a return value:
         ->where('email = ' .  $queryBuilder->createPositionalParameter($userInputEmail))
     ;
     // SELECT id, name FROM users WHERE email = ?
+
+Parameter Names
+---------------
+
+Parameter names may contain the characters ``[a-zA-Z0-9_]``, but may not
+begin with a digit.
+
+The associated placeholders must begin with ``:``, however the parameter
+names do not contain the colon and methods like ``setParameter()`` and
+``setParameters()`` automatically remove it.
+
+.. code-block:: php
+
+    <?php
+
+    $queryBuilder
+        ->select('id', 'name')
+        ->from('users')
+        ->where('email = :email')
+        ->setParameter('email', $userInputEmail)
+    ;
+
+    $queryBuilder->getParameter('email'); // 'user@example.com'
+
+    $queryBuilder->getParameter(':email'); // 'user@example.com'
+
+    $queryBuilder->getParameters(); // array('email' => 'user@example.com')

--- a/lib/Doctrine/DBAL/Query/QueryException.php
+++ b/lib/Doctrine/DBAL/Query/QueryException.php
@@ -51,4 +51,14 @@ class QueryException extends DBALException
             "in FROM and JOIN clause table. The currently registered " .
             "aliases are: " . implode(", ", $registeredAliases) . ".");
     }
+
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    static public function invalidParamName($name)
+    {
+        return new self("The given name '" . $name . "' is invalid.");
+    }
 }


### PR DESCRIPTION
Fetched array keys do not contain colons.
For BC, params/types can be still be accessed via names with colons.
Invalid names result in QueryException.
