### PR TITLE
Support `IS NULL` checking in `Connection#delete()` and `Connection#update()` generated criteria, allowing for `null` column searches

### DIFF
--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -34,6 +34,22 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
         $this->_conn = \Doctrine\DBAL\DriverManager::getConnection($this->params);
     }
 
+    public function getExecuteUpdateMockConnection()
+    {
+        $driverMock = $this->createMock(\Doctrine\DBAL\Driver::class);
+
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+
+        $conn = $this->getMockBuilder(Connection::class)
+            ->setMethods(['executeUpdate'])
+            ->setConstructorArgs([['platform' => new Mocks\MockPlatform()], $driverMock])
+            ->getMock();
+
+        return $conn;
+    }
+
     public function testIsConnected()
     {
         $this->assertFalse($this->_conn->isConnected());
@@ -285,16 +301,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
 
     public function testEmptyInsert()
     {
-        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
-
-        $driverMock->expects($this->any())
-            ->method('connect')
-            ->will($this->returnValue(new DriverConnectionMock()));
-
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
-            ->setMethods(array('executeUpdate'))
-            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
-            ->getMock();
+        $conn = $this->getExecuteUpdateMockConnection();
 
         $conn->expects($this->once())
             ->method('executeUpdate')
@@ -308,16 +315,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testUpdateWithDifferentColumnsInDataAndIdentifiers()
     {
-        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
-
-        $driverMock->expects($this->any())
-            ->method('connect')
-            ->will($this->returnValue(new DriverConnectionMock()));
-
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
-            ->setMethods(array('executeUpdate'))
-            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
-            ->getMock();
+        $conn = $this->getExecuteUpdateMockConnection();
 
         $conn->expects($this->once())
             ->method('executeUpdate')
@@ -361,16 +359,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testUpdateWithSameColumnInDataAndIdentifiers()
     {
-        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
-
-        $driverMock->expects($this->any())
-            ->method('connect')
-            ->will($this->returnValue(new DriverConnectionMock()));
-
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
-            ->setMethods(array('executeUpdate'))
-            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
-            ->getMock();
+        $conn = $this->getExecuteUpdateMockConnection();
 
         $conn->expects($this->once())
             ->method('executeUpdate')
@@ -413,16 +402,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testUpdateWithIsNull()
     {
-        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
-
-        $driverMock->expects($this->any())
-            ->method('connect')
-            ->will($this->returnValue(new DriverConnectionMock()));
-
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
-            ->setMethods(array('executeUpdate'))
-            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
-            ->getMock();
+        $conn = $this->getExecuteUpdateMockConnection();
 
         $conn->expects($this->once())
             ->method('executeUpdate')
@@ -464,16 +444,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testDeleteWithIsNull()
     {
-        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
-
-        $driverMock->expects($this->any())
-            ->method('connect')
-            ->will($this->returnValue(new DriverConnectionMock()));
-
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
-            ->setMethods(array('executeUpdate'))
-            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
-            ->getMock();
+        $conn = $this->getExecuteUpdateMockConnection();
 
         $conn->expects($this->once())
             ->method('executeUpdate')

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -408,6 +408,98 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
         );
     }
 
+    /**
+     * @group DBAL-2688
+     */
+    public function testUpdateWithIsNull()
+    {
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
+
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setMethods(array('executeUpdate'))
+            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
+            ->getMock();
+
+        $conn->expects($this->once())
+            ->method('executeUpdate')
+            ->with(
+                'UPDATE TestTable SET text = ?, is_edited = ? WHERE id IS NULL AND name = ?',
+                [
+                    'some text',
+                    null,
+                    'foo',
+                ],
+                [
+                    'string',
+                    'boolean',
+                    'string',
+                ]
+            );
+
+        $conn->update(
+            'TestTable',
+            [
+                'text' => 'some text',
+                'is_edited' => null,
+            ],
+            [
+                'id' => null,
+                'name' => 'foo',
+            ],
+            [
+                'text' => 'string',
+                'is_edited' => 'boolean',
+                'id' => 'integer',
+                'name' => 'string',
+            ]
+        );
+    }
+
+    /**
+     * @group DBAL-2688
+     */
+    public function testDeleteWithIsNull()
+    {
+        $driverMock = $this->createMock('Doctrine\DBAL\Driver');
+
+        $driverMock->expects($this->any())
+            ->method('connect')
+            ->will($this->returnValue(new DriverConnectionMock()));
+
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->setMethods(array('executeUpdate'))
+            ->setConstructorArgs(array(array('platform' => new Mocks\MockPlatform()), $driverMock))
+            ->getMock();
+
+        $conn->expects($this->once())
+            ->method('executeUpdate')
+            ->with(
+                'DELETE FROM TestTable WHERE id IS NULL AND name = ?',
+                [
+                    'foo',
+                ],
+                [
+                    'string',
+                ]
+            );
+
+        $conn->delete(
+            'TestTable',
+            [
+                'id' => null,
+                'name' => 'foo',
+            ],
+            [
+                'id' => 'integer',
+                'name' => 'string',
+            ]
+        );
+    }
+
     public function testFetchAssoc()
     {
         $statement = 'SELECT * FROM foo WHERE bar = ?';

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -285,4 +285,44 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
     }
 
+    /**
+     * @group DBAL-2688
+     */
+    public function testUpdateWhereIsNull()
+    {
+        $this->_conn->insert(
+            'write_table',
+            ['test_int' => '30', 'test_string' => null],
+            ['test_string' => 'string', 'test_int' => 'integer']
+        );
+
+        $data = $this->_conn->fetchAll('SELECT * FROM write_table WHERE test_int = 30');
+
+        $this->assertCount(1, $data);
+
+        $this->_conn->update('write_table', ['test_int' => 10], ['test_string' => null], ['test_string' => 'string', 'test_int' => 'integer']);
+
+        $data = $this->_conn->fetchAll('SELECT * FROM write_table WHERE test_int = 30');
+
+        $this->assertCount(0, $data);
+    }
+
+    public function testDeleteWhereIsNull()
+    {
+        $this->_conn->insert(
+            'write_table',
+            ['test_int' => '30', 'test_string' => null],
+            ['test_string' => 'string', 'test_int' => 'integer']
+        );
+
+        $data = $this->_conn->fetchAll('SELECT * FROM write_table WHERE test_int = 30');
+
+        $this->assertCount(1, $data);
+
+        $this->_conn->delete('write_table', ['test_string' => null], ['test_string' => 'string']);
+
+        $data = $this->_conn->fetchAll('SELECT * FROM write_table WHERE test_int = 30');
+
+        $this->assertCount(0, $data);
+    }
 }


### PR DESCRIPTION
If you pass a null to the where array of update or delete it's
pretty obvious what you want.

Most (all?) databases won't match anything if you actually try
to compare with NULL making this a silent failure without it.