### PR TITLE
Use platform agnostic date time format in access and write tests

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2655,6 +2655,124 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Some platforms have datetime strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into string with the defined time format
+     *
+     * @param \DateTime $value
+     *
+     * @return string
+     */
+    public function convertDateTimeToDatabaseValue(\DateTime $value)
+    {
+        return $value->format($this->getDateTimeFormatString());
+    }
+
+    /**
+     * Some platforms have datetime strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into \DateTime with the defined time format
+     *
+     * @param mixed $value
+     *
+     * @return \DateTime
+     */
+    public function convertFromDateTime($value)
+    {
+        $val = \DateTime::createFromFormat($this->getDateTimeFormatString(), $value);
+
+        if ( ! $val) {
+            $val = date_create($value);
+        }
+
+        return $val;
+    }
+
+    /**
+     * Some platforms have datetimetz strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into string with the defined time format
+     *
+     * @param \DateTime $value
+     *
+     * @return string
+     */
+    public function convertDateTimeTzToDatabaseValue(\DateTime $value)
+    {
+        return $value->format($this->getDateTimeTzFormatString());
+    }
+
+    /**
+     * Some platforms have datetimetz strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into \DateTime with the defined time format
+     *
+     * @param mixed $value
+     *
+     * @return \DateTime
+     */
+    public function convertFromDateTimeTz($value)
+    {
+        return \DateTime::createFromFormat($this->getDateTimeTzFormatString(), $value);
+    }
+
+    /**
+     * Some platforms have date strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into string with the defined time format
+     *
+     * @param \DateTime $value
+     *
+     * @return string
+     */
+    public function convertDateToDatabaseValue(\DateTime $value)
+    {
+        return $value->format($this->getDateFormatString());
+    }
+
+    /**
+     * Some platforms have date strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into \DateTime with the defined time format
+     *
+     * @param mixed $value
+     *
+     * @return \DateTime
+     */
+    public function convertFromDate($value)
+    {
+        return \DateTime::createFromFormat('!'.$this->getDateFormatString(), $value);
+    }
+
+    /**
+     * Some platforms have time strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into string with the defined time format
+     *
+     * @param \DateTime $value
+     *
+     * @return string
+     */
+    public function convertTimeToDatabaseValue(\DateTime $value)
+    {
+        return $value->format($this->getTimeFormatString());
+    }
+
+    /**
+     * Some platforms have time strings that needs to be correctly converted
+     *
+     * The default conversion tries to convert value into \DateTime with the defined time format
+     *
+     * @param mixed $value
+     *
+     * @return \DateTime
+     */
+    public function convertFromTime($value)
+    {
+        return \DateTime::createFromFormat('!' . $this->getTimeFormatString(), $value);
+    }
+
+    /**
      * Returns the SQL specific for the platform to get the current date.
      *
      * @return string

--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -54,7 +54,7 @@ class DateTimeType extends Type
         }
 
         if ($value instanceof \DateTime) {
-            return $value->format($platform->getDateTimeFormatString());
+            return $platform->convertDateTimeToDatabaseValue($value);
         }
 
         throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
@@ -69,11 +69,7 @@ class DateTimeType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if ( ! $val) {
-            $val = date_create($value);
-        }
+        $val = $platform->convertFromDateTime($value);
 
         if ( ! $val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateTimeFormatString());

--- a/lib/Doctrine/DBAL/Types/DateTimeTzType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeTzType.php
@@ -72,7 +72,7 @@ class DateTimeTzType extends Type
         }
 
         if ($value instanceof \DateTime) {
-            return $value->format($platform->getDateTimeTzFormatString());
+            return $platform->convertDateTimeTzToDatabaseValue($value);
         }
 
         throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
@@ -87,7 +87,8 @@ class DateTimeTzType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat($platform->getDateTimeTzFormatString(), $value);
+        $val = $platform->convertFromDateTimeTz($value);
+
         if ( ! $val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateTimeTzFormatString());
         }

--- a/lib/Doctrine/DBAL/Types/DateType.php
+++ b/lib/Doctrine/DBAL/Types/DateType.php
@@ -54,7 +54,7 @@ class DateType extends Type
         }
 
         if ($value instanceof \DateTime) {
-            return $value->format($platform->getDateFormatString());
+            return $platform->convertDateToDatabaseValue($value);
         }
 
         throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
@@ -69,7 +69,8 @@ class DateType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat('!'.$platform->getDateFormatString(), $value);
+        $val = $platform->convertFromDate($value);
+
         if ( ! $val) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateFormatString());
         }

--- a/lib/Doctrine/DBAL/Types/TimeType.php
+++ b/lib/Doctrine/DBAL/Types/TimeType.php
@@ -54,7 +54,7 @@ class TimeType extends Type
         }
 
         if ($value instanceof \DateTime) {
-            return $value->format($platform->getTimeFormatString());
+            return $platform->convertTimeToDatabaseValue($value);
         }
 
         throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
@@ -69,8 +69,9 @@ class TimeType extends Type
             return $value;
         }
 
-        $val = \DateTime::createFromFormat('!' . $platform->getTimeFormatString(), $value);
-        if ( ! $val) {
+        $val = $platform->convertFromTime($value);
+
+        if ( ! $val ) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getTimeFormatString());
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -969,7 +969,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals('foo', $results[0]->test_string);
         $this->assertStringStartsWith($datetimeString, $results[0]->test_datetime);
         $this->assertStringStartsWith($dateString, $results[0]->test_date);
-        $this->assertStringStartsWith($timeString, $results[0]->getTime());
+        $this->assertStringStartsWith($timeString, $results[0]->test_time);
     }
 
     /**
@@ -1005,7 +1005,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->assertEquals('foo', $results[0]->test_string);
         $this->assertStringStartsWith($datetimeString, $results[0]->test_datetime);
         $this->assertStringStartsWith($dateString, $results[0]->test_date);
-        $this->assertStringStartsWith($timeString, $results[0]->getTime());
+        $this->assertStringStartsWith($timeString, $results[0]->test_time);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -198,7 +198,11 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $data = $this->_conn->fetchColumn('SELECT test_string FROM write_table WHERE test_int = 30');
 
-        $this->assertEquals($testString->format($this->_conn->getDatabasePlatform()->getDateTimeFormatString()), $data);
+        $typeInstance = Type::getType('datetime');
+        $value = $typeInstance->convertToPHPValue($data, $this->_conn->getDatabasePlatform());
+        $testValue = $typeInstance->convertToPHPValue($testString, $this->_conn->getDatabasePlatform());
+
+        $this->assertEquals($value, $testValue);
     }
 
     /**
@@ -225,7 +229,11 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $data = $this->_conn->fetchColumn('SELECT test_string FROM write_table WHERE test_int = 30');
 
-        $this->assertEquals($testString->format($this->_conn->getDatabasePlatform()->getDateTimeFormatString()), $data);
+        $typeInstance = Type::getType('datetime');
+        $value = $typeInstance->convertToPHPValue($data, $this->_conn->getDatabasePlatform());
+        $testValue = $typeInstance->convertToPHPValue($testString, $this->_conn->getDatabasePlatform());
+
+        $this->assertEquals($value, $testValue);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -1359,6 +1359,181 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     }
 
     /**
+     * @return array
+     */
+    public function getDateTimeData()
+    {
+        return array(
+            array('2016-04-12T01:32:00+0200'),
+            array('2016-04-12T01:32:00+0000'),
+            array('2011-04-12T01:32:00+0000'),
+            array('2011-04-12T1:32:00+0000'),
+            array('2011-04-12T16:00:00+0000'),
+            array('2017-04-12T00:00:00+0000')
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateConvertsToPHPValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $expectedDateString = $date->format(
+            $this->_platform->getDateFormatString()
+        );
+
+        $date = $this->_platform->convertFromDate(
+            $expectedDateString
+        );
+
+        $this->assertEquals(
+            $expectedDateString,
+            $date->format($this->_platform->getDateFormatString())
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateConvertsToDatabaseValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $dateString = $date->format(
+            $this->_platform->getDateFormatString()
+        );
+
+        $databaseDate = $this->_platform->convertDateToDatabaseValue($date);
+
+        $this->assertEquals(
+            $dateString,
+            $databaseDate
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateTimeConvertsToPHPValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $expectedDateTimeString = $date->format(
+            $this->_platform->getDateTimeFormatString()
+        );
+
+        $date = $this->_platform->convertFromDateTime(
+            $expectedDateTimeString
+        );
+
+        $this->assertEquals(
+            $expectedDateTimeString,
+            $date->format($this->_platform->getDateTimeFormatString())
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateTimeConvertsToDatabaseValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $dateString = $date->format(
+            $this->_platform->getDateTimeFormatString()
+        );
+
+        $databaseDate = $this->_platform->convertDateTimeToDatabaseValue($date);
+
+        $this->assertEquals(
+            $dateString,
+            $databaseDate
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateTimeTzConvertsToPHPValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $expectedDateTimeString = $date->format(
+            $this->_platform->getDateTimeTzFormatString()
+        );
+
+        $date = $this->_platform->convertFromDateTimeTz(
+            $expectedDateTimeString
+        );
+
+        $this->assertEquals(
+            $expectedDateTimeString,
+            $date->format($this->_platform->getDateTimeTzFormatString())
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testDateTimeTzConvertsToDatabaseValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $dateString = $date->format(
+            $this->_platform->getDateTimeTzFormatString()
+        );
+
+        $databaseDate = $this->_platform->convertDateTimeTzToDatabaseValue($date);
+
+        $this->assertEquals(
+            $dateString,
+            $databaseDate
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testTimeConvertsToPHPValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $expectedTimeString = $date->format(
+            $this->_platform->getTimeFormatString()
+        );
+
+        $date = $this->_platform->convertFromTime(
+            $expectedTimeString
+        );
+
+        $this->assertEquals(
+            $expectedTimeString,
+            $date->format($this->_platform->getTimeFormatString())
+        );
+    }
+
+    /**
+     * @dataProvider getDateTimeData
+     */
+    public function testTimeConvertsToDatabaseValue($dateTime)
+    {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $dateTime);
+
+        $dateString = $date->format(
+            $this->_platform->getTimeFormatString()
+        );
+
+        $databaseDate = $this->_platform->convertTimeToDatabaseValue($date);
+
+        $this->assertEquals(
+            $dateString,
+            $databaseDate
+        );
+    }
+
+    /**
      * @group DBAL-1082
      *
      * @dataProvider getGeneratesFloatDeclarationSQL


### PR DESCRIPTION
This change was part of the "Add SAP Adaptive Server Enterprise support" PR doctrine/dbal#2347. It has been seperated because it is not ASE specific and would increase platform independence in general in the DBAL.

Some platforms cannot handle the date format that is specified in the tests at all and have a very different one.
The tests should only validate if the persistence and receival of the data works. For this purpose they dont need fixed date time formats and can rely on the platform to convert the data to the correct format.

This depends on doctrine/dbal#2362
