### PR TITLE
[DBAL-2555] Fix date and datetimetz type mapping on Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -1126,7 +1126,7 @@ END;';
             'nvarchar2'         => 'string',
             'char'              => 'string',
             'nchar'             => 'string',
-            'date'              => 'datetime',
+            'date'              => 'date',
             'timestamp'         => 'datetime',
             'timestamptz'       => 'datetimetz',
             'float'             => 'float',

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -102,7 +102,7 @@ class OracleSchemaManager extends AbstractSchemaManager
 
         $dbType = strtolower($tableColumn['data_type']);
         if (strpos($dbType, "timestamp(") === 0) {
-            if (strpos($dbType, "WITH TIME ZONE")) {
+            if (strpos($dbType, "with time zone")) {
                 $dbType = "timestamptz";
             } else {
                 $dbType = "timestamp";

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -240,6 +240,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table = new Table('tbl_date');
         $table->addColumn('col_date', 'date');
         $table->addColumn('col_datetime', 'datetime');
+        $table->addColumn('col_datetimetz', 'datetimetz');
 
         $this->_sm->dropAndCreateTable($table);
 
@@ -247,5 +248,6 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->assertSame('date', $columns['col_date']->getType()->getName());
         $this->assertSame('datetime', $columns['col_datetime']->getType()->getName());
+        $this->assertSame('datetimetz', $columns['col_datetimetz']->getType()->getName());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -231,4 +231,21 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $columns = $this->_sm->listTableColumns($table->getName(), $this->_conn->getUsername());
         $this->assertCount(7, $columns);
     }
+
+    /**
+     * @group DBAL-2555
+     */
+    public function testListTableDateTypeColumns()
+    {
+        $table = new Table('tbl_date');
+        $table->addColumn('col_date', 'date');
+        $table->addColumn('col_datetime', 'datetime');
+
+        $this->_sm->dropAndCreateTable($table);
+
+        $columns = $this->_sm->listTableColumns('tbl_date');
+
+        $this->assertSame('date', $columns['col_date']->getType()->getName());
+        $this->assertSame('datetime', $columns['col_datetime']->getType()->getName());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -412,6 +412,9 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         $this->assertEquals($expectedSql, $this->_platform->getAlterTableSQL($tableDiff));
     }
 
+    /**
+     * @group DBAK-2555
+     */
     public function testInitializesDoctrineTypeMappings()
     {
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('long raw'));
@@ -419,6 +422,9 @@ class OraclePlatformTest extends AbstractPlatformTestCase
 
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('raw'));
         $this->assertSame('binary', $this->_platform->getDoctrineTypeMapping('raw'));
+
+        $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('date'));
+        $this->assertSame('date', $this->_platform->getDoctrineTypeMapping('date'));
     }
 
     protected function getBinaryMaxLength()

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -413,7 +413,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
-     * @group DBAK-2555
+     * @group DBAL-2555
      */
     public function testInitializesDoctrineTypeMappings()
     {


### PR DESCRIPTION
Fixes #2555 

Oracle's `DATE` type was erroneously mapped to Doctrine's `DateTime` type. Although I wonder why nobody ever complained about that until now, the fix looks straight forward and also complies to what we have documented.

Additionally the instrospection of `DateTimeTzType` was wrong and has been fixed (wrong case in type comparison).

Tests pass locally.