### PR TITLE
sqlsrv - force string cast when parameter is of type string

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -264,6 +264,9 @@ class SQLSrvStatement implements IteratorAggregate, Statement
                     SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY),
                     SQLSRV_SQLTYPE_VARBINARY('max'),
                 ];
+            } elseif (PDO::PARAM_STR === $this->types[$column]) {
+                $variable = (string) $variable;
+                $params[$column - 1] =& $variable ;
             } else {
                 $params[$column - 1] =& $variable;
             }

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/StatementTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\SQLSrv;
 
 use Doctrine\DBAL\Driver\SQLSrv\Driver;
 use Doctrine\DBAL\Driver\SQLSrv\SQLSrvException;
+use Doctrine\DBAL\Driver\SQLSrv\SQLSrvStatement;
 use Doctrine\Tests\DbalFunctionalTestCase;
 
 class StatementTest extends DbalFunctionalTestCase
@@ -29,6 +30,20 @@ class StatementTest extends DbalFunctionalTestCase
         // it's impossible to prepare the statement without bound variables for SQL Server,
         // so the preparation happens before the first execution when variables are already in place
         $this->expectException(SQLSrvException::class);
+        $stmt->execute();
+    }
+
+    public function testObjectsWillBeCastedToString()
+    {
+        // use the driver connection directly to avoid having exception wrapped
+        /** @var SQLSrvStatement $stmt */
+        $stmt = $this->_conn->getWrappedConnection()->prepare("SELECT ?");
+
+        // create and bind an object that implements magic method __toString()
+        $object = new StringCastableObject('test string');
+        $stmt->bindParam(1, $object, \PDO::PARAM_STR);
+
+        // when executing the query, no Exception must be thrown
         $stmt->execute();
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/StringCastableObject.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/StringCastableObject.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\SQLSrv;
+
+/**
+ * Class StringCastableObject
+ * @package Doctrine\Tests\DBAL\Functional\Driver\SQLSrv
+ *
+ * simple object to test automatic string casts
+ */
+class StringCastableObject
+{
+    /**
+     * @var string
+     */
+    private $string;
+
+    public function __construct($string)
+    {
+        $this->string = $string;
+    }
+
+    public function __toString()
+    {
+        return $this->string;
+    }
+}


### PR DESCRIPTION
When an object that implements `__toString()` is bound as an parameter of type `PDO::PARAM_STR` it raised the following exception when using `sqlsrv` as driver:

```
1) Doctrine\Tests\DBAL\Functional\Driver\SQLSrv\StatementTest::testObjectsWillBeCastedToString
Doctrine\DBAL\Driver\SQLSrv\SQLSrvException: SQLSTATE [IMSSP, -16]: An invalid PHP type for parameter 1 was specified.
```

The problem was only reproducable with `sqlsrv` driver and came up when using `UUID` objects.

Since we still have projects running PHP 5.6 and MSSQL it would be nice to see this merged and backported to `2.5.x`.

Edit: this handles #2753