### PR TITLE
Whitespaces clean-up in docs

### DIFF
--- a/docs/LICENSE.md
+++ b/docs/LICENSE.md
@@ -337,7 +337,6 @@ BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
     License is not intended to restrict the license of any rights under
     applicable law.
 
-
 Creative Commons Notice
 
     Creative Commons is not a party to this License, and makes no warranty
@@ -360,4 +359,4 @@ Creative Commons Notice
     this trademark restriction does not form part of this License.
 
     Creative Commons may be contacted at http://creativecommons.org/.
-   
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,6 @@ Using Ubuntu 14.04 LTS:
 
 It will generate the documentation into the build directory of the checkout.
 
-
 ## Theme issues
 
 If you get a "Theme error", check if the `en/_theme` subdirectory is empty,

--- a/docs/en/reference/architecture.rst
+++ b/docs/en/reference/architecture.rst
@@ -45,7 +45,6 @@ Drivers
 The drivers abstract a PHP specific database API by enforcing two
 interfaces:
 
-
 -  ``\Doctrine\DBAL\Driver\Connection``
 -  ``\Doctrine\DBAL\Driver\Statement``
 
@@ -84,5 +83,4 @@ The types offer an abstraction layer for the converting and
 generation of types between Databases and PHP. Doctrine comes
 bundled with some common types but offers the ability for
 developers to define custom types or extend existing ones easily.
-
 

--- a/docs/en/reference/caching.rst
+++ b/docs/en/reference/caching.rst
@@ -45,7 +45,6 @@ object is closed:
     $data = $stmt->fetchAll();
     $stmt->closeCursor(); // at this point the result is cached
 
-
 .. warning::
 
     When using the cache layer not all fetch modes are supported. See the code of the `ResultCacheStatement <https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php>`_ for details.

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -117,13 +117,11 @@ database name::
     ``charset`` connection parameter next to ``url``, to provide a
     default value in case the URL doesn't contain a charset value.
 
-
 Driver
 ~~~~~~
 
 The driver specifies the actual implementations of the DBAL
 interfaces to use. It can be configured in one of three ways:
-
 
 -  ``driver``: The built-in driver implementation to use. The
    following drivers are currently available:
@@ -172,10 +170,8 @@ options recognized by each built-in driver.
     When using an existing PDO instance through the ``pdo``
     option, specifying connection details is obviously not necessary.
 
-
 pdo\_sqlite
 ^^^^^^^^^^^
-
 
 -  ``user`` (string): Username to use when connecting to the
    database.
@@ -189,7 +185,6 @@ pdo\_sqlite
 
 pdo\_mysql
 ^^^^^^^^^^
-
 
 -  ``user`` (string): Username to use when connecting to the
    database.
@@ -223,7 +218,6 @@ or ``/etc/drizzle/conf.d/mysql-unix-socket-protocol.cnf`` and restarting the dri
 mysqli
 ^^^^^^
 
-
 -  ``user`` (string): Username to use when connecting to the
    database.
 -  ``password`` (string): Password to use when connecting to the
@@ -244,7 +238,6 @@ mysqli
 
 pdo\_pgsql
 ^^^^^^^^^^
-
 
 -  ``user`` (string): Username to use when connecting to the
    database.
@@ -268,11 +261,11 @@ pdo\_pgsql
    See http://www.postgresql.org/docs/9.0/static/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT
 -  ``sslcert`` (string): specifies the file name of the client SSL certificate.
    See `https://www.postgresql.org/docs/9.1/static/libpq-connect.html#LIBPQ-CONNECT-SSLCERT`
--  ``sslkey`` (string): specifies the location for the secret key used for the 
+-  ``sslkey`` (string): specifies the location for the secret key used for the
    client certificate.
    See `https://www.postgresql.org/docs/9.1/static/libpq-connect.html#LIBPQ-CONNECT-SSLKEY`
--  ``sslcrl`` (string): specifies the file name of the SSL certificate 
-   revocation list (CRL). 
+-  ``sslcrl`` (string): specifies the file name of the SSL certificate
+   revocation list (CRL).
    See `https://www.postgresql.org/docs/9.1/static/libpq-connect.html#LIBPQ-CONNECT-SSLCRL`
 -  ``application_name`` (string): Name of the application that is
    connecting to database. Optional. It will be displayed at ``pg_stat_activity``.
@@ -284,7 +277,6 @@ and ``'false'`` as strings you can change to integers by using:
 
 pdo\_oci / oci8
 ^^^^^^^^^^^^^^^
