### PR TITLE
Added access to native close() method of mysqli

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -31,6 +31,7 @@ use Doctrine\DBAL\Cache\ResultCacheStatement;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Cache\ArrayStatement;
 use Doctrine\DBAL\Cache\CacheException;
+use Doctrine\DBAL\Driver\CloseableConnection;
 use Doctrine\DBAL\Driver\PingableConnection;
 use Throwable;
 
@@ -603,6 +604,9 @@ class Connection implements DriverConnection
      */
     public function close()
     {
+        if ($this->_conn && $this->_conn instanceof CloseableConnection) {
+            $this->_conn->close();
+        }
         $this->_conn = null;
 
         $this->_isConnected = false;

--- a/lib/Doctrine/DBAL/Driver/CloseableConnection.php
+++ b/lib/Doctrine/DBAL/Driver/CloseableConnection.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver;
+
+/**
+ * An interface for connections which support a "native" close method.
+ *
+ * @link   www.doctrine-project.org
+ */
+interface CloseableConnection
+{
+    /**
+     * Immediately close the current database connection.
+     *
+     * @return bool true on success or false on failure.
+     */
+    public function close();
+}

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\Connection as Connection;
+use Doctrine\DBAL\Driver\CloseableConnection;
 use Doctrine\DBAL\Driver\PingableConnection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 
@@ -27,7 +28,7 @@ use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
  * @author Kim Hemsø Rasmussen <kimhemsoe@gmail.com>
  * @author Till Klampaeckel <till@php.net>
  */
-class MysqliConnection implements Connection, PingableConnection, ServerInfoAwareConnection
+class MysqliConnection implements Connection, CloseableConnection, PingableConnection, ServerInfoAwareConnection
 {
     /**
      * Name of the option to set connection flags
@@ -262,6 +263,16 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
     public function ping()
     {
         return $this->_conn->ping();
+    }
+
+    /**
+     * Immediately close the current database connection.
+     *
+     * @return bool true on success or false on failure.
+     */
+    public function close()
+    {
+        return $this->_conn->close();
     }
 
     /**


### PR DESCRIPTION
I noticed that the `close()` method in class Connection does not close the driver connection, but only sets the reference to NULL. I added a CloseableConnection interface (implemented by MysqliConnection, for now) which allows to close the connection, if supported.