### PR TITLE
Fix problem with non-existing implicit indexes

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Index.php
+++ b/lib/Doctrine/DBAL/Schema/Index.php
@@ -202,7 +202,7 @@ class Index extends AbstractAsset implements Constraint
     {
         // allow the other index to be equally large only. It being larger is an option
         // but it creates a problem with scenarios of the kind PRIMARY KEY(foo,bar) UNIQUE(foo)
-        if (count($other->getColumns()) != count($this->getColumns())) {
+        if (count($other->getColumns()) < count($this->getColumns())) {
             return false;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -407,7 +407,6 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $diff->removedIndexes['index1'] = $table->getIndex('index1');
 
         $sql = array(
-            'DROP INDEX IDX_8D93D64923A0E66',
             'DROP INDEX IDX_8D93D6495A8A6C8D',
             'DROP INDEX IDX_8D93D6493D8E604F',
             'DROP INDEX index1',
@@ -422,7 +421,6 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'INSERT INTO user ("key", article, comment) SELECT id, article, post FROM __temp__user',
             'DROP TABLE __temp__user',
             'ALTER TABLE user RENAME TO client',
-            'CREATE INDEX IDX_8D93D64923A0E66 ON client (article)',
             'CREATE INDEX IDX_8D93D6495A8A6C8D ON client (comment)',
         );
 

--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -409,7 +409,7 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
 
         $table->addForeignKeyConstraint($foreignTable, array('bar', 'baz'), array('foo', 'baz'));
 
-        $this->assertCount(3, $table->getIndexes());
+        $this->assertCount(2, $table->getIndexes());
         $this->assertTrue($table->hasIndex('composite_idx'));
         $this->assertTrue($table->hasIndex('full_idx'));
         $this->assertTrue($table->hasIndex('idx_8c73652176ff8caa78240498'));

--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -401,7 +401,7 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         $table->addColumn('baz', 'string');
         $table->addColumn('bloo', 'string');
         $table->addIndex(array('baz', 'bar'), 'composite_idx');
-        $table->addIndex(array('bar', 'baz', 'bloo'), 'full_idx');
+        $table->addIndex(array('bloo', 'bar', 'baz'), 'full_idx');
 
         $foreignTable = new Table('bar');
         $foreignTable->addColumn('foo', 'integer');
@@ -409,12 +409,12 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
 
         $table->addForeignKeyConstraint($foreignTable, array('bar', 'baz'), array('foo', 'baz'));
 
-        $this->assertCount(2, $table->getIndexes());
+        $this->assertCount(3, $table->getIndexes());
         $this->assertTrue($table->hasIndex('composite_idx'));
         $this->assertTrue($table->hasIndex('full_idx'));
         $this->assertTrue($table->hasIndex('idx_8c73652176ff8caa78240498'));
         $this->assertSame(array('baz', 'bar'), $table->getIndex('composite_idx')->getColumns());
-        $this->assertSame(array('bar', 'baz', 'bloo'), $table->getIndex('full_idx')->getColumns());
+        $this->assertSame(array('bloo', 'bar', 'baz'), $table->getIndex('full_idx')->getColumns());
         $this->assertSame(array('bar', 'baz'), $table->getIndex('idx_8c73652176ff8caa78240498')->getColumns());
     }
 


### PR DESCRIPTION
On tables which contains a foreign key constraint with no explicit index, _addForeignKeyConstraint() in \Doctrine\DBAL\Schema\Table creates an implicit index. If that schema is used to create a SchemaDiff object, the diff creates a SQL statement to drop that implicit index that doesn't exist in the database, so DROP INDEX fails.

https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Schema/Table.php#L546
