### PR TITLE
Add mysql versions 5.6 and 5.7 to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,46 @@ env:
 before_script:
   - if [[ $TRAVIS_PHP_VERSION = '7.1' && $DB = 'sqlite' ]]; then PHPUNIT_FLAGS="--coverage-clover .clover.xml"; else PHPUNIT_FLAGS=""; fi
   - if [[ "$PHPUNIT_FLAGS" == "" ]]; then phpenv config-rm xdebug.ini || true; fi
+  - if [ "$MYSQL_VERSION" == "5.7" ]; then bash ./tests/travis/install-mysql-5.7.sh; fi;
+  - if [[ "$MYSQL_VERSION" == "5.6" || "$MYSQL_VERSION" == "5.7" ]]; then mysql -e "CREATE SCHEMA doctrine_tests; GRANT ALL PRIVILEGES ON doctrine_tests.* to travis@'%'"; fi;
+  - if [[ "$MYSQL_VERSION" == "5.6" || "$MYSQL_VERSION" == "5.7" ]]; then mysql -e "CREATE SCHEMA test_create_database; GRANT ALL PRIVILEGES ON test_create_database.* to travis@'%'"; fi;
+  - if [[ "$MYSQL_VERSION" == "5.6" || "$MYSQL_VERSION" == "5.7" ]]; then mysql -e "CREATE SCHEMA test_drop_database; GRANT ALL PRIVILEGES ON test_drop_database.* to travis@'%'"; fi;
 
 matrix:
   fast_finish: true
   include:
+    - php: 7.1
+      env: DB=mysql MYSQL_VERSION=5.6
+      dist: trusty
+    - php: nightly
+      env: DB=mysql MYSQL_VERSION=5.6
+      dist: trusty
+
+    - php: 7.1
+      env: DB=mysqli MYSQL_VERSION=5.6
+      dist: trusty
+    - php: nightly
+      env: DB=mysqli MYSQL_VERSION=5.6
+      dist: trusty
+
+    - php: 7.1
+      env: DB=mysql MYSQL_VERSION=5.7
+      dist: trusty
+      sudo: required
+    - php: nightly
+      env: DB=mysql MYSQL_VERSION=5.7
+      dist: trusty
+      sudo: required
+
+    - php: 7.1
+      env: DB=mysqli MYSQL_VERSION=5.7
+      dist: trusty
+      sudo: required
+    - php: nightly
+      env: DB=mysqli MYSQL_VERSION=5.7
+      dist: trusty
+      sudo: required
+
     - php: 7.1
       env: DB=mariadb MARIADB_VERSION=10.0
       addons:

--- a/tests/travis/install-mysql-5.7.sh
+++ b/tests/travis/install-mysql-5.7.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Installing MySQL 5.7..."
+
+sudo service mysql stop
+sudo apt-get remove "^mysql.*"
+sudo apt-get autoremove
+sudo apt-get autoclean
+echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
+wget http://dev.mysql.com/get/mysql-apt-config_0.8.6-1_all.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mysql-apt-config_0.8.6-1_all.deb
+sudo rm -rf /var/lib/apt/lists/*
+sudo apt-get clean
+sudo apt-get update -q
+sudo apt-get install -q -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" mysql-server libmysqlclient-dev
+sudo mysql_upgrade
+
+echo "Restart mysql..."
+sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
+


### PR DESCRIPTION
This pr improves on #2757 by @epinxteren I also added env mysqli to the 5.6 and 5.7 builds, but I'm not sure if they are needed

fixes #2755