### PR TITLE
[DBAL-2644] Fix fetchAll(PDO::FETCH_COLUMN) on DB2 with Portability wrapper

### DIFF
--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -71,11 +71,11 @@ class Connection extends \Doctrine\DBAL\Connection
                 } elseif ($this->getDatabasePlatform()->getName() === "sqlite") {
                     $params['portability'] = $params['portability'] & self::PORTABILITY_SQLITE;
                 } elseif ($this->getDatabasePlatform()->getName() === "drizzle") {
-                    $params['portability'] = self::PORTABILITY_DRIZZLE;
+                    $params['portability'] = $params['portability'] & self::PORTABILITY_DRIZZLE;
                 } elseif ($this->getDatabasePlatform()->getName() === 'sqlanywhere') {
-                    $params['portability'] = self::PORTABILITY_SQLANYWHERE;
+                    $params['portability'] = $params['portability'] & self::PORTABILITY_SQLANYWHERE;
                 } elseif ($this->getDatabasePlatform()->getName() === 'db2') {
-                    $params['portability'] = self::PORTABILITY_DB2;
+                    $params['portability'] = $params['portability'] & self::PORTABILITY_DB2;
                 } elseif ($this->getDatabasePlatform()->getName() === 'mssql') {
                     $params['portability'] = $params['portability'] & self::PORTABILITY_SQLSRV;
                 } else {

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -175,8 +175,20 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
             return $rows;
         }
 
+        if ($fetchMode === PDO::FETCH_COLUMN) {
+            foreach ($rows as $num => $row) {
+                $rows[$num] = array($row);
+            }
+        }
+
         foreach ($rows as $num => $row) {
             $rows[$num] = $this->fixRow($row, $iterateRow, $fixCase);
+        }
+
+        if ($fetchMode === PDO::FETCH_COLUMN) {
+            foreach ($rows as $num => $row) {
+                $rows[$num] = $row[0];
+            }
         }
 
         return $rows;

--- a/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
@@ -144,4 +144,39 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $this->assertEquals($portability, $connection->getPortability());
     }
+
+    /**
+     * @dataProvider fetchAllColumnProvider
+     */
+    public function testFetchAllColumn($field, array $expected)
+    {
+        $conn = $this->getPortableConnection();
+        $stmt = $conn->query('SELECT ' . $field . ' FROM portability_table');
+
+        $column = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertEquals($expected, $column);
+    }
+
+    public static function fetchAllColumnProvider()
+    {
+        return array(
+            'int' => array(
+                'Test_Int',
+                array(1, 2),
+            ),
+            'string' => array(
+                'Test_String',
+                array('foo', 'foo'),
+            ),
+        );
+    }
+
+    public function testFetchAllNullColumn()
+    {
+        $conn = $this->getPortableConnection();
+        $stmt = $conn->query('SELECT Test_Null FROM portability_table');
+
+        $column = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(array(null, null), $column);
+    }
 }


### PR DESCRIPTION
Fixes #2644:

1. Do not enforce platform-dependent portability settings
2. Properly handle the result of fetchAll(PDO::FETCH_COLUMN)