### PR TITLE
`SQLParserUtils::getPlaceholderPositions()` fails if there are quoted strings containing only backslashes

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -32,9 +32,9 @@ class SQLParserUtils
     const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
 
     // Quote characters within string literals can be preceded by a backslash.
-    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:[^'\\\\]|\\\\+|\\\\'?|'')*'";
-    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:[^"\\\\]|\\\\+|\\\\"?)*"';
-    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:[^`\\\\]|\\\\+|\\\\`?)*`';
+    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:[^'\\\\]|(\\\\)+|\\\\'?|'')*'";
+    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:[^"\\\\]|(\\\\)+|\\\\"?)*"';
+    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:[^`\\\\]|(\\\\)+|\\\\`?)*`';
     const ESCAPED_BRACKET_QUOTED_TEXT = '(?<!\bARRAY)\[(?:[^\]])*\]';
 
     /**

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -32,9 +32,9 @@ class SQLParserUtils
     const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
 
     // Quote characters within string literals can be preceded by a backslash.
-    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:(?:\\\\\\\\)*|[^'\\\\]|\\\\'?|'')*'";
-    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:(?:\\\\\\\\)*|[^"\\\\]|\\\\"?)*"';
-    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:(?:\\\\\\\\)*|[^`\\\\]|\\\\`?)*`';
+    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:(?:(?:\\\\\\\\)*)|(?:[^'\\\\]|\\\\'?|'')*)'";
+    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:(?:(?:\\\\\\\\)*)|(?:[^"\\\\]|\\\\"?)*)"';
+    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:(?:(?:\\\\\\\\)*)|(?:[^`\\\\]|\\\\`?)*)`';
     const ESCAPED_BRACKET_QUOTED_TEXT = '(?<!\bARRAY)\[(?:[^\]])*\]';
 
     /**

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -32,9 +32,9 @@ class SQLParserUtils
     const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
 
     // Quote characters within string literals can be preceded by a backslash.
-    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:[^'\\\\]|\\\\'?|'')*'";
-    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:[^"\\\\]|\\\\"?)*"';
-    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:[^`\\\\]|\\\\`?)*`';
+    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:[^'\\\\]|\\\\+|\\\\'?|'')*'";
+    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:[^"\\\\]|\\\\+|\\\\"?)*"';
+    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:[^`\\\\]|\\\\+|\\\\`?)*`';
     const ESCAPED_BRACKET_QUOTED_TEXT = '(?<!\bARRAY)\[(?:[^\]])*\]';
 
     /**

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -32,10 +32,10 @@ class SQLParserUtils
     const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
 
     // Quote characters within string literals can be preceded by a backslash.
-    const ESCAPED_SINGLE_QUOTED_TEXT = "(?:'(?:\\\\\\\\)*'[^']|'(?:[^'\\\\]|\\\\'?|'')*')";
-    const ESCAPED_DOUBLE_QUOTED_TEXT = '(?:"(?:\\\\\\\\)*"|"(?:[^"\\\\]|\\\\"?)*")';
-    const ESCAPED_BACKTICK_QUOTED_TEXT = '(?:`(?:\\\\\\\\)*`|`(?:[^`\\\\]|\\\\`?)*`)';
-    const ESCAPED_BRACKET_QUOTED_TEXT =  '(?<!\bARRAY)\[(?:[^\]])*\]';
+    const ESCAPED_SINGLE_QUOTED_TEXT = "(?:'(?:\\\\\\\\)+'|'(?:[^'\\\\]|\\\\'?|'')*')";
+    const ESCAPED_DOUBLE_QUOTED_TEXT = '(?:"(?:\\\\\\\\)+"|"(?:[^"\\\\]|\\\\"?)*")';
+    const ESCAPED_BACKTICK_QUOTED_TEXT = '(?:`(?:\\\\\\\\)+`|`(?:[^`\\\\]|\\\\`?)*`)';
+    const ESCAPED_BRACKET_QUOTED_TEXT = '(?<!\bARRAY)\[(?:[^\]])*\]';
 
     /**
      * Gets an array of the placeholders in an sql statements as keys and their positions in the query string.

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -32,10 +32,10 @@ class SQLParserUtils
     const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
 
     // Quote characters within string literals can be preceded by a backslash.
-    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:(?:(?:\\\\\\\\)*)|(?:[^'\\\\]|\\\\'?|'')*)'";
-    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:(?:(?:\\\\\\\\)*)|(?:[^"\\\\]|\\\\"?)*)"';
-    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:(?:(?:\\\\\\\\)*)|(?:[^`\\\\]|\\\\`?)*)`';
-    const ESCAPED_BRACKET_QUOTED_TEXT = '(?<!\bARRAY)\[(?:[^\]])*\]';
+    const ESCAPED_SINGLE_QUOTED_TEXT = "(?:'(?:\\\\\\\\)*'[^']|'(?:[^'\\\\]|\\\\'?|'')*')";
+    const ESCAPED_DOUBLE_QUOTED_TEXT = '(?:"(?:\\\\\\\\)*"|"(?:[^"\\\\]|\\\\"?)*")';
+    const ESCAPED_BACKTICK_QUOTED_TEXT = '(?:`(?:\\\\\\\\)*`|`(?:[^`\\\\]|\\\\`?)*`)';
+    const ESCAPED_BRACKET_QUOTED_TEXT =  '(?<!\bARRAY)\[(?:[^\]])*\]';
 
     /**
      * Gets an array of the placeholders in an sql statements as keys and their positions in the query string.

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -32,9 +32,9 @@ class SQLParserUtils
     const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
 
     // Quote characters within string literals can be preceded by a backslash.
-    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:[^'\\\\]|(\\\\)+|\\\\'?|'')*'";
-    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:[^"\\\\]|(\\\\)+|\\\\"?)*"';
-    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:[^`\\\\]|(\\\\)+|\\\\`?)*`';
+    const ESCAPED_SINGLE_QUOTED_TEXT = "'(?:(?:\\\\\\\\)*|[^'\\\\]|\\\\'?|'')*'";
+    const ESCAPED_DOUBLE_QUOTED_TEXT = '"(?:(?:\\\\\\\\)*|[^"\\\\]|\\\\"?)*"';
+    const ESCAPED_BACKTICK_QUOTED_TEXT = '`(?:(?:\\\\\\\\)*|[^`\\\\]|\\\\`?)*`';
     const ESCAPED_BRACKET_QUOTED_TEXT = '(?<!\bARRAY)\[(?:[^\]])*\]';
 
     /**

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -67,7 +67,11 @@ OR bar=:a_param3
 SQLDATA
                 , false, array(74 => 'a_param1', 91 => 'a_param2', 190 => 'a_param3')
             ),
-            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE \'\\\\\') AND (data.description LIKE :condition_1 ESCAPE \'\\\\\') ORDER BY id ASC', false, array(121 => 'condition_0', 174 => 'condition_1')),
+            array("SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE '\\\\') AND (data.description LIKE :condition_1 ESCAPE '\\\\') ORDER BY id ASC", false, array(121 => 'condition_0', 174 => 'condition_1')),
+            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE "\\\\") AND (data.description LIKE :condition_1 ESCAPE "\\\\") ORDER BY id ASC', false, array(121 => 'condition_0', 174 => 'condition_1')),
+            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE "\\\\") AND (data.description LIKE :condition_1 ESCAPE \'\\\\\') ORDER BY id ASC', false, array(121 => 'condition_0', 174 => 'condition_1')),
+            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE `\\\\`) AND (data.description LIKE :condition_1 ESCAPE `\\\\`) ORDER BY id ASC', false, array(121 => 'condition_0', 174 => 'condition_1')),
+            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE \'\\\\\') AND (data.description LIKE :condition_1 ESCAPE `\\\\`) ORDER BY id ASC', false, array(121 => 'condition_0', 174 => 'condition_1')),
             
         );
     }

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -67,6 +67,7 @@ OR bar=:a_param3
 SQLDATA
                 , false, array(74 => 'a_param1', 91 => 'a_param2', 190 => 'a_param3')
             ),
+            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE \'\\\\\') AND (data.description LIKE :condition_1 ESCAPE \'\\\\\') ORDER BY id ASC', false, array(121 => 'condition_0', 174 => 'condition_1')),
             
         );
     }


### PR DESCRIPTION
Passing the following statement to ```SQLParserUtils::getPlaceholderPositions``` results in failure to identify the second placeholder ```condition_1```.

```
SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id
FROM test_data data 
WHERE 
  (data.description LIKE :condition_0 ESCAPE '\\') AND 
  (data.description LIKE :condition_1 ESCAPE '\\')
ORDER BY id ASC
```
Apparently, ```::getUnquotedStatementFragments``` gets confused by escapes.

Added a test to prove the bug.