### PR TITLE
Store results of subsequents statement executions same as of the first one

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -191,6 +191,9 @@ class MysqliStatement implements \IteratorAggregate, Statement
             } else {
                 $this->_columnNames = false;
             }
+        } elseif ($this->_columnNames !== false) {
+            // store the result of a subsequent SELECT, SHOW, etc. statement execution
+            $this->_stmt->store_result();
         }
 
         return true;

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/StatementTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\Mysqli;
+
+use Doctrine\DBAL\Schema\Table;
+
+class StatementTest extends \Doctrine\Tests\DbalFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (!extension_loaded('mysqli')) {
+            $this->markTestSkipped('mysqli is not installed.');
+        }
+
+        parent::setUp();
+
+        if (!($this->_conn->getDriver() instanceof \Doctrine\DBAL\Driver\Mysqli\Driver)) {
+            $this->markTestSkipped('MySQLi only test.');
+        }
+    }
+
+    public function testSubsequentStatementResultIsBuffered()
+    {
+        $table = new Table('stmt_table');
+        $table->addColumn('id', 'integer');
+        $this->_conn->getSchemaManager()->createTable($table);
+        $this->_conn->insert('stmt_table', array('id' => 1));
+        $this->_conn->insert('stmt_table', array('id' => 2));
+
+        $stmt1 = $this->_conn->prepare('SELECT id FROM stmt_table');
+        $stmt1->execute();
+        $stmt1->fetch();
+        $stmt1->execute();
+        // fetching only one record out of two from a non-buffered result
+        $stmt1->fetch();
+        $stmt2 = $this->_conn->prepare('SELECT id FROM stmt_table WHERE id = ?');
+        $stmt2->execute(array(1));
+        $this->assertEquals(1, $stmt2->fetchColumn());
+    }
+}


### PR DESCRIPTION
`MysqliStatement` stores results (`$stmt->store_result()`) of only the first statement execution. In case if the statement is stored for further reuse in the application, but some of the statement callers didn't fetch all records from the statement, it's impossible to prepare another new one. Besides that, the results of all consequent statement executions become non-buffered.

``` php
$conn = \Doctrine\DBAL\DriverManager::getConnection(array(
    'driver' => 'mysqli',
    'host' => 'localhost',
    'user' => 'user',
    'password' => 'passw0rd',
    'dbname' => 'test',
));

$stmt1 = $conn->prepare('SELECT * FROM accounts');
$stmt1->execute();
$stmt2 = $conn->prepare('SELECT * FROM contacts');
$stmt1->execute();
// things going fine so far, since $stmt1 was executed only once
unset($stmt1, $stmt2);

$stmt1 = $conn->prepare('SELECT * FROM accounts');
$stmt1->execute();
$stmt1->execute(); // ← this is the difference
$stmt2 = $conn->prepare('SELECT * FROM contacts');
// MysqliException: Commands out of sync; you can't run this command now
```
