### PR TITLE
Blacklist buggy phpunit-mock-objects v3.2.5 from the dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.4.6",
-        "phpunit/phpunit-mock-objects": "!=3.2.4",
+        "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
         "symfony/console": "2.*||^3.0"
     },
     "suggest": {


### PR DESCRIPTION
The last release is still buggy, as proven here:
https://travis-ci.org/doctrine/dbal/builds/155125956
and as confirmed here:
https://github.com/sebastianbergmann/phpunit-mock-objects/pull/324
