### PR TITLE
DBAL-2427 Fix negative default value introspection on PostgreSQL 9.4

### DIFF
--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -316,7 +316,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
             $autoincrement = true;
         }
 
-        if (preg_match("/^'(.*)'::.*$/", $tableColumn['default'], $matches)) {
+        if (preg_match("/^['(](.*)[')]::.*$/", $tableColumn['default'], $matches)) {
             $tableColumn['default'] = $matches[1];
         }
 
@@ -354,15 +354,18 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         switch ($dbType) {
             case 'smallint':
             case 'int2':
+                $tableColumn['default'] = $this->fixVersion94NegativeNumericDefaultValue($tableColumn['default']);
                 $length = null;
                 break;
             case 'int':
             case 'int4':
             case 'integer':
+                $tableColumn['default'] = $this->fixVersion94NegativeNumericDefaultValue($tableColumn['default']);
                 $length = null;
                 break;
             case 'bigint':
             case 'int8':
+                $tableColumn['default'] = $this->fixVersion94NegativeNumericDefaultValue($tableColumn['default']);
                 $length = null;
                 break;
             case 'bool':
@@ -398,6 +401,8 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
             case 'decimal':
             case 'money':
             case 'numeric':
+                $tableColumn['default'] = $this->fixVersion94NegativeNumericDefaultValue($tableColumn['default']);
+
                 if (preg_match('([A-Za-z]+\(([0-9]+)\,([0-9]+)\))', $tableColumn['complete_type'], $match)) {
                     $precision = $match[1];
                     $scale = $match[2];
@@ -444,5 +449,21 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         }
 
         return $column;
+    }
+
+    /**
+     * PostgreSQL 9.4 puts parentheses around negative numeric default values that need to be stripped eventually.
+     *
+     * @param mixed $defaultValue
+     *
+     * @return mixed
+     */
+    private function fixVersion94NegativeNumericDefaultValue($defaultValue)
+    {
+        if (strpos($defaultValue, '(') === 0) {
+            return trim($defaultValue, '()');
+        }
+
+        return $defaultValue;
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -383,6 +383,31 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertEquals('json_array', $columns['foo']->getType()->getName());
         $this->assertEquals(true, $columns['foo']->getPlatformOption('jsonb'));
     }
+
+    /**
+     * @group DBAL-2427
+     */
+    public function testListNegativeColumnDefaultValue()
+    {
+        $table = new Schema\Table('test_default_negative');
+        $table->addColumn('col_smallint', 'smallint', array('default' => -1));
+        $table->addColumn('col_integer', 'integer', array('default' => -1));
+        $table->addColumn('col_bigint', 'bigint', array('default' => -1));
+        $table->addColumn('col_float', 'float', array('default' => -1.1));
+        $table->addColumn('col_decimal', 'decimal', array('default' => -1.1));
+        $table->addColumn('col_string', 'string', array('default' => '(-1)'));
+
+        $this->_sm->dropAndCreateTable($table);
+
+        $columns = $this->_sm->listTableColumns('test_default_negative');
+
+        $this->assertEquals(-1, $columns['col_smallint']->getDefault());
+        $this->assertEquals(-1, $columns['col_integer']->getDefault());
+        $this->assertEquals(-1, $columns['col_bigint']->getDefault());
+        $this->assertEquals(-1.1, $columns['col_float']->getDefault());
+        $this->assertEquals(-1.1, $columns['col_decimal']->getDefault());
+        $this->assertEquals('(-1)', $columns['col_string']->getDefault());
+    }
 }
 
 class MoneyType extends Type


### PR DESCRIPTION
Fixes #2427 

PostgreSQL 9.4 only bug. When defining negative default values like `-1` for numeric type columns, the server puts parentheses around the default value when introspected from the database (`(-1)`).

This is an approach to fix this incompatibility without breaking introspection for default values from strings for example (see test).

This is an ugly one :>