### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
@@ -75,7 +75,7 @@ class BlobTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         $rows = $this->_conn->fetchAll('SELECT * FROM blob_table');
 
-        self::assertEquals(1, count($rows));
+        self::assertCount(1, $rows);
         $row = array_change_key_case($rows[0], CASE_LOWER);
 
         $blobValue = Type::getType('binary')->convertToPHPValue($row['binaryfield'], $this->_conn->getDatabasePlatform());
@@ -88,7 +88,7 @@ class BlobTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         $rows = $this->_conn->fetchAll('SELECT * FROM blob_table');
 
-        self::assertEquals(1, count($rows));
+        self::assertCount(1, $rows);
         $row = array_change_key_case($rows[0], CASE_LOWER);
 
         $blobValue = Type::getType('blob')->convertToPHPValue($row['blobfield'], $this->_conn->getDatabasePlatform());

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -165,7 +165,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $stmt->execute(array($paramInt, $paramStr));
 
         $row = $stmt->fetch(\PDO::FETCH_ASSOC);
-        self::assertTrue($row !== false);
+        self::assertNotFalse($row);
         $row = array_change_key_case($row, \CASE_LOWER);
         self::assertEquals(array('test_int' => 1, 'test_string' => 'foo'), $row);
     }
@@ -175,10 +175,10 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $sql = "SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?";
         $data = $this->_conn->fetchAll($sql, array(1, 'foo'));
 
-        self::assertEquals(1, count($data));
+        self::assertCount(1, $data);
 
         $row = $data[0];
-        self::assertEquals(2, count($row));
+        self::assertCount(2, $row);
 
         $row = array_change_key_case($row, \CASE_LOWER);
         self::assertEquals(1, $row['test_int']);
@@ -195,10 +195,10 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
         $data = $this->_conn->fetchAll($sql, array(1, $datetime), array(PDO::PARAM_STR, Type::DATETIME));
 
-        self::assertEquals(1, count($data));
+        self::assertCount(1, $data);
 
         $row = $data[0];
-        self::assertEquals(2, count($row));
+        self::assertCount(2, $row);
 
         $row = array_change_key_case($row, \CASE_LOWER);
         self::assertEquals(1, $row['test_int']);
@@ -227,7 +227,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $sql = "SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?";
         $row = $this->_conn->executeQuery($sql, array(1, 'foo'))->fetch(\PDO::FETCH_BOTH);
 
-        self::assertTrue($row !== false);
+        self::assertNotFalse($row);
 
         $row = array_change_key_case($row, \CASE_LOWER);
 
@@ -249,7 +249,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $sql = "SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?";
         $row = $this->_conn->fetchAssoc($sql, array(1, 'foo'));
 
-        self::assertTrue($row !== false);
+        self::assertNotFalse($row);
 
         $row = array_change_key_case($row, \CASE_LOWER);
 
@@ -264,7 +264,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
         $row = $this->_conn->fetchAssoc($sql, array(1, $datetime), array(PDO::PARAM_STR, Type::DATETIME));
 
-        self::assertTrue($row !== false);
+        self::assertNotFalse($row);
 
         $row = array_change_key_case($row, \CASE_LOWER);
 
@@ -304,7 +304,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
         $row = $this->_conn->fetchArray($sql, array(1, $datetime), array(PDO::PARAM_STR, Type::DATETIME));
 
-        self::assertTrue($row !== false);
+        self::assertNotFalse($row);
 
         $row = array_change_key_case($row, \CASE_LOWER);
 
@@ -348,7 +348,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $sql = "SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?";
         $column = $this->_conn->fetchColumn($sql, array(1, $datetime), 1, array(PDO::PARAM_STR, Type::DATETIME));
 
-        self::assertTrue($column !== false);
+        self::assertNotFalse($column);
 
         self::assertStringStartsWith($datetimeString, $column);
     }
@@ -430,14 +430,14 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
             array(array(100, 101, 102, 103, 104)), array(Connection::PARAM_INT_ARRAY));
 
         $data = $stmt->fetchAll(PDO::FETCH_NUM);
