### PR TITLE
Let the user provide a previous exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.4.6",
+        "phpunit/phpunit-mock-objects": "!=3.2.4",
         "symfony/console": "2.*"
     },
     "suggest": {

--- a/lib/Doctrine/DBAL/Types/ConversionException.php
+++ b/lib/Doctrine/DBAL/Types/ConversionException.php
@@ -36,14 +36,19 @@ class ConversionException extends \Doctrine\DBAL\DBALException
      *
      * @param string $value
      * @param string $toType
+     * @param \Exception|null $previous
      *
      * @return \Doctrine\DBAL\Types\ConversionException
      */
-    static public function conversionFailed($value, $toType)
+    static public function conversionFailed($value, $toType, \Exception $previous = null)
     {
         $value = (strlen($value) > 32) ? substr($value, 0, 20) . '...' : $value;
 
-        return new self('Could not convert database value "' . $value . '" to Doctrine Type ' . $toType);
+        return new self(
+            'Could not convert database value "' . $value . '" to Doctrine Type ' . $toType,
+            0,
+            $previous
+        );
     }
 
     /**
@@ -75,10 +80,11 @@ class ConversionException extends \Doctrine\DBAL\DBALException
      * @param mixed    $value
      * @param string   $toType
      * @param string[] $possibleTypes
+     * @param \Exception|null $previous
      *
      * @return \Doctrine\DBAL\Types\ConversionException
      */
-    static public function conversionFailedInvalidType($value, $toType, array $possibleTypes)
+    static public function conversionFailedInvalidType($value, $toType, array $possibleTypes, \Exception $previous = null)
     {
         $actualType = is_object($value) ? get_class($value) : gettype($value);
 
@@ -89,7 +95,7 @@ class ConversionException extends \Doctrine\DBAL\DBALException
                 $actualType,
                 $toType,
                 implode(', ', $possibleTypes)
-            ));
+            ), 0, $previous);
         }
 
         return new self(sprintf(
@@ -97,7 +103,7 @@ class ConversionException extends \Doctrine\DBAL\DBALException
             $actualType,
             $toType,
             implode(', ', $possibleTypes)
-        ));
+        ), 0, $previous);
     }
 
     static public function conversionFailedSerialization($value, $format, $error, \Exception $previous = null)
@@ -109,6 +115,6 @@ class ConversionException extends \Doctrine\DBAL\DBALException
             $actualType,
             $format,
             $error
-        ));
+        ), 0, $previous);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Types/ConversionExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ConversionExceptionTest.php
@@ -40,12 +40,59 @@ class ConversionExceptionTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testConversionFailedFormatPreservesPreviousException()
+    public function exceptionWithPreviousProvider()
     {
         $previous = new \Exception();
+        return [
+            'conversion failed' => [$previous, ConversionException::conversionFailed(
+                'foo',
+                'bar',
+                $previous
+            )],
+            'conversion failed format' => [
+                $previous,
+                ConversionException::conversionFailedFormat(
+                    'foo',
+                    'bar',
+                    'baz',
+                    $previous
+                )
+            ],
+            'conversion failed invalid type' => [
+                $previous,
+                ConversionException::conversionFailedInvalidType(
+                    'foo',
+                    'bar',
+                    ['baz'],
+                    $previous
+                )
+            ],
+            'conversion failed invalid type non scalar' => [
+                $previous,
+                ConversionException::conversionFailedInvalidType(
+                    ['foo'],
+                    'bar',
+                    ['baz'],
+                    $previous
+                )
+            ],
+            'conversion failed serialization' => [
+                $previous,
+                ConversionException::conversionFailedSerialization(
+                    ['foo'],
+                    'bar',
+                    'Chair to keyboard interface error',
+                    $previous
+                )
+            ],
+        ];
+    }
 
-        $exception = ConversionException::conversionFailedFormat('foo', 'bar', 'baz', $previous);
-
+    /**
+     * @dataProvider exceptionWithPreviousProvider
+     */
+    public function testPreviousExceptionIsAlwaysPreserved(\Exception $previous, ConversionException $exception)
+    {
         $this->assertInstanceOf('Doctrine\DBAL\Types\ConversionException', $exception);
         $this->assertSame($previous, $exception->getPrevious());
     }


### PR DESCRIPTION
Previous exceptions might be very helpful when troubleshooting a
problem. Let's have a way to provide them.
