### PR TITLE
CS: correct annotation types to use symbols specified in the CS rules

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -30,17 +30,17 @@ class ArrayStatement implements \IteratorAggregate, ResultStatement
     private $data;
 
     /**
-     * @var integer
+     * @var int
      */
     private $columnCount = 0;
 
     /**
-     * @var integer
+     * @var int
      */
     private $num = 0;
 
     /**
-     * @var integer
+     * @var int
      */
     private $defaultFetchMode = PDO::FETCH_BOTH;
 

--- a/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
+++ b/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
@@ -36,7 +36,7 @@ class QueryCacheProfile
     private $resultCacheDriver;
 
     /**
-     * @var integer
+     * @var int
      */
     private $lifetime = 0;
 
@@ -46,7 +46,7 @@ class QueryCacheProfile
     private $cacheKey;
 
     /**
-     * @param integer                           $lifetime
+     * @param int                               $lifetime
      * @param string|null                       $cacheKey
      * @param \Doctrine\Common\Cache\Cache|null $resultCache
      */
@@ -66,7 +66,7 @@ class QueryCacheProfile
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getLifetime()
     {
@@ -135,7 +135,7 @@ class QueryCacheProfile
     }
 
     /**
-     * @param integer $lifetime
+     * @param int $lifetime
      *
      * @return \Doctrine\DBAL\Cache\QueryCacheProfile
      */

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -56,7 +56,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
     private $realKey;
 
     /**
-     * @var integer
+     * @var int
      */
     private $lifetime;
 
@@ -68,7 +68,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
     /**
      * Did we reach the end of the statement?
      *
-     * @var boolean
+     * @var bool
      */
     private $emptied = false;
 
@@ -78,7 +78,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
     private $data;
 
     /**
-     * @var integer
+     * @var int
      */
     private $defaultFetchMode = PDO::FETCH_BOTH;
 
@@ -87,7 +87,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
      * @param \Doctrine\Common\Cache\Cache    $resultCache
      * @param string                          $cacheKey
      * @param string                          $realKey
