### PR TITLE
DBAL-2565 Remove fragile test that cannot be abstracted across all PostgreSQL versions

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -353,7 +353,6 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $offlineTable->addColumn('name', 'string');
         $offlineTable->addColumn('email', 'string');
         $offlineTable->addUniqueIndex(array('id', 'name'), 'simple_partial_index', array('where' => '(id IS NULL)'));
-        $offlineTable->addIndex(array('id', 'name'), 'complex_partial_index', array(), array('where' => '(((id IS NOT NULL) AND (name IS NULL)) AND (email IS NULL))'));
 
         $this->_sm->dropAndCreateTable($offlineTable);
 
@@ -363,14 +362,8 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertFalse($comparator->diffTable($offlineTable, $onlineTable));
         $this->assertTrue($onlineTable->hasIndex('simple_partial_index'));
-        $this->assertTrue($onlineTable->hasIndex('complex_partial_index'));
         $this->assertTrue($onlineTable->getIndex('simple_partial_index')->hasOption('where'));
-        $this->assertTrue($onlineTable->getIndex('complex_partial_index')->hasOption('where'));
         $this->assertSame('(id IS NULL)', $onlineTable->getIndex('simple_partial_index')->getOption('where'));
-        $this->assertSame(
-            '(((id IS NOT NULL) AND (name IS NULL)) AND (email IS NULL))',
-            $onlineTable->getIndex('complex_partial_index')->getOption('where')
-        );
     }
 
     public function testJsonbColumn()


### PR DESCRIPTION
See https://github.com/doctrine/dbal/issues/2565

As discussed in https://github.com/doctrine/dbal/pull/600#issuecomment-273343134 we have to remove a functional test about partial index definition comparison in PostgreSQL, as since version `9.5` the definition is decompiled in a different format by the database server, which makes the original definition uncomparable to the introspected one without a complex expression parser.

As partial indexes are not portable anyways, we accept this incompatibility to happen.