-        self::assertEquals(5, count($data));
+        self::assertCount(5, $data);
         self::assertEquals(array(array(100), array(101), array(102), array(103), array(104)), $data);
 
         $stmt = $this->_conn->executeQuery('SELECT test_int FROM fetch_table WHERE test_string IN (?)',
             array(array('foo100', 'foo101', 'foo102', 'foo103', 'foo104')), array(Connection::PARAM_STR_ARRAY));
 
         $data = $stmt->fetchAll(PDO::FETCH_NUM);
-        self::assertEquals(5, count($data));
+        self::assertCount(5, $data);
         self::assertEquals(array(array(100), array(101), array(102), array(103), array(104)), $data);
     }
 
@@ -582,7 +582,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $sql = "SELECT * FROM fetch_table WHERE test_string = " . $this->_conn->quote("bar' OR '1'='1");
         $rows = $this->_conn->fetchAll($sql);
 
-        self::assertEquals(0, count($rows), "no result should be returned, otherwise SQL injection is possible");
+        self::assertCount(0, $rows, "no result should be returned, otherwise SQL injection is possible");
     }
 
     /**
@@ -617,7 +617,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $data   = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 
-        self::assertEquals(4, count($data));
+        self::assertCount(4, $data);
         self::assertEquals(count($bitmap), count($data));
         foreach ($data as $row) {
             $row = array_change_key_case($row, CASE_LOWER);
@@ -643,7 +643,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $stmt->setFetchMode(\PDO::FETCH_NUM);
 
         $row = array_keys($stmt->fetch());
-        self::assertEquals(0, count( array_filter($row, function($v) { return ! is_numeric($v); })), "should be no non-numerical elements in the result.");
+        self::assertCount(0, array_filter($row, function($v) { return ! is_numeric($v); }), "should be no non-numerical elements in the result.");
     }
 
     /**
@@ -694,7 +694,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
             __NAMESPACE__.'\\MyFetchClass'
         );
 
-        self::assertEquals(1, count($results));
+        self::assertCount(1, $results);
         self::assertInstanceOf(__NAMESPACE__.'\\MyFetchClass', $results[0]);
 
         self::assertEquals(1, $results[0]->test_int);
@@ -733,7 +733,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $results = $stmt->fetchAll();
 
-        self::assertEquals(1, count($results));
+        self::assertCount(1, $results);
         self::assertInstanceOf(__NAMESPACE__.'\\MyFetchClass', $results[0]);
 
         self::assertEquals(1, $results[0]->test_int);
@@ -758,7 +758,7 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
             $results[] = $row;
         }
 
-        self::assertEquals(1, count($results));
+        self::assertCount(1, $results);
         self::assertInstanceOf(__NAMESPACE__.'\\MyFetchClass', $results[0]);
 
         self::assertEquals(1, $results[0]->test_int);

--- a/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
@@ -108,7 +108,7 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
     public function assertFetchResultRows($rows)
     {
-        self::assertEquals(2, count($rows));
+        self::assertCount(2, $rows);
         foreach ($rows as $row) {
             $this->assertFetchResultRow($row);
         }
@@ -116,7 +116,7 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
     public function assertFetchResultRow($row)
     {
-        self::assertTrue(in_array($row['test_int'], array(1, 2)), "Primary key test_int should either be 1 or 2.");
+        self::assertContains($row['test_int'], array(1, 2), "Primary key test_int should either be 1 or 2.");
         self::assertArrayHasKey('test_string', $row, "Case should be lowered.");
         self::assertEquals(3, strlen($row['test_string']), "test_string should be rtrimed to length of three for CHAR(32) column.");
         self::assertNull($row['test_null']);

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -127,7 +127,7 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
             $data[] = $row;
         }
 
-        self::assertEquals(2, count($this->sqlLogger->queries));
+        self::assertCount(2, $this->sqlLogger->queries);
     }
 
     public function testDontFinishNoCache()
@@ -141,7 +141,7 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $data = $this->hydrateStmt($stmt, \PDO::FETCH_NUM);
 
-        self::assertEquals(2, count($this->sqlLogger->queries));
+        self::assertCount(2, $this->sqlLogger->queries);
     }
 
     public function assertCacheNonCacheSelectSameFetchModeAreEqual($expectedResult, $fetchMode)
@@ -157,7 +157,7 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         self::assertEquals(2, $stmt->columnCount());
         $data = $this->hydrateStmt($stmt, $fetchMode);
         self::assertEquals($expectedResult, $data);
-        self::assertEquals(1, count($this->sqlLogger->queries), "just one dbal hit");
+        self::assertCount(1, $this->sqlLogger->queries, "just one dbal hit");
     }
 
     public function testEmptyResultCache()
@@ -168,7 +168,7 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $stmt = $this->_conn->executeQuery("SELECT * FROM caching WHERE test_int > 500", array(), array(), new QueryCacheProfile(10, "emptycachekey"));
         $data = $this->hydrateStmt($stmt);
 
-        self::assertEquals(1, count($this->sqlLogger->queries), "just one dbal hit");
+        self::assertCount(1, $this->sqlLogger->queries, "just one dbal hit");
     }
 
     public function testChangeCacheImpl()
@@ -180,8 +180,8 @@ class ResultCacheTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $stmt = $this->_conn->executeQuery("SELECT * FROM caching WHERE test_int > 500", array(), array(), new QueryCacheProfile(10, "emptycachekey", $secondCache));
         $data = $this->hydrateStmt($stmt);
 
-        self::assertEquals(2, count($this->sqlLogger->queries), "two hits");
-        self::assertEquals(1, count($secondCache->fetch("emptycachekey")));
+        self::assertCount(2, $this->sqlLogger->queries, "two hits");
+        self::assertCount(1, $secondCache->fetch("emptycachekey"));
     }
 
     private function hydrateStmt($stmt, $fetchMode = \PDO::FETCH_ASSOC)

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -42,7 +42,7 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $names = $this->_sm->getSchemaNames();
 
         self::assertInternalType('array', $names);
-        self::assertTrue(count($names) > 0);
+        self::assertNotEmpty($names);
         self::assertContains('public', $names, 'The public schema should be found.');
     }
 
@@ -164,7 +164,7 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals(array('id'), $nestedSchemaTable->getPrimaryKey()->getColumns());
 
         $relatedFks = $nestedSchemaTable->getForeignKeys();
-        self::assertEquals(1, count($relatedFks));
+        self::assertCount(1, $relatedFks);
         $relatedFk = array_pop($relatedFks);
         self::assertEquals("nested.schemarelated", $relatedFk->getForeignTableName());
     }
@@ -206,11 +206,11 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->_conn->getConfiguration()->setFilterSchemaAssetsExpression('#^dbal204_#');
         $names = $this->_sm->listTableNames();
-        self::assertEquals(2, count($names));
+        self::assertCount(2, $names);
 
         $this->_conn->getConfiguration()->setFilterSchemaAssetsExpression('#^dbal204_test#');
         $names = $this->_sm->listTableNames();
-        self::assertEquals(1, count($names));
+        self::assertCount(1, $names);
     }
 
     public function testListForeignKeys()

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
@@ -21,7 +21,7 @@ class SQLAnywhereSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $views = $this->_sm->listViews();
 
-        self::assertEquals(1, count($views), "Database has to have one view.");
+        self::assertCount(1, $views, "Database has to have one view.");
         self::assertInstanceOf('Doctrine\DBAL\Schema\View', $views[$name]);
         self::assertEquals($name, $views[$name]->getName());
         self::assertEquals($sql, $views[$name]->getSql());

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -32,7 +32,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->_sm->alterTable($diff);
 
         $columns = $this->_sm->listTableColumns('sqlsrv_drop_column');
-        self::assertEquals(1, count($columns));
+        self::assertCount(1, $columns);
     }
 
     public function testColumnCollation()
@@ -193,7 +193,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->_sm->createTable($table);
 
         $columns = $this->_sm->listTableColumns("sqlsrv_column_comment");
-        self::assertEquals(12, count($columns));
+        self::assertCount(12, $columns);
         self::assertNull($columns['id']->getComment());
         self::assertNull($columns['comment_null']->getComment());
         self::assertNull($columns['comment_false']->getComment());
@@ -309,7 +309,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->_sm->alterTable($tableDiff);
 
         $columns = $this->_sm->listTableColumns("sqlsrv_column_comment");
-        self::assertEquals(23, count($columns));
+        self::assertCount(23, $columns);
         self::assertEquals('primary', $columns['id']->getComment());
         self::assertNull($columns['comment_null']->getComment());
         self::assertEquals('false', $columns['comment_false']->getComment());

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -155,7 +155,7 @@ EOS
 
         $tableIndexes = $this->_sm->listTableIndexes('non_default_pk_order');
 
-         self::assertEquals(1, count($tableIndexes));
+         self::assertCount(1, $tableIndexes);
 
         self::assertArrayHasKey('primary', $tableIndexes, 'listTableIndexes() has to return a "primary" array key.');
         self::assertEquals(array('other_id', 'id'), array_map('strtolower', $tableIndexes['primary']->getColumns()));

--- a/tests/Doctrine/Tests/DBAL/Functional/TableGeneratorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TableGeneratorTest.php
@@ -40,7 +40,7 @@ class TableGeneratorTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $id2 = $this->generator->nextValue("tbl1");
         $id3 = $this->generator->nextValue("tbl2");
 
-        self::assertTrue($id1 > 0, "First id has to be larger than 0");
+        self::assertGreaterThan(0, $id1, "First id has to be larger than 0");
         self::assertEquals($id1 + 1, $id2, "Second id is one larger than first one.");
         self::assertEquals($id1, $id3, "First ids from different tables are equal.");
     }
@@ -52,8 +52,7 @@ class TableGeneratorTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->_conn->rollBack();
         $id2 = $this->generator->nextValue("tbl1");
 
-        self::assertTrue($id1 > 0, "First id has to be larger than 0");
+        self::assertGreaterThan(0, $id1, "First id has to be larger than 0");
         self::assertEquals($id1 + 1, $id2, "Second id is one larger than first one.");
     }
 }
-

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -117,10 +117,10 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $this->insertRows();
 
         self::assertEquals(1, $this->_conn->delete('write_table', array('test_int' => 2)));
-        self::assertEquals(1, count($this->_conn->fetchAll('SELECT * FROM write_table')));
+        self::assertCount(1, $this->_conn->fetchAll('SELECT * FROM write_table'));
 
         self::assertEquals(1, $this->_conn->delete('write_table', array('test_int' => 1)));
-        self::assertEquals(0, count($this->_conn->fetchAll('SELECT * FROM write_table')));
+        self::assertCount(0, $this->_conn->fetchAll('SELECT * FROM write_table'));
     }
 
     public function testUpdate()
@@ -142,7 +142,7 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $num = $this->_conn->lastInsertId();
 
         self::assertNotNull($num, "LastInsertId() should not be null.");
-        self::assertTrue($num > 0, "LastInsertId() should be non-negative number.");
+        self::assertGreaterThan(0, $num, "LastInsertId() should be non-negative number.");
     }
 
     public function testLastInsertIdSequence()
@@ -158,16 +158,16 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
 
         $sequences = $this->_conn->getSchemaManager()->listSequences();
-        self::assertEquals(1, count(array_filter($sequences, function($sequence) {
+        self::assertCount(1, array_filter($sequences, function($sequence) {
             return strtolower($sequence->getName()) === 'write_table_id_seq';
-        })));
+        }));
 
         $stmt = $this->_conn->query($this->_conn->getDatabasePlatform()->getSequenceNextValSQL('write_table_id_seq'));
         $nextSequenceVal = $stmt->fetchColumn();
 
         $lastInsertId = $this->_conn->lastInsertId('write_table_id_seq');
 
-        self::assertTrue($lastInsertId > 0);
+        self::assertGreaterThan(0, $lastInsertId);
         self::assertEquals($nextSequenceVal, $lastInsertId);
     }
 
@@ -281,7 +281,7 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $secondId = $this->_conn->lastInsertId($seqName);
 
-        self::assertTrue($secondId > $firstId);
+        self::assertGreaterThan($firstId, $secondId);
 
     }
 

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
@@ -13,11 +13,11 @@ class CompositeExpressionTest extends \Doctrine\Tests\DbalTestCase
     {
         $expr = new CompositeExpression(CompositeExpression::TYPE_OR, array('u.group_id = 1'));
 
-        self::assertEquals(1, count($expr));
+        self::assertCount(1, $expr);
 
         $expr->add('u.group_id = 2');
 
-        self::assertEquals(2, count($expr));
+        self::assertCount(2, $expr);
     }
 
     public function testAdd()

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -758,8 +758,8 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
 
         $qb->andWhere('u.id = 1');
 
-        self::assertFalse($qb->getQueryParts() === $qb_clone->getQueryParts());
-        self::assertFalse($qb->getParameters() === $qb_clone->getParameters());
+        self::assertNotSame($qb->getQueryParts(), $qb_clone->getQueryParts());
+        self::assertNotSame($qb->getParameters(), $qb_clone->getParameters());
     }
 
     public function testSimpleSelectWithoutTableAlias()

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -451,7 +451,7 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $c = new Comparator();
         $diffSchema = $c->compare($schema1, $schema2);
 
-        self::assertEquals(1, count($diffSchema->removedSequences));
+        self::assertCount(1, $diffSchema->removedSequences);
         self::assertSame($seq, $diffSchema->removedSequences[0]);
     }
 
@@ -465,7 +465,7 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $c = new Comparator();
         $diffSchema = $c->compare($schema1, $schema2);
 
-        self::assertEquals(1, count($diffSchema->newSequences));
+        self::assertCount(1, $diffSchema->newSequences);
         self::assertSame($seq, $diffSchema->newSequences[0]);
     }
 
@@ -485,7 +485,7 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $tableDiff = $c->diffTable($table1, $table2);
 
         self::assertInstanceOf('Doctrine\DBAL\Schema\TableDiff', $tableDiff);
-        self::assertEquals(1, count($tableDiff->addedForeignKeys));
+        self::assertCount(1, $tableDiff->addedForeignKeys);
     }
 
     public function testTableRemoveForeignKey()
@@ -504,7 +504,7 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $tableDiff = $c->diffTable($table2, $table1);
 
         self::assertInstanceOf('Doctrine\DBAL\Schema\TableDiff', $tableDiff);
-        self::assertEquals(1, count($tableDiff->removedForeignKeys));
+        self::assertCount(1, $tableDiff->removedForeignKeys);
     }
 
     public function testTableUpdateForeignKey()
@@ -524,7 +524,7 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $tableDiff = $c->diffTable($table1, $table2);
 
         self::assertInstanceOf('Doctrine\DBAL\Schema\TableDiff', $tableDiff);
-        self::assertEquals(1, count($tableDiff->changedForeignKeys));
+        self::assertCount(1, $tableDiff->changedForeignKeys);
     }
 
     public function testMovedForeignKeyForeignTable()
@@ -547,7 +547,7 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $tableDiff = $c->diffTable($table1, $table2);
 
         self::assertInstanceOf('Doctrine\DBAL\Schema\TableDiff', $tableDiff);
-        self::assertEquals(1, count($tableDiff->changedForeignKeys));
+        self::assertCount(1, $tableDiff->changedForeignKeys);
     }
 
     public function testTablesCaseInsensitive()
@@ -673,8 +673,8 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $c = new Comparator();
         $tableDiff = $c->diffTable($tableA, $tableB);
 
-        self::assertEquals(0, count($tableDiff->addedColumns));
-        self::assertEquals(0, count($tableDiff->removedColumns));
+        self::assertCount(0, $tableDiff->addedColumns);
+        self::assertCount(0, $tableDiff->removedColumns);
         self::assertArrayHasKey('foo', $tableDiff->renamedColumns);
         self::assertEquals('bar', $tableDiff->renamedColumns['foo']->getName());
     }
@@ -698,12 +698,12 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $c = new Comparator();
         $tableDiff = $c->diffTable($tableA, $tableB);
 
-        self::assertEquals(1, count($tableDiff->addedColumns), "'baz' should be added, not created through renaming!");
+        self::assertCount(1, $tableDiff->addedColumns, "'baz' should be added, not created through renaming!");
         self::assertArrayHasKey('baz', $tableDiff->addedColumns, "'baz' should be added, not created through renaming!");
-        self::assertEquals(2, count($tableDiff->removedColumns), "'foo' and 'bar' should both be dropped, an ambiguity exists which one could be renamed to 'baz'.");
+        self::assertCount(2, $tableDiff->removedColumns, "'foo' and 'bar' should both be dropped, an ambiguity exists which one could be renamed to 'baz'.");
         self::assertArrayHasKey('foo', $tableDiff->removedColumns, "'foo' should be removed.");
         self::assertArrayHasKey('bar', $tableDiff->removedColumns, "'bar' should be removed.");
-        self::assertEquals(0, count($tableDiff->renamedColumns), "no renamings should take place.");
+        self::assertCount(0, $tableDiff->renamedColumns, "no renamings should take place.");
     }
 
     /**
@@ -801,7 +801,7 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         self::assertInstanceOf('Doctrine\DBAL\Schema\TableDiff', $tableDiff);
         self::assertEquals(array('twitterid', 'displayname'), array_keys($tableDiff->renamedColumns));
         self::assertEquals(array('logged_in_at'), array_keys($tableDiff->addedColumns));
-        self::assertEquals(0, count($tableDiff->removedColumns));
+        self::assertCount(0, $tableDiff->removedColumns);
     }
 
 
@@ -1073,9 +1073,9 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
      */
     public function assertSchemaTableChangeCount($diff, $newTableCount=0, $changeTableCount=0, $removeTableCount=0)
     {
-        self::assertEquals($newTableCount, count($diff->newTables));
-        self::assertEquals($changeTableCount, count($diff->changedTables));
-        self::assertEquals($removeTableCount, count($diff->removedTables));
+        self::assertCount($newTableCount, $diff->newTables);
+        self::assertCount($changeTableCount, $diff->changedTables);
+        self::assertCount($removeTableCount, $diff->removedTables);
     }
 
     /**
@@ -1086,9 +1086,9 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
      */
     public function assertSchemaSequenceChangeCount($diff, $newSequenceCount=0, $changeSequenceCount=0, $removeSequenceCount=0)
     {
-        self::assertEquals($newSequenceCount, count($diff->newSequences), "Expected number of new sequences is wrong.");
-        self::assertEquals($changeSequenceCount, count($diff->changedSequences), "Expected number of changed sequences is wrong.");
-        self::assertEquals($removeSequenceCount, count($diff->removedSequences), "Expected number of removed sequences is wrong.");
+        self::assertCount($newSequenceCount, $diff->newSequences, "Expected number of new sequences is wrong.");
+        self::assertCount($changeSequenceCount, $diff->changedSequences, "Expected number of changed sequences is wrong.");
+        self::assertCount($removeSequenceCount, $diff->removedSequences, "Expected number of removed sequences is wrong.");
     }
 
     public function testDiffColumnPlatformOptions()

