### PR TITLE
Test only for Optimize Oracle SchemaManager 

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -284,8 +284,11 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
           $this->_conn->executeUpdate($sql);
         }
 
-        $dbal_schema = $this->_sm->createSchema();
+        $startTime = microtime(TRUE);
+        $schema = $this->_sm->createSchema();
+        $endTime = microtime(TRUE);
 
-        $this->assertSame(150, count($dbal_schema->getTables()));
+        $this->assertGreaterThanOrEqual(150, count($schema->getTables()));
+        $this->assertLessThan(15, $endTime - $startTime, 'createSchema() executed in less than 15 sec.');
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -273,4 +273,19 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->assertSame('datetime', $columns['col_datetime']->getType()->getName());
         $this->assertSame('datetimetz', $columns['col_datetimetz']->getType()->getName());
     }
+
+    public function testCreateSchemaOnLargeNumberOfTables()
+    {
+        $sql = "CREATE TABLE tbl_test_2766_0 (x_id VARCHAR2(255) DEFAULT 'x' NOT NULL, x_data CLOB DEFAULT NULL NULL, x_number NUMBER(10) DEFAULT 0 NOT NULL, PRIMARY KEY(x_id))";
+        $this->_conn->executeUpdate($sql);
+
+        for ($i = 1; $i < 150; $i++) {
+          $sql = "CREATE TABLE tbl_test_2766_$i (x_id VARCHAR2(255) DEFAULT 'x' NOT NULL, x_data CLOB DEFAULT NULL NULL, x_number NUMBER(10) DEFAULT 0 NOT NULL, PRIMARY KEY(x_id))";
+          $this->_conn->executeUpdate($sql);
+        }
+
+        $dbal_schema = $this->_sm->createSchema();
+
+        $this->assertSame(150, count($dbal_schema->getTables()));
+    }
 }


### PR DESCRIPTION
This is a test only patch for https://github.com/doctrine/dbal/pull/2766, to measure the duration of running `createSchema` on an Oracle db with a significant number of tables.