### PR TITLE
Allow array of DateTime as param in executeQuery

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1581,7 +1581,11 @@ class Connection implements DriverConnection
     {
         if (is_string($type)) {
             $type = Type::getType($type);
+        } elseif (PDO::PARAM_STR === $type && $value instanceof \DateTime) {
+            // change the given PDO type to DBAL in case it's a \DateTime object
+            $type = Type::getType(Type::DATETIME);
         }
+
         if ($type instanceof Type) {
             $value = $type->convertToDatabaseValue($value, $this->getDatabasePlatform());
             $bindingType = $type->getBindingType();

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Functional;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -297,5 +298,34 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         self::assertSame($params, $connection->getParams());
 
         $connection->close();
+    }
+
+    /**
+     * @dataProvider executeQueryWithDateTimeParametersProvider
+     */
+    public function testExecuteQueryWithDateTimeParameters($query, $parameters, $types)
+    {
+        self::assertTrue($this->_conn->executeQuery($query, $parameters, $types)->execute());
+    }
+
+    public function executeQueryWithDateTimeParametersProvider()
+    {
+        return [
+            [
+                'SELECT ?',
+                [[new \DateTime('today'), new \DateTime('tomorrow')]],
+                [Connection::PARAM_STR_ARRAY],
+            ],
+            [
+                'SELECT ?, ?',
+                [new \DateTime('today'), new \DateTime('tomorrow')],
+                [Type::DATETIME, Type::DATETIME],
+            ],
+            [
+                'SELECT ?, ?',
+                [new \DateTime('today'), new \DateTime('tomorrow')],
+                [\PDO::PARAM_STR, \PDO::PARAM_STR],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Currently it's not possible to use an array of `\DateTime` objects as parameter, as reported in https://github.com/doctrine/doctrine2/issues/6934

I'm proposing a fix that changes the `PDO::PARAM_STR` to the DBAL `Type::DATETIME` when binding the parameters.

This allows to run the queries with `\DateTime` parameters and the additional types `Connection::PARAM_STR_ARRAY` and `\PDO::PARAM_STR`.