### PR TITLE
Fetch table options to improve dumping of table structure

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2837,6 +2837,20 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Returns the SQL Query that fetches a table's options like collation, charset or engine.
+     *
+     * @param string $table
+     *
+     * @return string
+     *
+     * @throws \Doctrine\DBAL\DBALException If not supported on this platform.
+     */
+    public function getTableOptionsSQL($table, $database = null)
+    {
+        throw DBALException::notSupported(__METHOD__);
+    }
+
+    /**
      * @param string $name
      * @param string $sql
      *

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -209,6 +209,32 @@ class MySqlPlatform extends AbstractPlatform
     }
 
     /**
+     * @param string $table
+     *
+     * @return string
+     *
+     * @throws \Doctrine\DBAL\DBALException If not supported on this platform.
+     */
+    public function getTableOptionsSQL($table, $database = null)
+    {
+        $table = $this->quoteStringLiteral($table);
+
+        if (null !== $database) {
+            $database = $this->quoteStringLiteral($database);
+        }
+
+        $sql = "SELECT t.ENGINE AS `engine`, t.table_collation AS `collate`, ccsa.character_set_name AS `charset`
+                FROM information_schema.`TABLES` t
+                JOIN information_schema.`COLLATION_CHARACTER_SET_APPLICABILITY` ccsa ON ccsa.collation_name = t.table_collation
+                WHERE t.table_name = $table";
+
+        $databaseNameSql = null === $database ? 'DATABASE()' : $database;
+        $sql .= " AND t.table_schema = $databaseNameSql";
+
+        return $sql;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getCreateViewSQL($name, $sql)

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -194,6 +194,20 @@ abstract class AbstractSchemaManager
     }
 
     /**
+     * Fetch table options.
+     *
+     * @param string $tableName
+     *
+     * @return array
+     */
+    public function getTableOptions($tableName)
+    {
+        $sql = $this->_platform->getTableOptionsSQL($tableName);
+
+        return $this->_conn->fetchAssoc($sql);
+    }
+
+    /**
      * Returns true if all the given tables exist.
      *
      * @param array $tableNames
@@ -284,8 +298,9 @@ abstract class AbstractSchemaManager
             $foreignKeys = $this->listTableForeignKeys($tableName);
         }
         $indexes = $this->listTableIndexes($tableName);
+        $options = $this->getTableOptions($tableName);
 
-        return new Table($tableName, $columns, $indexes, $foreignKeys, false, array());
+        return new Table($tableName, $columns, $indexes, $foreignKeys, false, $options);
     }
 
     /**


### PR DESCRIPTION
Currently, information like the collation, charset and the engine (in MySQL) get lost when I use Doctrine to analyze the data and to create "CREATE TABLE" statements.  When I have a table, that has for example a utf8_general_ci collation, Doctrine does not fetch this information. However, the collation of a column is fetched correctly.

Consider the following table:

<pre>
CREATE TABLE foo
(name VARCHAR(255) NOT NULL COLLATE utf8_general_ci)
DEFAULT CHARACTER SET utf8 COLLATE <b>utf8_general_ci</b> ENGINE = InnoDB;
</pre>

By dumping the table structure, we get the following result:

<pre>
CREATE TABLE foo
(name VARCHAR(255) NOT NULL COLLATE utf8_general_ci)
DEFAULT CHARACTER SET utf8 COLLATE <b>utf8_unicode_ci</b> ENGINE = InnoDB;
</pre>

As you can see, the collation information on the table got lost. And it is the same with the character set and the engine and probably other options I don't know about.

I'd like to propose a feature that analyses the tables and adds those options into the Table object.

Before I start to implement this feature for all platforms and build tests, I'd like to ask for your feedback. Are there any objections not to implement this feature?