### PR TITLE
Add missing SSL parameters to the pdo_pgsql driver

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -266,6 +266,14 @@ pdo\_pgsql
    the server's certificate will be verified to be signed by one of these
    authorities.
    See http://www.postgresql.org/docs/9.0/static/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT
+-  ``sslcert`` (string): specifies the file name of the client SSL certificate.
+   See `https://www.postgresql.org/docs/9.1/static/libpq-connect.html#LIBPQ-CONNECT-SSLCERT`
+-  ``sslkey`` (string): specifies the location for the secret key used for the 
+   client certificate.
+   See `https://www.postgresql.org/docs/9.1/static/libpq-connect.html#LIBPQ-CONNECT-SSLKEY`
+-  ``sslcrl`` (string): specifies the file name of the SSL certificate 
+   revocation list (CRL). 
+   See `https://www.postgresql.org/docs/9.1/static/libpq-connect.html#LIBPQ-CONNECT-SSLCRL`
 -  ``application_name`` (string): Name of the application that is
    connecting to database. Optional. It will be displayed at ``pg_stat_activity``.
 

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -105,6 +105,18 @@ class Driver extends AbstractPostgreSQLDriver
             $dsn .= 'sslrootcert=' . $params['sslrootcert'] . ';';
         }
 
+        if (isset($params['sslcert'])) {
+            $dsn .= 'sslcert=' . $params['sslcert'] . ';';
+        }
+
+        if (isset($params['sslkey'])) {
+            $dsn .= 'sslkey=' . $params['sslkey'] . ';';
+        }
+
+        if (isset($params['sslcrl'])) {
+            $dsn .= 'sslcrl=' . $params['sslcrl'] . ';';
+        }
+
         if (isset($params['application_name'])) {
             $dsn .= 'application_name=' . $params['application_name'] . ';';
         }


### PR DESCRIPTION
Add SSL parameters sslcert, sslkey and sslcrl to pdo_pgsql driver. See: https://www.postgresql.org/docs/9.1/static/libpq-connect.html