### PR TITLE
Making the `DBALException` implement `Throwable`

### DIFF
--- a/lib/Doctrine/DBAL/Driver/DriverException.php
+++ b/lib/Doctrine/DBAL/Driver/DriverException.php
@@ -29,7 +29,7 @@ namespace Doctrine\DBAL\Driver;
  * @link   www.doctrine-project.org
  * @since  2.5
  */
-interface DriverException
+interface DriverException extends \Throwable
 {
     /**
      * Returns the driver specific error code if available.


### PR DESCRIPTION
`Doctrine\DBAL\DBALException` does not implement `\Exception`