### PR TITLE
Fix `CompositeExpression#add()` optimization, which was leading to broken `CompositeExpression` instances

### DIFF
--- a/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
+++ b/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
@@ -91,9 +91,15 @@ class CompositeExpression implements \Countable
      */
     public function add($part)
     {
-        if ( ! empty($part) || ($part instanceof self && $part->count() > 0)) {
-            $this->parts[] = $part;
+        if (empty($part)) {
+            return $this;
         }
+
+        if ($part instanceof self && 0 === count($part)) {
+            return $this;
+        }
+
+        $this->parts[] = $part;
 
         return $this;
     }

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
@@ -20,6 +20,29 @@ class CompositeExpressionTest extends \Doctrine\Tests\DbalTestCase
         $this->assertEquals(2, count($expr));
     }
 
+    public function testAdd()
+    {
+        $expr = new CompositeExpression(CompositeExpression::TYPE_OR, array('u.group_id = 1'));
+
+        $this->assertCount(1, $expr);
+
+        $expr->add(new CompositeExpression(CompositeExpression::TYPE_AND, array()));
+
+        $this->assertCount(1, $expr);
+
+        $expr->add(new CompositeExpression(CompositeExpression::TYPE_OR, array('u.user_id = 1')));
+
+        $this->assertCount(2, $expr);
+
+        $expr->add(null);
+
+        $this->assertCount(2, $expr);
+
+        $expr->add('u.user_id = 1');
+
+        $this->assertCount(3, $expr);
+    }
+
     /**
      * @dataProvider provideDataForConvertToString
      */


### PR DESCRIPTION
Current implementation of CompositeExpression->add() has invalid rule for empty instances of self class (never executed).