### PR TITLE
Test default value declaration for the date type

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -563,6 +563,20 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
         }
     }
 
+    public function testGetDefaultValueDeclarationSQLForDateType()
+    {
+        $currentDateSql = $this->_platform->getCurrentDateSQL();
+        $field = array(
+            'type'    => Type::getType('date'),
+            'default' => $currentDateSql,
+        );
+
+        $this->assertEquals(
+            ' DEFAULT '.$currentDateSql,
+            $this->_platform->getDefaultValueDeclarationSQL($field)
+        );
+    }
+
     /**
      * @group DBAL-45
      */

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\SQLServer2008Platform;
+use Doctrine\DBAL\Types\Type;
 
 class SQLServer2008PlatformTest extends AbstractSQLServerPlatformTestCase
 {
@@ -17,6 +18,20 @@ class SQLServer2008PlatformTest extends AbstractSQLServerPlatformTestCase
             'DATETIMEOFFSET(6)',
             $this->_platform->getDateTimeTzTypeDeclarationSQL(
                 array())
+        );
+    }
+
+    public function testGetDefaultValueDeclarationSQLForDateType()
+    {
+        $currentDateSql = $this->_platform->getCurrentDateSQL();
+        $field = array(
+            'type'    => Type::getType('date'),
+            'default' => $currentDateSql,
+        );
+
+        $this->assertEquals(
+            " DEFAULT '".$currentDateSql."'",
+            $this->_platform->getDefaultValueDeclarationSQL($field)
         );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\Sequence;
+use Doctrine\DBAL\Types\Type;
 
 class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
 {
@@ -370,5 +371,19 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
         $expectedSql = "SELECT * FROM test\nORDER BY col DESC OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY";
         $sql = $this->_platform->modifyLimitQuery($querySql, 10);
         self::assertEquals($expectedSql, $sql);
+    }
+
+    public function testGetDefaultValueDeclarationSQLForDateType()
+    {
+        $currentDateSql = $this->_platform->getCurrentDateSQL();
+        $field = array(
+            'type'    => Type::getType('date'),
+            'default' => $currentDateSql,
+        );
+
+        $this->assertEquals(
+            " DEFAULT '".$currentDateSql."'",
+            $this->_platform->getDefaultValueDeclarationSQL($field)
+        );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Types\Type;
 
 class SQLServerPlatformTest extends AbstractSQLServerPlatformTestCase
 {
@@ -58,4 +59,17 @@ class SQLServerPlatformTest extends AbstractSQLServerPlatformTestCase
         );
     }
 
+    public function testGetDefaultValueDeclarationSQLForDateType()
+    {
+        $currentDateSql = $this->_platform->getCurrentDateSQL();
+        $field = array(
+            'type'    => Type::getType('date'),
+            'default' => $currentDateSql,
+        );
+
+        $this->assertEquals(
+            " DEFAULT '".$currentDateSql."'",
+            $this->_platform->getDefaultValueDeclarationSQL($field)
+        );
+    }
 }


### PR DESCRIPTION
It was not covered, probably because it was hard to do something
generic. I choose to duplicate some tests instead, so that things stay
relatively simple.