### PR TITLE
Don't Set a Default Value on PostgreSQL SERIAL Fields

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -26,7 +26,9 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\BinaryType;
+use Doctrine\DBAL\Types\BigIntType;
 use Doctrine\DBAL\Types\BlobType;
+use Doctrine\DBAL\Types\IntegerType;
 
 /**
  * PostgreSqlPlatform.
@@ -1185,5 +1187,23 @@ class PostgreSqlPlatform extends AbstractPlatform
         $str = str_replace('\\', '\\\\', $str); // PostgreSQL requires backslashes to be escaped aswell.
 
         return parent::quoteStringLiteral($str);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultValueDeclarationSQL($field)
+    {
+        if ($this->isSerialField($field)) {
+            return '';
+        }
+
+        return parent::getDefaultValueDeclarationSQL($field);
+    }
+
+    private function isSerialField(array $field) : bool
+    {
+        return $field['autoincrement'] ?? false === true && isset($field['type'])
+            && ($field['type'] instanceof IntegerType || $field['type'] instanceof BigIntType);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -419,6 +419,50 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals(-1.1, $columns['col_decimal']->getDefault());
         self::assertEquals('(-1)', $columns['col_string']->getDefault());
     }
+
+    public static function serialTypes() : array
+    {
+        return [
+            ['integer'],
+            ['bigint'],
+        ];
+    }
+
+    /**
+     * @dataProvider serialTypes
+     * @group 2906
+     */
+    public function testAutoIncrementCreatesSerialDataTypesWithoutADefaultValue(string $type) : void
+    {
+        $tableName = "test_serial_type_$type";
+
+        $table = new Schema\Table($tableName);
+        $table->addColumn('id', $type, ['autoincrement' => true, 'notnull' => false]);
+
+        $this->_sm->dropAndCreateTable($table);
+
+        $columns = $this->_sm->listTableColumns($tableName);
+
+        self::assertNull($columns['id']->getDefault());
+    }
+
+    /**
+     * @dataProvider serialTypes
+     * @group 2906
+     */
+    public function testAutoIncrementCreatesSerialDataTypesWithoutADefaultValueEvenWhenDefaultIsSet(string $type) : void
+    {
+        $tableName = "test_serial_type_with_default_$type";
+
+        $table = new Schema\Table($tableName);
+        $table->addColumn('id', $type, ['autoincrement' => true, 'notnull' => false, 'default' => 1]);
+
+        $this->_sm->dropAndCreateTable($table);
+
+        $columns = $this->_sm->listTableColumns($tableName);
+
+        self::assertNull($columns['id']->getDefault());
+    }
 }
 
 class MoneyType extends Type

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -144,6 +144,63 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
         self::assertEquals(array('CREATE TABLE autoinc_table (id SERIAL NOT NULL)'), $this->_platform->getCreateTableSQL($table));
     }
 
+    public static function serialTypes() : array
+    {
+        return [
+            ['integer', 'SERIAL'],
+            ['bigint', 'BIGSERIAL'],
+        ];
+    }
+
+    /**
+     * @dataProvider serialTypes
+     * @group 2906
+     */
+    public function testGenerateTableWithAutoincrementDoesNotSetDefault(string $type, string $definition) : void
+    {
+        $table  = new \Doctrine\DBAL\Schema\Table('autoinc_table_notnull');
+        $column = $table->addColumn('id', $type);
+        $column->setAutoIncrement(true);
+        $column->setNotNull(false);
+
+        $sql = $this->_platform->getCreateTableSQL($table);
+
+        self::assertEquals(["CREATE TABLE autoinc_table_notnull (id $definition)"], $sql);
+    }
+
+    /**
+     * @dataProvider serialTypes
+     * @group 2906
+     */
+    public function testCreateTableWithAutoincrementAndNotNullAddsConstraint(string $type, string $definition) : void
+    {
+        $table  = new \Doctrine\DBAL\Schema\Table('autoinc_table_notnull_enabled');
+        $column = $table->addColumn('id', $type);
+        $column->setAutoIncrement(true);
+        $column->setNotNull(true);
+
+        $sql = $this->_platform->getCreateTableSQL($table);
+
+        self::assertEquals(["CREATE TABLE autoinc_table_notnull_enabled (id $definition NOT NULL)"], $sql);
+    }
+
+    /**
+     * @dataProvider serialTypes
+     * @group 2906
+     */
+    public function testGetDefaultValueDeclarationSQLIgnoresTheDefaultKeyWhenTheFieldIsSerial(string $type) : void
+    {
+        $sql = $this->_platform->getDefaultValueDeclarationSQL(
+            [
+                'autoincrement' => true,
+                'type'          => Type::getType($type),
+                'default'       => 1,
+            ]
+        );
+
+        self::assertSame('', $sql);
+    }
+
     public function testGeneratesTypeDeclarationForIntegers()
     {
         self::assertEquals(


### PR DESCRIPTION
Specifically when `'notnull' => false` is in the column options.

Right now DBAL adds a `DEFAULT NULL` when that happens. `[BIG]SERIAL` fields already have a default value and adding the `DEFAULT NULL` produces an error.

Fixes #2906

Not sure if the functional tests here are necessary, but it seemed like a good idea.