### PR TITLE
Correct documented parameter and return types for `Connection#quote()`

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/Connection.php
@@ -48,10 +48,10 @@ interface Connection
     /**
      * Quotes a string for use in a query.
      *
-     * @param string  $input
+     * @param mixed  $input
      * @param integer $type
      *
-     * @return string
+     * @return mixed
      */
     function quote($input, $type=\PDO::PARAM_STR);
 


### PR DESCRIPTION
Single drivers get and return various types in quote(), the
interface docs should reflect that.