### PR TITLE
HHVM testing needs to be in PHP 7 mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,13 @@ matrix:
       env: DB=mariadb MARIADB_VERSION=10.0
       addons:
         mariadb: 10.0
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next Trusty update
-      addons:
-        mariadb: 10.0
-      env: DB=mariadb MARIADB_VERSION=10.0
+ #   - php: hhvm
+ #     sudo: true
+ #     dist: trusty
+ #     group: edge # until the next Trusty update
+ #     addons:
+ #       mariadb: 10.0
+ #     env: DB=mariadb MARIADB_VERSION=10.0
 
     - php: 7.0
       env: DB=mariadb MARIADB_VERSION=10.1
@@ -52,13 +52,13 @@ matrix:
       env: DB=mariadb MARIADB_VERSION=10.1
       addons:
         mariadb: 10.1
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next Trusty update
-      addons:
-        mariadb: 10.1
-      env: DB=mariadb MARIADB_VERSION=10.1
+ #   - php: hhvm
+ #     sudo: true
+ #     dist: trusty
+ #     group: edge # until the next Trusty update
+ #     addons:
+ #       mariadb: 10.1
+ #     env: DB=mariadb MARIADB_VERSION=10.1
 
     - php: 7.0
       addons:
@@ -167,80 +167,80 @@ matrix:
         - postgresql
       env: DB=pgsql POSTGRESQL_VERSION=9.6
 
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        apt:
-          packages:
-            - mysql-server-5.6
-            - mysql-client-core-5.6
-            - mysql-client-5.6
-      services:
-        - mysql
-      env: DB=mysql
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        apt:
-          packages:
-            - mysql-server-5.6
-            - mysql-client-core-5.6
-            - mysql-client-5.6
-      services:
-        - mysql
-      env: DB=mysqli
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        postgresql: "9.2"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.2
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        postgresql: "9.3"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.3
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      addons:
-        postgresql: "9.4"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.4
-    - php: hhvm
-      sudo: false
-      dist: trusty
-      addons:
-        postgresql: "9.5"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
-    - php: hhvm
-      sudo: false
-      dist: trusty
-      addons:
-        postgresql: "9.6"
-      services:
-        - postgresql
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next update
-      env: DB=sqlite
+#    - php: hhvm
+#      sudo: true
+#      dist: trusty
+#      group: edge # until the next update
+#      addons:
+#        apt:
+#          packages:
+#            - mysql-server-5.6
+#            - mysql-client-core-5.6
+#            - mysql-client-5.6
+#      services:
+#        - mysql
+#      env: DB=mysql
+#    - php: hhvm
+#      sudo: true
+#      dist: trusty
+#      group: edge # until the next update
+#      addons:
+#        apt:
+#          packages:
+#            - mysql-server-5.6
+#            - mysql-client-core-5.6
+#            - mysql-client-5.6
+#      services:
+#        - mysql
+#      env: DB=mysqli
+#    - php: hhvm
+#      sudo: true
+#      dist: trusty
+#      group: edge # until the next update
+#      addons:
+#        postgresql: "9.2"
+#      services:
+#        - postgresql
+#      env: DB=pgsql POSTGRESQL_VERSION=9.2
+#    - php: hhvm
+#      sudo: true
+#      dist: trusty
+#      group: edge # until the next update
+#      addons:
+#        postgresql: "9.3"
+#      services:
+#        - postgresql
+#      env: DB=pgsql POSTGRESQL_VERSION=9.3
+#    - php: hhvm
+#      sudo: true
+#      dist: trusty
+#      group: edge # until the next update
+#      addons:
+#        postgresql: "9.4"
+#      services:
+#        - postgresql
+#      env: DB=pgsql POSTGRESQL_VERSION=9.4
+#    - php: hhvm
+#      sudo: false
+#      dist: trusty
+#      addons:
+#        postgresql: "9.5"
+#      services:
+#        - postgresql
+#      env: DB=pgsql POSTGRESQL_VERSION=9.5
+#    - php: hhvm
+#      sudo: false
+#      dist: trusty
+#      addons:
+#        postgresql: "9.6"
+#      services:
+#        - postgresql
+#      env: DB=pgsql POSTGRESQL_VERSION=9.6
+#    - php: hhvm
+#      sudo: true
+#      dist: trusty
+#      group: edge # until the next update
+#      env: DB=sqlite
   allow_failures:
     - php: hhvm
     - php: nightly
@@ -255,6 +255,10 @@ matrix:
       env: DB=pgsql POSTGRESQL_VERSION=9.6
     - php: 7.1
       env: DB=pgsql POSTGRESQL_VERSION=9.6
