### PR TITLE
Add selectAliasColumn to AbstractPlatform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2655,6 +2655,20 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Some platforms need to convert aliases to workaround identity columns in deferred tables.
+     *
+     * @param string $column
+     * @param string $alias
+     * @param array  $mapping
+     *
+     * @return string
+     */
+    public function selectAliasColumn($column, $alias, array $mapping = array())
+    {
+        return $column . ' AS ' . $alias;
+    }
+
+    /**
      * Returns the SQL specific for the platform to get the current date.
      *
      * @return string

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -1382,4 +1382,9 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
             array(array('precision' => 8, 'scale' => 2), 'DOUBLE PRECISION'),
         );
     }
+
+    public function testSelectAliasColumn()
+    {
+        $this->assertSame('foo AS bar', $this->_platform->selectAliasColumn('foo', 'bar'));
+    }
 }


### PR DESCRIPTION
This change was part of the "Add SAP Adaptive Server Enterprise support" PR doctrine/dbal#2347. It has been seperated because it is not ASE specific and would increase platform independence in general in the DBAL.

This change is related to doctrine/doctrine2#5788 as well.
It is required in the platform if the "AS" keyword may differ in platforms (which is probably not very common) and for creating workarounds when using deferred tables to simulate ROWNUM() by identity columns.
