### PR TITLE
Remove support for PHP 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,6 @@ matrix:
         mariadb: 10.0
       env: DB=mariadb MARIADB_VERSION=10.0
 
-    - php: 5.6
-      env: DB=mariadb MARIADB_VERSION=10.1
-      addons:
-        mariadb: 10.1
     - php: 7.0
       env: DB=mariadb MARIADB_VERSION=10.1
       addons:
@@ -64,12 +60,6 @@ matrix:
         mariadb: 10.1
       env: DB=mariadb MARIADB_VERSION=10.1
 
-    - php: 5.6
-      addons:
-        postgresql: "9.2"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.2
     - php: 7.0
       addons:
         postgresql: "9.2"
@@ -89,12 +79,6 @@ matrix:
         - postgresql
       env: DB=pgsql POSTGRESQL_VERSION=9.2
 
-    - php: 5.6
-      addons:
-        postgresql: "9.3"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.3
     - php: 7.0
       addons:
         postgresql: "9.3"
@@ -114,12 +98,6 @@ matrix:
         - postgresql
       env: DB=pgsql POSTGRESQL_VERSION=9.3
 
-    - php: 5.6
-      addons:
-        postgresql: "9.4"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.4
     - php: 7.0
       addons:
         postgresql: "9.4"
@@ -139,15 +117,6 @@ matrix:
         - postgresql
       env: DB=pgsql POSTGRESQL_VERSION=9.4
 
-    - php: 5.6
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        postgresql: "9.5"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
     - php: 7.0
       sudo: true
       dist: trusty
@@ -246,7 +215,6 @@ matrix:
   allow_failures:
     - php: hhvm
     - php: nightly
-    - php: 5.6
       env: DB=pgsql POSTGRESQL_VERSION=9.5
     - php: 7.0
       env: DB=pgsql POSTGRESQL_VERSION=9.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
         - $HOME/.composer/cache
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - nightly
@@ -21,10 +20,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env: DB=mariadb MARIADB_VERSION=10.0
-      addons:
-        mariadb: 10.0
     - php: 7.0
       env: DB=mariadb MARIADB_VERSION=10.0
       addons:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0",
         "doctrine/common": "^2.7.1"
     },
     "require-dev": {


### PR DESCRIPTION
Removes support for PHP 5.x from composer.json and .travis.yml