### PR TITLE
Failing test to check for column orders of quoted columns

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,16 +1,3 @@
-# Upgrade to 2.6.2
-
-## MINOR BC BREAK:
-1 ``Doctrine\DBALDBALException::invalidPlatformSpecified()`` now has one argument which takes the invalid platform option.
-
-Before:
-
-    Doctrine\DBALDBALException::invalidPlatformSpecified();
-
-After:
-
-    Doctrine\DBALDBALException::invalidPlatformSpecified($invalidPlatform);
-
 # Upgrade to 2.6
 
 ## MINOR BC BREAK: `fetch()` and `fetchAll()` method signatures in `Doctrine\DBAL\Driver\ResultStatement`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,16 @@
+# Upgrade to 2.6.2
+
+## MINOR BC BREAK:
+1 ``Doctrine\DBALDBALException::invalidPlatformSpecified()`` now has one argument which takes the invalid platform option.
+
+Before:
+
+    Doctrine\DBALDBALException::invalidPlatformSpecified();
+
+After:
+
+    Doctrine\DBALDBALException::invalidPlatformSpecified($invalidPlatform);
+
 # Upgrade to 2.6
 
 ## MINOR BC BREAK: `fetch()` and `fetchAll()` method signatures in `Doctrine\DBAL\Driver\ResultStatement`

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -211,6 +211,15 @@ class Connection implements DriverConnection
             unset($this->_params['pdo']);
         }
 
