### PR TITLE
fix if statement when check for an array without elements

### DIFF
--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -142,7 +142,7 @@ class DBALException extends \Exception
     public static function driverExceptionDuringQuery(Driver $driver, \Exception $driverEx, $sql, array $params = [])
     {
         $msg = "An exception occurred while executing '".$sql."'";
-        if ($params) {
+        if (! empty($params)) {
             $msg .= " with params " . self::formatParameters($params);
         }
         $msg .= ":\n\n".$driverEx->getMessage();


### PR DESCRIPTION
Fix and if statement when check for an array without elements into dbal exception instead of compare It with a boolean