### PR TITLE
Use native JSON type on MySQL >=5.7

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
@@ -64,4 +64,29 @@ class MySQL57Platform extends MySqlPlatform
     {
         return 'Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initializeDoctrineTypeMappings()
+    {
+        parent::initializeDoctrineTypeMappings();
+        $this->doctrineTypeMapping['json'] = 'json_array';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasNativeJsonType()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJsonTypeDeclarationSQL(array $field)
+    {
+        return 'JSON';
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
@@ -57,8 +57,8 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
         return array(
             array('5.6.9', 'Doctrine\DBAL\Platforms\MySqlPlatform'),
             array('5.7', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
-            array('5.7.0', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
-            array('5.7.1', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
+            array('5.7.8', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
+            array('5.7.13', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
             array('6', 'Doctrine\DBAL\Platforms\MySQL57Platform'),
             array('10.0.15-MariaDB-1~wheezy', 'Doctrine\DBAL\Platforms\MySqlPlatform'),
             array('10.1.2a-MariaDB-a1~lenny-log', 'Doctrine\DBAL\Platforms\MySqlPlatform'),

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
@@ -65,4 +65,28 @@ class MySQL57PlatformTest extends AbstractMySQLPlatformTestCase
             'ALTER TABLE mytable RENAME INDEX idx_foo TO idx_foo_renamed',
         );
     }
+
+    /**
+     * @group DBAL-553
+     */
+    public function hasNativeJsonType()
+    {
+        $this->assertTrue($this->_platform->hasNativeJsonType());
+    }
+
+    /**
+     * @group DBAL-553
+     */
+    public function testReturnsJsonTypeDeclarationSQL()
+    {
+        $this->assertSame('JSON', $this->_platform->getJsonTypeDeclarationSQL(array()));
+    }
+    /**
+     * @group DBAL-553
+     */
+    public function testInitializesJsonTypeMapping()
+    {
+        $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('json'));
+        $this->assertEquals('json_array', $this->_platform->getDoctrineTypeMapping('json'));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
@@ -81,6 +81,7 @@ class MySQL57PlatformTest extends AbstractMySQLPlatformTestCase
     {
         $this->assertSame('JSON', $this->_platform->getJsonTypeDeclarationSQL(array()));
     }
+
     /**
      * @group DBAL-553
      */

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
@@ -87,6 +87,6 @@ class MySQL57PlatformTest extends AbstractMySQLPlatformTestCase
     public function testInitializesJsonTypeMapping()
     {
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('json'));
-        $this->assertEquals('json_array', $this->_platform->getDoctrineTypeMapping('json'));
+        $this->assertSame('json_array', $this->_platform->getDoctrineTypeMapping('json'));
     }
 }


### PR DESCRIPTION
This follows https://github.com/doctrine/dbal/pull/2266 , with changes merged into the MySQL57 platform as suggested by @guilhermeblanco and @beberlei.
