### PR TITLE
Change visibility of some Connection properties

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -118,14 +118,14 @@ class Connection implements DriverConnection
      *
      * @var boolean
      */
-    private $_isConnected = false;
+    protected $_isConnected = false;
 
     /**
      * The current auto-commit mode of this connection.
      *
      * @var boolean
      */
-    private $autoCommit = true;
+    protected $autoCommit = true;
 
     /**
      * The transaction nesting level.
@@ -153,7 +153,7 @@ class Connection implements DriverConnection
      *
      * @var array
      */
-    private $_params = [];
+    protected $_params = [];
 
     /**
      * The DatabasePlatform object that provides information about the


### PR DESCRIPTION
The purpose of this PR is to allow more flexibility in Connection's child, for example, when creating a ConnectionWrapper.

For example, I have a ConnectionWrapper which dynamically change the database name (based on some JWT informations), so with this PR I wouldn't have to duplicate $_params and some other functions.

I think other cases could take advantages of it.