### PR TITLE
Adds missing return statement on SQLSrvStatement.execute()

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -244,6 +244,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
         }
 
         $this->result = true;
+        return $this->result;
     }
 
     /**


### PR DESCRIPTION
The documentation states that the execute function requires a boolean return value. Based on `MysqliStatement` the return statement is missing on `SqlSrvStatement`.

The prevents `dbal:import` to run properly because it evaluates null to false although the statement ran successfully.