### PR TITLE
Fix: Doctrine custom types now accepts anything but ')'

### DIFF
--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -1093,7 +1093,7 @@ abstract class AbstractSchemaManager
      */
     public function extractDoctrineTypeFromComment($comment, $currentType)
     {
-        if (preg_match("(\(DC2Type:([a-zA-Z0-9_]+)\))", $comment, $match)) {
+        if (preg_match("(\(DC2Type:(((?!\)).)+)\))", $comment, $match)) {
             $currentType = $match[1];
         }
 


### PR DESCRIPTION
Hi Doctrine Community.

This pull request fixes the issue #2596.

So if you try to create a type named like `my.type` without to follow [the regex](https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php#L1096), everything works. You can use it and create new columns using this type.

But the problem appears when you try to update your schema or to generate a migration (using DoctrineMigrations for example). An "ALTER table" SQL command is always generated.

So why not allow any content but ")" ?