-
 
 -  ``user`` (string): Username to use when connecting to the
    database.
@@ -318,7 +310,6 @@ pdo\_oci / oci8
 pdo\_sqlsrv / sqlsrv
 ^^^^^^^^^^^^^^^^^^^^
 
-
 -  ``user`` (string): Username to use when connecting to the
    database.
 -  ``password`` (string): Password to use when connecting to the
@@ -329,7 +320,6 @@ pdo\_sqlsrv / sqlsrv
 
 sqlanywhere
 ^^^^^^^^^^^
-
 
 -  ``user`` (string): Username to use when connecting to the
    database.

--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -50,7 +50,7 @@ several drawbacks:
 
 -   There is no way to add dynamic parameters to the SQL query without modifying
     ``$sql`` itself. This can easily lead to a category of security
-    holes called **SQL injection**, where a third party can modify the SQL executed 
+    holes called **SQL injection**, where a third party can modify the SQL executed
     and even execute their own queries through clever exploiting of the security hole.
 -   **Quoting** dynamic parameters for an SQL query is tedious work and requires lots
     of use of the ``Doctrine\DBAL\Connection#quote()`` method, which makes the
@@ -60,7 +60,7 @@ several drawbacks:
     it could re-use this information easily using a technique called **prepared statements**.
 
 These three arguments and some more technical details hopefully convinced you to investigate
-prepared statements for accessing your database. 
+prepared statements for accessing your database.
 
 Dynamic Parameters and Prepared Statements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -190,7 +190,7 @@ If you don't specify an integer (through a ``PDO::PARAM*`` constant) to
 any of the parameter binding methods but a string, Doctrine DBAL will
 ask the type abstraction layer to convert the passed value from
 its PHP to a database representation. This way you can pass ``\DateTime``
-instances to a prepared statement and have Doctrine convert them 
+instances to a prepared statement and have Doctrine convert them
 to the appropriate vendors database format:
 
 .. code-block:: php
@@ -302,7 +302,7 @@ Prepare a given SQL statement and return the
     $statement = $conn->prepare('SELECT * FROM user');
     $statement->execute();
     $users = $statement->fetchAll();
-    
+
     /*
     array(
       0 => array(
@@ -340,7 +340,7 @@ parameters to the execute method, then returning the statement:
     <?php
     $statement = $conn->executeQuery('SELECT * FROM user WHERE username = ?', array('jwage'));
     $user = $statement->fetch();
-    
+
     /*
     array(
       0 => 'jwage',
@@ -362,7 +362,7 @@ Execute the query and fetch all results into an array:
 
     <?php
     $users = $conn->fetchAll('SELECT * FROM user');
-    
+
     /*
     array(
       0 => array(
@@ -381,7 +381,7 @@ Numeric index retrieval of first result row of the given query:
 
     <?php
     $user = $conn->fetchArray('SELECT * FROM user WHERE username = ?', array('jwage'));
-    
+
     /*
     array(
       0 => 'jwage',

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -20,7 +20,6 @@ instance.
 
 Doctrine ships with one implementation for the "PostConnect" event:
 
-
 -  ``Doctrine\DBAL\Event\Listeners\OracleSessionInit`` allows to
    specify any number of Oracle Session related enviroment variables
    that are set right after the connection is established.
@@ -35,9 +34,8 @@ instance passed to the Connection factory:
     $evm->addEventSubscriber(new OracleSessionInit(array(
         'NLS_TIME_FORMAT' => 'HH24:MI:SS',
     )));
-    
-    $conn = DriverManager::getConnection($connectionParams, null, $evm);
 
+    $conn = DriverManager::getConnection($connectionParams, null, $evm);
 
 Schema Events
 -------------
@@ -92,7 +90,6 @@ for event listeners.
 
 It allows you to access the ``Doctrine\DBAL\Schema\Table`` instance and its columns, the used Platform and
 provides a way to add additional SQL statements.
-
 
 OnSchemaCreateTableColumn Event
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -45,4 +45,3 @@ Now you are able to load classes that are in the
 use later in this documentation to configure our first Doctrine
 DBAL connection.
 
-

--- a/docs/en/reference/known-vendor-issues.rst
+++ b/docs/en/reference/known-vendor-issues.rst
@@ -35,7 +35,6 @@ passing the date to the constructor of ``DateTime``.
 This is why Doctrine always wants to create the time related types
 without microseconds:
 
-
 -  DateTime to ``TIMESTAMP(0) WITHOUT TIME ZONE``
 -  DateTimeTz to ``TIMESTAMP(0) WITH TIME ZONE``
 -  Time to ``TIME(0) WITHOUT TIME ZONE``

--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -108,4 +108,3 @@ Oracle NUMBER should be handled as integer. Doctrine 2 offers a
 powerful way to abstract the database to php and back conversion,
 which is described in the next section.
 
-

--- a/docs/en/reference/schema-manager.rst
+++ b/docs/en/reference/schema-manager.rst
@@ -25,7 +25,6 @@ available methods to learn about your database schema:
     when you accept data from user- or other sources not under your
     control.
 
-
 listDatabases()
 ---------------
 
@@ -227,11 +226,10 @@ table:
 
     <?php
     print_r($sql);
-    
+
     /*
     array(
       0 => 'DROP TABLE user'
     )
     */
