### PR TITLE
connect without host param or with 2 hosts

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -81,19 +81,37 @@ class Driver extends AbstractSQLAnywhereDriver
      */
     private function buildDsn($host, $port, $server, $dbname, $username = null, $password = null, array $driverOptions = array())
     {
-        $host = $host ?: 'localhost';
-        $port = $port ?: 2638;
+        $hostPart = "";
+        $serverPart = "";
+        $dbnamePart = "";
+        $linksPart = "";
 
-        if (! empty($server)) {
-            $server = ';ServerName=' . $server;
+        //if host is empty, "LINKS=tcpip()" has to be set and SQLAnywhere did broadcasts to find the right DB
+        //port-parameter is only used if host has no colon and has no comma (db-mirror configuration)
+        if (! empty($host)) {
+            $hostPart = 'HOST='.$host;
+            if (false === strpos($host,':') && false === strpos($host,',')) {
+                $hostPart .= isset($port)?':'.$port:':2638';
+            }
+        } else {
+            $linksPart = ';LINKS=tcpip()';
         }
 
-        return
-            'HOST=' . $host . ':' . $port .
-            $server .
-            ';DBN=' . $dbname .
+        if (! empty($server)) {
+            $serverPart = ';ServerName=' . $server;
+        }
+
+        if (! empty($dbname)) {
+            $dbnamePart = ';DBN=' . $dbname;
+        }
+
+        return 
+            $hostPart .
+            $serverPart .
+            $dbnamePart .
             ';UID=' . $username .
             ';PWD=' . $password .
+            $linksPart .
             ';' . implode(
                 ';',
                 array_map(function ($key, $value) {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -84,7 +84,7 @@ class Driver extends AbstractSQLAnywhereDriver
         $hostPart = "";
         $serverPart = "";
         $dbnamePart = "";
-        $linksPart = "";
+        $linksPart = ';LINKS=tcpip()';
 
         //if host is empty, "LINKS=tcpip()" has to be set and SQLAnywhere did broadcasts to find the right DB
         //port-parameter is only used if host has no colon and has no comma (db-mirror configuration)
@@ -93,8 +93,8 @@ class Driver extends AbstractSQLAnywhereDriver
             if (false === strpos($host,':') && false === strpos($host,',')) {
                 $hostPart .= isset($port)?':'.$port:':2638';
             }
-        } else {
-            $linksPart = ';LINKS=tcpip()';
+            //if host is specified, its not needed
+            $linksPart = "";
         }
 
         if (! empty($server)) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverMirrorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverMirrorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Driver\SQLAnywhere\Driver;
+use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+
+class DriverMirrorTest extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+    protected function setUp()
+    {
+        if (! extension_loaded('sqlanywhere')) {
+            $this->markTestSkipped('sqlanywhere is not installed.');
+        }
+
+        parent::setUp();
+
+        if (! $this->_conn->getDriver() instanceof Driver) {
+            $this->markTestSkipped('sqlanywhere only test.');
+        }
+    }
+
+    public function testConnectDatabaseNameWithoutHostParameter()
+    {
+        $params = $this->_conn->getParams();
+        unset($params['host']);
+        //servername must be set if no host specified
+        $params['server'] = $params['dbname'];
+
+        $conn = DriverManager::getConnection($params);
+
+        $conn->connect();
+
+        $this->assertTrue($conn->isConnected(), 'No SQLAnywhere connection established');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createDriver()
+    {
+        return new Driver();
+    }
+}


### PR DESCRIPTION
buildDsn has to recognize, that no host parameter is given. A tcpip-broadcast has to be made to find the right server/database.
Furthermore if I have a db-mirror-system, I have to get both hosts comma-separated as host parameter with or without ports (HOST=host1:1111,host2:2345)
