### PR TITLE
Correct `Connection#quote()` parameter hinting, now compatible with `PDO::PARAM_*` constants

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -798,7 +798,7 @@ class Connection implements DriverConnection
      * Quotes a given input parameter.
      *
      * @param mixed       $input The parameter to be quoted.
-     * @param string|null $type  The type of the parameter.
+     * @param int|null $type  The type of the parameter.
      *
      * @return string The quoted parameter.
      */


### PR DESCRIPTION
The param comment is currently set to string, which is wrong.
The correct hint would be integer/int

Issue: #2745 