### PR TITLE
Fix closing statement cursor on pdo_sqlsrv if not executed yet

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -85,6 +85,20 @@ class PDOStatement extends \PDOStatement implements Statement
     /**
      * {@inheritdoc}
      */
+    public function closeCursor()
+    {
+        try {
+            return parent::closeCursor();
+        } catch (\PDOException $exception) {
+            // Exceptions not allowed by the interface.
+            // In case driver implementations do not adhere to the interface, silence exceptions here.
+            return true;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function execute($params = null)
     {
         try {


### PR DESCRIPTION
`pdo_sqlsrv` does not strictly stick to the PDO interface, yet and throws and exception when trying to close a statement cursor if it has not been execute yet:

```
Exception: [PDOException] SQLSTATE[IMSSP]: The statement must be executed before results can be retrieved.
```

A patch is in the works, though: https://github.com/Microsoft/msphpsql/issues/267

Despite that, we should try to make the behaviour consistent for all kinds of PDO drivers, even those that we might not support in the core. Therefore silencing execptions in `closeCursor()`.