### PR TITLE
connect to sasql without host parameter per broadcast or with 2 hosts comma-separated

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -45,6 +45,7 @@ class Driver extends AbstractSQLAnywhereDriver
                     isset($params['port']) ? $params['port'] : null,
                     isset($params['server']) ? $params['server'] : null,
                     isset($params['dbname']) ? $params['dbname'] : null,
+                    isset($params['charset']) ? $params['charset'] : null,
                     $username,
                     $password,
                     $driverOptions
@@ -73,27 +74,40 @@ class Driver extends AbstractSQLAnywhereDriver
      *                               SQL Anywhere allows multiple database server instances on the same host,
      *                               therefore specifying the server instance name to use is mandatory.
      * @param string  $dbname        Name of the database on the server instance to connect to.
+     * @param string  $charset       Charset
      * @param string  $username      User name to use for connection authentication.
      * @param string  $password      Password to use for connection authentication.
      * @param array   $driverOptions Additional parameters to use for the connection.
      *
      * @return string
      */
-    private function buildDsn($host, $port, $server, $dbname, $username = null, $password = null, array $driverOptions = array())
+    private function buildDsn($host, $port, $server, $dbname, $charset, $username = null, $password = null, array $driverOptions = array())
     {
-        $host = $host ?: 'localhost';
-        $port = $port ?: 2638;
+        // $host = $host ?: 'localhost';
+        // $port = $port ?: 2638;
 
-        if (! empty($server)) {
-            $server = ';ServerName=' . $server;
+        if (!empty($host)) {
+            $host = 'HOST=' . $host . (isset($port) ? (':' . $port) : '');
+        }
+        if (!empty($server)) {
+            $server = 'ServerName=' . $server;
+        }
+
+        if (!empty($dbname)) {
+            $dbname = 'DBN=' . $dbname;
+        }
+
+        if (!empty($charset)) {
+            $charset = 'CS=' . $charset;
         }
 
         return
-            'HOST=' . $host . ':' . $port .
-            $server .
-            ';DBN=' . $dbname .
+            $host .
+            ';'. $server .
+            ';'. $dbname .
             ';UID=' . $username .
             ';PWD=' . $password .
+            ';' . $charset .
             ';' . implode(
                 ';',
                 array_map(function ($key, $value) {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -45,7 +45,6 @@ class Driver extends AbstractSQLAnywhereDriver
                     isset($params['port']) ? $params['port'] : null,
                     isset($params['server']) ? $params['server'] : null,
                     isset($params['dbname']) ? $params['dbname'] : null,
-                    isset($params['charset']) ? $params['charset'] : null,
                     $username,
                     $password,
                     $driverOptions
@@ -74,40 +73,27 @@ class Driver extends AbstractSQLAnywhereDriver
      *                               SQL Anywhere allows multiple database server instances on the same host,
      *                               therefore specifying the server instance name to use is mandatory.
      * @param string  $dbname        Name of the database on the server instance to connect to.
-     * @param string  $charset       Charset
      * @param string  $username      User name to use for connection authentication.
      * @param string  $password      Password to use for connection authentication.
      * @param array   $driverOptions Additional parameters to use for the connection.
      *
      * @return string
      */
-    private function buildDsn($host, $port, $server, $dbname, $charset, $username = null, $password = null, array $driverOptions = array())
+    private function buildDsn($host, $port, $server, $dbname, $username = null, $password = null, array $driverOptions = array())
     {
-        // $host = $host ?: 'localhost';
-        // $port = $port ?: 2638;
+        $host = $host ?: 'localhost';
+        $port = $port ?: 2638;
 
-        if (!empty($host)) {
-            $host = 'HOST=' . $host . (isset($port) ? (':' . $port) : '');
-        }
-        if (!empty($server)) {
-            $server = 'ServerName=' . $server;
-        }
-
-        if (!empty($dbname)) {
-            $dbname = 'DBN=' . $dbname;
-        }
-
-        if (!empty($charset)) {
-            $charset = 'CS=' . $charset;
+        if (! empty($server)) {
+            $server = ';ServerName=' . $server;
         }
 
         return
-            $host .
-            ';'. $server .
-            ';'. $dbname .
+            'HOST=' . $host . ':' . $port .
+            $server .
+            ';DBN=' . $dbname .
             ';UID=' . $username .
             ';PWD=' . $password .
-            ';' . $charset .
             ';' . implode(
                 ';',
                 array_map(function ($key, $value) {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -81,19 +81,37 @@ class Driver extends AbstractSQLAnywhereDriver
      */
     private function buildDsn($host, $port, $server, $dbname, $username = null, $password = null, array $driverOptions = array())
     {
-        $host = $host ?: 'localhost';
-        $port = $port ?: 2638;
+        $hostPart = "";
+        $serverPart = "";
+        $dbnamePart = "";
+        $linksPart = "";
 
-        if (! empty($server)) {
-            $server = ';ServerName=' . $server;
+        //if host is empty, "LINKS=tcpip()" has to be set and SQLAnywhere did broadcasts to find the right DB
+        //port-parameter is only used if host has no colon and has no comma (db-mirror configuration)
+        if (! empty($host)) {
+            $hostPart = 'HOST='.$host;
+            if (false === strpos($host,':') && false === strpos($host,',')) {
+                $hostPart .= isset($port)?':'.$port:':2638';
+            }
+        } else {
+            $linksPart = ';LINKS=tcpip()';
         }
 
-        return
-            'HOST=' . $host . ':' . $port .
-            $server .
-            ';DBN=' . $dbname .
+        if (! empty($server)) {
+            $serverPart = ';ServerName=' . $server;
+        }
+
+        if (! empty($dbname)) {
+            $dbnamePart = ';DBN=' . $dbname;
+        }
+
+        return 
+            $hostPart .
+            $serverPart .
+            $dbnamePart .
             ';UID=' . $username .
             ';PWD=' . $password .
+            $linksPart .
             ';' . implode(
                 ';',
                 array_map(function ($key, $value) {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -48,9 +48,16 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
      */
     public function __construct($dsn, $persistent = false)
     {
+        $allowedResourceTypes = array(
+            'SQLAnywhere connection'
+            ,'SQLAnywhere persistent connection ' //note the blank!
+        );
+
         $this->connection = $persistent ? @sasql_pconnect($dsn) : @sasql_connect($dsn);
 
-        if ( ! is_resource($this->connection) || !preg_match('/^SQLAnywhere.*connection.*/',get_resource_type($this->connection)) ) {
+        $resourceType = get_resource_type($this->connection);
+
+        if ( ! is_resource($this->connection) || !in_array($resourceType, $allowedResourceTypes, true)) {
             throw SQLAnywhereException::fromSQLAnywhereError();
         }
 

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -48,16 +48,9 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
      */
     public function __construct($dsn, $persistent = false)
     {
-        $allowedResourceTypes = array(
-            'SQLAnywhere connection'
-            ,'SQLAnywhere persistent connection ' //note the blank!
-        );
-
         $this->connection = $persistent ? @sasql_pconnect($dsn) : @sasql_connect($dsn);
 
-        $resourceType = get_resource_type($this->connection);
-
-        if ( ! is_resource($this->connection) || !in_array($resourceType, $allowedResourceTypes, true)) {
+        if ( ! is_resource($this->connection)) {
             throw SQLAnywhereException::fromSQLAnywhereError();
         }
 

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -50,7 +50,7 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
     {
         $this->connection = $persistent ? @sasql_pconnect($dsn) : @sasql_connect($dsn);
 
-        if ( ! is_resource($this->connection) || get_resource_type($this->connection) !== 'SQLAnywhere connection') {
+        if ( ! is_resource($this->connection) || !preg_match('/^SQLAnywhere.*connection.*/',get_resource_type($this->connection)) ) {
             throw SQLAnywhereException::fromSQLAnywhereError();
         }
 

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereException.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereException.php
@@ -42,11 +42,11 @@ class SQLAnywhereException extends AbstractDriverException
      */
     public static function fromSQLAnywhereError($conn = null, $stmt = null)
     {
-        if (null !== $conn && ! (is_resource($conn) && get_resource_type($conn) === 'SQLAnywhere connection')) {
+        if (null !== $conn && ! (is_resource($conn))) {
             throw new \InvalidArgumentException('Invalid SQL Anywhere connection resource given: ' . $conn);
         }
 
-        if (null !== $stmt && ! (is_resource($stmt) && get_resource_type($stmt) === 'SQLAnywhere statement')) {
+        if (null !== $stmt && ! (is_resource($stmt))) {
             throw new \InvalidArgumentException('Invalid SQL Anywhere statement resource given: ' . $stmt);
         }
 

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -74,21 +74,14 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
      */
     public function __construct($conn, $sql)
     {
-        $allowedResourceTypes = array(
-            'SQLAnywhere connection'
-            ,'SQLAnywhere persistent connection '  //note the blank! 
-        );
-
-        $resourceType = get_resource_type($conn);
-
-        if ( ! is_resource($conn) || !in_array($resourceType, $allowedResourceTypes, true)) {
+        if ( ! is_resource($conn)) {
             throw new SQLAnywhereException('Invalid SQL Anywhere connection resource: ' . $conn);
         }
 
         $this->conn = $conn;
         $this->stmt = sasql_prepare($conn, $sql);
 
-        if ( ! is_resource($this->stmt) || get_resource_type($this->stmt) !== 'SQLAnywhere statement') {
+        if ( ! is_resource($this->stmt)) {
             throw SQLAnywhereException::fromSQLAnywhereError($conn);
         }
     }
@@ -202,7 +195,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
      */
     public function fetch($fetchMode = null)
     {
-        if ( ! is_resource($this->result) || get_resource_type($this->result) !== 'SQLAnywhere result') {
+        if ( ! is_resource($this->result)) {
             return false;
         }
 

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -74,7 +74,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
      */
     public function __construct($conn, $sql)
     {
-        if ( ! is_resource($conn) || get_resource_type($conn) !== 'SQLAnywhere connection') {
+        if ( ! is_resource($conn) || !preg_match('/^SQLAnywhere.*connection.*/',get_resource_type($conn))) {
             throw new SQLAnywhereException('Invalid SQL Anywhere connection resource: ' . $conn);
         }
 

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -74,7 +74,14 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
      */
     public function __construct($conn, $sql)
     {
-        if ( ! is_resource($conn) || !preg_match('/^SQLAnywhere.*connection.*/',get_resource_type($conn))) {
+        $allowedResourceTypes = array(
+            'SQLAnywhere connection'
+            ,'SQLAnywhere persistent connection '  //note the blank! 
+        );
+
+        $resourceType = get_resource_type($conn);
+
+        if ( ! is_resource($conn) || !in_array($resourceType, $allowedResourceTypes, true)) {
             throw new SQLAnywhereException('Invalid SQL Anywhere connection resource: ' . $conn);
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/ConnectionTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
+
+use Doctrine\DBAL\DriverManager;
+
+class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+    protected function setUp()
+    {
+        if (!extension_loaded('sqlanywhere')) {
+            $this->markTestSkipped('sqlanywhere is not installed.');
+        }
+
+        parent::setUp();
+
+        if ( !($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLAnywhere\Driver)) {
+            $this->markTestSkipped('sqlanywhere only test.');
+        }
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    public function testNonPersistentConnection()
+    {
+        $params = $this->_conn->getParams();
+        $params['persistent'] = false;
+
+        $conn = DriverManager::getConnection($params);
+
+        $conn->connect();
+
+        $this->assertTrue($conn->isConnected(), 'No SQLAnywhere-nonpersistent connection established');
+    }
+
+    public function testPersistentConnection()
+    {
+        $params = $this->_conn->getParams();
+        $params['persistent'] = true;
+
+        $conn = DriverManager::getConnection($params);
+
+        $conn->connect();
+
+        $this->assertTrue($conn->isConnected(), 'No SQLAnywhere-persistent connection established');
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/ConnectionTest.php
@@ -1,28 +1,11 @@
 <?php
+
 namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
 
 use Doctrine\DBAL\DriverManager;
 
 class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
-    protected function setUp()
-    {
-        if (!extension_loaded('sqlanywhere')) {
-            $this->markTestSkipped('sqlanywhere is not installed.');
-        }
-
-        parent::setUp();
-
-        if ( !($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLAnywhere\Driver)) {
-            $this->markTestSkipped('sqlanywhere only test.');
-        }
-    }
-
-    protected function tearDown()
-    {
-        parent::tearDown();
-    }
-
     public function testNonPersistentConnection()
     {
         $params = $this->_conn->getParams();

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverMirrorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverMirrorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Driver\SQLAnywhere\Driver;
+use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+
+class DriverMirrorTest extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+    protected function setUp()
+    {
+        if (! extension_loaded('sqlanywhere')) {
+            $this->markTestSkipped('sqlanywhere is not installed.');
+        }
+
+        parent::setUp();
+
+        if (! $this->_conn->getDriver() instanceof Driver) {
+            $this->markTestSkipped('sqlanywhere only test.');
+        }
+    }
+
+    public function testConnectDatabaseNameWithoutHostParameter()
+    {
+        $params = $this->_conn->getParams();
+        unset($params['host']);
+        //servername must be set if no host specified
+        $params['server'] = $params['dbname'];
+
+        $conn = DriverManager::getConnection($params);
+
+        $conn->connect();
+
+        $this->assertTrue($conn->isConnected(), 'No SQLAnywhere connection established');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createDriver()
+    {
+        return new Driver();
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/StatementTest.php
@@ -1,28 +1,11 @@
 <?php
+
 namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
 
 use Doctrine\DBAL\DriverManager;
 
 class StatementTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {
-    protected function setUp()
-    {
-        if (!extension_loaded('sqlanywhere')) {
-            $this->markTestSkipped('sqlanywhere is not installed.');
-        }
-
-        parent::setUp();
-
-        if ( !($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLAnywhere\Driver)) {
-            $this->markTestSkipped('sqlanywhere only test.');
-        }
-    }
-
-    protected function tearDown()
-    {
-        parent::tearDown();
-    }
-
     public function testNonPersistentStatement()
     {
         $params = $this->_conn->getParams();

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/StatementTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
+
+use Doctrine\DBAL\DriverManager;
+
+class StatementTest extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+    protected function setUp()
+    {
+        if (!extension_loaded('sqlanywhere')) {
+            $this->markTestSkipped('sqlanywhere is not installed.');
+        }
+
+        parent::setUp();
+
+        if ( !($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\SQLAnywhere\Driver)) {
+            $this->markTestSkipped('sqlanywhere only test.');
+        }
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    public function testNonPersistentStatement()
+    {
+        $params = $this->_conn->getParams();
+        $params['persistent'] = false;
+
+        $conn = DriverManager::getConnection($params);
+
+        $conn->connect();
+
+        $this->assertTrue($conn->isConnected(),'No SQLAnywhere-Connection established');
+
+        $prepStmt = $conn->prepare('SELECT 1');
+        $this->assertTrue($prepStmt->execute(),' Statement non-persistent failed');
+    }
+
+    public function testPersistentStatement()
+    {
+        $params = $this->_conn->getParams();
+        $params['persistent'] = true;
+
+        $conn = DriverManager::getConnection($params);
+
+        $conn->connect();
+
+        $this->assertTrue($conn->isConnected(),'No SQLAnywhere-Connection established');
+
+        $prepStmt = $conn->prepare('SELECT 1');
+        $this->assertTrue($prepStmt->execute(),' Statement persistent failed');
+    }
+
+}


### PR DESCRIPTION
buildDsn has to recognize, that no host parameter is given. A tcpip-broadcast has to be made to find the right server/database.
Furthermore if I have a db-mirror-system, I have to get both hosts comma-separated as host parameter with or without ports (HOST=host1:1111,host2:2345)
