### PR TITLE
Mariadb 10.2.7 null values change in information schema, #2817

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -163,11 +163,11 @@ class MySqlPlatform extends AbstractPlatform
             $currentDatabase = $this->quoteStringLiteral($currentDatabase);
             $table = $this->quoteStringLiteral($table);
 
-            return "SELECT TABLE_NAME AS `Table`, NON_UNIQUE AS Non_Unique, INDEX_NAME AS Key_name, ".
-                   "SEQ_IN_INDEX AS Seq_in_index, COLUMN_NAME AS Column_Name, COLLATION AS Collation, ".
-                   "CARDINALITY AS Cardinality, SUB_PART AS Sub_Part, PACKED AS Packed, " .
-                   "NULLABLE AS `Null`, INDEX_TYPE AS Index_Type, COMMENT AS Comment " .
-                   "FROM information_schema.STATISTICS WHERE TABLE_NAME = " . $table . " AND TABLE_SCHEMA = " . $currentDatabase;
+            return "SELECT `TABLE_NAME` AS `Table`, `NON_UNIQUE` AS `Non_Unique`, `INDEX_NAME` AS `Key_name`, ".
+                   "`SEQ_IN_INDEX` AS `Seq_in_index`, `COLUMN_NAME` AS `Column_Name`, `COLLATION` AS `Collation`, ".
+                   "`CARDINALITY` AS `Cardinality`, `SUB_PART` AS `Sub_Part`, `PACKED` AS `Packed`, " .
+                   "`NULLABLE` AS `Null`, `INDEX_TYPE` AS `Index_Type`, `COMMENT` AS `Comment` " .
+                   "FROM `information_schema`.`STATISTICS` WHERE `TABLE_NAME` = " . $table . " AND `TABLE_SCHEMA` = " . $currentDatabase;
         }
 
         return 'SHOW INDEX FROM ' . $table;
@@ -180,7 +180,7 @@ class MySqlPlatform extends AbstractPlatform
     {
         $database = $this->quoteStringLiteral($database);
 
-        return "SELECT * FROM information_schema.VIEWS WHERE TABLE_SCHEMA = " . $database;
+        return "SELECT * FROM `information_schema`.`VIEWS` WHERE `TABLE_SCHEMA` = " . $database;
     }
 
     /**
@@ -194,17 +194,17 @@ class MySqlPlatform extends AbstractPlatform
             $database = $this->quoteStringLiteral($database);
         }
 
-        $sql = "SELECT DISTINCT k.`CONSTRAINT_NAME`, k.`COLUMN_NAME`, k.`REFERENCED_TABLE_NAME`, ".
-               "k.`REFERENCED_COLUMN_NAME` /*!50116 , c.update_rule, c.delete_rule */ ".
-               "FROM information_schema.key_column_usage k /*!50116 ".
-               "INNER JOIN information_schema.referential_constraints c ON ".
-               "  c.constraint_name = k.constraint_name AND ".
-               "  c.table_name = $table */ WHERE k.table_name = $table";
+        $sql = "SELECT DISTINCT `k`.`CONSTRAINT_NAME`, `k`.`COLUMN_NAME`, `k`.`REFERENCED_TABLE_NAME`, ".
+               "`k`.`REFERENCED_COLUMN_NAME` /*!50116 , `c`.`update_rule`, `c`.`delete_rule` */ ".
+               "FROM `information_schema`.`key_column_usage` AS k /*!50116 ".
+               "INNER JOIN `information_schema`.`referential_constraints` AS `c` ON ".
+               "  `c`.`constraint_name` = `k`.`constraint_name` AND ".
+               "  `c`.`table_name` = $table */ WHERE `k`.`table_name` = $table";
 
         $databaseNameSql = null === $database ? 'DATABASE()' : $database;
 
-        $sql .= " AND k.table_schema = $databaseNameSql /*!50116 AND c.constraint_schema = $databaseNameSql */";
-        $sql .= " AND k.`REFERENCED_COLUMN_NAME` is not NULL";
+        $sql .= " AND `k`.`table_schema` = $databaseNameSql /*!50116 AND `c`.`constraint_schema` = $databaseNameSql */";
+        $sql .= " AND `k`.`REFERENCED_COLUMN_NAME` is not NULL";
 
         return $sql;
     }
@@ -384,10 +384,10 @@ class MySqlPlatform extends AbstractPlatform
             $database = 'DATABASE()';
         }
 
-        return "SELECT COLUMN_NAME AS Field, COLUMN_TYPE AS Type, IS_NULLABLE AS `Null`, ".
-               "COLUMN_KEY AS `Key`, COLUMN_DEFAULT AS `Default`, EXTRA AS Extra, COLUMN_COMMENT AS Comment, " .
-               "CHARACTER_SET_NAME AS CharacterSet, COLLATION_NAME AS Collation ".
-               "FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = " . $database . " AND TABLE_NAME = " . $table;
+        return "SELECT `COLUMN_NAME` AS `Field`, `COLUMN_TYPE` AS `Type`, `IS_NULLABLE` AS `Null`, ".
+               "`COLUMN_KEY` AS `Key`, `COLUMN_DEFAULT` AS `Default`, `EXTRA` AS `Extra`, `COLUMN_COMMENT` AS `Comment`, " .
+               "`CHARACTER_SET_NAME` AS `CharacterSet`, `COLLATION_NAME` AS `Collation` ".
+               "FROM `information_schema`.`COLUMNS` WHERE `TABLE_SCHEMA` = " . $database . " AND `TABLE_NAME` = " . $table;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -178,12 +178,19 @@ class MySqlSchemaManager extends AbstractSchemaManager
 
         $length = ((int) $length == 0) ? null : (int) $length;
 
+        $isNotNull = ($tableColumn['null'] !== 'YES');
+        $columnDefault = (isset($tableColumn['default'])) ? $tableColumn['default'] : null;
+        if ($columnDefault === 'NULL' && !$isNotNull) {
+            // for mariadb 10.2.7
+            $columnDefault = null;
+        }
+
         $options = [
             'length'        => $length,
             'unsigned'      => (bool) (strpos($tableColumn['type'], 'unsigned') !== false),
             'fixed'         => (bool) $fixed,
-            'default'       => isset($tableColumn['default']) ? $tableColumn['default'] : null,
-            'notnull'       => (bool) ($tableColumn['null'] != 'YES'),
+            'default'       => $columnDefault,
+            'notnull'       => $isNotNull,
             'scale'         => null,
             'precision'     => null,
             'autoincrement' => (bool) (strpos($tableColumn['extra'], 'auto_increment') !== false),


### PR DESCRIPTION
Since MariaDB 10.2.7, `information_schema.columns` now stores `'null'` in `column_default` instead of `null`. MySQL 5.7 is not affected. 

This P/R should fix the two doctrine-related issues:

- https://github.com/doctrine/dbal/issues/2817 (invalid detection of column default values)
- https://github.com/doctrine/doctrine2/issues/6565 (schema update will alter all tables with columns_default='null')

Not very used to doctrine, so please check and correct me if I'm wrong somewhere.

*(see https://jira.mariadb.org/browse/MDEV-13132 and https://jira.mariadb.org/browse/MDEV-13341)*

