### PR TITLE
SQLite: Handle properly quoted table names with namespaces in SqlitePlatform:: _getCreateTableSQL()

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -317,7 +317,12 @@ class SqlitePlatform extends AbstractPlatform
      */
     protected function _getCreateTableSQL($name, array $columns, array $options = array())
     {
-        $name = str_replace('.', '__', $name);
+        $search = '.';
+        $c = $this->getIdentifierQuoteCharacter();
+        if (0 < strpos($name, '.') && false !== strpos($name, $c)) {
+            $search = $c . '.' . $c;
+        }
+        $name = str_replace($search, '__', $name);
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {

--- a/lib/Doctrine/DBAL/Schema/AbstractAsset.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractAsset.php
@@ -59,15 +59,22 @@ abstract class AbstractAsset
      */
     protected function _setName($name)
     {
-        if ($this->isIdentifierQuoted($name)) {
-            $this->_quoted = true;
-            $name = $this->trimQuotes($name);
-        }
         if (strpos($name, ".") !== false) {
             $parts = explode(".", $name);
             $this->_namespace = $parts[0];
             $name = $parts[1];
         }
+
+        if ($this->_namespace && $this->isIdentifierQuoted($this->_namespace)) {
+            $this->_quoted = true;
+            $this->_namespace = $this->trimQuotes($this->_namespace);
+        }
+
+        if ($this->isIdentifierQuoted($name)) {
+            $this->_quoted = true;
+            $name = $this->trimQuotes($name);
+        }
+
         $this->_name = $name;
     }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -744,4 +744,43 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     {
         $this->assertContains("'Foo''Bar\\'", $this->_platform->getListTableForeignKeysSQL("Foo'Bar\\"), '', true);
     }
+
+    public function testCreateTableSqlWithQuotedNamespaceAndQuotedTableName()
+    {
+        $tableName = '`test-db`.`test-table`';
+        $table = new Table($tableName);
+        $table->addColumn('foo', 'integer');
+
+        $sql = $this->_platform->getCreateTableSQL($table);
+        $this->assertEquals(
+            ['CREATE TABLE "test-db__test-table" (foo INTEGER NOT NULL)'],
+            $sql
+        );
+    }
+
+    public function testCreateTableSqlWithQuotedNamespaceAndUnquotedTableName()
+    {
+        $tableName = '`test-db`.test-table';
+        $table = new Table($tableName);
+        $table->addColumn('foo', 'integer');
+
+        $sql = $this->_platform->getCreateTableSQL($table);
+        $this->assertEquals(
+            ['CREATE TABLE "test-db__test-table" (foo INTEGER NOT NULL)'],
+            $sql
+        );
+    }
+
+    public function testCreateTableSqlWithUnquotedNamespaceAndQuotedTableName()
+    {
+        $tableName = 'test-db.`test-table`';
+        $table = new Table($tableName);
+        $table->addColumn('foo', 'integer');
+
+        $sql = $this->_platform->getCreateTableSQL($table);
+        $this->assertEquals(
+            ['CREATE TABLE "test-db__test-table" (foo INTEGER NOT NULL)'],
+            $sql
+        );
+    }
 }


### PR DESCRIPTION
If the table has quoted name with the namespace, e.g. `"some-namespace"."my-table"` the `SqlitePlatform:: _getCreateTableSQL()` will generate invalid SQL statement: `CREATE TABLE "some-namespace"__"my-table" ...`.
