### PR TITLE
Fixed bug with detection of changed datetime/datetimetz

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -431,7 +431,14 @@ class Comparator
 
         foreach (array('type', 'notnull', 'unsigned', 'autoincrement') as $property) {
             if ($properties1[$property] != $properties2[$property]) {
-                $changedProperties[] = $property;
+            	if(!(
+	                ($properties1[$property] instanceof Types\DateTimeType || $properties1[$property] instanceof Types\DateTimeTzType)
+		            &&
+	                ($properties2[$property] instanceof Types\DateTimeType || $properties2[$property] instanceof Types\DateTimeTzType)
+	            ))
+	            {
+		            $changedProperties[] = $property;
+	            }
             }
         }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -1276,4 +1276,40 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $actual->changedTables['table2']->addedForeignKeys, "FK to table3 should be added.");
         $this->assertEquals("table3", $actual->changedTables['table2']->addedForeignKeys[0]->getForeignTableName());
     }
+
+	/**
+	 * @see https://github.com/doctrine/dbal/pull/2537
+	 *
+	 * @dataProvider getCompareDateTimeTypes
+	 */
+    public function testDifferentDateTimeTypes($type1, $type2, $equals)
+    {
+	    $column1 = new Column('foo', Type::getType($type1));
+	    $column2 = new Column('foo', Type::getType($type2));
+
+	    $comparator = new Comparator();
+
+	    $expectedDiff = $equals ? array() : array('type');
+
+	    $actualDiff = $comparator->diffColumn($column1, $column2);
+	    $this->assertSame($expectedDiff, $actualDiff);
+
+	    $actualDiff = $comparator->diffColumn($column2, $column1);
+	    $this->assertSame($expectedDiff, $actualDiff);
+    }
+
+	public function getCompareDateTimeTypes()
+	{
+		return array(
+			array('datetime', 'datetime', true),
+			array('datetime', 'datetimetz', true),
+			array('datetimetz', 'datetimetz', true),
+
+			array('date', 'datetime', false),
+			array('date', 'datetimetz', false),
+
+			array('time', 'datetime', false),
+			array('time', 'datetimetz', false),
+		);
+	}
 }


### PR DESCRIPTION
I have a bug that after updating my fields from datetime to datetimetz that everytime I want to update my database I see the same changes:

```
ALTER TABLE cart CHANGE created_at created_at DATETIME NOT NULL, CHANGE updated_at updated_at DATETIME NOT NULL;
```

After executing:

```
doctrine:schema:update --force
```

and (again)

```
doctrine:schema:update --dump-sql
```

I got again

```
ALTER TABLE cart CHANGE created_at created_at DATETIME NOT NULL, CHANGE updated_at updated_at DATETIME NOT NULL
```

The problem is that the comparator not see the equality of DateTime and DateTimeTz in **MySQL databases**.
Or there is a problem with MySQL that they havent a special type for this and so doctrine think its different.

You can check this and merge if its useful.
