### PR TITLE
Add support for PDO_DBLIB driver (SQL Server and potentially Sybase ASE)

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractDbLibDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractDbLibDriver.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver;
+
+use Doctrine\DBAL\Driver\PDOException;
+
+/**
+ * DbLib Driver implementation.
+ *
+ * @since 2.6
+ * @author Maximilian Ruta <mr@xtain.net>
+ */
+class AbstractDbLibDriver
+{
+    /**
+     * @param array $params
+     * @param array $driverOptions
+     * @return string
+     */
+    public static function constructPdoDsn(array $params, array $driverOptions)
+    {
+        if (isset($driverOptions['protocol_version']) && !isset($params['protocol_version'])) {
+            $params['protocol_version'] = $driverOptions['protocol_version'];
+        }
+
+        $dsn = 'dblib:host=';
+
+        if (isset($params['host'])) {
+            $dsn .= $params['host'];
+        }
+
+        if (isset($params['port']) && !empty($params['port'])) {
+            $dsn .= ':' . $params['port'];
+        }
+
+        if (isset($params['dbname'])) {
+            $dsn .= ';dbname=' .  $params['dbname'];
+        }
+
+        if (isset($params['charset'])) {
+            $dsn .= ';chartset=' . $params['charset'];
+        }
+
+        if (isset($params['protocol_version'])) {
+            $dsn .= ';version=' . $params['protocol_version'];
+        }
+
+        return $dsn;
+    }
+
+    /**
+     * @param \PDO $PDO
+     * @param array $args
+     *
+     * @return \PDOStatement
+     * @throws \Exception
+     */
+    public static function emulateQuery(\PDO $PDO, array $args)
+    {
+        $argsCount = count($args);
+
+        try {
+            $stmt = $PDO->prepare($args[0]);
+
+            if ($stmt === false) {
+                throw new \Exception('prepare failed');
+            }
+
+            if ($argsCount == 4) {
+                $stmt->setFetchMode($args[1], $args[2], $args[3]);
+            }
+
+            if ($argsCount == 3) {
+                $stmt->setFetchMode($args[1], $args[2]);
+            }
+
+            if ($argsCount == 2) {
+                $stmt->setFetchMode($args[1]);
+            }
+
+            $stmt->execute();
+            return $stmt;
+        } catch (\PDOException $exception) {
+            throw new PDOException($exception);
+        }
+    }
+
+}

