### PR TITLE
Fixed unknown database type int4range and int8range requested

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -1134,6 +1134,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             'year'          => 'date',
             'uuid'          => 'guid',
             'bytea'         => 'blob',
+            'int4range'     => 'integer',
         ];
     }
 

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -1135,6 +1135,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             'uuid'          => 'guid',
             'bytea'         => 'blob',
             'int4range'     => 'integer',
+            'int8range'     => 'bigint',
         ];
     }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -285,6 +285,12 @@ class DB2PlatformTest extends AbstractPlatformTestCase
 
         self::assertTrue($this->_platform->hasDoctrineTypeMappingFor('timestamp'));
         self::assertSame('datetime', $this->_platform->getDoctrineTypeMapping('timestamp'));
+
+        self::assertTrue($this->_platform->hasDoctrineTypeMappingFor('int4range'));
+        self::assertSame('integer', $this->_platform->getDoctrineTypeMapping('int4range'));
+
+        self::assertTrue($this->_platform->hasDoctrineTypeMappingFor('int8range'));
+        self::assertSame('bigint', $this->_platform->getDoctrineTypeMapping('int8range'));
     }
 
     public function getIsCommentedDoctrineType()


### PR DESCRIPTION
```
[Doctrine\DBAL\DBALException]
  Unknown database type int4range requested, Doctrine\DBAL\Platforms\PostgreSQL92Platform may not support it.
```

It's fixed.