### PR TITLE
Failing test regarding ORA-24816, php 7 and CLOB

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/PHP72524Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/PHP72524Test.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Ticket;
+
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * @group DBAL-2386
+ */
+class DBAL2386Test extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if ($this->_conn->getDatabasePlatform()->getName() != 'oracle') {
+            $this->markTestSkipped('OCI8 only test');
+        }
+
+        if ($this->_conn->getSchemaManager()->tablesExist('DBAL2386')) {
+            $this->_conn->executeQuery('DELETE FROM DBAL2386');
+        } else {
+            $table = new \Doctrine\DBAL\Schema\Table('DBAL2386');
+            $table->addColumn('id', 'integer');
+            $table->setPrimaryKey(array('id'));
+            $table->addColumn('title', 'string', ['notnull' => false]);
+            $table->addColumn('address', 'text', ['notnull' => false]);
+            $table->addColumn('geo', 'json_array', ['notnull' => false]);
+            $table->addColumn('name', 'string', ['notnull' => false]);
+
+            $this->_conn->getSchemaManager()->createTable($table);
+        }
+    }
+
+    private function insertLobs(array $values) {
+        $stmt = $this->_conn->prepare('INSERT INTO DBAL2386 VALUES (:id, :title, :address, :geo, :name)');
+
+        $types = [
+            'id' => Type::getType('integer'),
+            'title' => Type::getType('string'),
+            'address' => Type::getType('text'),
+            'geo' => Type::getType('json_array'),
+            'name' => Type::getType('string')
+        ];
+
+        $platform = $this->_conn->getDatabasePlatform();
+
+        foreach ($types as $column => $type) {
+            $t = $type->getBindingType();
+
+            $value = $type->convertToDatabaseValue(isset($values[$column]) ? $values[$column] : null, $platform);
+            $stmt->bindValue(':' . $column, $value, $t);
+        }
+
+        $this->_conn->beginTransaction();
+        $stmt->execute();
+        $this->_conn->commit();
+
+        foreach ($this->_conn->query('SELECT * FROM DBAL2386')->fetch() as $column => $value) {
+            $column = strtolower($column);
+            $type = $types[$column];
+
+            if ($type === Type::getType('json_array')) {
+                $default = [];
+            } else {
+                $default = null;
+            }
+
+            $assert = isset($values[$column]) ? $values[$column] : $default;
+
+            $this->assertEquals($assert, $type->convertToPHPValue($value, $platform));
+        }
+    }
+
+    public function testInsertLobs()
+    {
+        $values = [
+            'id' => 0,
+            'title' => 'test',
+            'address' => implode(PHP_EOL, ['Thomas Nolan Kaszas II', '5322 Otter Lane', 'Middleberge FL 32068']),
+            'geo' => ['lat' => 30.0646966, 'long' => -81.9561377],
+            'name' => 'Foobar'
+        ];
+
+        $this->insertLobs($values);
+    }
+
+    public function testInsertNullLobs()
+    {
+        $values = [
+            'id' => 1
+        ];
+
+        $this->insertLobs($values);
+    }
+}


### PR DESCRIPTION
Ref bug discovery https://github.com/doctrine/dbal/pull/2386
Ref php bug https://bugs.php.net/bug.php?id=72524

Because @deeky666 just had the right words for this issue, I'm quoting him:

> There seems to be a difference between PHP5 and PHP7 in oci8 when binding `NULL` values to `LONG/LOB` type columns.
> In PHP5 it was possible to execute the following `INSERT` statement without any error (sample):
> 
> ```
> INSERT INTO mytable VALUES (:clob_col, :varchar2_col)
> ```
> 
> If the value bound to parameter `:varchar2_col` is `NULL`, the following error is triggered (no matter what value the parameter `:clob_col` is bound to):
> 
> ```
> ORA-24816: Expanded non LONG bind data supplied after actual LONG or LOB column
> ```
> 
> If you switch the parameter order and both parameter values are bound to `NULL`, the same error occurs:
> 
> ```
> INSERT INTO mytable VALUES (:varchar2_col, :clob_col)
> ```
> 
> So no matter what order, not matter what value is bound to `:clob_col`, if `:varchar2_col` is bound to NULL, the error occurs.
> If you have only one `VARCHAR2` column or two (without a `CLOB` column) there also is no error.

This Pull request adds a test case for this scenario by using the DBAL, it's obviously failing for now. 
