### PR TITLE
change DB2Connection _conn property from private to protected

### DIFF
--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -27,7 +27,7 @@ class DB2Connection implements Connection, ServerInfoAwareConnection
     /**
      * @var resource
      */
-    private $_conn = null;
+    protected $_conn = null;
 
     /**
      * @param array  $params


### PR DESCRIPTION
Allow classes extending DB2Connection to access _conn resource, i.e. necessary in IBMi systems to use XMLToolkit library
