### PR TITLE
Exclude buggy phpunit-mock-objects v3.2.4 from the allowed dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.4.6",
+        "phpunit/phpunit-mock-objects": "!=3.2.4",
         "symfony/console": "2.*"
     },
     "suggest": {


### PR DESCRIPTION
It has a bug that makes it incompatible with the doctrine dbal test
suite, see
https://github.com/sebastianbergmann/phpunit-mock-objects/issues/322
Fixes #2475
