### PR TITLE
Mock classes that do exist

### DIFF
--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -102,7 +102,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
 
     public function testConnectDispatchEvent()
     {
-        $listenerMock = $this->getMockBuilder('ConnectDispatchEventListener')
+        $listenerMock = $this->getMockBuilder('stdClass')
             ->setMethods(array('postConnect'))
             ->getMock();
         $listenerMock->expects($this->once())->method('postConnect');

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -284,7 +284,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->_sm->dropAndCreateTable($table);
 
         $listenerMock = $this
-            ->getMockBuilder('ListTableColumnsDispatchEventListener')
+            ->getMockBuilder('stdClass')
             ->setMethods(['onSchemaColumnDefinition'])
             ->getMock();
         $listenerMock
@@ -312,7 +312,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->_sm->dropAndCreateTable($table);
 
         $listenerMock = $this
-            ->getMockBuilder('ListTableIndexesDispatchEventListener')
+            ->getMockBuilder('stdClass')
             ->setMethods(['onSchemaIndexDefinition'])
             ->getMock();
         $listenerMock

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -318,7 +318,7 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 
     public function testGetCreateTableSqlDispatchEvent()
     {
-        $listenerMock = $this->getMockBuilder('GetCreateTableSqlDispatchEvenListener')
+        $listenerMock = $this->getMockBuilder('stdClass')
             ->setMethods(array('onSchemaCreateTable', 'onSchemaCreateTableColumn'))
             ->getMock();
         $listenerMock
@@ -342,7 +342,7 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 
     public function testGetDropTableSqlDispatchEvent()
     {
-        $listenerMock = $this->getMockBuilder('GetDropTableSqlDispatchEventListener')
+        $listenerMock = $this->getMockBuilder('stdClass')
             ->setMethods(array('onSchemaDropTable'))
             ->getMock();
         $listenerMock
@@ -367,7 +367,7 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
             'onSchemaAlterTableRenameColumn'
         );
 
-        $listenerMock = $this->getMockBuilder('GetAlterTableSqlDispatchEvenListener')
+        $listenerMock = $this->getMockBuilder('stdClass')
             ->setMethods($events)
             ->getMock();
         $listenerMock


### PR DESCRIPTION
Phpunit seems to be unable to build a mock from a class that does not
exist.
