### PR TITLE
Inherit table charset/collation from db charset

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -496,7 +496,7 @@ class MySqlPlatform extends AbstractPlatform
 
         // Collate
         if ( ! isset($options['collate'])) {
-            $options['collate'] = $options['charset'].'_unicode_ci';
+            $options['collate'] = $options['charset'] . '_unicode_ci';
         }
 
         $tableOptions[] = sprintf('COLLATE %s', $options['collate']);

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -496,7 +496,7 @@ class MySqlPlatform extends AbstractPlatform
 
         // Collate
         if ( ! isset($options['collate'])) {
-            $options['collate'] = 'utf8_unicode_ci';
+            $options['collate'] = $options['charset'].'_unicode_ci';
         }
 
         $tableOptions[] = sprintf('COLLATE %s', $options['collate']);

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -1058,9 +1058,13 @@ abstract class AbstractSchemaManager
         }
 
         $params = $this->_conn->getParams();
-        if (isset($params['defaultTableOptions'])) {
-            $schemaConfig->setDefaultTableOptions($params['defaultTableOptions']);
+        if (! isset($params['defaultTableOptions'])) {
+            $params['defaultTableOptions'] = [];
         }
+        if (! isset($params['defaultTableOptions']['charset']) && isset($params['charset'])) {
+            $params['defaultTableOptions']['charset'] = $params['charset'];
+        }
+        $schemaConfig->setDefaultTableOptions($params['defaultTableOptions']);
 
         return $schemaConfig;
     }

--- a/tests/Doctrine/Tests/DBAL/Schema/MySqlInheritCharsetTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/MySqlInheritCharsetTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Schema;
+
+use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\MySqlSchemaManager;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+
+class MySqlInheritCharsetTest extends TestCase
+{
+    public function testInheritTableOptionsFromDatabase() : void
+    {
+        // default, no overrides
+        $options = $this->getTableOptionsForOverride();
+        self::assertFalse(isset($options['charset']));
+
+        // explicit utf8
+        $options = $this->getTableOptionsForOverride(['charset' => 'utf8']);
+        self::assertTrue(isset($options['charset']));
+        self::assertSame($options['charset'], 'utf8');
+
+        // explicit utf8mb4
+        $options = $this->getTableOptionsForOverride(['charset' => 'utf8mb4']);
+        self::assertTrue(isset($options['charset']));
+        self::assertSame($options['charset'], 'utf8mb4');
+    }
+
+    public function testTableOptions() : void
+    {
+        $eventManager = new EventManager();
+        $driverMock   = $this->createMock('Doctrine\DBAL\Driver');
+        $platform     = new \Doctrine\DBAL\Platforms\MySqlPlatform();
+
+        // default, no overrides
+        $table = new Table('foobar', [new Column('aa', Type::getType('integer'))]);
+        self::assertSame(
+            $platform->getCreateTableSQL($table),
+            ['CREATE TABLE foobar (aa INT NOT NULL) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB']
+        );
+
+        // explicit utf8
+        $table = new Table('foobar', [new Column('aa', Type::getType('integer'))]);
+        $table->addOption('charset', 'utf8');
+        self::assertSame(
+            $platform->getCreateTableSQL($table),
+            ['CREATE TABLE foobar (aa INT NOT NULL) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB']
+        );
+
+        // explicit utf8mb4
+        $table = new Table('foobar', [new Column('aa', Type::getType('integer'))]);
+        $table->addOption('charset', 'utf8mb4');
+        self::assertSame(
+            $platform->getCreateTableSQL($table),
+            ['CREATE TABLE foobar (aa INT NOT NULL) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB']
+        );
+    }
+
+    /**
+     * @param string[] $overrideOptions
+     *
+     * @return string[]
+     */
+    private function getTableOptionsForOverride(array $overrideOptions = []) : array
+    {
+        $eventManager = new EventManager();
+        $driverMock   = $this->createMock('Doctrine\DBAL\Driver');
+        $platform     = new MySqlPlatform();
+        $connOptions  = array_merge(['platform' => $platform], $overrideOptions);
+        $conn         = new Connection($connOptions, $driverMock, new Configuration(), $eventManager);
+        $manager      = new MySqlSchemaManager($conn, $platform);
+
+        $schemaConfig = $manager->createSchemaConfig();
+
+        return $schemaConfig->getDefaultTableOptions();
+    }
+}


### PR DESCRIPTION
If the database is utf8mb4, tables should be utf8mb4 by default.