+        if (isset($params["platform"])) {
+            if ( ! $params['platform'] instanceof Platforms\AbstractPlatform) {
+                throw DBALException::invalidPlatformSpecified();
+            }
+
+            $this->platform = $params["platform"];
+            unset($this->_params["platform"]);
+        }
+
         // Create default config and event manager if none given
         if ( ! $config) {
             $config = new Configuration();
@@ -384,18 +393,12 @@ class Connection implements DriverConnection
      */
     private function detectDatabasePlatform()
     {
-        if ( ! isset($this->_params['platform'])) {
-            $version = $this->getDatabasePlatformVersion();
+        $version = $this->getDatabasePlatformVersion();
 
-            if (null !== $version) {
-                $this->platform = $this->_driver->createDatabasePlatformForVersion($version);
-            } else {
-                $this->platform = $this->_driver->getDatabasePlatform();
-            }
-        } elseif ($this->_params['platform'] instanceof Platforms\AbstractPlatform) {
-            $this->platform = $this->_params['platform'];
+        if (null !== $version) {
+            $this->platform = $this->_driver->createDatabasePlatformForVersion($version);
         } else {
-            throw DBALException::invalidPlatformSpecified();
+            $this->platform = $this->_driver->getDatabasePlatform();
         }
 
         $this->platform->setEventManager($this->_eventManager);

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -213,7 +213,7 @@ class Connection implements DriverConnection
 
         if (isset($params["platform"])) {
             if ( ! $params['platform'] instanceof Platforms\AbstractPlatform) {
-                throw DBALException::invalidPlatformSpecified($params['platform']);
+                throw DBALException::invalidPlatformType($params['platform']);
             }
 
             $this->platform = $params["platform"];

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -213,7 +213,7 @@ class Connection implements DriverConnection
 
         if (isset($params["platform"])) {
             if ( ! $params['platform'] instanceof Platforms\AbstractPlatform) {
-                throw DBALException::invalidPlatformSpecified();
+                throw DBALException::invalidPlatformSpecified($params['platform']);
             }
 
             $this->platform = $params["platform"];

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -22,6 +22,7 @@ namespace Doctrine\DBAL;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class DBALException extends \Exception
 {
@@ -36,13 +37,19 @@ class DBALException extends \Exception
     }
 
     /**
-     * @return \Doctrine\DBAL\DBALException
+     * @param $invalidPlatform
+     * @return DBALException
      */
-    public static function invalidPlatformSpecified()
+    public static function invalidPlatformSpecified($invalidPlatform): self
     {
         return new self(
-            "Invalid 'platform' option specified, need to give an instance of ".
-            "\Doctrine\DBAL\Platforms\AbstractPlatform.");
+            sprintf(
+            "Given 'platform' option '%s' must be a subtype of '%s'",
+            get_class($invalidPlatform),
+            AbstractPlatform::class
+            )
+        );
+
     }
 
     /**

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -37,19 +37,31 @@ class DBALException extends \Exception
     }
 
     /**
-     * @param $invalidPlatform
+     * Returns a new instance for an invalid platform specified.
+     *
+     * @param mixed $invalidPlatform The invalid platform given.
+     *
      * @return DBALException
      */
     public static function invalidPlatformSpecified($invalidPlatform): self
     {
+        if (is_object($invalidPlatform)) {
+            return new self(
+                sprintf(
+                    "Option 'platform' must be a subtype of '%s', instance of '%s' given",
+                    AbstractPlatform::class,
+                    get_class($invalidPlatform)
+                )
+            );
+        }
+
         return new self(
             sprintf(
-            "Given 'platform' option '%s' must be a subtype of '%s'",
-            get_class($invalidPlatform),
-            AbstractPlatform::class
+                "Option 'platform' must be an object and subtype of '%s'. Got '%s'",
+                AbstractPlatform::class,
+                gettype($invalidPlatform)
             )
         );
-
     }
 
     /**

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -36,21 +36,24 @@ class DBALException extends \Exception
         return new self("Operation '$method' is not supported by platform.");
     }
 
-    /**
-     * Returns a new instance for an invalid platform specified.
-     *
-     * @param mixed $invalidPlatform The invalid platform given.
-     *
-     * @return DBALException
-     */
-    public static function invalidPlatformSpecified($invalidPlatform): self
+    public static function invalidPlatformSpecified() : self
     {
-        if (is_object($invalidPlatform)) {
+        return new self(
+            "Invalid 'platform' option specified, need to give an instance of ".
+            "\Doctrine\DBAL\Platforms\AbstractPlatform.");
+    }
+
+    /**
+     * @param mixed $invalidPlatform
+     */
+    public static function invalidPlatformType($invalidPlatform) : self
+    {
+        if (\is_object($invalidPlatform)) {
             return new self(
                 sprintf(
                     "Option 'platform' must be a subtype of '%s', instance of '%s' given",
                     AbstractPlatform::class,
-                    get_class($invalidPlatform)
+                    \get_class($invalidPlatform)
                 )
             );
         }
@@ -59,7 +62,7 @@ class DBALException extends \Exception
             sprintf(
                 "Option 'platform' must be an object and subtype of '%s'. Got '%s'",
                 AbstractPlatform::class,
-                gettype($invalidPlatform)
+                \gettype($invalidPlatform)
             )
         );
     }

--- a/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
+++ b/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
@@ -91,9 +91,15 @@ class CompositeExpression implements \Countable
      */
     public function add($part)
     {
-        if ( ! empty($part) || ($part instanceof self && $part->count() > 0)) {
-            $this->parts[] = $part;
+        if (empty($part)) {
+            return $this;
         }
+
+        if ($part instanceof self && 0 === count($part)) {
+            return $this;
+        }
+
+        $this->parts[] = $part;
 
         return $this;
     }

--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -53,7 +53,7 @@ class DateTimeType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value instanceof \DateTimeInterface) {
             return $value->format($platform->getDateTimeFormatString());
         }
 
@@ -65,7 +65,7 @@ class DateTimeType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value === null || $value instanceof \DateTimeInterface) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -53,7 +53,7 @@ class DateTimeType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value->format($platform->getDateTimeFormatString());
         }
 
@@ -65,7 +65,7 @@ class DateTimeType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime) {
+        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/DateTimeTzType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeTzType.php
@@ -71,7 +71,7 @@ class DateTimeTzType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value->format($platform->getDateTimeTzFormatString());
         }
 
@@ -83,7 +83,7 @@ class DateTimeTzType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime) {
+        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/DateTimeTzType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeTzType.php
@@ -71,7 +71,7 @@ class DateTimeTzType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value instanceof \DateTimeInterface) {
             return $value->format($platform->getDateTimeTzFormatString());
         }
 
