### PR TITLE
Single quotes on mysql reserved keywords in schema creation

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
@@ -64,4 +64,31 @@ class MySQL57Platform extends MySqlPlatform
     {
         return 'Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords';
     }
+
+    /**
+     * Get reserved keywords for default
+     *
+     * @return array
+     */
+    public static function getReservedDefaultKeywords()
+    {
+        return [
+            'NULL',
+            'CURRENT_DATE',
+            'CURRENT_TIME',
+            'CURRENT_TIMESTAMP',
+        ];
+    }
+
+    /**
+     * @see Doctrine\DBAL\Platforms\MySqlPlatform::getDefaultValueDeclarationSQL()
+     */
+    public function getDefaultValueDeclarationSQL($field)
+    {
+        if (in_array($field['default'], self::getReservedDefaultKeywords())) {
+            return " DEFAULT ".$field['default'];
+        }
+
+        return parent::getDefaultValueDeclarationSQL($field);
+    }
 }

--- a/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
@@ -71,7 +71,7 @@ class MySQL57Platform extends MySqlPlatform
      *
      * @return array
      */
-    public static function getReservedDefaultKeywords()
+    public static function getReservedDatetimeKeywords()
     {
         return array(
             'NULL',
@@ -87,7 +87,7 @@ class MySQL57Platform extends MySqlPlatform
     public function getDefaultValueDeclarationSQL($field)
     {
         if ($field['type'] instanceof DateTimeType &&
-            in_array($field['default'], self::getReservedDefaultKeywords())
+            in_array($field['default'], self::getReservedDatetimeKeywords())
         ) {
             $default = ' DEFAULT ' . $field['default'];
         } else {
@@ -112,7 +112,7 @@ class MySQL57Platform extends MySqlPlatform
     {
         if ($field['type'] instanceof DateTimeType &&
             isset($field['onUpdate']) &&
-            in_array($field['onUpdate'], self::getReservedDefaultKeywords())
+            in_array($field['onUpdate'], self::getReservedDatetimeKeywords())
         ) {
             return ' ON UPDATE ' . $field['onUpdate'];
         }

--- a/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
@@ -111,6 +111,7 @@ class MySQL57Platform extends MySqlPlatform
     public function getOnUpdateValueDeclarationSQL($field)
     {
         if ($field['type'] instanceof DateTimeType &&
+            isset($field['onUpdate']) &&
             in_array($field['onUpdate'], self::getReservedDefaultKeywords())
         ) {
             return ' ON UPDATE ' . $field['onUpdate'];

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\MySQL57Platform;
+use Doctrine\DBAL\Types\Type;
 
 class MySQL57PlatformTest extends AbstractMySQLPlatformTestCase
 {
@@ -64,5 +65,22 @@ class MySQL57PlatformTest extends AbstractMySQLPlatformTestCase
         return array(
             'ALTER TABLE mytable RENAME INDEX idx_foo TO idx_foo_renamed',
         );
+    }
+
+    public function testGetOnUpdateDeclarationSQLDateTime()
+    {
+        foreach (array('datetime') as $type) {
+
+            $field = array(
+                'type' => Type::getType($type),
+                'default' => 'NULL',
+                'onUpdate' => $this->_platform->getCurrentTimestampSQL(),
+            );
+
+            $this->assertEquals(
+                ' ON UPDATE ' . $this->_platform->getCurrentTimestampSQL(),
+                $this->_platform->getOnUpdateValueDeclarationSQL($field)
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #2582 

Now have `onUpdate` on `customSchemaOptions`, this option will be supported only by Mysql 5.7, will be accepted by only `Doctrine\DBAL\Types\DateTimeType` and reserved keywords listed on `Doctrine\DBAL\Platforms\MySQL57Platform::getReservedDefaultKeywords()`

Examples:

```php

$schema = new \Doctrine\DBAL\Schema\Schema();
$products = $schema->createTable('products');

$products->addColumn(
    'date_update',
    'datetime',
    [
        'notnull' => false,
        'customSchemaOptions' => [
            'onUpdate' => 'CURRENT_TIMESTAMP',
        ]
    ]
);
$queries = $schema->toSql(new Doctrine\DBAL\Platforms\MySQL57Platform());
echo $queries[0];
// CREATE TABLE products (date_update DATETIME DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB

$schema = new \Doctrine\DBAL\Schema\Schema();
$products = $schema->createTable('products');
$products->addColumn(
    'date_update',
    'datetime',
    [
        'notnull' => false,
        'customSchemaOptions' => [
            'onUpdate' => 'YEAR',
        ]
    ]
);
$queries = $schema->toSql(new Doctrine\DBAL\Platforms\MySQL57Platform());
echo $queries[0];
//CREATE TABLE products (date_update DATETIME DEFAULT NULL) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB
```


Will be necessary documentation update on item 10.1.1.3.

```
* customSchemaOptions (array): Additional options for the column that are supported by some vendors but not portable:

    onUpdate (string): Implement `ON UPDATE` using specific reserverd datetime keywords. Supported by MySQL 5.7 only.
```

