### PR TITLE
 adding ORDER BY to OVER() on IBMDB2

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -894,10 +894,12 @@ class DB2Platform extends AbstractPlatform
         $orderByArray = [];
 
         //determine if 'ORDER BY' is part of the query
-        $orderByPosition = strrpos($query, 'ORDER BY');
+        $orderByFound = preg_match('/(\bORDER\b)(\s*)(\bBY\b)(?!.*\b\1\b)/i', $query, $orderByPositionArray, PREG_OFFSET_CAPTURE);
 
         // ORDER BY found in query string
-        if (false !== $orderByPosition) {
+        if (0 !== $orderByFound) {
+            $orderByPosition = $orderByPositionArray[0][1];
+
             $queryArray = preg_split('/[, ]/', substr($query, 0, $orderByPosition -1));
             $orderByArray = preg_split('/[, ]/', substr($query, $orderByPosition));
 
@@ -912,8 +914,8 @@ class DB2Platform extends AbstractPlatform
                         $orderByArray[$orderIndex] = ',';
                         break;
                     default:
-                        $orderByArray[$orderIndex] = array_search($orderValue, $queryArray) === false 
-                                                     ? $orderValue 
+                        $orderByArray[$orderIndex] = array_search($orderValue, $queryArray) === false
+                                                     ? $orderValue
                                                      : $queryArray[array_search($orderValue, $queryArray)+2];
                         break;
                 }

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -900,37 +900,39 @@ class DB2Platform extends AbstractPlatform
         //determine if 'ORDER BY' is part of the query
         $orderByFound = preg_match('/(\bORDER\b)(\s*)(\bBY\b)(?!.*\b\1\b)/i', $query, $orderByPositionArray, PREG_OFFSET_CAPTURE);
 
-        // ORDER BY found in query string
-        if (0 !== $orderByFound) {
-            $orderByPosition = $orderByPositionArray[0][1];
-
-            $queryArray = preg_split('/[, ]/', substr($query, 0, $orderByPosition -1));
-            $orderByArray = explode(',', substr($query, $orderByPosition + strlen('ORDER BY')));
-
-            foreach ($orderByArray as $orderIndex => $orderValue) {
-                $splitOrder = explode(' ', $orderValue);
-
-                foreach ($splitOrder as $splitIndex => $splitValue) {
-                    switch (strtoupper($splitValue)) {
-                        case 'ASC':
-                        case 'DESC':
-                            break;
-                        default:
-                            $splitOrder[$splitIndex] = array_search($splitValue, $queryArray) === false
-                                                       ? $splitValue
-                                                       : $queryArray[array_search($splitValue, $queryArray)+2];
-                            break;
-                    }
-                }
-                $orderByArray[$orderIndex] = array_filter($splitOrder);
-            }
-
-            foreach ($orderByArray as $orderIndex => $orderValue) {
-                $orderByArray[$orderIndex] = implode(' ', $orderValue);
-            }
-
-            $orderByArray[0] = 'ORDER BY ' . $orderByArray[0];
+        // early return if ORDER BY not found in query string
+        if (0 === $orderByFound) {
+            return '';
         }
+        
+        $orderByPosition = $orderByPositionArray[0][1];
+
+        $queryArray = preg_split('/[, ]/', substr($query, 0, $orderByPosition -1));
+        $orderByArray = explode(',', substr($query, $orderByPosition + strlen('ORDER BY')));
+
+        foreach ($orderByArray as $orderIndex => $orderValue) {
+            $splitOrder = explode(' ', $orderValue);
+
+            foreach ($splitOrder as $splitIndex => $splitValue) {
+                switch (strtoupper($splitValue)) {
+                    case 'ASC':
+                    case 'DESC':
+                        break;
+                    default:
+                        $splitOrder[$splitIndex] = array_search($splitValue, $queryArray) === false
+                                                   ? $splitValue
+                                                   : $queryArray[array_search($splitValue, $queryArray)+2];
+                        break;
+                }
+            }
+            $orderByArray[$orderIndex] = array_filter($splitOrder);
+        }
+
+        foreach ($orderByArray as $orderIndex => $orderValue) {
+            $orderByArray[$orderIndex] = implode(' ', $orderValue);
+        }
+
+        $orderByArray[0] = 'ORDER BY ' . $orderByArray[0];
 
         return implode(',', $oderByArray;
     }

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -934,6 +934,6 @@ class DB2Platform extends AbstractPlatform
 
         $orderByArray[0] = 'ORDER BY ' . $orderByArray[0];
 
-        return implode(',', $oderByArray;
+        return implode(',', $oderByArray);
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -785,6 +785,7 @@ class DB2Platform extends AbstractPlatform
             return $query;
         }
 
+        // retrieve ORDER BY string
         $orderBy = $this->getOrderByForOver($query);
         
         return sprintf(

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -891,9 +891,6 @@ class DB2Platform extends AbstractPlatform
      */
     private function getOrderByForOver(string $query): string
     {
-        //preset empty array
-        $orderByArray = [];
-
         //determine if 'ORDER BY' is part of the query
         $orderByPosition = strripos($query, 'order by');
 
@@ -913,7 +910,11 @@ class DB2Platform extends AbstractPlatform
                                   substr($query, 0, $orderByPosition -1))
                               , function($element) {
                                     // don't return 'AS' and empty elements
-                                    return (strtoupper($element) !== 'AS' && trim($element !== ''));
+                                    return (
+                                        strtoupper($element) !== 'AS'
+                                        && trim($element !== '')
+                                        && $element !== false
+                                    );
                                 }
                           )
         );

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -912,7 +912,9 @@ class DB2Platform extends AbstractPlatform
                         $orderByArray[$orderIndex] = ',';
                         break;
                     default:
-                        $orderByArray[$orderIndex] = $queryArray[array_search($orderValue, $queryArray)+2];
+                        $orderByArray[$orderIndex] = array_search($orderValue, $queryArray) === false 
+                                                     ? $orderValue 
+                                                     : $queryArray[array_search($orderValue, $queryArray)+2];
                         break;
                 }
             }

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -904,22 +904,15 @@ class DB2Platform extends AbstractPlatform
             $orderByPosition = $orderByPositionArray[0][1];
 
             $queryArray = preg_split('/[, ]/', substr($query, 0, $orderByPosition -1));
