### PR TITLE
Bump HHVM version to 3.15.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,14 @@ php:
   - nightly
 
 env:
+  - DB=sqlite
   - DB=mysql
-  - DB=pgsql POSTGRESQL_VERSION=9.1
+  - DB=mysqli
   - DB=pgsql POSTGRESQL_VERSION=9.2
   - DB=pgsql POSTGRESQL_VERSION=9.3
   - DB=pgsql POSTGRESQL_VERSION=9.4
-  - DB=sqlite
-  - DB=mysqli
+  - DB=pgsql POSTGRESQL_VERSION=9.5
+  - DB=pgsql POSTGRESQL_VERSION=9.6
 
 matrix:
   fast_finish: true
@@ -110,6 +111,43 @@ matrix:
         - postgresql
       env: DB=pgsql POSTGRESQL_VERSION=9.5
 
+    - php: 5.6
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.6"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
+    - php: 7.0
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.6"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
+    - php: 7.1
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.6"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
+    - php: nightly
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.6"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
+
     - php: hhvm
       sudo: true
       dist: trusty
@@ -136,15 +174,6 @@ matrix:
       services:
         - mysql
       env: DB=mysqli
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        postgresql: "9.1"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.1
     - php: hhvm
       sudo: true
       dist: trusty
@@ -185,6 +214,15 @@ matrix:
       sudo: true
       dist: trusty
       group: edge # until the next update
+      addons:
+        postgresql: "9.6"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
       env: DB=sqlite
   allow_failures:
     - php: hhvm
@@ -199,7 +237,7 @@ matrix:
       env: DB=pgsql POSTGRESQL_VERSION=9.5
 
 addons:
-  postgresql: '9.4'
+  #postgresql: '9.4'
 
 install:
   - travis_retry composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -237,7 +237,7 @@ matrix:
       env: DB=pgsql POSTGRESQL_VERSION=9.5
 
 addons:
-  #postgresql: '9.4'
+  - if [ '$DB' = 'pgsql' ]; then postgresql: $POSTGRESQL_VERSION; fi
 
 install:
   - travis_retry composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -181,43 +181,6 @@ matrix:
         - postgresql
       env: DB=pgsql POSTGRESQL_VERSION=9.5
 
-    - php: 5.6
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        postgresql: "9.6"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
-    - php: 7.0
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        postgresql: "9.6"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
-    - php: 7.1
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        postgresql: "9.6"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
-    - php: nightly
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        postgresql: "9.6"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
-
     - php: hhvm
       sudo: true
       dist: trusty
@@ -284,21 +247,10 @@ matrix:
       sudo: true
       dist: trusty
       group: edge # until the next update
-      addons:
-        postgresql: "9.6"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
       env: DB=sqlite
   allow_failures:
     - php: hhvm
     - php: nightly
-    - php: 7.1
-      env: DB=mariadb MARIADB_VERSION=10.1
     - php: 5.6
       env: DB=pgsql POSTGRESQL_VERSION=9.5
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ env:
   - DB=sqlite
   - DB=mysql
   - DB=mysqli
-  - DB=pgsql POSTGRESQL_VERSION=9.2
-  - DB=pgsql POSTGRESQL_VERSION=9.3
-  - DB=pgsql POSTGRESQL_VERSION=9.4
-  - DB=pgsql POSTGRESQL_VERSION=9.5
-  - DB=pgsql POSTGRESQL_VERSION=9.6
+  - DB=pgsql POSTGRESQL_VERSION='9.2'
+  - DB=pgsql POSTGRESQL_VERSION='9.3'
+  - DB=pgsql POSTGRESQL_VERSION='9.4'
+  - DB=pgsql POSTGRESQL_VERSION='9.5'
+  - DB=pgsql POSTGRESQL_VERSION='9.6'
 
 matrix:
   fast_finish: true
@@ -82,7 +82,7 @@ matrix:
         postgresql: "9.5"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
+      env: DB=pgsql POSTGRESQL_VERSION='9.5'
     - php: 7.0
       sudo: true
       dist: trusty
@@ -91,7 +91,7 @@ matrix:
         postgresql: "9.5"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
+      env: DB=pgsql POSTGRESQL_VERSION='9.5'
     - php: 7.1
       sudo: true
       dist: trusty
@@ -100,7 +100,7 @@ matrix:
         postgresql: "9.5"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
