### PR TITLE
Replace double quotes when the schema is named as keyword

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -366,7 +366,7 @@ class PostgreSqlPlatform extends AbstractPlatform
             list($schema, $table) = explode(".", $table);
             $schema = $this->quoteStringLiteral($schema);
         } else {
-            $schema = "ANY(string_to_array((select replace(replace(setting,'\"\$user\"',user),' ','') from pg_catalog.pg_settings where name = 'search_path'),','))";
+            $schema = "ANY(string_to_array((select replace(replace(replace(setting,'\"\$user\"',user),' ',''),'\"','') from pg_catalog.pg_settings where name = 'search_path'),','))";
         }
 
         $table = new Identifier($table);

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -62,7 +62,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         $schema = explode(",", $this->_conn->fetchColumn('SHOW search_path'));
 
         if (isset($params['user'])) {
-            $schema = str_replace('"$user"', $params['user'], $schema);
+            $schema = str_replace(['"', '$user'], ['', $params['user']], $schema);
         }
 
         return array_map('trim', $schema);

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -32,6 +32,20 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     }
 
     /**
+     * @group DBAL-177
+     */
+    public function testGetSearchPathContainsKeywords()
+    {
+        $stmt = $this->_conn->prepare('SET search_path TO "$user", public, "user";');
+        $stmt->execute();
+
+        $params = $this->_conn->getParams();
+
+        $paths = $this->_sm->getSchemaSearchPaths();
+        self::assertEquals([$params['user'], 'public', 'user'], $paths);
+    }
+
+    /**
      * @group DBAL-244
      */
     public function testGetSchemaNames()


### PR DESCRIPTION
If some schemas are named as keywords such as `user`, `order`. 
The result of SQL: `select setting from pg_catalog.pg_settings where name = 'search_path'` will be like this.

```
+----------------------------------------------+
| setting                                      |
+----------------------------------------------+
| "$user", public, "user", "order"             |
+----------------------------------------------+
1 row in set
```

All the keywords will be quoted by `""`, so we should replace it.