### PR TITLE
Escape LIKE metacharacters

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3603,7 +3603,7 @@ abstract class AbstractPlatform
     /**
      * @return string[]
      */
-    protected function getLikeWildcardCharacters() : iterable
+    protected function getLikeWildcardCharacters() : array
     {
         return ['%', '_'];
     }

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -42,6 +42,9 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
+use function sprintf;
+use function strlen;
+use function strtr;
 
 /**
  * Base class for all DatabasePlatforms. The DatabasePlatforms are the central
@@ -3577,5 +3580,28 @@ abstract class AbstractPlatform
     public function getStringLiteralQuoteCharacter()
     {
         return "'";
+    }
+
+    /**
+     * Escapes metacharacters in a string intended to be used with a LIKE
+     * operator.
+     *
+     * @param string $inputString a literal, unquoted string
+     * @param string $escapeChar  should be reused by the caller in the LIKE
+     *                            expression.
+     */
+    final public function escapeStringForLike(string $inputString, string $escapeChar) : string
+    {
+        $replacePairs = [$escapeChar => $escapeChar.$escapeChar];
+        foreach ($this->getLikeWildcardCharacters() as $wildcardChar) {
+            $replacePairs[$wildcardChar] = $escapeChar.$wildcardChar;
+        }
+
+        return strtr($inputString, $replacePairs);
+    }
+
+    protected function getLikeWildcardCharacters() : iterable
+    {
+        return ['%', '_'];
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -43,7 +43,6 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use function addcslashes;
-use function implode;
 use function preg_quote;
 use function preg_replace;
 use function sprintf;
@@ -3596,17 +3595,14 @@ abstract class AbstractPlatform
     final public function escapeStringForLike(string $inputString, string $escapeChar) : string
     {
         return preg_replace(
-            '~([' . preg_quote(implode('', $this->getLikeWildcardCharacters()) . $escapeChar, '~') . '])~u',
+            '~([' . preg_quote($this->getLikeWildcardCharacters() . $escapeChar, '~') . '])~u',
             addcslashes($escapeChar, '\\') . '$1',
             $inputString
         );
     }
 
-    /**
-     * @return string[]
-     */
-    protected function getLikeWildcardCharacters() : array
+    protected function getLikeWildcardCharacters() : string
     {
-        return ['%', '_'];
+        return '%_';
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -42,9 +42,12 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
+use function addcslashes;
+use function implode;
+use function preg_quote;
+use function preg_replace;
 use function sprintf;
 use function strlen;
-use function strtr;
 
 /**
  * Base class for all DatabasePlatforms. The DatabasePlatforms are the central
@@ -3592,12 +3595,11 @@ abstract class AbstractPlatform
      */
     final public function escapeStringForLike(string $inputString, string $escapeChar) : string
     {
-        $replacePairs = [$escapeChar => $escapeChar . $escapeChar];
-        foreach ($this->getLikeWildcardCharacters() as $wildcardChar) {
-            $replacePairs[$wildcardChar] = $escapeChar . $wildcardChar;
-        }
-
-        return strtr($inputString, $replacePairs);
+        return preg_replace(
+            '~([' . preg_quote(implode('', $this->getLikeWildcardCharacters()) . $escapeChar, '~') . '])~u',
+            addcslashes($escapeChar, '\\') . '$1',
+            $inputString
+        );
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3592,14 +3592,17 @@ abstract class AbstractPlatform
      */
     final public function escapeStringForLike(string $inputString, string $escapeChar) : string
     {
-        $replacePairs = [$escapeChar => $escapeChar.$escapeChar];
+        $replacePairs = [$escapeChar => $escapeChar . $escapeChar];
         foreach ($this->getLikeWildcardCharacters() as $wildcardChar) {
-            $replacePairs[$wildcardChar] = $escapeChar.$wildcardChar;
+            $replacePairs[$wildcardChar] = $escapeChar . $wildcardChar;
         }
 
         return strtr($inputString, $replacePairs);
     }
 
+    /**
+     * @return string[]
+     */
     protected function getLikeWildcardCharacters() : iterable
     {
         return ['%', '_'];

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -120,7 +120,7 @@ class SQLServer2008Platform extends SQLServer2005Platform
     /**
      * {@inheritDoc}
      */
-    protected function getLikeWildcardCharacters() : iterable
+    protected function getLikeWildcardCharacters() : array
     {
         return array_merge(parent::getLikeWildcardCharacters(), ['[', ']', '^']);
     }

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -117,11 +117,8 @@ class SQLServer2008Platform extends SQLServer2005Platform
         return Keywords\SQLServer2008Keywords::class;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function getLikeWildcardCharacters() : array
+    protected function getLikeWildcardCharacters() : string
     {
-        return array_merge(parent::getLikeWildcardCharacters(), ['[', ']', '^']);
+        return parent::getLikeWildcardCharacters() . '[]^';
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -117,6 +117,9 @@ class SQLServer2008Platform extends SQLServer2005Platform
         return Keywords\SQLServer2008Keywords::class;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function getLikeWildcardCharacters() : iterable
     {
         return array_merge(parent::getLikeWildcardCharacters(), ['[', ']', '^']);

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -116,4 +116,9 @@ class SQLServer2008Platform extends SQLServer2005Platform
     {
         return Keywords\SQLServer2008Keywords::class;
     }
+
+    protected function getLikeWildcardCharacters() : iterable
+    {
+        return array_merge(parent::getLikeWildcardCharacters(), ['[', ']', '^']);
+    }
 }

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -257,7 +257,7 @@ class ExpressionBuilder
      *
      * @return string
      */
-    public function like($x, $y)
+    public function like($x, $y/*, ?string $escapeChar = null */)
     {
         return $this->comparison($x, 'LIKE', $y) .
             (func_num_args() >= 3 ? sprintf(" ESCAPE '%s'", func_get_arg(2)) : '');
@@ -271,7 +271,7 @@ class ExpressionBuilder
      *
      * @return string
      */
-    public function notLike($x, $y)
+    public function notLike($x, $y/*, ?string $escapeChar = null */)
     {
         return $this->comparison($x, 'NOT LIKE', $y) .
             (func_num_args() >= 3 ? sprintf(" ESCAPE '%s'", func_get_arg(2)) : '');

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -20,7 +20,7 @@
 namespace Doctrine\DBAL\Query\Expression;
 
 use Doctrine\DBAL\Connection;
-use function func_get_args;
+use function func_get_arg;
 use function func_num_args;
 use function sprintf;
 
@@ -260,7 +260,7 @@ class ExpressionBuilder
     public function like($x, $y)
     {
         return $this->comparison($x, 'LIKE', $y) .
-            (func_num_args() >= 3 ? sprintf(" ESCAPE '%s'", func_get_args()[2]) : '');
+            (func_num_args() >= 3 ? sprintf(" ESCAPE '%s'", func_get_arg(2)) : '');
     }
 
     /**
@@ -274,7 +274,7 @@ class ExpressionBuilder
     public function notLike($x, $y)
     {
         return $this->comparison($x, 'NOT LIKE', $y) .
-            (func_num_args() >= 3 ? sprintf(" ESCAPE '%s'", func_get_args()[2]) : '');
+            (func_num_args() >= 3 ? sprintf(" ESCAPE '%s'", func_get_arg(2)) : '');
     }
 
     /**

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -20,6 +20,9 @@
 namespace Doctrine\DBAL\Query\Expression;
 
 use Doctrine\DBAL\Connection;
+use function func_get_args;
+use function func_num_args;
+use function sprintf;
 
 /**
  * ExpressionBuilder class is responsible to dynamically create SQL query parts.
@@ -256,7 +259,8 @@ class ExpressionBuilder
      */
     public function like($x, $y)
     {
-        return $this->comparison($x, 'LIKE', $y);
+        return $this->comparison($x, 'LIKE', $y) .
+            (func_num_args() >= 3 ? sprintf(" ESCAPE '%s'", func_get_args()[2]) : '');
     }
 
     /**
@@ -269,7 +273,8 @@ class ExpressionBuilder
      */
     public function notLike($x, $y)
     {
-        return $this->comparison($x, 'NOT LIKE', $y);
+        return $this->comparison($x, 'NOT LIKE', $y) .
+            (func_num_args() >= 3 ? sprintf(" ESCAPE '%s'", func_get_args()[2]) : '');
     }
 
     /**

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -260,7 +260,7 @@ class ExpressionBuilder
     public function like($x, $y/*, ?string $escapeChar = null */)
     {
         return $this->comparison($x, 'LIKE', $y) .
-            (func_num_args() >= 3 ? sprintf(" ESCAPE '%s'", func_get_arg(2)) : '');
+            (func_num_args() >= 3 ? sprintf(' ESCAPE %s', func_get_arg(2)) : '');
     }
 
     /**
@@ -274,7 +274,7 @@ class ExpressionBuilder
     public function notLike($x, $y/*, ?string $escapeChar = null */)
     {
         return $this->comparison($x, 'NOT LIKE', $y) .
-            (func_num_args() >= 3 ? sprintf(" ESCAPE '%s'", func_get_arg(2)) : '');
+            (func_num_args() >= 3 ? sprintf(' ESCAPE %s', func_get_arg(2)) : '');
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
@@ -2,8 +2,9 @@
 
 namespace Doctrine\Tests\DBAL\Functional;
 
-use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\Tests\DbalFunctionalTestCase;
+use function sprintf;
+use function str_replace;
 
 final class LikeWildcardsEscapingTest extends DbalFunctionalTestCase
 {
@@ -12,12 +13,15 @@ final class LikeWildcardsEscapingTest extends DbalFunctionalTestCase
         $string           = '_25% off_ your next purchase \o/';
         $escapeChar       = '!';
         $databasePlatform = $this->_conn->getDatabasePlatform();
-        $stmt             = $this->_conn->prepare(sprintf(
-            "SELECT (CASE WHEN '%s' LIKE '%s' ESCAPE '%s' THEN 1 ELSE 0 END)" .
-                ($databasePlatform instanceof OraclePlatform ? ' FROM dual' : ''),
-            $string,
-            $databasePlatform->escapeStringForLike($string, $escapeChar),
-            $escapeChar
+        $stmt             = $this->_conn->prepare(str_replace(
+            '1',
+            sprintf(
+                "(CASE WHEN '%s' LIKE '%s' ESCAPE '%s' THEN 1 ELSE 0 END)",
+                $string,
+                $databasePlatform->escapeStringForLike($string, $escapeChar),
+                $escapeChar
+            ),
+            $databasePlatform->getDummySelectSQL()
         ));
         $stmt->execute();
         $this->assertTrue((bool) $stmt->fetchColumn());

--- a/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
@@ -8,9 +8,9 @@ final class LikeWildcardsEscapingTest extends DbalFunctionalTestCase
 {
     public function testFetchLikeExpressionResult() : void
     {
-        $string = '_25% off_ your next purchase \o/';
+        $string     = '_25% off_ your next purchase \o/';
         $escapeChar = '!';
-        $stmt = $this->_conn->prepare(sprintf(
+        $stmt       = $this->_conn->prepare(sprintf(
             "SELECT '%s' LIKE '%s' ESCAPE '%s' as it_matches",
             $string,
             $this->_conn->getDatabasePlatform()->escapeStringForLike($string, $escapeChar),

--- a/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
@@ -9,7 +9,7 @@ final class LikeWildcardsEscapingTest extends DbalFunctionalTestCase
     public function testFetchLikeExpressionResult() : void
     {
         $string = '_25% off_ your next purchase \o/';
-        $escapeChar = '£';
+        $escapeChar = '!';
         $stmt = $this->_conn->prepare(sprintf(
             "SELECT '%s' LIKE '%s' ESCAPE '%s' as it_matches",
             $string,

--- a/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
@@ -10,7 +10,7 @@ final class LikeWildcardsEscapingTest extends DbalFunctionalTestCase
 {
     public function testFetchLikeExpressionResult() : void
     {
-        $string           = '_25% off_ your next purchase \o/';
+        $string           = '_25% off_ your next purchase \o/ [$̲̅(̲̅5̲̅)̲̅$̲̅] (^̮^)';
         $escapeChar       = '!';
         $databasePlatform = $this->_conn->getDatabasePlatform();
         $stmt             = $this->_conn->prepare(str_replace(

--- a/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional;
+
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+final class LikeWildcardsEscapingTest extends DbalFunctionalTestCase
+{
+    public function testFetchLikeExpressionResult() : void
+    {
+        $string = '_25% off_ your next purchase \o/';
+        $escapeChar = '£';
+        $stmt = $this->_conn->prepare(sprintf(
+            "SELECT '%s' LIKE '%s' ESCAPE '%s' as it_matches",
+            $string,
+            $this->_conn->getDatabasePlatform()->escapeStringForLike($string, $escapeChar),
+            $escapeChar
+        ));
+        $stmt->execute();
+        $this->assertTrue((bool) $stmt->fetch()['it_matches']);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
@@ -17,6 +17,6 @@ final class LikeWildcardsEscapingTest extends DbalFunctionalTestCase
             $escapeChar
         ));
         $stmt->execute();
-        $this->assertTrue((bool) $stmt->fetch()['it_matches']);
+        $this->assertTrue((bool) $stmt->fetchColumn());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
@@ -2,18 +2,21 @@
 
 namespace Doctrine\Tests\DBAL\Functional;
 
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\Tests\DbalFunctionalTestCase;
 
 final class LikeWildcardsEscapingTest extends DbalFunctionalTestCase
 {
     public function testFetchLikeExpressionResult() : void
     {
-        $string     = '_25% off_ your next purchase \o/';
-        $escapeChar = '!';
-        $stmt       = $this->_conn->prepare(sprintf(
-            "SELECT '%s' LIKE '%s' ESCAPE '%s' as it_matches",
+        $string           = '_25% off_ your next purchase \o/';
+        $escapeChar       = '!';
+        $databasePlatform = $this->_conn->getDatabasePlatform();
+        $stmt             = $this->_conn->prepare(sprintf(
+            "SELECT (CASE WHEN '%s' LIKE '%s' ESCAPE '%s' THEN 1 ELSE 0 END)" .
+                ($databasePlatform instanceof OraclePlatform ? ' FROM dual' : ''),
             $string,
-            $this->_conn->getDatabasePlatform()->escapeStringForLike($string, $escapeChar),
+            $databasePlatform->escapeStringForLike($string, $escapeChar),
             $escapeChar
         ));
         $stmt->execute();

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -1468,4 +1468,12 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
             array(array('precision' => 8, 'scale' => 2), 'DOUBLE PRECISION'),
         );
     }
+
+    public function testItEscapesStringsForLike() : void
+    {
+        self::assertSame(
+            '\_25\% off\_ your next purchase \\\\o/',
+            $this->_platform->escapeStringForLike('_25% off_ your next purchase \o/', '\\')
+        );
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
@@ -229,7 +229,7 @@ class ExpressionBuilderTest extends \Doctrine\Tests\DbalTestCase
     {
         self::assertEquals(
             "a.song LIKE 'a virgin' ESCAPE '💩'",
-            $this->expr->like('a.song', "'a virgin'", '💩')
+            $this->expr->like('a.song', "'a virgin'", "'💩'")
         );
     }
 
@@ -245,7 +245,7 @@ class ExpressionBuilderTest extends \Doctrine\Tests\DbalTestCase
     {
         self::assertEquals(
             "p.description NOT LIKE '20💩%' ESCAPE '💩'",
-            $this->expr->notLike('p.description', "'20💩%'", '💩')
+            $this->expr->notLike('p.description', "'20💩%'", "'💩'")
         );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
@@ -219,4 +219,33 @@ class ExpressionBuilderTest extends \Doctrine\Tests\DbalTestCase
     {
         self::assertEquals('u.groups NOT IN (:values)', $this->expr->notIn('u.groups', ':values'));
     }
+
+    public function testLikeWithoutEscape()
+    {
+        self::assertEquals("a.song LIKE 'a virgin'", $this->expr->like('a.song', "'a virgin'"));
+    }
+
+    public function testLikeWithEscape()
+    {
+        self::assertEquals(
+            "a.song LIKE 'a virgin' ESCAPE '💩'",
+            $this->expr->like('a.song', "'a virgin'", '💩')
+        );
+    }
+
+    public function testNotLikeWithoutEscape()
+    {
+        self::assertEquals(
+            "s.last_words NOT LIKE 'this'",
+            $this->expr->notLike('s.last_words', "'this'")
+        );
+    }
+
+    public function testNotLikeWithEscape()
+    {
+        self::assertEquals(
+            "p.description NOT LIKE '20💩%' ESCAPE '💩'",
+            $this->expr->notLike('p.description', "'20💩%'", '💩')
+        );
+    }
 }


### PR DESCRIPTION
There seems to be a lack of tools to fight against [wildcard attacks](https://www.owasp.org/index.php/Testing_for_SQL_Wildcard_Attacks_(OWASP-DS-001) ), or to simply provide a way to let your users search for strings that include metacharacters

# todo

- [x] add a functional test to make sure valid SQL expressions are built by means of the new API.
- [x] allow specifying an escape character in the expression builder `like` and `notLike` methods.
- [x] implement `getWildcardCharacters` for RDBMSs that have more than the default wildcard characters.
