### PR TITLE
Allow usage of symfony/console ^3.0 in dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",
-        "symfony/console": "2.*"
+        "symfony/console": "2.*||^3.0"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."


### PR DESCRIPTION
Some packages are using symfony/console 3.0 and newer as requirement, and doctrine/dbal works well with this contstrain.
