### PR TITLE
Add getMaxIndexColumns to AbstractPlatform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3401,6 +3401,16 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Maximum number of columns in a index. If unlimited return 0
+     *
+     * @return integer
+     */
+    public function getMaxIndexColumns()
+    {
+        return 0;
+    }
+
+    /**
      * Maximum length of any given database identifier, like tables or column names.
      *
      * @return integer

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -1382,4 +1382,14 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
             array(array('precision' => 8, 'scale' => 2), 'DOUBLE PRECISION'),
         );
     }
+
+    protected function getMaxIndexColumns()
+    {
+        return 0;
+    }
+
+    public function testMaxIndexColumns()
+    {
+        $this->assertSame($this->getMaxIndexColumns(), $this->_platform->getMaxIndexColumns());
+    }
 }


### PR DESCRIPTION
This change was part of the "Add SAP Adaptive Server Enterprise support" PR doctrine/dbal#2347. It has been seperated because it is not ASE specific and would increase platform independence in general in the DBAL.

Some platforms have a maximum number of columns that can be used in one index.
This feature can be used later on in the ORM to create better error messages when a index on more then allowed fields should be created.
One the other hand this value may changes in different versions of a platform and then can be used in other classes to receive the maximum number of index columns and do whatever stuff with it.

In the ASE implementation i use it in the platform `getColumnConstraintSQL`.
