### PR TITLE
Revert PgSQL and MariaDB Travis-CI build matrix simplification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-
 sudo: false
 
 cache:
@@ -16,17 +15,143 @@ env:
   - DB=sqlite
   - DB=mysql
   - DB=mysqli
-  - DB=mariadb MARIADB_VERSION=10.0
-  - DB=mariadb MARIADB_VERSION=10.1
-  - DB=pgsql POSTGRESQL_VERSION=9.2
-  - DB=pgsql POSTGRESQL_VERSION=9.3
-  - DB=pgsql POSTGRESQL_VERSION=9.4
-  - DB=pgsql POSTGRESQL_VERSION=9.5
-  - DB=pgsql POSTGRESQL_VERSION=9.6
 
 matrix:
   fast_finish: true
   include:
+    - php: 7.0
+      env: DB=mariadb MARIADB_VERSION=10.0
+      addons:
+        mariadb: 10.0
+    - php: 7.1
+      env: DB=mariadb MARIADB_VERSION=10.0
+      addons:
+        mariadb: 10.0
+    - php: nightly
+      env: DB=mariadb MARIADB_VERSION=10.0
+      addons:
+        mariadb: 10.0
+
+    - php: 7.0
+      env: DB=mariadb MARIADB_VERSION=10.1
+      addons:
+        mariadb: 10.1
+    - php: 7.1
+      env: DB=mariadb MARIADB_VERSION=10.1
+      addons:
+        mariadb: 10.1
+    - php: nightly
+      env: DB=mariadb MARIADB_VERSION=10.1
+      addons:
+        mariadb: 10.1
+
+    - php: 7.0
+      addons:
+        postgresql: "9.2"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.2
+    - php: 7.1
+      addons:
+        postgresql: "9.2"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.2
+    - php: nightly
+      addons:
+        postgresql: "9.2"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.2
+
+    - php: 7.0
+      addons:
+        postgresql: "9.3"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.3
+    - php: 7.1
+      addons:
+        postgresql: "9.3"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.3
+    - php: nightly
+      addons:
+        postgresql: "9.3"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.3
+
+    - php: 7.0
+      addons:
+        postgresql: "9.4"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.4
+    - php: 7.1
+      addons:
+        postgresql: "9.4"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.4
+    - php: nightly
+      addons:
+        postgresql: "9.4"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.4
+
+    - php: 7.0
+      sudo: false
+      dist: trusty
+      addons:
+        postgresql: "9.5"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
+    - php: 7.1
+      sudo: false
+      dist: trusty
+      addons:
+        postgresql: "9.5"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
+    - php: nightly
+      sudo: false
+      dist: trusty
+      addons:
+        postgresql: "9.5"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.5
+
+    - php: 7.0
+      sudo: false
+      dist: trusty
+      addons:
+        postgresql: "9.6"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
+    - php: 7.1
+      sudo: false
+      dist: trusty
+      addons:
+        postgresql: "9.6"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
+    - php: nightly
+      sudo: false
+      dist: trusty
+      addons:
+        postgresql: "9.6"
+      services:
+        - postgresql
+      env: DB=pgsql POSTGRESQL_VERSION=9.6
+
     - php: hhvm
       sudo: true
       dist: trusty
@@ -34,7 +159,6 @@ matrix:
       addons:
         mariadb: 10.0
       env: DB=mariadb MARIADB_VERSION=10.0
-
     - php: hhvm
       sudo: true
       dist: trusty
@@ -42,7 +166,6 @@ matrix:
       addons:
         mariadb: 10.1
       env: DB=mariadb MARIADB_VERSION=10.1
-
     - php: hhvm
       sudo: true
       dist: trusty
@@ -127,14 +250,8 @@ matrix:
 before_install:
   # Force hhvm PHP 7 mode
   - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo hhvm.php7.all=1 >> /etc/hhvm/php.ini; fi
-  - if [ '$DB' = 'pgsql' ]; then sudo apt-get install postgresql-$POSTGRESQL_VERSION; fi
-  - if [ '$DB' = 'mariadb' ]; then sudo add-apt-repository 'deb http://ftp.kaist.ac.kr/mariadb/repo/$MARIADB_VERSION/ubuntu precise main'; fi
-  - if [ '$DB' = 'mariadb' ]; then sudo apt-get install mariadb-server; fi
 
 install:
   - travis_retry composer install
-
-before_script:
-  - if [ '$DB' = 'pgsql' ]; then sudo service postgresql stop; sudo service postgresql start $POSTGRESQL_VERSION; fi
 
 script: ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -243,9 +243,6 @@ matrix:
   allow_failures:
     - php: hhvm
     - php: nightly
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
-    - php: nightly
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
 
 before_install:
   # Force hhvm PHP 7 mode


### PR DESCRIPTION
Removes all sudo items (except hhvm which currently still requires sudo)
reverting the other simpler matrix attempt at #2655 