--- a/tests/Doctrine/Tests/DBAL/Schema/IndexTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/IndexTest.php
@@ -16,7 +16,7 @@ class IndexTest extends \PHPUnit\Framework\TestCase
         $idx = $this->createIndex();
         self::assertEquals("foo", $idx->getName());
         $columns = $idx->getColumns();
-        self::assertEquals(2, count($columns));
+        self::assertCount(2, $columns);
         self::assertEquals(array("bar", "baz"), $columns);
         self::assertFalse($idx->isUnique());
         self::assertFalse($idx->isPrimary());

--- a/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
@@ -30,7 +30,7 @@ class MySqlSchemaManagerTest extends \PHPUnit\Framework\TestCase
     {
         $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue($this->getFKDefinition()));
         $fkeys = $this->manager->listTableForeignKeys('dummy');
-        self::assertEquals(1, count($fkeys), "Table has to have one foreign key.");
+        self::assertCount(1, $fkeys, "Table has to have one foreign key.");
 
         self::assertInstanceOf('Doctrine\DBAL\Schema\ForeignKeyConstraint', $fkeys[0]);
         self::assertEquals(array('column_1', 'column_2', 'column_3'), array_map('strtolower', $fkeys[0]->getLocalColumns()));

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
@@ -18,7 +18,7 @@ class SchemaTest extends \PHPUnit\Framework\TestCase
         self::assertTrue($schema->hasTable($tableName));
 
         $tables = $schema->getTables();
