### PR TITLE
Store results of subsequents statement executions same as of the first one

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -191,6 +191,9 @@ class MysqliStatement implements \IteratorAggregate, Statement
             } else {
                 $this->_columnNames = false;
             }
+        } elseif ($this->_columnNames !== false) {
+            // store the result of a subsequent SELECT, SHOW, etc. statement execution
+            $this->_stmt->store_result();
         }
 
         return true;


### PR DESCRIPTION
`MysqliStatement` stores results (`$stmt->store_result()`) of only the first statement execution. In case if the statement is stored for further reuse in the application, but some of the statement callers didn't fetch all records from the statement, it's impossible to prepare another new one. Besides that, the results of all consequent statement executions become non-buffered.

``` php
$conn = \Doctrine\DBAL\DriverManager::getConnection(array(
    'driver' => 'mysqli',
    'host' => 'localhost',
    'user' => 'user',
    'password' => 'passw0rd',
    'dbname' => 'test',
));

$stmt1 = $conn->prepare('SELECT * FROM accounts');
$stmt1->execute();
$stmt2 = $conn->prepare('SELECT * FROM contacts');
$stmt1->execute();
// things going fine so far, since $stmt1 was executed only once
unset($stmt1, $stmt2);

$stmt1 = $conn->prepare('SELECT * FROM accounts');
$stmt1->execute();
$stmt1->execute(); // ← this is the difference
$stmt2 = $conn->prepare('SELECT * FROM contacts');
// MysqliException: Commands out of sync; you can't run this command now
```
