### PR TITLE
Allow secure connections using SSL on mysqli

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -235,6 +235,11 @@ mysqli
    the database.
 -  ``charset`` (string): The charset used when connecting to the
    database.
+-  ``ssl_key`` (string): The path name to the key file to use for SSL encryption.
+-  ``ssl_cert`` (string): The path name to the certificate file to use for SSL encryption.
+-  ``ssl_ca`` (string): The path name to the certificate authority file to use for SSL encryption.
+-  ``ssl_capath`` (string): The pathname to a directory that contains trusted SSL CA certificates in PEM format.
+-  ``ssl_cipher`` (string): A list of allowable ciphers to use for SSL encryption.
 -  ``driverOptions`` Any supported flags for mysqli found on `http://www.php.net/manual/en/mysqli.real-connect.php`
 
 pdo\_pgsql

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -63,6 +63,7 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
 
         $this->_conn = mysqli_init();
 
+        $this->setSecureConnection($params);
         $this->setDriverOptions($driverOptions);
 
         set_error_handler(function () {});
@@ -262,5 +263,36 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
     public function ping()
     {
         return $this->_conn->ping();
+    }
+
+    /**
+     * Establish a secure connection
+     *
+     * @param array $params
+     * @throws MysqliException
+     */
+    private function setSecureConnection(array $params)
+    {
+        if (! isset($params['ssl_key']) &&
+            ! isset($params['ssl_cert']) &&
+            ! isset($params['ssl_ca']) &&
+            ! isset($params['ssl_capath']) &&
+            ! isset($params['ssl_cipher'])
+        ) {
+            return;
+        }
+
+        if (! isset($params['ssl_key']) || ! isset($params['ssl_cert'])) {
+            $msg = '"ssl_key" and "ssl_cert" parameters are mandatory when using secure connection parameters.';
+            throw new MysqliException($msg);
+        }
+
+        $this->_conn->ssl_set(
+            $params['ssl_key'],
+            $params['ssl_cert'],
+            $params['ssl_ca']     ?? null,
+            $params['ssl_capath'] ?? null,
+            $params['ssl_cipher'] ?? null
+        );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\DBAL\Driver\Mysqli;
 
+use Doctrine\DBAL\Driver\Mysqli\MysqliConnection;
+use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\Tests\DbalTestCase;
 
 class MysqliConnectionTest extends DbalTestCase
@@ -21,7 +23,7 @@ class MysqliConnectionTest extends DbalTestCase
 
         parent::setUp();
 
-        $this->connectionMock = $this->getMockBuilder('Doctrine\DBAL\Driver\Mysqli\MysqliConnection')
+        $this->connectionMock = $this->getMockBuilder(MysqliConnection::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
     }
@@ -30,4 +32,35 @@ class MysqliConnectionTest extends DbalTestCase
     {
         $this->assertFalse($this->connectionMock->requiresQueryForServerVersion());
     }
+
+    /**
+     * @dataProvider secureMissingParamsProvider
+     */
+    public function testThrowsExceptionWhenMissingMandatorySecureParams(array $secureParams)
+    {
+        $this->expectException(MysqliException::class);
+        $msg = '"ssl_key" and "ssl_cert" parameters are mandatory when using secure connection parameters.';
+        $this->expectExceptionMessage($msg);
+
+        new MysqliConnection($secureParams, 'xxx', 'xxx');
+    }
+
+    public function secureMissingParamsProvider()
+    {
+        return [
+            [
+                ['ssl_cert' => 'cert.pem']
+            ],
+            [
+                ['ssl_key' => 'key.pem']
+            ],
+            [
+                ['ssl_key' => 'key.pem', 'ssl_ca' => 'ca.pem', 'ssl_capath' => 'xxx', 'ssl_cipher' => 'xxx']
+            ],
+            [
+                ['ssl_ca' => 'ca.pem', 'ssl_capath' => 'xxx', 'ssl_cipher' => 'xxx']
+            ]
+        ];
+    }
 }
+


### PR DESCRIPTION
The current driver has no option to allow the usage of SSL connections on mysql. I've used the same name params as mysql client. 
An example of mysql client usage would be: 

mysql --ssl-ca='path_to_ca.pem' --ssl-cert='path_to_client_cert.pem' --ssl-key='path_to_client_key.pem'