### PR TITLE
Added Interface for Drivers for Platforms that support deactivation of foreign key checks

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -34,7 +34,11 @@ use Doctrine\DBAL\VersionAwarePlatformDriver;
  * @link   www.doctrine-project.org
  * @since  2.5
  */
-abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, VersionAwarePlatformDriver
+abstract class AbstractMySQLDriver implements
+    Driver,
+    ExceptionConverterDriver,
+    VersionAwarePlatformDriver,
+    ForeignKeyCheckDeactivatableDriver
 {
     /**
      * {@inheritdoc}
@@ -146,6 +150,22 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
         }
 
         return $this->getDatabasePlatform();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function activateForeignKeyChecks(\Doctrine\DBAL\Connection $conn)
+    {
+        $conn->query('SET FOREIGN_KEY_CHECKS=1');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deactivateForeignKeyChecks(\Doctrine\DBAL\Connection $conn)
+    {
+        $conn->query('SET FOREIGN_KEY_CHECKS=0');
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/ForeignKeyCheckDeactivatableDriver.php
+++ b/lib/Doctrine/DBAL/Driver/ForeignKeyCheckDeactivatableDriver.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Contract for a driver that is able to deactivate foreign key checks.
+ *
+ * @author naitsirch
+ * @link   www.doctrine-project.org
+ * @since  2.5
+ */
+interface ForeignKeyCheckDeactivatableDriver
+{
+    /**
+     * Activates the foreign key checks of the database system.
+     *
+     * @param Connection $conn
+     */
+    public function activateForeignKeyChecks(Connection $conn);
+
+    /**
+     * Deactivates the foreign key checks of the database system.
+     *
+     * @param Connection $conn
+     */
+    public function deactivateForeignKeyChecks(Connection $conn);
+}


### PR DESCRIPTION
MySQL supports the deactivation of foreign key checks. This is helpful if one wants to purge the database. Usually Doctrine tries to figure out in which order tables have to be cleared. This must not be done if the platform supports the deactivation of foreign key checks.

This feature may be used in the ORMPurger of [doctrine/data-fixtures](https://github.com/doctrine/data-fixtures). This would fix the issue with purging tables that have self-referencing associations (see doctrine/data-fixtures#147, doctrine/data-fixtures#159 or doctrine/data-fixtures#251)

I'll create a PR that uses this feature in the ORMPurger of [doctrine/data-fixtures](https://github.com/doctrine/data-fixtures).

I hope that this could be merge.