### PR TITLE
Map error code 1429 to `ConnectionException` in the `AbstractMySQLDriver`

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -102,6 +102,7 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
             case '1143':
             case '1227':
             case '1370':
+            case '1429':
             case '2002':
             case '2005':
                 return new Exception\ConnectionException($message, $exception);


### PR DESCRIPTION
`1429 Unable to connect to foreign data source`

It might be even better to split up the `ConnectionException`,
making `ConnectionException` an interface and have one implementation for `client-to-server/node` exceptions and one for `server/node-server/node` exception.
However that would be a BC break.
Other way could be to have a new exception for  `server/node-server/node` issue.

Any thoughts?