### PR TITLE
Fixes custom type comment regex

### DIFF
--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -1093,7 +1093,7 @@ abstract class AbstractSchemaManager
      */
     public function extractDoctrineTypeFromComment($comment, $currentType)
     {
-        if (preg_match("(\(DC2Type:([a-zA-Z0-9_]+)\))", $comment, $match)) {
+        if (preg_match("(\(DC2Type:(((?!\)).)+)\))", $comment, $match)) {
             $currentType = $match[1];
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1334,4 +1334,30 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
 
         self::assertFalse($tableDiff);
     }
+
+    /**
+     * @dataProvider commentsProvider
+     *
+     * @group 2596
+     */
+    public function testExtractDoctrineTypeFromComment(string $comment, string $expected, string $currentType) : void
+    {
+        $result = $this->_sm->extractDoctrineTypeFromComment($comment, $currentType);
+
+        self::assertSame($expected, $result);
+    }
+
+    public function commentsProvider() : array
+    {
+        $currentType = 'current type';
+
+        return [
+            'invalid custom type comments'      => ['should.return.current.type', $currentType, $currentType],
+            'valid doctrine type'               => ['(DC2Type:guid)', 'guid', $currentType],
+            'valid with dots'                   => ['(DC2Type:type.should.return)', 'type.should.return', $currentType],
+            'valid with namespace'              => ['(DC2Type:Namespace\Class)', 'Namespace\Class', $currentType],
+            'valid with extra closing bracket'  => ['(DC2Type:should.stop)).before)', 'should.stop', $currentType],
+            'valid with extra opening brackets' => ['(DC2Type:should((.stop)).before)', 'should((.stop', $currentType],
+        ];
+    }
 }


### PR DESCRIPTION
This is the same fix as #2679 which fixes the issue #2596 but this PR has tests for the change.