### PR TITLE
[DBAL-2508] Pass through index options when renaming index on table

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -253,10 +253,10 @@ class Table extends AbstractAsset
         unset($this->_indexes[$oldIndexName]);
 
         if ($oldIndex->isUnique()) {
-            return $this->addUniqueIndex($oldIndex->getColumns(), $newIndexName);
+            return $this->addUniqueIndex($oldIndex->getColumns(), $newIndexName, $oldIndex->getOptions());
         }
 
-        return $this->addIndex($oldIndex->getColumns(), $newIndexName, $oldIndex->getFlags());
+        return $this->addIndex($oldIndex->getColumns(), $newIndexName, $oldIndex->getFlags(), $oldIndex->getOptions());
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -742,6 +742,34 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
     }
 
     /**
+     * @group DBAL-2508
+     */
+    public function testKeepsIndexOptionsOnRenamingRegularIndex()
+    {
+        $table = new Table('foo');
+        $table->addColumn('id', 'integer');
+        $table->addIndex(array('id'), 'idx_bar', array(), array('where' => '1 = 1'));
+
+        $table->renameIndex('idx_bar', 'idx_baz');
+
+        $this->assertSame(array('where' => '1 = 1'), $table->getIndex('idx_baz')->getOptions());
+    }
+
+    /**
+     * @group DBAL-2508
+     */
+    public function testKeepsIndexOptionsOnRenamingUniqueIndex()
+    {
+        $table = new Table('foo');
+        $table->addColumn('id', 'integer');
+        $table->addUniqueIndex(array('id'), 'idx_bar', array('where' => '1 = 1'));
+
+        $table->renameIndex('idx_bar', 'idx_baz');
+
+        $this->assertSame(array('where' => '1 = 1'), $table->getIndex('idx_baz')->getOptions());
+    }
+
+    /**
      * @group DBAL-234
      * @expectedException \Doctrine\DBAL\Schema\SchemaException
      */


### PR DESCRIPTION
Fixes #2508 

Renaming an index on a table object in fact creates a new index object from the old one internally but did not pass index options from the old index to the new one.