### PR TITLE
Type and name sql argument of query function

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1006,25 +1006,26 @@ class Connection implements DriverConnection
     /**
      * Executes an SQL statement, returning a result set as a Statement object.
      *
+     * @param string $sql
+     * @param array $args
+     *
      * @return \Doctrine\DBAL\Driver\Statement
      *
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function query()
+    public function query($sql, ...$args)
     {
         $this->connect();
 
-        $args = func_get_args();
-
         $logger = $this->_config->getSQLLogger();
         if ($logger) {
-            $logger->startQuery($args[0]);
+            $logger->startQuery($sql);
         }
 
         try {
-            $statement = $this->_conn->query(...$args);
+            $statement = $this->_conn->query($sql, ...$args);
         } catch (Exception $ex) {
-            throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $args[0]);
+            throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $sql);
         }
 
         $statement->setFetchMode($this->defaultFetchMode);

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -360,18 +360,16 @@ class MasterSlaveConnection extends Connection
     /**
      * {@inheritDoc}
      */
-    public function query()
+    public function query($sql, ...$args)
     {
         $this->connect('master');
 
-        $args = func_get_args();
-
         $logger = $this->getConfiguration()->getSQLLogger();
         if ($logger) {
-            $logger->startQuery($args[0]);
+            $logger->startQuery($sql);
         }
 
-        $statement = $this->_conn->query(...$args);
+        $statement = $this->_conn->query($sql, ...$args);
 
         if ($logger) {
             $logger->stopQuery();

--- a/lib/Doctrine/DBAL/Driver/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/Connection.php
@@ -41,9 +41,12 @@ interface Connection
     /**
      * Executes an SQL statement, returning a result set as a Statement object.
      *
+     * @param string $sql
+     * @param array $args
+     *
      * @return \Doctrine\DBAL\Driver\Statement
      */
-    function query();
+    function query($sql, ...$args);
 
     /**
      * Quotes a string for use in a query.

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -85,10 +85,8 @@ class DB2Connection implements Connection, ServerInfoAwareConnection
     /**
      * {@inheritdoc}
      */
-    public function query()
+    public function query($sql, ...$args)
     {
-        $args = func_get_args();
-        $sql = $args[0];
         $stmt = $this->prepare($sql);
         $stmt->execute();
 

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -132,10 +132,8 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
     /**
      * {@inheritdoc}
      */
-    public function query()
+    public function query($sql, ...$args)
     {
-        $args = func_get_args();
-        $sql = $args[0];
         $stmt = $this->prepare($sql);
         $stmt->execute();
 

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -106,10 +106,8 @@ class OCI8Connection implements Connection, ServerInfoAwareConnection
     /**
      * {@inheritdoc}
      */
-    public function query()
+    public function query($sql, ...$args)
     {
-        $args = func_get_args();
-        $sql = $args[0];
         //$fetchMode = $args[1];
         $stmt = $this->prepare($sql);
         $stmt->execute();

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -83,25 +83,24 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
     /**
      * {@inheritdoc}
      */
-    public function query()
+    public function query($sql, ...$args)
     {
-        $args = func_get_args();
         $argsCount = count($args);
 
         try {
-            if ($argsCount == 4) {
-                return parent::query($args[0], $args[1], $args[2], $args[3]);
-            }
-
             if ($argsCount == 3) {
-                return parent::query($args[0], $args[1], $args[2]);
+                return parent::query($sql, $args[0], $args[1], $args[2]);
             }
 
             if ($argsCount == 2) {
-                return parent::query($args[0], $args[1]);
+                return parent::query($sql, $args[0], $args[1]);
             }
 
-            return parent::query($args[0]);
+            if ($argsCount == 1) {
+                return parent::query($sql, $args[0]);
+            }
+
+            return parent::query($sql);
         } catch (\PDOException $exception) {
             throw new PDOException($exception);
         }

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -85,22 +85,8 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
      */
     public function query($sql, ...$args)
     {
-        $argsCount = count($args);
-
         try {
-            if ($argsCount == 3) {
-                return parent::query($sql, $args[0], $args[1], $args[2]);
-            }
-
-            if ($argsCount == 2) {
-                return parent::query($sql, $args[0], $args[1]);
-            }
-
-            if ($argsCount == 1) {
-                return parent::query($sql, $args[0]);
-            }
-
-            return parent::query($sql);
+            return parent::query($sql, ...$args);
         } catch (\PDOException $exception) {
             throw new PDOException($exception);
         }

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -159,10 +159,9 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
     /**
      * {@inheritdoc}
      */
-    public function query()
+    public function query($sql, ...$args)
     {
-        $args = func_get_args();
-        $stmt = $this->prepare($args[0]);
+        $stmt = $this->prepare($sql);
 
         $stmt->execute();
 

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -88,10 +88,8 @@ class SQLSrvConnection implements Connection, ServerInfoAwareConnection
     /**
      * {@inheritDoc}
      */
-    public function query()
+    public function query($sql, ...$args)
     {
-        $args = func_get_args();
-        $sql = $args[0];
         $stmt = $this->prepare($sql);
         $stmt->execute();
 

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -137,11 +137,11 @@ class Connection extends \Doctrine\DBAL\Connection
     /**
      * {@inheritdoc}
      */
-    public function query()
+    public function query($sql, ...$args)
     {
         $this->connect();
 
-        $stmt = $this->_conn->query(...func_get_args());
+        $stmt = $this->_conn->query($sql, ...$args);
         $stmt = new Statement($stmt, $this);
         $stmt->setFetchMode($this->defaultFetchMode);
 

--- a/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\Mocks;
 class DriverConnectionMock implements \Doctrine\DBAL\Driver\Connection
 {
     public function prepare($prepareString) {}
-    public function query() {}
+    public function query($sql, ...$args) {}
     public function quote($input, $type=\PDO::PARAM_STR) {}
     public function exec($statement) {}
     public function lastInsertId($name = null) {}


### PR DESCRIPTION
Several functions use first argument of `Connection::query` function. This argument is named and typed as string in functions which use it, but is not documented in `query` function.

For example, in `Doctrine\DBAL\Connection`, the logger uses it in `startQuery` function. `$sql` is named and typed in `SQLLogger` interface, but not in `query` function.

This PR names this argument to increase visibility and avoid to use `func_get_args` and `$args[0]` for `$sql` parameter.