+
+before_install:
+  # Force hhvm PHP 7 mode
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo hhvm.php7.all=1 >> /etc/hhvm/php.ini; fi
 
 install:
   - travis_retry composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,13 @@ matrix:
       env: DB=mariadb MARIADB_VERSION=10.0
       addons:
         mariadb: 10.0
- #   - php: hhvm
- #     sudo: true
- #     dist: trusty
- #     group: edge # until the next Trusty update
- #     addons:
- #       mariadb: 10.0
- #     env: DB=mariadb MARIADB_VERSION=10.0
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next Trusty update
+      addons:
+        mariadb: 10.0
+      env: DB=mariadb MARIADB_VERSION=10.0
 
     - php: 7.0
       env: DB=mariadb MARIADB_VERSION=10.1
@@ -52,13 +52,13 @@ matrix:
       env: DB=mariadb MARIADB_VERSION=10.1
       addons:
         mariadb: 10.1
- #   - php: hhvm
- #     sudo: true
- #     dist: trusty
- #     group: edge # until the next Trusty update
- #     addons:
- #       mariadb: 10.1
- #     env: DB=mariadb MARIADB_VERSION=10.1
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next Trusty update
+      addons:
+        mariadb: 10.1
+      env: DB=mariadb MARIADB_VERSION=10.1
 
     - php: 7.0
       addons:
@@ -167,80 +167,80 @@ matrix:
         - postgresql
       env: DB=pgsql POSTGRESQL_VERSION=9.6
 
-#    - php: hhvm
-#      sudo: true
-#      dist: trusty
-#      group: edge # until the next update
-#      addons:
-#        apt:
-#          packages:
-#            - mysql-server-5.6
-#            - mysql-client-core-5.6
-#            - mysql-client-5.6
-#      services:
-#        - mysql
-#      env: DB=mysql
-#    - php: hhvm
-#      sudo: true
-#      dist: trusty
-#      group: edge # until the next update
-#      addons:
-#        apt:
-#          packages:
-#            - mysql-server-5.6
-#            - mysql-client-core-5.6
-#            - mysql-client-5.6
-#      services:
-#        - mysql
-#      env: DB=mysqli
-#    - php: hhvm
-#      sudo: true
-#      dist: trusty
-#      group: edge # until the next update
-#      addons:
-#        postgresql: "9.2"
-#      services:
-#        - postgresql
-#      env: DB=pgsql POSTGRESQL_VERSION=9.2
-#    - php: hhvm
-#      sudo: true
-#      dist: trusty
-#      group: edge # until the next update
-#      addons:
-#        postgresql: "9.3"
-#      services:
-#        - postgresql
-#      env: DB=pgsql POSTGRESQL_VERSION=9.3
-#    - php: hhvm
-#      sudo: true
-#      dist: trusty
-#      group: edge # until the next update
-#      addons:
-#        postgresql: "9.4"
-#      services:
-#        - postgresql
-#      env: DB=pgsql POSTGRESQL_VERSION=9.4
-#    - php: hhvm
-#      sudo: false
-#      dist: trusty
-#      addons:
-#        postgresql: "9.5"
-#      services:
-#        - postgresql
-#      env: DB=pgsql POSTGRESQL_VERSION=9.5
-#    - php: hhvm
-#      sudo: false
-#      dist: trusty
-#      addons:
-#        postgresql: "9.6"
-#      services:
-#        - postgresql
-#      env: DB=pgsql POSTGRESQL_VERSION=9.6
-#    - php: hhvm
-#      sudo: true
-#      dist: trusty
-#      group: edge # until the next update
-#      env: DB=sqlite
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+      env: DB=mysql
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+      env: DB=mysqli
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.2"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.2
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.3"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.3
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        postgresql: "9.4"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.4
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      addons:
+        postgresql: "9.5"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      addons:
+        postgresql: "9.6"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      env: DB=sqlite
   allow_failures:
     - php: hhvm
     - php: nightly


### PR DESCRIPTION
- ~~Suspend~~ HHVM testing is broken until the following items are resolved
  - HHVM PHP 7 mode issues.
    - facebook/hhvm#7626 php 7 mode not recognized by composer as PHP 7
    - facebook/hhvm#7198 type annotations on internal functions, `expects parameter 1 to be _______, null given`
    - facebook/hhvm#7544 HHVM INI settings for PHP7 mode `php 7 is not the same as php 7.1`
  - Trusty Container issues (currently beta) (this will reduce build times)
    - https://github.com/travis-ci/travis-ci/issues/6842 - MySQL socket issue on Trusty beta Container (assume fixed sometime after 1Q17)
- Add line to Force hhvm PHP 7 mode for testing
  - HHVM fails on composer `This package requires php ^7.0 but your HHVM version does not satisfy that requirement`
  - reference for change https://docs.hhvm.com/hhvm/configuration/INI-settings#php-7-settings