### PR TITLE
WIP: Rework type system

### DIFF
--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -19,10 +19,12 @@
 
 namespace Doctrine\DBAL;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
 
 class DBALException extends \Exception
 {
@@ -263,14 +265,16 @@ class DBALException extends \Exception
 
     /**
      * @param string $name
+     * @param bool   $legacy whether to recommend the legacy workflow
      *
      * @return \Doctrine\DBAL\DBALException
      */
-    public static function unknownColumnType($name)
+    public static function unknownColumnType($name, $legacy = false)
     {
+        $recommendedAPI = $legacy ? Type::class : TypeRegistry::class;
         return new self('Unknown column type "'.$name.'" requested. Any Doctrine type that you use has ' .
-            'to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the ' .
-            'known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database ' .
+            'to be registered with '.$recommendedAPI.'::addType(). You can get a list of all the ' .
+            'known types with '.$recommendedAPI.'::getTypesMap(). If this error occurs during database ' .
             'introspection then you might have forgotten to register all database types for a Doctrine Type. Use ' .
             'AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement ' .
             'Type#getMappedDatabaseTypes(). If the type name is empty you might ' .

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -31,7 +31,7 @@ use Doctrine\DBAL\DBALException;
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  * @since  2.0
  */
-abstract class Type
+abstract class Type implements TypeInterface
 {
     const TARRAY = 'array';
     const SIMPLE_ARRAY = 'simple_array';
@@ -101,13 +101,7 @@ abstract class Type
 
 
     /**
-     * Converts a value from its PHP representation to its database representation
-     * of this type.
-     *
-     * @param mixed                                     $value    The value to convert.
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform The currently used database platform.
-     *
-     * @return mixed The database representation of the value.
+     * {@inheritdoc}
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -115,13 +109,7 @@ abstract class Type
     }
 
     /**
-     * Converts a value from its database representation to its PHP representation
-     * of this type.
-     *
-     * @param mixed                                     $value    The value to convert.
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform The currently used database platform.
-     *
-     * @return mixed The PHP representation of the value.
+     * {@inheritdoc}
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
@@ -143,12 +131,7 @@ abstract class Type
     }
 
     /**
-     * Gets the SQL declaration snippet for a field of this type.
-     *
-     * @param array                                     $fieldDeclaration The field declaration.
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform         The currently used database platform.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     abstract public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform);
 
@@ -258,18 +241,7 @@ abstract class Type
     }
 
     /**
-     * Gets the (preferred) binding type for values of this type that
-     * can be used when binding parameters to prepared statements.
-     *
-     * This method should return one of the PDO::PARAM_* constants, that is, one of:
-     *
-     * PDO::PARAM_BOOL
-     * PDO::PARAM_NULL
-     * PDO::PARAM_INT
-     * PDO::PARAM_STR
-     * PDO::PARAM_LOB
-     *
-     * @return integer
+     * {@inheritdoc}
      */
     public function getBindingType()
     {
@@ -298,14 +270,7 @@ abstract class Type
     }
 
     /**
-     * Does working with this column require SQL conversion functions?
-     *
-     * This is a metadata function that is required for example in the ORM.
-     * Usage of {@link convertToDatabaseValueSQL} and
-     * {@link convertToPHPValueSQL} works for any type and mostly
-     * does nothing. This method can additionally be used for optimization purposes.
-     *
-     * @return boolean
+     * {@inheritdoc}
      */
     public function canRequireSQLConversion()
     {
@@ -313,12 +278,7 @@ abstract class Type
     }
 
     /**
-     * Modifies the SQL expression (identifier, parameter) to convert to a database value.
-     *
-     * @param string                                    $sqlExpr
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform)
     {
@@ -326,12 +286,7 @@ abstract class Type
     }
 
     /**
-     * Modifies the SQL expression (identifier, parameter) to convert to a PHP value.
-     *
-     * @param string                                    $sqlExpr
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function convertToPHPValueSQL($sqlExpr, $platform)
     {
@@ -339,11 +294,7 @@ abstract class Type
     }
 
     /**
-     * Gets an array of database types that map to this Doctrine type.
-     *
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getMappedDatabaseTypes(AbstractPlatform $platform)
     {
@@ -351,14 +302,7 @@ abstract class Type
     }
 
     /**
-     * If this Doctrine Type maps to an already mapped database type,
-     * reverse schema engineering can't tell them apart. You need to mark
-     * one of those types as commented, which will have Doctrine use an SQL
-     * comment to typehint the actual Doctrine Type.
-     *
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     *
-     * @return boolean
+     * {@inheritdoc}
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -99,12 +99,6 @@ abstract class Type
         self::DATEINTERVAL => DateIntervalType::class,
     ];
 
-    /**
-     * Prevents instantiation and forces use of the factory method.
-     */
-    final private function __construct()
-    {
-    }
 
     /**
      * Converts a value from its PHP representation to its database representation
@@ -167,6 +161,15 @@ abstract class Type
      */
     abstract public function getName();
 
+    private static function warnAgainstUsingTheOldAPI()
+    {
+        @trigger_error(
+            'Using '.__CLASS__.' as a type registry is deprecated, please use '.
+            TypeRegistry::class.' instead',
+            E_USER_DEPRECATED
+        );
+    }
+
     /**
      * Factory method to create type instances.
      * Type instances are implemented as flyweights.
@@ -179,14 +182,19 @@ abstract class Type
      */
     public static function getType($name)
     {
-        if ( ! isset(self::$_typeObjects[$name])) {
-            if ( ! isset(self::$_typesMap[$name])) {
-                throw DBALException::unknownColumnType($name);
+        self::warnAgainstUsingTheOldAPI();
+        try {
+            return TypeRegistry::getType($name);
+        } catch (DBALException $e) {
+            if ( ! isset(self::$_typeObjects[$name])) {
+                if ( ! isset(self::$_typesMap[$name])) {
+                    throw DBALException::unknownColumnType($name, true);
+                }
+                self::$_typeObjects[$name] = new self::$_typesMap[$name]();
             }
-            self::$_typeObjects[$name] = new self::$_typesMap[$name]();
-        }
 
-        return self::$_typeObjects[$name];
+            return self::$_typeObjects[$name];
+        }
     }
 
     /**
@@ -201,6 +209,11 @@ abstract class Type
      */
     public static function addType($name, $className)
     {
+        self::warnAgainstUsingTheOldAPI();
+        if ($name === $className) {
+            TypeRegistry::addType($className);
+            return;
+        }
         if (isset(self::$_typesMap[$name])) {
             throw DBALException::typeExists($name);
         }
@@ -217,6 +230,7 @@ abstract class Type
      */
     public static function hasType($name)
     {
+        self::warnAgainstUsingTheOldAPI();
         return isset(self::$_typesMap[$name]);
     }
 

--- a/lib/Doctrine/DBAL/Types/TypeInterface.php
+++ b/lib/Doctrine/DBAL/Types/TypeInterface.php
@@ -1,0 +1,135 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * The registry for so-called Doctrine mapping types.
+ *
+ * A Type object is obtained by calling the static {@link getType()} method.
+ *
+ * @author Roman Borschel <roman@code-factory.org>
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @since  2.0
+ */
+interface TypeInterface
+{
+    /**
+     * Converts a value from its PHP representation to its database representation
+     * of this type.
+     *
+     * @param mixed                                     $value    The value to convert.
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform The currently used database platform.
+     *
+     * @return mixed The database representation of the value.
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform);
+
+    /**
+     * Converts a value from its database representation to its PHP representation
+     * of this type.
+     *
+     * @param mixed                                     $value    The value to convert.
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform The currently used database platform.
+     *
+     * @return mixed The PHP representation of the value.
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform);
+
+    /**
+     * Gets the SQL declaration snippet for a field of this type.
+     *
+     * @param array                                     $fieldDeclaration The field declaration.
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform         The currently used database platform.
+     *
+     * @return string
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform);
+
+    /**
+     * Gets the (preferred) binding type for values of this type that
+     * can be used when binding parameters to prepared statements.
+     *
+     * This method should return one of the PDO::PARAM_* constants, that is, one of:
+     *
+     * PDO::PARAM_BOOL
+     * PDO::PARAM_NULL
+     * PDO::PARAM_INT
+     * PDO::PARAM_STR
+     * PDO::PARAM_LOB
+     *
+     * @return integer
+     */
+    public function getBindingType();
+
+    /**
+     * Does working with this column require SQL conversion functions?
+     *
+     * This is a metadata function that is required for example in the ORM.
+     * Usage of {@link convertToDatabaseValueSQL} and
+     * {@link convertToPHPValueSQL} works for any type and mostly
+     * does nothing. This method can additionally be used for optimization purposes.
+     *
+     * @return boolean
+     */
+    public function canRequireSQLConversion();
+
+    /**
+     * Modifies the SQL expression (identifier, parameter) to convert to a database value.
+     *
+     * @param string                                    $sqlExpr
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     *
+     * @return string
+     */
+    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform);
+
+    /**
+     * Modifies the SQL expression (identifier, parameter) to convert to a PHP value.
+     *
+     * @param string                                    $sqlExpr
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     *
+     * @return string
+     */
+    public function convertToPHPValueSQL($sqlExpr, $platform);
+
+    /**
+     * Gets an array of database types that map to this Doctrine type.
+     *
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     *
+     * @return array
+     */
+    public function getMappedDatabaseTypes(AbstractPlatform $platform);
+
+    /**
+     * If this Doctrine Type maps to an already mapped database type,
+     * reverse schema engineering can't tell them apart. You need to mark
+     * one of those types as commented, which will have Doctrine use an SQL
+     * comment to typehint the actual Doctrine Type.
+     *
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     *
+     * @return boolean
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform);
+}

--- a/lib/Doctrine/DBAL/Types/TypeRegistry.php
+++ b/lib/Doctrine/DBAL/Types/TypeRegistry.php
@@ -1,0 +1,138 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\DBALException;
+
+/**
+ * The registry for so-called Doctrine mapping types.
+ *
+ * A Type object is obtained by calling the static {@link getType()} method.
+ *
+ * @author Roman Borschel <roman@code-factory.org>
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @since  2.0
+ */
+final class TypeRegistry
+{
+    /**
+     * Map of already instantiated type objects. One instance per type (flyweight).
+     *
+     * @var array
+     */
+    private static $_typeObjects = array();
+
+    /**
+     * The map of supported doctrine mapping types for the current platform.
+     *
+     * @var array
+     */
+    private static $_typesMap = array(
+        ArrayType::class,
+        SimpleArrayType::class,
+        JsonArrayType::class,
+        JsonType::class,
+        ObjectType::class,
+        BooleanType::class,
+        IntegerType::class,
+        SmallIntType::class,
+        BigIntType::class,
+        StringType::class,
+        TextType::class,
+        DateTimeType::class,
+        DateTimeImmutableType::class,
+        DateTimeTzType::class,
+        DateTimeTzImmutableType::class,
+        DateType::class,
+        DateImmutableType::class,
+        TimeType::class,
+        TimeImmutableType::class,
+        DecimalType::class,
+        FloatType::class,
+        BinaryType::class,
+        BlobType::class,
+        GuidType::class,
+        DateIntervalType::class,
+    );
+
+    /**
+     * Factory method to create type instances.
+     * Type instances are implemented as flyweights.
+     *
+     * @param string $class The FQCN of the type
+     *
+     * @return \Doctrine\DBAL\Types\Type
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public static function getType(string $class): Doctrine\DBAL\Types\Type
+    {
+        if (!self::hasType($class)) {
+            throw DBALException::unknownColumnType($class);
+        }
+        if (!isset(self::$_typeObjects[$class])) {
+            self::$_typeObjects[$class] = new $class();
+        }
+
+        return self::$_typeObjects[$class];
+    }
+
+    /**
+     * Adds a custom type to the type map.
+     *
+     * @param string $class The class name of the custom type.
+     *
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public static function addType(string $class)
+    {
+        if (self::hasType($class)) {
+            throw DBALException::typeExists($name);
+        }
+
+        self::$_typesMap[] = $class;
+    }
+
+    /**
+     * Checks if exists support for a type.
+     *
+     * @param string $class The classname of the type.
+     *
+     * @return boolean TRUE if type is supported; FALSE otherwise.
+     */
+    public static function hasType(string $class): bool
+    {
+        return in_array($class, self::$_typesMap);
+    }
+
+    /**
+     * Gets the types array map which holds all registered types and the corresponding
+     * type class
+     *
+     * @return array
+     */
+    public static function getTypesMap()
+    {
+        return self::$_typesMap;
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Types/TypeRegistryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/TypeRegistryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
+
+class TypeRegistryTest extends \Doctrine\Tests\DbalTestCase
+{
+    public function testRegisteredTypeCanBeRetrieved()
+    {
+        $class = DummyType::class;
+        $this->assertFalse(TypeRegistry::hasType($class));
+        TypeRegistry::addType($class);
+        $this->assertTrue(TypeRegistry::hasType($class));
+        $this->assertInstanceOf(\stdClass::class, TypeRegistry::getType($class));
+    }
+}
+
+class DummyType extends Type
+{
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return 'whatever';
+    }
+
+    public function getName()
+    {
+        'dummy';
+    }
+}


### PR DESCRIPTION
From @Majkl578 on slack:

just a quick thought of a possible approach:
1) introduce TypeInterface with required methods (or different name)
2) make types implement it
3) introduce some kind of Types enum-like empty class for implictly supported types, just like i.e. GeneratorType in ORM develop (edit: maybe this could stay in Type to lower BC implications and make Type an enum class in 3.0)
4) introduce non-static TypeRegistry with no default types hardcoded in it - this would allow different connections/platforms use different type mappings (as @ocramius suggested in https://symfony-devs.slack.com/archives/C3FQPE6LE/p1504362019000073)
5) make TypeRegistry work with type instances instead of their class names (sounds good, but unsure about consequences)
6) migrate Type::<typenames> to Types enum, keep BC by aliasing them and deprecate in 2,7
7) migrate Type::<static-registry> mechanics to TypeRegistry, keep BC by using private static TypeRegistry internally in 2.7 (some kittens may die during this process)
8) in 3.0 (develop) drop these BC hacks (so no more kittens die) 