### PR TITLE
Platform names as constants

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -12,6 +12,8 @@ use Doctrine\DBAL\Types\Type;
 
 class DB2Platform extends AbstractPlatform
 {
+    public const NAME = 'db2';
+
     /**
      * {@inheritdoc}
      */
@@ -104,9 +106,9 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
-        return 'db2';
+        return self::NAME;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
@@ -15,12 +15,14 @@ use Doctrine\DBAL\Types\BinaryType;
  */
 class DrizzlePlatform extends AbstractPlatform
 {
+    public const NAME = 'drizzle';
+
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
-        return 'drizzle';
+        return self::NAME;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -29,6 +29,7 @@ class MySqlPlatform extends AbstractPlatform
     const LENGTH_LIMIT_TINYBLOB   = 255;
     const LENGTH_LIMIT_BLOB       = 65535;
     const LENGTH_LIMIT_MEDIUMBLOB = 16777215;
+    public const NAME             = 'mysql';
 
     /**
      * Adds MySQL-specific LIMIT clause to the query
@@ -979,9 +980,9 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
-        return 'mysql';
+        return self::NAME;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -21,6 +21,8 @@ use Doctrine\DBAL\Types\BinaryType;
  */
 class OraclePlatform extends AbstractPlatform
 {
+    public const NAME = 'oracle';
+
     /**
      * Assertion for Oracle identifiers.
      *
@@ -950,9 +952,9 @@ END;';
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
-        return 'oracle';
+        return self::NAME;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -25,6 +25,8 @@ use Doctrine\DBAL\Types\Type;
  */
 class PostgreSqlPlatform extends AbstractPlatform
 {
+    public const NAME = 'postgresql';
+
     /**
      * @var bool
      */
@@ -1025,9 +1027,9 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
-        return 'postgresql';
+        return self::NAME;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Schema\TableDiff;
  */
 class SQLAnywherePlatform extends AbstractPlatform
 {
+    public const NAME = 'sqlanywhere';
     /**
      * @var integer
      */
@@ -963,9 +964,9 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
-        return 'sqlanywhere';
+        return self::NAME;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -24,6 +24,8 @@ use Doctrine\DBAL\Types;
  */
 class SQLServerPlatform extends AbstractPlatform
 {
+    public const NAME = 'mssql';
+
     /**
      * {@inheritdoc}
      */
@@ -1375,9 +1377,9 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
-        return 'mssql';
+        return self::NAME;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -24,6 +24,8 @@ use Doctrine\DBAL\Types;
  */
 class SqlitePlatform extends AbstractPlatform
 {
+    public const NAME = 'sqlite';
+
     /**
      * {@inheritDoc}
      */
@@ -492,9 +494,9 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
-        return 'sqlite';
+        return self::NAME;
     }
 
     /**


### PR DESCRIPTION
I'd like to reference these from outside for eg. platform mapping to other db libraries.

Is this therefore viable?