### PR TITLE
fix for comparator so it can correctly see added indexes.

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -620,8 +620,9 @@ class MySqlPlatform extends AbstractPlatform
             }
             $sql = array_merge(
                 $this->getPreAlterTableIndexForeignKeySQL($diff),
-                $sql,
-                $this->getPostAlterTableIndexForeignKeySQL($diff)
+                $sql
+            //this is causing trouble, adds another drop primary key
+//                $this->getPostAlterTableIndexForeignKeySQL($diff)
             );
         }
 

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -244,7 +244,10 @@ class Comparator
 
         /* See if all the indexes in table 1 exist in table 2 */
         foreach ($table2Indexes as $indexName => $index) {
-            if (($index->isPrimary() && $table1->hasPrimaryKey()) || $table1->hasIndex($indexName)) {
+            //comparison should be on column name of the index, because the primary key has always "primary" as index name even though the index might be totally different
+            //if (($index->isPrimary() && $table1->hasPrimaryKey()) || $table1->hasIndex($indexName))
+            // is therefor not a good comparison, Primary (id) will be seen as the same as Primary (someOtherColumn)
+            if ($table1->hasIndex($indexName) && $table1->hasColumn($index->getColumns()[0])) {
                 continue;
             }
 


### PR DESCRIPTION
starting point:
```sql
CREATE TABLE `someTable` (
	`datum` DATE NOT NULL,
	PRIMARY KEY (`datum`),
	INDEX `i_system_date_changed` (`system_date_changed`),
	INDEX `datum` (`datum`)
)
COLLATE='utf8_unicode_ci'
ENGINE=InnoDB
;
```

new situation:
```sql
CREATE TABLE `someTable` (
	`datum` DATE NOT NULL,
	`id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
	PRIMARY KEY (`id`),
	INDEX `i_system_date_changed` (`system_date_changed`),
	INDEX `datum` (`datum`)
)
COLLATE='utf8_unicode_ci'
ENGINE=InnoDB
;
```
The current comparison in comparator will not see a change here because the index name will return primary for both tables. Causing it not to trigger addedIndexes, which in turn will lead to an incorrect statement where the id key and the primary tag get added separately. MySQL will not allow this because AUTOINCREMENT can only be applied on the primary key.

```sql
ALTER TABLE someTable ADD id INT UNSIGNED AUTO_INCREMENT NOT NULL;
ALTER TABLE someTable ADD PRIMARY KEY (id);
```

```
SQLSTATE[42000]: Syntax error or access violation: 1075 Incorrect table definition; there can be only one auto column and it must be defined as a key
```

This, however, is accepted.
```sql
ALTER TABLE someTable ADD id INT UNSIGNED AUTO_INCREMENT NOT NULL, ADD PRIMARY KEY (id); 
```


