### PR TITLE
ref #2586 Fix function getCurrentDateSql() for SQL Server 2008 and above

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -95,6 +95,14 @@ class SQLServer2008Platform extends SQLServer2005Platform
 
     /**
      * {@inheritDoc}
+     */
+    public function getCurrentDateSQL()
+    {
+        return 'CONVERT(date, GETDATE())';
+    }
+
+    /**
+     * {@inheritDoc}
      *
      * Adding Datetime2 Type
      */


### PR DESCRIPTION
Fix done. Up to you.