### PR TITLE
Added test case for resource as parameter

### DIFF
--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -190,6 +190,10 @@ class DBALException extends \Exception
     private static function formatParameters(array $params)
     {
         return '[' . implode(', ', array_map(function ($param) {
+            if (is_resource($param)) {
+                return (string) $param;
+            }
+            
             $json = @json_encode($param);
 
             if (! is_string($json) || $json == 'null' && is_string($param)) {

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -22,7 +22,7 @@ class DBALExceptionTest extends DbalTestCase
     {
         /* @var $driver Driver */
         $driver = $this->createMock(Driver::class);
-        $e = \Doctrine\DBAL\DBALException::driverExceptionDuringQuery($driver, new \Exception, "INSERT INTO file (`content`) VALUES (?)", [1 => tmpfile()]);
+        $e = \Doctrine\DBAL\DBALException::driverExceptionDuringQuery($driver, new \Exception, "INSERT INTO file (`content`) VALUES (?)", [1 => fopen(__FILE__, 'r')]);
         self::assertContains('Resource', $e->getMessage());
     }
 

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -17,6 +17,14 @@ class DBALExceptionTest extends DbalTestCase
         $e = DBALException::driverExceptionDuringQuery($driver, new \Exception, '', array('ABC', chr(128)));
         self::assertContains('with params ["ABC", "\x80"]', $e->getMessage());
     }
+    
+    public function testDriverExceptionDuringQueryAcceptsResource()
+    {
+        /* @var $driver Driver */
+        $driver = $this->createMock(Driver::class);
+        $e = \Doctrine\DBAL\DBALException::driverExceptionDuringQuery($driver, new \Exception, "INSERT INTO file (`content`) VALUES (?)", [1 => tmpfile()]);
+        self::assertContains('Resource', $e->getMessage());
+    }
 
     public function testAvoidOverWrappingOnDriverException()
     {


### PR DESCRIPTION
Added test case for PHP Resource as parameter in Driver exception.

See [this](https://github.com/doctrine/doctrine2/issues/6864)

Can be fixed by something like this.

`Doctrine\DBAL\DBALException::formatParameters()`
```php
private static function formatParameters(array $params)
    {
        return '[' . implode(', ', array_map(function ($param) {
            if (is_resource($param)) {
                return (string) $param;
            }

            $json = @json_encode($param);

            if (! is_string($json) || $json == 'null' && is_string($param)) {
                // JSON encoding failed, this is not a UTF-8 string.
                return '"\x' . implode('\x', str_split(bin2hex($param), 2)) . '"';
            }

            return $json;
        }, $params)) . ']';
    }
```