### PR TITLE
Support array binding for custom types

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -98,7 +98,7 @@ class SQLParserUtils
         foreach ($types as $name => $type) {
             ++$bindIndex;
 
-            if ($type !== Connection::PARAM_INT_ARRAY && $type !== Connection::PARAM_STR_ARRAY) {
+            if ($type !== Connection::PARAM_INT_ARRAY && $type !== Connection::PARAM_STR_ARRAY && !(isset($params[$name]) && is_array($params[$name])) ) {
                 continue;
             }
 
@@ -139,7 +139,7 @@ class SQLParserUtils
                 $types = array_merge(
                     array_slice($types, 0, $needle),
                     $count ?
-                        array_fill(0, $count, $types[$needle] - Connection::ARRAY_PARAM_OFFSET) : // array needles are at PDO::PARAM_* + 100
+                        array_fill(0, $count, is_int($types[$needle]) ? $types[$needle] - Connection::ARRAY_PARAM_OFFSET : $types[$needle]) : // array needles are at PDO::PARAM_* + 100
                         array(),
                     array_slice($types, $needle + 1)
                 );
@@ -177,7 +177,7 @@ class SQLParserUtils
 
             foreach ($value as $val) {
                 $paramsOrd[] = $val;
-                $typesOrd[]  = static::extractParam($paramName, $types, false) - Connection::ARRAY_PARAM_OFFSET;
+                $typesOrd[]  = is_int(static::extractParam($paramName, $types, false)) ? static::extractParam($paramName, $types, false) - Connection::ARRAY_PARAM_OFFSET : static::extractParam($paramName, $types, false);
             }
 
             $pos         += $queryOffset;

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -356,6 +356,15 @@ SQLDATA
                 array(1, 2),
                 array(\PDO::PARAM_INT, \PDO::PARAM_INT)
             ),
+            // Test parameters that require a different binding type provided by Type::getBindingType()
+            array(
+                "SELECT * FROM Foo WHERE foo IN (?)",
+                array(array('oof', 'rab')),
+                array('customReverseType'),
+                'SELECT * FROM Foo WHERE foo IN (?, ?)',
+                array('oof', 'rab'),
+                array('customReverseType', 'customReverseType')
+            )
         );
     }
 


### PR DESCRIPTION
At present you are only able to have string and integer arrays as a binding parameter. If you needed any custom parsing of variables using the `Type::convertToDatabaseValue` method that needs to be executed manually on the array before, this also meant that the binding type could not be overridden, in my case of implementing binary guid `\PDO::PARAM_LOB;` needed to be set before sqlite would accept it. 

This PR should hopefully take care of that by testing whether the incoming param is an array and then extract it into separate params.
