### PR TITLE
Require PHP 7.2, drop <7.2 in Composer & on CI

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,7 +3,7 @@ build:
         analysis:
             environment:
                 php:
-                    version: 7.1
+                    version: 7.2
             cache:
                 disabled: false
                 directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
         - $HOME/.composer/cache
 
 php:
-  - 7.1
   - 7.2
   - nightly
 
@@ -34,12 +33,6 @@ jobs:
 
   include:
     - stage: Test
-      php: 7.1
-      env: DB=mysql MYSQL_VERSION=5.7
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
-    - stage: Test
       php: 7.2
       env: DB=mysql MYSQL_VERSION=5.7
       sudo: required
@@ -52,12 +45,6 @@ jobs:
       before_script:
         - bash ./tests/travis/install-mysql-5.7.sh
 
-    - stage: Test
-      php: 7.1
-      env: DB=mysqli MYSQL_VERSION=5.7
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
     - stage: Test
       php: 7.2
       env: DB=mysqli MYSQL_VERSION=5.7
@@ -72,11 +59,6 @@ jobs:
         - bash ./tests/travis/install-mysql-5.7.sh
 
     - stage: Test
-      php: 7.1
-      env: DB=mariadb MARIADB_VERSION=10.0
-      addons:
-        mariadb: 10.0
-    - stage: Test
       php: 7.2
       env: DB=mariadb MARIADB_VERSION=10.0
       addons:
@@ -87,11 +69,6 @@ jobs:
       addons:
         mariadb: 10.0
 
-    - stage: Test
-      php: 7.1
-      env: DB=mariadb MARIADB_VERSION=10.1
-      addons:
-        mariadb: 10.1
     - stage: Test
       php: 7.2
       env: DB=mariadb MARIADB_VERSION=10.1
@@ -104,11 +81,6 @@ jobs:
         mariadb: 10.1
 
     - stage: Test
-      php: 7.1
-      env: DB=mariadb MARIADB_VERSION=10.2
-      addons:
-        mariadb: 10.2
-    - stage: Test
       php: 7.2
       env: DB=mariadb MARIADB_VERSION=10.2
       addons:
@@ -120,11 +92,6 @@ jobs:
         mariadb: 10.2
 
     - stage: Test
-      php: 7.1
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.2
-      addons:
-        mariadb: 10.2
-    - stage: Test
       php: 7.2
       env: DB=mariadb.mysqli MARIADB_VERSION=10.2
       addons:
@@ -135,13 +102,6 @@ jobs:
       addons:
         mariadb: 10.2
 
-    - stage: Test
-      php: 7.1
-      env: DB=pgsql POSTGRESQL_VERSION=9.2
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.2"
     - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=9.2
@@ -158,13 +118,6 @@ jobs:
         postgresql: "9.2"
 
     - stage: Test
-      php: 7.1
-      env: DB=pgsql POSTGRESQL_VERSION=9.3
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.3"
-    - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=9.3
       services:
@@ -179,13 +132,6 @@ jobs:
       addons:
         postgresql: "9.3"
 
-    - stage: Test
-      php: 7.1
-      env: DB=pgsql POSTGRESQL_VERSION=9.4
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.4"
     - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=9.4
@@ -202,13 +148,6 @@ jobs:
         postgresql: "9.4"
 
     - stage: Test
-      php: 7.1
-      env: DB=pgsql POSTGRESQL_VERSION=9.5
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.5"
-    - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=9.5
       services:
@@ -224,13 +163,6 @@ jobs:
         postgresql: "9.5"
 
     - stage: Test
-      php: 7.1
-      env: DB=pgsql POSTGRESQL_VERSION=9.6
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.6"
-    - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=9.6
       services:
@@ -245,16 +177,6 @@ jobs:
       addons:
         postgresql: "9.6"
 
-    - stage: Test
-      php: 7.1
-      env: DB=pgsql POSTGRESQL_VERSION=10.0
-      sudo: required
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.6"
-      before_script:
-        - bash ./tests/travis/install-postgres-10.sh
     - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=10.0
@@ -277,7 +199,7 @@ jobs:
         - bash ./tests/travis/install-postgres-10.sh
 
     - stage: Test
-      php: 7.1
+      php: 7.2
       env: DB=sqlite DEPENDENCIES=low
       install:
         - travis_retry composer update --prefer-dist --prefer-lowest
@@ -291,7 +213,7 @@ jobs:
         - travis_retry composer update --prefer-dist
 
     - stage: Coverage
-      php: 7.1
+      php: 7.2
       env: DB=sqlite
       before_script:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ext-pdo": "*",
         "doctrine/common": "^2.7.1"
     },


### PR DESCRIPTION
Same reasons as in doctrine/doctrine2#6529, but parameter type widening seems more important here.