### PR TITLE
#889 On OracleDB, primary key is considered missing if index_name != constraint_name

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -443,7 +443,7 @@ class OraclePlatform extends AbstractPlatform
                        (
                            SELECT ucon.constraint_type
                            FROM   user_constraints ucon
-                           WHERE  ucon.constraint_name = uind_col.index_name
+                           WHERE  ucon.index_name = uind_col.index_name
                        ) AS is_primary
              FROM      user_ind_columns uind_col
              WHERE     uind_col.table_name = " . $table . "

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -233,6 +233,29 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
     }
 
     /**
+     * @group DBAL-1234
+     */
+    public function testListTableIndexesPrimaryKeyConstraintNameDiffersFromIndexName()
+    {
+        $table = new Table('list_table_indexes_pk_id_test');
+        $table->setSchemaConfig($this->_sm->createSchemaConfig());
+        $table->addColumn('id', 'integer', ['notnull' => true]);
+        $table->addUniqueIndex(['id'], 'id_unique_index');
+        $this->_sm->dropAndCreateTable($table);
+
+        // Adding a primary key on already indexed columns
+        // Oracle will reuse the unique index, which cause a constraint name differing from the index name
+        $this->_sm->createConstraint(new Schema\Index('id_pk_id_index', ['id'], true, true), 'list_table_indexes_pk_id_test');
+
+        $tableIndexes = $this->_sm->listTableIndexes('list_table_indexes_pk_id_test');
+
+        $this->assertArrayHasKey('primary', $tableIndexes, 'listTableIndexes() has to return a "primary" array key.');
+        $this->assertEquals(['id'], array_map('strtolower', $tableIndexes['primary']->getColumns()));
+        $this->assertTrue($tableIndexes['primary']->isUnique());
+        $this->assertTrue($tableIndexes['primary']->isPrimary());
+    }
+
+    /**
      * @group DBAL-2555
      */
     public function testListTableDateTypeColumns()

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -239,18 +239,18 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $table = new Table('list_table_indexes_pk_id_test');
         $table->setSchemaConfig($this->_sm->createSchemaConfig());
-        $table->addColumn('id', 'integer', ['notnull' => true]);
-        $table->addUniqueIndex(['id'], 'id_unique_index');
+        $table->addColumn('id', 'integer', array('notnull' => true));
+        $table->addUniqueIndex(array('id'), 'id_unique_index');
         $this->_sm->dropAndCreateTable($table);
 
         // Adding a primary key on already indexed columns
         // Oracle will reuse the unique index, which cause a constraint name differing from the index name
-        $this->_sm->createConstraint(new Schema\Index('id_pk_id_index', ['id'], true, true), 'list_table_indexes_pk_id_test');
+        $this->_sm->createConstraint(new Schema\Index('id_pk_id_index', array('id'), true, true), 'list_table_indexes_pk_id_test');
 
         $tableIndexes = $this->_sm->listTableIndexes('list_table_indexes_pk_id_test');
 
         $this->assertArrayHasKey('primary', $tableIndexes, 'listTableIndexes() has to return a "primary" array key.');
-        $this->assertEquals(['id'], array_map('strtolower', $tableIndexes['primary']->getColumns()));
+        $this->assertEquals(array('id'), array_map('strtolower', $tableIndexes['primary']->getColumns()));
         $this->assertTrue($tableIndexes['primary']->isUnique());
         $this->assertTrue($tableIndexes['primary']->isPrimary());
     }


### PR DESCRIPTION
Same as pull request #889, but with added test.
Fixes issue doctrine/dbal#1234 and doctrine/doctrine2#6206