### PR TITLE
[DBAL-2637] Fix closing prepared statement cursor with LOB column on Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -188,11 +188,7 @@ class OCI8Statement implements \IteratorAggregate, Statement
             return true;
         }
 
-        // emulate it by fetching and discarding rows, similarly to what PDO does in this case
-        // @link http://php.net/manual/en/pdostatement.closecursor.php
-        // @link https://github.com/php/php-src/blob/php-7.0.11/ext/pdo/pdo_stmt.c#L2075
-        // deliberately do not consider multiple result sets, since doctrine/dbal doesn't support them
-        while (oci_fetch($this->_sth));
+        oci_cancel($this->_sth);
 
         $this->result = false;
 

--- a/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
@@ -14,6 +14,7 @@ class StatementTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $table = new Table('stmt_test');
         $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'text', array('notnull' => false));
         $this->_conn->getSchemaManager()->dropAndCreateTable($table);
     }
 
@@ -186,6 +187,19 @@ EOF
     public function testCloseCursorOnNonExecutedStatement()
     {
         $stmt = $this->_conn->prepare('SELECT id FROM stmt_test');
+
+        $this->assertTrue($stmt->closeCursor());
+    }
+
+    /**
+     * @group DBAL-2637
+     */
+    public function testCloseCursorAfterCursorEnd()
+    {
+        $stmt = $this->_conn->prepare('SELECT name FROM stmt_test');
+
+        $stmt->execute();
+        $stmt->fetch();
 
         $this->assertTrue($stmt->closeCursor());
     }


### PR DESCRIPTION
Fixes #2637 

Closing the cursor on the prepared statement errors if any previous call to `oci_fetch_array()` in the `oci8` driver returned `false` because of having reached the end of the result cursor. This also only occurs if a LOB type column is part of the selected result.

This is a regression introduced in #2546 