-        self::assertTrue( isset($tables[$tableName]) );
+        self::assertArrayHasKey($tableName, $tables);
         self::assertSame($table, $tables[$tableName]);
         self::assertSame($table, $schema->getTable($tableName));
         self::assertTrue($schema->hasTable($tableName));

--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -39,7 +39,7 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         self::assertInstanceOf('Doctrine\DBAL\Schema\Column', $table->getColumn("foo"));
         self::assertInstanceOf('Doctrine\DBAL\Schema\Column', $table->getColumn("bar"));
 
-        self::assertEquals(2, count($table->getColumns()));
+        self::assertCount(2, $table->getColumns());
     }
 
     public function testColumnsCaseInsensitive()
@@ -197,7 +197,7 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         $tableA = new Table("foo", array(), array(), array($constraint));
         $constraints = $tableA->getForeignKeys();
 
-        self::assertEquals(1, count($constraints));
+        self::assertCount(1, $constraints);
         self::assertSame($constraint, array_shift($constraints));
     }
 
@@ -308,7 +308,7 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         $table->addForeignKeyConstraint($foreignTable, array("id"), array("id"), array("foo" => "bar"));
 
         $constraints = $table->getForeignKeys();
-        self::assertEquals(1, count($constraints));
+        self::assertCount(1, $constraints);
         $constraint = current($constraints);
 
         self::assertInstanceOf('Doctrine\DBAL\Schema\ForeignKeyConstraint', $constraint);
