### PR TITLE
Added guid type support to DB2 platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -878,4 +878,20 @@ class DB2Platform extends AbstractPlatform
     {
         return Keywords\DB2Keywords::class;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGuidTypeDeclarationSQL(array $field)
+    {
+        return 'CHAR(13) FOR BIT DATA';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGuidExpression()
+    {
+        return 'GENERATE_UNIQUE()';
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -504,7 +504,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
      */
     public function testReturnsGuidTypeDeclarationSQL()
     {
-        self::assertSame('CHAR(36)', $this->_platform->getGuidTypeDeclarationSQL(array()));
+        self::assertSame('CHAR(13) FOR BIT DATA', $this->_platform->getGuidTypeDeclarationSQL(array()));
     }
 
     /**


### PR DESCRIPTION
DB2 has GENERATE_UNIQUE for "UUID" generation, see https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.1.0/com.ibm.db2.luw.sql.ref.doc/doc/r0000809.html