### PR TITLE
Avoid latest version of phpunit mock object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.4.6",
+        "phpunit/phpunit-mock-objects": "<3.2.4",
         "symfony/console": "2.*"
     },
     "suggest": {


### PR DESCRIPTION
That way, people can still work on their PR until the build is fixed.

Workaround for #2475 (not a proper fix)
