### PR TITLE
Add tests for column collation to prove it works

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1487,7 +1487,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         $currentDateSql = $this->_platform->getCurrentDateSQL();
         foreach (['date', 'date_immutable'] as $type) {
             $field = [
-                'type'    => Type::getType($type),
+                'type' => Type::getType($type),
                 'default' => $currentDateSql,
             ];
 
@@ -1496,6 +1496,32 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
                 $this->_platform->getDefaultValueDeclarationSQL($field)
             );
         }
+    }
+
+    public function testSupportsColumnCollation() : void
+    {
+        self::assertTrue($this->_platform->supportsColumnCollation());
+    }
+
+    public function testColumnCollationDeclarationSQL() : void
+    {
+        self::assertSame(
+            'COLLATE Latin1_General_CS_AS_KS_WS',
+            $this->_platform->getColumnCollationDeclarationSQL('Latin1_General_CS_AS_KS_WS')
+        );
+    }
+
+    public function testGetCreateTableSQLWithColumnCollation() : void
+    {
+        $table = new Table('foo');
+        $table->addColumn('no_collation', 'string');
+        $table->addColumn('column_collation', 'string')->setPlatformOption('collation', 'Latin1_General_CS_AS_KS_WS');
+
+        self::assertSame(
+            ['CREATE TABLE foo (no_collation NVARCHAR(255) NOT NULL, column_collation NVARCHAR(255) COLLATE Latin1_General_CS_AS_KS_WS NOT NULL)'],
+            $this->_platform->getCreateTableSQL($table),
+            'Column "no_collation" will use the default collation from the table/database and "column_collation" overwrites the collation on this column'
+        );
     }
 
     private function expectCteWithMaxRowNum(string $expectedSql, int $expectedMax, string $sql) : void

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL91PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL91PlatformTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\PostgreSQL91Platform;
+use Doctrine\DBAL\Schema\Table;
 
 class PostgreSql91PlatformTest extends PostgreSqlPlatformTest
 {
@@ -11,11 +12,29 @@ class PostgreSql91PlatformTest extends PostgreSqlPlatformTest
         return new PostgreSQL91Platform();
     }
 
-    public function testColumnCollationDeclarationSQL()
+    public function testSupportsColumnCollation() : void
     {
-        self::assertEquals(
+        self::assertTrue($this->_platform->supportsColumnCollation());
+    }
+
+    public function testColumnCollationDeclarationSQL() : void
+    {
+        self::assertSame(
             'COLLATE "en_US.UTF-8"',
             $this->_platform->getColumnCollationDeclarationSQL('en_US.UTF-8')
+        );
+    }
+
+    public function testGetCreateTableSQLWithColumnCollation() : void
+    {
+        $table = new Table('foo');
+        $table->addColumn('no_collation', 'string');
+        $table->addColumn('column_collation', 'string')->setPlatformOption('collation', 'en_US.UTF-8');
+
+        self::assertSame(
+            ['CREATE TABLE foo (no_collation VARCHAR(255) NOT NULL, column_collation VARCHAR(255) NOT NULL COLLATE "en_US.UTF-8")'],
+            $this->_platform->getCreateTableSQL($table),
+            'Column "no_collation" will use the default collation from the table/database and "column_collation" overwrites the collation on this column'
         );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -759,4 +759,30 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     {
         self::assertSame("DATE(rentalBeginsOn,'+' || duration || ' DAY')", $this->_platform->getDateAddDaysExpression('rentalBeginsOn', 'duration'));
     }
+
+    public function testSupportsColumnCollation() : void
+    {
+        self::assertTrue($this->_platform->supportsColumnCollation());
+    }
+
+    public function testColumnCollationDeclarationSQL() : void
+    {
+        self::assertSame(
+            'COLLATE NOCASE',
+            $this->_platform->getColumnCollationDeclarationSQL('NOCASE')
+        );
+    }
+
+    public function testGetCreateTableSQLWithColumnCollation() : void
+    {
+        $table = new Table('foo');
+        $table->addColumn('no_collation', 'string');
+        $table->addColumn('column_collation', 'string')->setPlatformOption('collation', 'NOCASE');
+
+        self::assertSame(
+            ['CREATE TABLE foo (no_collation VARCHAR(255) NOT NULL, column_collation VARCHAR(255) NOT NULL COLLATE NOCASE)'],
+            $this->_platform->getCreateTableSQL($table),
+            'Column "no_collation" will use the default collation (BINARY) and "column_collation" overwrites the collation on this column'
+        );
+    }
 }


### PR DESCRIPTION
Fixes #2551

The main point is that one must use the platform or the custom option for the `collation` and not the standard option for columns. The reasoning I guess is that those options are not cross-RDBMS compatible. There are two things that are inconsistent and causing alot of the confusion:

1. platform vs custom schema option (both result in the same outcome)
    - SchemaManager uses `\Doctrine\DBAL\Schema\Column::setPlatformOption`, see https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php#L203
    - SchemaTool uses `\Doctrine\DBAL\Schema\Column::setCustomSchemaOption`, see https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Tools/SchemaTool.php#L460
2. on the column level the option is called `collation` but on the table level the option is called `collate` (only relevant for mysql, see https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php#L499 )