### PR TITLE
Correcting references to `Driver\Connection` in the documentation

### DIFF
--- a/docs/en/reference/architecture.rst
+++ b/docs/en/reference/architecture.rst
@@ -46,7 +46,7 @@ The drivers abstract a PHP specific database API by enforcing two
 interfaces:
 
 
--  ``\Doctrine\DBAL\Driver\Driver``
+-  ``\Doctrine\DBAL\Driver\Connection``
 -  ``\Doctrine\DBAL\Driver\Statement``
 
 The above two interfaces require exactly the same methods as PDO.


### PR DESCRIPTION
At least it looks like one to me.