@@ -350,7 +350,7 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         $table->addColumn('baz', 'integer', array());
         $table->addIndex(array('baz'));
 
-        self::assertEquals(1, count($table->getIndexes()));
+        self::assertCount(1, $table->getIndexes());
     }
 
     /**
@@ -367,7 +367,7 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         $table->addForeignKeyConstraint($foreignTable, array("id"), array("id"), array("foo" => "bar"));
 
         $indexes = $table->getIndexes();
-        self::assertEquals(1, count($indexes));
+        self::assertCount(1, $indexes);
         $index = current($indexes);
 
         self::assertTrue($table->hasIndex($index->getName()));
@@ -431,11 +431,11 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         $table->addIndex(array('baz'));
 
         $indexes = $table->getIndexes();
-        self::assertEquals(1, count($indexes));
+        self::assertCount(1, $indexes);
         $index = current($indexes);
 
         $table->addUniqueIndex(array('baz'));
-        self::assertEquals(2, count($table->getIndexes()));
+        self::assertCount(2, $table->getIndexes());
         self::assertTrue($table->hasIndex($index->getName()));
     }
 
@@ -487,7 +487,7 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         $table->setPrimaryKey(array('baz'));
 
         $indexes = $table->getIndexes();
-        self::assertEquals(2, count($indexes), "Table should only contain both the primary key table index and the unique one, even though it was overruled.");
+        self::assertCount(2, $indexes, "Table should only contain both the primary key table index and the unique one, even though it was overruled.");
 
         self::assertTrue($table->hasPrimaryKey());
         self::assertTrue($table->hasIndex('idx_unique'));

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/RemoveNamespacedAssetsTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/RemoveNamespacedAssetsTest.php
@@ -48,7 +48,7 @@ class RemoveNamespacedAssetsTest extends \PHPUnit\Framework\TestCase
         $schema->visit(new RemoveNamespacedAssets());
 
         $sql = $schema->toSql(new MySqlPlatform());
-        self::assertEquals(1, count($sql), "Just one CREATE TABLE statement, no foreign key and table to foo.bar");
+        self::assertCount(1, $sql, "Just one CREATE TABLE statement, no foreign key and table to foo.bar");
     }
 
     /**
@@ -71,7 +71,6 @@ class RemoveNamespacedAssetsTest extends \PHPUnit\Framework\TestCase
         $schema->visit(new RemoveNamespacedAssets());
 
         $sql = $schema->toSql(new MySqlPlatform());
-        self::assertEquals(1, count($sql), "Just one CREATE TABLE statement, no foreign key and table to foo.bar");
+        self::assertCount(1, $sql, "Just one CREATE TABLE statement, no foreign key and table to foo.bar");
     }
 }
-

--- a/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/FunctionalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/FunctionalTest.php
@@ -31,14 +31,13 @@ class FunctionalTest extends AbstractTestCase
 
         $query = "SELECT * FROM Products";
         $data = $this->conn->fetchAll($query);
-        self::assertTrue(count($data) > 0);
+        self::assertGreaterThan(0, count($data));
 
         $query = "SELECT * FROM Customers";
         $data = $this->conn->fetchAll($query);
-        self::assertTrue(count($data) > 0);
+        self::assertGreaterThan(0, count($data));
 
         $data = $this->sm->queryAll("SELECT * FROM Customers");
-        self::assertTrue(count($data) > 0);
+        self::assertGreaterThan(0, count($data));
     }
 }
-

--- a/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizerTest.php
@@ -43,7 +43,6 @@ class SQLAzureFederationsSynchronizerTest extends AbstractTestCase
         $synchronizer->createSchema($schema);
         $sql = $synchronizer->getDropSchema($schema);
 
-        self::assertEQuals(5, count($sql));
+        self::assertCount(5, $sql);
     }
 }
-

--- a/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
@@ -25,15 +25,17 @@ class ArrayTest extends \Doctrine\Tests\DbalTestCase
 
     public function testArrayConvertsToDatabaseValue()
     {
-        self::assertTrue(
-            is_string($this->_type->convertToDatabaseValue(array(), $this->_platform))
+        self::assertInternalType(
+            'string',
+            $this->_type->convertToDatabaseValue(array(), $this->_platform)
         );
     }
 
     public function testArrayConvertsToPHPValue()
     {
-        self::assertTrue(
-            is_array($this->_type->convertToPHPValue(serialize(array()), $this->_platform))
+        self::assertInternalType(
+            'array',
+            $this->_type->convertToPHPValue(serialize(array()), $this->_platform)
         );
     }
 

--- a/tests/Doctrine/Tests/DBAL/Types/DateTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTest.php
@@ -19,9 +19,9 @@ class DateTest extends BaseDateTypeTestCase
     public function testDateConvertsToPHPValue()
     {
         // Birthday of jwage and also birthday of Doctrine. Send him a present ;)
-        self::assertTrue(
+        self::assertInstanceOf(
+            \Datetime::class,
             $this->type->convertToPHPValue('1985-09-01', $this->platform)
-            instanceof \DateTime
         );
     }
 


### PR DESCRIPTION
I've refactored more tests, like #2927, using:
- `assertInternalType` instead of `is_*` functions;
- `assertNotFalse` instead of strict comparisons with `false` keyword;
- `assertGreaterThan` for mathematical comparisons;
- `assertNotSame` instead of strict comparisons;
- `assertContains` instead of `in_array` function;
- `assertCount` instead of `count` function;
- `assertInstanceOf` instead of `instanceof` operator;
- `assertArrayHasKey` instead of `isset` function.