### PR TITLE
Ensure deterministic results in the `ModifyLimitQueryTest`, which may otherwise fail depending on database settings and provisioning

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
@@ -103,11 +103,11 @@ class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->_conn->insert('modify_limit_table', array('test_int' => 3));
         $this->_conn->insert('modify_limit_table', array('test_int' => 4));
 
-        $sql = "SELECT modify_limit_table.*, (SELECT COUNT(*) FROM modify_limit_table) AS cnt FROM modify_limit_table";
+        $sql = "SELECT modify_limit_table.*, (SELECT COUNT(*) FROM modify_limit_table) AS cnt FROM modify_limit_table ORDER BY test_int DESC";
 
-        $this->assertLimitResult(array(4, 3, 2, 1), $sql, 10, 0, false);
-        $this->assertLimitResult(array(4, 3), $sql, 2, 0, false);
-        $this->assertLimitResult(array(2, 1), $sql, 2, 2, false);
+        $this->assertLimitResult(array(4, 3, 2, 1), $sql, 10, 0);
+        $this->assertLimitResult(array(4, 3), $sql, 2, 0);
+        $this->assertLimitResult(array(2, 1), $sql, 2, 2);
     }
 
     public function assertLimitResult($expectedResults, $sql, $limit, $offset, $deterministic = true)


### PR DESCRIPTION
As changed in PR doctrine/dbal#2363 it would be better if the tests in ModifyLimitQueryTest return more deterministic results.
