### PR TITLE
#2802 Add NumericType for Database Platforms

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2261,6 +2261,23 @@ abstract class AbstractPlatform
         $columnDef['scale'] = ( ! isset($columnDef['scale']) || empty($columnDef['scale']))
             ? 0 : $columnDef['scale'];
 
+        return 'DECIMAL(' . $columnDef['precision'] . ', ' . $columnDef['scale'] . ')';
+    }
+
+    /**
+     * Returns the SQL snippet that declares a floating point column of arbitrary precision.
+     *
+     * @param array $columnDef
+     *
+     * @return string
+     */
+    public function getNumericTypeDeclarationSQL(array $columnDef)
+    {
+        $columnDef['precision'] = ( ! isset($columnDef['precision']) || empty($columnDef['precision']))
+            ? 10 : $columnDef['precision'];
+        $columnDef['scale'] = ( ! isset($columnDef['scale']) || empty($columnDef['scale']))
+            ? 0 : $columnDef['scale'];
+
         return 'NUMERIC(' . $columnDef['precision'] . ', ' . $columnDef['scale'] . ')';
     }
 

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -72,6 +72,7 @@ class DB2Platform extends AbstractPlatform
             'clob'          => 'text',
             'blob'          => 'blob',
             'decimal'       => 'decimal',
+            'numeric'       => 'numeric',
             'double'        => 'float',
             'real'          => 'float',
             'timestamp'     => 'datetime',

--- a/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
@@ -149,6 +149,7 @@ class DrizzlePlatform extends AbstractPlatform
             'integer'       => 'integer',
             'blob'          => 'blob',
             'decimal'       => 'decimal',
+            'numeric'       => 'numeric',
             'datetime'      => 'datetime',
             'date'          => 'date',
             'time'          => 'time',

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -1037,7 +1037,7 @@ class MySqlPlatform extends AbstractPlatform
             'double'        => 'float',
             'real'          => 'float',
             'decimal'       => 'decimal',
-            'numeric'       => 'decimal',
+            'numeric'       => 'numeric',
             'year'          => 'date',
             'longblob'      => 'blob',
             'blob'          => 'blob',

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -910,6 +910,14 @@ class MySqlPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getNumericTypeDeclarationSQL(array $columnDef)
+    {
+        return parent::getNumericTypeDeclarationSQL($columnDef) . $this->getUnsignedDeclaration($columnDef);
+    }
+
+    /**
      * Get unsigned declaration for a column.
      *
      * @param array $columnDef

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -1140,6 +1140,7 @@ END;';
             'rowid'             => 'string',
             'urowid'            => 'string',
             'blob'              => 'blob',
+            'numeric'           => 'numeric',
         ];
     }
 

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -1130,7 +1130,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             'real'          => 'float',
             'decimal'       => 'decimal',
             'money'         => 'decimal',
-            'numeric'       => 'numeric',
+            'numeric'       => 'decimal',
             'year'          => 'date',
             'uuid'          => 'guid',
             'bytea'         => 'blob',

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -1130,7 +1130,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             'real'          => 'float',
             'decimal'       => 'decimal',
             'money'         => 'decimal',
-            'numeric'       => 'decimal',
+            'numeric'       => 'numeric',
             'year'          => 'date',
             'uuid'          => 'guid',
             'bytea'         => 'blob',

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -1469,7 +1469,7 @@ class SQLAnywherePlatform extends AbstractPlatform
             'int' => 'integer',
             'integer' => 'integer',
             'unsigned int' => 'integer',
-            'numeric' => 'decimal',
+            'numeric' => 'numeric',
             'smallint' => 'smallint',
             'unsigned smallint', 'smallint',
             'tinyint' => 'smallint',

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1415,7 +1415,7 @@ class SQLServerPlatform extends AbstractPlatform
     {
         $this->doctrineTypeMapping = [
             'bigint' => 'bigint',
-            'numeric' => 'decimal',
+            'numeric' => 'numeric',
             'bit' => 'boolean',
             'smallint' => 'smallint',
             'decimal' => 'decimal',

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -623,7 +623,7 @@ class SqlitePlatform extends AbstractPlatform
             'double precision' => 'float',
             'real'             => 'float',
             'decimal'          => 'decimal',
-            'numeric'          => 'decimal',
+            'numeric'          => 'numeric',
             'blob'             => 'blob',
         ];
     }

--- a/lib/Doctrine/DBAL/Types/NumericType.php
+++ b/lib/Doctrine/DBAL/Types/NumericType.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * Type that maps an SQL NUMERIC to a PHP string.
+ *
+ * @since 2.0
+ */
+class NumericType extends DecimalType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return Type::NUMERIC;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getNumericTypeDeclarationSQL($fieldDeclaration);
+    }
+}

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -48,6 +48,7 @@ abstract class Type
     const TIME = 'time';
     const TIME_IMMUTABLE = 'time_immutable';
     const DECIMAL = 'decimal';
