### PR TITLE
Display further contextual information on failed functional tests

### DIFF
--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -50,7 +50,15 @@ class DbalFunctionalTestCase extends DbalTestCase
             $queries = "";
             $i = count($this->_sqlLoggerStack->queries);
             foreach (array_reverse($this->_sqlLoggerStack->queries) as $query) {
-                $params = array_map(function($p) { if (is_object($p)) return get_class($p); else return "'".$p."'"; }, $query['params'] ?: array());
+                $params = array_map(function($p) {
+                    if (is_object($p)) {
+                        return get_class($p);
+                    } elseif (is_scalar($p)) {
+                        return "'".$p."'";
+                    } else {
+                        return var_export($p, true);
+                    }
+                }, $query['params'] ?: array());
                 $queries .= ($i+1).". SQL: '".$query['sql']."' Params: ".implode(", ", $params).PHP_EOL;
                 $i--;
             }


### PR DESCRIPTION
This change was part of the "Add SAP Adaptive Server Enterprise support" PR doctrine/dbal#2347. It has been seperated because it is not ASE specific and would increase platform independence in general in the DBAL.

This is useful if you have arrays as parameter to a query to see actual value.
