### PR TITLE
Fix fetching last insert ID for sequences on SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -40,6 +40,21 @@ class Connection extends PDOConnection implements \Doctrine\DBAL\Driver\Connecti
     /**
      * {@inheritDoc}
      */
+    public function lastInsertId($name = null)
+    {
+        if (null === $name) {
+            return parent::lastInsertId($name);
+        }
+
+        $stmt = $this->prepare('SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?');
+        $stmt->execute(array($name));
+
+        return $stmt->fetchColumn();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function quote($value, $type=\PDO::PARAM_STR)
     {
         $val = parent::quote($value, $type);

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -130,9 +130,8 @@ class SQLSrvConnection implements Connection, ServerInfoAwareConnection
     public function lastInsertId($name = null)
     {
         if ($name !== null) {
-            $sql = "SELECT IDENT_CURRENT(".$this->quote($name).") AS LastInsertId";
-            $stmt = $this->prepare($sql);
-            $stmt->execute();
+            $stmt = $this->prepare('SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?');
+            $stmt->execute(array($name));
 
             return $stmt->fetchColumn();
         }


### PR DESCRIPTION
Fixes fetching last insert ID for sequences on both `sqlsrv` and `pdo_sqlsrv` drivers. The implementation on `sqlsrv` was wrong and `pdo_sqlsrv` does not support this out of the box.

The issue was revealed in #2617. See:

- https://ci.appveyor.com/project/photodude/dbal/build/1.0.138/job/r1twtafm8vsaswy4#L441
- https://ci.appveyor.com/project/photodude/dbal/build/1.0.140/job/878bxlaoeiiajsqs