### PR TITLE
DBAL-2594 Implicitly mark types as commented in all platforms

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -400,6 +400,12 @@ abstract class AbstractPlatform
 
         $dbType = strtolower($dbType);
         $this->doctrineTypeMapping[$dbType] = $doctrineType;
+
+        $doctrineType = Type::getType($doctrineType);
+
+        if ($doctrineType->requiresSQLCommentHint($this)) {
+            $this->markDoctrineTypeCommented($doctrineType);
+        }
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\Types\CommentedType;
 
 abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 {
@@ -105,6 +106,21 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     {
         $this->setExpectedException('Doctrine\DBAL\DBALException');
         $this->_platform->registerDoctrineTypeMapping('foo', 'bar');
+    }
+
+    /**
+     * @group DBAL-2594
+     */
+    public function testRegistersCommentedDoctrineMappingTypeImplicitly()
+    {
+        if (!Type::hasType('my_commented')) {
+            Type::addType('my_commented', CommentedType::class);
+        }
+
+        $type = Type::getType('my_commented');
+        $this->_platform->registerDoctrineTypeMapping('foo', 'my_commented');
+
+        $this->assertTrue($this->_platform->isCommentedDoctrineType($type));
     }
 
     /**

--- a/tests/Doctrine/Tests/Types/CommentedType.php
+++ b/tests/Doctrine/Tests/Types/CommentedType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\Tests\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+class CommentedType extends Type
+{
+    public function getName()
+    {
+        return 'my_commented';
+    }
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return strtoupper($this->getName());
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
See #2594 

This patch removes the requirement to mark custom Doctrine types as commented via `AbstractPlatform::markDoctrineTypeCommented()`.