### PR TITLE
Handle errors during DB2 fetch operations

### DIFF
--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -231,9 +231,9 @@ class DB2Statement implements \IteratorAggregate, Statement
                 throw new DB2Exception("Given Fetch-Style " . $fetchMode . " is not supported.");
         }
 
-        $error = db2_stmt_errormsg();
-        if (false === $result && $error) {
-            throw new DB2Exception("Error during fetch: " . $error);
+        list($errorMessage, $errorCode) = $this->errorInfo();
+        if (false === $result && !empty($errorMessage)) {
+            throw new DB2Exception("Error during fetch: " . $errorMessage);
         }
 
         return $result;

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -233,7 +233,7 @@ class DB2Statement implements \IteratorAggregate, Statement
 
         $error = db2_stmt_errormsg();
         if (false === $result && $error) {
-            throw new DB2Exception($error);
+            throw new DB2Exception("Error during fetch: " . $error);
         }
 
         return $result;

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -232,7 +232,7 @@ class DB2Statement implements \IteratorAggregate, Statement
         }
 
         $error = db2_stmt_errormsg();
-        if ($result === false && $error) {
+        if (false === $result && $error) {
             throw new DB2Exception($error);
         }
 

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -200,10 +200,10 @@ class DB2Statement implements \IteratorAggregate, Statement
         $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
         switch ($fetchMode) {
             case \PDO::FETCH_BOTH:
-                $result = @db2_fetch_both($this->_stmt);
+                $result = db2_fetch_both($this->_stmt);
                 break;
             case \PDO::FETCH_ASSOC:
-                $result = @db2_fetch_assoc($this->_stmt);
+                $result = db2_fetch_assoc($this->_stmt);
                 break;
             case \PDO::FETCH_CLASS:
                 $className = $this->defaultFetchClass;
@@ -215,17 +215,17 @@ class DB2Statement implements \IteratorAggregate, Statement
                     $ctorArgs  = isset($args[2]) ? $args[2] : array();
                 }
 
-                $result = @db2_fetch_object($this->_stmt);
+                $result = db2_fetch_object($this->_stmt);
 
                 if ($result instanceof \stdClass) {
                     $result = $this->castObject($result, $className, $ctorArgs);
                 }
                 break;
             case \PDO::FETCH_NUM:
-                $result = @db2_fetch_array($this->_stmt);
+                $result = db2_fetch_array($this->_stmt);
                 break;
             case \PDO::FETCH_OBJ:
-                $result = @db2_fetch_object($this->_stmt);
+                $result = db2_fetch_object($this->_stmt);
                 break;
             default:
                 throw new DB2Exception("Given Fetch-Style " . $fetchMode . " is not supported.");

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -200,9 +200,11 @@ class DB2Statement implements \IteratorAggregate, Statement
         $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
         switch ($fetchMode) {
             case \PDO::FETCH_BOTH:
-                return db2_fetch_both($this->_stmt);
+                $result = @db2_fetch_both($this->_stmt);
+                break;
             case \PDO::FETCH_ASSOC:
-                return db2_fetch_assoc($this->_stmt);
+                $result = @db2_fetch_assoc($this->_stmt);
+                break;
             case \PDO::FETCH_CLASS:
                 $className = $this->defaultFetchClass;
                 $ctorArgs  = $this->defaultFetchClassCtorArgs;
@@ -213,20 +215,28 @@ class DB2Statement implements \IteratorAggregate, Statement
                     $ctorArgs  = isset($args[2]) ? $args[2] : array();
                 }
 
-                $result = db2_fetch_object($this->_stmt);
+                $result = @db2_fetch_object($this->_stmt);
 
                 if ($result instanceof \stdClass) {
                     $result = $this->castObject($result, $className, $ctorArgs);
                 }
-
-                return $result;
+                break;
             case \PDO::FETCH_NUM:
-                return db2_fetch_array($this->_stmt);
+                $result = @db2_fetch_array($this->_stmt);
+                break;
             case \PDO::FETCH_OBJ:
-                return db2_fetch_object($this->_stmt);
+                $result = @db2_fetch_object($this->_stmt);
+                break;
             default:
                 throw new DB2Exception("Given Fetch-Style " . $fetchMode . " is not supported.");
         }
+
+        $error = db2_stmt_errormsg();
+        if ($result === false && $error) {
+            throw new DB2Exception($error);
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
I recently ran into a situation where one of our DB2 tables got into an error state due to a failed/interrupted LOAD operation. While the table was in this state, running a SELECT query against it from the DB2 command line returned an error message. However, running the same query through Doctrine DBAL produced no errors - just an empty result set. This was misleading because the query should have failed completely if the table was in the error state, or returned a valid, non-empty result set otherwise.

It turns out that this particular error only occurs when the `db2_fetch_xxx()` functions are called - the connect, prepare, and execute steps all run fine without errors. DBAL currently doesn't check for errors during the fetch. This pull request updates `DB2Statement::fetch()` to check if the result is `false`, and if so throws an exception if `db2_stmt_errormsg()` returns a non-empty result. I also `@`-silenced each of the `db2_fetch_xxx()` calls, since they emit PHP warnings when the fetch fails.
