### PR TITLE
DDC-3924 Comparator can detect a renamed foreign key

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -408,6 +408,10 @@ class Comparator
             return true;
         }
 
+        if ($key1->getName() !== $key2->getName()){
+            return true;
+        }
+
         return false;
     }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -629,16 +629,33 @@ class ComparatorTest extends \PHPUnit_Framework_TestCase
     {
         $tableA = new Table("foo");
         $tableA->addColumn('id', 'integer');
-        $tableA->addNamedForeignKeyConstraint('foo_constraint', 'bar', array('id'), array('id'));
+        $tableA->addForeignKeyConstraint('bar', array('id'), array('id'));
 
         $tableB = new Table("foo");
         $tableB->addColumn('ID', 'integer');
-        $tableB->addNamedForeignKeyConstraint('bar_constraint', 'bar', array('id'), array('id'));
+        $tableB->addForeignKeyConstraint('bar', array('id'), array('id'));
 
         $c = new Comparator();
         $tableDiff = $c->diffTable($tableA, $tableB);
 
         $this->assertFalse($tableDiff);
+    }
+
+    public function testCompareForeignKeyBasedOnNameNotProperties()
+    {
+        $tableA = new Table("foo");
+        $tableA->addColumn('id', 'integer');
+        $tableA->addForeignKeyConstraint('bar', array('id'), array('id'), array(), 'foo_constraint');
+
+        $tableB = new Table("foo");
+        $tableB->addColumn('id', 'integer');
+        $tableB->addForeignKeyConstraint('bar', array('ID'), array('id'), array(), 'bar_constraint');
+
+        $c = new Comparator();
+        $tableDiff = $c->diffTable($tableA, $tableB);
+
+        $this->assertCount(1, $tableDiff->addedForeignKeys);
+        $this->assertCount(1, $tableDiff->removedForeignKeys);
     }
 
     public function testCompareForeignKey_RestrictNoAction_AreTheSame()


### PR DESCRIPTION
Q | A
------ | ------
|Branch? 	| "master"
|Bug fix? 	| yes
|BC breaks? 	| no
|Deprecations?  |no
|Tests pass? 	|yes
|Referres to | #2360

As it appears, the Comparator was not able to detect changed foreign key names. Now it is...