### PR TITLE
URL-decode URL-style DSN

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,13 @@
+# Upgrade to 2.6
+
+## MINOR BC BREAK: URL-style DSN with percentage sign in password
+
+URL-style DSNs (e.g. ``mysql://foo@bar:localhost/db``) are now assumed to be percent-encoded
+in order to allow certain special characters in usernames, paswords and database names. If
+you are using a URL-style DSN and have a username, password or database name containing a
+percentage sign, you need to update your DSN. If your password is, say, ``foo%foo``, it
+should be encoded as ``foo%25foo``.
+
 # Upgrade to 2.5.1
 
 ## MINOR BC BREAK: Doctrine\DBAL\Schema\Table

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -259,6 +259,8 @@ final class DriverManager
             throw new DBALException('Malformed parameter "url".');
         }
 
+        $url = array_map('rawurldecode', $url);
+
         // If we have a connection URL, we have to unset the default PDO instance connection parameter (if any)
         // as we cannot merge connection details from the URL into the PDO instance (URL takes precedence).
         unset($params['pdo']);

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -199,6 +199,10 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
                 'drizzle-pdo-mysql://foo:bar@localhost/baz',
                 array('user' => 'foo', 'password' => 'bar', 'host' => 'localhost', 'dbname' => 'baz', 'driver' => 'Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver'),
             ),
+            'simple URL with percent encoding' => array(
+                'mysql://foo%3A:bar%2F@localhost/baz+baz%40',
+                array('user' => 'foo:', 'password' => 'bar/', 'host' => 'localhost', 'dbname' => 'baz+baz@', 'driver' => 'Doctrine\DBAL\Driver\PDOMySQL\Driver'),
+            ),
 
             // DBAL-1234
             'URL without scheme and without any driver information' => array(

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -203,6 +203,10 @@ class DriverManagerTest extends \Doctrine\Tests\DbalTestCase
                 'mysql://foo%3A:bar%2F@localhost/baz+baz%40',
                 array('user' => 'foo:', 'password' => 'bar/', 'host' => 'localhost', 'dbname' => 'baz+baz@', 'driver' => 'Doctrine\DBAL\Driver\PDOMySQL\Driver'),
             ),
+            'simple URL with percent sign in password' => array(
+                'mysql://foo:bar%25bar@localhost/baz',
+                array('user' => 'foo', 'password' => 'bar%bar', 'host' => 'localhost', 'dbname' => 'baz', 'driver' => 'Doctrine\DBAL\Driver\PDOMySQL\Driver'),
+            ),
 
             // DBAL-1234
             'URL without scheme and without any driver information' => array(


### PR DESCRIPTION
The URL-style DSN does not support escaping, so if the username/password/database name contains certain characters, the connection options simply cannot be represented this way.

This patch URL-decodes the different parts. It introduces a small BC break for usernames/passwords/database names containing the character `%`.