+      env: DB=pgsql POSTGRESQL_VERSION='9.5'
     - php: nightly
       sudo: true
       dist: trusty
@@ -109,7 +109,7 @@ matrix:
         postgresql: "9.5"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
+      env: DB=pgsql POSTGRESQL_VERSION='9.5'
 
     - php: 5.6
       sudo: true
@@ -119,7 +119,7 @@ matrix:
         postgresql: "9.6"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
+      env: DB=pgsql POSTGRESQL_VERSION='9.6'
     - php: 7.0
       sudo: true
       dist: trusty
@@ -128,7 +128,7 @@ matrix:
         postgresql: "9.6"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
+      env: DB=pgsql POSTGRESQL_VERSION='9.6'
     - php: 7.1
       sudo: true
       dist: trusty
@@ -137,7 +137,7 @@ matrix:
         postgresql: "9.6"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
+      env: DB=pgsql POSTGRESQL_VERSION='9.6'
     - php: nightly
       sudo: true
       dist: trusty
@@ -146,7 +146,7 @@ matrix:
         postgresql: "9.6"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
+      env: DB=pgsql POSTGRESQL_VERSION='9.6'
 
     - php: hhvm
       sudo: true
@@ -182,7 +182,7 @@ matrix:
         postgresql: "9.2"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.2
+      env: DB=pgsql POSTGRESQL_VERSION='9.2'
     - php: hhvm
       sudo: true
       dist: trusty
@@ -191,7 +191,7 @@ matrix:
         postgresql: "9.3"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.3
+      env: DB=pgsql POSTGRESQL_VERSION='9.3'
     - php: hhvm
       sudo: true
       dist: trusty
@@ -200,7 +200,7 @@ matrix:
         postgresql: "9.4"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.4
+      env: DB=pgsql POSTGRESQL_VERSION='9.4'
     - php: hhvm
       sudo: true
       dist: trusty
@@ -209,7 +209,7 @@ matrix:
         postgresql: "9.5"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
+      env: DB=pgsql POSTGRESQL_VERSION='9.5'
     - php: hhvm
       sudo: true
       dist: trusty
@@ -218,7 +218,7 @@ matrix:
         postgresql: "9.6"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
+      env: DB=pgsql POSTGRESQL_VERSION='9.6'
     - php: hhvm
       sudo: true
       dist: trusty
@@ -230,11 +230,11 @@ matrix:
     - php: 7.1
       env: DB=mariadb MARIADB_VERSION=10.1
     - php: 5.6
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
+      env: DB=pgsql POSTGRESQL_VERSION='9.5'
     - php: 7.0
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
+      env: DB=pgsql POSTGRESQL_VERSION='9.5'
     - php: 7.1
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
+      env: DB=pgsql POSTGRESQL_VERSION='9.5'
 
 addons:
   postgresql: $POSTGRESQL_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -237,12 +237,7 @@ matrix:
       env: DB=pgsql POSTGRESQL_VERSION=9.5
 
 addons:
-  - postgresql: '9.2'
-  - postgresql: '9.3'
-  - postgresql: '9.4'
-  - postgresql: '9.5'
-  - postgresql: '9.6'
-  
+  postgresql: '9.4'
 
 install:
   - travis_retry composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ env:
   - DB=sqlite
   - DB=mysql
   - DB=mysqli
-  - DB=pgsql POSTGRESQL_VERSION='9.2'
-  - DB=pgsql POSTGRESQL_VERSION='9.3'
-  - DB=pgsql POSTGRESQL_VERSION='9.4'
-  - DB=pgsql POSTGRESQL_VERSION='9.5'
-  - DB=pgsql POSTGRESQL_VERSION='9.6'
+  - DB=pgsql POSTGRESQL_VERSION=9.2
+  - DB=pgsql POSTGRESQL_VERSION=9.3
+  - DB=pgsql POSTGRESQL_VERSION=9.4
+  - DB=pgsql POSTGRESQL_VERSION=9.5
+  - DB=pgsql POSTGRESQL_VERSION=9.6
 
 matrix:
   fast_finish: true
@@ -82,7 +82,7 @@ matrix:
         postgresql: "9.5"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.5'
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
     - php: 7.0
       sudo: true
       dist: trusty
