### PR TITLE
Add oci8 persistent connection support to the configuration documentation

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -305,6 +305,7 @@ pdo\_oci / oci8
    you will still need to provide the ``user`` and ``password`` parameters, but the other
    parameters will no longer be used. Note that when using this parameter, the ``getHost``
    and ``getPort`` methods from ``Doctrine\DBAL\Connection`` will no longer function as expected.
+-  ``persistent`` (boolean): Whether to establish a persistent connection.
 
 pdo\_sqlsrv / sqlsrv
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The oci8 driver can connect using oci_pconnect to make persistent connections. Doctrine has support for this if the persistent boolean value is set to true in the configuration. However, this information was not documented.