### PR TITLE
Fix: executionMS should be milliseconds not seconds

### DIFF
--- a/lib/Doctrine/DBAL/Logging/DebugStack.php
+++ b/lib/Doctrine/DBAL/Logging/DebugStack.php
@@ -72,7 +72,7 @@ class DebugStack implements SQLLogger
     public function stopQuery()
     {
         if ($this->enabled) {
-            $this->queries[$this->currentQuery]['executionMS'] = microtime(true) - $this->start;
+            $this->queries[$this->currentQuery]['executionMS'] = (microtime(true) - $this->start) * 1000;
         }
     }
 }


### PR DESCRIPTION
Looks like this is a mistake.