-     * @param integer                         $lifetime
+     * @param int                             $lifetime
      */
     public function __construct(Statement $stmt, Cache $resultCache, $cacheKey, $realKey, $lifetime)
     {
@@ -209,7 +209,7 @@ class ResultCacheStatement implements \IteratorAggregate, ResultStatement
      * this behaviour is not guaranteed for all databases and should not be
      * relied on for portable applications.
      *
-     * @return integer The number of rows.
+     * @return int The number of rows.
      */
     public function rowCount()
     {

--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -119,7 +119,7 @@ class Configuration
      * transactions. Otherwise, its SQL statements are grouped into transactions that are terminated by a call to either
      * the method commit or the method rollback. By default, new connections are in auto-commit mode.
      *
-     * @param boolean $autoCommit True to enable auto-commit mode; false to disable it.
+     * @param bool $autoCommit True to enable auto-commit mode; false to disable it.
      *
      * @see   getAutoCommit
      */
@@ -131,7 +131,7 @@ class Configuration
     /**
      * Returns the default auto-commit mode for connections.
      *
-     * @return boolean True if auto-commit mode is enabled by default for connections, false otherwise.
+     * @return bool True if auto-commit mode is enabled by default for connections, false otherwise.
      *
      * @see    setAutoCommit
      */

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -73,21 +73,21 @@ class Connection implements DriverConnection
     /**
      * Represents an array of ints to be expanded by Doctrine SQL parsing.
      *
-     * @var integer
+     * @var int
      */
     const PARAM_INT_ARRAY = 101;
 
     /**
      * Represents an array of strings to be expanded by Doctrine SQL parsing.
      *
-     * @var integer
+     * @var int
      */
     const PARAM_STR_ARRAY = 102;
 
     /**
      * Offset by which PARAM_* constants are detected as arrays of the param type.
      *
-     * @var integer
+     * @var int
      */
     const ARRAY_PARAM_OFFSET = 100;
 
@@ -116,35 +116,35 @@ class Connection implements DriverConnection
     /**
      * Whether or not a connection has been established.
      *
-     * @var boolean
+     * @var bool
      */
     private $_isConnected = false;
 
     /**
      * The current auto-commit mode of this connection.
      *
-     * @var boolean
+     * @var bool
      */
     private $autoCommit = true;
 
     /**
      * The transaction nesting level.
      *
-     * @var integer
+     * @var int
      */
     private $_transactionNestingLevel = 0;
 
     /**
      * The currently active transaction isolation level.
      *
-     * @var integer
+     * @var int
      */
     private $_transactionIsolationLevel;
 
     /**
      * If nested transactions should use savepoints.
      *
-     * @var boolean
+     * @var bool
      */
     private $_nestTransactionsWithSavepoints = false;
 
@@ -180,12 +180,12 @@ class Connection implements DriverConnection
     /**
      * Flag that indicates whether the current transaction is marked for rollback only.
      *
-     * @var boolean
+     * @var bool
      */
     private $_isRollbackOnly = false;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $defaultFetchMode = PDO::FETCH_ASSOC;
 
@@ -356,8 +356,8 @@ class Connection implements DriverConnection
     /**
      * Establishes the connection with the database.
      *
-     * @return boolean TRUE if the connection was successfully established, FALSE if
-     *                 the connection is already open.
+     * @return bool TRUE if the connection was successfully established, FALSE if
+     *              the connection is already open.
      */
     public function connect()
     {
@@ -489,7 +489,7 @@ class Connection implements DriverConnection
     /**
      * Returns the current auto-commit mode for this connection.
      *
-     * @return boolean True if auto-commit mode is currently enabled for this connection, false otherwise.
+     * @return bool True if auto-commit mode is currently enabled for this connection, false otherwise.
      *
      * @see    setAutoCommit
      */
@@ -508,7 +508,7 @@ class Connection implements DriverConnection
      * NOTE: If this method is called during a transaction and the auto-commit mode is changed, the transaction is
      * committed. If this method is called and the auto-commit mode is not changed, the call is a no-op.
      *
-     * @param boolean $autoCommit True to enable auto-commit mode; false to disable it.
+     * @param bool $autoCommit True to enable auto-commit mode; false to disable it.
      *
      * @see   isAutoCommit
      */
@@ -532,7 +532,7 @@ class Connection implements DriverConnection
     /**
      * Sets the fetch mode.
      *
-     * @param integer $fetchMode
+     * @param int $fetchMode
      *
      * @return void
      */
@@ -577,10 +577,10 @@ class Connection implements DriverConnection
      * Prepares and executes an SQL query and returns the value of a single column
      * of the first row of the result.
      *
-     * @param string  $statement The SQL query to be executed.
-     * @param array   $params    The prepared statement params.
-     * @param integer $column    The 0-indexed column number to retrieve.
-     * @param array  $types      The query parameter types.
+     * @param string $statement The SQL query to be executed.
+     * @param array  $params    The prepared statement params.
+     * @param int    $column    The 0-indexed column number to retrieve.
+     * @param array  $types     The query parameter types.
      *
      * @return mixed|bool False is returned if no rows are found.
      *
@@ -594,7 +594,7 @@ class Connection implements DriverConnection
     /**
      * Whether an actual connection to the database is established.
      *
-     * @return boolean
+     * @return bool
      */
     public function isConnected()
     {
@@ -604,7 +604,7 @@ class Connection implements DriverConnection
     /**
      * Checks whether a transaction is currently active.
      *
-     * @return boolean TRUE if a transaction is currently active, FALSE otherwise.
+     * @return bool TRUE if a transaction is currently active, FALSE otherwise.
      */
     public function isTransactionActive()
     {
@@ -646,11 +646,11 @@ class Connection implements DriverConnection
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param string $tableExpression  The expression of the table on which to delete.
-     * @param array  $identifier The deletion criteria. An associative array containing column-value pairs.
-     * @param array  $types      The types of identifiers.
+     * @param string $tableExpression The expression of the table on which to delete.
+     * @param array  $identifier      The deletion criteria. An associative array containing column-value pairs.
+     * @param array  $types           The types of identifiers.
      *
-     * @return integer The number of affected rows.
+     * @return int The number of affected rows.
      *
      * @throws \Doctrine\DBAL\DBALException
      * @throws InvalidArgumentException
@@ -685,9 +685,9 @@ class Connection implements DriverConnection
     /**
      * Sets the transaction isolation level.
      *
-     * @param integer $level The level to set.
+     * @param int $level The level to set.
      *
-     * @return integer
+     * @return int
      */
     public function setTransactionIsolation($level)
     {
@@ -699,7 +699,7 @@ class Connection implements DriverConnection
     /**
      * Gets the currently active transaction isolation level.
      *
-     * @return integer The current transaction isolation level.
+     * @return int The current transaction isolation level.
      */
     public function getTransactionIsolation()
     {
@@ -715,12 +715,12 @@ class Connection implements DriverConnection
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param string $tableExpression  The expression of the table to update quoted or unquoted.
-     * @param array  $data       An associative array containing column-value pairs.
-     * @param array  $identifier The update criteria. An associative array containing column-value pairs.
-     * @param array  $types      Types of the merged $data and $identifier arrays in that order.
+     * @param string $tableExpression The expression of the table to update quoted or unquoted.
+     * @param array  $data            An associative array containing column-value pairs.
+     * @param array  $identifier      The update criteria. An associative array containing column-value pairs.
+     * @param array  $types           Types of the merged $data and $identifier arrays in that order.
      *
-     * @return integer The number of affected rows.
+     * @return int The number of affected rows.
      *
      * @throws \Doctrine\DBAL\DBALException
      */
@@ -756,10 +756,10 @@ class Connection implements DriverConnection
      * Table expression and columns are not escaped and are not safe for user-input.
      *
      * @param string $tableExpression The expression of the table to insert data into, quoted or unquoted.
-     * @param array  $data      An associative array containing column-value pairs.
-     * @param array  $types     Types of the inserted data.
+     * @param array  $data            An associative array containing column-value pairs.
+     * @param array  $types           Types of the inserted data.
      *
-     * @return integer The number of affected rows.
+     * @return int The number of affected rows.
      *
      * @throws \Doctrine\DBAL\DBALException
      */
@@ -828,7 +828,7 @@ class Connection implements DriverConnection
     /**
      * Quotes a given input parameter.
      *
-     * @param mixed       $input The parameter to be quoted.
+     * @param mixed    $input The parameter to be quoted.
      * @param int|null $type  The type of the parameter.
      *
      * @return string The quoted parameter.
@@ -1042,7 +1042,7 @@ class Connection implements DriverConnection
      * @param array  $params The query parameters.
      * @param array  $types  The parameter types.
      *
-     * @return integer The number of affected rows.
+     * @return int The number of affected rows.
      *
      * @throws \Doctrine\DBAL\DBALException
      */
@@ -1086,7 +1086,7 @@ class Connection implements DriverConnection
      *
      * @param string $statement
      *
-     * @return integer The number of affected rows.
+     * @return int The number of affected rows.
      *
      * @throws \Doctrine\DBAL\DBALException
      */
@@ -1115,7 +1115,7 @@ class Connection implements DriverConnection
     /**
      * Returns the current transaction nesting level.
      *
-     * @return integer The nesting level. A value of 0 means there's no active transaction.
+     * @return int The nesting level. A value of 0 means there's no active transaction.
      */
     public function getTransactionNestingLevel()
     {
@@ -1125,7 +1125,7 @@ class Connection implements DriverConnection
     /**
      * Fetches the SQLSTATE associated with the last database operation.
      *
-     * @return integer The last error code.
+     * @return int The last error code.
      */
     public function errorCode()
     {
@@ -1199,7 +1199,7 @@ class Connection implements DriverConnection
     /**
      * Sets if nested transactions should use savepoints.
      *
-     * @param boolean $nestTransactionsWithSavepoints
+     * @param bool $nestTransactionsWithSavepoints
      *
      * @return void
      *
@@ -1221,7 +1221,7 @@ class Connection implements DriverConnection
     /**
      * Gets if nested transactions should use savepoints.
      *
-     * @return boolean
+     * @return bool
      */
     public function getNestTransactionsWithSavepoints()
     {
@@ -1481,7 +1481,7 @@ class Connection implements DriverConnection
     /**
      * Checks whether the current transaction is marked for rollback only.
      *
-     * @return boolean
+     * @return bool
      *
      * @throws \Doctrine\DBAL\ConnectionException If no transaction is active.
      */

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -93,7 +93,7 @@ class MasterSlaveConnection extends Connection
      * You can keep the slave connection and then switch back to it
      * during the request if you know what you are doing.
      *
-     * @var boolean
+     * @var bool
      */
     protected $keepSlave = false;
 
@@ -129,7 +129,7 @@ class MasterSlaveConnection extends Connection
     /**
      * Checks if the connection is currently towards the master or not.
      *
-     * @return boolean
+     * @return bool
      */
     public function isConnectedToMaster()
     {

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -132,10 +132,10 @@ class DBALException extends \Exception
     }
 
     /**
-     * @param \Doctrine\DBAL\Driver     $driver
-     * @param \Exception $driverEx
-     * @param string     $sql
-     * @param array      $params
+     * @param \Doctrine\DBAL\Driver $driver
+     * @param \Exception            $driverEx
+     * @param string                $sql
+     * @param array                 $params
      *
      * @return \Doctrine\DBAL\DBALException
      */
@@ -151,8 +151,8 @@ class DBALException extends \Exception
     }
 
     /**
-     * @param \Doctrine\DBAL\Driver     $driver
-     * @param \Exception $driverEx
+     * @param \Doctrine\DBAL\Driver $driver
+     * @param \Exception            $driverEx
      *
      * @return \Doctrine\DBAL\DBALException
      */
@@ -162,8 +162,8 @@ class DBALException extends \Exception
     }
 
     /**
-     * @param \Doctrine\DBAL\Driver     $driver
-     * @param \Exception $driverEx
+     * @param \Doctrine\DBAL\Driver $driver
+     * @param \Exception            $driverEx
      *
      * @return \Doctrine\DBAL\DBALException
      */

--- a/lib/Doctrine/DBAL/Driver/AbstractDriverException.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractDriverException.php
@@ -31,7 +31,7 @@ abstract class AbstractDriverException extends \Exception implements DriverExcep
     /**
      * The driver specific error code.
      *
-     * @var integer|string|null
+     * @var int|string|null
      */
     private $errorCode;
 
@@ -45,9 +45,9 @@ abstract class AbstractDriverException extends \Exception implements DriverExcep
     /**
      * Constructor.
      *
-     * @param string              $message   The driver error message.
-     * @param string|null         $sqlState  The SQLSTATE the driver is in at the time the error occurred, if any.
-     * @param integer|string|null $errorCode The driver specific error code if any.
+     * @param string          $message   The driver error message.
+     * @param string|null     $sqlState  The SQLSTATE the driver is in at the time the error occurred, if any.
+     * @param int|string|null $errorCode The driver specific error code if any.
      */
     public function __construct($message, $sqlState = null, $errorCode = null)
     {

--- a/lib/Doctrine/DBAL/Driver/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/Connection.php
@@ -48,8 +48,8 @@ interface Connection
     /**
      * Quotes a string for use in a query.
      *
-     * @param mixed  $input
-     * @param integer $type
+     * @param mixed $input
+     * @param int   $type
      *
      * @return mixed
      */
@@ -60,7 +60,7 @@ interface Connection
      *
      * @param string $statement
      *
-     * @return integer
+     * @return int
      */
     function exec($statement);
 
@@ -76,21 +76,21 @@ interface Connection
     /**
      * Initiates a transaction.
      *
-     * @return boolean TRUE on success or FALSE on failure.
+     * @return bool TRUE on success or FALSE on failure.
      */
     function beginTransaction();
 
     /**
      * Commits a transaction.
      *
-     * @return boolean TRUE on success or FALSE on failure.
+     * @return bool TRUE on success or FALSE on failure.
      */
     function commit();
 
     /**
      * Rolls back the current transaction, as initiated by beginTransaction().
      *
-     * @return boolean TRUE on success or FALSE on failure.
+     * @return bool TRUE on success or FALSE on failure.
      */
     function rollBack();
 

--- a/lib/Doctrine/DBAL/Driver/DriverException.php
+++ b/lib/Doctrine/DBAL/Driver/DriverException.php
@@ -37,7 +37,7 @@ interface DriverException extends \Throwable
      * Returns null if no driver specific error code is available
      * for the error raised by the driver.
      *
-     * @return integer|string|null
+     * @return int|string|null
      */
     public function getErrorCode();
 

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -45,7 +45,7 @@ class DB2Statement implements \IteratorAggregate, Statement
     private $defaultFetchClassCtorArgs = [];
 
     /**
-     * @var integer
+     * @var int
      */
     private $_defaultFetchMode = \PDO::FETCH_BOTH;
 

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -77,7 +77,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
     protected $_values = [];
 
     /**
-     * @var integer
+     * @var int
      */
     protected $_defaultFetchMode = PDO::FETCH_BOTH;
 
@@ -227,7 +227,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
      *
      * @param array $values
      *
-     * @return boolean
+     * @return bool
      */
     private function _bindValues($values)
     {
@@ -243,7 +243,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
     }
 
     /**
-     * @return boolean|array
+     * @return bool|array
      */
     private function _fetch()
     {

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -35,7 +35,7 @@ class OCI8Connection implements Connection, ServerInfoAwareConnection
     protected $dbh;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $executeMode = OCI_COMMIT_ON_SUCCESS;
 
@@ -46,8 +46,8 @@ class OCI8Connection implements Connection, ServerInfoAwareConnection
      * @param string      $password
      * @param string      $db
      * @param string|null $charset
-     * @param integer     $sessionMode
-     * @param boolean     $persistent
+     * @param int         $sessionMode
+     * @param bool        $persistent
      *
      * @throws OCI8Exception
      */
@@ -164,7 +164,7 @@ class OCI8Connection implements Connection, ServerInfoAwareConnection
     /**
      * Returns the current execution mode.
      *
-     * @return integer
+     * @return int
      */
     public function getExecuteMode()
     {

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -63,7 +63,7 @@ class OCI8Statement implements IteratorAggregate, Statement
     ];
 
     /**
-     * @var integer
+     * @var int
      */
     protected $_defaultFetchMode = PDO::FETCH_BOTH;
 
@@ -161,13 +161,13 @@ class OCI8Statement implements IteratorAggregate, Statement
     /**
      * Finds next placeholder or opening quote.
      *
-     * @param string $statement The SQL statement to parse
-     * @param string $tokenOffset The offset to start searching from
-     * @param int $fragmentOffset The offset to build the next fragment from
-     * @param string[] $fragments Fragments of the original statement not containing placeholders
-     * @param string|null $currentLiteralDelimiter The delimiter of the current string literal
-     *                                             or NULL if not currently in a literal
-     * @param array<int, string> $paramMap Mapping of the original parameter positions to their named replacements
+     * @param string             $statement               The SQL statement to parse
+     * @param string             $tokenOffset             The offset to start searching from
+     * @param int                $fragmentOffset          The offset to build the next fragment from
+     * @param string[]           $fragments               Fragments of the original statement not containing placeholders
+     * @param string|null        $currentLiteralDelimiter The delimiter of the current string literal
+     *                                                    or NULL if not currently in a literal
+     * @param array<int, string> $paramMap                Mapping of the original parameter positions to their named replacements
      * @return bool Whether the token was found
      */
     private static function findPlaceholderOrOpeningQuote(
@@ -205,8 +205,8 @@ class OCI8Statement implements IteratorAggregate, Statement
     /**
      * Finds closing quote
      *
-     * @param string $statement The SQL statement to parse
-     * @param string $tokenOffset The offset to start searching from
+     * @param string      $statement               The SQL statement to parse
+     * @param string      $tokenOffset             The offset to start searching from
      * @param string|null $currentLiteralDelimiter The delimiter of the current string literal
      *                                             or NULL if not currently in a literal
      * @return bool Whether the token was found
@@ -237,8 +237,8 @@ class OCI8Statement implements IteratorAggregate, Statement
      * where the token was found.
      *
      * @param string $statement The SQL statement to parse
-     * @param string $offset The offset to start searching from
-     * @param string $regex The regex containing token pattern
+     * @param string $offset    The offset to start searching from
+     * @param string $regex     The regex containing token pattern
      * @return string|null Token or NULL if not found
      */
     private static function findToken($statement, &$offset, $regex)

--- a/lib/Doctrine/DBAL/Driver/PDOException.php
+++ b/lib/Doctrine/DBAL/Driver/PDOException.php
@@ -31,7 +31,7 @@ class PDOException extends \PDOException implements DriverException
     /**
      * The driver specific error code.
      *
-     * @var integer|string|null
+     * @var int|string|null
      */
     private $errorCode;
 

--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -29,14 +29,14 @@ interface ResultStatement extends \Traversable
     /**
      * Closes the cursor, enabling the statement to be executed again.
      *
-     * @return boolean TRUE on success or FALSE on failure.
+     * @return bool TRUE on success or FALSE on failure.
      */
     public function closeCursor();
 
     /**
      * Returns the number of columns in the result set
      *
-     * @return integer The number of columns in the result set represented
+     * @return int The number of columns in the result set represented
      *                 by the PDOStatement object. If there is no result set,
      *                 this method should return 0.
      */
@@ -45,11 +45,11 @@ interface ResultStatement extends \Traversable
     /**
      * Sets the fetch mode to use while iterating this statement.
      *
-     * @param integer $fetchMode The fetch mode must be one of the PDO::FETCH_* constants.
-     * @param mixed   $arg2
-     * @param mixed   $arg3
+     * @param int   $fetchMode The fetch mode must be one of the PDO::FETCH_* constants.
+     * @param mixed $arg2
+     * @param mixed $arg3
      *
-     * @return boolean
+     * @return bool
      *
      * @see PDO::FETCH_* constants.
      */
@@ -58,24 +58,24 @@ interface ResultStatement extends \Traversable
     /**
      * Returns the next row of a result set.
      *
-     * @param int|null $fetchMode    Controls how the next row will be returned to the caller.
-     *                               The value must be one of the \PDO::FETCH_* constants,
-     *                               defaulting to \PDO::FETCH_BOTH.
-     * @param int $cursorOrientation For a ResultStatement object representing a scrollable cursor,
-     *                               this value determines which row will be returned to the caller.
-     *                               This value must be one of the \PDO::FETCH_ORI_* constants,
-     *                               defaulting to \PDO::FETCH_ORI_NEXT. To request a scrollable
-     *                               cursor for your ResultStatement object, you must set the \PDO::ATTR_CURSOR
-     *                               attribute to \PDO::CURSOR_SCROLL when you prepare the SQL statement with
-     *                               \PDO::prepare().
-     * @param int $cursorOffset      For a ResultStatement object representing a scrollable cursor for which the
-     *                               cursorOrientation parameter is set to \PDO::FETCH_ORI_ABS, this value
-     *                               specifies the absolute number of the row in the result set that shall be
-     *                               fetched.
-     *                               For a ResultStatement object representing a scrollable cursor for which the
-     *                               cursorOrientation parameter is set to \PDO::FETCH_ORI_REL, this value
-     *                               specifies the row to fetch relative to the cursor position before
-     *                               ResultStatement::fetch() was called.
+     * @param int|null $fetchMode         Controls how the next row will be returned to the caller.
+     *                                    The value must be one of the \PDO::FETCH_* constants,
+     *                                    defaulting to \PDO::FETCH_BOTH.
+     * @param int      $cursorOrientation For a ResultStatement object representing a scrollable cursor,
+     *                                    this value determines which row will be returned to the caller.
+     *                                    This value must be one of the \PDO::FETCH_ORI_* constants,
+     *                                    defaulting to \PDO::FETCH_ORI_NEXT. To request a scrollable
+     *                                    cursor for your ResultStatement object, you must set the \PDO::ATTR_CURSOR
+     *                                    attribute to \PDO::CURSOR_SCROLL when you prepare the SQL statement with
+     *                                    \PDO::prepare().
+     * @param int      $cursorOffset      For a ResultStatement object representing a scrollable cursor for which the
+     *                                    cursorOrientation parameter is set to \PDO::FETCH_ORI_ABS, this value
+     *                                    specifies the absolute number of the row in the result set that shall be
+     *                                    fetched.
+     *                                    For a ResultStatement object representing a scrollable cursor for which the
+     *                                    cursorOrientation parameter is set to \PDO::FETCH_ORI_REL, this value
+     *                                    specifies the row to fetch relative to the cursor position before
+     *                                    ResultStatement::fetch() was called.
      *
      * @return mixed The return value of this method on success depends on the fetch mode. In all cases, FALSE is
      *               returned on failure.
@@ -87,18 +87,18 @@ interface ResultStatement extends \Traversable
     /**
      * Returns an array containing all of the result set rows.
      *
-     * @param int|null $fetchMode     Controls how the next row will be returned to the caller.
-     *                                The value must be one of the \PDO::FETCH_* constants,
-     *                                defaulting to \PDO::FETCH_BOTH.
-     * @param int|null $fetchArgument This argument has a different meaning depending on the value of the $fetchMode parameter:
-     *                                * \PDO::FETCH_COLUMN: Returns the indicated 0-indexed column.
-     *                                * \PDO::FETCH_CLASS: Returns instances of the specified class, mapping the columns of each
+     * @param int|null   $fetchMode     Controls how the next row will be returned to the caller.
+     *                                  The value must be one of the \PDO::FETCH_* constants,
+     *                                  defaulting to \PDO::FETCH_BOTH.
+     * @param int|null   $fetchArgument This argument has a different meaning depending on the value of the $fetchMode parameter:
+     *                                  * \PDO::FETCH_COLUMN: Returns the indicated 0-indexed column.
+     *                                  * \PDO::FETCH_CLASS: Returns instances of the specified class, mapping the columns of each
      *                                  row to named properties in the class.
-     *                                * \PDO::FETCH_FUNC: Returns the results of calling the specified function, using each row's
+     *                                  * \PDO::FETCH_FUNC: Returns the results of calling the specified function, using each row's
      *                                  columns as parameters in the call.
-     * @param array|null $ctorArgs    Controls how the next row will be returned to the caller.
-     *                                The value must be one of the \PDO::FETCH_* constants,
-     *                                defaulting to \PDO::FETCH_BOTH.
+     * @param array|null $ctorArgs      Controls how the next row will be returned to the caller.
+     *                                  The value must be one of the \PDO::FETCH_* constants,
+     *                                  defaulting to \PDO::FETCH_BOTH.
      *
      * @return array
      *
@@ -109,9 +109,9 @@ interface ResultStatement extends \Traversable
     /**
      * Returns a single column from the next row of a result set or FALSE if there are no more rows.
      *
-     * @param integer $columnIndex 0-indexed number of the column you wish to retrieve from the row.
-     *                             If no value is supplied, PDOStatement->fetchColumn()
-     *                             fetches the first column.
+     * @param int $columnIndex 0-indexed number of the column you wish to retrieve from the row.
+     *                         If no value is supplied, PDOStatement->fetchColumn()
+     *                         fetches the first column.
      *
      * @return string|boolean A single column in the next row of a result set, or FALSE if there are no more rows.
      */

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -67,15 +67,15 @@ class Driver extends AbstractSQLAnywhereDriver
     /**
      * Build the connection string for given connection parameters and driver options.
      *
-     * @param string  $host          Host address to connect to.
-     * @param integer $port          Port to use for the connection (default to SQL Anywhere standard port 2638).
-     * @param string  $server        Database server name on the host to connect to.
-     *                               SQL Anywhere allows multiple database server instances on the same host,
-     *                               therefore specifying the server instance name to use is mandatory.
-     * @param string  $dbname        Name of the database on the server instance to connect to.
-     * @param string  $username      User name to use for connection authentication.
-     * @param string  $password      Password to use for connection authentication.
-     * @param array   $driverOptions Additional parameters to use for the connection.
+     * @param string $host          Host address to connect to.
+     * @param int    $port          Port to use for the connection (default to SQL Anywhere standard port 2638).
+     * @param string $server        Database server name on the host to connect to.
+     *                              SQL Anywhere allows multiple database server instances on the same host,
+     *                              therefore specifying the server instance name to use is mandatory.
+     * @param string $dbname        Name of the database on the server instance to connect to.
+     * @param string $username      User name to use for connection authentication.
+     * @param string $password      Password to use for connection authentication.
+     * @param array  $driverOptions Additional parameters to use for the connection.
      *
      * @return string
      */

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -41,8 +41,8 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
      *
      * Connects to database with given connection string.
      *
-     * @param string  $dsn        The connection string.
-     * @param boolean $persistent Whether or not to establish a persistent connection.
+     * @param string $dsn        The connection string.
+     * @param bool   $persistent Whether or not to establish a persistent connection.
      *
      * @throws SQLAnywhereException
      */
@@ -210,7 +210,7 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
      *
      * @throws SQLAnywhereException
      *
-     * @return boolean Whether or not ending transactional mode succeeded.
+     * @return bool Whether or not ending transactional mode succeeded.
      */
     private function endTransaction()
     {

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/LastInsertId.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/LastInsertId.php
@@ -28,12 +28,12 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 class LastInsertId
 {
     /**
-     * @var integer
+     * @var int
      */
     private $id;
 
     /**
-     * @param integer $id
+     * @param int $id
      */
     public function setId($id)
     {
@@ -41,7 +41,7 @@ class LastInsertId
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getId()
     {

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -95,7 +95,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
     /**
      * The fetch style.
      *
-     * @param integer
+     * @param int
      */
     private $defaultFetchMode = PDO::FETCH_BOTH;
 

--- a/lib/Doctrine/DBAL/Driver/ServerInfoAwareConnection.php
+++ b/lib/Doctrine/DBAL/Driver/ServerInfoAwareConnection.php
@@ -38,7 +38,7 @@ interface ServerInfoAwareConnection
     /**
      * Checks whether a query is required to retrieve the database server version.
      *
-     * @return boolean True if a query is required to retrieve the database server version, false otherwise.
+     * @return bool True if a query is required to retrieve the database server version, false otherwise.
      */
     public function requiresQueryForServerVersion();
 }

--- a/lib/Doctrine/DBAL/Driver/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/Statement.php
@@ -39,13 +39,13 @@ interface Statement extends ResultStatement
      * As mentioned above, the named parameters are not natively supported by the mysqli driver, use executeQuery(),
      * fetchAll(), fetchArray(), fetchColumn(), fetchAssoc() methods to have the named parameter emulated by doctrine.
      *
-     * @param mixed   $param Parameter identifier. For a prepared statement using named placeholders,
-     *                       this will be a parameter name of the form :name. For a prepared statement
-     *                       using question mark placeholders, this will be the 1-indexed position of the parameter.
-     * @param mixed   $value The value to bind to the parameter.
-     * @param integer $type  Explicit data type for the parameter using the PDO::PARAM_* constants.
+     * @param mixed $param Parameter identifier. For a prepared statement using named placeholders,
+     *                     this will be a parameter name of the form :name. For a prepared statement
+     *                     using question mark placeholders, this will be the 1-indexed position of the parameter.
+     * @param mixed $value The value to bind to the parameter.
+     * @param int   $type  Explicit data type for the parameter using the PDO::PARAM_* constants.
      *
-     * @return boolean TRUE on success or FALSE on failure.
+     * @return bool TRUE on success or FALSE on failure.
      */
     function bindValue($param, $value, $type = null);
 
@@ -64,17 +64,17 @@ interface Statement extends ResultStatement
      * of stored procedures that return data as output parameters, and some also as input/output
      * parameters that both send in data and are updated to receive it.
      *
-     * @param mixed        $column   Parameter identifier. For a prepared statement using named placeholders,
-     *                               this will be a parameter name of the form :name. For a prepared statement using
-     *                               question mark placeholders, this will be the 1-indexed position of the parameter.
-     * @param mixed        $variable Name of the PHP variable to bind to the SQL statement parameter.
-     * @param integer|null $type     Explicit data type for the parameter using the PDO::PARAM_* constants. To return
-     *                               an INOUT parameter from a stored procedure, use the bitwise OR operator to set the
-     *                               PDO::PARAM_INPUT_OUTPUT bits for the data_type parameter.
-     * @param integer|null $length   You must specify maxlength when using an OUT bind
-     *                               so that PHP allocates enough memory to hold the returned value.
+     * @param mixed    $column   Parameter identifier. For a prepared statement using named placeholders,
+     *                           this will be a parameter name of the form :name. For a prepared statement using
+     *                           question mark placeholders, this will be the 1-indexed position of the parameter.
+     * @param mixed    $variable Name of the PHP variable to bind to the SQL statement parameter.
+     * @param int|null $type     Explicit data type for the parameter using the PDO::PARAM_* constants. To return
+     *                           an INOUT parameter from a stored procedure, use the bitwise OR operator to set the
+     *                           PDO::PARAM_INPUT_OUTPUT bits for the data_type parameter.
+     * @param int|null $length   You must specify maxlength when using an OUT bind
+     *                           so that PHP allocates enough memory to hold the returned value.
      *
-     * @return boolean TRUE on success or FALSE on failure.
+     * @return bool TRUE on success or FALSE on failure.
      */
     function bindParam($column, &$variable, $type = null, $length = null);
 
@@ -109,7 +109,7 @@ interface Statement extends ResultStatement
      * @param array|null $params An array of values with as many elements as there are
      *                           bound parameters in the SQL statement being executed.
      *
-     * @return boolean TRUE on success or FALSE on failure.
+     * @return bool TRUE on success or FALSE on failure.
      */
     function execute($params = null);
 
@@ -122,7 +122,7 @@ interface Statement extends ResultStatement
      * this behaviour is not guaranteed for all databases and should not be
      * relied on for portable applications.
      *
-     * @return integer The number of rows.
+     * @return int The number of rows.
      */
     function rowCount();
 }

--- a/lib/Doctrine/DBAL/Event/SchemaEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaEventArgs.php
@@ -31,7 +31,7 @@ use Doctrine\Common\EventArgs;
 class SchemaEventArgs extends EventArgs
 {
     /**
-     * @var boolean
+     * @var bool
      */
     private $_preventDefault = false;
 
@@ -46,7 +46,7 @@ class SchemaEventArgs extends EventArgs
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isDefaultPrevented()
     {

--- a/lib/Doctrine/DBAL/Exception/DriverException.php
+++ b/lib/Doctrine/DBAL/Exception/DriverException.php
@@ -61,7 +61,7 @@ class DriverException extends DBALException
      *
      * Returns null if no error code was given by the driver.
      *
-     * @return integer|string|null
+     * @return int|string|null
      */
     public function getErrorCode()
     {

--- a/lib/Doctrine/DBAL/Id/TableGenerator.php
+++ b/lib/Doctrine/DBAL/Id/TableGenerator.php
@@ -99,7 +99,7 @@ class TableGenerator
      *
      * @param string $sequenceName
      *
-     * @return integer
+     * @return int
      *
      * @throws \Doctrine\DBAL\DBALException
      */

--- a/lib/Doctrine/DBAL/Logging/DebugStack.php
+++ b/lib/Doctrine/DBAL/Logging/DebugStack.php
@@ -41,7 +41,7 @@ class DebugStack implements SQLLogger
     /**
      * If Debug Stack is enabled (log queries) or not.
      *
-     * @var boolean
+     * @var bool
      */
     public $enabled = true;
 
@@ -51,7 +51,7 @@ class DebugStack implements SQLLogger
     public $start = null;
 
     /**
-     * @var integer
+     * @var int
      */
     public $currentQuery = 0;
 

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -60,12 +60,12 @@ use Doctrine\DBAL\Types\Type;
 abstract class AbstractPlatform
 {
     /**
-     * @var integer
+     * @var int
      */
     const CREATE_INDEXES = 1;
 
     /**
-     * @var integer
+     * @var int
      */
     const CREATE_FOREIGNKEYS = 2;
 
@@ -110,22 +110,22 @@ abstract class AbstractPlatform
     const DATE_INTERVAL_UNIT_YEAR = 'YEAR';
 
     /**
-     * @var integer
+     * @var int
      */
     const TRIM_UNSPECIFIED = 0;
 
     /**
-     * @var integer
+     * @var int
      */
     const TRIM_LEADING = 1;
 
     /**
-     * @var integer
+     * @var int
      */
     const TRIM_TRAILING = 2;
 
     /**
-     * @var integer
+     * @var int
      */
     const TRIM_BOTH = 3;
 
@@ -328,8 +328,8 @@ abstract class AbstractPlatform
     }
 
     /**
-     * @param integer $length
-     * @param boolean $fixed
+     * @param int  $length
+     * @param bool $fixed
      *
      * @return string
      *
@@ -343,8 +343,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL snippet used to declare a BINARY/VARBINARY column type.
      *
-     * @param integer $length The length of the column.
-     * @param boolean $fixed  Whether the column length is fixed.
+     * @param int  $length The length of the column.
+     * @param bool $fixed  Whether the column length is fixed.
      *
      * @return string
      *
@@ -437,7 +437,7 @@ abstract class AbstractPlatform
      *
      * @param string $dbType
      *
-     * @return boolean
+     * @return bool
      */
     public function hasDoctrineTypeMappingFor($dbType)
     {
@@ -473,7 +473,7 @@ abstract class AbstractPlatform
      *
      * @param \Doctrine\DBAL\Types\Type $doctrineType
      *
-     * @return boolean
+     * @return bool
      */
     public function isCommentedDoctrineType(Type $doctrineType)
     {
@@ -563,7 +563,7 @@ abstract class AbstractPlatform
     /**
      * Gets the maximum length of a varchar field.
      *
-     * @return integer
+     * @return int
      */
     public function getVarcharMaxLength()
     {
@@ -573,7 +573,7 @@ abstract class AbstractPlatform
     /**
      * Gets the default length of a varchar field.
      *
-     * @return integer
+     * @return int
      */
     public function getVarcharDefaultLength()
     {
@@ -583,7 +583,7 @@ abstract class AbstractPlatform
     /**
      * Gets the maximum length of a binary field.
      *
-     * @return integer
+     * @return int
      */
     public function getBinaryMaxLength()
     {
@@ -593,7 +593,7 @@ abstract class AbstractPlatform
     /**
      * Gets the default length of a binary field.
      *
-     * @return integer
+     * @return int
      */
     public function getBinaryDefaultLength()
     {
@@ -739,8 +739,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL snippet to round a numeric field to the number of decimals specified.
      *
-     * @param string  $column
-     * @param integer $decimals
+     * @param string $column
+     * @param int    $decimals
      *
      * @return string
      */
@@ -766,7 +766,7 @@ abstract class AbstractPlatform
      * Returns the SQL snippet to trim a string.
      *
      * @param string         $str  The expression to apply the trim to.
-     * @param integer        $pos  The position of the trim (leading/trailing/both).
+     * @param int            $pos  The position of the trim (leading/trailing/both).
      * @param string|boolean $char The char to trim, has to be quoted already. Defaults to space.
      *
      * @return string
@@ -853,9 +853,9 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL snippet to get the position of the first occurrence of substring $substr in string $str.
      *
-     * @param string          $str      Literal string.
-     * @param string          $substr   Literal string to find.
-     * @param integer|boolean $startPos Position to start at, beginning of string by default.
+     * @param string   $str      Literal string.
+     * @param string   $substr   Literal string to find.
+     * @param int|bool $startPos Position to start at, beginning of string by default.
      *
      * @return string
      *
@@ -883,9 +883,9 @@ abstract class AbstractPlatform
      *
      * SQLite only supports the 2 parameter variant of this function.
      *
-     * @param string       $value  An sql string literal or column name/alias.
-     * @param integer      $from   Where to start the substring portion.
-     * @param integer|null $length The substring portion length.
+     * @param string   $value  An sql string literal or column name/alias.
+     * @param int      $from   Where to start the substring portion.
+     * @param int|null $length The substring portion length.
      *
      * @return string
      */
@@ -1040,8 +1040,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given seconds to a date.
      *
-     * @param string  $date
-     * @param integer $seconds
+     * @param string $date
+     * @param int    $seconds
      *
      * @return string
      *
@@ -1055,8 +1055,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given seconds from a date.
      *
-     * @param string  $date
-     * @param integer $seconds
+     * @param string $date
+     * @param int    $seconds
      *
      * @return string
      *
@@ -1070,8 +1070,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given minutes to a date.
      *
-     * @param string  $date
-     * @param integer $minutes
+     * @param string $date
+     * @param int    $minutes
      *
      * @return string
      *
@@ -1085,8 +1085,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given minutes from a date.
      *
-     * @param string  $date
-     * @param integer $minutes
+     * @param string $date
+     * @param int    $minutes
      *
      * @return string
      *
@@ -1100,8 +1100,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given hours to a date.
      *
-     * @param string  $date
-     * @param integer $hours
+     * @param string $date
+     * @param int    $hours
      *
      * @return string
      *
@@ -1115,8 +1115,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given hours to a date.
      *
-     * @param string  $date
-     * @param integer $hours
+     * @param string $date
+     * @param int    $hours
      *
      * @return string
      *
@@ -1130,8 +1130,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given days to a date.
      *
-     * @param string  $date
-     * @param integer $days
+     * @param string $date
+     * @param int    $days
      *
      * @return string
      *
@@ -1145,8 +1145,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given days to a date.
      *
-     * @param string  $date
-     * @param integer $days
+     * @param string $date
+     * @param int    $days
      *
      * @return string
      *
@@ -1160,8 +1160,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given weeks to a date.
      *
-     * @param string  $date
-     * @param integer $weeks
+     * @param string $date
+     * @param int    $weeks
      *
      * @return string
      *
@@ -1175,8 +1175,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given weeks from a date.
      *
-     * @param string  $date
-     * @param integer $weeks
+     * @param string $date
+     * @param int    $weeks
      *
      * @return string
      *
@@ -1190,8 +1190,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given months to a date.
      *
-     * @param string  $date
-     * @param integer $months
+     * @param string $date
+     * @param int    $months
      *
      * @return string
      *
@@ -1205,8 +1205,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given months to a date.
      *
-     * @param string  $date
-     * @param integer $months
+     * @param string $date
+     * @param int    $months
      *
      * @return string
      *
@@ -1220,8 +1220,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given quarters to a date.
      *
-     * @param string  $date
-     * @param integer $quarters
+     * @param string $date
+     * @param int    $quarters
      *
      * @return string
      *
@@ -1235,8 +1235,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given quarters from a date.
      *
-     * @param string  $date
-     * @param integer $quarters
+     * @param string $date
+     * @param int    $quarters
      *
      * @return string
      *
@@ -1250,8 +1250,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given years to a date.
      *
-     * @param string  $date
-     * @param integer $years
+     * @param string $date
+     * @param int    $years
      *
      * @return string
      *
@@ -1265,8 +1265,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given years from a date.
      *
-     * @param string  $date
-     * @param integer $years
+     * @param string $date
+     * @param int    $years
      *
      * @return string
      *
@@ -1280,11 +1280,11 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL for a date arithmetic expression.
      *
-     * @param string  $date     The column or literal representing a date to perform the arithmetic operation on.
-     * @param string  $operator The arithmetic operator (+ or -).
-     * @param integer $interval The interval that shall be calculated into the date.
-     * @param string  $unit     The unit of the interval that shall be calculated into the date.
-     *                          One of the DATE_INTERVAL_UNIT_* constants.
+     * @param string $date     The column or literal representing a date to perform the arithmetic operation on.
+     * @param string $operator The arithmetic operator (+ or -).
+     * @param int    $interval The interval that shall be calculated into the date.
+     * @param string $unit     The unit of the interval that shall be calculated into the date.
+     *                         One of the DATE_INTERVAL_UNIT_* constants.
      *
      * @return string
      *
@@ -1334,9 +1334,9 @@ abstract class AbstractPlatform
     /**
      * Honors that some SQL vendors such as MsSql use table hints for locking instead of the ANSI SQL FOR UPDATE specification.
      *
-     * @param string       $fromClause The FROM clause to append the hint for the given lock mode to.
-     * @param integer|null $lockMode   One of the Doctrine\DBAL\LockMode::* constants. If null is given, nothing will
-     *                                 be appended to the FROM clause.
+     * @param string   $fromClause The FROM clause to append the hint for the given lock mode to.
+     * @param int|null $lockMode   One of the Doctrine\DBAL\LockMode::* constants. If null is given, nothing will
+     *                             be appended to the FROM clause.
      *
      * @return string
      */
@@ -1498,8 +1498,8 @@ abstract class AbstractPlatform
      * Returns the SQL statement(s) to create a table with the specified name, columns and constraints
      * on this platform.
      *
-     * @param \Doctrine\DBAL\Schema\Table   $table
-     * @param integer                       $createFlags
+     * @param \Doctrine\DBAL\Schema\Table $table
+     * @param int                         $createFlags
      *
      * @return array The sequence of SQL statements.
      *
@@ -1922,7 +1922,7 @@ abstract class AbstractPlatform
      * @param \Doctrine\DBAL\Schema\TableDiff $diff
      * @param array                           $columnSql
      *
-     * @return boolean
+     * @return bool
      */
     protected function onSchemaAlterTableAddColumn(Column $column, TableDiff $diff, &$columnSql)
     {
@@ -1947,7 +1947,7 @@ abstract class AbstractPlatform
      * @param \Doctrine\DBAL\Schema\TableDiff $diff
      * @param array                           $columnSql
      *
-     * @return boolean
+     * @return bool
      */
     protected function onSchemaAlterTableRemoveColumn(Column $column, TableDiff $diff, &$columnSql)
     {
@@ -1972,7 +1972,7 @@ abstract class AbstractPlatform
      * @param \Doctrine\DBAL\Schema\TableDiff  $diff
      * @param array                            $columnSql
      *
-     * @return boolean
+     * @return bool
      */
     protected function onSchemaAlterTableChangeColumn(ColumnDiff $columnDiff, TableDiff $diff, &$columnSql)
     {
@@ -1998,7 +1998,7 @@ abstract class AbstractPlatform
      * @param \Doctrine\DBAL\Schema\TableDiff $diff
      * @param array                           $columnSql
      *
-     * @return boolean
+     * @return bool
      */
     protected function onSchemaAlterTableRenameColumn($oldColumnName, Column $column, TableDiff $diff, &$columnSql)
     {
@@ -2022,7 +2022,7 @@ abstract class AbstractPlatform
      * @param \Doctrine\DBAL\Schema\TableDiff $diff
      * @param array                           $sql
      *
-     * @return boolean
+     * @return bool
      */
     protected function onSchemaAlterTable(TableDiff $diff, &$sql)
     {
@@ -2597,7 +2597,7 @@ abstract class AbstractPlatform
      * Whether the platform prefers sequences for ID generation.
      * Subclasses should override this method to return TRUE if they prefer sequences.
      *
-     * @return boolean
+     * @return bool
      */
     public function prefersSequences()
     {
@@ -2608,7 +2608,7 @@ abstract class AbstractPlatform
      * Whether the platform prefers identity columns (eg. autoincrement) for ID generation.
      * Subclasses should override this method to return TRUE if they prefer identity columns.
      *
-     * @return boolean
+     * @return bool
      */
     public function prefersIdentityColumns()
     {
@@ -2706,7 +2706,7 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL for a given transaction isolation level Connection constant.
      *
-     * @param integer $level
+     * @param int $level
      *
      * @return string
      *
@@ -2923,7 +2923,7 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to set the transaction isolation level.
      *
-     * @param integer $level
+     * @param int $level
      *
      * @return string
      *
@@ -3005,7 +3005,7 @@ abstract class AbstractPlatform
     /**
      * Gets the default transaction isolation level of the platform.
      *
-     * @return integer The default isolation level.
+     * @return int The default isolation level.
      *
      * @see Doctrine\DBAL\Connection\TRANSACTION_* constants.
      */
@@ -3019,7 +3019,7 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports sequences.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsSequences()
     {
@@ -3032,7 +3032,7 @@ abstract class AbstractPlatform
      * Identity columns are columns that receive an auto-generated value from the
      * database on insert of a row.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsIdentityColumns()
     {
@@ -3046,7 +3046,7 @@ abstract class AbstractPlatform
      * but support sequences can emulate identity columns by using
      * sequences.
      *
-     * @return boolean
+     * @return bool
      */
     public function usesSequenceEmulatedIdentityColumns()
     {
@@ -3073,7 +3073,7 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports indexes.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsIndexes()
     {
@@ -3083,7 +3083,7 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports partial indexes.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsPartialIndexes()
     {
@@ -3093,7 +3093,7 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports altering tables.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsAlterTable()
     {
@@ -3103,7 +3103,7 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports transactions.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsTransactions()
     {
@@ -3113,7 +3113,7 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports savepoints.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsSavepoints()
     {
@@ -3123,7 +3123,7 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports releasing savepoints.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsReleaseSavepoints()
     {
@@ -3133,7 +3133,7 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports primary key constraints.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsPrimaryConstraints()
     {
@@ -3143,7 +3143,7 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports foreign key constraints.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsForeignKeyConstraints()
     {
@@ -3153,7 +3153,7 @@ abstract class AbstractPlatform
     /**
      * Whether this platform supports onUpdate in foreign key constraints.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsForeignKeyOnUpdate()
     {
@@ -3163,7 +3163,7 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports database schemas.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsSchemas()
     {
@@ -3177,7 +3177,7 @@ abstract class AbstractPlatform
      * filter a schema for the namespaced elements in {@link
      * AbstractManager#createSchema}.
      *
-     * @return boolean
+     * @return bool
      */
     public function canEmulateSchemas()
     {
@@ -3201,7 +3201,7 @@ abstract class AbstractPlatform
      *
      * Some databases don't allow to create and drop databases at all or only with certain tools.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsCreateDropDatabase()
     {
@@ -3211,7 +3211,7 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports getting the affected rows of a recent update/delete type query.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsGettingAffectedRows()
     {
@@ -3221,7 +3221,7 @@ abstract class AbstractPlatform
     /**
      * Whether this platform support to add inline column comments as postfix.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsInlineColumnComments()
     {
@@ -3231,7 +3231,7 @@ abstract class AbstractPlatform
     /**
      * Whether this platform support the proprietary syntax "COMMENT ON asset".
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsCommentOnStatement()
     {
@@ -3241,7 +3241,7 @@ abstract class AbstractPlatform
     /**
      * Does this platform have native guid type.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasNativeGuidType()
     {
@@ -3251,7 +3251,7 @@ abstract class AbstractPlatform
     /**
      * Does this platform have native JSON type.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasNativeJsonType()
     {
@@ -3270,7 +3270,7 @@ abstract class AbstractPlatform
     /**
      * Whether this platform supports views.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsViews()
     {
@@ -3280,7 +3280,7 @@ abstract class AbstractPlatform
     /**
      * Does this platform support column collation?
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsColumnCollation()
     {
@@ -3334,9 +3334,9 @@ abstract class AbstractPlatform
     /**
      * Adds an driver-specific LIMIT clause to the query.
      *
-     * @param string       $query
-     * @param integer|null $limit
-     * @param integer|null $offset
+     * @param string   $query
+     * @param int|null $limit
+     * @param int|null $offset
      *
      * @return string
      *
@@ -3365,9 +3365,9 @@ abstract class AbstractPlatform
     /**
      * Adds an driver-specific LIMIT clause to the query.
      *
-     * @param string       $query
-     * @param integer|null $limit
-     * @param integer|null $offset
+     * @param string   $query
+     * @param int|null $limit
+     * @param int|null $offset
      *
      * @return string
      */
@@ -3387,7 +3387,7 @@ abstract class AbstractPlatform
     /**
      * Whether the database platform support offsets in modify limit clauses.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsLimitOffset()
     {
@@ -3422,7 +3422,7 @@ abstract class AbstractPlatform
     /**
      * Maximum length of any given database identifier, like tables or column names.
      *
-     * @return integer
+     * @return int
      */
     public function getMaxIdentifierLength()
     {
@@ -3448,8 +3448,8 @@ abstract class AbstractPlatform
      * Cascade is not supported on many platforms but would optionally cascade the truncate by
      * following the foreign keys.
      *
-     * @param string  $tableName
-     * @param boolean $cascade
+     * @param string $tableName
+     * @param bool   $cascade
      *
      * @return string
      */

--- a/lib/Doctrine/DBAL/Platforms/Keywords/KeywordList.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/KeywordList.php
@@ -38,7 +38,7 @@ abstract class KeywordList
      *
      * @param string $word
      *
-     * @return boolean
+     * @return bool
      */
     public function isKeyword($word)
     {

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -51,9 +51,9 @@ class MySqlPlatform extends AbstractPlatform
      * Adds MySQL-specific LIMIT clause to the query
      * 18446744073709551615 is 2^64-1 maximum of unsigned BIGINT the biggest limit possible
      *
-     * @param string  $query
-     * @param integer $limit
-     * @param integer $offset
+     * @param string $query
+     * @param int    $limit
+     * @param int    $offset
      *
      * @return string
      */

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -483,9 +483,9 @@ class OraclePlatform extends AbstractPlatform
     }
 
     /**
-     * @param string  $name
-     * @param string  $table
-     * @param integer $start
+     * @param string $name
+     * @param string $table
+     * @param int    $start
      *
      * @return array
      */

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -631,7 +631,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      *
      * @param ColumnDiff $columnDiff The column diff to check against.
      *
-     * @return boolean True if the given column diff is an unchanged binary type column, false otherwise.
+     * @return bool True if the given column diff is an unchanged binary type column, false otherwise.
      */
     private function isUnchangedBinaryColumn(ColumnDiff $columnDiff)
     {

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -42,19 +42,19 @@ use Doctrine\DBAL\Schema\TableDiff;
 class SQLAnywherePlatform extends AbstractPlatform
 {
     /**
-     * @var integer
+     * @var int
      */
     const FOREIGN_KEY_MATCH_SIMPLE = 1;
     /**
-     * @var integer
+     * @var int
      */
     const FOREIGN_KEY_MATCH_FULL = 2;
     /**
-     * @var integer
+     * @var int
      */
     const FOREIGN_KEY_MATCH_SIMPLE_UNIQUE = 129;
     /**
-     * @var integer
+     * @var int
      */
     const FOREIGN_KEY_MATCH_FULL_UNIQUE = 130;
 
@@ -628,7 +628,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * Returns foreign key MATCH clause for given type.
      *
-     * @param integer $type The foreign key match type
+     * @param int $type The foreign key match type
      *
      * @return string
      *

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -630,7 +630,7 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * @param ColumnDiff $columnDiff The column diff to evaluate.
      *
-     * @return boolean True if the column alteration requires dropping its default constraint first, false otherwise.
+     * @return bool True if the column alteration requires dropping its default constraint first, false otherwise.
      */
     private function alterColumnRequiresDropDefaultConstraint(ColumnDiff $columnDiff)
     {
@@ -1295,8 +1295,8 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * Check an ORDER BY clause to see if it is in a TOP N query or subquery.
      *
-     * @param string $query The query
-     * @param int $currentPosition Start position of ORDER BY clause
+     * @param string $query           The query
+     * @param int    $currentPosition Start position of ORDER BY clause
      * @return bool true if ORDER BY is in a TOP N query, false otherwise
      */
     private function isOrderByInTopNSubquery($query, $currentPosition)

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -526,7 +526,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * User-defined function for Sqlite that is used with PDO::sqliteCreateFunction().
      *
-     * @param integer|float $value
+     * @param int|float $value
      *
      * @return float
      */
@@ -538,10 +538,10 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * User-defined function for Sqlite that implements MOD(a, b).
      *
-     * @param integer $a
-     * @param integer $b
+     * @param int $a
+     * @param int $b
      *
-     * @return integer
+     * @return int
      */
     public static function udfMod($a, $b)
     {
@@ -549,11 +549,11 @@ class SqlitePlatform extends AbstractPlatform
     }
 
     /**
-     * @param string  $str
-     * @param string  $substr
-     * @param integer $offset
+     * @param string $str
+     * @param string $substr
+     * @param int    $offset
      *
-     * @return integer
+     * @return int
      */
     public static function udfLocate($str, $substr, $offset = 0)
     {

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -46,12 +46,12 @@ class Connection extends \Doctrine\DBAL\Connection
     const PORTABILITY_SQLSRV            = 13;
 
     /**
-     * @var integer
+     * @var int
      */
     private $portability = self::PORTABILITY_NONE;
 
     /**
-     * @var integer
+     * @var int
      */
     private $case;
 
@@ -97,7 +97,7 @@ class Connection extends \Doctrine\DBAL\Connection
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getPortability()
     {
@@ -105,7 +105,7 @@ class Connection extends \Doctrine\DBAL\Connection
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getFetchCase()
     {

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -31,7 +31,7 @@ use PDO;
 class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
 {
     /**
-     * @var integer
+     * @var int
      */
     private $portability;
 
@@ -41,12 +41,12 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
     private $stmt;
 
     /**
-     * @var integer
+     * @var int
      */
     private $case;
 
     /**
-     * @var integer
+     * @var int
      */
     private $defaultFetchMode = PDO::FETCH_BOTH;
 
@@ -195,9 +195,9 @@ class Statement implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
     }
 
     /**
-     * @param mixed   $row
-     * @param integer $iterateRow
-     * @param boolean $fixCase
+     * @param mixed $row
+     * @param int   $iterateRow
+     * @param bool  $fixCase
      *
      * @return array
      */

--- a/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
+++ b/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
@@ -107,7 +107,7 @@ class CompositeExpression implements \Countable
     /**
      * Retrieves the amount of expressions on composite expression.
      *
-     * @return integer
+     * @return int
      */
     public function count()
     {

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -99,35 +99,35 @@ class QueryBuilder
     /**
      * The type of query this is. Can be select, update or delete.
      *
-     * @var integer
+     * @var int
      */
     private $type = self::SELECT;
 
     /**
      * The state of the query object. Can be dirty or clean.
      *
-     * @var integer
+     * @var int
      */
     private $state = self::STATE_CLEAN;
 
     /**
      * The index of the first result to retrieve.
      *
-     * @var integer
+     * @var int
      */
     private $firstResult = null;
 
     /**
      * The maximum number of results to retrieve.
      *
-     * @var integer
+     * @var int
      */
     private $maxResults = null;
 
     /**
      * The counter of bound parameters used with {@see bindValue).
      *
-     * @var integer
+     * @var int
      */
     private $boundCounter = 0;
 
@@ -165,7 +165,7 @@ class QueryBuilder
     /**
      * Gets the type of the currently built query.
      *
-     * @return integer
+     * @return int
      */
     public function getType()
     {
@@ -185,7 +185,7 @@ class QueryBuilder
     /**
      * Gets the state of this query builder instance.
      *
-     * @return integer Either QueryBuilder::STATE_DIRTY or QueryBuilder::STATE_CLEAN.
+     * @return int Either QueryBuilder::STATE_DIRTY or QueryBuilder::STATE_CLEAN.
      */
     public function getState()
     {
@@ -353,7 +353,7 @@ class QueryBuilder
     /**
      * Sets the position of the first result to retrieve (the "offset").
      *
-     * @param integer $firstResult The first result to return.
+     * @param int $firstResult The first result to return.
      *
      * @return $this This QueryBuilder instance.
      */
@@ -369,7 +369,7 @@ class QueryBuilder
      * Gets the position of the first result the query object was set to retrieve (the "offset").
      * Returns NULL if {@link setFirstResult} was not applied to this QueryBuilder.
      *
-     * @return integer The position of the first result.
+     * @return int The position of the first result.
      */
     public function getFirstResult()
     {
@@ -379,7 +379,7 @@ class QueryBuilder
     /**
      * Sets the maximum number of results to retrieve (the "limit").
      *
-     * @param integer $maxResults The maximum number of results to retrieve.
+     * @param int $maxResults The maximum number of results to retrieve.
      *
      * @return $this This QueryBuilder instance.
      */
@@ -395,7 +395,7 @@ class QueryBuilder
      * Gets the maximum number of results the query object was set to retrieve (the "limit").
      * Returns NULL if {@link setMaxResults} was not applied to this query builder.
      *
-     * @return integer The maximum number of results.
+     * @return int The maximum number of results.
      */
     public function getMaxResults()
     {
@@ -408,9 +408,9 @@ class QueryBuilder
      * The available parts are: 'select', 'from', 'set', 'where',
      * 'groupBy', 'having' and 'orderBy'.
      *
-     * @param string  $sqlPartName
-     * @param string  $sqlPart
-     * @param boolean $append
+     * @param string $sqlPartName
+     * @param string $sqlPart
+     * @param bool   $append
      *
      * @return $this This QueryBuilder instance.
      */
@@ -1284,8 +1284,8 @@ class QueryBuilder
      *     ->orWhere('u.username = ' . $qb->createPositionalParameter('Bar', PDO::PARAM_STR))
      * </code>
      *
-     * @param mixed   $value
-     * @param integer $type
+     * @param mixed $value
+     * @param int   $type
      *
      * @return string
      */

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -43,8 +43,8 @@ class SQLParserUtils
      * Returns an integer => integer pair (indexed from zero) for a positional statement
      * and a string => int[] pair for a named statement.
      *
-     * @param string  $statement
-     * @param boolean $isPositional
+     * @param string $statement
+     * @param bool   $isPositional
      *
      * @return array
      */
@@ -211,10 +211,10 @@ class SQLParserUtils
     }
 
     /**
-     * @param string    $paramName      The name of the parameter (without a colon in front)
-     * @param array     $paramsOrTypes  A hash of parameters or types
-     * @param bool      $isParam
-     * @param mixed     $defaultValue   An optional default value. If omitted, an exception is thrown
+     * @param string $paramName     The name of the parameter (without a colon in front)
+     * @param array  $paramsOrTypes A hash of parameters or types
+     * @param bool   $isParam
+     * @param mixed  $defaultValue  An optional default value. If omitted, an exception is thrown
      *
      * @throws SQLParserUtilsException
      * @return mixed

--- a/lib/Doctrine/DBAL/Schema/AbstractAsset.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractAsset.php
@@ -46,7 +46,7 @@ abstract class AbstractAsset
     protected $_namespace = null;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $_quoted = false;
 
@@ -76,7 +76,7 @@ abstract class AbstractAsset
      *
      * @param string $defaultNamespaceName
      *
-     * @return boolean
+     * @return bool
      */
     public function isInDefaultNamespace($defaultNamespaceName)
     {
@@ -139,7 +139,7 @@ abstract class AbstractAsset
     /**
      * Checks if this asset's name is quoted.
      *
-     * @return boolean
+     * @return bool
      */
     public function isQuoted()
     {
@@ -151,7 +151,7 @@ abstract class AbstractAsset
      *
      * @param string $identifier
      *
-     * @return boolean
+     * @return bool
      */
     protected function isIdentifierQuoted($identifier)
     {
@@ -210,9 +210,9 @@ abstract class AbstractAsset
      * however building idents automatically for foreign keys, composite keys or such can easily create
      * very long names.
      *
-     * @param array   $columnNames
-     * @param string  $prefix
-     * @param integer $maxSize
+     * @param array  $columnNames
+     * @param string $prefix
+     * @param int    $maxSize
      *
      * @return string
      */

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -198,7 +198,7 @@ abstract class AbstractSchemaManager
      *
      * @param array $tableNames
      *
-     * @return boolean
+     * @return bool
      */
     public function tablesExist($tableNames)
     {

--- a/lib/Doctrine/DBAL/Schema/Column.php
+++ b/lib/Doctrine/DBAL/Schema/Column.php
@@ -36,32 +36,32 @@ class Column extends AbstractAsset
     protected $_type;
 
     /**
-     * @var integer|null
+     * @var int|null
      */
     protected $_length = null;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $_precision = 10;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $_scale = 0;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $_unsigned = false;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $_fixed = false;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $_notnull = true;
 
@@ -71,7 +71,7 @@ class Column extends AbstractAsset
     protected $_default = null;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $_autoincrement = false;
 
@@ -147,7 +147,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @param integer|null $length
+     * @param int|null $length
      *
      * @return Column
      */
@@ -163,7 +163,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @param integer $precision
+     * @param int $precision
      *
      * @return Column
      */
@@ -179,7 +179,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @param integer $scale
+     * @param int $scale
      *
      * @return Column
      */
@@ -195,7 +195,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @param boolean $unsigned
+     * @param bool $unsigned
      *
      * @return Column
      */
@@ -207,7 +207,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @param boolean $fixed
+     * @param bool $fixed
      *
      * @return Column
      */
@@ -219,7 +219,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @param boolean $notnull
+     * @param bool $notnull
      *
      * @return Column
      */
@@ -288,7 +288,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @return integer|null
+     * @return int|null
      */
     public function getLength()
     {
@@ -296,7 +296,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getPrecision()
     {
@@ -304,7 +304,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getScale()
     {
@@ -312,7 +312,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getUnsigned()
     {
@@ -320,7 +320,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getFixed()
     {
@@ -328,7 +328,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getNotnull()
     {
@@ -354,7 +354,7 @@ class Column extends AbstractAsset
     /**
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function hasPlatformOption($name)
     {
@@ -380,7 +380,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getAutoincrement()
     {
@@ -388,7 +388,7 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @param boolean $flag
+     * @param bool $flag
      *
      * @return Column
      */
@@ -435,7 +435,7 @@ class Column extends AbstractAsset
     /**
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function hasCustomSchemaOption($name)
     {

--- a/lib/Doctrine/DBAL/Schema/ColumnDiff.php
+++ b/lib/Doctrine/DBAL/Schema/ColumnDiff.php
@@ -65,7 +65,7 @@ class ColumnDiff
     /**
      * @param string $propertyName
      *
-     * @return boolean
+     * @return bool
      */
     public function hasChanged($propertyName)
     {

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -159,7 +159,7 @@ class Comparator
      * @param \Doctrine\DBAL\Schema\Schema   $schema
      * @param \Doctrine\DBAL\Schema\Sequence $sequence
      *
-     * @return boolean
+     * @return bool
      */
     private function isAutoIncrementSequenceInSchema($schema, $sequence)
     {
@@ -176,7 +176,7 @@ class Comparator
      * @param \Doctrine\DBAL\Schema\Sequence $sequence1
      * @param \Doctrine\DBAL\Schema\Sequence $sequence2
      *
-     * @return boolean
+     * @return bool
      */
     public function diffSequence(Sequence $sequence1, Sequence $sequence2)
     {
@@ -199,7 +199,7 @@ class Comparator
      * @param \Doctrine\DBAL\Schema\Table $table1
      * @param \Doctrine\DBAL\Schema\Table $table2
      *
-     * @return boolean|\Doctrine\DBAL\Schema\TableDiff
+     * @return bool|\Doctrine\DBAL\Schema\TableDiff
      */
     public function diffTable(Table $table1, Table $table2)
     {
@@ -386,7 +386,7 @@ class Comparator
      * @param \Doctrine\DBAL\Schema\ForeignKeyConstraint $key1
      * @param \Doctrine\DBAL\Schema\ForeignKeyConstraint $key2
      *
-     * @return boolean
+     * @return bool
      */
     public function diffForeignKey(ForeignKeyConstraint $key1, ForeignKeyConstraint $key2)
     {
@@ -530,7 +530,7 @@ class Comparator
      * @param \Doctrine\DBAL\Schema\Index $index1
      * @param \Doctrine\DBAL\Schema\Index $index2
      *
-     * @return boolean
+     * @return bool
      */
     public function diffIndex(Index $index1, Index $index2)
     {

--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -292,7 +292,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      *
      * @param string $name Name of the option to check.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasOption($name)
     {
@@ -372,7 +372,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      *
      * @param Index $index The index to be checked against.
      *
-     * @return boolean
+     * @return bool
      */
     public function intersectsIndexColumns(Index $index)
     {

--- a/lib/Doctrine/DBAL/Schema/Index.php
+++ b/lib/Doctrine/DBAL/Schema/Index.php
@@ -32,12 +32,12 @@ class Index extends AbstractAsset implements Constraint
     protected $_columns = [];
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $_isUnique = false;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $_isPrimary = false;
 
@@ -61,8 +61,8 @@ class Index extends AbstractAsset implements Constraint
     /**
      * @param string   $indexName
      * @param string[] $columns
-     * @param boolean  $isUnique
-     * @param boolean  $isPrimary
+     * @param bool     $isUnique
+     * @param bool     $isPrimary
      * @param string[] $flags
      * @param array    $options
      */
@@ -132,7 +132,7 @@ class Index extends AbstractAsset implements Constraint
     /**
      * Is the index neither unique nor primary key?
      *
-     * @return boolean
+     * @return bool
      */
     public function isSimpleIndex()
     {
@@ -140,7 +140,7 @@ class Index extends AbstractAsset implements Constraint
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isUnique()
     {
@@ -148,7 +148,7 @@ class Index extends AbstractAsset implements Constraint
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isPrimary()
     {
@@ -156,10 +156,10 @@ class Index extends AbstractAsset implements Constraint
     }
 
     /**
-     * @param string  $columnName
-     * @param integer $pos
+     * @param string $columnName
+     * @param int    $pos
      *
-     * @return boolean
+     * @return bool
      */
     public function hasColumnAtPosition($columnName, $pos = 0)
     {
@@ -174,7 +174,7 @@ class Index extends AbstractAsset implements Constraint
      *
      * @param array $columnNames
      *
-     * @return boolean
+     * @return bool
      */
     public function spansColumns(array $columnNames)
     {
@@ -196,7 +196,7 @@ class Index extends AbstractAsset implements Constraint
      *
      * @param Index $other
      *
-     * @return boolean
+     * @return bool
      */
     public function isFullfilledBy(Index $other)
     {
@@ -241,7 +241,7 @@ class Index extends AbstractAsset implements Constraint
      *
      * @param Index $other
      *
-     * @return boolean
+     * @return bool
      */
     public function overrules(Index $other)
     {
@@ -289,7 +289,7 @@ class Index extends AbstractAsset implements Constraint
      *
      * @param string $flag
      *
-     * @return boolean
+     * @return bool
      */
     public function hasFlag($flag)
     {
@@ -311,7 +311,7 @@ class Index extends AbstractAsset implements Constraint
     /**
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function hasOption($name)
     {
@@ -340,7 +340,7 @@ class Index extends AbstractAsset implements Constraint
      * Return whether the two indexes have the same partial index
      * @param \Doctrine\DBAL\Schema\Index $other
      *
-     * @return boolean
+     * @return bool
      */
     private function samePartialIndex(Index $other)
     {

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -343,7 +343,7 @@ class OracleSchemaManager extends AbstractSchemaManager
     /**
      * @param string $table
      *
-     * @return boolean
+     * @return bool
      */
     public function dropAutoincrement($table)
     {

--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -109,7 +109,7 @@ class Schema extends AbstractAsset
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function hasExplicitForeignKeyIndexes()
     {
@@ -237,7 +237,7 @@ class Schema extends AbstractAsset
      *
      * @param string $namespaceName
      *
-     * @return boolean
+     * @return bool
      */
     public function hasNamespace($namespaceName)
     {
@@ -251,7 +251,7 @@ class Schema extends AbstractAsset
      *
      * @param string $tableName
      *
-     * @return boolean
+     * @return bool
      */
     public function hasTable($tableName)
     {
@@ -273,7 +273,7 @@ class Schema extends AbstractAsset
     /**
      * @param string $sequenceName
      *
-     * @return boolean
+     * @return bool
      */
     public function hasSequence($sequenceName)
     {
@@ -386,9 +386,9 @@ class Schema extends AbstractAsset
     /**
      * Creates a new sequence.
      *
-     * @param string  $sequenceName
-     * @param integer $allocationSize
-     * @param integer $initialValue
+     * @param string $sequenceName
+     * @param int    $allocationSize
+     * @param int    $initialValue
      *
      * @return \Doctrine\DBAL\Schema\Sequence
      */

--- a/lib/Doctrine/DBAL/Schema/SchemaConfig.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaConfig.php
@@ -29,12 +29,12 @@ namespace Doctrine\DBAL\Schema;
 class SchemaConfig
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected $hasExplicitForeignKeyIndexes = false;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $maxIdentifierLength = 63;
 
@@ -49,7 +49,7 @@ class SchemaConfig
     protected $defaultTableOptions = [];
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function hasExplicitForeignKeyIndexes()
     {
@@ -57,7 +57,7 @@ class SchemaConfig
     }
 
     /**
-     * @param boolean $flag
+     * @param bool $flag
      *
      * @return void
      */
@@ -67,7 +67,7 @@ class SchemaConfig
     }
 
     /**
-     * @param integer $length
+     * @param int $length
      *
      * @return void
      */
@@ -77,7 +77,7 @@ class SchemaConfig
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getMaxIdentifierLength()
     {

--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -138,7 +138,7 @@ class SchemaDiff
 
     /**
      * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     * @param boolean                                   $saveMode
+     * @param bool                                      $saveMode
      *
      * @return array
      */

--- a/lib/Doctrine/DBAL/Schema/Sequence.php
+++ b/lib/Doctrine/DBAL/Schema/Sequence.php
@@ -31,25 +31,25 @@ use Doctrine\DBAL\Schema\Visitor\Visitor;
 class Sequence extends AbstractAsset
 {
     /**
-     * @var integer
+     * @var int
      */
     protected $allocationSize = 1;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $initialValue = 1;
 
     /**
-     * @var integer|null
+     * @var int|null
      */
     protected $cache = null;
 
     /**
-     * @param string       $name
-     * @param integer      $allocationSize
-     * @param integer      $initialValue
-     * @param integer|null $cache
+     * @param string   $name
+     * @param int      $allocationSize
+     * @param int      $initialValue
+     * @param int|null $cache
      */
     public function __construct($name, $allocationSize = 1, $initialValue = 1, $cache = null)
     {
@@ -60,7 +60,7 @@ class Sequence extends AbstractAsset
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getAllocationSize()
     {
@@ -68,7 +68,7 @@ class Sequence extends AbstractAsset
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getInitialValue()
     {
@@ -76,7 +76,7 @@ class Sequence extends AbstractAsset
     }
 
     /**
-     * @return integer|null
+     * @return int|null
      */
     public function getCache()
     {
@@ -84,7 +84,7 @@ class Sequence extends AbstractAsset
     }
 
     /**
-     * @param integer $allocationSize
+     * @param int $allocationSize
      *
      * @return \Doctrine\DBAL\Schema\Sequence
      */
@@ -96,7 +96,7 @@ class Sequence extends AbstractAsset
     }
 
     /**
-     * @param integer $initialValue
+     * @param int $initialValue
      *
      * @return \Doctrine\DBAL\Schema\Sequence
      */
@@ -108,7 +108,7 @@ class Sequence extends AbstractAsset
     }
 
     /**
-     * @param integer $cache
+     * @param int $cache
      *
      * @return \Doctrine\DBAL\Schema\Sequence
      */
@@ -127,7 +127,7 @@ class Sequence extends AbstractAsset
      *
      * @param \Doctrine\DBAL\Schema\Table $table
      *
-     * @return boolean
+     * @return bool
      */
     public function isAutoIncrementsFor(Table $table)
     {

--- a/lib/Doctrine/DBAL/Schema/Synchronizer/SchemaSynchronizer.php
+++ b/lib/Doctrine/DBAL/Schema/Synchronizer/SchemaSynchronizer.php
@@ -42,7 +42,7 @@ interface SchemaSynchronizer
      * Gets the SQL Statements to update given schema with the underlying db.
      *
      * @param \Doctrine\DBAL\Schema\Schema $toSchema
-     * @param boolean                      $noDrops
+     * @param bool                         $noDrops
      *
      * @return array
      */
@@ -77,7 +77,7 @@ interface SchemaSynchronizer
      * Updates the Schema to new schema version.
      *
      * @param \Doctrine\DBAL\Schema\Schema $toSchema
-     * @param boolean                      $noDrops
+     * @param bool                         $noDrops
      *
      * @return void
      */

--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -77,7 +77,7 @@ class Table extends AbstractAsset
      * @param Column[]               $columns
      * @param Index[]                $indexes
      * @param ForeignKeyConstraint[] $fkConstraints
-     * @param integer                $idGeneratorType
+     * @param int                    $idGeneratorType
      * @param array                  $options
      *
      * @throws DBALException
@@ -116,7 +116,7 @@ class Table extends AbstractAsset
     }
 
     /**
-     * @return integer
+     * @return int
      */
     protected function _getMaxIdentifierLength()
     {
@@ -264,7 +264,7 @@ class Table extends AbstractAsset
      *
      * @param array $columnsNames
      *
-     * @return boolean
+     * @return bool
      */
     public function columnsAreIndexed(array $columnsNames)
     {
@@ -279,12 +279,12 @@ class Table extends AbstractAsset
     }
 
     /**
-     * @param array   $columnNames
-     * @param string  $indexName
-     * @param boolean $isUnique
-     * @param boolean $isPrimary
-     * @param array   $flags
-     * @param array   $options
+     * @param array  $columnNames
+     * @param string $indexName
+     * @param bool   $isUnique
+     * @param bool   $isPrimary
+     * @param array  $flags
+     * @param array  $options
      *
      * @return Index
      *
@@ -378,7 +378,7 @@ class Table extends AbstractAsset
      *
      * Name is inferred from the local columns.
      *
-     * @param Table|string $foreignTable Table schema instance or table name
+     * @param Table|string $foreignTable       Table schema instance or table name
      * @param array        $localColumnNames
      * @param array        $foreignColumnNames
      * @param array        $options
@@ -400,7 +400,7 @@ class Table extends AbstractAsset
      *
      * @deprecated Use {@link addForeignKeyConstraint}
      *
-     * @param Table|string $foreignTable Table schema instance or table name
+     * @param Table|string $foreignTable       Table schema instance or table name
      * @param array        $localColumnNames
      * @param array        $foreignColumnNames
      * @param array        $options
@@ -418,7 +418,7 @@ class Table extends AbstractAsset
      * @deprecated Use {@link addForeignKeyConstraint}
      *
      * @param string       $name
-     * @param Table|string $foreignTable Table schema instance or table name
+     * @param Table|string $foreignTable       Table schema instance or table name
      * @param array        $localColumnNames
      * @param array        $foreignColumnNames
      * @param array        $options
@@ -568,7 +568,7 @@ class Table extends AbstractAsset
      *
      * @param string $constraintName
      *
-     * @return boolean
+     * @return bool
      */
     public function hasForeignKey($constraintName)
     {
@@ -660,7 +660,7 @@ class Table extends AbstractAsset
      *
      * @param string $columnName The column name.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasColumn($columnName)
     {
@@ -720,7 +720,7 @@ class Table extends AbstractAsset
     /**
      * Returns whether this table has a primary key.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasPrimaryKey()
     {
@@ -732,7 +732,7 @@ class Table extends AbstractAsset
      *
      * @param string $indexName The index name.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasIndex($indexName)
     {
@@ -781,7 +781,7 @@ class Table extends AbstractAsset
     /**
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function hasOption($name)
     {

--- a/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
@@ -70,7 +70,7 @@ class PoolingShardConnection extends Connection
     private $activeConnections;
 
     /**
-     * @var integer
+     * @var int
      */
     private $activeShardId;
 
@@ -129,7 +129,7 @@ class PoolingShardConnection extends Connection
     /**
      * Get active shard id.
      *
-     * @return integer
+     * @return int
      */
     public function getActiveShardId()
     {
@@ -189,7 +189,7 @@ class PoolingShardConnection extends Connection
      *
      * @param mixed $shardId
      *
-     * @return boolean
+     * @return bool
      *
      * @throws \Doctrine\DBAL\Sharding\ShardingException
      */
@@ -249,7 +249,7 @@ class PoolingShardConnection extends Connection
     /**
      * @param string|null $shardId
      *
-     * @return boolean
+     * @return bool
      */
     public function isConnected($shardId = null)
     {

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizer.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizer.php
@@ -191,7 +191,7 @@ class SQLAzureFederationsSynchronizer extends AbstractSchemaSynchronizer
 
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
-     * @param boolean                      $isFederation
+     * @param bool                         $isFederation
      *
      * @return \Doctrine\DBAL\Schema\Schema
      *

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
@@ -37,7 +37,7 @@ class SQLAzureShardManager implements ShardManager
     private $federationName;
 
     /**
-     * @var boolean
+     * @var bool
      */
     private $filteringEnabled;
 
@@ -122,7 +122,7 @@ class SQLAzureShardManager implements ShardManager
     /**
      * Sets Enabled/Disable filtering on the fly.
      *
-     * @param boolean $flag
+     * @param bool $flag
      *
      * @return void
      */

--- a/lib/Doctrine/DBAL/Sharding/ShardChoser/ShardChoser.php
+++ b/lib/Doctrine/DBAL/Sharding/ShardChoser/ShardChoser.php
@@ -35,7 +35,7 @@ interface ShardChoser
      * @param string                                         $distributionValue
      * @param \Doctrine\DBAL\Sharding\PoolingShardConnection $conn
      *
-     * @return integer
+     * @return int
      */
     function pickShard($distributionValue, PoolingShardConnection $conn);
 }

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -100,7 +100,7 @@ class Statement implements \IteratorAggregate, DriverStatement
      * @param mixed  $value The value of the parameter.
      * @param mixed  $type  Either a PDO binding type or a DBAL mapping type name or instance.
      *
-     * @return boolean TRUE on success, FALSE on failure.
+     * @return bool TRUE on success, FALSE on failure.
      */
     public function bindValue($name, $value, $type = null)
     {
@@ -128,13 +128,13 @@ class Statement implements \IteratorAggregate, DriverStatement
      *
      * Binding a parameter by reference does not support DBAL mapping types.
      *
-     * @param string       $name   The name or position of the parameter.
-     * @param mixed        $var    The reference to the variable to bind.
-     * @param integer      $type   The PDO binding type.
-     * @param integer|null $length Must be specified when using an OUT bind
-     *                             so that PHP allocates enough memory to hold the returned value.
+     * @param string   $name   The name or position of the parameter.
+     * @param mixed    $var    The reference to the variable to bind.
+     * @param int      $type   The PDO binding type.
+     * @param int|null $length Must be specified when using an OUT bind
+     *                         so that PHP allocates enough memory to hold the returned value.
      *
-     * @return boolean TRUE on success, FALSE on failure.
+     * @return bool TRUE on success, FALSE on failure.
      */
     public function bindParam($name, &$var, $type = PDO::PARAM_STR, $length = null)
     {
@@ -149,7 +149,7 @@ class Statement implements \IteratorAggregate, DriverStatement
      *
      * @param array|null $params
      *
-     * @return boolean TRUE on success, FALSE on failure.
+     * @return bool TRUE on success, FALSE on failure.
      *
      * @throws \Doctrine\DBAL\DBALException
      */
@@ -190,7 +190,7 @@ class Statement implements \IteratorAggregate, DriverStatement
     /**
      * Closes the cursor, freeing the database resources used by this statement.
      *
-     * @return boolean TRUE on success, FALSE on failure.
+     * @return bool TRUE on success, FALSE on failure.
      */
     public function closeCursor()
     {
@@ -200,7 +200,7 @@ class Statement implements \IteratorAggregate, DriverStatement
     /**
      * Returns the number of columns in the result set.
      *
-     * @return integer
+     * @return int
      */
     public function columnCount()
     {
@@ -274,7 +274,7 @@ class Statement implements \IteratorAggregate, DriverStatement
     /**
      * Returns a single column from the next row of a result set.
      *
-     * @param integer $columnIndex
+     * @param int $columnIndex
      *
      * @return mixed A single column from the next row of a result set or FALSE if there are no more rows.
      */
@@ -286,7 +286,7 @@ class Statement implements \IteratorAggregate, DriverStatement
     /**
      * Returns the number of rows affected by the last execution of this statement.
      *
-     * @return integer The number of affected rows.
+     * @return int The number of affected rows.
      */
     public function rowCount()
     {

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -139,7 +139,7 @@ abstract class Type
      *
      * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
      *
-     * @return integer|null
+     * @return int|null
      *
      * @todo Needed?
      */
@@ -213,7 +213,7 @@ abstract class Type
      *
      * @param string $name The name of the type.
      *
-     * @return boolean TRUE if type is supported; FALSE otherwise.
+     * @return bool TRUE if type is supported; FALSE otherwise.
      */
     public static function hasType($name)
     {
@@ -255,7 +255,7 @@ abstract class Type
      * PDO::PARAM_STR
      * PDO::PARAM_LOB
      *
-     * @return integer
+     * @return int
      */
     public function getBindingType()
     {
@@ -291,7 +291,7 @@ abstract class Type
      * {@link convertToPHPValueSQL} works for any type and mostly
      * does nothing. This method can additionally be used for optimization purposes.
      *
-     * @return boolean
+     * @return bool
      */
     public function canRequireSQLConversion()
     {
@@ -344,7 +344,7 @@ abstract class Type
      *
      * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
      *
-     * @return boolean
+     * @return bool
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -41,7 +41,7 @@ class Version
      *
      * @param string $version The Doctrine version to compare to.
      *
-     * @return integer -1 if older, 0 if it is the same, 1 if version passed as argument is newer.
+     * @return int -1 if older, 0 if it is the same, 1 if version passed as argument is newer.
      */
     public static function compare($version)
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -144,9 +144,9 @@ class NamedParametersTest extends \Doctrine\Tests\DbalFunctionalTestCase
     /**
      * @dataProvider ticketProvider
      * @param string $query
-     * @param array $params
-     * @param array $types
-     * @param array $expected
+     * @param array  $params
+     * @param array  $types
+     * @param array  $expected
      */
     public function testTicket($query,$params,$types,$expected)
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
@@ -24,8 +24,8 @@ class PortabilityTest extends \Doctrine\Tests\DbalFunctionalTestCase
     }
 
     /**
-     * @param   integer     $portabilityMode
-     * @param   integer     $case
+     * @param int $portabilityMode
+     * @param int $case
      * @return  Connection
      */
     private function getPortableConnection($portabilityMode = \Doctrine\DBAL\Portability\Connection::PORTABILITY_ALL, $case = \PDO::CASE_LOWER)

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -868,7 +868,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
 
     /**
      * @param string $name
-     * @param array $data
+     * @param array  $data
      * @return Table
      */
     protected function createTestTable($name = 'test_table', $data = array())

--- a/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
@@ -68,7 +68,7 @@ class TypeConversionTest extends \Doctrine\Tests\DbalFunctionalTestCase
     /**
      * @dataProvider dataIdempotentDataConversion
      * @param string $type
-     * @param mixed $originalValue
+     * @param mixed  $originalValue
      * @param string $expectedPhpType
      */
     public function testIdempotentDataConversion($type, $originalValue, $expectedPhpType)

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -733,7 +733,7 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
     abstract protected function getQuotesReservedKeywordInIndexDeclarationSQL();
 
     /**
-     * @return boolean
+     * @return bool
      */
     protected function supportsInlineIndexDeclaration()
     {

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -369,8 +369,8 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
      *
      * @param string $databaseValue
      * @param string $preparedStatementValue
-     * @param integer $integerValue
-     * @param boolean $booleanValue
+     * @param int    $integerValue
+     * @param bool   $booleanValue
      */
     public function testConvertBooleanAsLiteralStrings(
         $databaseValue,
@@ -404,8 +404,8 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
      *
      * @param string $databaseValue
      * @param string $preparedStatementValue
-     * @param integer $integerValue
-     * @param boolean $booleanValue
+     * @param int    $integerValue
+     * @param bool   $booleanValue
      */
     public function testConvertBooleanAsDatabaseValueStrings(
         $databaseValue,
@@ -436,8 +436,8 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
      *
      * @param string $databaseValue
      * @param string $prepareStatementValue
-     * @param integer $integerValue
-     * @param boolean $booleanValue
+     * @param int    $integerValue
+     * @param bool   $booleanValue
      */
     public function testConvertFromBoolean($databaseValue, $prepareStatementValue, $integerValue, $booleanValue)
     {

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -1067,9 +1067,9 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param SchemaDiff $diff
-     * @param int $newTableCount
-     * @param int $changeTableCount
-     * @param int $removeTableCount
+     * @param int        $newTableCount
+     * @param int        $changeTableCount
+     * @param int        $removeTableCount
      */
     public function assertSchemaTableChangeCount($diff, $newTableCount=0, $changeTableCount=0, $removeTableCount=0)
     {
@@ -1080,9 +1080,9 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param SchemaDiff $diff
-     * @param int $newSequenceCount
-     * @param int $changeSequenceCount
-     * @param int $changeSequenceCount
+     * @param int        $newSequenceCount
+     * @param int        $changeSequenceCount
+     * @param int        $changeSequenceCount
      */
     public function assertSchemaSequenceChangeCount($diff, $newSequenceCount=0, $changeSequenceCount=0, $removeSequenceCount=0)
     {

--- a/tests/Doctrine/Tests/DBAL/UtilTest.php
+++ b/tests/Doctrine/Tests/DBAL/UtilTest.php
@@ -64,7 +64,7 @@ class UtilTest extends \Doctrine\Tests\DbalTestCase
      * @dataProvider dataConvertPositionalToNamedParameters
      * @param string $inputSQL
      * @param string $expectedOutputSQL
-     * @param array $expectedOutputParamsMap
+     * @param array  $expectedOutputParamsMap
      */
     public function testConvertPositionalToNamedParameters($inputSQL, $expectedOutputSQL, $expectedOutputParamsMap)
     {

--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -15,7 +15,7 @@ class HydratorMockStatement implements \Doctrine\DBAL\Driver\Statement
     /**
      * Creates a new mock statement that will serve the provided fake result set to clients.
      *
-     * @param array $resultSet  The faked SQL result set.
+     * @param array $resultSet The faked SQL result set.
      */
     public function __construct(array $resultSet)
     {
@@ -54,7 +54,7 @@ class HydratorMockStatement implements \Doctrine\DBAL\Driver\Statement
     /**
      * Closes the cursor, enabling the statement to be executed again.
      *
-     * @return boolean
+     * @return bool
      */
     public function closeCursor()
     {

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -13,7 +13,7 @@ use Doctrine\DBAL\DriverManager;
 class TestUtil
 {
     /**
-     * @var boolean Whether the database schema is initialized.
+     * @var bool Whether the database schema is initialized.
      */
     private static $initialized = false;
 


### PR DESCRIPTION
As requested by @morozov in #2996