### PR TITLE
Use the same statement resource for repeated execution of the same statement on SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -197,8 +197,17 @@ class SQLSrvStatement implements IteratorAggregate, Statement
             }
         }
 
-        $this->stmt = sqlsrv_query($this->conn, $this->sql, $this->params);
         if ( ! $this->stmt) {
+            $stmt = sqlsrv_prepare($this->conn, $this->sql, $this->params);
+
+            if (!$stmt) {
+                throw SQLSrvException::fromSqlSrvErrors();
+            }
+
+            $this->stmt = $stmt;
+        }
+
+        if (!sqlsrv_execute($this->stmt)) {
             throw SQLSrvException::fromSqlSrvErrors();
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/StatementTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\SQLSrv;
+
+use Doctrine\DBAL\Driver\SQLSrv\Driver;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+class StatementTest extends DbalFunctionalTestCase
+{
+    protected function setUp()
+    {
+        if (!extension_loaded('sqlsrv')) {
+            $this->markTestSkipped('sqlsrv is not installed.');
+        }
+
+        parent::setUp();
+
+        if (!$this->_conn->getDriver() instanceof Driver) {
+            $this->markTestSkipped('sqlsrv only test');
+        }
+    }
+
+    public function testFailureToPrepareResultsInException()
+    {
+        // use the driver connection directly to avoid having exception wrapped
+        $stmt = $this->_conn->getWrappedConnection()->prepare(null);
+
+        // it's impossible to prepare the statement without bound variables for SQL Server,
+        // so the preparation happens before the first execution when variables are already in place
+        $this->setExpectedException('Doctrine\\DBAL\\Driver\\SQLSrv\\SQLSrvException');
+        $stmt->execute();
+    }
+}


### PR DESCRIPTION
Fixes #2493.
