### PR TITLE
Warning: implode(): Invalid arguments passed in SimpleArrayType.php

### DIFF
--- a/lib/Doctrine/DBAL/Types/SimpleArrayType.php
+++ b/lib/Doctrine/DBAL/Types/SimpleArrayType.php
@@ -47,6 +47,10 @@ class SimpleArrayType extends Type
         if (!$value) {
             return null;
         }
+        
+        if (!is_array($value)) {
+            $value = array($value);
+        }
 
         return implode(',', $value);
     }


### PR DESCRIPTION
Warning: implode(): Invalid arguments passed in SimpleArrayType.php line 52

The warning happens when you set field value to something different than array, ie. string.

I will provide test later.