-            $orderByArray = explode(',', substr($query, $orderByPosition));
+            $orderByArray = explode(',', substr($query, $orderByPosition + strlen('ORDER BY')));
 
             foreach ($orderByArray as $orderIndex => $orderValue) {
                 $splitOrder = explode(' ', $orderValue);
 
                 foreach ($splitOrder as $splitIndex => $splitValue) {
                     switch (strtoupper($splitValue)) {
-                        case 'ORDER':
-                        case 'BY':
-                            $splitOrder[$splitIndex] = '';
-                            break;
                         case 'ASC':
                         case 'DESC':
-                            break;
-                        case '':
-                            unset($splitOrder[$splitIndex]);
                             break;
                         default:
                             $splitOrder[$splitIndex] = array_search($splitValue, $queryArray) === false

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -934,6 +934,6 @@ class DB2Platform extends AbstractPlatform
 
         $orderByArray[0] = 'ORDER BY ' . $orderByArray[0];
 
-        return implode(',', $oderByArray);
+        return implode(',', $orderByArray);
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -894,9 +894,6 @@ class DB2Platform extends AbstractPlatform
         //preset empty array
         $orderByArray = [];
 
-        // remove extra white space
-        $query = preg_replace('/\s+/', ' ', $query);
-
         //determine if 'ORDER BY' is part of the query
         $orderByPosition = strripos($query, 'order by');
 
@@ -915,8 +912,8 @@ class DB2Platform extends AbstractPlatform
                                   '/[, ]/',
                                   substr($query, 0, $orderByPosition -1))
                               , function($element) {
-                                    // don't return 'AS'
-                                    return strtoupper($element) !== 'AS';
+                                    // don't return 'AS' and empty elements
+                                    return (strtoupper($element) !== 'AS' && trim($element !== ''));
                                 }
                           )
         );
