### PR TITLE
Decimal Type

### DIFF
--- a/lib/Doctrine/DBAL/Types/DecimalType.php
+++ b/lib/Doctrine/DBAL/Types/DecimalType.php
@@ -49,6 +49,6 @@ class DecimalType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        return $value;
+        return (null === $value) ? null : floatval($value);
     }
 }


### PR DESCRIPTION
# If you don`t like my decision, then please fix comparison for field type "Decimal" in function computeChangeSet (class UnitOfWork).

Problem:
If we have field with type decimal in entity.
```
/**
* @ORM\Column(name="amount", type="decimal", scale=2)
*/
private $amount;
```

And if we have relation in form.
`->add('amount', NumberType::class)`

then we always will get this field as changed from UnitOfWork.

`$diff = $uow->getEntityChangeSet($entity);`

so $diff always will be like this
```
[
    'amount'  => [
        '0' => "188.00",
        '1' => 188,
    ]
]
```

So as you can see we have different types from "get" and "set" value.

Thank you.