### PR TITLE
Add Connection::fetchAllArray() method to allow a convenience method …

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -784,6 +784,20 @@ class Connection implements DriverConnection
     }
 
     /**
+     * Prepares and executes an SQL query and returns the result as a numerically indexed array.
+     *
+     * @param string $sql    The SQL query.
+     * @param array  $params The query parameters.
+     * @param array  $types  The query parameter types.
+     *
+     * @return array All rows returned by the SQL query as a two dimensional numerically indexed array.
+     */
+    public function fetchAllArray($sql, array $params = array(), $types = array())
+    {
+        return $this->executeQuery($sql, $params, $types)->fetchAll(PDO::FETCH_NUM);
+    }
+
+    /**
      * Prepares an SQL statement.
      *
      * @param string $statement The SQL statement to prepare.

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -471,6 +471,40 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
         $this->assertSame($result, $conn->fetchArray($statement, $params, $types));
     }
 
+    public function testFetchAllArray()
+    {
+        $statement = 'SELECT * FROM foo WHERE bar = ?';
+        $params    = array(666);
+        $types     = array(\PDO::PARAM_INT);
+        $result    = array();
+
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
+
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+
+        $driverStatementMock = $this->createMock('Doctrine\Tests\Mocks\DriverStatementMock');
+
+        $driverStatementMock->expects($this->once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_NUM)
+            ->will($this->returnValue($result));
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\Doctrine\DBAL\Connection $conn */
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setMethods(array('executeQuery'))
+            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
+            ->getMock();
+
+        $conn->expects($this->once())
+            ->method('executeQuery')
+            ->with($statement, $params, $types)
+            ->will($this->returnValue($driverStatementMock));
+
+        $this->assertSame($result, $conn->fetchAllArray($statement, $params, $types));
+    }
+
     public function testFetchColumn()
     {
         $statement = 'SELECT * FROM foo WHERE bar = ?';


### PR DESCRIPTION
…for getting all records as a two-dimensional numerically indexed array.

Add PHPunit test for fetchAllArray()