### PR TITLE
Fixes for Sqlite schema regex

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -264,7 +264,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
 
             $comment = $this->parseColumnCommentFromSQL($columnName, $createSql);
 
-            if (false !== $comment) {
+            if ($comment !== null) {
                 $type = $this->extractDoctrineTypeFromComment($comment, null);
 
                 if (null !== $type) {
@@ -435,38 +435,29 @@ class SqliteSchemaManager extends AbstractSchemaManager
         return $tableDiff;
     }
 
-    /**
-     * @param string $column
-     * @param string $sql
-     *
-     * @return string|false
-     */
-    private function parseColumnCollationFromSQL($column, $sql)
+    private function parseColumnCollationFromSQL(string $column, string $sql) : ?string
     {
         $pattern = '{(?:\W' . preg_quote($column) . '\W|\W' . preg_quote($this->_platform->quoteSingleIdentifier($column))
                  . '\W)[^,(]+(?:\([^()]+\)[^,]*)?(?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*COLLATE\s+["\']?([^\s,"\')]+)}isx';
 
-        if (preg_match($pattern, $sql, $match) === 1) {
-            return $match[1];
+        if (preg_match($pattern, $sql, $match) !== 1) {
+            return null;
         }
 
-        return false;
+        return $match[1];
     }
 
-    /**
-     * @return string|false
-     */
-    private function parseColumnCommentFromSQL($column, $sql)
+    private function parseColumnCommentFromSQL(string $column, string $sql) : ?string
     {
         $pattern = '{[\s(,](?:\W' . preg_quote($this->_platform->quoteSingleIdentifier($column)) . '\W|\W' . preg_quote($column)
                  . '\W)(?:\(.*?\)|[^,(])*?,?((?:(?!\n))(?:\s*--[^\n]*\n?)+)}ix';
 
-        if (preg_match($pattern, $sql, $match) === 1) {
-            $comment = preg_replace('{^\s*--}m', '', rtrim($match[1], "\n"));
-
-            return '' === $comment ? false : $comment;
+        if (preg_match($pattern, $sql, $match) !== 1) {
+            return null;
         }
 
-        return false;
+        $comment = preg_replace('{^\s*--}m', '', rtrim($match[1], "\n"));
+
+        return '' === $comment ? null : $comment;
     }
 }

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -443,11 +443,10 @@ class SqliteSchemaManager extends AbstractSchemaManager
      */
     private function parseColumnCollationFromSQL($column, $sql)
     {
-        if (preg_match(
-            '{(?:'.preg_quote($column).'|'.preg_quote($this->_platform->quoteSingleIdentifier($column)).')
-                [^,(]+(?:\([^()]+\)[^,]*)?
-                (?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*
-                COLLATE\s+["\']?([^\s,"\')]+)}isx', $sql, $match)) {
+        $pattern = '{(?:\W' . preg_quote($column) . '\W|\W' . preg_quote($this->_platform->quoteSingleIdentifier($column))
+                 . '\W)[^,(]+(?:\([^()]+\)[^,]*)?(?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*COLLATE\s+["\']?([^\s,"\')]+)}isx';
+
+        if (preg_match($pattern, $sql, $match) === 1) {
             return $match[1];
         }
 

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -454,18 +454,14 @@ class SqliteSchemaManager extends AbstractSchemaManager
     }
 
     /**
-     * @param string $column
-     * @param string $sql
-     *
      * @return string|false
      */
     private function parseColumnCommentFromSQL($column, $sql)
     {
-        if (preg_match(
-            '{[\s(,](?:'.preg_quote($this->_platform->quoteSingleIdentifier($column)).'|'.preg_quote($column).')
-            (?:\(.*?\)|[^,(])*?,?((?:\s*--[^\n]*\n?)+)
-            }isx', $sql, $match
-        )) {
+        $pattern = '{[\s(,](?:\W' . preg_quote($this->_platform->quoteSingleIdentifier($column)) . '\W|\W' . preg_quote($column)
+                 . '\W)(?:\(.*?\)|[^,(])*?,?((?:(?!\n))(?:\s*--[^\n]*\n?)+)}ix';
+
+        if (preg_match($pattern, $sql, $match) === 1) {
             $comment = preg_replace('{^\s*--}m', '', rtrim($match[1], "\n"));
 
             return '' === $comment ? false : $comment;

--- a/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Schema;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\SqliteSchemaManager;
 
@@ -9,37 +10,32 @@ class SqliteSchemaManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider getDataColumnCollation
+     *
+     * @group 2865
      */
-    public function testParseColumnCollation($collation, $column, $sql)
+    public function testParseColumnCollation($collation, string $column, string $sql) : void
     {
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
-        $conn->expects($this->any())->method('getDatabasePlatform')->will($this->returnValue(new SqlitePlatform()));
+        $conn = $this->createMock(Connection::class);
+        $conn->method('getDatabasePlatform')->willReturn(new SqlitePlatform());
 
         $manager = new SqliteSchemaManager($conn);
-        $ref = new \ReflectionMethod($manager, 'parseColumnCollationFromSQL');
+        $ref     = new \ReflectionMethod($manager, 'parseColumnCollationFromSQL');
         $ref->setAccessible(true);
 
-        self::assertEquals($collation, $ref->invoke($manager, $column, $sql));
+        self::assertSame($collation, $ref->invoke($manager, $column, $sql));
     }
 
     public function getDataColumnCollation()
     {
-        return array(
-            array(
-                'RTRIM', 'a', 'CREATE TABLE "a" ("a" text DEFAULT "aa" COLLATE "RTRIM" NOT NULL)'
-            ),
-            array(
-                'utf-8', 'a', 'CREATE TABLE "a" ("b" text UNIQUE NOT NULL COLLATE NOCASE, "a" text DEFAULT "aa" COLLATE "utf-8" NOT NULL)'
-            ),
-            array(
-                'NOCASE', 'a', 'CREATE TABLE "a" ("a" text DEFAULT (lower(ltrim(" a") || rtrim("a "))) CHECK ("a") NOT NULL COLLATE NOCASE UNIQUE, "b" text COLLATE RTRIM)'
-            ),
-            array(
-                false, 'a', 'CREATE TABLE "a" ("a" text CHECK ("a") NOT NULL, "b" text COLLATE RTRIM)'
-            ),
-            array(
-                'RTRIM', 'a"b', 'CREATE TABLE "a" ("a""b" text COLLATE RTRIM)'
-            ),
-        );
+        return [
+            ['RTRIM', 'a', 'CREATE TABLE "a" ("a" text DEFAULT "aa" COLLATE "RTRIM" NOT NULL)'],
+            ['utf-8', 'a', 'CREATE TABLE "a" ("b" text UNIQUE NOT NULL COLLATE NOCASE, "a" text DEFAULT "aa" COLLATE "utf-8" NOT NULL)'],
+            ['NOCASE', 'a', 'CREATE TABLE "a" ("a" text DEFAULT (lower(ltrim(" a") || rtrim("a "))) CHECK ("a") NOT NULL COLLATE NOCASE UNIQUE, "b" text COLLATE RTRIM)'],
+            [false, 'a', 'CREATE TABLE "a" ("a" text CHECK ("a") NOT NULL, "b" text COLLATE RTRIM)'],
+            ['RTRIM', 'a"b', 'CREATE TABLE "a" ("a""b" text COLLATE RTRIM)'],
+            ['BINARY', 'b', 'CREATE TABLE "a" (bb TEXT COLLATE RTRIM, b VARCHAR(42) NOT NULL COLLATE BINARY)'],
+            ['BINARY', 'b', 'CREATE TABLE "a" (bbb TEXT COLLATE NOCASE, bb TEXT COLLATE RTRIM, b VARCHAR(42) NOT NULL COLLATE BINARY)'],
+            ['BINARY', 'b', 'CREATE TABLE "a" (b VARCHAR(42) NOT NULL COLLATE BINARY, bb TEXT COLLATE RTRIM)'],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaManagerTest.php
@@ -38,4 +38,65 @@ class SqliteSchemaManagerTest extends \PHPUnit\Framework\TestCase
             ['BINARY', 'b', 'CREATE TABLE "a" (b VARCHAR(42) NOT NULL COLLATE BINARY, bb TEXT COLLATE RTRIM)'],
         ];
     }
+
+    /**
+     * @dataProvider getDataColumnComment
+     *
+     * @group 2865
+     */
+    public function testParseColumnCommentFromSQL($comment, string $column, string $sql) : void
+    {
+        $conn = $this->createMock(Connection::class);
+        $conn->method('getDatabasePlatform')->willReturn(new SqlitePlatform());
+
+        $manager = new SqliteSchemaManager($conn);
+        $ref     = new \ReflectionMethod($manager, 'parseColumnCommentFromSQL');
+        $ref->setAccessible(true);
+
+        self::assertSame($comment, $ref->invoke($manager, $column, $sql));
+    }
+
+    public function getDataColumnComment()
+    {
+        return [
+            'Single column with no comment' => [
+                false, 'a', 'CREATE TABLE "a" ("a" TEXT DEFAULT "a" COLLATE RTRIM)',
+            ],
+            'Single column with type comment' => [
+                '(DC2Type:x)', 'a', 'CREATE TABLE "a" ("a" CLOB DEFAULT NULL COLLATE BINARY --(DC2Type:x)
+)',
+            ],
+            'Multiple similar columns with type comment 1' => [
+                false, 'b', 'CREATE TABLE "a" (a TEXT COLLATE RTRIM, "b" TEXT DEFAULT "a" COLLATE RTRIM, "bb" CLOB DEFAULT NULL COLLATE BINARY --(DC2Type:x)
+)',
+            ],
+            'Multiple similar columns with type comment 2' => [
+                '(DC2Type:x)', 'b', 'CREATE TABLE "a" (a TEXT COLLATE RTRIM, "bb" TEXT DEFAULT "a" COLLATE RTRIM, "b" CLOB DEFAULT NULL COLLATE BINARY --(DC2Type:x)
+)',
+            ],
+            'Multiple similar columns on different lines, with type comment 1' => [
+                false, 'bb', 'CREATE TABLE "a" (a TEXT COLLATE RTRIM, "b" CLOB DEFAULT NULL COLLATE BINARY --(DC2Type:x)
+, "bb" TEXT DEFAULT "a" COLLATE RTRIM',
+            ],
+            'Multiple similar columns on different lines, with type comment 2' => [
+                '(DC2Type:x)', 'bb', 'CREATE TABLE "a" (a TEXT COLLATE RTRIM, "bb" CLOB DEFAULT NULL COLLATE BINARY --(DC2Type:x)
+, "b" TEXT DEFAULT "a" COLLATE RTRIM',
+            ],
+            'Column with numeric but no comment 1' => [
+                false, 'a', 'CREATE TABLE "a" ("a" NUMERIC(10, 0) NOT NULL, "b" CLOB NOT NULL --(DC2Type:array)
+, "c" CHAR(36) NOT NULL --(DC2Type:guid)
+)',
+            ],
+            'Column with numeric but no comment 2' => [
+                false, 'a', 'CREATE TABLE "b" ("a" NUMERIC(10, 0) NOT NULL, "b" CLOB NOT NULL --(DC2Type:array)
+, "c" CHAR(36) NOT NULL --(DC2Type:guid)
+)',
+            ],
+            'Column with numeric but no comment 3' => [
+                '(DC2Type:guid)', 'c', 'CREATE TABLE "b" ("a" NUMERIC(10, 0) NOT NULL, "b" CLOB NOT NULL --(DC2Type:array)
+, "c" CHAR(36) NOT NULL --(DC2Type:guid)
+)',
+            ],
+        ];
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaManagerTest.php
@@ -13,7 +13,7 @@ class SqliteSchemaManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @group 2865
      */
-    public function testParseColumnCollation($collation, string $column, string $sql) : void
+    public function testParseColumnCollation(?string $collation, string $column, string $sql) : void
     {
         $conn = $this->createMock(Connection::class);
         $conn->method('getDatabasePlatform')->willReturn(new SqlitePlatform());
@@ -31,7 +31,7 @@ class SqliteSchemaManagerTest extends \PHPUnit\Framework\TestCase
             ['RTRIM', 'a', 'CREATE TABLE "a" ("a" text DEFAULT "aa" COLLATE "RTRIM" NOT NULL)'],
             ['utf-8', 'a', 'CREATE TABLE "a" ("b" text UNIQUE NOT NULL COLLATE NOCASE, "a" text DEFAULT "aa" COLLATE "utf-8" NOT NULL)'],
             ['NOCASE', 'a', 'CREATE TABLE "a" ("a" text DEFAULT (lower(ltrim(" a") || rtrim("a "))) CHECK ("a") NOT NULL COLLATE NOCASE UNIQUE, "b" text COLLATE RTRIM)'],
-            [false, 'a', 'CREATE TABLE "a" ("a" text CHECK ("a") NOT NULL, "b" text COLLATE RTRIM)'],
+            [null, 'a', 'CREATE TABLE "a" ("a" text CHECK ("a") NOT NULL, "b" text COLLATE RTRIM)'],
             ['RTRIM', 'a"b', 'CREATE TABLE "a" ("a""b" text COLLATE RTRIM)'],
             ['BINARY', 'b', 'CREATE TABLE "a" (bb TEXT COLLATE RTRIM, b VARCHAR(42) NOT NULL COLLATE BINARY)'],
             ['BINARY', 'b', 'CREATE TABLE "a" (bbb TEXT COLLATE NOCASE, bb TEXT COLLATE RTRIM, b VARCHAR(42) NOT NULL COLLATE BINARY)'],
@@ -44,7 +44,7 @@ class SqliteSchemaManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @group 2865
      */
-    public function testParseColumnCommentFromSQL($comment, string $column, string $sql) : void
+    public function testParseColumnCommentFromSQL(?string $comment, string $column, string $sql) : void
     {
         $conn = $this->createMock(Connection::class);
         $conn->method('getDatabasePlatform')->willReturn(new SqlitePlatform());
@@ -60,14 +60,14 @@ class SqliteSchemaManagerTest extends \PHPUnit\Framework\TestCase
     {
         return [
             'Single column with no comment' => [
-                false, 'a', 'CREATE TABLE "a" ("a" TEXT DEFAULT "a" COLLATE RTRIM)',
+                null, 'a', 'CREATE TABLE "a" ("a" TEXT DEFAULT "a" COLLATE RTRIM)',
             ],
             'Single column with type comment' => [
                 '(DC2Type:x)', 'a', 'CREATE TABLE "a" ("a" CLOB DEFAULT NULL COLLATE BINARY --(DC2Type:x)
 )',
             ],
             'Multiple similar columns with type comment 1' => [
-                false, 'b', 'CREATE TABLE "a" (a TEXT COLLATE RTRIM, "b" TEXT DEFAULT "a" COLLATE RTRIM, "bb" CLOB DEFAULT NULL COLLATE BINARY --(DC2Type:x)
+                null, 'b', 'CREATE TABLE "a" (a TEXT COLLATE RTRIM, "b" TEXT DEFAULT "a" COLLATE RTRIM, "bb" CLOB DEFAULT NULL COLLATE BINARY --(DC2Type:x)
 )',
             ],
             'Multiple similar columns with type comment 2' => [
@@ -75,7 +75,7 @@ class SqliteSchemaManagerTest extends \PHPUnit\Framework\TestCase
 )',
             ],
             'Multiple similar columns on different lines, with type comment 1' => [
-                false, 'bb', 'CREATE TABLE "a" (a TEXT COLLATE RTRIM, "b" CLOB DEFAULT NULL COLLATE BINARY --(DC2Type:x)
+                null, 'bb', 'CREATE TABLE "a" (a TEXT COLLATE RTRIM, "b" CLOB DEFAULT NULL COLLATE BINARY --(DC2Type:x)
 , "bb" TEXT DEFAULT "a" COLLATE RTRIM',
             ],
             'Multiple similar columns on different lines, with type comment 2' => [
@@ -83,12 +83,12 @@ class SqliteSchemaManagerTest extends \PHPUnit\Framework\TestCase
 , "b" TEXT DEFAULT "a" COLLATE RTRIM',
             ],
             'Column with numeric but no comment 1' => [
-                false, 'a', 'CREATE TABLE "a" ("a" NUMERIC(10, 0) NOT NULL, "b" CLOB NOT NULL --(DC2Type:array)
+                null, 'a', 'CREATE TABLE "a" ("a" NUMERIC(10, 0) NOT NULL, "b" CLOB NOT NULL --(DC2Type:array)
 , "c" CHAR(36) NOT NULL --(DC2Type:guid)
 )',
             ],
             'Column with numeric but no comment 2' => [
-                false, 'a', 'CREATE TABLE "b" ("a" NUMERIC(10, 0) NOT NULL, "b" CLOB NOT NULL --(DC2Type:array)
+                null, 'a', 'CREATE TABLE "b" ("a" NUMERIC(10, 0) NOT NULL, "b" CLOB NOT NULL --(DC2Type:array)
 , "c" CHAR(36) NOT NULL --(DC2Type:guid)
 )',
             ],


### PR DESCRIPTION
Both column collation & comments were not respecting word boundaries so `foo` and `foobar` would conflict depending on order in the schema.

Capable & happy to make adjustments to tests, commits, etc, as requested.