### PR TITLE
Replacing spaces in the pgsql DSN string with semicolons for consistency with pdo_pgsql

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -79,34 +79,34 @@ class Driver extends AbstractPostgreSQLDriver
         $dsn = 'pgsql:';
 
         if (isset($params['host']) && $params['host'] != '') {
-            $dsn .= 'host=' . $params['host'] . ' ';
+            $dsn .= 'host=' . $params['host'] . ';';
         }
 
         if (isset($params['port']) && $params['port'] != '') {
-            $dsn .= 'port=' . $params['port'] . ' ';
+            $dsn .= 'port=' . $params['port'] . ';';
         }
 
         if (isset($params['dbname'])) {
-            $dsn .= 'dbname=' . $params['dbname'] . ' ';
+            $dsn .= 'dbname=' . $params['dbname'] . ';';
         } elseif (isset($params['default_dbname'])) {
-            $dsn .= 'dbname=' . $params['default_dbname'] . ' ';
+            $dsn .= 'dbname=' . $params['default_dbname'] . ';';
         } else {
             // Used for temporary connections to allow operations like dropping the database currently connected to.
             // Connecting without an explicit database does not work, therefore "postgres" database is used
             // as it is mostly present in every server setup.
-            $dsn .= 'dbname=postgres' . ' ';
+            $dsn .= 'dbname=postgres' . ';';
         }
 
         if (isset($params['sslmode'])) {
-            $dsn .= 'sslmode=' . $params['sslmode'] . ' ';
+            $dsn .= 'sslmode=' . $params['sslmode'] . ';';
         }
 
         if (isset($params['sslrootcert'])) {
-            $dsn .= 'sslrootcert=' . $params['sslrootcert'] . ' ';
+            $dsn .= 'sslrootcert=' . $params['sslrootcert'] . ';';
         }
 
         if (isset($params['application_name'])) {
-            $dsn .= 'application_name=' . $params['application_name'] . ' ';
+            $dsn .= 'application_name=' . $params['application_name'] . ';';
         }
 
         return $dsn;


### PR DESCRIPTION
…ore consistent with the other drivers and makes the PDOPgSQL driver work in hhvm 3.15.2 as well.