### PR TITLE
Optimize and improve parameter conversion in OCI8Statement

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -151,10 +151,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
             ));
         }
 
-        if ($fragmentOffset < strlen($statement)) {
-            $fragments[] = substr($statement, $fragmentOffset);
-        }
-
+        $fragments[] = substr($statement, $fragmentOffset);
         $statement = implode('', $fragments);
 
         return array($statement, $paramMap);

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -218,7 +218,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
         $token = self::findToken(
             $statement,
             $tokenOffset,
-            '/(?<!\\\\)' . preg_quote($currentLiteralDelimiter, '/') . '/'
+            '/' . preg_quote($currentLiteralDelimiter, '/') . '/'
         );
 
         if (!$token) {

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -118,6 +118,13 @@ class OCI8StatementTest extends DbalTestCase
                 "SELECT id FROM table WHERE col = :param1",
                 1,
             ),
+            'multi-line-literal' => array(
+                "SELECT id FROM table WHERE col1 = ? AND col2 = 'Hello,
+World!' AND col3 = ?",
+                "SELECT id FROM table WHERE col1 = :param1 AND col2 = 'Hello,
+World!' AND col3 = :param2",
+                2,
+            ),
         );
     }
 

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -113,24 +113,18 @@ class OCI8StatementTest extends DbalTestCase
                 "INSERT INTO table (col1, col2, col3, col4) VALUES('?\"?\'?', :param1, \"?'?\\\"?\", :param2)",
                 2,
             ),
-        );
-    }
-
-    /**
-     * @dataProvider convertFailureProvider
-     */
-    public function testConvertFailure($statement)
-    {
-        $this->expectException(OCI8Exception::class);
-        OCI8Statement::convertPositionalToNamedPlaceholders($statement);
-    }
-
-    public static function convertFailureProvider()
-    {
-        return array(
-            'non-terminated-literal' => array(
-                'SELECT "literal',
+            'placeholder-at-the-end' => array(
+                "SELECT id FROM table WHERE col = ?",
+                "SELECT id FROM table WHERE col = :param1",
+                1,
             ),
         );
+    }
+
+    public function testConvertNonTerminatedLiteral()
+    {
+        $this->expectException(OCI8Exception::class);
+        $this->expectExceptionMessageRegExp('/offset 7/');
+        OCI8Statement::convertPositionalToNamedPlaceholders('SELECT "literal');
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/StatementTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\OCI8;
+
+use Doctrine\DBAL\Driver\OCI8\Driver;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+class StatementTest extends DbalFunctionalTestCase
+{
+    protected function setUp()
+    {
+        if (! extension_loaded('oci8')) {
+            $this->markTestSkipped('oci8 is not installed.');
+        }
+
+        parent::setUp();
+
+        if (! $this->_conn->getDriver() instanceof Driver) {
+            $this->markTestSkipped('oci8 only test.');
+        }
+    }
+
+    /**
+     * @dataProvider queryConversionProvider
+     */
+    public function testQueryConversion($query, array $params, array $expected)
+    {
+        $this->assertEquals(
+            $expected,
+            $this->_conn->executeQuery($query, $params)->fetch()
+        );
+    }
+
+    public static function queryConversionProvider()
+    {
+        return array(
+            'simple' => array(
+                'SELECT ? COL1 FROM DUAL',
+                array(1),
+                array(
+                    'COL1' => 1,
+                ),
+            ),
+            'literal-with-placeholder' => array(
+                "SELECT '?' COL1, ? COL2 FROM DUAL",
+                array(2),
+                array(
+                    'COL1' => '?',
+                    'COL2' => 2,
+                ),
+            ),
+            'literal-with-quotes' => array(
+                "SELECT ? COL1, '?\"?''?' \"COL?\" FROM DUAL",
+                array(3),
+                array(
+                    'COL1' => 3,
+                    'COL?' => '?"?\'?',
+                ),
+            ),
+            'placeholder-at-the-end' => array(
+                'SELECT ? COL1 FROM DUAL WHERE 1 = ?',
+                array(4, 1),
+                array(
+                    'COL1' => 4,
+                ),
+            ),
+            'multi-line-literal' => array(
+                "SELECT 'Hello,
+World?!' COL1 FROM DUAL WHERE 1 = ?",
+                array(1),
+                array(
+                    'COL1' => 'Hello,
+World?!',
+                ),
+            ),
+            'empty-literal' => array(
+                "SELECT '' COL1 FROM DUAL",
+                array(),
+                array(
+                    'COL1' => '',
+                ),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Current implementation of `OCI8Statement::convertPositionalToNamedPlaceholders()` is relatively slow. In a worst case scenario I observed during profiling the app I'm working on, parsing takes up to 10% of the execution time.

It could be sped up by getting rid of a character-by-character string traversal in PHP and using regular expressions.

Besides the performance problem, the current implementation incorrectly handles escaped quotes and quotes of another kind in string literals. Given that in many cases string literals contain user input, it may lead to all sort of issues including security ones:

``` php
$query = <<<SQL
SELECT * FROM table WHERE name = 'How is O\'Reilly?'
SQL;
list($converted) = OCI8Statement::convertPositionalToNamedPlaceholders($query);
echo $converted, PHP_EOL;
// SELECT * FROM table WHERE name = 'How is O\'Reilly:param1'

$query = <<<SQL
SELECT * FROM table WHERE name = 'What about a 65" 4K TV?'
SQL;
list($converted) = OCI8Statement::convertPositionalToNamedPlaceholders($query);
echo $converted, PHP_EOL;
// SELECT * FROM table WHERE name = 'What about a 65" 4K TV:param1'
```

The suggested implementation is times faster and handles the described above literals correctly.

Additionally, it introduces throwing exception in case of parsing errors. It will be mostly useful in cases if the converter is unable to parse a correct query and thus produces a knowingly invalid result.
