### PR TITLE
Travis: Test against lowest and dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -276,6 +276,20 @@ jobs:
       before_script:
         - bash ./tests/travis/install-postgres-10.sh
 
+    - stage: Test
+      php: 7.1
+      env: DB=sqlite DEPENDENCIES=low
+      install:
+        - travis_retry composer update --prefer-dist --prefer-lowest
+
+    - stage: Test
+      if: type = cron
+      php: 7.2
+      env: DB=sqlite DEPENDENCIES=dev
+      install:
+        - composer config minimum-stability dev
+        - travis_retry composer update --prefer-dist
+
     - stage: Coverage
       php: 7.1
       env: DB=sqlite

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpunit/phpunit": "^6.3",
         "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
         "squizlabs/php_codesniffer": "^3.0",
-        "symfony/console": "2.*||^3.0",
+        "symfony/console": "^2.0.5||^3.0",
         "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {


### PR DESCRIPTION
Extends build matrix with:
 * lowest dependencies
    * on lowest supported PHP version (7.1)
    * sqlite
    * always executed
 * dev dependencies
    *  on current PHP version (7.2)
    * sqlite
    * only executed as part of daily cron build - see doctrine/doctrine2#6887

~Currently fails, will need some investigation (the class exists, any idea anyone?):~
```
1) Doctrine\Tests\DBAL\Tools\Console\RunSqlCommandTest::testMissingSqlArgument
Error: Class 'Symfony\Component\Console\Application' not found
/home/travis/build/Majkl578/doctrine-dbal/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php:21
```
Found it: Symfony packages <2.0.5 didn't have autoload entry.