### PR TITLE
Corrected duplicate 'COMMENT' part in DDL statement

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2238,10 +2238,10 @@ abstract class AbstractPlatform
 
             $typeDecl = $field['type']->getSQLDeclaration($field, $this);
             $columnDef = $typeDecl . $charset . $default . $notnull . $unique . $check . $collation;
-        }
 
-        if ($this->supportsInlineColumnComments() && isset($field['comment']) && $field['comment'] !== '') {
-            $columnDef .= ' ' . $this->getInlineColumnCommentSQL($field['comment']);
+            if ($this->supportsInlineColumnComments() && isset($field['comment']) && $field['comment'] !== '') {
+                $columnDef .= ' ' . $this->getInlineColumnCommentSQL($field['comment']);
+            }
         }
 
         return $name . ' ' . $columnDef;

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1057,7 +1057,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $options = array(
             'type' => Type::getType('integer'),
             'default' => 0,
-            'notnull' => TRUE,
+            'notnull' => true,
             'comment' => 'expected+column+comment',
         );
         $columnDefinition = substr($this->_conn->getDatabasePlatform()->getColumnDeclarationSQL('id', $options), strlen('id') + 1);

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1048,6 +1048,28 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $this->assertEquals("It's a comment with a quote", $columns['id']->getComment());
     }
 
+    public function testCommentNotDuplicated()
+    {
+        if ( ! $this->_conn->getDatabasePlatform()->supportsInlineColumnComments()) {
+            $this->markTestSkipped('Database does not support column comments.');
+        }
+
+        $options = array(
+            'type' => Type::getType('integer'),
+            'default' => 0,
+            'notnull' => TRUE,
+            'comment' => 'expected+column+comment',
+        );
+        $columnDefinition = substr($this->_conn->getDatabasePlatform()->getColumnDeclarationSQL('id', $options), strlen('id') + 1);
+
+        $table = new Table('my_table');
+        $table->addColumn('id', 'integer', array('columnDefinition' => $columnDefinition, 'comment' => 'unexpected_column_comment'));
+        $sql = $this->_conn->getDatabasePlatform()->getCreateTableSQL($table);
+
+        $this->assertContains('expected+column+comment', $sql[0]);
+        $this->assertNotContains('unexpected_column_comment', $sql[0]);
+    }
+
     /**
      * @group DBAL-1009
      *


### PR DESCRIPTION
If you pass both a 'columnDefinition' containing a comment, _and_ a 'comment' option, to a column when creating /altering a table, the SQL statement produced by the schema has a duplicate COMMENT part.

The following code
```
  $table = new Table('my_table');
  $table->addColumn('id', 'integer', array(
    'columnDefinition' => 'INT DEFAULT 0 NOT NULL COMMENT \'expected+column+comment\'', 
    'comment' => 'unexpected_column_comment')
  );
  $sql = $this->_conn->getDatabasePlatform()->getCreateTableSQL($table);
```
will generate:
```
CREATE TABLE my_table 
(id INT DEFAULT 0 NOT NULL COMMENT 'expected+column+comment' COMMENT 'unexpected_column_comment') 
DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB
```
