### PR TITLE
Tear down active transactions in functional test cases

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
@@ -19,6 +19,8 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
         if ($this->portableConnection) {
             $this->portableConnection->close();
         }
+
+        parent::tearDown();
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
@@ -25,6 +25,8 @@ class TemporaryTableTest extends \Doctrine\Tests\DbalFunctionalTestCase
                 $this->_conn->exec($this->_conn->getDatabasePlatform()->getDropTemporaryTableSQL($tempTable));
             } catch(\Exception $e) { }
         }
+
+        parent::tearDown();
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
@@ -41,6 +41,8 @@ class DBAL630Test extends \Doctrine\Tests\DbalFunctionalTestCase
                 $this->_conn->getWrappedConnection()->setAttribute(PDO::PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT, false);
             }
         }
+
+        parent::tearDown();
     }
 
     public function testBooleanConversionSqlLiteral()

--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -40,6 +40,13 @@ class DbalFunctionalTestCase extends DbalTestCase
         $this->_conn->getConfiguration()->setSQLLogger($this->_sqlLoggerStack);
     }
 
+    protected function tearDown()
+    {
+        while ($this->_conn->isTransactionActive()) {
+            $this->_conn->rollBack();
+        }
+    }
+
     protected function onNotSuccessfulTest($e)
     {
         if ($e instanceof \PHPUnit_Framework_AssertionFailedError) {


### PR DESCRIPTION
I recently discovered a hard to debug issue where I was writing functional tests and suddenly the testsuite was hanging. After hours of debugging I found out that a previous test, involving transactions, failed inside a transaction and was affecting all subsequent tests as the transaction was marked as "rollback only" and still active. As we are mainly using a shared connection for performance reasons, this can get quite nasty.
I added a `tearDown` method to the base functional test case that checks, whether a transaction is active and rolls it back if that is the case.