### PR TITLE
Escape "#" in regex in SqliteSchemaManager

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -427,7 +427,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     private function parseColumnCollationFromSQL($column, $sql)
     {
         if (preg_match(
-            '/(?:'.preg_quote($column).'|'.preg_quote($this->_platform->quoteSingleIdentifier($column)).')
+            '/(?:'.$this->pregQuote($column).'|'.$this->pregQuote($this->_platform->quoteSingleIdentifier($column)).')
                 [^,(]+(?:\([^()]+\)[^,]*)?
                 (?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*
                 COLLATE\s+["\']?([^\s,"\')]+)/isx', $sql, $match)) {
@@ -446,7 +446,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     private function parseColumnCommentFromSQL($column, $sql)
     {
         if (preg_match(
-            '/[\s(,](?:'.preg_quote($this->_platform->quoteSingleIdentifier($column)).'|'.preg_quote($column).')
+            '/[\s(,](?:'.$this->pregQuote($this->_platform->quoteSingleIdentifier($column)).'|'.$this->pregQuote($column).')
             (?:\(.*?\)|[^,(])*?,?((?:\s*--[^\n]*\n?)+)
             /isx', $sql, $match
         )) {
@@ -456,5 +456,10 @@ class SqliteSchemaManager extends AbstractSchemaManager
         }
 
         return false;
+    }
+    
+    private function pregQuote($str)
+    {
+        return preg_quote($str, '#');
     }
 }

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -427,7 +427,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     private function parseColumnCollationFromSQL($column, $sql)
     {
         if (preg_match(
-            '{(?:'.preg_quote($column).'|'.preg_quote($this->_platform->quoteSingleIdentifier($column)).')
+            '{(?:'.$this->escapeRegex($column).'|'.$this->escapeRegex($this->_platform->quoteSingleIdentifier($column)).')
                 [^,(]+(?:\([^()]+\)[^,]*)?
                 (?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*
                 COLLATE\s+["\']?([^\s,"\')]+)}isx', $sql, $match)) {
@@ -446,7 +446,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     private function parseColumnCommentFromSQL($column, $sql)
     {
         if (preg_match(
-            '{[\s(,](?:'.preg_quote($this->_platform->quoteSingleIdentifier($column)).'|'.preg_quote($column).')
+            '{[\s(,](?:'.$this->escapeRegex($this->_platform->quoteSingleIdentifier($column)).'|'.$this->escapeRegex($column).')
             (?:\(.*?\)|[^,(])*?,?((?:\s*--[^\n]*\n?)+)
             }isx', $sql, $match
         )) {
@@ -456,5 +456,10 @@ class SqliteSchemaManager extends AbstractSchemaManager
         }
 
         return false;
+    }
+
+    private function escapeRegex($str)
+    {
+        return str_replace(['#'], ['\#'], preg_quote($str));
     }
 }

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -427,10 +427,10 @@ class SqliteSchemaManager extends AbstractSchemaManager
     private function parseColumnCollationFromSQL($column, $sql)
     {
         if (preg_match(
-            '{(?:'.$this->escapeRegex($column).'|'.$this->escapeRegex($this->_platform->quoteSingleIdentifier($column)).')
+            '/(?:'.preg_quote($column).'|'.preg_quote($this->_platform->quoteSingleIdentifier($column)).')
                 [^,(]+(?:\([^()]+\)[^,]*)?
                 (?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*
-                COLLATE\s+["\']?([^\s,"\')]+)}isx', $sql, $match)) {
+                COLLATE\s+["\']?([^\s,"\')]+)/isx', $sql, $match)) {
             return $match[1];
         }
 
@@ -446,9 +446,9 @@ class SqliteSchemaManager extends AbstractSchemaManager
     private function parseColumnCommentFromSQL($column, $sql)
     {
         if (preg_match(
-            '{[\s(,](?:'.$this->escapeRegex($this->_platform->quoteSingleIdentifier($column)).'|'.$this->escapeRegex($column).')
+            '/[\s(,](?:'.preg_quote($this->_platform->quoteSingleIdentifier($column)).'|'.preg_quote($column).')
             (?:\(.*?\)|[^,(])*?,?((?:\s*--[^\n]*\n?)+)
-            }isx', $sql, $match
+            /isx', $sql, $match
         )) {
             $comment = preg_replace('{^\s*--}m', '', rtrim($match[1], "\n"));
 
@@ -456,10 +456,5 @@ class SqliteSchemaManager extends AbstractSchemaManager
         }
 
         return false;
-    }
-
-    private function escapeRegex($str)
-    {
-        return str_replace(['#'], ['\#'], preg_quote($str));
     }
 }

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -458,6 +458,11 @@ class SqliteSchemaManager extends AbstractSchemaManager
         return false;
     }
     
+    /**
+     * @param string $str
+     * 
+     * @return string
+     */
     private function pregQuote($str)
     {
         return preg_quote($str, '#');

--- a/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaManagerTest.php
@@ -41,6 +41,12 @@ class SqliteSchemaManagerTest extends \PHPUnit_Framework_TestCase
             array(
                 'RTRIM', 'a"b', 'CREATE TABLE "a" ("a""b" text COLLATE RTRIM)'
             ),
+            array(
+                'utf-8', 'bar#', 'CREATE TABLE dummy_table (id INTEGER NOT NULL, foo VARCHAR(255) COLLATE "utf-8" NOT NULL, "bar#" VARCHAR(255) COLLATE "utf-8" NOT NULL, baz VARCHAR(255) COLLATE "utf-8" NOT NULL, PRIMARY KEY(id))'
+            ),
+            array(
+                'utf-8', 'baz', 'CREATE TABLE dummy_table (id INTEGER NOT NULL, foo VARCHAR(255) COLLATE "utf-8" NOT NULL, "bar#" INTEGER NOT NULL, baz VARCHAR(255) COLLATE "utf-8" NOT NULL, PRIMARY KEY(id))'
+            ),
         );
     }
 }


### PR DESCRIPTION
This pull request escapes `#` in sqlite db column names.

See issue https://github.com/doctrine/dbal/issues/2881 for more information.