### PR TITLE
Fix BC-break regarding JsonArrayType

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -435,6 +435,13 @@ class Comparator
             }
         }
 
+        // This is a very nasty hack to make comparator work with the legacy json_array type, which should be killed in v3
+        if ($this->isALegacyJsonComparison($properties1['type'], $properties2['type'])) {
+            array_shift($changedProperties);
+
+            $changedProperties[] = 'comment';
+        }
+
         if ($properties1['default'] != $properties2['default'] ||
             // Null values need to be checked additionally as they tell whether to create or drop a default value.
             // null != 0, null != false, null != '' etc. This affects platform's table alteration SQL generation.
@@ -495,6 +502,21 @@ class Comparator
         }
 
         return array_unique($changedProperties);
+    }
+
+    /**
+     * TODO: kill with fire on v3.0
+     *
+     * @deprecated
+     */
+    private function isALegacyJsonComparison(Types\Type $one, Types\Type $other) : bool
+    {
+        if ( ! $one instanceof Types\JsonType || ! $other instanceof Types\JsonType) {
+            return false;
+        }
+
+        return ( ! $one instanceof Types\JsonArrayType && $other instanceof Types\JsonArrayType)
+            || ( ! $other instanceof Types\JsonArrayType && $one instanceof Types\JsonArrayType);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/JsonArrayType.php
+++ b/lib/Doctrine/DBAL/Types/JsonArrayType.php
@@ -57,6 +57,6 @@ class JsonArrayType extends JsonType
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
-        return ! $platform->hasNativeJsonType();
+        return true;
     }
 }

--- a/lib/Doctrine/DBAL/Types/JsonType.php
+++ b/lib/Doctrine/DBAL/Types/JsonType.php
@@ -90,12 +90,7 @@ class JsonType extends Type
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
-        /*
-         * should be switched back to the platform detection at 3.0, when
-         * JsonArrayType will be dropped
-         */
-        //return ! $platform->hasNativeJsonType();
-        return true;
+        return ! $platform->hasNativeJsonType();
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -383,7 +383,7 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         /** @var Schema\Column[] $columns */
         $columns = $this->_sm->listTableColumns('test_jsonb');
 
-        self::assertSame(TYPE::JSON, $columns['foo']->getType()->getName());
+        self::assertSame($type, $columns['foo']->getType()->getName());
         self::assertTrue(true, $columns['foo']->getPlatformOption('jsonb'));
     }
 


### PR DESCRIPTION
As reported on https://github.com/doctrine/dbal/pull/2782#issuecomment-322246167 we've introduced a BC-break on 2.6.x regarding the `json_array` type. This fixes it for good.