### PR TITLE
Fix dropping in use databases on SQL Server and Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvException.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvException.php
@@ -19,9 +19,10 @@
 
 namespace Doctrine\DBAL\Driver\SQLSrv;
 
-use Doctrine\DBAL\DBALException;
 
-class SQLSrvException extends DBALException
+use Doctrine\DBAL\Driver\AbstractDriverException;
+
+class SQLSrvException extends AbstractDriverException
 {
     /**
      * Helper method to turn sql server errors into exception.
@@ -32,13 +33,24 @@ class SQLSrvException extends DBALException
     {
         $errors = sqlsrv_errors(SQLSRV_ERR_ERRORS);
         $message = "";
+        $sqlState = null;
+        $errorCode = null;
+
         foreach ($errors as $error) {
             $message .= "SQLSTATE [".$error['SQLSTATE'].", ".$error['code']."]: ". $error['message']."\n";
+
+            if (null === $sqlState) {
+                $sqlState = $error['SQLSTATE'];
+            }
+
+            if (null === $errorCode) {
+                $errorCode = $error['code'];
+            }
         }
         if ( ! $message) {
             $message = "SQL Server error occurred but no error message was retrieved from driver.";
         }
 
-        return new self(rtrim($message));
+        return new self(rtrim($message), $sqlState, $errorCode);
     }
 }

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Types\Type;
 
 /**
@@ -31,6 +33,34 @@ use Doctrine\DBAL\Types\Type;
  */
 class OracleSchemaManager extends AbstractSchemaManager
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function dropDatabase($database)
+    {
+        try {
+            parent::dropDatabase($database);
+        } catch (DBALException $exception) {
+            $exception = $exception->getPrevious();
+
+            if (! $exception instanceof DriverException) {
+                throw $exception;
+            }
+
+            // If we have a error code 1940 (ORA-01940), the drop database operation failed
+            // because of active connections on the database.
+            // To force dropping the database, we first have to close all active connections
+            // on that database and issue the drop database operation again.
+            if ($exception->getErrorCode() !== 1940) {
+                throw $exception;
+            }
+
+            $this->killUserSessions($database);
+
+            parent::dropDatabase($database);
+        }
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -305,7 +335,7 @@ class OracleSchemaManager extends AbstractSchemaManager
         $query  = 'CREATE USER ' . $username . ' IDENTIFIED BY ' . $password;
         $this->_conn->executeUpdate($query);
 
-        $query = 'GRANT CREATE SESSION, CREATE TABLE, UNLIMITED TABLESPACE, CREATE SEQUENCE, CREATE TRIGGER TO ' . $username;
+        $query = 'GRANT DBA TO ' . $username;
         $this->_conn->executeUpdate($query);
 
         return true;
@@ -353,5 +383,43 @@ class OracleSchemaManager extends AbstractSchemaManager
         }
 
         return $identifier;
+    }
+
+    /**
+     * Kills sessions connected with the given user.
+     *
+     * This is useful to force DROP USER operations which could fail because of active user sessions.
+     *
+     * @param string $user The name of the user to kill sessions for.
+     *
+     * @return void
+     */
+    private function killUserSessions($user)
+    {
+        $sql = <<<SQL
+SELECT
+    s.sid,
+    s.serial#
+FROM
+    gv\$session s,
+    gv\$process p
+WHERE
+    s.username = ?
+    AND p.addr(+) = s.paddr
+SQL;
+
+        $activeUserSessions = $this->_conn->fetchAll($sql, array(strtoupper($user)));
+
+        foreach ($activeUserSessions as $activeUserSession) {
+            $activeUserSession = array_change_key_case($activeUserSession, \CASE_LOWER);
+
+            $this->_execSql(
+                sprintf(
+                    "ALTER SYSTEM KILL SESSION '%s, %s' IMMEDIATE",
+                    $activeUserSession['sid'],
+                    $activeUserSession['serial#']
+                )
+            );
+        }
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -73,8 +73,6 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
 
         $this->assertInstanceOf('Doctrine\DBAL\Driver\Connection', $connection);
 
-        unset($connection);
-
         $this->_sm->dropDatabase('test_drop_database');
 
         $this->assertNotContains('test_drop_database', $this->_sm->listDatabases());


### PR DESCRIPTION
This patch follows the same approach as for PostgreSQL. If trying to drop a database with active connections, the database server will refuse with:

```
SQLSTATE [42000, 3702]: [Microsoft][ODBC Driver 13 for SQL Server][SQL Server]Cannot drop database "%s" because it is currently in use.
```

The schema manager catches that specific error code now, closes all active connections on that database and executes a `DROP DATABASE` again.

I had to fix the `SQLSrvException` to carry around the SQLSTATE and error code information.