### PR TITLE
Mysql Unknown database type geometry requested

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -1018,6 +1018,7 @@ class MySqlPlatform extends AbstractPlatform
             'binary'        => 'binary',
             'varbinary'     => 'binary',
             'set'           => 'simple_array',
+            'geometry'      => 'geometry',
         );
     }
 

--- a/lib/Doctrine/DBAL/Types/GeometryType.php
+++ b/lib/Doctrine/DBAL/Types/GeometryType.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * Class for database column "geometry".
+ *
+ * @author Rauni Lillemets
+ */
+class GeometryType extends Type
+{
+
+    const GEOMETRY = 'geometry';
+    const SRID = 3301;
+
+
+    public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return 'geometry';
+    }
+
+
+    //Should create WKT object from WKT string. (or leave as WKT string)
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return $value;
+    }
+
+
+    //Should create WKT string from WKT object. (or leave as WKT string)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return $value;
+    }
+
+
+    public function getName()
+    {
+        return self::GEOMETRY;
+    }
+
+
+    public function canRequireSQLConversion()
+    {
+        return true;
+    }
+
+
+    //Should give WKT
+    public function convertToPHPValueSQL($sqlExpr, $platform)
+    {
+        return 'ST_AsText(\'' . $sqlExpr . '\') ';
+    }
+
+
+    //Should create WKB
+    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform)
+    {
+        return 'ST_GeomFromText(\'' . $sqlExpr . '\', ' . self::SRID . ')';
+    }
+}

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -54,6 +54,7 @@ abstract class Type
     const FLOAT = 'float';
     const GUID = 'guid';
     const DATEINTERVAL = 'dateinterval';
+    const GEOMETRY = 'geometry';
 
     /**
      * Map of already instantiated type objects. One instance per type (flyweight).
@@ -89,6 +90,7 @@ abstract class Type
         self::BLOB => 'Doctrine\DBAL\Types\BlobType',
         self::GUID => 'Doctrine\DBAL\Types\GuidType',
         self::DATEINTERVAL => 'Doctrine\DBAL\Types\DateIntervalType',
+        self::GEOMETRY => 'Doctrine\DBAL\Types\GeometryType',
     );
 
     /**


### PR DESCRIPTION
Hi, there :)
I'm using mysql and laravel framework, and want to use geometry type column.
But, when I try to migrate, I had an error below.

```
  [Doctrine\DBAL\DBALException]
  Unknown database type geometry requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it.
```

So, I wanted to add type of geometry type to Mysql platform.

And I tried to find people who is on a same kind of situation, and found PR below.
https://github.com/doctrine/dbal/pull/920

he was talking about postgreSQL, and mine is Mysql, but same issue.
I read a review, and it does't make sense, because...

on `lib/Doctrine/DBAL/Types/Type.php` , '$_typesMap' is just define supported doctrine mapping types

on review, it says

```
I'm sorry to disappoint you but this type isn't portable across different vendors and thus we cannot add it to the core. Please add a custom type in your application yourself for that purpose.
```

but each platform ( mysql, postgreSQL... etc) can determine which type they need to use by `initializeDoctrineTypeMappings` method.
To add type to `lib/Doctrine/DBAL/Types/Type.php` , '$_typesMap' does not affect to the all platform.

Thank you for your code review, and your support.
thank you. ;)