@@ -83,7 +83,7 @@ class DateTimeTzType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value === null || $value instanceof \DateTimeInterface) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/DateType.php
+++ b/lib/Doctrine/DBAL/Types/DateType.php
@@ -53,7 +53,7 @@ class DateType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value->format($platform->getDateFormatString());
         }
 
@@ -65,7 +65,7 @@ class DateType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime) {
+        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/DateType.php
+++ b/lib/Doctrine/DBAL/Types/DateType.php
@@ -53,7 +53,7 @@ class DateType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value instanceof \DateTimeInterface) {
             return $value->format($platform->getDateFormatString());
         }
 
@@ -65,7 +65,7 @@ class DateType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value === null || $value instanceof \DateTimeInterface) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/TimeType.php
+++ b/lib/Doctrine/DBAL/Types/TimeType.php
@@ -53,7 +53,7 @@ class TimeType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value->format($platform->getTimeFormatString());
         }
 
@@ -65,7 +65,7 @@ class TimeType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime) {
+        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Types/TimeType.php
+++ b/lib/Doctrine/DBAL/Types/TimeType.php
@@ -53,7 +53,7 @@ class TimeType extends Type
             return $value;
         }
 
-        if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value instanceof \DateTimeInterface) {
             return $value->format($platform->getTimeFormatString());
         }
 
@@ -65,7 +65,7 @@ class TimeType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+        if ($value === null || $value instanceof \DateTimeInterface) {
             return $value;
         }
 

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.6.1';
+    const VERSION = '2.6.2-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.6.0';
+    const VERSION = '2.6.1-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.6.1-DEV';
+    const VERSION = '2.6.1';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.6.2';
+    const VERSION = '2.6.3-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.6.2-DEV';
+    const VERSION = '2.6.2';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -804,7 +804,6 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
 
         $connectionParams = $this->params;
 
-        // This is our main expectation
         $queryCacheProfileMock
             ->expects($this->once())
             ->method('generateCacheKeys')
