### PR TITLE
Enabled testFetchLongBlob() for PDO SQL Server driver

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
@@ -115,10 +115,6 @@ EOF
                 $this->_conn->getDatabasePlatform()
             );
 
-        if ($this->_conn->getDriver()->getName() === 'pdo_sqlsrv') {
-            $this->markTestSkipped('Skipping on pdo_sqlsrv due to https://github.com/Microsoft/msphpsql/issues/270');
-        }
-
         self::assertSame($contents, stream_get_contents($stream));
     }
 


### PR DESCRIPTION
The test was disabled as part of #2546 because of microsoft/msphpsql/issues/270. It can be enabled since the issue is now fixed.