### PR TITLE
Exclude spatial extension tables

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -386,7 +386,7 @@ class MySqlPlatform extends AbstractPlatform
         return "SELECT COLUMN_NAME AS Field, COLUMN_TYPE AS Type, IS_NULLABLE AS `Null`, ".
                "COLUMN_KEY AS `Key`, COLUMN_DEFAULT AS `Default`, EXTRA AS Extra, COLUMN_COMMENT AS Comment, " .
                "CHARACTER_SET_NAME AS CharacterSet, COLLATION_NAME AS Collation ".
-               "FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = " . $database . " AND TABLE_NAME = " . $table;
+               "FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = " . $database . " AND TABLE_NAME = " . $table . " AND DATA_TYPE != 'geometry'";
     }
 
     /**


### PR DESCRIPTION
Hi, there :)
I'm using mysql and laravel framework, and want to use geometry type column.
But, when I try to migrate, I had an error below.

```
  [Doctrine\DBAL\DBALException]
  Unknown database type geometry requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it.
```

I sent PR https://github.com/doctrine/dbal/pull/2459 , but it couldn't be accepted.
because `The GeometryType presented here can't work on non-mysql systems`.

so, now I think the problem is spatial extension tables does not work well.
Like postgresql platform system, I add the code to exclude spatial extension tables with mysql-systems.

Thank you for your review ;)
