### PR TITLE
Add number of maximum allowed placeholders in prepared statements

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -601,6 +601,16 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Gets the maximum number of placeholders for prepared statements
+     *
+     * @return integer
+     */
+    public function getMaximumNumberOfPreparedStatementPlaceholders()
+    {
+        return 950;
+    }
+
+    /**
      * Gets all SQL wildcard characters of the platform.
      *
      * @return array

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -1066,6 +1066,14 @@ class MySqlPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getMaximumNumberOfPreparedStatementPlaceholders()
+    {
+        return 65535;
+    }
+
+    /**
      * {@inheritDoc}
      */
     protected function getReservedKeywordsClass()

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -354,6 +354,14 @@ class OraclePlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getMaximumNumberOfPreparedStatementPlaceholders()
+    {
+        return 64000;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getClobTypeDeclarationSQL(array $field)

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -1162,6 +1162,14 @@ class PostgreSqlPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getMaximumNumberOfPreparedStatementPlaceholders()
+    {
+        return 34464;
+    }
+
+    /**
      * {@inheritDoc}
      */
     protected function getReservedKeywordsClass()

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1158,6 +1158,14 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getMaximumNumberOfPreparedStatementPlaceholders()
+    {
+        return 2100;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getClobTypeDeclarationSQL(array $field)

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -394,6 +394,14 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getMaximumNumberOfPreparedStatementPlaceholders()
+    {
+        return 999;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getClobTypeDeclarationSQL(array $field)
     {
         return 'CLOB';


### PR DESCRIPTION
The platform should provide an information how many values can be bound
in a prepared statement.

This adds the possibility to split up big quries if the limit of placeholders
is reached.

Closes #2748