+    const NUMERIC = 'numeric';
     const INTEGER = 'integer';
     const OBJECT = 'object';
     const SMALLINT = 'smallint';
@@ -92,6 +93,7 @@ abstract class Type
         self::TIME => TimeType::class,
         self::TIME_IMMUTABLE => TimeImmutableType::class,
         self::DECIMAL => DecimalType::class,
+        self::NUMERIC => NumericType::class,
         self::FLOAT => FloatType::class,
         self::BINARY => BinaryType::class,
         self::BLOB => BlobType::class,

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -473,7 +473,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             "ALTER TABLE mytable ADD PRIMARY KEY (foo)",
         ), $sql);
     }
-    
+
     public function testAlterPrimaryKeyWithNewColumn()
     {
         $table = new Table("yolo");
@@ -483,7 +483,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
         $comparator = new Comparator();
         $diffTable = clone $table;
-        
+
         $diffTable->addColumn('pkc2', 'integer');
         $diffTable->dropPrimaryKey();
         $diffTable->setPrimaryKey(array('pkc1', 'pkc2'));
@@ -495,7 +495,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
                 'ALTER TABLE yolo ADD PRIMARY KEY (pkc1, pkc2)',
             ),
             $this->_platform->getAlterTableSQL($comparator->diffTable($table, $diffTable))
-        );      
+        );
     }
 
     public function testInitializesDoctrineTypeMappings()
@@ -814,6 +814,21 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
      * {@inheritdoc}
      */
     public function getGeneratesDecimalTypeDeclarationSQL()
