### PR TITLE
Fixed "PHP Strict standards:  Declaration of Doctrine\Tests\DbalFunct…

### DIFF
--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -40,7 +40,7 @@ class DbalFunctionalTestCase extends DbalTestCase
         $this->_conn->getConfiguration()->setSQLLogger($this->_sqlLoggerStack);
     }
 
-    protected function onNotSuccessfulTest($e)
+    protected function onNotSuccessfulTest(\Exception $e)
     {
         if ($e instanceof \PHPUnit_Framework_AssertionFailedError) {
             throw $e;


### PR DESCRIPTION
…ionalTestCase::onNotSuccessfulTest() should be compatible with PHPUnit_Framework_TestCase::onNotSuccessfulTest(Exception $e)"
