### PR TITLE
Fix result cache and PDO connection test on pdo_sqlsrv

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOConnectionTest.php
@@ -64,6 +64,10 @@ class PDOConnectionTest extends DbalFunctionalTestCase
      */
     public function testThrowsWrappedExceptionOnPrepare()
     {
+        if ($this->_conn->getDriver()->getName() === 'pdo_sqlsrv') {
+            $this->markTestSkipped('pdo_sqlsrv does not allow setting PDO::ATTR_EMULATE_PREPARES at connection level.');
+        }
+
         // Emulated prepared statements have to be disabled for this test
         // so that PDO actually communicates with the database server to check the query.
         $this->driverConnection->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -16,19 +16,14 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            /* @var $sm \Doctrine\DBAL\Schema\AbstractSchemaManager */
-            $table = new \Doctrine\DBAL\Schema\Table("caching");
-            $table->addColumn('test_int', 'integer');
-            $table->addColumn('test_string', 'string', array('notnull' => false));
-            $table->setPrimaryKey(array('test_int'));
+        $table = new \Doctrine\DBAL\Schema\Table("caching");
+        $table->addColumn('test_int', 'integer');
+        $table->addColumn('test_string', 'string', array('notnull' => false));
+        $table->setPrimaryKey(array('test_int'));
 
-            $sm = $this->_conn->getSchemaManager();
-            $sm->createTable($table);
-        } catch(\Exception $e) {
+        $sm = $this->_conn->getSchemaManager();
+        $sm->createTable($table);
 
-        }
-        $this->_conn->executeUpdate('DELETE FROM caching');
         foreach ($this->expectedResult as $row) {
             $this->_conn->insert('caching', $row);
         }
@@ -38,6 +33,13 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $cache = new \Doctrine\Common\Cache\ArrayCache;
         $config->setResultCacheImpl($cache);
+    }
+
+    protected function tearDown()
+    {
+        $this->_conn->getSchemaManager()->dropTable('caching');
+
+        parent::tearDown();
     }
 
     public function testCacheFetchAssoc()


### PR DESCRIPTION
The story continues...

This fixes two test cases where `pdo_sqlsrv` fails.

**ResultCacheTest**
```
Exception: [Doctrine\DBAL\DBALException] An exception occurred while executing 'DELETE FROM caching':

SQLSTATE[HY010]: [unixODBC][Driver Manager]Function sequence error
```

Each test errors with that message. It is caused by the `setUp()` which tries to create the test table and silences exceptions. There seems to be a bug in the driver, that leaves the connection in an erroneous state when managing exceptions in userland: https://github.com/Microsoft/msphpsql/issues/49#issuecomment-137774580

To make the tests pass for now, we correctly create the table on setup and drop it on teardown now.

**PDOConnectionTest**
```
1) Doctrine\Tests\DBAL\Functional\Driver\PDOConnectionTest::testThrowsWrappedExceptionOnPrepare
Failed asserting that exception of type "PDOException" matches expected exception "\Doctrine\DBAL\Driver\PDOException". Message was: "SQLSTATE[IMSSP]: The given attribute is only supported on the PDOStatement object." at
/php/srv/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOConnectionTest.php:69
```

`pdo_sqlsrv` for some reason only supports setting `PDO::ATTR_EMULATE_PREPARES` on the statement object but not on the connection object, which makes the test useless (so skipping that one).