### PR TITLE
Add method to get affected column name in constraint exception

### DIFF
--- a/lib/Doctrine/DBAL/Exception/ConstraintViolationException.php
+++ b/lib/Doctrine/DBAL/Exception/ConstraintViolationException.php
@@ -28,4 +28,17 @@ namespace Doctrine\DBAL\Exception;
  */
 class ConstraintViolationException extends ServerException
 {
+	/**
+	 * Get the name of affected column.
+	 *
+	 * @return string|NULL
+	 */
+	public function getAffectedColumnName()
+	{
+		if (preg_match_all('/^DETAIL\:\s+Key\s+\((\w+)\)/im', $this->getMessage(), $matches)) {
+			return $matches[1][0];
+		}
+
+		return NULL;
+	}
 }


### PR DESCRIPTION
I sometimes need to get the column name causing this exception and I don't want to parse exception message in the catch clause.