@@ -929,16 +926,19 @@ class DB2Platform extends AbstractPlatform
             foreach ($splitOrder as $splitIndex => $splitValue) {
                 switch (strtoupper($splitValue)) {
                     case 'ASC':
+                        // no break
                     case 'DESC':
                         break;
                     default:
                         $arrayFound = array_search($splitValue, $queryArray);
 
+                        $arrayPosition = substr(trim($splitValue), 0, 6) === 'dctrn_' ? 0 : 1;
+
                         $splitOrder[$splitIndex] = $arrayFound === false ||
                                                    $arrayFound >= count($queryArray) ||
-                                                   $queryArray[$arrayFound + 1] === ""
+                                                   $queryArray[$arrayFound + $arrayPosition] === ""
                                                    ? $splitValue
-                                                   : $queryArray[$arrayFound + 1];
+                                                   : $queryArray[$arrayFound + $arrayPosition];
                         break;
                 }
             }

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -898,7 +898,7 @@ class DB2Platform extends AbstractPlatform
 
         // ORDER BY found in query string
         if (false !== $orderByPosition) {
-            $queryArray = preg_split('/[, ]/', $query);
+            $queryArray = preg_split('/[, ]/', substr($query, 0, $orderByPosition -1));
             $orderByArray = preg_split('/[, ]/', substr($query, $orderByPosition));
 
             foreach ($orderByArray as $orderIndex => $orderValue) {

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -785,11 +785,11 @@ class DB2Platform extends AbstractPlatform
             return $query;
         }
 
-        $orderByArray = $this->getOrderByForOver($query);
+        $orderBy = $this->getOrderByForOver($query);
         
         return sprintf(
             'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(%s) AS DC_ROWNUM FROM (%s) db21) db22 WHERE %s',
-            implode(',', $orderByArray),
+            $orderBy,
             $query,
             implode(' AND ', $where)
         );
@@ -886,7 +886,7 @@ class DB2Platform extends AbstractPlatform
      * 
      * @param  string $query
      * 
-     * @return array|string[]|mixed[]
+     * @return string
      */
     private function getOrderByForOver($query)
     {
@@ -938,6 +938,6 @@ class DB2Platform extends AbstractPlatform
             $orderByArray[0] = 'ORDER BY ' . $orderByArray[0];
         }
 
-        return $orderByArray;
+        return implode(',', $oderByArray;
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -934,7 +934,9 @@ class DB2Platform extends AbstractPlatform
                     default:
                         $arrayFound = array_search($splitValue, $queryArray);
 
-                        $splitOrder[$splitIndex] = $arrayFound === false
+                        $splitOrder[$splitIndex] = $arrayFound === false ||
+                                                   $arrayFound >= count($queryArray) ||
+                                                   $queryArray[$arrayFound + 1] === ""
                                                    ? $splitValue
                                                    : $queryArray[$arrayFound + 1];
                         break;

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -889,7 +889,7 @@ class DB2Platform extends AbstractPlatform
      * 
      * @return string
      */
-    private function getOrderByForOver($query)
+    private function getOrderByForOver(string $query): string
     {
         //preset empty array
         $orderByArray = [];

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -377,6 +377,33 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function testModifiesLimitQueryWithOrderBy()
+    {
+        self::assertEquals(
+            'SELECT * FROM user ORDER BY id',
+            $this->_platform->modifyLimitQuery('SELECT * FROM user ORDER BY id', null, null)
+        );
+
+        self::assertEquals(
+            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user) db21) db22 WHERE db22.DC_ROWNUM <= 10',
+            $this->_platform->modifyLimitQuery('SELECT * FROM user ORDER BY id', 10, 0)
+        );
+
+        self::assertEquals(
+            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user) db21) db22 WHERE db22.DC_ROWNUM <= 10',
+            $this->_platform->modifyLimitQuery('SELECT * FROM user', 10)
+        );
+
+        self::assertEquals(
+            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user) db21) db22 WHERE db22.DC_ROWNUM >= 6 AND db22.DC_ROWNUM <= 15',
+            $this->_platform->modifyLimitQuery('SELECT * FROM user', 10, 5)
+        );
+        self::assertEquals(
+            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user) db21) db22 WHERE db22.DC_ROWNUM >= 6 AND db22.DC_ROWNUM <= 5',
+            $this->_platform->modifyLimitQuery('SELECT * FROM user', 0, 5)
+        );
+    }
+    
     public function testPrefersIdentityColumns()
     {
         self::assertTrue($this->_platform->prefersIdentityColumns());

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -379,28 +379,22 @@ class DB2PlatformTest extends AbstractPlatformTestCase
 
     public function testModifiesLimitQueryWithOrderBy()
     {
+        // no limit, no offset, order by id
         self::assertEquals(
             'SELECT * FROM user ORDER BY id',
             $this->_platform->modifyLimitQuery('SELECT * FROM user ORDER BY id', null, null)
         );
 
+        // 10 row limit, no offset, order by id
         self::assertEquals(
             'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user) db21) db22 WHERE db22.DC_ROWNUM <= 10',
-            $this->_platform->modifyLimitQuery('SELECT * FROM user ORDER BY id', 10, 0)
+            $this->_platform->modifyLimitQuery('SELECT * FROM user ORDER BY id', 10)
         );
 
+        // no limit, 10 rows offset, order by id
         self::assertEquals(
             'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user) db21) db22 WHERE db22.DC_ROWNUM <= 10',
-            $this->_platform->modifyLimitQuery('SELECT * FROM user', 10)
-        );
-
-        self::assertEquals(
-            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user) db21) db22 WHERE db22.DC_ROWNUM >= 6 AND db22.DC_ROWNUM <= 15',
-            $this->_platform->modifyLimitQuery('SELECT * FROM user', 10, 5)
-        );
-        self::assertEquals(
-            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user) db21) db22 WHERE db22.DC_ROWNUM >= 6 AND db22.DC_ROWNUM <= 5',
-            $this->_platform->modifyLimitQuery('SELECT * FROM user', 0, 5)
+            $this->_platform->modifyLimitQuery('SELECT * FROM user ORDER BY id', 0, 10)
         );
     }
     

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -402,6 +402,12 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY USERID_3 ASC) AS DC_ROWNUM FROM (SELECT t0.manager AS MANAGER_1, t0.name AS NAME_2, t0.userId AS USERID_3, t0.email AS EMAIL_4 FROM user t0 ORDER BY t0.userId ASC) db21) db22 WHERE db22.DC_ROWNUM >= 11 AND db22.DC_ROWNUM <= 20',
             $this->_platform->modifyLimitQuery('SELECT t0.manager AS MANAGER_1, t0.name AS NAME_2, t0.userId AS USERID_3, t0.email AS EMAIL_4 FROM user t0 ORDER BY t0.userId ASC', 10, 10)
         );
