### PR TITLE
#2393 - Move partial index support to SQL Server 2008+

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Schema\Index;
+
 /**
  * Platform to ensure compatibility of Doctrine with Microsoft SQL Server 2008 version.
  *
@@ -115,5 +117,27 @@ class SQLServer2008Platform extends SQLServer2005Platform
     protected function getReservedKeywordsClass()
     {
         return 'Doctrine\DBAL\Platforms\Keywords\SQLServer2008Keywords';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCreateIndexSQL(Index $index, $table)
+    {
+        $constraint = parent::getCreateIndexSQL($index, $table);
+
+        if ($index->isUnique() && !$index->isPrimary()) {
+            $constraint = $this->_appendUniqueConstraintDefinition($constraint, $index);
+        }
+
+        return $constraint;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsPartialIndexes()
+    {
+        return true;
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -350,20 +350,6 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateIndexSQL(Index $index, $table)
-    {
-        $constraint = parent::getCreateIndexSQL($index, $table);
-
-        if ($index->isUnique() && !$index->isPrimary()) {
-            $constraint = $this->_appendUniqueConstraintDefinition($constraint, $index);
-        }
-
-        return $constraint;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     protected function getCreateIndexSQLFlags(Index $index)
     {
         $type = '';
@@ -388,7 +374,7 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * @return string
      */
-    private function _appendUniqueConstraintDefinition($sql, Index $index)
+    protected function _appendUniqueConstraintDefinition($sql, Index $index)
     {
         $fields = array();
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -157,7 +157,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
 
     public function getGenerateUniqueIndexSql()
     {
-        return 'CREATE UNIQUE INDEX index_name ON test (test, test2) WHERE test IS NOT NULL AND test2 IS NOT NULL';
+        return 'CREATE UNIQUE INDEX index_name ON test (test, test2)';
     }
 
     public function getGenerateForeignKeySql()

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
@@ -19,4 +19,9 @@ class SQLServer2008PlatformTest extends AbstractSQLServerPlatformTestCase
                 array())
         );
     }
+
+    public function getGenerateUniqueIndexSql()
+    {
+        return 'CREATE UNIQUE INDEX index_name ON test (test, test2) WHERE test IS NOT NULL AND test2 IS NOT NULL';
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -363,4 +363,9 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
         $sql = $this->_platform->modifyLimitQuery($querySql, 10);
         $this->assertEquals($expectedSql, $sql);
     }
+
+    public function getGenerateUniqueIndexSql()
+    {
+        return 'CREATE UNIQUE INDEX index_name ON test (test, test2) WHERE test IS NOT NULL AND test2 IS NOT NULL';
+    }
 }


### PR DESCRIPTION
Fixes #2393. Unique indexes where breaking on SQL Server 2005 as partial indexes are not supported: 
https://msdn.microsoft.com/en-us/library/ms188783.aspx
