### PR TITLE
Truncate params in DBALException::formatParameters

### DIFF
--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -25,6 +25,9 @@ use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 
 class DBALException extends \Exception
 {
+    /** Length after which a parameter argument is truncated in the formatted error message */
+    const MAX_PARAM_LENGTH = 240;
+
     /**
      * @param string $method
      *
@@ -168,8 +171,8 @@ class DBALException extends \Exception
     private static function formatParameters(array $params)
     {
         return '[' . implode(', ', array_map(function ($param) {
-            if (is_string ($param)) {
-                $param = mb_strimwidth($param, 0, 240, "...");
+            if (is_string ($param) && strlen($param) > static::MAX_PARAM_LENGTH) {
+                $param = substr($param, 0, static::MAX_PARAM_LENGTH) . '...';
             }
             $json = @json_encode($param);
 

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -168,6 +168,9 @@ class DBALException extends \Exception
     private static function formatParameters(array $params)
     {
         return '[' . implode(', ', array_map(function ($param) {
+            if (is_string ($param)) {
+                $param = mb_strimwidth($param, 0, 240, "...");
+            }
             $json = @json_encode($param);
 
             if (! is_string($json) || $json == 'null' && is_string($param)) {


### PR DESCRIPTION
This is a fix for #2523.

This simply uses `mb_strimwidth` to add an ellipsis at the end of string parameters longer than 240  characters. Doing so allows to remove information overload from long parameters, while retaining details from other parameters and subsequent information in the exception message (e.g., stacktrace).

Signed-off-by: Olivier Mehani shtrom@ssji.net
