### PR TITLE
New driver enabling Doctrine to use REST APIs as databases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": ">=5.4",
-        "doctrine/common": "~2.4"
+        "doctrine/common": "~2.4",
+        "circle/doctrine-rest-driver": "^0.2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -49,6 +49,7 @@ final class DriverManager
          'drizzle_pdo_mysql'  => 'Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver',
          'sqlanywhere'        => 'Doctrine\DBAL\Driver\SQLAnywhere\Driver',
          'sqlsrv'             => 'Doctrine\DBAL\Driver\SQLSrv\Driver',
+         'circle_rest'        => 'Circle\DoctrineRestDriver\Driver',
     );
 
     /**
@@ -64,6 +65,7 @@ final class DriverManager
         'pgsql'      => 'pdo_pgsql',
         'sqlite'     => 'pdo_sqlite',
         'sqlite3'    => 'pdo_sqlite',
+        'rest'       => 'circle_rest',
     );
 
     /**


### PR DESCRIPTION
Just have a lookg at https://github.com/CircleOfNice/DoctrineRestDriver .
It's working fine and adding some new features to Doctrine allowing Doctrine to act as a REST client.

I'd like to add this driver as an official Doctrine driver so that you can configure it by 
'driver: "rest"' instead of 'driver_class: "Circle\DoctrineRestDriver\Driver"'

What do you think about it?
