### PR TITLE
Add more options to TestUtil

### DIFF
--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -61,16 +61,28 @@ class TestUtil
             $GLOBALS['db_type'],
             $GLOBALS['db_username'],
             $GLOBALS['db_password'],
-            $GLOBALS['db_host'],
-            $GLOBALS['db_name'],
-            $GLOBALS['db_port']
+            $GLOBALS['db_name']
+        )
+        && (
+            isset(
+                $GLOBALS['db_host'],
+                $GLOBALS['db_port']
+            ) || isset(
+                $GLOBALS['db_server']
+            )
         )
         && isset(
             $GLOBALS['tmpdb_type'],
             $GLOBALS['tmpdb_username'],
-            $GLOBALS['tmpdb_password'],
-            $GLOBALS['tmpdb_host'],
-            $GLOBALS['tmpdb_port']
+            $GLOBALS['tmpdb_password']
+        )
+        && (
+            isset(
+                $GLOBALS['tmpdb_host'],
+                $GLOBALS['tmpdb_port']
+            ) || isset(
+                $GLOBALS['tmpdb_server']
+            )
         );
     }
 
@@ -140,10 +152,16 @@ class TestUtil
             'driver' => $GLOBALS['tmpdb_type'],
             'user' => $GLOBALS['tmpdb_username'],
             'password' => $GLOBALS['tmpdb_password'],
-            'host' => $GLOBALS['tmpdb_host'],
-            'dbname' => null,
-            'port' => $GLOBALS['tmpdb_port']
+            'dbname' => null
         );
+
+        if (isset($GLOBALS['tmpdb_host'])) {
+            $connectionParams['host'] = $GLOBALS['tmpdb_host'];
+        }
+
+        if (isset($GLOBALS['tmpdb_port'])) {
+            $connectionParams['port'] = $GLOBALS['tmpdb_port'];
+        }
 
         if (isset($GLOBALS['tmpdb_name'])) {
             $connectionParams['dbname'] = $GLOBALS['tmpdb_name'];
@@ -157,6 +175,10 @@ class TestUtil
             $connectionParams['unix_socket'] = $GLOBALS['tmpdb_unix_socket'];
         }
 
+        if (isset($GLOBALS['tmpdb_platform_options'])) {
+            $connectionParams['platform_options'] = json_decode($GLOBALS['tmpdb_platform_options'], true);
+        }
+
         return $connectionParams;
     }
 
@@ -166,10 +188,16 @@ class TestUtil
             'driver' => $GLOBALS['db_type'],
             'user' => $GLOBALS['db_username'],
             'password' => $GLOBALS['db_password'],
-            'host' => $GLOBALS['db_host'],
-            'dbname' => $GLOBALS['db_name'],
-            'port' => $GLOBALS['db_port']
+            'dbname' => $GLOBALS['db_name']
         );
+
+        if (isset($GLOBALS['db_host'])) {
+            $connectionParams['host'] = $GLOBALS['db_host'];
+        }
+
+        if (isset($GLOBALS['db_port'])) {
+            $connectionParams['port'] = $GLOBALS['db_port'];
+        }
 
         if (isset($GLOBALS['db_server'])) {
             $connectionParams['server'] = $GLOBALS['db_server'];
@@ -177,6 +205,10 @@ class TestUtil
 
         if (isset($GLOBALS['db_unix_socket'])) {
             $connectionParams['unix_socket'] = $GLOBALS['db_unix_socket'];
+        }
+
+        if (isset($GLOBALS['db_platform_options'])) {
+            $connectionParams['platform_options'] = json_decode($GLOBALS['db_platform_options'], true);
         }
 
         return $connectionParams;

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -61,28 +61,16 @@ class TestUtil
             $GLOBALS['db_type'],
             $GLOBALS['db_username'],
             $GLOBALS['db_password'],
-            $GLOBALS['db_name']
-        )
-        && (
-            isset(
-                $GLOBALS['db_host'],
-                $GLOBALS['db_port']
-            ) || isset(
-                $GLOBALS['db_server']
-            )
+            $GLOBALS['db_host'],
+            $GLOBALS['db_name'],
+            $GLOBALS['db_port']
         )
         && isset(
             $GLOBALS['tmpdb_type'],
             $GLOBALS['tmpdb_username'],
-            $GLOBALS['tmpdb_password']
-        )
-        && (
-            isset(
-                $GLOBALS['tmpdb_host'],
-                $GLOBALS['tmpdb_port']
-            ) || isset(
-                $GLOBALS['tmpdb_server']
-            )
+            $GLOBALS['tmpdb_password'],
+            $GLOBALS['tmpdb_host'],
+            $GLOBALS['tmpdb_port']
         );
     }
 
@@ -152,16 +140,10 @@ class TestUtil
             'driver' => $GLOBALS['tmpdb_type'],
             'user' => $GLOBALS['tmpdb_username'],
             'password' => $GLOBALS['tmpdb_password'],
-            'dbname' => null
+            'host' => $GLOBALS['tmpdb_host'],
+            'dbname' => null,
+            'port' => $GLOBALS['tmpdb_port']
         );
-
-        if (isset($GLOBALS['tmpdb_host'])) {
-            $connectionParams['host'] = $GLOBALS['tmpdb_host'];
-        }
-
-        if (isset($GLOBALS['tmpdb_port'])) {
-            $connectionParams['port'] = $GLOBALS['tmpdb_port'];
-        }
 
         if (isset($GLOBALS['tmpdb_name'])) {
             $connectionParams['dbname'] = $GLOBALS['tmpdb_name'];
@@ -188,16 +170,10 @@ class TestUtil
             'driver' => $GLOBALS['db_type'],
             'user' => $GLOBALS['db_username'],
             'password' => $GLOBALS['db_password'],
-            'dbname' => $GLOBALS['db_name']
+            'host' => $GLOBALS['db_host'],
+            'dbname' => $GLOBALS['db_name'],
+            'port' => $GLOBALS['db_port']
         );
-
-        if (isset($GLOBALS['db_host'])) {
-            $connectionParams['host'] = $GLOBALS['db_host'];
-        }
-
-        if (isset($GLOBALS['db_port'])) {
-            $connectionParams['port'] = $GLOBALS['db_port'];
-        }
 
         if (isset($GLOBALS['db_server'])) {
             $connectionParams['server'] = $GLOBALS['db_server'];


### PR DESCRIPTION
This change was part of the "Add SAP Adaptive Server Enterprise support" PR doctrine/dbal#2347. It has been seperated because it is not ASE specific and would increase platform independence in general in the DBAL.

Some drivers (for example sybase_ct or sqlanywhere) can use a servername instead of a hostname to connect to a database server.
Also some platforms need aditional configuration for working with the database server correctly. Like they need to know about given devices etc.
