### PR TITLE
fix grammar in DBALException messages

### DIFF
--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -214,7 +214,7 @@ class DBALException extends \Exception
      */
     public static function limitOffsetInvalid()
     {
-        return new self("Invalid Offset in Limit Query, it has to be larger or equal to 0.");
+        return new self("Invalid Offset in Limit Query, it has to be larger than or equal to 0.");
     }
 
     /**
@@ -237,7 +237,7 @@ class DBALException extends \Exception
         return new self('Unknown column type "'.$name.'" requested. Any Doctrine type that you use has ' .
             'to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the ' .
             'known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database ' .
-            'introspection then you might have forgot to register all database types for a Doctrine Type. Use ' .
+            'introspection then you might have forgotten to register all database types for a Doctrine Type. Use ' .
             'AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement ' .
             'Type#getMappedDatabaseTypes(). If the type name is empty you might ' .
             'have a problem with the cache or forgot some mapping information.'


### PR DESCRIPTION
This just fixes two small typo in the messages used in Doctrine\DBAL\DBALException
- have forgot -> have forgotten
- larger or equal to 0 -> larger than or equal to 0
