### PR TITLE
unit tests for oracle type consistency.

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2214,24 +2214,8 @@ abstract class AbstractPlatform
         if (isset($field['columnDefinition'])) {
             $columnDef = $this->getCustomTypeDeclarationSQL($field);
         } else {
-            $default = $this->getDefaultValueDeclarationSQL($field);
-
-            $charset = (isset($field['charset']) && $field['charset']) ?
-                    ' ' . $this->getColumnCharsetDeclarationSQL($field['charset']) : '';
-
-            $collation = (isset($field['collation']) && $field['collation']) ?
-                    ' ' . $this->getColumnCollationDeclarationSQL($field['collation']) : '';
-
-            $notnull = (isset($field['notnull']) && $field['notnull']) ? ' NOT NULL' : '';
-
-            $unique = (isset($field['unique']) && $field['unique']) ?
-                    ' ' . $this->getUniqueFieldDeclarationSQL() : '';
-
-            $check = (isset($field['check']) && $field['check']) ?
-                    ' ' . $field['check'] : '';
-
-            $typeDecl = $field['type']->getSQLDeclaration($field, $this);
-            $columnDef = $typeDecl . $charset . $default . $notnull . $unique . $check . $collation;
+            $values = $this->getColumnDeclarationValues($field);
+            $columnDef = $values['typeDecl'] . $values['charset'] . $values['default'] . $values['notnull'] . $values['unique'] . $values['check'] . $values['collation'];
         }
 
         if ($this->supportsInlineColumnComments() && isset($field['comment']) && $field['comment'] !== '') {
@@ -2239,6 +2223,40 @@ abstract class AbstractPlatform
         }
 
         return $name . ' ' . $columnDef;
+    }
+
+    /**
+     * @param array $field
+     * @return array
+     */
+    public function getColumnDeclarationValues($field)
+    {
+        $default = $this->getDefaultValueDeclarationSQL($field);
+
+        $charset = (isset($field['charset']) && $field['charset']) ?
+                ' ' . $this->getColumnCharsetDeclarationSQL($field['charset']) : '';
+
+        $collation = (isset($field['collation']) && $field['collation']) ?
+                ' ' . $this->getColumnCollationDeclarationSQL($field['collation']) : '';
+
+        $notnull = (isset($field['notnull']) && $field['notnull']) ? ' NOT NULL' : '';
+
+        $unique = (isset($field['unique']) && $field['unique']) ?
+                ' ' . $this->getUniqueFieldDeclarationSQL() : '';
+
+        $check = (isset($field['check']) && $field['check']) ?
+                ' ' . $field['check'] : '';
+
+        $typeDecl = $field['type']->getSQLDeclaration($field, $this);
+        return array(
+            'default' => $default,
+            'charset' => $charset,
+            'collation' => $collation,
+            'notnull' => $notnull,
+            'unique' => $unique,
+            'check' => $check,
+            'typeDecl' => $typeDecl,
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Schema/AbstractSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/AbstractSchemaManagerTest.php
@@ -1,0 +1,94 @@
+<?php
+namespace Doctrine\Tests\DBAL\Schema;
+
+abstract class AbstractSchemaManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Doctrine\DBAL\Schema\AbstractSchemaManager
+     */
+    protected $schemaManager;
+
+    /**
+     * @var \Doctrine\DBAL\Connection|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $connection;
+    
+    /**
+     *
+     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
+     */
+    protected $platform;
+    
+    /**
+     *
+     * @var \Doctrine\DBAL\Schema\Table 
+     */
+    protected $table;
+
+    protected function setUp()
+    {
+        $this->connection->expects($this->any())->method('fetchAll')->willReturnCallback(function(){
+            $columns = array();
+            foreach($this->table->getColumns() as $name => $column) {
+                $parts = $this->platform->getColumnDeclarationValues($column->toArray());
+                preg_match('/(?P<type>[A-Z0-9 ]+)\(?(?P<precision>[0-9]*)[, ]*(?P<scale>[0-9]*)\)?(?P<extra>[A-Z ]*)/', $parts['typeDecl'], $matches);
+                $type = isset($matches['type']) ? $matches['type']: null;
+                $precision = isset($matches['precision']) ? $matches['precision'] : null;
+                $scale = isset($matches['scale']) ? $matches['scale'] : null;
+                $extra = isset($matches['extra']) ? $matches['extra'] : null;
+                $columns[] = array(
+                    'data_type' => $type.$extra,
+                    'column_name' => $name,
+                    'data_default' => null,
+                    'data_precision' => (int) $precision,
+                    'data_scale' => (int) $scale,
+                    'char_length' => (int) $precision,
+                    'nullable' => 'N',
+                    'comments' => null,
+                );
+            }
+            return $columns;
+        });
+    }
+
+    /**
+     * Test that creating a column with a doctrine type results in the same column type from schema manager
+     * 
+     * @param string $type
+     * @dataProvider doctrineTypeProvider
+     */
+    public function testGenerateColumnTypeMatchesExtractColumnType($type)
+    {
+        $platformName = $this->platform->getName();
+        $fromTable = new \Doctrine\DBAL\Schema\Table('test');
+        $fromTable->addColumn('col_'.$type, $type);
+        $this->table = $fromTable;
+        $fromCreateSql = $this->platform->getCreateTableSQL($fromTable);
+        try {
+            $dbColumns = $this->schemaManager->listTableColumns('test');
+        }
+        catch (\Doctrine\DBAL\DBALException $e){
+            if (strpos($e->getMessage(), 'Unknown database type') !== false){
+                $this->markTestSkipped(sprintf('Type not supported by %s driver: %s', $platformName, $type));
+                return;
+            }
+            throw $e;
+        }
+        
+        $toTable = new \Doctrine\DBAL\Schema\Table('test', $dbColumns);
+        $toCreateSql = $this->platform->getCreateTableSQL($toTable);
+        
+        $fromCreate = $fromCreateSql[0];
+        $toCreate = str_replace('"', '', $toCreateSql[0]);
+        $this->assertEquals($fromCreate, $toCreate, sprintf('Create statement from doctrine type equals create statement from (%s) database type', $platformName));
+    }
+    
+    public function doctrineTypeProvider()
+    {
+        $types = array();
+        foreach (array_keys(\Doctrine\DBAL\Types\Type::getTypesMap()) as $type) {
+            $types[] = array($type);
+        }
+        return $types;
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/OracleSchemaManagerTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Doctrine\Tests\DBAL\Schema;
+
+class OracleSchemaManagerTest extends AbstractSchemaManagerTest
+{
+    protected function setUp()
+    {
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
+        $this->platform = new \Doctrine\DBAL\Platforms\OraclePlatform();
+        $this->connection = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setConstructorArgs(array(array('platform' => $this->platform), $driverMock))
+            ->getMock();
+        $this->schemaManager = new \Doctrine\DBAL\Schema\OracleSchemaManager($this->connection, $this->platform);
+        parent::setUp();
+    }
+}


### PR DESCRIPTION
add unit tests that try to generate a table with a column type for every
available doctrine data type. inject the data type information from the
platform's CreateTableSQL back through the schema manager to confirm that
the types are consistent. Any types that are not implemented by the platform
are marked as skipped.

This only tests Oracle types for now, but I've implemented an
AbstractSchemaManagerTest as I think that the principle can be applied to
other platforms as well.