+    {
+        return array(
+            array(array(), 'DECIMAL(10, 0)'),
+            array(array('unsigned' => true), 'DECIMAL(10, 0) UNSIGNED'),
+            array(array('unsigned' => false), 'DECIMAL(10, 0)'),
+            array(array('precision' => 5), 'DECIMAL(5, 0)'),
+            array(array('scale' => 5), 'DECIMAL(10, 5)'),
+            array(array('precision' => 8, 'scale' => 2), 'DECIMAL(8, 2)'),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getGeneratesNumericTypeDeclarationSQL()
     {
         return array(
             array(array(), 'NUMERIC(10, 0)'),

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -1412,6 +1412,31 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     public function getGeneratesDecimalTypeDeclarationSQL()
     {
         return array(
+            array(array(), 'DECIMAL(10, 0)'),
+            array(array('unsigned' => true), 'DECIMAL(10, 0)'),
+            array(array('unsigned' => false), 'DECIMAL(10, 0)'),
+            array(array('precision' => 5), 'DECIMAL(5, 0)'),
+            array(array('scale' => 5), 'DECIMAL(10, 5)'),
+            array(array('precision' => 8, 'scale' => 2), 'DECIMAL(8, 2)'),
+        );
+    }
+
+    /**
+     * @group DBAL-1082
+     *
+     * @dataProvider getGeneratesNumericTypeDeclarationSQL
+     */
+    public function testGeneratesNumericTypeDeclarationSQL(array $column, $expectedSql)
+    {
+        $this->assertSame($expectedSql, $this->_platform->getNumericTypeDeclarationSQL($column));
+    }
+
+    /**
+     * @return array
+     */
+    public function getGeneratesNumericTypeDeclarationSQL()
+    {
+        return array(
             array(array(), 'NUMERIC(10, 0)'),
             array(array('unsigned' => true), 'NUMERIC(10, 0)'),
             array(array('unsigned' => false), 'NUMERIC(10, 0)'),

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -445,6 +445,54 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
         $sql = $this->_platform->getAlterTableSQL($tableDiff);
 
         $expectedSql = array(
+            'ALTER TABLE mytable ALTER dloo1 TYPE DECIMAL(16, 6)',
+            'ALTER TABLE mytable ALTER dloo2 TYPE DECIMAL(10, 4)',
+            'ALTER TABLE mytable ALTER dloo4 TYPE DECIMAL(16, 8)',
+        );
+
+        $this->assertEquals($expectedSql, $sql);
+    }
+
+    public function testAlterNumericPrecisionScale()
+    {
+
+        $table = new Table('mytable');
+        $table->addColumn('dfoo1', 'numeric');
+        $table->addColumn('dfoo2', 'numeric', array('precision' => 10, 'scale' => 6));
+        $table->addColumn('dfoo3', 'numeric', array('precision' => 10, 'scale' => 6));
+        $table->addColumn('dfoo4', 'numeric', array('precision' => 10, 'scale' => 6));
+
+        $tableDiff = new TableDiff('mytable');
+        $tableDiff->fromTable = $table;
+
+        $tableDiff->changedColumns['dloo1'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'dloo1', new \Doctrine\DBAL\Schema\Column(
+                'dloo1', \Doctrine\DBAL\Types\Type::getType('numeric'), array('precision' => 16, 'scale' => 6)
+            ),
+            array('precision')
+        );
+        $tableDiff->changedColumns['dloo2'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'dloo2', new \Doctrine\DBAL\Schema\Column(
+                'dloo2', \Doctrine\DBAL\Types\Type::getType('numeric'), array('precision' => 10, 'scale' => 4)
+            ),
+            array('scale')
+        );
+        $tableDiff->changedColumns['dloo3'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'dloo3', new \Doctrine\DBAL\Schema\Column(
+                'dloo3', \Doctrine\DBAL\Types\Type::getType('numeric'), array('precision' => 10, 'scale' => 6)
+            ),
+            array()
+        );
+        $tableDiff->changedColumns['dloo4'] = new \Doctrine\DBAL\Schema\ColumnDiff(
+            'dloo4', new \Doctrine\DBAL\Schema\Column(
+                'dloo4', \Doctrine\DBAL\Types\Type::getType('numeric'), array('precision' => 16, 'scale' => 8)
+            ),
+            array('precision', 'scale')
+        );
+
+        $sql = $this->_platform->getAlterTableSQL($tableDiff);
+
+        $expectedSql = array(
             'ALTER TABLE mytable ALTER dloo1 TYPE NUMERIC(16, 6)',
             'ALTER TABLE mytable ALTER dloo2 TYPE NUMERIC(10, 4)',
             'ALTER TABLE mytable ALTER dloo4 TYPE NUMERIC(16, 8)',

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -843,7 +843,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         $this->assertSame('bigint', $this->_platform->getDoctrineTypeMapping('bigint'));
 
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('numeric'));
-        $this->assertSame('decimal', $this->_platform->getDoctrineTypeMapping('numeric'));
+        $this->assertSame('numeric', $this->_platform->getDoctrineTypeMapping('numeric'));
 
         $this->assertTrue($this->_platform->hasDoctrineTypeMappingFor('bit'));
         $this->assertSame('boolean', $this->_platform->getDoctrineTypeMapping('bit'));

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -595,11 +595,21 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             array(
                 'precision',
                 new Column('bar', Type::getType('decimal'), array('precision' => 10, 'scale' => 2)),
-                'SET DATA TYPE NUMERIC(10, 2)'
+                'SET DATA TYPE DECIMAL(10, 2)'
             ),
             array(
                 'scale',
                 new Column('bar', Type::getType('decimal'), array('precision' => 5, 'scale' => 4)),
+                'SET DATA TYPE DECIMAL(5, 4)'
+            ),
+            array(
+                'precision',
+                new Column('bar', Type::getType('numeric'), array('precision' => 10, 'scale' => 2)),
+                'SET DATA TYPE NUMERIC(10, 2)'
+            ),
+            array(
+                'scale',
+                new Column('bar', Type::getType('numeric'), array('precision' => 5, 'scale' => 4)),
                 'SET DATA TYPE NUMERIC(5, 4)'
             ),
             array(

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -153,6 +153,22 @@ class OraclePlatformTest extends AbstractPlatformTestCase
             ));
     }
 
+    public function testGeneratesTypeDeclarationForNumerics()
+    {
+        $this->assertEquals(
+            'NUMERIC(10, 2)',
+            $this->_platform->getNumericTypeDeclarationSQL(array('precision' => 10, 'scale' => 2))
+        );
+        $this->assertEquals(
+            'NUMERIC(10, 2)',
+            $this->_platform->getNumericTypeDeclarationSQL(array('precision' => 10, 'scale' => 2)
+            ));
+        $this->assertEquals(
+            'NUMERIC(10, 2)',
+            $this->_platform->getNumericTypeDeclarationSQL(array('precision' => 10, 'scale' => 2)
+            ));
+    }
+
     public function testGeneratesTypeDeclarationsForStrings()
     {
         $this->assertEquals(


### PR DESCRIPTION
#2802

Add NumericType and wire it into the Platforms. Unit tests added/modified, and all pass (except for an unrelated one in `Doctrine\Tests\DBAL\Driver\Mysqli\MysqliConnectionTest::testRestoresErrorHandlerOnException`.

```
1) Doctrine\Tests\DBAL\Driver\Mysqli\MysqliConnectionTest::testRestoresErrorHandlerOnException
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-Network is unreachable
+Permission denied

/Users/dohpaz42/Development/doctrine-dbal/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php:45
``` 

I also wired up my version of dbal into my project and it generated the expected SQL Alter statements.