### PR TITLE
Platform from params are not correctly passed to a `QueryCacheProfile`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,16 @@
+# Upgrade to 2.6.2
+
+## MINOR BC BREAK:
+1 ``Doctrine\DBALDBALException::invalidPlatformSpecified()`` now has one argument which takes the invalid platform option.
+
+Before:
+
+    Doctrine\DBALDBALException::invalidPlatformSpecified();
+
+After:
+
+    Doctrine\DBALDBALException::invalidPlatformSpecified($invalidPlatform);
+
 # Upgrade to 2.6
 
 ## MINOR BC BREAK: `fetch()` and `fetchAll()` method signatures in `Doctrine\DBAL\Driver\ResultStatement`

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -211,6 +211,15 @@ class Connection implements DriverConnection
             unset($this->_params['pdo']);
         }
 
+        if (isset($params["platform"])) {
+            if ( ! $params['platform'] instanceof Platforms\AbstractPlatform) {
+                throw DBALException::invalidPlatformSpecified();
+            }
+
+            $this->platform = $params["platform"];
+            unset($this->_params["platform"]);
+        }
+
         // Create default config and event manager if none given
         if ( ! $config) {
             $config = new Configuration();
@@ -386,18 +395,12 @@ class Connection implements DriverConnection
      */
     private function detectDatabasePlatform()
     {
-        if ( ! isset($this->_params['platform'])) {
-            $version = $this->getDatabasePlatformVersion();
+        $version = $this->getDatabasePlatformVersion();
 
-            if (null !== $version) {
-                $this->platform = $this->_driver->createDatabasePlatformForVersion($version);
-            } else {
-                $this->platform = $this->_driver->getDatabasePlatform();
-            }
-        } elseif ($this->_params['platform'] instanceof Platforms\AbstractPlatform) {
-            $this->platform = $this->_params['platform'];
+        if (null !== $version) {
+            $this->platform = $this->_driver->createDatabasePlatformForVersion($version);
         } else {
-            throw DBALException::invalidPlatformSpecified();
+            $this->platform = $this->_driver->getDatabasePlatform();
         }
 
         $this->platform->setEventManager($this->_eventManager);

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -213,7 +213,7 @@ class Connection implements DriverConnection
 
         if (isset($params["platform"])) {
             if ( ! $params['platform'] instanceof Platforms\AbstractPlatform) {
-                throw DBALException::invalidPlatformSpecified();
+                throw DBALException::invalidPlatformSpecified($params['platform']);
             }
 
             $this->platform = $params["platform"];

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -22,6 +22,7 @@ namespace Doctrine\DBAL;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class DBALException extends \Exception
 {
@@ -36,13 +37,19 @@ class DBALException extends \Exception
     }
 
     /**
-     * @return \Doctrine\DBAL\DBALException
+     * @param $invalidPlatform
+     * @return DBALException
      */
-    public static function invalidPlatformSpecified()
+    public static function invalidPlatformSpecified($invalidPlatform): self
     {
         return new self(
-            "Invalid 'platform' option specified, need to give an instance of ".
-            "\Doctrine\DBAL\Platforms\AbstractPlatform.");
+            sprintf(
+            "Given 'platform' option '%s' must be a subtype of '%s'",
+            get_class($invalidPlatform),
+            AbstractPlatform::class
+            )
+        );
+
     }
 
     /**

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -37,19 +37,31 @@ class DBALException extends \Exception
     }
 
     /**
-     * @param $invalidPlatform
+     * Returns a new instance for an invalid platform specified.
+     *
+     * @param mixed $invalidPlatform The invalid platform given.
+     *
      * @return DBALException
      */
     public static function invalidPlatformSpecified($invalidPlatform): self
     {
+        if (is_object($invalidPlatform)) {
+            return new self(
+                sprintf(
+                    "Option 'platform' must be a subtype of '%s', instance of '%s' given",
+                    AbstractPlatform::class,
+                    get_class($invalidPlatform)
+                )
+            );
+        }
+
         return new self(
             sprintf(
-            "Given 'platform' option '%s' must be a subtype of '%s'",
-            get_class($invalidPlatform),
-            AbstractPlatform::class
+                "Option 'platform' must be an object and subtype of '%s'. Got '%s'",
+                AbstractPlatform::class,
+                gettype($invalidPlatform)
             )
         );
-
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -804,7 +804,6 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
 
         $connectionParams = $this->params;
 
-        // This is our main expectation
         $queryCacheProfileMock
             ->expects($this->once())
             ->method('generateCacheKeys')
@@ -824,16 +823,14 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testThrowsExceptionWhenInValidPlatformSpecified(): void
     {
-        self::expectException(DBALException::class);
-        self::expectExceptionMessage(
-            "Given 'platform' option 'stdClass' must be a subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform'"
-        );
 
         $connectionParams = $this->params;
         $connectionParams['platform'] = new \stdClass();
 
         /* @var $driver Driver */
         $driver = $this->createMock(Driver::class);
+
+        $this->expectException(DBALException::class);
 
         new Connection($connectionParams, $driver);
     }

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -823,7 +823,6 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testThrowsExceptionWhenInValidPlatformSpecified(): void
     {
-
         $connectionParams = $this->params;
         $connectionParams['platform'] = new \stdClass();
 

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -7,6 +7,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Events;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -816,6 +817,25 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
         $driver = $this->createMock(Driver::class);
 
         (new Connection($connectionParams, $driver))->executeCacheQuery($query, [], [], $queryCacheProfileMock);
+    }
+
+    /**
+     * @group DBAL-2821
+     */
+    public function testThrowsExceptionWhenInValidPlatformSpecified(): void
+    {
+        self::expectException(DBALException::class);
+        self::expectExceptionMessage(
+            "Given 'platform' option 'stdClass' must be a subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform'"
+        );
+
+        $connectionParams = $this->params;
+        $connectionParams['platform'] = new \stdClass();
+
+        /* @var $driver Driver */
+        $driver = $this->createMock(Driver::class);
+
+        new Connection($connectionParams, $driver);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -58,4 +58,30 @@ class DBALExceptionTest extends DbalTestCase
             $exception->getMessage()
         );
     }
+
+    /**
+     * @group DBAL-2821
+     */
+    public function testInvalidPlatformSpecifiedObject(): void
+    {
+
+        $exception = DBALException::invalidPlatformSpecified(new \stdClass());
+        self::assertSame(
+            "Option 'platform' must be a subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform', instance of 'stdClass' given",
+            $exception->getMessage()
+        );
+    }
+
+    /**
+     * @group DBAL-2821
+     */
+    public function testInvalidPlatformSpecifiedScalar(): void
+    {
+        $exception = DBALException::invalidPlatformSpecified("some string");
+
+        self::assertSame(
+            "Option 'platform' must be an object and subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform'. Got 'string'",
+            $exception->getMessage()
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -64,8 +64,8 @@ class DBALExceptionTest extends DbalTestCase
      */
     public function testInvalidPlatformSpecifiedObject(): void
     {
-
         $exception = DBALException::invalidPlatformSpecified(new \stdClass());
+
         self::assertSame(
             "Option 'platform' must be a subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform', instance of 'stdClass' given",
             $exception->getMessage()


### PR DESCRIPTION
If you pass in the platform from connection params it will be used to generate the cache key, which in most cases is not serializable.

https://github.com/doctrine/dbal/blob/db1395b7d2baaa3a027a3727fa34e17a5a85d54f/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php#L105

I can create a better test case where it will fail from the serialize() call if needed. But i was lazy, copy pasted one there fitted my case :D
