### PR TITLE
Fix drivers' `exec()` method to not execute queries via prepared statements

### DIFF
--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -113,10 +113,13 @@ class DB2Connection implements Connection, ServerInfoAwareConnection
      */
     public function exec($statement)
     {
-        $stmt = $this->prepare($statement);
-        $stmt->execute();
+        $stmt = @db2_exec($this->_conn, $statement);
 
-        return $stmt->rowCount();
+        if (false === $stmt) {
+            throw new DB2Exception(db2_stmt_errormsg());
+        }
+
+        return db2_num_rows($stmt);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -121,11 +121,11 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
      */
     public function exec($statement)
     {
-        $stmt = $this->prepare($statement);
+        if (false === sasql_real_query($this->connection, $statement)) {
+            throw SQLAnywhereException::fromSQLAnywhereError($this->connection);
+        }
 
-        $stmt->execute();
-
-        return $stmt->rowCount();
+        return sasql_affected_rows($this->connection);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -118,10 +118,13 @@ class SQLSrvConnection implements Connection, ServerInfoAwareConnection
      */
     public function exec($statement)
     {
-        $stmt = $this->prepare($statement);
-        $stmt->execute();
+        $stmt = sqlsrv_query($this->conn, $statement);
 
-        return $stmt->rowCount();
+        if (false === $stmt) {
+            throw SQLSrvException::fromSqlSrvErrors();
+        }
+
+        return sqlsrv_rows_affected($stmt);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -590,7 +590,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
      */
     public function testBitComparisonExpressionSupport()
     {
-        $this->_conn->executeQuery('DELETE FROM fetch_table')->execute();
+        $this->_conn->exec('DELETE FROM fetch_table');
         $platform = $this->_conn->getDatabasePlatform();
         $bitmap   = array();
 
@@ -771,7 +771,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
      */
     public function testEmptyFetchColumnReturnsFalse()
     {
-        $this->_conn->executeQuery('DELETE FROM fetch_table')->execute();
+        $this->_conn->exec('DELETE FROM fetch_table');
         $this->assertFalse($this->_conn->fetchColumn('SELECT test_int FROM fetch_table'));
         $this->assertFalse($this->_conn->query('SELECT test_int FROM fetch_table')->fetchColumn());
     }
@@ -846,7 +846,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
     private function setupFixture()
     {
-        $this->_conn->executeQuery('DELETE FROM fetch_table')->execute();
+        $this->_conn->exec('DELETE FROM fetch_table');
         $this->_conn->insert('fetch_table', array(
             'test_int'      => 1,
             'test_string'   => 'foo',

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -22,9 +22,7 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $table->addColumn('id', 'integer', array());
         $table->setPrimaryKey(array('id'));
 
-        foreach ($this->_conn->getDatabasePlatform()->getCreateTableSQL($table) as $sql) {
-            $this->_conn->executeQuery($sql);
-        }
+        $this->_conn->getSchemaManager()->createTable($table);
 
         $this->_conn->insert("duplicatekey_table", array('id' => 1));
 
@@ -43,17 +41,14 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
     public function testTableExistsException()
     {
+        $schemaManager = $this->_conn->getSchemaManager();
         $table = new \Doctrine\DBAL\Schema\Table("alreadyexist_table");
         $table->addColumn('id', 'integer', array());
         $table->setPrimaryKey(array('id'));
 
         $this->setExpectedException('\Doctrine\DBAL\Exception\TableExistsException');
-        foreach ($this->_conn->getDatabasePlatform()->getCreateTableSQL($table) as $sql) {
-            $this->_conn->executeQuery($sql);
-        }
-        foreach ($this->_conn->getDatabasePlatform()->getCreateTableSQL($table) as $sql) {
-            $this->_conn->executeQuery($sql);
-        }
+        $schemaManager->createTable($table);
+        $schemaManager->createTable($table);
     }
 
     public function testForeignKeyConstraintViolationExceptionOnInsert()
@@ -204,7 +199,7 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $table->setPrimaryKey(array('id'));
 
         foreach ($schema->toSql($this->_conn->getDatabasePlatform()) as $sql) {
-            $this->_conn->executeQuery($sql);
+            $this->_conn->exec($sql);
         }
 
         $this->setExpectedException('\Doctrine\DBAL\Exception\NotNullConstraintViolationException');
@@ -219,7 +214,7 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $table->addColumn('id', 'integer', array());
 
         foreach ($schema->toSql($this->_conn->getDatabasePlatform()) as $sql) {
-            $this->_conn->executeQuery($sql);
+            $this->_conn->exec($sql);
         }
 
         $this->setExpectedException('\Doctrine\DBAL\Exception\InvalidFieldNameException');
@@ -237,7 +232,7 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $table2->addColumn('id', 'integer');
 
         foreach ($schema->toSql($this->_conn->getDatabasePlatform()) as $sql) {
-            $this->_conn->executeQuery($sql);
+            $this->_conn->exec($sql);
         }
 
         $sql = 'SELECT id FROM ambiguous_list_table, ambiguous_list_table_2';
@@ -254,7 +249,7 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $table->addUniqueIndex(array('id'));
 
         foreach ($schema->toSql($this->_conn->getDatabasePlatform()) as $sql) {
-            $this->_conn->executeQuery($sql);
+            $this->_conn->exec($sql);
         }
 
         $this->_conn->insert("unique_field_table", array('id' => 5));
@@ -268,9 +263,7 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $table->addColumn('id', 'integer', array());
         $table->setPrimaryKey(array('id'));
 
-        foreach ($this->_conn->getDatabasePlatform()->getCreateTableSQL($table) as $sql) {
-            $this->_conn->executeQuery($sql);
-        }
+        $this->_conn->getSchemaManager()->createTable($table);
 
         $sql = 'SELECT id FRO syntax_error_table';
         $this->setExpectedException('\Doctrine\DBAL\Exception\SyntaxErrorException');
@@ -308,7 +301,7 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $this->setExpectedException($exceptionClass);
         foreach ($schema->toSql($conn->getDatabasePlatform()) as $sql) {
-            $conn->executeQuery($sql);
+            $conn->exec($sql);
         }
     }
 
@@ -350,7 +343,7 @@ class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->setExpectedException('Doctrine\DBAL\Exception\ConnectionException');
 
         foreach ($schema->toSql($conn->getDatabasePlatform()) as $sql) {
-            $conn->executeQuery($sql);
+            $conn->exec($sql);
         }
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -73,7 +73,7 @@ class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testListForeignKeysFromExistingDatabase()
     {
-        $this->_conn->executeQuery(<<<EOS
+        $this->_conn->exec(<<<EOS
 CREATE TABLE user (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     page INTEGER CONSTRAINT FK_1 REFERENCES page (key) DEFERRABLE INITIALLY DEFERRED,
@@ -144,7 +144,7 @@ EOS
         if(version_compare($version['versionString'], '3.7.16', '<')) {
             $this->markTestSkipped('This version of sqlite doesn\'t return the order of the Primary Key.');
         }
-        $this->_conn->executeQuery(<<<EOS
+        $this->_conn->exec(<<<EOS
 CREATE TABLE non_default_pk_order (
     id INTEGER,
     other_id INTEGER,
@@ -173,7 +173,7 @@ CREATE TABLE dbal_1779 (
 )
 SQL;
 
-        $this->_conn->executeQuery($sql);
+        $this->_conn->exec($sql);
 
         $columns = $this->_sm->listTableColumns('dbal_1779');
 

--- a/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
@@ -50,9 +50,7 @@ class TemporaryTableTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $table->addColumn("id", "integer");
         $table->setPrimaryKey(array('id'));
 
-        foreach ($platform->getCreateTableSQL($table) as $sql) {
-            $this->_conn->executeQuery($sql);
-        }
+        $this->_conn->getSchemaManager()->createTable($table);
 
         $this->_conn->beginTransaction();
         $this->_conn->insert("nontemporary", array("id" => 1));
@@ -87,9 +85,7 @@ class TemporaryTableTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $table->addColumn("id", "integer");
         $table->setPrimaryKey(array('id'));
 
-        foreach ($platform->getCreateTableSQL($table) as $sql) {
-            $this->_conn->executeQuery($sql);
-        }
+        $this->_conn->getSchemaManager()->createTable($table);
 
         $this->_conn->beginTransaction();
         $this->_conn->insert("nontemporary", array("id" => 1));

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL202Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL202Test.php
@@ -16,7 +16,7 @@ class DBAL202Test extends \Doctrine\Tests\DbalFunctionalTestCase
         }
 
         if ($this->_conn->getSchemaManager()->tablesExist('DBAL202')) {
-            $this->_conn->executeQuery('DELETE FROM DBAL202');
+            $this->_conn->exec('DELETE FROM DBAL202');
         } else {
             $table = new \Doctrine\DBAL\Schema\Table('DBAL202');
             $table->addColumn('id', 'integer');

--- a/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
@@ -34,9 +34,7 @@ class TypeConversionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $table->setPrimaryKey(array('id'));
 
         try {
-            foreach ($this->_conn->getDatabasePlatform()->getCreateTableSQL($table) as $sql) {
-                $this->_conn->executeQuery($sql);
-            }
+            $this->_conn->getSchemaManager()->createTable($table);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -18,9 +18,7 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
             $table->addColumn('test_string', 'string', array('notnull' => false));
             $table->setPrimaryKey(array('id'));
 
-            foreach ($this->_conn->getDatabasePlatform()->getCreateTableSQL($table) as $sql) {
-                $this->_conn->executeQuery($sql);
-            }
+            $this->_conn->getSchemaManager()->createTable($table);
         } catch(\Exception $e) {
 
         }


### PR DESCRIPTION
Even though the driver connection interface is not quite clear about this, the `exec()` method is obviously intended for DML/DDL statements to be directly executed without preparing the statement beforehand. It is not possible to bind parameters here and it will only ever return affected rows.
Now while nevertheless using prepared statements internally might not seem like such a big deal, there are some cons about this approach:

- SQL Server requires some DDL statements like creating/dropping temporary tables to be executed directly without prepared statements because of database internals (See: https://github.com/Microsoft/msphpsql/issues/276)
- Using prepared statements if not necessary creates unwanted overhead
- The behaviour is not consistent with the PDO implementations, which do not use prepared statement either if the driver in question is capable of doing so

I also updated the testsuite where invalid `executeQuery()` calls for DML/DDL statement where done.

This bugfix is required for the SQL Server testsuite to succeed. It makes 16 errors succeed on this branch with `sqlsrv`.

I did not add any additonal tests because it is not possible to mock whether prepared statements are used or not and also all of the various test cases are already covered by functional tests.