### PR TITLE
Detect foreign key renaming using Comparator

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2092,6 +2092,14 @@ abstract class AbstractPlatform
             foreach ($diff->changedForeignKeys as $foreignKey) {
                 $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableName);
             }
+
+            foreach ($diff->renamedForeignKeys as $oldForeignKeyName =>$foreignKey) {
+                $oldForeignKeyName = new Identifier($oldForeignKeyName);
+                $sql               = array_merge(
+                    $sql,
+                    $this->getRenameForeignKeySQL($oldForeignKeyName->getQuotedName($this), $foreignKey, $tableName)
+                );
+            }
         }
 
         foreach ($diff->addedIndexes as $index) {
@@ -2127,6 +2135,23 @@ abstract class AbstractPlatform
         return [
             $this->getDropIndexSQL($oldIndexName, $tableName),
             $this->getCreateIndexSQL($index, $tableName)
+        ];
+    }
+
+    /**
+     * Returns the SQL for renaming a foreign key on a table.
+     *
+     * @param string                                     $oldForeignKeyName The name of the foreign key to rename from.
+     * @param \Doctrine\DBAL\Schema\ForeignKeyConstraint $foreignKey        The definition of the index to rename to.
+     * @param string                                     $tableName         The table to rename the given index on.
+     *
+     * @return array The sequence of SQL statements for renaming the given index.
+     */
+    protected function getRenameForeignKeySQL(string $oldForeignKeyName, ForeignKeyConstraint $foreignKey, string $tableName): array
+    {
+        return [
+            $this->getDropForeignKeySQL($oldForeignKeyName, $tableName),
+            $this->getCreateForeignKeySQL($foreignKey, $tableName)
         ];
     }
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -678,6 +678,7 @@ class MySqlPlatform extends AbstractPlatform
             $diff->addedForeignKeys   = [];
             $diff->changedForeignKeys = [];
             $diff->removedForeignKeys = [];
