### PR TITLE
Added updateTable that doesn't throw an exception on m2m if join table already exists

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -125,10 +125,35 @@ class Schema extends AbstractAsset
      */
     protected function _addTable(Table $table)
     {
+        $this->_addTableEvenIfExists($table);
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Table $table
+     *
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    protected function _updateTable(Table $table)
+    {
+        $this->_addTableEvenIfExists($table, true);
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Table $table
+     * @param boolean $allowExistentTable
+     *
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    private function _addTableEvenIfExists(Table $table, $allowExistentTable = false)
+    {
         $namespaceName = $table->getNamespaceName();
         $tableName = $table->getFullQualifiedName($this->getName());
 
-        if (isset($this->_tables[$tableName])) {
+        if (isset($this->_tables[$tableName]) && !$allowExistentTable) {
             throw SchemaException::tableAlreadyExists($tableName);
         }
 
@@ -340,6 +365,25 @@ class Schema extends AbstractAsset
     {
         $table = new Table($tableName);
         $this->_addTable($table);
+
+        foreach ($this->_schemaConfig->getDefaultTableOptions() as $name => $value) {
+            $table->addOption($name, $value);
+        }
+
+        return $table;
+    }
+
+    /**
+     * Creates or updates table.
+     *
+     * @param string $tableName
+     *
+     * @return \Doctrine\DBAL\Schema\Table
+     */
+    public function createOrUpdateTable($tableName)
+    {
+        $table = new Table($tableName);
+        $this->_updateTable($table);
 
         foreach ($this->_schemaConfig->getDefaultTableOptions() as $name => $value) {
             $table->addOption($name, $value);

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
@@ -95,6 +95,19 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($schema->hasTable("foo"));
     }
 
+    public function testCreateOrUpdateTable()
+    {
+        $tableName = "foo";
+        $table = new Table($tableName);
+        $schema = new Schema(array($table));
+        $this->assertTrue($schema->hasTable("foo"));
+
+        $table = $schema->createOrUpdateTable("foo");
+        $this->assertInstanceOf('Doctrine\DBAL\Schema\Table', $table);
+        $this->assertEquals("foo", $table->getName());
+        $this->assertTrue($schema->hasTable("foo"));
+    }
+
     public function testAddSequences()
     {
         $sequence = new Sequence("a_seq", 1, 1);


### PR DESCRIPTION
This PR fixes the following issue: https://github.com/doctrine/dbal/issues/2502
It is aimed at support the ORM cli tool: doctrine:schema:update reported here.

https://github.com/doctrine/doctrine2/issues/6016
