### PR TITLE
Allow dynamic intervals in DATE_ADD & DATE_SUB for SQLite

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -150,6 +150,10 @@ class SqlitePlatform extends AbstractPlatform
                         break;
                 }
 
+                if (!is_numeric($interval)) {
+                    $interval = "' || " . $interval . " || '";
+                }
+
                 return "DATE(" . $date . ",'" . $operator . $interval . " " . $unit . "')";
         }
     }

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -150,7 +150,7 @@ class SqlitePlatform extends AbstractPlatform
                         break;
                 }
 
-                if (!is_numeric($interval)) {
+                if (! is_numeric($interval)) {
                     $interval = "' || " . $interval . " || '";
                 }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -749,4 +749,14 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     {
         self::assertContains("'Foo''Bar\\'", $this->_platform->getListTableForeignKeysSQL("Foo'Bar\\"), '', true);
     }
+
+    public function testDateAddStaticNumberOfDays()
+    {
+        self::assertSame("DATE(rentalBeginsOn,'+12 DAY')", $this->_platform->getDateAddDaysExpression('rentalBeginsOn', 12));
+    }
+
+    public function testDateAddNumberOfDaysFromColumn()
+    {
+        self::assertSame("DATE(rentalBeginsOn,'+' || duration || ' DAY')", $this->_platform->getDateAddDaysExpression('rentalBeginsOn', 'duration'));
+    }
 }


### PR DESCRIPTION
Fixing #2983
Replacing https://github.com/doctrine/dbal/pull/2984