@@ -91,7 +91,7 @@ matrix:
         postgresql: "9.5"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.5'
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
     - php: 7.1
       sudo: true
       dist: trusty
@@ -100,7 +100,7 @@ matrix:
         postgresql: "9.5"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.5'
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
     - php: nightly
       sudo: true
       dist: trusty
@@ -109,7 +109,7 @@ matrix:
         postgresql: "9.5"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.5'
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
 
     - php: 5.6
       sudo: true
@@ -119,7 +119,7 @@ matrix:
         postgresql: "9.6"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.6'
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
     - php: 7.0
       sudo: true
       dist: trusty
@@ -128,7 +128,7 @@ matrix:
         postgresql: "9.6"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.6'
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
     - php: 7.1
       sudo: true
       dist: trusty
@@ -137,7 +137,7 @@ matrix:
         postgresql: "9.6"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.6'
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
     - php: nightly
       sudo: true
       dist: trusty
@@ -146,7 +146,7 @@ matrix:
         postgresql: "9.6"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.6'
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
 
     - php: hhvm
       sudo: true
@@ -182,7 +182,7 @@ matrix:
         postgresql: "9.2"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.2'
+      env: DB=pgsql POSTGRESQL_VERSION=9.2
     - php: hhvm
       sudo: true
       dist: trusty
@@ -191,7 +191,7 @@ matrix:
         postgresql: "9.3"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.3'
+      env: DB=pgsql POSTGRESQL_VERSION=9.3
     - php: hhvm
       sudo: true
       dist: trusty
@@ -200,7 +200,7 @@ matrix:
         postgresql: "9.4"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.4'
+      env: DB=pgsql POSTGRESQL_VERSION=9.4
     - php: hhvm
       sudo: true
       dist: trusty
@@ -209,7 +209,7 @@ matrix:
         postgresql: "9.5"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.5'
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
     - php: hhvm
       sudo: true
       dist: trusty
@@ -218,7 +218,7 @@ matrix:
         postgresql: "9.6"
       services:
         - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION='9.6'
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
     - php: hhvm
       sudo: true
       dist: trusty
@@ -230,14 +230,18 @@ matrix:
     - php: 7.1
       env: DB=mariadb MARIADB_VERSION=10.1
     - php: 5.6
-      env: DB=pgsql POSTGRESQL_VERSION='9.5'
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
     - php: 7.0
-      env: DB=pgsql POSTGRESQL_VERSION='9.5'
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
     - php: 7.1
-      env: DB=pgsql POSTGRESQL_VERSION='9.5'
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
 
 addons:
-  postgresql: $POSTGRESQL_VERSION
+  - postgresql: 9.2
+  - postgresql: 9.3
+  - postgresql: 9.4
+  - postgresql: 9.5
+  - postgresql: 9.6
 
 install:
   - travis_retry composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -237,11 +237,7 @@ matrix:
       env: DB=pgsql POSTGRESQL_VERSION=9.5
 
 addons:
-  - postgresql: 9.2
-  - postgresql: 9.3
   - postgresql: 9.4
-  - postgresql: 9.5
-  - postgresql: 9.6
 
 install:
   - travis_retry composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ env:
   - DB=sqlite
   - DB=mysql
   - DB=mysqli
-  - DB=pgsql POSTGRESQL_VERSION=9.2
-  - DB=pgsql POSTGRESQL_VERSION=9.3
-  - DB=pgsql POSTGRESQL_VERSION=9.4
-  - DB=pgsql POSTGRESQL_VERSION=9.5
-  - DB=pgsql POSTGRESQL_VERSION=9.6
+  - DB=pgsql POSTGRESQL_VERSION=9.2 PGRV="9.2"
+  - DB=pgsql POSTGRESQL_VERSION=9.3 PGRV="9.3"
+  - DB=pgsql POSTGRESQL_VERSION=9.4 PGRV="9.4"
+  - DB=pgsql POSTGRESQL_VERSION=9.5 PGRV="9.5"
+  - DB=pgsql POSTGRESQL_VERSION=9.6 PGRV="9.6"
 
 matrix:
   fast_finish: true
@@ -237,7 +237,7 @@ matrix:
       env: DB=pgsql POSTGRESQL_VERSION=9.5
 
 addons:
-  postgresql: '9.4'
+  postgresql: $PGRV
 
 install:
   - travis_retry composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       env: DB=mariadb MARIADB_VERSION=10.0
 
     - php: 5.6
