### PR TITLE
Use $strict param in functions that have it

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -204,7 +204,7 @@ final class DriverManager
             throw DBALException::unknownDriver($params['driver'], array_keys(self::$_driverMap));
         }
 
-        if (isset($params['driverClass']) && ! in_array('Doctrine\DBAL\Driver', class_implements($params['driverClass'], true))) {
+        if (isset($params['driverClass']) && ! in_array('Doctrine\DBAL\Driver', class_implements($params['driverClass'], true), true)) {
             throw DBALException::invalidDriverClass($params['driverClass']);
         }
     }

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -481,7 +481,7 @@ abstract class AbstractPlatform
             $this->initializeCommentedDoctrineTypes();
         }
 
-        return in_array($doctrineType->getName(), $this->doctrineTypeComments);
+        return in_array($doctrineType->getName(), $this->doctrineTypeComments, true);
     }
 
     /**
@@ -1560,7 +1560,7 @@ abstract class AbstractPlatform
                 $columnData['length'] = 255;
             }
 
-            if (in_array($column->getName(), $options['primary'])) {
+            if (in_array($column->getName(), $options['primary'], true)) {
                 $columnData['primary'] = true;
             }
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -745,7 +745,7 @@ class MySqlPlatform extends AbstractPlatform
                     $column = $diff->fromTable->getColumn($columnName);
 
                     // Check if an autoincrement column was dropped from the primary key.
-                    if ($column->getAutoincrement() && ! in_array($columnName, $changedIndex->getColumns())) {
+                    if ($column->getAutoincrement() && ! in_array($columnName, $changedIndex->getColumns(), true)) {
                         // The autoincrement attribute needs to be removed from the dropped column
                         // before we can drop and recreate the primary key.
                         $column->setAutoincrement(false);

--- a/lib/Doctrine/DBAL/Schema/ColumnDiff.php
+++ b/lib/Doctrine/DBAL/Schema/ColumnDiff.php
@@ -69,7 +69,7 @@ class ColumnDiff
      */
     public function hasChanged($propertyName)
     {
-        return in_array($propertyName, $this->changedProperties);
+        return in_array($propertyName, $this->changedProperties, true);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -356,7 +356,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
         if (isset($this->_options[$event])) {
             $onEvent = strtoupper($this->_options[$event]);
 
-            if ( ! in_array($onEvent, ['NO ACTION', 'RESTRICT'])) {
+            if ( ! in_array($onEvent, ['NO ACTION', 'RESTRICT'], true)) {
                 return $onEvent;
             }
         }

--- a/lib/Doctrine/DBAL/Schema/Index.php
+++ b/lib/Doctrine/DBAL/Schema/Index.php
@@ -166,7 +166,7 @@ class Index extends AbstractAsset implements Constraint
         $columnName   = $this->trimQuotes(strtolower($columnName));
         $indexColumns = array_map('strtolower', $this->getUnquotedColumns());
 
-        return array_search($columnName, $indexColumns) === $pos;
+        return array_search($columnName, $indexColumns, true) === $pos;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -97,7 +97,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         $paths = $this->getSchemaSearchPaths();
 
         $this->existingSchemaPaths = array_filter($paths, function ($v) use ($names) {
-            return in_array($v, $names);
+            return in_array($v, $names, true);
         });
     }
 

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -117,7 +117,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
         $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);
 
         $options = [
-            'length'        => ($length == 0 || !in_array($type, ['text', 'string'])) ? null : $length,
+            'length'        => ($length == 0 || !in_array($type, ['text', 'string'], true)) ? null : $length,
             'unsigned'      => false,
             'fixed'         => (bool) $fixed,
             'default'       => $default !== 'NULL' ? $default : null,

--- a/lib/Doctrine/DBAL/Schema/Visitor/Graphviz.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/Graphviz.php
@@ -98,7 +98,7 @@ class Graphviz extends AbstractVisitor
             $label .= '<FONT COLOR="#2e3436" FACE="Helvetica" POINT-SIZE="12">' . $columnLabel . '</FONT>';
             $label .= '</TD><TD BORDER="0" ALIGN="LEFT" BGCOLOR="#eeeeec"><FONT COLOR="#2e3436" FACE="Helvetica" POINT-SIZE="10">' . strtolower($column->getType()) . '</FONT></TD>';
             $label .= '<TD BORDER="0" ALIGN="RIGHT" BGCOLOR="#eeeeec" PORT="col'.$column->getName().'">';
-            if ($table->hasPrimaryKey() && in_array($column->getName(), $table->getPrimaryKey()->getColumns())) {
+            if ($table->hasPrimaryKey() && in_array($column->getName(), $table->getPrimaryKey()->getColumns(), true)) {
                 $label .= "\xe2\x9c\xb7";
             }
             $label .= '</TD></TR>';

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/Schema/MultiTenantVisitor.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/Schema/MultiTenantVisitor.php
@@ -90,7 +90,7 @@ class MultiTenantVisitor implements Visitor
      */
     public function acceptTable(Table $table)
     {
-        if (in_array($table->getName(), $this->excludedTables)) {
+        if (in_array($table->getName(), $this->excludedTables, true)) {
             return;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -160,7 +160,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $namespaces = $this->_sm->listNamespaceNames();
         $namespaces = array_map('strtolower', $namespaces);
 
-        if (!in_array('test_create_schema', $namespaces)) {
+        if (!in_array('test_create_schema', $namespaces, true)) {
             $this->_conn->executeUpdate($this->_sm->getDatabasePlatform()->getCreateSchemaSQL('test_create_schema'));
 
             $namespaces = $this->_sm->listNamespaceNames();
@@ -218,7 +218,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         $columnsKeys = array_keys($columns);
 
         self::assertArrayHasKey('id', $columns);
-        self::assertEquals(0, array_search('id', $columnsKeys));
+        self::assertEquals(0, array_search('id', $columnsKeys, true));
         self::assertEquals('id',   strtolower($columns['id']->getname()));
         self::assertInstanceOf('Doctrine\DBAL\Types\IntegerType', $columns['id']->gettype());
         self::assertEquals(false,  $columns['id']->getunsigned());
@@ -227,7 +227,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         self::assertInternalType('array',  $columns['id']->getPlatformOptions());
 
         self::assertArrayHasKey('test', $columns);
-        self::assertEquals(1, array_search('test', $columnsKeys));
+        self::assertEquals(1, array_search('test', $columnsKeys, true));
         self::assertEquals('test', strtolower($columns['test']->getname()));
         self::assertInstanceOf('Doctrine\DBAL\Types\StringType', $columns['test']->gettype());
         self::assertEquals(255,    $columns['test']->getlength());
@@ -237,7 +237,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         self::assertInternalType('array',  $columns['test']->getPlatformOptions());
 
         self::assertEquals('foo',  strtolower($columns['foo']->getname()));
-        self::assertEquals(2, array_search('foo', $columnsKeys));
+        self::assertEquals(2, array_search('foo', $columnsKeys, true));
         self::assertInstanceOf('Doctrine\DBAL\Types\TextType', $columns['foo']->gettype());
         self::assertEquals(false,  $columns['foo']->getunsigned());
         self::assertEquals(false,  $columns['foo']->getfixed());
@@ -246,7 +246,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         self::assertInternalType('array',  $columns['foo']->getPlatformOptions());
 
         self::assertEquals('bar',  strtolower($columns['bar']->getname()));
-        self::assertEquals(3, array_search('bar', $columnsKeys));
+        self::assertEquals(3, array_search('bar', $columnsKeys, true));
         self::assertInstanceOf('Doctrine\DBAL\Types\DecimalType', $columns['bar']->gettype());
         self::assertEquals(null,   $columns['bar']->getlength());
         self::assertEquals(10,     $columns['bar']->getprecision());
@@ -258,21 +258,21 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         self::assertInternalType('array',  $columns['bar']->getPlatformOptions());
 
         self::assertEquals('baz1', strtolower($columns['baz1']->getname()));
-        self::assertEquals(4, array_search('baz1', $columnsKeys));
+        self::assertEquals(4, array_search('baz1', $columnsKeys, true));
         self::assertInstanceOf('Doctrine\DBAL\Types\DateTimeType', $columns['baz1']->gettype());
         self::assertEquals(true,   $columns['baz1']->getnotnull());
         self::assertEquals(null,   $columns['baz1']->getdefault());
         self::assertInternalType('array',  $columns['baz1']->getPlatformOptions());
 
         self::assertEquals('baz2', strtolower($columns['baz2']->getname()));
-        self::assertEquals(5, array_search('baz2', $columnsKeys));
+        self::assertEquals(5, array_search('baz2', $columnsKeys, true));
         self::assertContains($columns['baz2']->gettype()->getName(), array('time', 'date', 'datetime'));
         self::assertEquals(true,   $columns['baz2']->getnotnull());
         self::assertEquals(null,   $columns['baz2']->getdefault());
         self::assertInternalType('array',  $columns['baz2']->getPlatformOptions());
 
         self::assertEquals('baz3', strtolower($columns['baz3']->getname()));
-        self::assertEquals(6, array_search('baz3', $columnsKeys));
+        self::assertEquals(6, array_search('baz3', $columnsKeys, true));
         self::assertContains($columns['baz3']->gettype()->getName(), array('time', 'date', 'datetime'));
         self::assertEquals(true,   $columns['baz3']->getnotnull());
         self::assertEquals(null,   $columns['baz3']->getdefault());

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL421Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL421Test.php
@@ -12,7 +12,7 @@ class DBAL421Test extends \Doctrine\Tests\DbalFunctionalTestCase
         parent::setUp();
 
         $platform = $this->_conn->getDatabasePlatform()->getName();
-        if (!in_array($platform, array('mysql', 'sqlite'))) {
+        if (!in_array($platform, array('mysql', 'sqlite'), true)) {
             $this->markTestSkipped('Currently restricted to MySQL and SQLite.');
         }
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
@@ -18,7 +18,7 @@ class DBAL630Test extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $platform = $this->_conn->getDatabasePlatform()->getName();
 
-        if (!in_array($platform, array('postgresql'))) {
+        if (!in_array($platform, array('postgresql'), true)) {
             $this->markTestSkipped('Currently restricted to PostgreSQL');
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL752Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL752Test.php
@@ -13,7 +13,7 @@ class DBAL752Test extends \Doctrine\Tests\DbalFunctionalTestCase
 
         $platform = $this->_conn->getDatabasePlatform()->getName();
 
-        if (!in_array($platform, array('sqlite'))) {
+        if (!in_array($platform, array('sqlite'), true)) {
             $this->markTestSkipped('Related to SQLite only');
         }
     }


### PR DESCRIPTION
Some functions, e.g. `in_array`, have a third param to enable strict comparison :shield: