### PR TITLE
[CS] Remove emtpy lines before and after function braces

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
@@ -92,7 +92,6 @@ abstract class AbstractSQLServerDriver implements Driver, VersionAwarePlatformDr
     /**
      * {@inheritdoc}
      */
-
     public function getSchemaManager(\Doctrine\DBAL\Connection $conn)
     {
         return new SQLServerSchemaManager($conn);

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -183,7 +183,6 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
 
         self::assertFalse($this->_conn->lastInsertId( null ));
-
     }
 
     /**
@@ -287,7 +286,6 @@ class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $secondId = $this->_conn->lastInsertId($seqName);
 
         self::assertGreaterThan($firstId, $secondId);
-
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Mocks/MockPlatform.php
+++ b/tests/Doctrine/Tests/DBAL/Mocks/MockPlatform.php
@@ -61,6 +61,5 @@ class MockPlatform extends AbstractPlatform
     }
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
-
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -1360,7 +1360,6 @@ abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
      */
     public function testAlterStringToFixedString()
     {
-
         $table = new Table('mytable');
         $table->addColumn('name', 'string', array('length' => 2));
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -465,7 +465,6 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
 
     public function testAlterDecimalPrecisionScale()
     {
-
         $table = new Table('mytable');
         $table->addColumn('dfoo1', 'decimal');
         $table->addColumn('dfoo2', 'decimal', array('precision' => 10, 'scale' => 6));

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -58,7 +58,6 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
         $this->conn->expects($this->any())
             ->method('getDriver')
             ->will($this->returnValue($driver));
-
     }
 
     public function testExecuteCallsLoggerStartQueryWithParametersWhenValuesBound()

--- a/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
+++ b/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
@@ -89,7 +89,6 @@ class DatabasePlatformMock extends \Doctrine\DBAL\Platforms\AbstractPlatform
     }
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
-
     }
     /**
      * Gets the SQL Snippet used to declare a BLOB column type.


### PR DESCRIPTION
Fixes related to `found 1 blank lines before/after brace`