### PR TITLE
Fix Date & Time formats for SQL Server Date & Time Types

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1382,7 +1382,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getDateFormatString()
     {
-        return 'Y-m-d H:i:s.000';
+        return 'Y-m-d';
     }
 
     /**
@@ -1390,7 +1390,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getTimeFormatString()
     {
-        return 'Y-m-d H:i:s.000';
+        return 'H:i:s.000';
     }
 
     /**


### PR DESCRIPTION
Format with the proper expected formats for date `Y-m-d` & time `H:i:s.000` in Sql Server Platform.
#2908