### PR TITLE
Correct classes referenced in the `Driver` implementation details in the documentation

### DIFF
--- a/docs/en/reference/supporting-other-databases.rst
+++ b/docs/en/reference/supporting-other-databases.rst
@@ -6,13 +6,14 @@ you have to implement the following interfaces and abstract
 classes:
 
 
--  ``\Doctrine\DBAL\Driver\Driver``
+-  ``\Doctrine\DBAL\Driver\Connection``
 -  ``\Doctrine\DBAL\Driver\Statement``
+-  ``\Doctrine\DBAL\Driver``
 -  ``\Doctrine\DBAL\Platforms\AbstractPlatform``
 -  ``\Doctrine\DBAL\Schema\AbstractSchemaManager``
 
 For an already supported platform but unsupported driver you only
-need to implement the first two interfaces, since the SQL
+need to implement the first three interfaces, since the SQL
 Generation and Schema Management is already supported by the
 respective platform and schema instances. You can also make use of
 several Abstract Unittests in the ``\Doctrine\Tests\DBAL`` package
@@ -31,7 +32,7 @@ Implementation Steps in Detail
 
 1. Add your driver shortcut to class-name `Doctrine\DBAL\DriverManager`.
 2. Make a copy of tests/dbproperties.xml.dev and adjust the values to your driver shortcut and testdatabase.
-3. Create three new classes implementing ``\Doctrine\DBAL\Driver\Driver``, ``\Doctrine\DBAL\Driver\Statement``
+3. Create three new classes implementing ``\Doctrine\DBAL\Driver\Connection``, ``\Doctrine\DBAL\Driver\Statement``
    and ``Doctrine\DBAL\Driver``. You can take a look at the ``Doctrine\DBAL\Driver\OCI8`` driver.
 4. You can run the testsuite of your new database driver by calling "phpunit -c .". You can set your own settings in phpunit.xml file. 
 5. Start implementing AbstractPlatform and AbstractSchemaManager. Other implementations should serve as good example.


### PR DESCRIPTION
One class missed and one non-existing at "Supporting Other Databases" page.