### PR TITLE
Add error as well as exception handling to Mysqli drivers

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -67,14 +67,13 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
         $this->setDriverOptions($driverOptions);
 
         set_error_handler(function () {});
-
-        if ( ! $this->_conn->real_connect($params['host'], $username, $password, $dbname, $port, $socket, $flags)) {
+        try {
+            if ( ! $this->_conn->real_connect($params['host'], $username, $password, $dbname, $port, $socket, $flags)) {
+                throw new MysqliException($this->_conn->connect_error, $this->_conn->sqlstate ?? 'HY000', $this->_conn->connect_errno);
+            }
+        } finally {
             restore_error_handler();
-
-            throw new MysqliException($this->_conn->connect_error, @$this->_conn->sqlstate ?: 'HY000', $this->_conn->connect_errno);
         }
-
-        restore_error_handler();
 
         if (isset($params['charset'])) {
             $this->_conn->set_charset($params['charset']);


### PR DESCRIPTION
This patch restores the error handler if mysqli_real_connect throws an exception.