### PR TITLE
[Postgre] Fix migrating column with type comment

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -568,7 +568,7 @@ class PostgreSqlPlatform extends AbstractPlatform
                 }
             }
 
-            if ($columnDiff->hasChanged('comment')) {
+            if ($columnDiff->hasChanged('type') || $columnDiff->hasChanged('comment')) {
                 $commentsSQL[] = $this->getCommentOnColumnSQL(
                     $diff->getName($this)->getQuotedName($this),
                     $column->getQuotedName($this),


### PR DESCRIPTION
I've changed datetime fields in my entities to use [UtcDateTimeType](https://gist.github.com/enumag/ba402aed1365479b96728b679a03328e) instead of the default DateTimeType. I didn't want to override the default datetime type completely to my implementation, but rather add it separately. Of course this new type has `requiresSQLCommentHint` set to true, otherwise it could not be distinguished from normal datetime type. Obviously the two types still have the same representation in the database and the comment is the only thing allowing to tell them apart.

The problem is that when I run SchemaTool it finds out that the type has changed but the generated ALTER TABLE sql is wrong:

```
-- This is the generated SQL.
ALTER TABLE email_log ALTER created_date TYPE TIMESTAMP(0) WITHOUT TIME ZONE;
ALTER TABLE email_log ALTER created_date DROP DEFAULT;
-- This line should be there as well but is missing.
COMMENT ON COLUMN email_log.created_date IS '(DC2Type:datetime_utc)';
```

The result is that when I run the migration (without the missing line) doctrine then generates the very same migration again and again - never adding the comment which is the only thing that would stop it.

This PR makes sure that comment is also updated when the doctrine type is changed.
