### PR TITLE
Add fix for broken decimals

### DIFF
--- a/lib/Doctrine/DBAL/Types/DecimalType.php
+++ b/lib/Doctrine/DBAL/Types/DecimalType.php
@@ -49,6 +49,10 @@ class DecimalType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
+        if (is_float($value)) {
+            return (string) $value;
+        }
+
         return $value;
     }
 }


### PR DESCRIPTION
This change was part of the "Add SAP Adaptive Server Enterprise support" PR doctrine/dbal#2347. It has been seperated because it is not ASE specific and would increase platform independence in general in the DBAL.

Some drivers (for example sybase_ct) return decimal types as float and not as string. The tests currently expect a decimal to be a string.

 I did not had any other idea to work around this, then converting the float to a string in the decimal type. Any better solutions are very appreciated.
