### PR TITLE
Catch Throwable in Connection::transactional()

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -773,7 +773,7 @@ class Connection implements DriverConnection
     {
         try {
             $stmt = new Statement($statement, $this);
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $statement);
         }
 
@@ -824,7 +824,7 @@ class Connection implements DriverConnection
             } else {
                 $stmt = $this->_conn->query($query);
             }
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));
         }
 
@@ -933,7 +933,7 @@ class Connection implements DriverConnection
                     $statement = call_user_func_array(array($this->_conn, 'query'), $args);
                     break;
             }
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $args[0]);
         }
 
@@ -984,7 +984,7 @@ class Connection implements DriverConnection
             } else {
                 $result = $this->_conn->exec($query);
             }
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));
         }
 
@@ -1015,7 +1015,7 @@ class Connection implements DriverConnection
 
         try {
             $result = $this->_conn->exec($statement);
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $statement);
         }
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -32,6 +32,7 @@ use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Cache\ArrayStatement;
 use Doctrine\DBAL\Cache\CacheException;
 use Doctrine\DBAL\Driver\PingableConnection;
+use Throwable;
 
 /**
  * A wrapper around a Doctrine\DBAL\Driver\Connection that adds features like
@@ -1101,6 +1102,9 @@ class Connection implements DriverConnection
             $this->commit();
             return $res;
         } catch (Exception $e) {
+            $this->rollBack();
+            throw $e;
+        } catch (Throwable $e) {
             $this->rollBack();
             throw $e;
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -201,6 +201,24 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
     }
 
+    public function testTransactionalWithThrowable()
+    {
+        if (version_compare(PHP_VERSION, '7.0', '<')) {
+            $this->markTestSkipped('Only for PHP 7.0 and above.');
+        }
+
+        try {
+            $this->_conn->transactional(function($conn) {
+                /* @var $conn \Doctrine\DBAL\Connection */
+                $conn->executeQuery($conn->getDatabasePlatform()->getDummySelectSQL());
+                throw new \Error("Ooops!");
+            });
+            $this->fail('Expected exception');
+        } catch (\Error $expected) {
+            $this->assertEquals(0, $this->_conn->getTransactionNestingLevel());
+        }
+    }
+
     public function testTransactional()
     {
         $this->_conn->transactional(function($conn) {

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -196,6 +196,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 $conn->executeQuery($conn->getDatabasePlatform()->getDummySelectSQL());
                 throw new \RuntimeException("Ooops!");
             });
+            $this->fail('Expected exception');
         } catch (\RuntimeException $expected) {
             $this->assertEquals(0, $this->_conn->getTransactionNestingLevel());
         }


### PR DESCRIPTION
I was considering adding it to other places, that use "catch-all", but none of them can invoke user-provided code, so it makes little sense adding the catch there.
