### PR TITLE
#2794 revert bc break preventing `DateTimeImmutable` conversion

### DIFF
--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -53,7 +53,7 @@ class DateTimeType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value instanceof \DateTimeInterface) {
             return $value->format($platform->getDateTimeFormatString());
         }
 
@@ -65,7 +65,7 @@ class DateTimeType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value === null || $value instanceof \DateTimeInterface) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -53,7 +53,7 @@ class DateTimeType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value->format($platform->getDateTimeFormatString());
         }
 
@@ -65,7 +65,7 @@ class DateTimeType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime) {
+        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/DateTimeTzType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeTzType.php
@@ -71,7 +71,7 @@ class DateTimeTzType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value->format($platform->getDateTimeTzFormatString());
         }
 
@@ -83,7 +83,7 @@ class DateTimeTzType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime) {
+        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/DateTimeTzType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeTzType.php
@@ -71,7 +71,7 @@ class DateTimeTzType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value instanceof \DateTimeInterface) {
             return $value->format($platform->getDateTimeTzFormatString());
         }
 
@@ -83,7 +83,7 @@ class DateTimeTzType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value === null || $value instanceof \DateTimeInterface) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/DateType.php
+++ b/lib/Doctrine/DBAL/Types/DateType.php
@@ -53,7 +53,7 @@ class DateType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value->format($platform->getDateFormatString());
         }
 
@@ -65,7 +65,7 @@ class DateType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime) {
+        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/DateType.php
+++ b/lib/Doctrine/DBAL/Types/DateType.php
@@ -53,7 +53,7 @@ class DateType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value instanceof \DateTimeInterface) {
             return $value->format($platform->getDateFormatString());
         }
 
@@ -65,7 +65,7 @@ class DateType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value === null || $value instanceof \DateTimeInterface) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/TimeType.php
+++ b/lib/Doctrine/DBAL/Types/TimeType.php
@@ -53,7 +53,7 @@ class TimeType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value->format($platform->getTimeFormatString());
         }
 
@@ -65,7 +65,7 @@ class TimeType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime) {
+        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/TimeType.php
+++ b/lib/Doctrine/DBAL/Types/TimeType.php
@@ -53,7 +53,7 @@ class TimeType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value instanceof \DateTimeInterface) {
             return $value->format($platform->getTimeFormatString());
         }
 
@@ -65,7 +65,7 @@ class TimeType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value === null || $value instanceof \DateTimeInterface) {
             return $value;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Types/BaseDateTypeTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BaseDateTypeTestCase.php
@@ -71,6 +71,35 @@ abstract class BaseDateTypeTestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group #2794
+     *
+     * Note that while DateTimeImmutable is supposed to be handled by @see \Doctrine\DBAL\Types\DateTimeImmutableType,
+     * previous DBAL versions handled it just fine. This test is just in place to prevent further regressions, even
+     * if the type is being misused
+     */
+    public function testConvertDateTimeImmutableToPHPValue()
+    {
+        $date = new \DateTimeImmutable('now');
+
+        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
+    }
+
+    /**
+     * @group #2794
+     *
+     * Note that while DateTimeImmutable is supposed to be handled by @see \Doctrine\DBAL\Types\DateTimeImmutableType,
+     * previous DBAL versions handled it just fine. This test is just in place to prevent further regressions, even
+     * if the type is being misused
+     */
+    public function testDateTimeImmutableConvertsToDatabaseValue()
+    {
+        self::assertInternalType(
+            'string',
+            $this->type->convertToDatabaseValue(new \DateTimeImmutable(), $this->platform)
+        );
+    }
+
+    /**
      * @return mixed[][]
      */
     public function invalidPHPValuesProvider()

--- a/tests/Doctrine/Tests/DBAL/Types/BaseDateTypeTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BaseDateTypeTestCase.php
@@ -73,9 +73,9 @@ abstract class BaseDateTypeTestCase extends PHPUnit_Framework_TestCase
     /**
      * @group #2794
      *
-     * Note that while DateTimeImmutable is supposed to be handled by @see \Doctrine\DBAL\Types\DateTimeImmutableType,
-     * previous DBAL versions handled it just fine. This test is just in place to prevent further regressions, even
-     * if the type is being misused
+     * Note that while \@see \DateTimeImmutable is supposed to be handled
+     * by @see \Doctrine\DBAL\Types\DateTimeImmutableType, previous DBAL versions handled it just fine.
+     * This test is just in place to prevent further regressions, even if the type is being misused
      */
     public function testConvertDateTimeImmutableToPHPValue()
     {
@@ -87,9 +87,9 @@ abstract class BaseDateTypeTestCase extends PHPUnit_Framework_TestCase
     /**
      * @group #2794
      *
-     * Note that while DateTimeImmutable is supposed to be handled by @see \Doctrine\DBAL\Types\DateTimeImmutableType,
-     * previous DBAL versions handled it just fine. This test is just in place to prevent further regressions, even
-     * if the type is being misused
+     * Note that while \@see \DateTimeImmutable is supposed to be handled
+     * by @see \Doctrine\DBAL\Types\DateTimeImmutableType, previous DBAL versions handled it just fine.
+     * This test is just in place to prevent further regressions, even if the type is being misused
      */
     public function testDateTimeImmutableConvertsToDatabaseValue()
     {


### PR DESCRIPTION
Reverts the unintentional BC break reported in #2794