### PR TITLE
DBAL-858: Workaround for Oracle's limit in IN clause items

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL;
 
+use Doctrine\DBAL\Driver\AbstractOracleDriver;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use PDO;
@@ -837,6 +838,11 @@ class Connection implements DriverConnection
             if ($params) {
                 list($query, $params, $types) = SQLParserUtils::expandListParameters($query, $params, $types);
 
+                //Oracle does not allow more than 1000 elements in IN clause, we need to split it
+                if ($this->getDriver() instanceof AbstractOracleDriver) {
+                    $query = SQLParserUtils::splitInClause($query, 1000);
+                }
+
                 $stmt = $this->_conn->prepare($query);
                 if ($types) {
                     $this->_bindTypedValues($stmt, $params, $types);
@@ -985,6 +991,11 @@ class Connection implements DriverConnection
         try {
             if ($params) {
                 list($query, $params, $types) = SQLParserUtils::expandListParameters($query, $params, $types);
+
+                //Oracle does not allow more than 1000 elements in IN clause, we need to split it
+                if ($this->getDriver() instanceof AbstractOracleDriver) {
+                    $query = SQLParserUtils::splitInClause($query, 1000);
+                }
 
                 $stmt = $this->_conn->prepare($query);
                 if ($types) {

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -421,4 +421,43 @@ SQLDATA
 
         SQLParserUtils::expandListParameters($query, $params, $types);
     }
+
+    public function dataSplitInClause()
+    {
+        return [
+            //two IN clauses, only one requires splitting
+            [
+                "SELECT * FROM Foo WHERE bar IN (?, ?, ?) AND baz IN (?)",
+                "SELECT * FROM Foo WHERE (bar IN (?, ?) OR bar IN (?)) AND baz IN (?)",
+                2,
+            ],
+            //two IN clauses, both requires splitting
+            [
+                "SELECT * FROM Foo WHERE bar IN (?, ?, ?, ?, ?) AND baz IN (?, ?, ?, ?)",
+                "SELECT * FROM Foo WHERE (bar IN (?, ?, ?) OR bar IN (?, ?)) AND (baz IN (?, ?, ?) OR baz IN (?))",
+                3,
+            ],
+            //IN clauses (requiring and not requiring spliting) mixed with non IN clause
+            [
+                "SELECT * FROM Foo WHERE bar = ? AND baz IN (?, ?, ?, ?) OR ban IN (?, ?)",
+                "SELECT * FROM Foo WHERE bar = ? AND (baz IN (?, ?, ?) OR baz IN (?)) OR ban IN (?, ?)",
+                3,
+            ],
+            //no IN clauses, nothing should happen
+            [
+                "SELECT * FROM Foo WHERE bar = ? AND baz = ?",
+                "SELECT * FROM Foo WHERE bar = ? AND baz = ?",
+                3,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataSplitInClause
+     */
+    public function testSplitInClause($query, $expectedQuery, $maxInElementsCount)
+    {
+        $resultQuery = SQLParserUtils::splitInClause($query, $maxInElementsCount);
+        $this->assertEquals($expectedQuery, $resultQuery, "IN clause was not split correctly");
+    }
 }


### PR DESCRIPTION
Oracle does not allow queries with more than 1000 elements in IN clause

Query:
`SELECT ... WHERE foo IN (1,..., 1001)` 

will result in `ORA-01795 maximum number of expressions in a list is 1000`

This PR introduces method to convert such queries from
`SELECT ... WHERE foo IN (1,..., 1001)` 
to
`SELECT ... WHERE (foo IN (1,..., 1000) OR foo IN (1001))` 
and does this conversion before parsing query

It fixes https://github.com/doctrine/dbal/issues/2095 