### PR TITLE
Create date strings compatible to datetime and datetime2

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -49,7 +49,7 @@ class SQLServer2008Platform extends SQLServer2005Platform
      */
     public function getDateTimeFormatString()
     {
-        return 'Y-m-d H:i:s.u';
+        return 'Y-m-dTH:i:s.u';
     }
 
     /**
@@ -57,7 +57,7 @@ class SQLServer2008Platform extends SQLServer2005Platform
      */
     public function getDateTimeTzFormatString()
     {
-        return 'Y-m-d H:i:s.u P';
+        return 'Y-m-dTH:i:s.uP';
     }
 
     /**


### PR DESCRIPTION
Hello,

in SQLServer the format (dmy or ymd) of datetime values depends on the value of the variable `DATEFORMAT`. When you have a schema you can't manage, you can get wrong results when querying a table with a different `DATEFORMAT` set. It seems that SQLServer support ISO 8601-like values, which seems always to be correct on `datetime` and `datetime2`.

I suggest changing that DateTime objects are always turned into the ISO 8601-like strings, to make it work with both types.

I'm not sure if this is a bc break, but I guess this could introduce some cache-related issue to some end-users.