### PR TITLE
Adds default namespace to schema.

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Visitor/AddDefaultNamespace.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/AddDefaultNamespace.php
@@ -25,21 +25,31 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 /**
  * Adds default namespace to schema
  *
- * Some databases supports namespaces and has default one. For example Postgres has default "public".
+ * Some databases supports namespaces and has default one.
+ * For example Postgres has default "public".
  *
- * When schema created from classes, which has table names without namespaces, but this namespace is assumed,
- * we should add it explicitly, if it not exists yet.
+ * When schema created from classes, which has table names without namespaces,
+ * but this namespace is assumed, we should add it explicitly, if it not exists
+ * yet.
  *
  * It will help in diffs between real DB and config shemas.
  *
+ * The visitor is skipping platforms that don't support schemas.
+ *
  * @author Alexander Ustimenko <a@ustimen.co>
- * @since  2.5
+ * @since  2.6
  */
 class AddDefaultNamespace extends AbstractVisitor
 {
 
+    /**
+     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
+     */
     private $platform;
 
+    /**
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     */
     public function __construct(AbstractPlatform $platform)
     {
         $this->platform = $platform;

--- a/lib/Doctrine/DBAL/Schema/Visitor/AddDefaultNamespace.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/AddDefaultNamespace.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Schema\Visitor;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * Adds default namespace to schema
+ *
+ * Some databases supports namespaces and has default one. For example Postgres has default "public".
+ *
+ * When schema created from classes, which has table names without namespaces, but this namespace is assumed,
+ * we should add it explicitly, if it not exists yet.
+ *
+ * It will help in diffs between real DB and config shemas.
+ *
+ * @author Alexander Ustimenko <a@ustimen.co>
+ * @since  2.5
+ */
+class AddDefaultNamespace extends AbstractVisitor
+{
+
+    private $platform;
+
+    public function __construct(AbstractPlatform $platform)
+    {
+        $this->platform = $platform;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function acceptSchema(Schema $schema)
+    {
+        $namespaceName = $this->platform->getDefaultSchemaName();
+        if (!$schema->hasNamespace($namespaceName)) {
+            $schema->createNamespace($namespaceName);
+        }
+    }
+}

--- a/lib/Doctrine/DBAL/Schema/Visitor/AddDefaultNamespace.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/AddDefaultNamespace.php
@@ -41,7 +41,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class AddDefaultNamespace extends AbstractVisitor
 {
-
     /**
      * @var \Doctrine\DBAL\Platforms\AbstractPlatform
      */

--- a/lib/Doctrine/DBAL/Schema/Visitor/AddDefaultNamespace.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/AddDefaultNamespace.php
@@ -60,6 +60,9 @@ class AddDefaultNamespace extends AbstractVisitor
      */
     public function acceptSchema(Schema $schema)
     {
+        if (!$this->platform->supportsSchemas()) {
+            return;
+        }
         $namespaceName = $this->platform->getDefaultSchemaName();
         if (!$schema->hasNamespace($namespaceName)) {
             $schema->createNamespace($namespaceName);

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/AddDefaultNamespaceTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/AddDefaultNamespaceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Schema\Visitor;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaConfig;
+use Doctrine\DBAL\Schema\Visitor\AddDefaultNamespace;
+
+/**
+ * @group DBAL-1168
+ */
+class AddDefaultNamespaceTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider namespacedPlatforms
+     */
+    public function testNoNamespacesAndDefaultNamespaceAdded(AbstractPlatform $platform)
+    {
+        $config = new SchemaConfig();
+        $config->setName('test');
+        $schema = new Schema(array(), array(), $config);
+        $schema->createTable('foo');
+
+        $this->assertEmpty($schema->getNamespaces());
+
+        $schema->visit(new AddDefaultNamespace($platform));
+
+        $this->assertNotEmpty($schema->getNamespaces());
+        $this->assertCount(1, $schema->getNamespaces());
+    }
+
+    /**
+     * @dataProvider namespacedPlatforms
+     */
+    public function testCustomNamespaceAndDefaultNamespaceAdded(AbstractPlatform $platform)
+    {
+        $config = new SchemaConfig();
+        $config->setName('test');
+        $schema = new Schema(array(), array(), $config);
+        $schema->createTable('foo');
+        $schema->createTable('bar.baz');
+
+        $this->assertNotEmpty($schema->getNamespaces());
+        $this->assertCount(1, $schema->getNamespaces());
+
+        $schema->visit(new AddDefaultNamespace($platform));
+
+        $this->assertNotEmpty($schema->getNamespaces());
+        $this->assertCount(2, $schema->getNamespaces());
+    }
+
+    /**
+     * @dataProvider namespacedPlatforms
+     */
+    public function testExplicitDefaultNamespaceAndDefaultNamespaceNotAdded(AbstractPlatform $platform)
+    {
+        $config = new SchemaConfig();
+        $config->setName('test');
+        $schema = new Schema(array(), array(), $config);
+        $schema->createTable('foo');
+        $schema->createTable($platform->getDefaultSchemaName().'.baz');
+
+        $this->assertNotEmpty($schema->getNamespaces());
+        $this->assertCount(1, $schema->getNamespaces());
+
+        $schema->visit(new AddDefaultNamespace($platform));
+
+        $this->assertNotEmpty($schema->getNamespaces());
+        $this->assertCount(1, $schema->getNamespaces());
+    }
+
+    public function namespacedPlatforms()
+    {
+        return [
+            [new PostgreSqlPlatform()],
+            [new SQLServerPlatform()],
+        ];
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/AddDefaultNamespaceTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/AddDefaultNamespaceTest.php
@@ -21,7 +21,7 @@ class AddDefaultNamespaceTest extends \PHPUnit_Framework_TestCase
     {
         $config = new SchemaConfig();
         $config->setName('test');
-        $schema = new Schema(array(), array(), $config);
+        $schema = new Schema([], [], $config);
         $schema->createTable('foo');
 
         $this->assertEmpty($schema->getNamespaces());
@@ -39,7 +39,7 @@ class AddDefaultNamespaceTest extends \PHPUnit_Framework_TestCase
     {
         $config = new SchemaConfig();
         $config->setName('test');
-        $schema = new Schema(array(), array(), $config);
+        $schema = new Schema([], [], $config);
         $schema->createTable('foo');
         $schema->createTable('bar.baz');
 
@@ -59,7 +59,7 @@ class AddDefaultNamespaceTest extends \PHPUnit_Framework_TestCase
     {
         $config = new SchemaConfig();
         $config->setName('test');
-        $schema = new Schema(array(), array(), $config);
+        $schema = new Schema([], [], $config);
         $schema->createTable('foo');
         $schema->createTable($platform->getDefaultSchemaName().'.baz');
 
@@ -72,11 +72,37 @@ class AddDefaultNamespaceTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $schema->getNamespaces());
     }
 
+    /**
+     * @dataProvider notNamespacedPlatforms
+     */
+    public function testIncompatiblePlatformsUnaffected(AbstractPlatform $platform)
+    {
+        $config = new SchemaConfig();
+        $config->setName('test');
+        $schema = new Schema([], [], $config);
+        $schema->createTable('foo');
+
+        $this->assertEmpty($schema->getNamespaces());
+
+        $schema->visit(new AddDefaultNamespace($platform));
+
+        $this->assertEmpty($schema->getNamespaces());
+    }
+
     public function namespacedPlatforms()
     {
         return [
             [new PostgreSqlPlatform()],
             [new SQLServerPlatform()],
+        ];
+    }
+
+    public function notNamespacedPlatforms()
+    {
+        return [
+            [new MySqlPlatform()],
+            [new OraclePlatform()],
+            [new SqlitePlatform()],
         ];
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/AddDefaultNamespaceTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/AddDefaultNamespaceTest.php
@@ -3,7 +3,10 @@
 namespace Doctrine\Tests\DBAL\Schema\Visitor;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/AddDefaultNamespaceTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/AddDefaultNamespaceTest.php
@@ -64,7 +64,7 @@ class AddDefaultNamespaceTest extends \PHPUnit_Framework_TestCase
         $config->setName('test');
         $schema = new Schema([], [], $config);
         $schema->createTable('foo');
-        $schema->createTable($platform->getDefaultSchemaName().'.baz');
+        $schema->createTable($platform->getDefaultSchemaName() . '.baz');
 
         $this->assertNotEmpty($schema->getNamespaces());
         $this->assertCount(1, $schema->getNamespaces());


### PR DESCRIPTION
Adds default namespace to schema

Some databases supports namespaces and has default one. For example Postgres has default "public".

When schema created from classes, which has table names without namespaces, but this namespace is assumed, we should add it explicitly, if it not exists yet.

It will help in diffs between real DB and config shemas.

The visitor is skipping platforms that don't support schemas.

This is 1st part of fix DBAL-1168 #1110
