### PR TITLE
Remove empty verification after isset

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
@@ -136,7 +136,7 @@ abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
                 $service = 'SERVICE_NAME=' . $serviceName;
             }
 
-            if (isset($params['instancename']) && ! empty($params['instancename'])) {
+            if (isset($params['instancename'])) {
                 $instance = '(INSTANCE_NAME = ' . $params['instancename'] . ')';
             }
 

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -60,7 +60,7 @@ class Driver extends AbstractMySQLDriver
     protected function constructPdoDsn(array $params)
     {
         $dsn = 'mysql:';
-        if (isset($params['host']) && $params['host'] != '') {
+        if (isset($params['host'])) {
             $dsn .= 'host=' . $params['host'] . ';';
         }
         if (isset($params['port'])) {

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -78,11 +78,11 @@ class Driver extends AbstractPostgreSQLDriver
     {
         $dsn = 'pgsql:';
 
-        if (isset($params['host']) && $params['host'] != '') {
+        if (isset($params['host'])) {
             $dsn .= 'host=' . $params['host'] . ';';
         }
 
-        if (isset($params['port']) && $params['port'] != '') {
+        if (isset($params['port'])) {
             $dsn .= 'port=' . $params['port'] . ';';
         }
 

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
@@ -56,7 +56,7 @@ class Driver extends AbstractSQLServerDriver
             $dsn .= $params['host'];
         }
 
-        if (isset($params['port']) && !empty($params['port'])) {
+        if (isset($params['port'])) {
             $dsn .= ',' . $params['port'];
         }
 

--- a/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
@@ -99,7 +99,7 @@ class DB2SchemaManager extends AbstractSchemaManager
             'notnull'       => (bool) ($tableColumn['nulls'] == 'N'),
             'scale'         => null,
             'precision'     => null,
-            'comment'       => isset($tableColumn['comment']) && $tableColumn['comment'] !== ''
+            'comment'       => isset($tableColumn['comment'])
                 ? $tableColumn['comment']
                 : null,
             'platformOptions' => [],

--- a/lib/Doctrine/DBAL/Schema/DrizzleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DrizzleSchemaManager.php
@@ -46,7 +46,7 @@ class DrizzleSchemaManager extends AbstractSchemaManager
             'autoincrement' => (bool) $tableColumn['IS_AUTO_INCREMENT'],
             'scale' => (int) $tableColumn['NUMERIC_SCALE'],
             'precision' => (int) $tableColumn['NUMERIC_PRECISION'],
-            'comment' => isset($tableColumn['COLUMN_COMMENT']) && '' !== $tableColumn['COLUMN_COMMENT']
+            'comment' => isset($tableColumn['COLUMN_COMMENT'])
                 ? $tableColumn['COLUMN_COMMENT']
                 : null,
         ];

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -235,7 +235,7 @@ class OracleSchemaManager extends AbstractSchemaManager
             'length'     => $length,
             'precision'  => $precision,
             'scale'      => $scale,
-            'comment'    => isset($tableColumn['comments']) && '' !== $tableColumn['comments']
+            'comment'    => isset($tableColumn['comments'])
                 ? $tableColumn['comments']
                 : null,
         ];


### PR DESCRIPTION
As `isset` also verifies if the given value isn't null, and by the [`PHP type comparison tables`](http://php.net/manual/en/types.comparisons.php#types.comparisons), couldn't we remove some `empty` verifications?