### PR TITLE
[WIP] Change unique indexes to be created as unique constraints

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -315,9 +315,9 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL($name, array $columns, array $options = array())
+    protected function _getCreateTableSQL($tableName, array $columns, array $options = array())
     {
-        $name = str_replace('.', '__', $name);
+        $tableName   = str_replace('.', '__', $tableName);
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
@@ -337,7 +337,7 @@ class SqlitePlatform extends AbstractPlatform
             }
         }
 
-        $query[] = 'CREATE TABLE ' . $name . ' (' . $queryFields . ')';
+        $query[] = 'CREATE TABLE ' . $tableName . ' (' . $queryFields . ')';
 
         if (isset($options['alter']) && true === $options['alter']) {
             return $query;
@@ -345,13 +345,13 @@ class SqlitePlatform extends AbstractPlatform
 
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach ($options['indexes'] as $indexDef) {
-                $query[] = $this->getCreateIndexSQL($indexDef, $name);
+                $query[] = $this->getCreateIndexSQL($indexDef, $tableName);
             }
         }
 
         if (isset($options['unique']) && ! empty($options['unique'])) {
             foreach ($options['unique'] as $indexDef) {
-                $query[] = $this->getCreateIndexSQL($indexDef, $name);
+                $query[] = $this->getCreateIndexSQL($indexDef, $tableName);
             }
         }
 


### PR DESCRIPTION
Currently WIP, wanna see which drivers break first... =)

SQL-92 advocates that unique constraints should be created as unique constraints, not unique indexes. This is the standard and works on all SQL-92 compatible RDBMS. 

Unfortunately, Schema\Table have no support to unique constraints, and only exposed support is via unique indexes. We have the option to differentiate unique constraints from indexes or make unique indexes behave as unique constraint, following SQL-92 support. 

After implementing this change, it exposed a hidden bug on SqlitePlatform, where table name is overwritten by unique constraint name.
## Are unique constraints, unique indexes or vice-versa or what?

Of course, explanations are not clear on this, but here are my findings after digging. There are primarily 2 differences between them:

1- Primary difference between unique index and unique constraint is how it handles DML statements. Unique constraints are checked at the end of statement, while unique indexes are checked on a row-by-row basis. This means that if you have a column “number” and rows with values 1, 2, 3… and you issue an update statement with set number = number + 1, it would work on unique constraint, but fail on unique index

2- Oracle infers index information into its optimizer, and it looks like it’s the only driver that does that. This means that foreign key constraints would also have to match uniqueness and not null when making references, while on unique constraint this is not valid

This means that this will work:

``` sql
create table t1 (col1 number, col2 varchar2(20), constraint t1_uq unique (col1));
create table t3 (col1 number, col2 number, col3 varchar2(20), constraint t3_fk foreign key (col2) references t1 (col1));
```

But this would not work:

``` sql
create table t2 (col1 number, col2 varchar2(20));
create unique index t2_idx on t2 (col1);
create table t4 (col1 number, col2 number, col3 varchar2(20), constraint t4_fk foreign key (col2) references t2 (col1));
```

You’d get something like this:

```
ORA-02270: no matching unique or primary key for this column-list
```
## Does a unique constraint create a unique index behind of the scenes?

Short answer: YES

Long version:
A unique index creates a check to ensure all values are unique. This means null, 1, 2, 3, 4 are unique in a table.
A unique constraint forces the column to also be not-null. This is a specialization of the unique index making sure the null value is not allowed (which means absence of value).

Conceptually, adding a unique constraint in ORM (which is where I came from to do this change) should also switch the column nullable definition to false, or like it does... nothing, because DDL would crash. ORM delegates the creation to DBAL, which switches from a unique constraint to unique index, leading to null acceptance.
## So... what we do?

We have 2 options:

1- Decouple uniqueness definitions into unique index and unique constraints and make them work accordingly
2- Blindly accept this PR and "Let it blow!"
