### PR TITLE
Add restart identity command to truncate SQL code

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -1072,7 +1072,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     public function getTruncateTableSQL($tableName, $cascade = false)
     {
         $tableIdentifier = new Identifier($tableName);
-        $sql = 'TRUNCATE ' . $tableIdentifier->getQuotedName($this);
+        $sql = 'TRUNCATE ' . $tableIdentifier->getQuotedName($this) . ' RESTART IDENTITY';
 
         if ($cascade) {
             $sql .= ' CASCADE';


### PR DESCRIPTION
I was looking for a way to reset the ids between tests. Postgres needs the addition of 'RESTART IDENTITY' to the truncate command in order to do that. Maybe this would be a useful default, as rollbacks of truncate are impossible anyway.
This would make truncate behave like it does in MySQL.