### PR TITLE
Remove dead code from `MasterSlaveConnection::connect()`

### DIFF
--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -173,13 +173,9 @@ class MasterSlaveConnection extends Connection
         }
 
         if ($connectionName === 'master') {
-            // Set slave connection to master to avoid invalid reads
-            if ($this->connections['slave'] && ! $this->keepSlave) {
-                unset($this->connections['slave']);
-            }
-
             $this->connections['master'] = $this->_conn = $this->connectTo($connectionName);
 
+            // Set slave connection to master to avoid invalid reads
             if ( ! $this->keepSlave) {
                 $this->connections['slave'] = $this->connections['master'];
             }


### PR DESCRIPTION
Currently connect unsets the slave connection right before overwriting it with the master anyway.

