### PR TITLE
Replace `getMock()` with `createMock()`

### DIFF
--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -102,13 +102,15 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
 
     public function testConnectDispatchEvent()
     {
-        $listenerMock = $this->getMock('ConnectDispatchEventListener', array('postConnect'));
+        $listenerMock = $this->getMockBuilder('ConnectDispatchEventListener')
+            ->setMethods(array('postConnect'))
+            ->getMock();
         $listenerMock->expects($this->once())->method('postConnect');
 
         $eventManager = new EventManager();
         $eventManager->addEventListener(array(Events::postConnect), $listenerMock);
 
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
         $driverMock->expects(($this->at(0)))
                    ->method('connect');
         $platform = new Mocks\MockPlatform();
@@ -200,7 +202,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testConnectStartsTransactionInNoAutoCommitMode()
     {
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
         $driverMock->expects($this->any())
             ->method('connect')
             ->will($this->returnValue(new DriverConnectionMock()));
@@ -220,7 +222,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testCommitStartsTransactionInNoAutoCommitMode()
     {
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
         $driverMock->expects($this->any())
             ->method('connect')
             ->will($this->returnValue(new DriverConnectionMock()));
@@ -238,7 +240,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testRollBackStartsTransactionInNoAutoCommitMode()
     {
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
         $driverMock->expects($this->any())
             ->method('connect')
             ->will($this->returnValue(new DriverConnectionMock()));
@@ -256,7 +258,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testSwitchingAutoCommitModeCommitsAllCurrentTransactions()
     {
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
         $driverMock->expects($this->any())
             ->method('connect')
             ->will($this->returnValue(new DriverConnectionMock()));
@@ -278,7 +280,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
 
     public function testEmptyInsert()
     {
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
 
         $driverMock->expects($this->any())
             ->method('connect')
@@ -303,13 +305,13 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
         $types     = array(\PDO::PARAM_INT);
         $result    = array();
 
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
 
         $driverMock->expects($this->any())
             ->method('connect')
             ->will($this->returnValue(new DriverConnectionMock()));
 
-        $driverStatementMock = $this->getMock('Doctrine\Tests\Mocks\DriverStatementMock');
+        $driverStatementMock = $this->createMock('Doctrine\Tests\Mocks\DriverStatementMock');
 
         $driverStatementMock->expects($this->once())
             ->method('fetch')
@@ -337,13 +339,13 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
         $types     = array(\PDO::PARAM_INT);
         $result    = array();
 
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
 
         $driverMock->expects($this->any())
             ->method('connect')
             ->will($this->returnValue(new DriverConnectionMock()));
 
-        $driverStatementMock = $this->getMock('Doctrine\Tests\Mocks\DriverStatementMock');
+        $driverStatementMock = $this->createMock('Doctrine\Tests\Mocks\DriverStatementMock');
 
         $driverStatementMock->expects($this->once())
             ->method('fetch')
@@ -372,13 +374,13 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
         $column    = 0;
         $result    = array();
 
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
 
         $driverMock->expects($this->any())
             ->method('connect')
             ->will($this->returnValue(new DriverConnectionMock()));
 
-        $driverStatementMock = $this->getMock('Doctrine\Tests\Mocks\DriverStatementMock');
+        $driverStatementMock = $this->createMock('Doctrine\Tests\Mocks\DriverStatementMock');
 
         $driverStatementMock->expects($this->once())
             ->method('fetchColumn')
@@ -429,13 +431,13 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
         $types     = array(\PDO::PARAM_INT);
         $result    = array();
 
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
 
         $driverMock->expects($this->any())
             ->method('connect')
             ->will($this->returnValue(new DriverConnectionMock()));
 
-        $driverStatementMock = $this->getMock('Doctrine\Tests\Mocks\DriverStatementMock');
+        $driverStatementMock = $this->createMock('Doctrine\Tests\Mocks\DriverStatementMock');
 
         $driverStatementMock->expects($this->once())
             ->method('fetchAll')
@@ -459,7 +461,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
     {
         $params['pdo'] = new \stdClass();
 
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
 
         $conn = new Connection($params, $driverMock);
 
@@ -470,7 +472,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
     {
         $params['pdo'] = new \stdClass();
 
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
 
         $conn = new Connection($params, $driverMock);
 
@@ -480,8 +482,8 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
     public function testCallingDeleteWithNoDeletionCriteriaResultsInInvalidArgumentException()
     {
         /* @var $driver \Doctrine\DBAL\Driver */
-        $driver  = $this->getMock('Doctrine\DBAL\Driver');
-        $pdoMock = $this->getMock('Doctrine\DBAL\Driver\Connection');
+        $driver  = $this->createMock('Doctrine\DBAL\Driver');
+        $pdoMock = $this->createMock('Doctrine\DBAL\Driver\Connection');
 
         // should never execute queries with invalid arguments
         $pdoMock->expects($this->never())->method('exec');
@@ -509,10 +511,10 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testCallConnectOnce($method, $params)
     {
-        $driverMock   = $this->getMock('Doctrine\DBAL\Driver');
-        $pdoMock      = $this->getMock('Doctrine\DBAL\Driver\Connection');
+        $driverMock   = $this->createMock('Doctrine\DBAL\Driver');
+        $pdoMock      = $this->createMock('Doctrine\DBAL\Driver\Connection');
         $platformMock = new Mocks\MockPlatform();
-        $stmtMock     = $this->getMock('Doctrine\DBAL\Driver\Statement');
+        $stmtMock     = $this->createMock('Doctrine\DBAL\Driver\Statement');
 
         $pdoMock->expects($this->any())
             ->method('prepare')
@@ -534,10 +536,10 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
     public function testPlatformDetectionIsTriggerOnlyOnceOnRetrievingPlatform()
     {
         /** @var \Doctrine\Tests\Mocks\VersionAwarePlatformDriverMock|\PHPUnit_Framework_MockObject_MockObject $driverMock */
-        $driverMock = $this->getMock('Doctrine\Tests\Mocks\VersionAwarePlatformDriverMock');
+        $driverMock = $this->createMock('Doctrine\Tests\Mocks\VersionAwarePlatformDriverMock');
 
         /** @var \Doctrine\Tests\Mocks\ServerInfoAwareConnectionMock|\PHPUnit_Framework_MockObject_MockObject $driverConnectionMock */
-        $driverConnectionMock = $this->getMock('Doctrine\Tests\Mocks\ServerInfoAwareConnectionMock');
+        $driverConnectionMock = $this->createMock('Doctrine\Tests\Mocks\ServerInfoAwareConnectionMock');
 
         /** @var \Doctrine\DBAL\Platforms\AbstractPlatform|\PHPUnit_Framework_MockObject_MockObject $platformMock */
         $platformMock = $this->getMockForAbstractClass('Doctrine\DBAL\Platforms\AbstractPlatform');

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -9,15 +9,15 @@ class DBALExceptionTest extends \Doctrine\Tests\DbalTestCase
 {
     public function testDriverExceptionDuringQueryAcceptsBinaryData()
     {
-        $driver = $this->getMock('\Doctrine\DBAL\Driver');
+        $driver = $this->createMock('\Doctrine\DBAL\Driver');
         $e = DBALException::driverExceptionDuringQuery($driver, new \Exception, '', array('ABC', chr(128)));
         $this->assertContains('with params ["ABC", "\x80"]', $e->getMessage());
     }
 
     public function testAvoidOverWrappingOnDriverException()
     {
-        $driver = $this->getMock('\Doctrine\DBAL\Driver');
-        $ex = new DriverException('', $this->getMock('\Doctrine\DBAL\Driver\DriverException'));
+        $driver = $this->createMock('\Doctrine\DBAL\Driver');
+        $ex = new DriverException('', $this->createMock('\Doctrine\DBAL\Driver\DriverException'));
         $e = DBALException::driverExceptionDuringQuery($driver, $ex, '');
         $this->assertSame($ex, $e);
     }

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
@@ -59,7 +59,7 @@ abstract class AbstractDriverTest extends DbalTestCase
             );
         }
 
-        $driverException = $this->getMock('Doctrine\DBAL\Driver\DriverException');
+        $driverException = $this->createMock('Doctrine\DBAL\Driver\DriverException');
 
         $driverException->expects($this->any())
             ->method('getErrorCode')
@@ -209,7 +209,7 @@ abstract class AbstractDriverTest extends DbalTestCase
 
         foreach ($this->getExceptionConversionData() as $convertedExceptionClassName => $errors) {
             foreach ($errors as $error) {
-                $driverException = $this->getMock('Doctrine\DBAL\Driver\DriverException');
+                $driverException = $this->createMock('Doctrine\DBAL\Driver\DriverException');
 
                 $driverException->expects($this->any())
                     ->method('getErrorCode')

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
@@ -18,7 +18,7 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
             'password' => 'bar',
         );
 
-        $statement = $this->getMock('Doctrine\Tests\Mocks\DriverResultStatementMock');
+        $statement = $this->createMock('Doctrine\Tests\Mocks\DriverResultStatementMock');
 
         $statement->expects($this->once())
             ->method('fetchColumn')

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractPostgreSQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractPostgreSQLDriverTest.php
@@ -18,7 +18,7 @@ class AbstractPostgreSQLDriverTest extends AbstractDriverTest
             'password' => 'bar',
         );
 
-        $statement = $this->getMock('Doctrine\Tests\Mocks\DriverResultStatementMock');
+        $statement = $this->createMock('Doctrine\Tests\Mocks\DriverResultStatementMock');
 
         $statement->expects($this->once())
             ->method('fetchColumn')

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -27,9 +27,10 @@ class OCI8StatementTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testExecute(array $params)
     {
-        $statement = $this->getMock('\Doctrine\DBAL\Driver\OCI8\OCI8Statement',
-            array('bindValue', 'errorInfo'),
-            array(), '', false);
+        $statement = $this->getMockBuilder('\Doctrine\DBAL\Driver\OCI8\OCI8Statement')
+            ->setMethods(array('bindValue', 'errorInfo'))
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $statement->expects($this->at(0))
             ->method('bindValue')
@@ -52,7 +53,10 @@ class OCI8StatementTest extends \Doctrine\Tests\DbalTestCase
 
         // can't pass to constructor since we don't have a real database handle,
         // but execute must check the connection for the executeMode
-        $conn = $this->getMock('\Doctrine\DBAL\Driver\OCI8\OCI8Connection', array('getExecuteMode'), array(), '', false);
+        $conn = $this->getMockBuilder('\Doctrine\DBAL\Driver\OCI8\OCI8Connection')
+            ->setMethods(array('getExecuteMode'))
+            ->disableOriginalConstructor()
+            ->getMock();
         $conn->expects($this->once())
             ->method('getExecuteMode');
 

--- a/tests/Doctrine/Tests/DBAL/Events/MysqlSessionInitTest.php
+++ b/tests/Doctrine/Tests/DBAL/Events/MysqlSessionInitTest.php
@@ -11,7 +11,7 @@ class MysqlSessionInitTest extends DbalTestCase
 {
     public function testPostConnect()
     {
-        $connectionMock = $this->getMock('Doctrine\DBAL\Connection', array(), array(), '', false);
+        $connectionMock = $this->createMock('Doctrine\DBAL\Connection');
         $connectionMock->expects($this->once())
                        ->method('executeUpdate')
                        ->with($this->equalTo("SET NAMES foo COLLATE bar"));

--- a/tests/Doctrine/Tests/DBAL/Events/OracleSessionInitTest.php
+++ b/tests/Doctrine/Tests/DBAL/Events/OracleSessionInitTest.php
@@ -11,7 +11,7 @@ class OracleSessionInitTest extends DbalTestCase
 {
     public function testPostConnect()
     {
-        $connectionMock = $this->getMock('Doctrine\DBAL\Connection', array(), array(), '', false);
+        $connectionMock = $this->createMock('Doctrine\DBAL\Connection');
         $connectionMock->expects($this->once())
                        ->method('executeUpdate')
                        ->with($this->isType('string'));

--- a/tests/Doctrine/Tests/DBAL/Events/SQLSessionInitTest.php
+++ b/tests/Doctrine/Tests/DBAL/Events/SQLSessionInitTest.php
@@ -14,7 +14,7 @@ class SQLSessionInitTest extends DbalTestCase
 {
     public function testPostConnect()
     {
-        $connectionMock = $this->getMock('Doctrine\DBAL\Connection', array(), array(), '', false);
+        $connectionMock = $this->createMock('Doctrine\DBAL\Connection');
         $connectionMock->expects($this->once())
                        ->method('exec')
                        ->with($this->equalTo("SET SEARCH_PATH TO foo, public, TIMEZONE TO 'Europe/Berlin'"));

--- a/tests/Doctrine/Tests/DBAL/Functional/LoggingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/LoggingTest.php
@@ -8,7 +8,7 @@ class LoggingTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         $sql = $this->_conn->getDatabasePlatform()->getDummySelectSQL();
 
-        $logMock = $this->getMock('Doctrine\DBAL\Logging\SQLLogger');
+        $logMock = $this->createMock('Doctrine\DBAL\Logging\SQLLogger');
         $logMock->expects($this->at(0))
                 ->method('startQuery')
                 ->with($this->equalTo($sql), $this->equalTo(array()), $this->equalTo(array()));
@@ -24,7 +24,7 @@ class LoggingTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $sql = $this->_conn->getDatabasePlatform()->getDummySelectSQL();
 
-        $logMock = $this->getMock('Doctrine\DBAL\Logging\SQLLogger');
+        $logMock = $this->createMock('Doctrine\DBAL\Logging\SQLLogger');
         $logMock->expects($this->at(0))
                 ->method('startQuery')
                 ->with($this->equalTo($sql), $this->equalTo(array()), $this->equalTo(array()));
@@ -38,7 +38,7 @@ class LoggingTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         $sql = $this->_conn->getDatabasePlatform()->getDummySelectSQL();
 
-        $logMock = $this->getMock('Doctrine\DBAL\Logging\SQLLogger');
+        $logMock = $this->createMock('Doctrine\DBAL\Logging\SQLLogger');
         $logMock->expects($this->once())
                 ->method('startQuery')
                 ->with($this->equalTo($sql), $this->equalTo(array()));

--- a/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
@@ -128,7 +128,9 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
             'portability' => $portability
         );
 
-        $driverMock = $this->getMock('Doctrine\\DBAL\\Driver\\PDOSqlsrv\\Driver', array('connect'));
+        $driverMock = $this->getMockBuilder('Doctrine\\DBAL\\Driver\\PDOSqlsrv\\Driver')
+            ->setMethods(array('connect'))
+            ->getMock();
 
         $driverMock->expects($this->once())
                    ->method('connect')

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL461Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL461Test.php
@@ -11,7 +11,7 @@ class DBAL461Test extends \PHPUnit_Framework_TestCase
 {
     public function testIssue()
     {
-        $conn = $this->getMock('Doctrine\DBAL\Connection', array(), array(), '', false);
+        $conn = $this->createMock('Doctrine\DBAL\Connection');
         $platform = $this->getMockForAbstractClass('Doctrine\DBAL\Platforms\AbstractPlatform');
         $platform->registerDoctrineTypeMapping('numeric', 'decimal');
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -318,7 +318,9 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 
     public function testGetCreateTableSqlDispatchEvent()
     {
-        $listenerMock = $this->getMock('GetCreateTableSqlDispatchEvenListener', array('onSchemaCreateTable', 'onSchemaCreateTableColumn'));
+        $listenerMock = $this->getMockBuilder('GetCreateTableSqlDispatchEvenListener')
+            ->setMethods(array('onSchemaCreateTable', 'onSchemaCreateTableColumn'))
+            ->getMock();
         $listenerMock
             ->expects($this->once())
             ->method('onSchemaCreateTable');
@@ -340,7 +342,9 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 
     public function testGetDropTableSqlDispatchEvent()
     {
-        $listenerMock = $this->getMock('GetDropTableSqlDispatchEventListener', array('onSchemaDropTable'));
+        $listenerMock = $this->getMockBuilder('GetDropTableSqlDispatchEventListener')
+            ->setMethods(array('onSchemaDropTable'))
+            ->getMock();
         $listenerMock
             ->expects($this->once())
             ->method('onSchemaDropTable');
@@ -363,7 +367,9 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
             'onSchemaAlterTableRenameColumn'
         );
 
-        $listenerMock = $this->getMock('GetAlterTableSqlDispatchEvenListener', $events);
+        $listenerMock = $this->getMockBuilder('GetAlterTableSqlDispatchEvenListener')
+            ->setMethods($events)
+            ->getMock();
         $listenerMock
             ->expects($this->once())
             ->method('onSchemaAlterTable');

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -456,7 +456,7 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     {
         $this->setExpectedException('\InvalidArgumentException');
 
-        $this->_platform->getCreateConstraintSQL($this->getMock('\Doctrine\DBAL\Schema\Constraint'), 'footable');
+        $this->_platform->getCreateConstraintSQL($this->createMock('\Doctrine\DBAL\Schema\Constraint'), 'footable');
     }
 
     public function testGeneratesCreateIndexWithAdvancedPlatformOptionsSQL()

--- a/tests/Doctrine/Tests/DBAL/Portability/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Portability/StatementTest.php
@@ -188,6 +188,6 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
      */
     protected function createWrappedStatement()
     {
-        return $this->getMock('Doctrine\Tests\Mocks\DriverStatementMock');
+        return $this->createMock('Doctrine\Tests\Mocks\DriverStatementMock');
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
@@ -14,7 +14,7 @@ class ExpressionBuilderTest extends \Doctrine\Tests\DbalTestCase
 
     protected function setUp()
     {
-        $conn = $this->getMock('Doctrine\DBAL\Connection', array(), array(), '', false);
+        $conn = $this->createMock('Doctrine\DBAL\Connection');
 
         $this->expr = new ExpressionBuilder($conn);
 

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -14,7 +14,7 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
 
     protected function setUp()
     {
-        $this->conn = $this->getMock('Doctrine\DBAL\Connection', array(), array(), '', false);
+        $this->conn = $this->createMock('Doctrine\DBAL\Connection');
 
         $expressionBuilder = new ExpressionBuilder($this->conn);
 

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -1131,8 +1131,12 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
     public function testComparesNamespaces()
     {
         $comparator = new Comparator();
-        $fromSchema = $this->getMock('Doctrine\DBAL\Schema\Schema', array('getNamespaces', 'hasNamespace'));
-        $toSchema = $this->getMock('Doctrine\DBAL\Schema\Schema', array('getNamespaces', 'hasNamespace'));
+        $fromSchema = $this->getMockBuilder('Doctrine\DBAL\Schema\Schema')
+            ->setMethods(array('getNamespaces', 'hasNamespace'))
+            ->getMock();
+        $toSchema = $this->getMockBuilder('Doctrine\DBAL\Schema\Schema')
+            ->setMethods(array('getNamespaces', 'hasNamespace'))
+            ->getMock();
 
         $fromSchema->expects($this->once())
             ->method('getNamespaces')

--- a/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
@@ -17,13 +17,12 @@ class MySqlSchemaManagerTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $eventManager = new EventManager();
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
-        $platform = $this->getMock('Doctrine\DBAL\Platforms\MySqlPlatform');
-        $this->conn = $this->getMock(
-            'Doctrine\DBAL\Connection',
-            array('fetchAll'),
-            array(array('platform' => $platform), $driverMock, new Configuration(), $eventManager)
-        );
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
+        $platform = $this->createMock('Doctrine\DBAL\Platforms\MySqlPlatform');
+        $this->conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setMethods(array('fetchAll'))
+            ->setConstructorArgs(array(array('platform' => $platform), $driverMock, new Configuration(), $eventManager))
+            ->getMock();
         $this->manager = new MySqlSchemaManager($this->conn);
     }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/PostgreSQLSchemaManagerTest.php
@@ -20,13 +20,11 @@ class PostgreSQLSchemaManagerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $driverMock = $this->getMock('Doctrine\DBAL\Driver');
-        $platform = $this->getMock('Doctrine\DBAL\Platforms\PostgreSqlPlatform');
-        $this->connection = $this->getMock(
-            'Doctrine\DBAL\Connection',
-            array(),
-            array(array('platform' => $platform), $driverMock)
-        );
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
+        $platform = $this->createMock('Doctrine\DBAL\Platforms\PostgreSqlPlatform');
+        $this->connection = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setConstructorArgs(array(array('platform' => $platform), $driverMock))
+            ->getMock();
         $this->schemaManager = new PostgreSqlSchemaManager($this->connection, $platform);
     }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
@@ -35,7 +35,7 @@ class SchemaDiffTest extends \PHPUnit_Framework_TestCase
 
     public function createPlatform($unsafe = false)
     {
-        $platform = $this->getMock('Doctrine\Tests\DBAL\Mocks\MockPlatform');
+        $platform = $this->createMock('Doctrine\Tests\DBAL\Mocks\MockPlatform');
         $platform->expects($this->exactly(1))
             ->method('getCreateSchemaSQL')
             ->with('foo_ns')

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
@@ -349,7 +349,7 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
     public function testVisitsVisitor()
     {
         $schema = new Schema();
-        $visitor = $this->getMock('Doctrine\DBAL\Schema\Visitor\Visitor');
+        $visitor = $this->createMock('Doctrine\DBAL\Schema\Visitor\Visitor');
 
         $schema->createNamespace('foo');
         $schema->createNamespace('bar');
@@ -363,9 +363,6 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
         $visitor->expects($this->once())
             ->method('acceptSchema')
             ->with($schema);
-
-        $visitor->expects($this->never())
-            ->method('acceptNamespace');
 
         $visitor->expects($this->at(1))
             ->method('acceptTable')
@@ -398,7 +395,7 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
     public function testVisitsNamespaceVisitor()
     {
         $schema = new Schema();
-        $visitor = $this->getMock('Doctrine\DBAL\Schema\Visitor\AbstractVisitor');
+        $visitor = $this->createMock('Doctrine\DBAL\Schema\Visitor\AbstractVisitor');
 
         $schema->createNamespace('foo');
         $schema->createNamespace('bar');

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -105,7 +105,7 @@ class CreateSchemaSqlCollectorTest extends \PHPUnit_Framework_TestCase
 
     public function testResetsQueries()
     {
-        foreach (array('supportsSchemas', 'supportsForeignKeys') as $method) {
+        foreach (array('supportsSchemas', 'supportsForeignKeyConstraints') as $method) {
             $this->platformMock->expects($this->any())
                 ->method($method)
                 ->will($this->returnValue(true));

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
@@ -8,10 +8,9 @@ class SchemaSqlCollectorTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreateSchema()
     {
-        $platformMock = $this->getMock(
-            'Doctrine\DBAL\Platforms\MySqlPlatform',
-            array('getCreateTableSql', 'getCreateSequenceSql', 'getCreateForeignKeySql')
-        );
+        $platformMock = $this->getMockBuilder('Doctrine\DBAL\Platforms\MySqlPlatform')
+            ->setMethods(array('getCreateTableSql', 'getCreateSequenceSql', 'getCreateForeignKeySql'))
+            ->getMock();
         $platformMock->expects($this->exactly(2))
                      ->method('getCreateTableSql')
                      ->will($this->returnValue(array("foo")));
@@ -31,10 +30,9 @@ class SchemaSqlCollectorTest extends \PHPUnit_Framework_TestCase
 
     public function testDropSchema()
     {
-        $platformMock = $this->getMock(
-            'Doctrine\DBAL\Platforms\MySqlPlatform',
-            array('getDropTableSql', 'getDropSequenceSql', 'getDropForeignKeySql')
-        );
+        $platformMock = $this->getMockBuilder('Doctrine\DBAL\Platforms\MySqlPlatform')
+            ->setMethods(array('getDropTableSql', 'getDropSequenceSql', 'getDropForeignKeySql'))
+            ->getMock();
         $platformMock->expects($this->exactly(2))
                      ->method('getDropTableSql')
                      ->will($this->returnValue("tbl"));

--- a/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
@@ -24,12 +24,15 @@ class PoolingShardManagerTest extends \PHPUnit_Framework_TestCase
 {
     private function createConnectionMock()
     {
-        return $this->getMock('Doctrine\DBAL\Sharding\PoolingShardConnection', array('connect', 'getParams', 'fetchAll'), array(), '', false);
+        return $this->getMockBuilder('Doctrine\DBAL\Sharding\PoolingShardConnection')
+            ->setMethods(array('connect', 'getParams', 'fetchAll'))
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     private function createPassthroughShardChoser()
     {
-        $mock = $this->getMock('Doctrine\DBAL\Sharding\ShardChoser\ShardChoser');
+        $mock = $this->createMock('Doctrine\DBAL\Sharding\ShardChoser\ShardChoser');
         $mock->expects($this->any())
              ->method('pickShard')
              ->will($this->returnCallback(function($value) { return $value; }));
@@ -38,7 +41,7 @@ class PoolingShardManagerTest extends \PHPUnit_Framework_TestCase
 
     private function createStaticShardChoser()
     {
-        $mock = $this->getMock('Doctrine\DBAL\Sharding\ShardChoser\ShardChoser');
+        $mock = $this->createMock('Doctrine\DBAL\Sharding\ShardChoser\ShardChoser');
         $mock->expects($this->any())
             ->method('pickShard')
             ->will($this->returnCallback(function($value) { return 1; }));

--- a/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/SQLAzureShardManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/SQLAzureShardManagerTest.php
@@ -85,7 +85,10 @@ class SQLAzureShardManagerTest extends \PHPUnit_Framework_TestCase
 
     private function createConnection(array $params)
     {
-        $conn = $this->getMock('Doctrine\DBAL\Connection', array('getParams', 'exec', 'isTransactionActive'), array(), '', false);
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setMethods(array('getParams', 'exec', 'isTransactionActive'))
+            ->disableOriginalConstructor()
+            ->getMock();
         $conn->expects($this->at(0))->method('getParams')->will($this->returnValue($params));
         return $conn;
     }

--- a/tests/Doctrine/Tests/DBAL/Sharding/ShardChoser/MultiTenantShardChoserTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/ShardChoser/MultiTenantShardChoserTest.php
@@ -34,7 +34,10 @@ class MultiTenantShardChoserTest extends \PHPUnit_Framework_TestCase
 
     private function createConnectionMock()
     {
-        return $this->getMock('Doctrine\DBAL\Sharding\PoolingShardConnection', array('connect', 'getParams', 'fetchAll'), array(), '', false);
+        return $this->getMockBuilder('Doctrine\DBAL\Sharding\PoolingShardConnection')
+            ->setMethods(array('connect', 'getParams', 'fetchAll'))
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 }
 

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -8,13 +8,13 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
 {
     /**
      *
-     * @var \Doctrine\DBAL\Connection 
+     * @var \Doctrine\DBAL\Connection
      */
     private $conn;
-    
+
     /**
      *
-     * @var \Doctrine\DBAL\Configuration 
+     * @var \Doctrine\DBAL\Configuration
      */
     private $configuration;
 
@@ -25,26 +25,30 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
 
     protected function setUp()
     {
-        $this->pdoStatement = $this->getMock('\PDOStatement', array('execute', 'bindParam', 'bindValue'));
+        $this->pdoStatement = $this->getMockBuilder('\PDOStatement')
+            ->setMethods(array('execute', 'bindParam', 'bindValue'))
+            ->getMock();
         $platform = new \Doctrine\Tests\DBAL\Mocks\MockPlatform();
-        $driverConnection = $this->getMock('\Doctrine\DBAL\Driver\Connection');
+        $driverConnection = $this->createMock('\Doctrine\DBAL\Driver\Connection');
         $driverConnection->expects($this->any())
                 ->method('prepare')
                 ->will($this->returnValue($this->pdoStatement));
-        
-        $driver = $this->getMock('\Doctrine\DBAL\Driver');
+
+        $driver = $this->createMock('\Doctrine\DBAL\Driver');
         $constructorArgs = array(
             array(
                 'platform' => $platform
             ),
             $driver
         );
-        $this->conn = $this->getMock('\Doctrine\DBAL\Connection', array(), $constructorArgs);
+        $this->conn = $this->getMockBuilder('\Doctrine\DBAL\Connection')
+            ->setConstructorArgs($constructorArgs)
+            ->getMock();
         $this->conn->expects($this->atLeastOnce())
                 ->method('getWrappedConnection')
                 ->will($this->returnValue($driverConnection));
-        
-        $this->configuration = $this->getMock('\Doctrine\DBAL\Configuration');
+
+        $this->configuration = $this->createMock('\Doctrine\DBAL\Configuration');
         $this->conn->expects($this->any())
                 ->method('getConfiguration')
                 ->will($this->returnValue($this->configuration));
@@ -54,7 +58,7 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
             ->will($this->returnValue($driver));
 
     }
-    
+
     public function testExecuteCallsLoggerStartQueryWithParametersWhenValuesBound()
     {
         $name = 'foo';
@@ -63,21 +67,21 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
         $values = array($name => $var);
         $types = array($name => $type);
         $sql = '';
-        
-        $logger = $this->getMock('\Doctrine\DBAL\Logging\SQLLogger');
+
+        $logger = $this->createMock('\Doctrine\DBAL\Logging\SQLLogger');
         $logger->expects($this->once())
                 ->method('startQuery')
                 ->with($this->equalTo($sql), $this->equalTo($values), $this->equalTo($types));
-        
+
         $this->configuration->expects($this->once())
                 ->method('getSQLLogger')
                 ->will($this->returnValue($logger));
-        
+
         $statement = new Statement($sql, $this->conn);
         $statement->bindValue($name, $var, $type);
         $statement->execute();
     }
-    
+
     public function testExecuteCallsLoggerStartQueryWithParametersWhenParamsPassedToExecute()
     {
         $name = 'foo';
@@ -85,16 +89,16 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
         $values = array($name => $var);
         $types = array();
         $sql = '';
-        
-        $logger = $this->getMock('\Doctrine\DBAL\Logging\SQLLogger');
+
+        $logger = $this->createMock('\Doctrine\DBAL\Logging\SQLLogger');
         $logger->expects($this->once())
                 ->method('startQuery')
                 ->with($this->equalTo($sql), $this->equalTo($values), $this->equalTo($types));
-        
+
         $this->configuration->expects($this->once())
                 ->method('getSQLLogger')
                 ->will($this->returnValue($logger));
-        
+
         $statement = new Statement($sql, $this->conn);
         $statement->execute($values);
     }
@@ -104,7 +108,7 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testExecuteCallsLoggerStopQueryOnException()
     {
-        $logger = $this->getMock('\Doctrine\DBAL\Logging\SQLLogger');
+        $logger = $this->createMock('\Doctrine\DBAL\Logging\SQLLogger');
 
         $this->configuration->expects($this->once())
             ->method('getSQLLogger')

--- a/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
@@ -24,7 +24,7 @@ class RunSqlCommandTest extends \PHPUnit_Framework_TestCase
         $this->command = $application->find('dbal:run-sql');
         $this->commandTester = new CommandTester($this->command);
 
-        $this->connectionMock = $this->getMock('\Doctrine\DBAL\Connection', array(), array(), '', false);
+        $this->connectionMock = $this->createMock('\Doctrine\DBAL\Connection');
         $this->connectionMock->method('fetchAll')
             ->willReturn(array(array(1)));
         $this->connectionMock->method('executeUpdate')

--- a/tests/Doctrine/Tests/DBAL/Types/GuidTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/GuidTypeTest.php
@@ -32,7 +32,7 @@ class GuidTest extends \Doctrine\Tests\DbalTestCase
     {
         $this->assertTrue($this->_type->requiresSQLCommentHint($this->_platform));
 
-        $mock = $this->getMock(get_class($this->_platform));
+        $mock = $this->createMock(get_class($this->_platform));
         $mock->expects($this->any())
              ->method('hasNativeGuidType')
              ->will($this->returnValue(true));


### PR DESCRIPTION
As a result of bumping PHPUnit requirement to `^5.4.6` in https://github.com/doctrine/dbal/pull/2419 we get a lot of deprecation warnings for `PHPUnit_Framework_TestCase::getMock()` in our test suite.

This PR fixes all of them. Also two tests had to be adjusted, because they were doing expectations on non-existing methods which PHPUnit now warns about.