+
+        // select specific columns, order on 3 columns in different directions
+        self::assertEquals(
+            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY USERID_3 ASC,MANAGER_1 DESC,EMAIL_4 ASC) AS DC_ROWNUM FROM (SELECT t0.manager AS MANAGER_1, t0.name AS NAME_2, t0.userId AS USERID_3, t0.email AS EMAIL_4 FROM driverManagerEmployed t0 ORDER BY t0.userId ASC, t0.manager DESC, t0.email ASC) db21) db22 WHERE db22.DC_ROWNUM >= 11 AND db22.DC_ROWNUM <= 20',
+            $this->_platform->modifyLimitQuery('SELECT t0.manager AS MANAGER_1, t0.name AS NAME_2, t0.userId AS USERID_3, t0.email AS EMAIL_4 FROM driverManagerEmployed t0 ORDER BY t0.userId ASC, t0.manager DESC, t0.email ASC', 10, 10)
+        );
     }
     
     public function testPrefersIdentityColumns()

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -391,9 +391,9 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             $this->_platform->modifyLimitQuery('SELECT * FROM user ORDER BY id', 10)
         );
 
-        // no limit, 10 rows offset, order by id
+        // 0 limit, 10 rows offset, order by id
         self::assertEquals(
-            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user ORDER BY id) db21) db22 WHERE db22.DC_ROWNUM <= 10',
+            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user ORDER BY id) db21) db22 WHERE db22.DC_ROWNUM >= 11 AND db22.DC_ROWNUM <= 10',
             $this->_platform->modifyLimitQuery('SELECT * FROM user ORDER BY id', 0, 10)
         );
         

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -387,14 +387,20 @@ class DB2PlatformTest extends AbstractPlatformTestCase
 
         // 10 row limit, no offset, order by id
         self::assertEquals(
-            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user) db21) db22 WHERE db22.DC_ROWNUM <= 10',
+            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user ORDER BY id) db21) db22 WHERE db22.DC_ROWNUM <= 10',
             $this->_platform->modifyLimitQuery('SELECT * FROM user ORDER BY id', 10)
         );
 
         // no limit, 10 rows offset, order by id
         self::assertEquals(
-            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user) db21) db22 WHERE db22.DC_ROWNUM <= 10',
+            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY id) AS DC_ROWNUM FROM (SELECT * FROM user ORDER BY id) db21) db22 WHERE db22.DC_ROWNUM <= 10',
             $this->_platform->modifyLimitQuery('SELECT * FROM user ORDER BY id', 0, 10)
+        );
+        
+        // select specific columns
+        self::assertEquals(
+            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER(ORDER BY USERID_3 ASC) AS DC_ROWNUM FROM (SELECT t0.manager AS MANAGER_1, t0.name AS NAME_2, t0.userId AS USERID_3, t0.email AS EMAIL_4 FROM user t0 ORDER BY t0.userId ASC) db21) db22 WHERE db22.DC_ROWNUM >= 11 AND db22.DC_ROWNUM <= 20',
+            $this->_platform->modifyLimitQuery('SELECT t0.manager AS MANAGER_1, t0.name AS NAME_2, t0.userId AS USERID_3, t0.email AS EMAIL_4 FROM user t0 ORDER BY t0.userId ASC', 10, 10)
         );
     }
     


### PR DESCRIPTION
Finished up the missing ORDER BY within OVER() on IBMDB2.  
Might not be the best and most elegant approach, but that's how it works for us.
I am sure many IBM shops would appreciate it.