### PR TITLE
Oracle fix binding null values to long/lob type columns

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -168,7 +168,10 @@ class OCI8Statement implements \IteratorAggregate, Statement
 
         $this->boundValues[$column] =& $variable;
 
-        return oci_bind_by_name($this->_sth, $column, $variable);
+        //fix issue ORA-24816: Expanded non LONG bind data supplied after actual LONG or LOB, see https://bugs.php.net/bug.php?id=72524
+        $l = strlen($variable);
+
+        return oci_bind_by_name($this->_sth, $column, $variable, $l === 0 ? 1 : $l);
     }
 
     /**


### PR DESCRIPTION
Php bug ref: https://bugs.php.net/bug.php?id=72524

According to _sixd_, to avoid this issue we should either reorder columns to put lobs at the end or always specify a length greater than 0 when using `oci_bind`.

This uses the second alternative because reordering insert columns would be a lot more work.

A test is available here: #2433 

ping @deeky666 
