### PR TITLE
Array Type - Empty String (NOT NULL) support

### DIFF
--- a/lib/Doctrine/DBAL/Types/ArrayType.php
+++ b/lib/Doctrine/DBAL/Types/ArrayType.php
@@ -55,6 +55,11 @@ class ArrayType extends Type
         }
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
+        // Declaring array type on NOT NULL column with existing table data will save '' for array column in existing rows.
+        if( $value === '' )
+        {
+            return [];
+        }
         $val = unserialize($value);
         if ($val === false && $value != 'b:0;') {
             throw ConversionException::conversionFailed($value, $this->getName());

--- a/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
@@ -56,4 +56,10 @@ class ArrayTest extends \Doctrine\Tests\DbalTestCase
     {
         $this->assertFalse($this->_type->convertToPHPValue(serialize(false), $this->_platform));
     }
+
+    public function testEmptyStringConvertsToEmptyArray()
+    {
+        $this->assertEquals([], $this->_type->convertToPHPValue('', $this->_platform));
+    }
+
 }


### PR DESCRIPTION
Setting a column as Array and NOT NULL for a table with existing data - database (at least MySQL) will set that column as '' (empty string) for existing rows.
And fetching those rows, Doctrine throws a ``Converstion Exception`` with message ``Could not convert database value "" to Doctrine Type array``

This PR fixes that by assuming empty string as empty array.