### PR TITLE
Sqlite support both integer and field reference intervals in date functions

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1034,8 +1034,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given seconds to a date.
      *
-     * @param string  $date
-     * @param integer $seconds
+     * @param string         $date
+     * @param integer|string $seconds
      *
      * @return string
      *
@@ -1049,8 +1049,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given seconds from a date.
      *
-     * @param string  $date
-     * @param integer $seconds
+     * @param string         $date
+     * @param integer|string $seconds
      *
      * @return string
      *
@@ -1064,8 +1064,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given minutes to a date.
      *
-     * @param string  $date
-     * @param integer $minutes
+     * @param string         $date
+     * @param integer|string $minutes
      *
      * @return string
      *
@@ -1079,8 +1079,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given minutes from a date.
      *
-     * @param string  $date
-     * @param integer $minutes
+     * @param string         $date
+     * @param integer|string $minutes
      *
      * @return string
      *
@@ -1094,8 +1094,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given hours to a date.
      *
-     * @param string  $date
-     * @param integer $hours
+     * @param string         $date
+     * @param integer|string $hours
      *
      * @return string
      *
@@ -1109,8 +1109,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given hours to a date.
      *
-     * @param string  $date
-     * @param integer $hours
+     * @param string         $date
+     * @param integer|string $hours
      *
      * @return string
      *
@@ -1124,8 +1124,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given days to a date.
      *
-     * @param string  $date
-     * @param integer $days
+     * @param string         date
+     * @param integer|string $days
      *
      * @return string
      *
@@ -1139,8 +1139,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given days to a date.
      *
-     * @param string  $date
-     * @param integer $days
+     * @param string         $date
+     * @param integer|string $days
      *
      * @return string
      *
@@ -1154,8 +1154,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given weeks to a date.
      *
-     * @param string  $date
-     * @param integer $weeks
+     * @param string         $date
+     * @param integer|string $weeks
      *
      * @return string
      *
@@ -1169,8 +1169,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given weeks from a date.
      *
-     * @param string  $date
-     * @param integer $weeks
+     * @param string         $date
+     * @param integer|string $weeks
      *
      * @return string
      *
@@ -1184,8 +1184,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given months to a date.
      *
-     * @param string  $date
-     * @param integer $months
+     * @param string         $date
+     * @param integer|string $months
      *
      * @return string
      *
@@ -1199,8 +1199,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given months to a date.
      *
-     * @param string  $date
-     * @param integer $months
+     * @param string         $date
+     * @param integer|string $months
      *
      * @return string
      *
@@ -1214,8 +1214,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given quarters to a date.
      *
-     * @param string  $date
-     * @param integer $quarters
+     * @param string         $date
+     * @param integer|string $quarters
      *
      * @return string
      *
@@ -1229,8 +1229,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given quarters from a date.
      *
-     * @param string  $date
-     * @param integer $quarters
+     * @param string         $date
+     * @param integer|string $quarters
      *
      * @return string
      *
@@ -1244,8 +1244,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given years to a date.
      *
-     * @param string  $date
-     * @param integer $years
+     * @param string         $date
+     * @param integer|string $years
      *
      * @return string
      *
@@ -1259,8 +1259,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given years from a date.
      *
-     * @param string  $date
-     * @param integer $years
+     * @param string         $date
+     * @param integer|string $years
      *
      * @return string
      *
@@ -1274,11 +1274,11 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL for a date arithmetic expression.
      *
-     * @param string  $date     The column or literal representing a date to perform the arithmetic operation on.
-     * @param string  $operator The arithmetic operator (+ or -).
-     * @param integer $interval The interval that shall be calculated into the date.
-     * @param string  $unit     The unit of the interval that shall be calculated into the date.
-     *                          One of the DATE_INTERVAL_UNIT_* constants.
+     * @param string         $date     The column or literal representing a date to perform the arithmetic operation on.
+     * @param string         $operator The arithmetic operator (+ or -).
+     * @param integer|string $interval The interval that shall be calculated into the date.
+     * @param string         $unit     The unit of the interval that shall be calculated into the date.
+     *                                 One of the DATE_INTERVAL_UNIT_* constants.
      *
      * @return string
      *

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -744,4 +744,19 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     {
         $this->assertContains("'Foo''Bar\\'", $this->_platform->getListTableForeignKeysSQL("Foo'Bar\\"), '', true);
     }
+
+    public function testSupportsIntAndStringInDateArithmeticExpressions()
+    {
+        // Test Integer
+        $sql = $this->_platform->getDateAddMinutesExpression("CURRENT_TIMESTAMP()", 4);
+        $this->assertEquals('DATETIME(CURRENT_TIMESTAMP(),"+4 MINUTE")', $sql);
+
+        // Test string
+        $sql = $this->_platform->getDateAddMinutesExpression("CURRENT_TIMESTAMP()", "foo.bar");
+        $this->assertEquals('DATETIME(CURRENT_TIMESTAMP(),"+" || foo.bar || " MINUTE")', $sql);
+
+        // Test unexpected type
+        $this->expectException(DBALException::class);
+        $this->_platform->getDateAddMinutesExpression("CURRENT_TIMESTAMP()", array("unsupported" => "type"));
+    }
 }


### PR DESCRIPTION
I stumbled upon a problem that my query worked in MySQL but not SQLite. As it turns out, when using SQLite it is not possible to perform date arithmetic on field references, only on actual integers.

This works

```
$qb = $this->repo->createQueryBuilder('foo');
$qb->join("foo.bar", "bar")
       ->where("CURRENT_TIMESTAMP() BETWEEN
                            DATE_SUB(foo.time, 1, 'hour')
                     AND
                            DATE_SUB(foo.time, 2, 'hour')
                     ");
```

generating (roughly)

> SELECT foo.time
> INNER JOIN bar ON foo.bar_id = bar.id
> WHERE CURRENT_TIMESTAMP() BETWEEN
>    DATETIME(foo.time,"-1 HOUR") 
> AND 
>    DATETIME(p0_.time,"-2 HOUR");

This does not

```
$qb = $this->repo->createQueryBuilder('foo');
$qb->join("foo.bar", "bar")
       ->where("CURRENT_TIMESTAMP() BETWEEN
                            DATE_SUB(foo.time, bar.start, 'hour')
                     AND
                            DATE_SUB(foo.time, bar.end, 'hour')
                     ");
```

Because this will get generated

> SELECT foo.time
> INNER JOIN bar ON foo.bar_id = bar.id
> WHERE CURRENT_TIMESTAMP() BETWEEN
>    DATETIME(foo.time,"-bar.start HOUR") 
> AND 
>    DATETIME(p0_.time,"-bar.end HOUR");

My fix adds support to reference other fields in the query, so that the first code example works the same way, but the second one uses SQLite concat symbol and generates the following:

> SELECT foo.time
> INNER JOIN bar ON foo.bar_id = bar.id
> WHERE CURRENT_TIMESTAMP() BETWEEN
>    DATETIME(foo.time,"-" || bar.start || " HOUR") 
> AND 
>    DATETIME(p0_.time,"-" || bar.end || " HOUR");

I've got only two concerns regarding this:
- Currently functional tests do not check for this case at all, but I added an SQLite platform test. Is this enough?
- I had to modify PHPDocs in AbstractPlatform to reflect that some methods now accept string or integer as $interval for date arithmetics. I know for sure this is the case for MySQL and, given this fix, SQLite, but other platforms may not support it. This brings inconsistency in what different platforms support
