### PR TITLE
Fix primary key alteration when adding new columns on MySQL platforms.

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\Index;
@@ -708,6 +709,10 @@ class MySqlPlatform extends AbstractPlatform
 
         // Dropping primary keys requires to unset autoincrement attribute on the particular column first.
         foreach ($index->getColumns() as $columnName) {
+            if(isset($diff->addedColumns[$columnName]) && $diff->addedColumns[$columnName] instanceof Column) {
+                continue;
+            }
+          
             $column = $diff->fromTable->getColumn($columnName);
 
             if ($column->getAutoincrement() === true) {

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -473,6 +473,31 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             "ALTER TABLE mytable ADD PRIMARY KEY (foo)",
         ), $sql);
     }
+    
+    public function testAlterPrimaryKeyWithNewColumn()
+    {
+        $table = new Table("yolo");
+        $table->addColumn('pkc1', 'integer');
+        $table->addColumn('col_a', 'integer');
+        $table->setPrimaryKey(array('pkc1'));
+
+        $comparator = new Comparator();
+        $diffTable = clone $table;
+
+        
+        $diffTable->addColumn('pkc2', 'integer');
+        $diffTable->dropPrimaryKey();
+        $diffTable->setPrimaryKey(array('pkc1', 'pkc2'));
+
+        $this->assertSame(
+            array(
+                'ALTER TABLE yolo DROP PRIMARY KEY',
+                'ALTER TABLE yolo ADD pkc2 INT NOT NULL',
+                'ALTER TABLE yolo ADD PRIMARY KEY (pkc1, pkc2)',
+            ),
+            $this->_platform->getAlterTableSQL($comparator->diffTable($table, $diffTable))
+        );      
+    }
 
     public function testInitializesDoctrineTypeMappings()
     {


### PR DESCRIPTION
Trying to get a column in a table which is not added yet, will result in throwing a SchemaException. Also altering not yet added columns does not make sense.