### PR TITLE
Normalize method signatures for `fetch()` and `fetchAll()`, ensuring compatibility with the `PDOStatement` signature

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,30 @@
 # Upgrade to 2.6
 
+## MINOR BC BREAK: `fetch()` and `fetchAll()` method signatures in `Doctrine\DBAL\Driver\ResultStatement`
+
+1. ``Doctrine\DBAL\Driver\ResultStatement::fetch()`` now has 3 arguments instead of 1, respecting
+``PDO::fetch()`` signature.
+
+Before:
+
+    Doctrine\DBAL\Driver\ResultStatement::fetch($fetchMode);
+
+After:
+
+    Doctrine\DBAL\Driver\ResultStatement::fetch($fetchMode, $cursorOrientation, $cursorOffset);
+
+2. ``Doctrine\DBAL\Driver\ResultStatement::fetchAll()`` now has 3 arguments instead of 1, respecting
+``PDO::fetchAll()`` signature.
+
+Before:
+
+    Doctrine\DBAL\Driver\ResultStatement::fetchAll($fetchMode);
+
+After:
+
+    Doctrine\DBAL\Driver\ResultStatement::fetch($fetchMode, $fetchArgument, $ctorArgs);
+
+
 ## MINOR BC BREAK: URL-style DSN with percentage sign in password
 
 URL-style DSNs (e.g. ``mysql://foo@bar:localhost/db``) are now assumed to be percent-encoded

--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -98,7 +98,7 @@ class ArrayStatement implements \IteratorAggregate, ResultStatement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchMode = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         if (isset($this->data[$this->num])) {
             $row = $this->data[$this->num++];
@@ -122,7 +122,7 @@ class ArrayStatement implements \IteratorAggregate, ResultStatement
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
         $rows = array();
         while ($row = $this->fetch($fetchMode)) {

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -147,7 +147,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchMode = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         if ($this->data === null) {
             $this->data = array();
@@ -179,7 +179,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
         $rows = array();
         while ($row = $this->fetch($fetchMode)) {

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -26,7 +26,7 @@ class DB2Statement implements \IteratorAggregate, Statement
     /**
      * @var resource
      */
-    private $_stmt = null;
+    private $_stmt;
 
     /**
      * @var array
@@ -147,8 +147,8 @@ class DB2Statement implements \IteratorAggregate, Statement
     public function errorInfo()
     {
         return array(
-            0 => db2_stmt_errormsg(),
-            1 => db2_stmt_error(),
+            db2_stmt_errormsg(),
+            db2_stmt_error(),
         );
     }
 
@@ -207,7 +207,7 @@ class DB2Statement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchMode = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         // do not try fetching from the statement if it's not expected to contain result
         // in order to prevent exceptional situation
@@ -243,14 +243,14 @@ class DB2Statement implements \IteratorAggregate, Statement
             case \PDO::FETCH_OBJ:
                 return db2_fetch_object($this->_stmt);
             default:
-                throw new DB2Exception("Given Fetch-Style " . $fetchMode . " is not supported.");
+                throw new DB2Exception('Given Fetch-Style ' . $fetchMode . ' is not supported.');
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
         $rows = array();
 

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -263,7 +263,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchMode = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         // do not try fetching from the statement if it's not expected to contain result
         // in order to prevent exceptional situation
@@ -313,7 +313,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
         $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
 

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -378,7 +378,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchMode = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         // do not try fetching from the statement if it's not expected to contain result
         // in order to prevent exceptional situation
@@ -405,7 +405,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
         $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
 

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -111,18 +111,18 @@ class PDOStatement extends \PDOStatement implements Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchMode = null, $cursorOrientation = null, $cursorOffset = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         try {
-            if ($fetchMode === null && $cursorOrientation === null && $cursorOffset === null) {
+            if ($fetchMode === null && \PDO::FETCH_ORI_NEXT === $cursorOrientation && 0 === $cursorOffset) {
                 return parent::fetch();
             }
 
-            if ($cursorOrientation === null && $cursorOffset === null) {
+            if (\PDO::FETCH_ORI_NEXT === $cursorOrientation && 0 === $cursorOffset) {
                 return parent::fetch($fetchMode);
             }
 
-            if ($cursorOffset === null) {
+            if (0 === $cursorOffset) {
                 return parent::fetch($fetchMode, $cursorOrientation);
             }
 
@@ -138,15 +138,15 @@ class PDOStatement extends \PDOStatement implements Statement
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
         try {
-            if ($fetchMode === null && $fetchArgument === null && $ctorArgs === null) {
+            if ($fetchMode === null && null === $fetchArgument && null === $ctorArgs) {
                 return parent::fetchAll();
             }
 
-            if ($fetchArgument === null && $ctorArgs === null) {
+            if (null === $fetchArgument && null === $ctorArgs) {
                 return parent::fetchAll($fetchMode);
             }
 
-            if ($ctorArgs === null) {
+            if (null === $ctorArgs) {
                 return parent::fetchAll($fetchMode, $fetchArgument);
             }
 

--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -58,29 +58,53 @@ interface ResultStatement extends \Traversable
     /**
      * Returns the next row of a result set.
      *
-     * @param integer|null $fetchMode Controls how the next row will be returned to the caller.
-     *                                The value must be one of the PDO::FETCH_* constants,
-     *                                defaulting to PDO::FETCH_BOTH.
+     * * @param int|null $fetchMode  Controls how the next row will be returned to the caller.
+     *                               The value must be one of the \PDO::FETCH_* constants,
+     *                               defaulting to \PDO::FETCH_BOTH.
+     * @param int $cursorOrientation For a ResultStatement object representing a scrollable cursor,
+     *                               this value determines which row will be returned to the caller.
+     *                               This value must be one of the \PDO::FETCH_ORI_* constants,
+     *                               defaulting to \PDO::FETCH_ORI_NEXT. To request a scrollable
+     *                               cursor for your ResultStatement object, you must set the \PDO::ATTR_CURSOR
+     *                               attribute to \PDO::CURSOR_SCROLL when you prepare the SQL statement with
+     *                               \PDO::prepare().
+     * @param int $cursorOffset      For a ResultStatement object representing a scrollable cursor for which the
+     *                               cursorOrientation parameter is set to \PDO::FETCH_ORI_ABS, this value
+     *                               specifies the absolute number of the row in the result set that shall be
+     *                               fetched.
+     *                               For a ResultStatement object representing a scrollable cursor for which the
+     *                               cursorOrientation parameter is set to \PDO::FETCH_ORI_REL, this value
+     *                               specifies the row to fetch relative to the cursor position before
+     *                               ResultStatement::fetch() was called.
      *
      * @return mixed The return value of this method on success depends on the fetch mode. In all cases, FALSE is
      *               returned on failure.
      *
      * @see PDO::FETCH_* constants.
      */
-    public function fetch($fetchMode = null);
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0);
 
     /**
      * Returns an array containing all of the result set rows.
      *
-     * @param integer|null $fetchMode Controls how the next row will be returned to the caller.
-     *                                The value must be one of the PDO::FETCH_* constants,
-     *                                defaulting to PDO::FETCH_BOTH.
+     * @param int|null $fetchMode     Controls how the next row will be returned to the caller.
+     *                                The value must be one of the \PDO::FETCH_* constants,
+     *                                defaulting to \PDO::FETCH_BOTH.
+     * @param int|null $fetchArgument This argument has a different meaning depending on the value of the $fetchMode parameter:
+     *                                * \PDO::FETCH_COLUMN: Returns the indicated 0-indexed column.
+     *                                * \PDO::FETCH_CLASS: Returns instances of the specified class, mapping the columns of each
+     *                                  row to named properties in the class.
+     *                                * \PDO::FETCH_FUNC: Returns the results of calling the specified function, using each row's
+     *                                  columns as parameters in the call.
+     * @param array|null $ctorArgs    Controls how the next row will be returned to the caller.
+     *                                The value must be one of the \PDO::FETCH_* constants,
+     *                                defaulting to \PDO::FETCH_BOTH.
      *
      * @return array
      *
-     * @see PDO::FETCH_* constants.
+     * @see \PDO::FETCH_* constants.
      */
-    public function fetchAll($fetchMode = null);
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null);
 
     /**
      * Returns a single column from the next row of a result set or FALSE if there are no more rows.

--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -58,7 +58,7 @@ interface ResultStatement extends \Traversable
     /**
      * Returns the next row of a result set.
      *
-     * * @param int|null $fetchMode  Controls how the next row will be returned to the caller.
+     * @param int|null $fetchMode    Controls how the next row will be returned to the caller.
      *                               The value must be one of the \PDO::FETCH_* constants,
      *                               defaulting to \PDO::FETCH_BOTH.
      * @param int $cursorOrientation For a ResultStatement object representing a scrollable cursor,

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -193,7 +193,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
      *
      * @throws SQLAnywhereException
      */
-    public function fetch($fetchMode = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         if ( ! is_resource($this->result)) {
             return false;
@@ -235,7 +235,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
         $rows = array();
 

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -142,7 +142,7 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchMode = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         $fetchMode = $fetchMode ?: $this->defaultFetchMode;
 
@@ -159,12 +159,12 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null, $columnIndex = 0)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
         $fetchMode = $fetchMode ?: $this->defaultFetchMode;
 
-        if ($columnIndex != 0) {
-            $rows = $this->stmt->fetchAll($fetchMode, $columnIndex);
+        if ($fetchArgument) {
+            $rows = $this->stmt->fetchAll($fetchMode, $fetchArgument);
         } else {
             $rows = $this->stmt->fetchAll($fetchMode);
         }

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -252,29 +252,19 @@ class Statement implements \IteratorAggregate, DriverStatement
     }
 
     /**
-     * Fetches the next row from a result set.
-     *
-     * @param integer|null $fetchMode
-     *
-     * @return mixed The return value of this function on success depends on the fetch type.
-     *               In all cases, FALSE is returned on failure.
+     * {@inheritdoc}
      */
-    public function fetch($fetchMode = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         return $this->stmt->fetch($fetchMode);
     }
 
     /**
-     * Returns an array containing all of the result set rows.
-     *
-     * @param integer|null $fetchMode
-     * @param mixed        $fetchArgument
-     *
-     * @return array An array containing all of the remaining rows in the result set.
+     * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null, $fetchArgument = 0)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
-        if ($fetchArgument !== 0) {
+        if ($fetchArgument) {
             return $this->stmt->fetchAll($fetchMode, $fetchArgument);
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.5 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #2519 |
| License | MIT |
| Doc PR | n/a |

**TODO**
- [x] Check usage of `func_get_args()` at `DB2Statement`, `SQLAnywhereStatement` and `SQLSrvStatement`.

Close #2519.
