### PR TITLE
Support for MySQL database names with leading digits

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -394,7 +394,7 @@ class MySqlPlatform extends AbstractPlatform
      */
     public function getCreateDatabaseSQL($name)
     {
-        return 'CREATE DATABASE ' . $name;
+        return 'CREATE DATABASE ' . $this->quoteSingleIdentifier($name);
     }
 
     /**
@@ -402,7 +402,7 @@ class MySqlPlatform extends AbstractPlatform
      */
     public function getDropDatabaseSQL($name)
     {
-        return 'DROP DATABASE ' . $name;
+        return 'DROP DATABASE ' . $this->quoteSingleIdentifier($name);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -77,8 +77,8 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testGeneratesDDLSnippets()
     {
         $this->assertEquals('SHOW DATABASES', $this->_platform->getListDatabasesSQL());
-        $this->assertEquals('CREATE DATABASE foobar', $this->_platform->getCreateDatabaseSQL('foobar'));
-        $this->assertEquals('DROP DATABASE foobar', $this->_platform->getDropDatabaseSQL('foobar'));
+        $this->assertEquals('CREATE DATABASE `foobar`', $this->_platform->getCreateDatabaseSQL('foobar'));
+        $this->assertEquals('DROP DATABASE `foobar`', $this->_platform->getDropDatabaseSQL('foobar'));
         $this->assertEquals('DROP TABLE foobar', $this->_platform->getDropTableSQL('foobar'));
     }
 


### PR DESCRIPTION
Currently the following operation will fail:

```
$connection->getSchemaManager()->createDatabase("1337");
```

This is because MySQL database names with leading numbers must be quoted.

**Wrong**

```
mysql> CREATE DATABASE 1337;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '1337' at line 1
```

**Correct**

```
mysql> CREATE DATABASE `1337`;
Query OK, 1 row affected (0,01 sec)
```

Sure there are not much use-cases where you want to do that and we only discovered this misbehavior because we're using md5 hashed database names for unit-testing.