### PR TITLE
#2714 `Sequence::isAutoIncrementsFor()` is now case-insensitive

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Sequence.php
+++ b/lib/Doctrine/DBAL/Schema/Sequence.php
@@ -149,7 +149,7 @@ class Sequence extends AbstractAsset
 
         $sequenceName      = $this->getShortestName($table->getNamespaceName());
         $tableName         = $table->getShortestName($table->getNamespaceName());
-        $tableSequenceName = sprintf('%s_%s_seq', $tableName, $pkColumns[0]);
+        $tableSequenceName = sprintf('%s_%s_seq', $tableName, $column->getShortestName($table->getNamespaceName()));
 
         return $tableSequenceName === $sequenceName;
     }

--- a/tests/Doctrine/Tests/DBAL/Schema/SequenceTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SequenceTest.php
@@ -24,5 +24,24 @@ class SequenceTest extends \Doctrine\Tests\DbalTestCase
         $this->assertFalse($sequence2->isAutoIncrementsFor($table));
         $this->assertFalse($sequence3->isAutoIncrementsFor($table));
     }
+
+    public function testIsAutoincrementForCaseInsensitive()
+    {
+        $table = new Table('foo');
+        $table->addColumn('ID', 'integer', array('autoincrement' => true));
+        $table->setPrimaryKey(array('ID'));
+
+        $sequence = new Sequence("foo_id_seq");
+        $sequence1 = new Sequence("foo_ID_seq");
+        $sequence2 = new Sequence("bar_id_seq");
+        $sequence3 = new Sequence("bar_ID_seq");
+        $sequence4 = new Sequence("other.foo_id_seq");
+
+        $this->assertTrue($sequence->isAutoIncrementsFor($table));
+        $this->assertTrue($sequence1->isAutoIncrementsFor($table));
+        $this->assertFalse($sequence2->isAutoIncrementsFor($table));
+        $this->assertFalse($sequence3->isAutoIncrementsFor($table));
+        $this->assertFalse($sequence4->isAutoIncrementsFor($table));
+    }
 }
 


### PR DESCRIPTION
Fixes #2714 