### PR TITLE
Run SQL Azure tests conditionally

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/AbstractTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/AbstractTestCase.php
@@ -32,6 +32,13 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
             'driverOptions' => array('MultipleActiveResultSets' => false)
         );
         $this->conn = DriverManager::getConnection($params);
+
+        $serverEdition = $this->conn->fetchColumn("SELECT CONVERT(NVARCHAR(128), SERVERPROPERTY('Edition'))");
+
+        if (0 !== strpos($serverEdition, 'SQL Azure')) {
+            $this->markTestSkipped('SQL Azure only test.');
+        }
+
         // assume database is created and schema is:
         // Global products table
         // Customers, Orders, OrderItems federation tables.


### PR DESCRIPTION
SQL Azure related tests should not run, if the SQL Server edition does not support Azure related features. This patch marks the tests in question as skipped, if the database server edition is not `SQL Azure`.