--- a/lib/Doctrine/DBAL/Driver/DbLibPDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/DbLibPDOStatement.php
@@ -1,0 +1,207 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver;
+
+/**
+ * DbLib Driver implementation.
+ *
+ * @since 2.6
+ * @author Maximilian Ruta <mr@xtain.net>
+ */
+class DbLibPDOStatement extends PDOStatement
+{
+    /**
+     * @var self
+     */
+    protected static $lastActive;
+
+    /**
+     * @var array
+     */
+    protected $resultCache;
+
+    /**
+     * @param mixed $value
+     * @param int   $type
+     *
+     * @return mixed
+     */
+    protected function guessType($value)
+    {
+        if (is_scalar($value)) {
+            if (is_int($value) || is_float($value)) {
+                return \PDO::PARAM_INT;
+            } else if (is_bool($value)) {
+                return \PDO::PARAM_BOOL;
+            }
+        }
+
+        return \PDO::PARAM_STR;
+    }
+
+    /**
+     * @param mixed $value
+     * @param int   $type
+     *
+     * @return mixed
+     */
+    protected function fixType($value, $type = \PDO::PARAM_STR)
+    {
+        switch ($type) {
+            case \PDO::PARAM_NULL:
+                return null;
+            case \PDO::PARAM_INT:
+                $float = floatval($value);
+                $int = intval($float);
+                if ($float && $int != $float) {
+                    return $float;
+                }
+
+                return $int;
+            case \PDO::PARAM_BOOL:
+                return $value ? 1 : 0;
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindValue($param, $value, $type = null)
+    {
+        if ($type === null) {
+            $type = $this->guessType($value);
+        }
+
+        return parent::bindValue(
+            $param,
+            $this->fixType($value, $type),
+            $type
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindParam($column, &$variable, $type = null, $length = null, $driverOptions = null)
+    {
+        if ($type === null) {
+            $type = $this->guessType($variable);
+        }
+
+        $variable = $this->fixType($variable, $type);
+        return parent::bindParam($column, $variable, $type, $length, $driverOptions);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchColumn($columnIndex = 0)
+    {
+        if (isset($this->resultCache)) {
+            if (count($this->resultCache) == 0) {
+                return false;
+            }
+
+            $item = array_values(array_shift($this->resultCache));
+
+            return $item[$columnIndex];
+        } else {
+            return parent::fetchColumn($columnIndex);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch($fetchMode = null, $cursorOrientation = null, $cursorOffset = null)
+    {
+        if (isset($this->resultCache)) {
+            if ($fetchMode != \PDO::FETCH_ASSOC && $cursorOrientation !== null || $cursorOffset !== null) {
+                throw new \RuntimeException('result caching is only implemented for PDO::FETCH_ASSOC');
+            }
+
+            if (count($this->resultCache) == 0) {
+                return false;
+            }
+
+            return array_shift($this->resultCache);
+        } else {
+            return parent::fetch($fetchMode, $cursorOrientation, $cursorOffset);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
+    {
+        if (isset($this->resultCache)) {
+            if ($fetchMode != \PDO::FETCH_ASSOC && $fetchArgument !== null || $ctorArgs !== null) {
+                throw new \RuntimeException('result caching is only implemented for PDO::FETCH_ASSOC');
+            }
+
+            $data = $this->resultCache;
+            $this->resultCache = array();
+            return $data;
+        } else {
+            return parent::fetchAll($fetchMode, $fetchArgument, $ctorArgs);
+        }
+    }
+
+    protected function cacheResults()
+    {
+        $this->resultCache = parent::fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($params = null)
+    {
+        if ($params !== null) {
+            foreach ($params as $key => $value) {
+                if (is_int($key)) {
+                    $key++;
+                }
+
+                $this->bindValue($key, $value, null);
+            }
+        }
+
+        if (self::$lastActive instanceof self) {
+            self::$lastActive->cacheResults();
+        }
+
+        $result = parent::execute();
+
+        self::$lastActive = $this;
+
+        // forward to the result set which is not empty
+        while ($this->columnCount() == 0) {
+            if (!$this->nextRowset()) {
+                break;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/PDOMSSQL/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMSSQL/Connection.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver\PDOMSSQL;
+
+use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\AbstractDbLibDriver;
+
+/**
+ * DbLib implementation.
+ *
+ * @since 2.0
+ */
+class Connection extends PDOConnection implements \Doctrine\DBAL\Driver\Connection
+{
+    /**
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * @param string      $dsn
+     * @param string|null $user
+     * @param string|null $password
+     * @param array|null  $options
+     *
+     * @throws \PDOException in case of an error.
+     */
+    public function __construct($dsn, $user = null, $password = null, array $options = null)
+    {
+        parent::__construct($dsn, $user, $password, $options);
+        $this->setAttribute(\PDO::ATTR_STATEMENT_CLASS, array('Doctrine\DBAL\Driver\DbLibPDOStatement', array()));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getServerVersion()
+    {
+        // The PDO version method is not supported by dblib currently
+        $result = $this->prepare('SELECT @@version');
+        $result->execute();
+        return $result->fetchColumn(0);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function query()
+    {
+        return AbstractDbLibDriver::emulateQuery($this, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresQueryForServerVersion()
+    {
+        return true;
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/PDOMSSQL/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMSSQL/Driver.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Driver\PDOMSSQL;
+
+use Doctrine\DBAL\Driver\AbstractDbLibDriver;
+use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
+
+/**
+ * DbLib implementation.
+ *
+ * @since 2.0
+ */
+class Driver extends AbstractSQLServerDriver
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
+    {
+        $connection = new Connection(
+            AbstractDbLibDriver::constructPdoDsn($params, $driverOptions),
+            $username,
+            $password,
+            $driverOptions
+        );
+
+        return $connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'pdo_mssql';
+    }
+}

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -45,6 +45,7 @@ final class DriverManager
          'oci8'               => 'Doctrine\DBAL\Driver\OCI8\Driver',
          'ibm_db2'            => 'Doctrine\DBAL\Driver\IBMDB2\DB2Driver',
          'pdo_sqlsrv'         => 'Doctrine\DBAL\Driver\PDOSqlsrv\Driver',
+         'pdo_mssql'          => 'Doctrine\DBAL\Driver\PDOMSSQL\Driver',
          'mysqli'             => 'Doctrine\DBAL\Driver\Mysqli\Driver',
          'drizzle_pdo_mysql'  => 'Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver',
          'sqlanywhere'        => 'Doctrine\DBAL\Driver\SQLAnywhere\Driver',


### PR DESCRIPTION
The current official Version for SQL Server is not available in a stable version for PHP7 and only from the latest version on available for Linux. The FreeTDS PDO_DBLIB driver is there since ages and is also part of PHP7.

It is working without problems for SQL Server, and Sybase ASE. So why should we not support it?

The there are two issues i had to add workarounds for:
 - You can only read the results of one query in parallel.
 - SQL Server and Sybase ASE are very strict in type checking. So we have to pass always the correct type.