### PR TITLE
#2515 fix schema listing when having identical tables in databases

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -674,6 +674,7 @@ END;';
                              FROM   $colCommentsTableName d
                              WHERE  d.TABLE_NAME = c.TABLE_NAME
                              AND    d.COLUMN_NAME = c.COLUMN_NAME
+                             " . ($ownerCondition ? "AND d.OWNER = c.OWNER": "") . "
                          ) AS comments
                 FROM     $tabColumnsTableName c
                 WHERE    c.table_name = " . $table . " $ownerCondition


### PR DESCRIPTION
Subquery may return more than one row, so additional owner condition was added
