### PR TITLE
#2815 don't require `ssl_key` and `ssl_cert` to use `ssl_ca`

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -281,14 +281,9 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
             return;
         }
 
-        if (! isset($params['ssl_key']) || ! isset($params['ssl_cert'])) {
-            $msg = '"ssl_key" and "ssl_cert" parameters are mandatory when using secure connection parameters.';
-            throw new MysqliException($msg);
-        }
-
         $this->_conn->ssl_set(
-            $params['ssl_key'],
-            $params['ssl_cert'],
+            $params['ssl_key']    ?? null,
+            $params['ssl_cert']   ?? null,
             $params['ssl_ca']     ?? null,
             $params['ssl_capath'] ?? null,
             $params['ssl_cipher'] ?? null

--- a/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
@@ -50,34 +50,5 @@ class MysqliConnectionTest extends DbalTestCase
         restore_error_handler();
     }
 
-    /**
-     * @dataProvider secureMissingParamsProvider
-     */
-    public function testThrowsExceptionWhenMissingMandatorySecureParams(array $secureParams)
-    {
-        $this->expectException(MysqliException::class);
-        $msg = '"ssl_key" and "ssl_cert" parameters are mandatory when using secure connection parameters.';
-        $this->expectExceptionMessage($msg);
-
-        new MysqliConnection($secureParams, 'xxx', 'xxx');
-    }
-
-    public function secureMissingParamsProvider()
-    {
-        return [
-            [
-                ['ssl_cert' => 'cert.pem']
-            ],
-            [
-                ['ssl_key' => 'key.pem']
-            ],
-            [
-                ['ssl_key' => 'key.pem', 'ssl_ca' => 'ca.pem', 'ssl_capath' => 'xxx', 'ssl_cipher' => 'xxx']
-            ],
-            [
-                ['ssl_ca' => 'ca.pem', 'ssl_capath' => 'xxx', 'ssl_cipher' => 'xxx']
-            ]
-        ];
-    }
 }
 

--- a/tests/travis/install-mysql-5.7.sh
+++ b/tests/travis/install-mysql-5.7.sh
@@ -9,8 +9,8 @@ sudo apt-get remove "^mysql.*"
 sudo apt-get autoremove
 sudo apt-get autoclean
 echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
-wget http://dev.mysql.com/get/mysql-apt-config_0.8.6-1_all.deb
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mysql-apt-config_0.8.6-1_all.deb
+wget http://dev.mysql.com/get/mysql-apt-config_0.8.9-1_all.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mysql-apt-config_0.8.9-1_all.deb
 sudo rm -rf /var/lib/apt/lists/*
 sudo apt-get clean
 sudo apt-get update -q


### PR DESCRIPTION
See #2815  -- you should be able to use ssl_ca for mysqli connections without specifying ssl_key and ssl_cert.