-
 

--- a/docs/en/reference/sharding.rst
+++ b/docs/en/reference/sharding.rst
@@ -269,7 +269,6 @@ you have to sort the data in the application.
     $sql = "SELECT * FROM customers";
     $rows = $shardManager->queryAll($sql, $params);
 
-
 Schema Operations: SchemaSynchronizer Interface
 -----------------------------------------------
 

--- a/docs/en/reference/supporting-other-databases.rst
+++ b/docs/en/reference/supporting-other-databases.rst
@@ -5,7 +5,6 @@ To support a database which is not currently shipped with Doctrine
 you have to implement the following interfaces and abstract
 classes:
 
-
 -  ``\Doctrine\DBAL\Driver\Connection``
 -  ``\Doctrine\DBAL\Driver\Statement``
 -  ``\Doctrine\DBAL\Driver``
@@ -19,7 +18,6 @@ respective platform and schema instances. You can also make use of
 several Abstract Unittests in the ``\Doctrine\Tests\DBAL`` package
 to check if your platform behaves like all the others which is
 necessary for SchemaTool support, namely:
-
 
 -  ``\Doctrine\Tests\DBAL\Platforms\AbstractPlatformTestCase``
 -  ``\Doctrine\Tests\DBAL\Functional\Schema\AbstractSchemaManagerTestCase``

--- a/docs/en/reference/transactions.rst
+++ b/docs/en/reference/transactions.rst
@@ -174,7 +174,6 @@ you can disable auto-commit mode with ``setAutoCommit(false)``.
 
     // still transactional
 
-
 .. note::
 
     Changing auto-commit mode during an active transaction, implicitly
@@ -198,7 +197,6 @@ you can disable auto-commit mode with ``setAutoCommit(false)``.
 
     // enable auto-commit again, commits currently active transaction
     $conn->setAutoCommit(true); // does not start a new transaction automatically
-
 
 Committing or rolling back an active transaction will of course only
 open up a new transaction automatically if the particular action causes
@@ -230,12 +228,10 @@ by this behaviour.
         $conn->rollBack(); // rolls back outer transaction, and immediately starts a new one
     }
 
-
 To initialize a ``Doctrine\DBAL\Connection`` with auto-commit disabled,
 you can also use the ``Doctrine\DBAL\Configuration`` container to modify the
 default auto-commit mode via ``Doctrine\DBAL\Configuration::setAutoCommit(false)``
 and pass it to a ``Doctrine\DBAL\Connection`` when instantiating.
-
 
 Error handling
 --------------
@@ -255,12 +251,11 @@ A practical example is as follows:
         // retry the processing
     }
 
-
 If you need stricter control, you can catch the concrete exceptions directly:
 
 - ``Doctrine\DBAL\Exception\DeadlockException``: this can happen when each member
   of a group of actions is waiting for some other member to release a shared lock.
-- ``Doctrine\DBAL\Exception\LockWaitTimeoutException``: this exception happens when 
+- ``Doctrine\DBAL\Exception\LockWaitTimeoutException``: this exception happens when
   a transaction has to wait a considerable amount of time to obtain a lock, even if
   a deadlock is not involved.
 

--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -872,7 +872,6 @@ method to add new database types or overwrite existing ones.
     Database vendors that allow to define custom types like PostgreSql
     can help to overcome this issue.
 
-
 Custom Mapping Types
 --------------------
 
@@ -955,7 +954,6 @@ Then you override the ``convertToPhpValueSQL`` and
     {
         return 'MyFunction('.$sqlExpr.')';
     }
-
 
 Now we have to register this type with the Doctrine Type system and
 hook it into the database platform:


### PR DESCRIPTION
I've removed all white spaces and extra lines from our documentation :smile: 