### PR TITLE
Track the Values & Types Passed to Statement::bindParam

### DIFF
--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -138,6 +138,8 @@ class Statement implements \IteratorAggregate, DriverStatement
      */
     public function bindParam($name, &$var, $type = PDO::PARAM_STR, $length = null)
     {
+        $this->params[$name] = $var;
+        $this->types[$name] = $type;
         return $this->stmt->bindParam($name, $var, $type, $length);
     }
 

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -140,6 +140,7 @@ class Statement implements \IteratorAggregate, DriverStatement
     {
         $this->params[$name] = $var;
         $this->types[$name] = $type;
+
         return $this->stmt->bindParam($name, $var, $type, $length);
     }
 

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -103,6 +103,28 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
         $statement->execute($values);
     }
 
+    public function testExecuteCallsStartQueryWithTheParametersBoundViaBindParam()
+    {
+        $name = 'foo';
+        $var = 'bar';
+        $values = array($name => $var);
+        $types = array($name => \PDO::PARAM_STR);
+        $sql = '';
+
+        $logger = $this->createMock('\Doctrine\DBAL\Logging\SQLLogger');
+        $logger->expects($this->once())
+                ->method('startQuery')
+                ->with($this->equalTo($sql), $this->equalTo($values), $this->equalTo($types));
+
+        $this->configuration->expects($this->once())
+                ->method('getSQLLogger')
+                ->will($this->returnValue($logger));
+
+        $statement = new Statement($sql, $this->conn);
+        $statement->bindParam($name, $var);
+        $statement->execute();
+    }
+
     /**
      * @expectedException \Doctrine\DBAL\DBALException
      */

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL;
 
 use Doctrine\DBAL\Statement;
+use Doctrine\DBAL\Logging\SQLLogger;
 
 class StatementTest extends \Doctrine\Tests\DbalTestCase
 {
@@ -111,10 +112,10 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
         $types = array($name => \PDO::PARAM_STR);
         $sql = '';
 
-        $logger = $this->createMock('\Doctrine\DBAL\Logging\SQLLogger');
-        $logger->expects($this->once())
+        $logger = $this->createMock(SQLLogger::class);
+        $logger->expects(self::once())
                 ->method('startQuery')
-                ->with($this->equalTo($sql), $this->equalTo($values), $this->equalTo($types));
+                ->with(self::equalTo($sql), self::equalTo($values), self::equalTo($types));
 
         $this->configuration->expects($this->once())
                 ->method('getSQLLogger')

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -108,8 +108,8 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
     {
         $name = 'foo';
         $var = 'bar';
-        $values = array($name => $var);
-        $types = array($name => \PDO::PARAM_STR);
+        $values = [$name => $var];
+        $types = [$name => \PDO::PARAM_STR];
         $sql = '';
 
         $logger = $this->createMock(SQLLogger::class);
@@ -117,9 +117,9 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
                 ->method('startQuery')
                 ->with(self::equalTo($sql), self::equalTo($values), self::equalTo($types));
 
-        $this->configuration->expects($this->once())
+        $this->configuration->expects(self::once())
                 ->method('getSQLLogger')
-                ->will($this->returnValue($logger));
+                ->willReturn($logger);
 
         $statement = new Statement($sql, $this->conn);
         $statement->bindParam($name, $var);


### PR DESCRIPTION
So they get passed to the SQLLogger on `Statement::execute`.

Hopefully fixes #2440
