### PR TITLE
[DBAL-2586] Fix current date and time SQL generation on SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -43,6 +43,35 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
+    public function getCurrentDateSQL()
+    {
+        return $this->getConvertExpression('date', 'GETDATE()');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrentTimeSQL()
+    {
+        return $this->getConvertExpression('time', 'GETDATE()');
+    }
+
+    /**
+     * Returns an expression that converts an expression of one data type to another.
+     *
+     * @param string $dataType   The target native data type. Alias data types cannot be used.
+     * @param string $expression The SQL expression to convert.
+     *
+     * @return string
+     */
+    private function getConvertExpression($dataType, $expression)
+    {
+        return sprintf('CONVERT(%s, %s)', $dataType, $expression);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getDateArithmeticIntervalExpression($date, $operator, $interval, $unit)
     {
         $factorClause = '';

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -55,6 +55,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testDefaultConstraints()
     {
+        $platform = $this->_sm->getDatabasePlatform();
         $table = new Table('sqlsrv_default_constraints');
         $table->addColumn('no_default', 'string');
         $table->addColumn('df_integer', 'integer', array('default' => 666));
@@ -63,6 +64,8 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('df_string_3', 'string', array('default' => 'another default value'));
         $table->addColumn('df_string_4', 'string', array('default' => 'column to rename'));
         $table->addColumn('df_boolean', 'boolean', array('default' => true));
+        $table->addColumn('df_current_date', 'date', array('default' => $platform->getCurrentDateSQL()));
+        $table->addColumn('df_current_time', 'time', array('default' => $platform->getCurrentTimeSQL()));
 
         $this->_sm->createTable($table);
         $columns = $this->_sm->listTableColumns('sqlsrv_default_constraints');
@@ -73,6 +76,8 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertEquals('Doctrine rocks!!!', $columns['df_string_2']->getDefault());
         $this->assertEquals('another default value', $columns['df_string_3']->getDefault());
         $this->assertEquals(1, $columns['df_boolean']->getDefault());
+        $this->assertSame($platform->getCurrentDateSQL(), $columns['df_current_date']->getDefault());
+        $this->assertSame($platform->getCurrentTimeSQL(), $columns['df_current_time']->getDefault());
 
         $diff = new TableDiff(
             'sqlsrv_default_constraints',

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -55,6 +55,9 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
 
     public function testGeneratesSqlSnippets()
     {
+        $this->assertEquals('CONVERT(date, GETDATE())', $this->_platform->getCurrentDateSQL());
+        $this->assertEquals('CONVERT(time, GETDATE())', $this->_platform->getCurrentTimeSQL());
+        $this->assertEquals('CURRENT_TIMESTAMP', $this->_platform->getCurrentTimestampSQL());
         $this->assertEquals('"', $this->_platform->getIdentifierQuoteCharacter(), 'Identifier quote character is not correct');
         $this->assertEquals('(column1 + column2 + column3)', $this->_platform->getConcatExpression('column1', 'column2', 'column3'), 'Concatenation expression is not correct');
     }


### PR DESCRIPTION
See #2586 

Affects both date and time expressions.