### PR TITLE
Map custom exceptions for the "no default value" (1364) error in the MySQL drivers

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -112,6 +112,7 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
             case '1171':
             case '1252':
             case '1263':
+            case '1364':
             case '1566':
                 return new Exception\NotNullConstraintViolationException($message, $exception);
         }

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
@@ -105,6 +105,7 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
                 array('1171', null, null),
                 array('1252', null, null),
                 array('1263', null, null),
+                array('1364', null, null),
                 array('1566', null, null),
             ),
             self::EXCEPTION_SYNTAX_ERROR => array(


### PR DESCRIPTION
When following error message is shown, then it will get converted to the
correct Exception classs of NotNullConstraintViolationException:

  PDOException: SQLSTATE[HY000]: General error: 1364 Field '...' doesn't have a
  default value

The mentioned field has a Not Null constraint but no default value. I tested this with the latest mysql and mariadb docker container today (and with the mysql and mysqlnd PHP extension of the current Debian stable).
