### PR TITLE
Update Doctrine CS requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script: ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml
 jobs:
   allow_failures:
     - php: nightly
+    - stage: Coding standard
 
   include:
     - stage: Test
@@ -304,7 +305,7 @@ jobs:
 
     - stage: Pull request coding standard
       if: type = pull_request
-      php: 7.2
+      php: 7.1
       script:
         - |
           if [ $TRAVIS_BRANCH != "master" ]; then
@@ -317,6 +318,6 @@ jobs:
 
     - stage: Coding standard
       if: NOT type = pull_request
-      php: nightly
+      php: 7.1
       script:
         - ./vendor/bin/phpcs

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,9 @@
         "doctrine/common": "^2.7.1"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^1.0",
+        "doctrine/coding-standard": "~2.0.0",
         "phpunit/phpunit": "^6.3",
         "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
-        "squizlabs/php_codesniffer": "^3.0",
         "symfony/console": "^2.0.5||^3.0",
         "symfony/phpunit-bridge": "^3.3"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,9 +12,17 @@
     <file>lib</file>
     <file>tests</file>
 
-    <rule ref="Doctrine"/>
+    <rule ref="Doctrine">
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
+    </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
+    <rule ref="Squiz.Classes.ClassFileName.NoMatch">
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 


### PR DESCRIPTION
Disabled checks for strict types and native types to avoid BC issues, should be fine for master.
Must be run on lowest PHP version - some of the sniffs are version-dependent.

Not going to apply CS globally anytime soon, at least until 2.x is closed for features and develop merged. 🔧 

This should be ok since PRs are checked only for issues in modified code, right? 😊 