+            $diff->renamedForeignKeys = [];
         }
 
         $sql = array_merge(

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -928,7 +928,7 @@ class SqlitePlatform extends AbstractPlatform
         if ( ! empty($diff->renamedColumns) || ! empty($diff->addedForeignKeys) || ! empty($diff->addedIndexes)
                 || ! empty($diff->changedColumns) || ! empty($diff->changedForeignKeys) || ! empty($diff->changedIndexes)
                 || ! empty($diff->removedColumns) || ! empty($diff->removedForeignKeys) || ! empty($diff->removedIndexes)
-                || ! empty($diff->renamedIndexes)
+                || ! empty($diff->renamedIndexes) || ! empty($diff->renamedForeignKeys)
         ) {
             return false;
         }
@@ -1078,6 +1078,12 @@ class SqlitePlatform extends AbstractPlatform
         $columnNames = $this->getColumnNamesInAlteredTable($diff);
 
         foreach ($foreignKeys as $key => $constraint) {
+            foreach ($diff->renamedForeignKeys as $oldForeignKeyName => $renamedForeignKey) {
+                if (strcasecmp($key, $oldForeignKeyName) === 0) {
+                    unset($foreignKeys[$key]);
+                }
+            }
+
             $changed = false;
             $localColumns = [];
             foreach ($constraint->getLocalColumns() as $columnName) {
@@ -1105,7 +1111,7 @@ class SqlitePlatform extends AbstractPlatform
             }
         }
 
-        foreach (array_merge($diff->changedForeignKeys, $diff->addedForeignKeys) as $constraint) {
+        foreach (array_merge($diff->changedForeignKeys, $diff->addedForeignKeys, $diff->renamedForeignKeys) as $constraint) {
             $constraintName = strtolower($constraint->getName());
             if (strlen($constraintName)) {
                 $foreignKeys[$constraintName] = $constraint;

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -279,6 +279,10 @@ class Comparator
         foreach ($fromFkeys as $key1 => $constraint1) {
             foreach ($toFkeys as $key2 => $constraint2) {
                 if ($this->diffForeignKey($constraint1, $constraint2) === false) {
+                    if (strcasecmp($constraint1->getName(), $constraint2->getName()) !== 0) {
+                        $tableDifferences->renamedForeignKeys[$constraint1->getName()] = $constraint2;
+                        $changes++;
+                    }
                     unset($fromFkeys[$key1], $toFkeys[$key2]);
                 } else {
                     if (strtolower($constraint1->getName()) == strtolower($constraint2->getName())) {

--- a/lib/Doctrine/DBAL/Schema/TableDiff.php
+++ b/lib/Doctrine/DBAL/Schema/TableDiff.php
@@ -118,6 +118,13 @@ class TableDiff
     public $removedForeignKeys = [];
 
     /**
+     * All changed foreign keys
+     *
+     * @var \Doctrine\DBAL\Schema\ForeignKeyConstraint[]
+     */
+    public $renamedForeignKeys = [];
+
+    /**
      * @var \Doctrine\DBAL\Schema\Table
      */
     public $fromTable;

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -854,6 +854,35 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     /**
      * @group DBAL-234
      */
+    public function testAlterTableRenameForeignKey(): void
+    {
+        $tableDiff = new TableDiff('mytable');
+        $tableDiff->fromTable = new Table('mytable');
+        $tableDiff->fromTable->addColumn('fk', 'integer');
+        $tableDiff->renamedForeignKeys = array(
+            'fk1' => new ForeignKeyConstraint(array('fk'), 'fk_table', array('id'), 'fk2')
+        );
+
+        self::assertSame(
+            $this->getAlterTableRenameForeignKeySQL(),
+            $this->_platform->getAlterTableSQL($tableDiff)
+        );
+    }
+
+    /**
+     * @group DBAL-234
+     */
+    protected function getAlterTableRenameForeignKeySQL(): array
+    {
+        return [
+            'ALTER TABLE mytable DROP FOREIGN KEY fk1',
+            'ALTER TABLE mytable ADD CONSTRAINT fk2 FOREIGN KEY (fk) REFERENCES fk_table (id)',
+        ];
+    }
+
+    /**
+     * @group DBAL-234
+     */
     public function testAlterTableRenameIndex()
     {
         $tableDiff = new TableDiff('mytable');

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -634,6 +634,17 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     /**
      * @group DBAL-234
      */
+    protected function getAlterTableRenameForeignKeySQL(): array
+    {
+        return [
+            'ALTER TABLE mytable DROP CONSTRAINT fk1',
+            'ALTER TABLE mytable ADD CONSTRAINT fk2 FOREIGN KEY (fk) REFERENCES fk_table (id) NOT DEFERRABLE INITIALLY IMMEDIATE',
+        ];
+    }
+
+    /**
+     * @group DBAL-234
+     */
     protected function getAlterTableRenameIndexSQL()
     {
         return array(

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -936,6 +936,17 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     /**
      * @group DBAL-234
      */
+    protected function getAlterTableRenameForeignKeySQL(): array
+    {
+        return [
+            'ALTER TABLE mytable DROP CONSTRAINT fk1',
+            'ALTER TABLE mytable ADD CONSTRAINT fk2 FOREIGN KEY (fk) REFERENCES fk_table (id)',
+        ];
+    }
+
+    /**
+     * @group DBAL-234
+     */
     protected function getAlterTableRenameIndexSQL()
     {
         return array(

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -508,6 +508,17 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     /**
      * @group DBAL-234
      */
+    protected function getAlterTableRenameForeignKeySQL(): array
+    {
+        return [
+            'ALTER TABLE mytable DROP CONSTRAINT fk1',
+            'ALTER TABLE mytable ADD CONSTRAINT fk2 FOREIGN KEY (fk) REFERENCES fk_table (id)',
+        ];
+    }
+
+    /**
+     * @group DBAL-234
+     */
     protected function getAlterTableRenameIndexSQL()
     {
         return array(

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -491,6 +491,20 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     /**
      * @group DBAL-234
      */
+    protected function getAlterTableRenameForeignKeySQL(): array
+    {
+        return [
+            'CREATE TEMPORARY TABLE __temp__mytable AS SELECT fk FROM mytable',
+            'DROP TABLE mytable',
+            'CREATE TABLE mytable (fk INTEGER NOT NULL, CONSTRAINT fk2 FOREIGN KEY (fk) REFERENCES fk_table (id) NOT DEFERRABLE INITIALLY IMMEDIATE)',
+            'INSERT INTO mytable (fk) SELECT fk FROM __temp__mytable',
+            'DROP TABLE __temp__mytable',
+        ];
+    }
+
+    /**
+     * @group DBAL-234
+     */
     protected function getAlterTableRenameIndexSQL()
     {
         return array(

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -527,6 +527,26 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         self::assertCount(1, $tableDiff->changedForeignKeys);
     }
 
+    public function testTableRenamedForeignKey(): void
+    {
+        $tableForeign = new Table("bar");
+        $tableForeign->addColumn('id', 'integer');
+
+        $table1 = new Table("foo");
+        $table1->addColumn('fk', 'integer');
+        $table1->addForeignKeyConstraint($tableForeign, ['fk'], ['id'], [], 'fk_name1');
+
+        $table2 = new Table("foo");
+        $table2->addColumn('fk', 'integer');
+        $table2->addForeignKeyConstraint($tableForeign, ['fk'], ['id'], [], 'fk_name2');
+
+        $c = new Comparator();
+        $tableDiff = $c->diffTable($table1, $table2);
+
+        self::assertInstanceOf('Doctrine\DBAL\Schema\TableDiff', $tableDiff);
+        self::assertCount(1, $tableDiff->renamedForeignKeys);
+    }
+
     public function testMovedForeignKeyForeignTable()
     {
         $tableForeign = new Table("bar");

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -636,9 +636,16 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $tableB->addNamedForeignKeyConstraint('bar_constraint', 'bar', array('id'), array('id'));
 
         $c = new Comparator();
-        $tableDiff = $c->diffTable($tableA, $tableB);
+        $tableDiff = new TableDiff('foo');
+        $tableDiff->fromTable = $tableA;
+        $foreignKey = new ForeignKeyConstraint(['id'], 'bar', ['id'], 'bar_constraint');
+        $foreignKey->setLocalTable($tableB);
+        $tableDiff->renamedForeignKeys['foo_constraint'] = $foreignKey;
 
-        self::assertFalse($tableDiff);
+        self::assertEquals(
+            $tableDiff,
+            $c->diffTable($tableA, $tableB)
+        );
     }
 
     public function testCompareForeignKey_RestrictNoAction_AreTheSame()


### PR DESCRIPTION
These modifications intend to detect foreign key renaming when using a `Comparator` object to compare two `Table` objects.

To do so, I had to slightly change `TableDiff` class, adding new public member variable `renamedForeignKeys` (typed as `array<string, ForeignKeyConstraint>`).

Similarly to the indexes, the SQL generated by a renamed foreign key will, by default, drop the original constraint and create a new one; if a platform actually supports constraint renaming, method `AbstractPlatform::getRenameForeignKeySQL` should be overridden.

Since this changes current behaviours, some tests were impacted: therefore, the expected result of test case `ComparatorTest::testCompareForeignKeyBasedOnPropertiesNotName` needed some updating.

*Note: This would solve issue **#2360 (Comparator does not detect renamed foreign keys)***