-      env: DB=mariadb
+      env: DB=mariadb MARIADB_VERSION=10.1
       addons:
         mariadb: 10.1
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ cache:
 php:
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
+  - nightly
 
 env:
   - DB=mysql
@@ -21,6 +22,177 @@ env:
   - DB=sqlite
   - DB=mysqli
 
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.6
+      env: DB=mariadb
+      addons:
+        mariadb: 10.0
+    - php: 7.0
+      env: DB=mariadb
+      addons:
+        mariadb: 10.0
+    - php: 7.1
+      env: DB=mariadb
+      addons:
+        mariadb: 10.0
+    - php: nightly
+      env: DB=mariadb
+      addons:
+        mariadb: 10.0
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next Trusty update
+      addons:
+        mariadb: 10.0
+      env: DB=mariadb
+
+    - php: 5.6
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
+    - php: 7.0
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
+    - php: 7.1
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
+    - php: nightly
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next Trusty update
+      addons:
+        mariadb: 10.1
+      env: DB=mariadb
+
+    - php: 5.6
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.5"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
+    - php: 7.0
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.5"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
+    - php: 7.1
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.5"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
+    - php: nightly
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.5"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
+
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+      env: DB=mysql
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+      env: DB=mysqli
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.1"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.1
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.2"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.2
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.3"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.3
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.4"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.4
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.5"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      env: DB=sqlite
+  allow_failures:
+    - php: hhvm
+    - php: nightly
+
+addons:
+  postgresql: '9.4'
+
 install:
   - travis_retry composer install
 
@@ -28,59 +200,3 @@ before_script:
   - if [ '$DB' = 'pgsql' ]; then sudo service postgresql stop; sudo service postgresql start $POSTGRESQL_VERSION; fi
 
 script: ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml
-
-matrix:
-  fast_finish: true
-  include:
-    - php: 5.6
-      env: DB=mariadb
-      addons:
-        mariadb: 5.5
-    - php: 7.0
-      env: DB=mariadb
-      addons:
-        mariadb: 5.5
-    - php: hhvm
-      env: DB=mariadb
-      addons:
-        mariadb: 5.5
-
-    - php: 5.6
-      env: DB=mariadb
-      addons:
-        mariadb: 10.0
-    - php: 7.0
-      env: DB=mariadb
-      addons:
-        mariadb: 10.0
-    - php: hhvm
-      env: DB=mariadb
-      addons:
-        mariadb: 10.0
-
-    - php: 5.6
-      env: DB=mariadb
-      addons:
-        mariadb: 10.1
-    - php: 7.0
-      env: DB=mariadb
-      addons:
-        mariadb: 10.1
-    - php: hhvm
-      env: DB=mariadb
-      addons:
-        mariadb: 10.1
-  allow_failures:
-    - php: hhvm
-  exclude:
-    - php: hhvm
-      env: DB=pgsql POSTGRESQL_VERSION=9.1 # driver currently unsupported by HHVM
-    - php: hhvm
-      env: DB=pgsql POSTGRESQL_VERSION=9.2 # driver currently unsupported by HHVM
-    - php: hhvm
-      env: DB=pgsql POSTGRESQL_VERSION=9.3 # driver currently unsupported by HHVM
-    - php: hhvm
-      env: DB=pgsql POSTGRESQL_VERSION=9.4 # driver currently unsupported by HHVM
-
-addons:
-  postgresql: '9.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -237,7 +237,7 @@ matrix:
       env: DB=pgsql POSTGRESQL_VERSION=9.5
 
 addons:
-  - if [ '$DB' = 'pgsql' ]; then postgresql: $POSTGRESQL_VERSION; fi
+  postgresql: $POSTGRESQL_VERSION
 
 install:
   - travis_retry composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,19 +26,19 @@ matrix:
   fast_finish: true
   include:
     - php: 5.6
-      env: DB=mariadb
+      env: DB=mariadb MARIADB_VERSION=10.0
       addons:
         mariadb: 10.0
     - php: 7.0
-      env: DB=mariadb
+      env: DB=mariadb MARIADB_VERSION=10.0
       addons:
         mariadb: 10.0
     - php: 7.1
-      env: DB=mariadb
+      env: DB=mariadb MARIADB_VERSION=10.0
       addons:
         mariadb: 10.0
     - php: nightly
