### PR TITLE
MS-SQL namespace

### DIFF
--- a/lib/Doctrine/DBAL/Schema/AbstractAsset.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractAsset.php
@@ -64,9 +64,9 @@ abstract class AbstractAsset
             $name = $this->trimQuotes($name);
         }
         if (strpos($name, ".") !== false) {
-            $parts = explode(".", $name);
-            $this->_namespace = $parts[0];
-            $name = $parts[1];
+            $pos = strrpos($name, ".");
+            $this->_namespace = substr($name, 0, $pos);
+            $name = substr($name, $pos + 1);
         }
         $this->_name = $name;
     }


### PR DESCRIPTION
On MS-SQL full name is not simply "database.table" but "database.dbo.table" so namespace should be full text till last dot