@@ -824,16 +823,14 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testThrowsExceptionWhenInValidPlatformSpecified(): void
     {
-        self::expectException(DBALException::class);
-        self::expectExceptionMessage(
-            "Given 'platform' option 'stdClass' must be a subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform'"
-        );
 
         $connectionParams = $this->params;
         $connectionParams['platform'] = new \stdClass();
 
         /* @var $driver Driver */
         $driver = $this->createMock(Driver::class);
+
+        $this->expectException(DBALException::class);
 
         new Connection($connectionParams, $driver);
     }

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -823,7 +823,6 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      */
     public function testThrowsExceptionWhenInValidPlatformSpecified(): void
     {
-
         $connectionParams = $this->params;
         $connectionParams['platform'] = new \stdClass();
 

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -7,6 +7,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Events;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -816,6 +817,25 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
         $driver = $this->createMock(Driver::class);
 
         (new Connection($connectionParams, $driver))->executeCacheQuery($query, [], [], $queryCacheProfileMock);
+    }
+
+    /**
+     * @group DBAL-2821
+     */
+    public function testThrowsExceptionWhenInValidPlatformSpecified(): void
+    {
+        self::expectException(DBALException::class);
+        self::expectExceptionMessage(
+            "Given 'platform' option 'stdClass' must be a subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform'"
+        );
+
+        $connectionParams = $this->params;
+        $connectionParams['platform'] = new \stdClass();
+
+        /* @var $driver Driver */
+        $driver = $this->createMock(Driver::class);
+
+        new Connection($connectionParams, $driver);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -62,9 +62,9 @@ class DBALExceptionTest extends DbalTestCase
     /**
      * @group DBAL-2821
      */
-    public function testInvalidPlatformSpecifiedObject(): void
+    public function testInvalidPlatformTypeObject(): void
     {
-        $exception = DBALException::invalidPlatformSpecified(new \stdClass());
+        $exception = DBALException::invalidPlatformType(new \stdClass());
 
         self::assertSame(
             "Option 'platform' must be a subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform', instance of 'stdClass' given",
@@ -75,9 +75,9 @@ class DBALExceptionTest extends DbalTestCase
     /**
      * @group DBAL-2821
      */
-    public function testInvalidPlatformSpecifiedScalar(): void
+    public function testInvalidPlatformTypeScalar(): void
     {
-        $exception = DBALException::invalidPlatformSpecified("some string");
+        $exception = DBALException::invalidPlatformType('some string');
 
         self::assertSame(
             "Option 'platform' must be an object and subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform'. Got 'string'",

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -58,4 +58,30 @@ class DBALExceptionTest extends DbalTestCase
             $exception->getMessage()
         );
     }
+
+    /**
+     * @group DBAL-2821
+     */
+    public function testInvalidPlatformSpecifiedObject(): void
+    {
+
+        $exception = DBALException::invalidPlatformSpecified(new \stdClass());
+        self::assertSame(
+            "Option 'platform' must be a subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform', instance of 'stdClass' given",
+            $exception->getMessage()
+        );
+    }
+
+    /**
+     * @group DBAL-2821
+     */
+    public function testInvalidPlatformSpecifiedScalar(): void
+    {
+        $exception = DBALException::invalidPlatformSpecified("some string");
+
+        self::assertSame(
+            "Option 'platform' must be an object and subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform'. Got 'string'",
+            $exception->getMessage()
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -64,8 +64,8 @@ class DBALExceptionTest extends DbalTestCase
      */
     public function testInvalidPlatformSpecifiedObject(): void
     {
-
         $exception = DBALException::invalidPlatformSpecified(new \stdClass());
+
         self::assertSame(
             "Option 'platform' must be a subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform', instance of 'stdClass' given",
             $exception->getMessage()

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/TableTest.php
@@ -1,0 +1,60 @@
+<?php
+
+
+namespace Doctrine\Tests\DBAL\Functional\Schema;
+
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+class TableTest extends DbalFunctionalTestCase
+{
+    public function testColumnsOrder()
+    {
+        $this->initSchema();
+
+        $schema = $this->_conn->getSchemaManager()->createSchema();
+
+        $columns = array_keys($schema->getTable('myusers')->getColumns());
+
+        $this->assertSame('id', $columns[0]);
+        $this->assertSame('country_id', $columns[1]);
+        $this->assertSame('name', $columns[2]);
+
+        $this->cleanupSchema();
+    }
+
+    private function getTestSchema()
+    {
+        $schema = new \Doctrine\DBAL\Schema\Schema();
+
+        $countries = $schema->createTable('countries');
+        $countries->addColumn('id', 'integer');
+        $countries->setPrimaryKey(array('id'));
+
+        $users = $schema->createTable('myusers');
+        $users->addColumn('id', 'integer');
+        $users->addColumn('name', 'string');
+        $users->addColumn($this->_conn->quoteIdentifier('country_id'), 'integer');
+        $users->setPrimaryKey(array('id'));
+        $users->addForeignKeyConstraint($countries, array($this->_conn->quoteIdentifier('country_id')), array('id'));
+
+        return $schema;
+    }
+
+    private function initSchema()
+    {
+        $queries = $this->getTestSchema()->toSql($this->_conn->getDatabasePlatform());
+
+        foreach ($queries as $query) {
+            $this->_conn->exec($query);
+        }
+    }
+
+    private function cleanupSchema()
+    {
+        $queries = $this->getTestSchema()->toDropSql($this->_conn->getDatabasePlatform());
+
+        foreach ($queries as $query) {
+            $this->_conn->exec($query);
+        }
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
@@ -20,6 +20,29 @@ class CompositeExpressionTest extends \Doctrine\Tests\DbalTestCase
         $this->assertEquals(2, count($expr));
     }
 
+    public function testAdd()
+    {
+        $expr = new CompositeExpression(CompositeExpression::TYPE_OR, array('u.group_id = 1'));
+
+        $this->assertCount(1, $expr);
+
+        $expr->add(new CompositeExpression(CompositeExpression::TYPE_AND, array()));
+
+        $this->assertCount(1, $expr);
+
+        $expr->add(new CompositeExpression(CompositeExpression::TYPE_OR, array('u.user_id = 1')));
+
+        $this->assertCount(2, $expr);
+
+        $expr->add(null);
+
+        $this->assertCount(2, $expr);
+
+        $expr->add('u.user_id = 1');
+
+        $this->assertCount(3, $expr);
+    }
+
     /**
      * @dataProvider provideDataForConvertToString
      */

--- a/tests/Doctrine/Tests/DBAL/Types/BaseDateTypeTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BaseDateTypeTestCase.php
@@ -71,6 +71,35 @@ abstract class BaseDateTypeTestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group #2794
+     *
+     * Note that while DateTimeImmutable is supposed to be handled by @see \Doctrine\DBAL\Types\DateTimeImmutableType,
+     * previous DBAL versions handled it just fine. This test is just in place to prevent further regressions, even
+     * if the type is being misused
+     */
+    public function testConvertDateTimeImmutableToPHPValue()
+    {
+        $date = new \DateTimeImmutable('now');
+
+        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
+    }
+
+    /**
+     * @group #2794
+     *
+     * Note that while DateTimeImmutable is supposed to be handled by @see \Doctrine\DBAL\Types\DateTimeImmutableType,
+     * previous DBAL versions handled it just fine. This test is just in place to prevent further regressions, even
+     * if the type is being misused
+     */
+    public function testDateTimeImmutableConvertsToDatabaseValue()
+    {
+        self::assertInternalType(
+            'string',
+            $this->type->convertToDatabaseValue(new \DateTimeImmutable(), $this->platform)
+        );
+    }
+
+    /**
      * @return mixed[][]
      */
     public function invalidPHPValuesProvider()

--- a/tests/Doctrine/Tests/DBAL/Types/BaseDateTypeTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BaseDateTypeTestCase.php
@@ -73,9 +73,9 @@ abstract class BaseDateTypeTestCase extends PHPUnit_Framework_TestCase
     /**
      * @group #2794
      *
-     * Note that while DateTimeImmutable is supposed to be handled by @see \Doctrine\DBAL\Types\DateTimeImmutableType,
-     * previous DBAL versions handled it just fine. This test is just in place to prevent further regressions, even
-     * if the type is being misused
+     * Note that while \@see \DateTimeImmutable is supposed to be handled
+     * by @see \Doctrine\DBAL\Types\DateTimeImmutableType, previous DBAL versions handled it just fine.
+     * This test is just in place to prevent further regressions, even if the type is being misused
      */
     public function testConvertDateTimeImmutableToPHPValue()
     {
@@ -87,9 +87,9 @@ abstract class BaseDateTypeTestCase extends PHPUnit_Framework_TestCase
     /**
      * @group #2794
      *
-     * Note that while DateTimeImmutable is supposed to be handled by @see \Doctrine\DBAL\Types\DateTimeImmutableType,
-     * previous DBAL versions handled it just fine. This test is just in place to prevent further regressions, even
-     * if the type is being misused
+     * Note that while \@see \DateTimeImmutable is supposed to be handled
+     * by @see \Doctrine\DBAL\Types\DateTimeImmutableType, previous DBAL versions handled it just fine.
+     * This test is just in place to prevent further regressions, even if the type is being misused
      */
     public function testDateTimeImmutableConvertsToDatabaseValue()
     {


### PR DESCRIPTION
This PR contains a failing test for #2844 .

As suggested by @morozov , I wrote an integration test for the `Table` class, created a data model using DBAL, stored it, retrieved it and checked the columns order.

I know that @deeky666 provides a test environment for Oracle, but I don't know if the test results are public and if they can be seen somewhere for this PR.

Also, this PR needs some more work, since the test should not run for platforms having no notion of foreign keys by default (like SQLite). Any help regarding how to do that would be appreciated :)