### PR TITLE
fixed doc param inside Query Builder

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -409,7 +409,7 @@ class QueryBuilder
      * 'groupBy', 'having' and 'orderBy'.
      *
      * @param string  $sqlPartName
-     * @param string  $sqlPart
+     * @param mixed  $sqlPart
      * @param boolean $append
      *
      * @return $this This QueryBuilder instance.
@@ -420,7 +420,7 @@ class QueryBuilder
         $isMultiple = is_array($this->sqlParts[$sqlPartName]);
 
         if ($isMultiple && !$isArray) {
-            $sqlPart = array($sqlPart);
+            $sqlPart = [$sqlPart];
         }
 
         $this->state = self::STATE_DIRTY;


### PR DESCRIPTION
Fixed a parameter documentation from string to mixed because it can be a string or an array