### PR TITLE
OraclePlatform : Add an owner condition to the list table column comment subquery

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -672,8 +672,7 @@ LEFT JOIN user_cons_columns r_cols
                              SELECT d.comments
                              FROM   $colCommentsTableName d
                              WHERE  d.TABLE_NAME = c.TABLE_NAME
-                             AND    d.COLUMN_NAME = c.COLUMN_NAME
-                             $ownerCommentsCondition
+                             AND    d.COLUMN_NAME = c.COLUMN_NAME $ownerCommentsCondition
                          ) AS comments
                 FROM     $tabColumnsTableName c
                 WHERE    c.table_name = " . $table . " $ownerCondition

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -656,6 +656,7 @@ LEFT JOIN user_cons_columns r_cols
         $tabColumnsTableName = "user_tab_columns";
         $colCommentsTableName = "user_col_comments";
         $ownerCondition = '';
+        $ownerCommentsCondition = '';
 
         if (null !== $database && '/' !== $database) {
             $database = $this->normalizeIdentifier($database);
@@ -663,6 +664,7 @@ LEFT JOIN user_cons_columns r_cols
             $tabColumnsTableName = "all_tab_columns";
             $colCommentsTableName = "all_col_comments";
             $ownerCondition = "AND c.owner = " . $database;
+            $ownerCommentsCondition = "AND d.owner = " . $database;
         }
 
         return "SELECT   c.*,
@@ -671,6 +673,7 @@ LEFT JOIN user_cons_columns r_cols
                              FROM   $colCommentsTableName d
                              WHERE  d.TABLE_NAME = c.TABLE_NAME
                              AND    d.COLUMN_NAME = c.COLUMN_NAME
+                             $ownerCommentsCondition
                          ) AS comments
                 FROM     $tabColumnsTableName c
                 WHERE    c.table_name = " . $table . " $ownerCondition

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -728,7 +728,7 @@ EOD;
                              SELECT d.comments
                              FROM   user_col_comments d
                              WHERE  d.TABLE_NAME = c.TABLE_NAME
-                             AND    d.COLUMN_NAME = c.COLUMN_NAME
+                             AND    d.COLUMN_NAME = c.COLUMN_NAME 
                          ) AS comments
                 FROM     user_tab_columns c
                 WHERE    c.table_name = 'test' 
@@ -741,7 +741,7 @@ EOD;
                              SELECT d.comments
                              FROM   user_col_comments d
                              WHERE  d.TABLE_NAME = c.TABLE_NAME
-                             AND    d.COLUMN_NAME = c.COLUMN_NAME
+                             AND    d.COLUMN_NAME = c.COLUMN_NAME 
                          ) AS comments
                 FROM     user_tab_columns c
                 WHERE    c.table_name = 'test' 
@@ -754,7 +754,7 @@ EOD;
                              SELECT d.comments
                              FROM   all_col_comments d
                              WHERE  d.TABLE_NAME = c.TABLE_NAME
-                             AND    d.COLUMN_NAME = c.COLUMN_NAME
+                             AND    d.COLUMN_NAME = c.COLUMN_NAME AND d.owner = 'SCOTT'
                          ) AS comments
                 FROM     all_tab_columns c
                 WHERE    c.table_name = 'test' AND c.owner = 'SCOTT'


### PR DESCRIPTION
This PR is to fix #2584.

It adds a complementary where condition on the request in the `getListTableColumnsSQL` of `OraclePlatform`class.