-      env: DB=mariadb
+      env: DB=mariadb MARIADB_VERSION=10.0
       addons:
         mariadb: 10.0
     - php: hhvm
@@ -47,22 +47,22 @@ matrix:
       group: edge # until the next Trusty update
       addons:
         mariadb: 10.0
-      env: DB=mariadb
+      env: DB=mariadb MARIADB_VERSION=10.0
 
     - php: 5.6
       env: DB=mariadb
       addons:
         mariadb: 10.1
     - php: 7.0
-      env: DB=mariadb
+      env: DB=mariadb MARIADB_VERSION=10.1
       addons:
         mariadb: 10.1
     - php: 7.1
-      env: DB=mariadb
+      env: DB=mariadb MARIADB_VERSION=10.1
       addons:
         mariadb: 10.1
     - php: nightly
-      env: DB=mariadb
+      env: DB=mariadb MARIADB_VERSION=10.1
       addons:
         mariadb: 10.1
     - php: hhvm
@@ -71,7 +71,7 @@ matrix:
       group: edge # until the next Trusty update
       addons:
         mariadb: 10.1
-      env: DB=mariadb
+      env: DB=mariadb MARIADB_VERSION=10.1
 
     - php: 5.6
       sudo: true
@@ -189,6 +189,14 @@ matrix:
   allow_failures:
     - php: hhvm
     - php: nightly
+    - php: 7.1
+      env: DB=mariadb MARIADB_VERSION=10.1
+    - php: 5.6
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
+    - php: 7.0
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
+    - php: 7.1
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
 
 addons:
   postgresql: '9.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,6 @@ env:
   - DB=sqlite
   - DB=mysql
   - DB=mysqli
-  - DB=pgsql POSTGRESQL_VERSION=9.2 PGRV="9.2"
-  - DB=pgsql POSTGRESQL_VERSION=9.3 PGRV="9.3"
-  - DB=pgsql POSTGRESQL_VERSION=9.4 PGRV="9.4"
-  - DB=pgsql POSTGRESQL_VERSION=9.5 PGRV="9.5"
-  - DB=pgsql POSTGRESQL_VERSION=9.6 PGRV="9.6"
 
 matrix:
   fast_finish: true
@@ -73,6 +68,81 @@ matrix:
       addons:
         mariadb: 10.1
       env: DB=mariadb MARIADB_VERSION=10.1
+
+    - php: 5.6
+      addons:
+        postgresql: "9.2"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.2
+    - php: 7.0
+      addons:
+        postgresql: "9.2"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.2
+    - php: 7.1
+      addons:
+        postgresql: "9.2"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.2
+    - php: nightly
+      addons:
+        postgresql: "9.2"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.2
+
+    - php: 5.6
+      addons:
+        postgresql: "9.3"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.3
+    - php: 7.0
+      addons:
+        postgresql: "9.3"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.3
+    - php: 7.1
+      addons:
+        postgresql: "9.3"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.3
+    - php: nightly
+      addons:
+        postgresql: "9.3"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.3
+
+    - php: 5.6
+      addons:
+        postgresql: "9.4"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.4
+    - php: 7.0
+      addons:
+        postgresql: "9.4"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.4
+    - php: 7.1
+      addons:
+        postgresql: "9.4"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.4
+    - php: nightly
+      addons:
+        postgresql: "9.4"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.4
 
     - php: 5.6
       sudo: true
@@ -235,9 +305,6 @@ matrix:
       env: DB=pgsql POSTGRESQL_VERSION=9.5
     - php: 7.1
       env: DB=pgsql POSTGRESQL_VERSION=9.5
-
-addons:
-  postgresql: $PGRV
 
 install:
   - travis_retry composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -237,7 +237,12 @@ matrix:
       env: DB=pgsql POSTGRESQL_VERSION=9.5
 
 addons:
-  - postgresql: 9.4
+  - postgresql: '9.2'
+  - postgresql: '9.3'
+  - postgresql: '9.4'
+  - postgresql: '9.5'
+  - postgresql: '9.6'
+  
 
 install:
   - travis_retry composer install


### PR DESCRIPTION
- fixes version of HHVM being tested
- drops mariadb 5.5
- adds POSTGRESQL_VERSION=9.5 (only available with sudo enabled trusty) https://www.postgresql.org/support/versioning/