### PR TITLE
Correct `testListTableColumns` checked keys

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -249,7 +249,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->assertInternalType('array',  $columns['baz2']->getPlatformOptions());
 
         $this->assertEquals('baz3', strtolower($columns['baz3']->getname()));
-        $this->assertContains($columns['baz2']->gettype()->getName(), array('time', 'date', 'datetime'));
+        $this->assertContains($columns['baz3']->gettype()->getName(), array('time', 'date', 'datetime'));
         $this->assertEquals(true,   $columns['baz3']->getnotnull());
         $this->assertEquals(null,   $columns['baz3']->getdefault());
         $this->assertInternalType('array',  $columns['baz3']->getPlatformOptions());


### PR DESCRIPTION
While working on #2673, I noticed an apparent error in a test assertion and wanted to keep it separate from my other PR. In a repetitive assertion block for `SchemaManagerFunctionalTestCase#testListTableColumns`, a column named `baz3` is being tested while a single assertion was testing `baz2` from the block before.