### PR TITLE
Add the character `

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
@@ -70,7 +70,7 @@ class MySQL57Platform extends MySqlPlatform
     protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
     {
         return array(
-            'ALTER TABLE ' . $tableName . ' RENAME INDEX ' . $oldIndexName . ' TO ' . $index->getQuotedName($this)
+            'ALTER TABLE ' . $tableName . ' RENAME INDEX `' . $oldIndexName . '` TO ' . $index->getQuotedName($this)
         );
     }
 


### PR DESCRIPTION
I am using doctrine on symfony and i did need to rename a index called year-month and i found this error because missing this char and mysql dont work, the, i add this char and all work very fine.

The log of the error:

[Doctrine\DBAL\Exception\SyntaxErrorException]                               
  An exception occurred while executing 'ALTER TABLE balances RENAME INDEX ye  
  ar-month-cuenta TO year_month_cuenta':                                       
  SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error i  
  n your SQL syntax; check the manual that corresponds to your MySQL server v  
  ersion for the right syntax to use near '-month-cuenta TO year_month_cuenta  
  ' at line 1 

the sentence wrong

ALTER TABLE balances RENAME INDEX year-month-cuenta TO year_month_cuenta;

the right sentence:

ALTER TABLE balances RENAME INDEX &#96;year-month-cuenta&#96; TO year_month_cuenta;