### PR TITLE
Update Version.php

### DIFF
--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.5.5-DEV';
+    const VERSION = '2.5.12-DEV';
 
     /**
      * Compares a Doctrine version with the current one.


### PR DESCRIPTION
The VERSION const is still outdated, after release 2.5.11 it is still at 2.5.5-DEV.

Was raised already in https://github.com/doctrine/dbal/issues/2613.
