### PR TITLE
Fix `CREATE`/`DROP DATABASE` support on SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -173,7 +173,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function supportsCreateDropDatabase()
     {
-        return false;
+        return true;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -143,6 +143,11 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         $this->assertTrue($this->_platform->supportsIdentityColumns());
     }
 
+    public function testSupportsCreateDropDatabase()
+    {
+        $this->assertTrue($this->_platform->supportsCreateDropDatabase());
+    }
+
     public function testSupportsSchemas()
     {
         $this->assertTrue($this->_platform->supportsSchemas());


### PR DESCRIPTION
It is actually possible to use `CREATE DATABASE` and `DROP DATABASE` on SQL Server. The platform did not reflect that. The issue arised when testing SQL Server where the testsuite failed, if the database used by the testsuite didn't exist. With this patch, it works as expected.