### PR TITLE
Allow doctrine/common 2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.4,<2.7-dev"
+        "doctrine/common": ">=2.4,<2.8-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
To ease the process I just edited the current constraint schema, but I would rather use caret version `^2.4` if you agree.