### PR TITLE
Add test case scenario for `LIMIT`/`OFFSET` when selecting from a sub-`SELECT`

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
@@ -110,6 +110,20 @@ class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertLimitResult(array(2, 1), $sql, 2, 2, false);
     }
 
+    public function testModifyLimitQueryFromSubSelect()
+    {
+        $this->_conn->insert('modify_limit_table', array('test_int' => 1));
+        $this->_conn->insert('modify_limit_table', array('test_int' => 2));
+        $this->_conn->insert('modify_limit_table', array('test_int' => 3));
+        $this->_conn->insert('modify_limit_table', array('test_int' => 4));
+
+        $sql = "SELECT * FROM (SELECT * FROM modify_limit_table) sub";
+
+        $this->assertLimitResult(array(4, 3, 2, 1), $sql, 10, 0, false);
+        $this->assertLimitResult(array(4, 3), $sql, 2, 0, false);
+        $this->assertLimitResult(array(2, 1), $sql, 2, 2, false);
+    }
+
     public function assertLimitResult($expectedResults, $sql, $limit, $offset, $deterministic = true)
     {
         $p = $this->_conn->getDatabasePlatform();

--- a/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
@@ -117,11 +117,11 @@ class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->_conn->insert('modify_limit_table', array('test_int' => 3));
         $this->_conn->insert('modify_limit_table', array('test_int' => 4));
 
-        $sql = "SELECT * FROM (SELECT * FROM modify_limit_table) sub";
+        $sql = "SELECT * FROM (SELECT * FROM modify_limit_table) sub ORDER BY test_int DESC";
 
-        $this->assertLimitResult(array(4, 3, 2, 1), $sql, 10, 0, false);
-        $this->assertLimitResult(array(4, 3), $sql, 2, 0, false);
-        $this->assertLimitResult(array(2, 1), $sql, 2, 2, false);
+        $this->assertLimitResult(array(4, 3, 2, 1), $sql, 10, 0);
+        $this->assertLimitResult(array(4, 3), $sql, 2, 0);
+        $this->assertLimitResult(array(2, 1), $sql, 2, 2);
     }
 
     public function assertLimitResult($expectedResults, $sql, $limit, $offset, $deterministic = true)


### PR DESCRIPTION
This change was part of the "Add SAP Adaptive Server Enterprise support" PR doctrine/dbal#2347. It has been seperated because it is not ASE specific and would increase platform independence in general in the DBAL.

Some platforms like ASE and SQL Server need to do a lot of modifications to the queries to simulate LIMIT/OFFSET. Selecting from a subselect is one more case that can cause problems here.
Therefore a tests should cover this case.
