### PR TITLE
Move DateTime conversion to AbstractPlatform to be more flexible

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2655,6 +2655,124 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Some platforms have datetime strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into string with the defined time format
+     *
+     * @param \DateTime $value
+     *
+     * @return string
+     */
+    public function convertDateTimeToDatabaseValue(\DateTime $value)
+    {
+        return $value->format($this->getDateTimeFormatString());
+    }
+
+    /**
+     * Some platforms have datetime strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into \DateTime with the defined time format
+     *
+     * @param mixed $value
+     *
+     * @return \DateTime
+     */
+    public function convertFromDateTime($value)
+    {
+        $val = \DateTime::createFromFormat($this->getDateTimeFormatString(), $value);
+
+        if ( ! $val) {
+            $val = date_create($value);
+        }
+
+        return $val;
+    }
+
+    /**
+     * Some platforms have datetimetz strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into string with the defined time format
+     *
+     * @param \DateTime $value
+     *
+     * @return string
+     */
+    public function convertDateTimeTzToDatabaseValue(\DateTime $value)
+    {
+        return $value->format($this->getDateTimeTzFormatString());
+    }
+
+    /**
+     * Some platforms have datetimetz strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into \DateTime with the defined time format
+     *
+     * @param mixed $value
+     *
+     * @return \DateTime
+     */
+    public function convertFromDateTimeTz($value)
+    {
+        return \DateTime::createFromFormat($this->getDateTimeTzFormatString(), $value);
+    }
+
+    /**
+     * Some platforms have date strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into string with the defined time format
+     *
+     * @param \DateTime $value
+     *
+     * @return string
+     */
+    public function convertDateToDatabaseValue(\DateTime $value)
+    {
+        return $value->format($this->getDateFormatString());
+    }
+
+    /**
+     * Some platforms have date strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into \DateTime with the defined time format
+     *
+     * @param mixed $value
+     *
+     * @return \DateTime
+     */
+    public function convertFromDate($value)
+    {
+        return \DateTime::createFromFormat('!'.$this->getDateFormatString(), $value);
+    }
+
+    /**
+     * Some platforms have time strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into string with the defined time format
+     *
+     * @param \DateTime $value
+     *
+     * @return string
+     */
+    public function convertTimeToDatabaseValue(\DateTime $value)
+    {
+        return $value->format($this->getTimeFormatString());
+    }
+
+    /**
+     * Some platforms have time strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into \DateTime with the defined time format
+     *
+     * @param mixed $value
+     *
+     * @return \DateTime
+     */
+    public function convertFromTime($value)
+    {
+        return \DateTime::createFromFormat('!' . $this->getTimeFormatString(), $value);
+    }
+
+    /**
      * Returns the SQL specific for the platform to get the current date.
      *
      * @return string

--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -54,7 +54,7 @@ class DateTimeType extends Type
         }
 
         if ($value instanceof \DateTime) {
-            return $value->format($platform->getDateTimeFormatString());
+            return $platform->convertDateTimeToDatabaseValue($value);
         }
 
         throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
@@ -69,11 +69,7 @@ class DateTimeType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if ( ! $val) {
-            $val = date_create($value);
-        }
+        $val = $platform->convertFromDateTime($value);
 
         if ( ! $val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateTimeFormatString());

--- a/lib/Doctrine/DBAL/Types/DateTimeTzType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeTzType.php
@@ -72,7 +72,7 @@ class DateTimeTzType extends Type
         }
 
         if ($value instanceof \DateTime) {
-            return $value->format($platform->getDateTimeTzFormatString());
+            return $platform->convertDateTimeTzToDatabaseValue($value);
         }
 
         throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
@@ -87,7 +87,8 @@ class DateTimeTzType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat($platform->getDateTimeTzFormatString(), $value);
+        $val = $platform->convertFromDateTimeTz($value);
+
         if ( ! $val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateTimeTzFormatString());
         }

--- a/lib/Doctrine/DBAL/Types/DateType.php
+++ b/lib/Doctrine/DBAL/Types/DateType.php
@@ -54,7 +54,7 @@ class DateType extends Type
         }
 
         if ($value instanceof \DateTime) {
-            return $value->format($platform->getDateFormatString());
+            return $platform->convertDateToDatabaseValue($value);
         }
 
         throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
@@ -69,7 +69,8 @@ class DateType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat('!'.$platform->getDateFormatString(), $value);
+        $val = $platform->convertFromDate($value);
+
         if ( ! $val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateFormatString());
         }

--- a/lib/Doctrine/DBAL/Types/TimeType.php
+++ b/lib/Doctrine/DBAL/Types/TimeType.php
@@ -54,7 +54,7 @@ class TimeType extends Type
         }
 
         if ($value instanceof \DateTime) {
-            return $value->format($platform->getTimeFormatString());
+            return $platform->convertTimeToDatabaseValue($value);
         }
 
         throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
@@ -69,8 +69,9 @@ class TimeType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat('!' . $platform->getTimeFormatString(), $value);
-        if ( ! $val) {
+        $val = $platform->convertFromTime($value);
+
+        if ( ! $val ) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getTimeFormatString());
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -1359,6 +1359,181 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     }
 
     /**
+     * @return array
+     */
+    public function getDateTimeData()
+    {
+        return array(
+            array('2016-04-12T01:32:00+0200'),
+            array('2016-04-12T01:32:00+0000'),
+            array('2011-04-12T01:32:00+0000'),
+            array('2011-04-12T1:32:00+0000'),
+            array('2011-04-12T16:00:00+0000'),
+            array('2017-04-12T00:00:00+0000')
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateConvertsToPHPValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $expectedDateString = $date->format(
+            $this->_platform->getDateFormatString()
+        );
+
+        $date = $this->_platform->convertFromDate(
+            $expectedDateString
+        );
+
+        $this->assertEquals(
+            $expectedDateString,
+            $date->format($this->_platform->getDateFormatString())
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateConvertsToDatabaseValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $dateString = $date->format(
+            $this->_platform->getDateFormatString()
+        );
+
+        $databaseDate = $this->_platform->convertDateToDatabaseValue($date);
+
+        $this->assertEquals(
+            $dateString,
+            $databaseDate
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateTimeConvertsToPHPValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $expectedDateTimeString = $date->format(
+            $this->_platform->getDateTimeFormatString()
+        );
+
+        $date = $this->_platform->convertFromDateTime(
+            $expectedDateTimeString
+        );
+
+        $this->assertEquals(
+            $expectedDateTimeString,
+            $date->format($this->_platform->getDateTimeFormatString())
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateTimeConvertsToDatabaseValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $dateString = $date->format(
+            $this->_platform->getDateTimeFormatString()
+        );
+
+        $databaseDate = $this->_platform->convertDateTimeToDatabaseValue($date);
+
+        $this->assertEquals(
+            $dateString,
+            $databaseDate
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateTimeTzConvertsToPHPValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $expectedDateTimeString = $date->format(
+            $this->_platform->getDateTimeTzFormatString()
+        );
+
+        $date = $this->_platform->convertFromDateTimeTz(
+            $expectedDateTimeString
+        );
+
+        $this->assertEquals(
+            $expectedDateTimeString,
+            $date->format($this->_platform->getDateTimeTzFormatString())
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateTimeTzConvertsToDatabaseValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $dateString = $date->format(
+            $this->_platform->getDateTimeTzFormatString()
+        );
+
+        $databaseDate = $this->_platform->convertDateTimeTzToDatabaseValue($date);
+
+        $this->assertEquals(
+            $dateString,
+            $databaseDate
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testTimeConvertsToPHPValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $expectedTimeString = $date->format(
+            $this->_platform->getTimeFormatString()
+        );
+
+        $date = $this->_platform->convertFromTime(
+            $expectedTimeString
+        );
+
+        $this->assertEquals(
+            $expectedTimeString,
+            $date->format($this->_platform->getTimeFormatString())
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testTimeConvertsToDatabaseValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $dateString = $date->format(
+            $this->_platform->getTimeFormatString()
+        );
+
+        $databaseDate = $this->_platform->convertTimeToDatabaseValue($date);
+
+        $this->assertEquals(
+            $dateString,
+            $databaseDate
+        );
+    }
+
+    /**
      * @group DBAL-1082
      *
      * @dataProvider getGeneratesFloatDeclarationSQL


### PR DESCRIPTION
This change was part of the "Add SAP Adaptive Server Enterprise support" PR doctrine/dbal#2347. It has been seperated because it is not ASE specific and would increase platform independence in general in the DBAL.

For the most platforms the standard PHP date format patterns are enough for creating compliant date strings. But some platforms have date format's that have a fixed length and filled up with spaces between parts where the length of the replacement differ (like for patterns: n, F or z).
To achieve a correct conversion of those formats we need more logic then just a PHP format pattern.

In my case ASE has very strange date formats. It uses `Aug 24 1998  5:36PM` or `Aug  4 1998 11:36PM` where the length of this date is always the same. It is filled up with spaces to stretch the string to the defined length.
