### PR TITLE
Improve handling of schemas in SQL Server >= 2008

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -30,6 +30,16 @@ class SQLServer2008Platform extends SQLServer2005Platform
     /**
      * {@inheritDoc}
      */
+    public function getListTablesSQL()
+    {
+        // "sysdiagrams" table must be ignored as it's internal SQL Server table for Database Diagrams
+        // Category 2 must be ignored as it is "MS SQL Server 'pseudo-system' object[s]" for replication
+        return "SELECT name, SCHEMA_NAME (uid) AS schema_name FROM sysobjects WHERE type = 'U' AND name != 'sysdiagrams' AND category != 2 ORDER BY name";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration)
     {
         // 3 - microseconds precision length

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -28,8 +28,10 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types;
+use function explode;
 use function implode;
 use function sprintf;
+use function strpos;
 
 /**
  * The SQLServerPlatform provides the behavior, features and SQL dialect of the
@@ -330,13 +332,22 @@ class SQLServerPlatform extends AbstractPlatform
      */
     protected function getCreateColumnCommentSQL($tableName, $columnName, $comment)
     {
+        if (strpos($tableName, '.') !== false) {
+            [$schemaSQL, $tableSQL] = explode('.', $tableName);
+            $schemaSQL              = $this->quoteStringLiteral($schemaSQL);
+            $tableSQL               = $this->quoteStringLiteral($tableSQL);
+        } else {
+            $schemaSQL = "'dbo'";
+            $tableSQL  = $this->quoteStringLiteral($tableName);
+        }
+
         return $this->getAddExtendedPropertySQL(
             'MS_Description',
             $comment,
             'SCHEMA',
-            'dbo',
+            $schemaSQL,
             'TABLE',
-            $tableName,
+            $tableSQL,
             'COLUMN',
             $columnName
         );
@@ -678,13 +689,22 @@ class SQLServerPlatform extends AbstractPlatform
      */
     protected function getAlterColumnCommentSQL($tableName, $columnName, $comment)
     {
+        if (strpos($tableName, '.') !== false) {
+            [$schemaSQL, $tableSQL] = explode('.', $tableName);
+            $schemaSQL              = $this->quoteStringLiteral($schemaSQL);
+            $tableSQL               = $this->quoteStringLiteral($tableSQL);
+        } else {
+            $schemaSQL = "'dbo'";
+            $tableSQL  = $this->quoteStringLiteral($tableName);
+        }
+
         return $this->getUpdateExtendedPropertySQL(
             'MS_Description',
             $comment,
             'SCHEMA',
-            'dbo',
+            $schemaSQL,
             'TABLE',
-            $tableName,
+            $tableSQL,
             'COLUMN',
             $columnName
         );
@@ -708,12 +728,21 @@ class SQLServerPlatform extends AbstractPlatform
      */
     protected function getDropColumnCommentSQL($tableName, $columnName)
     {
+        if (strpos($tableName, '.') !== false) {
+            [$schemaSQL, $tableSQL] = explode('.', $tableName);
+            $schemaSQL              = $this->quoteStringLiteral($schemaSQL);
+            $tableSQL               = $this->quoteStringLiteral($tableSQL);
+        } else {
+            $schemaSQL = "'dbo'";
+            $tableSQL  = $this->quoteStringLiteral($tableName);
+        }
+
         return $this->getDropExtendedPropertySQL(
             'MS_Description',
             'SCHEMA',
-            'dbo',
+            $schemaSQL,
             'TABLE',
-            $tableName,
+            $tableSQL,
             'COLUMN',
             $columnName
         );

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -198,6 +198,10 @@ class SQLServerSchemaManager extends AbstractSchemaManager
      */
     protected function _getPortableTableDefinition($table)
     {
+        if (isset($table['schema_name']) && $table['schema_name'] !== 'dbo') {
+            return $table['schema_name'] . '.' . $table['name'];
+        }
+
         return $table['name'];
     }
 


### PR DESCRIPTION
Table listings do not consider schema names for the SQL Server platform.
This fix adds the schema name to SQL Server >= 2008 table listingss using SQL Sever built-in function SCHEMA_NAME() applied to column uid.

Funtion reference: https://docs.microsoft.com/en-us/sql/t-sql/functions/schema-name-transact-sql
Column reference: https://docs.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-sysobjects-transact-sql

Without this fix doctrine will always try to create the whole schema, even if you only triggered an update. This is because the state of the current schema stored in database is not read correctly.


**Note:** This fix might also be necessary for SQL Server platforms older than 2008. Unfortunately, I have no possibility to test it.
If anyone wants to backport this fix, be aware that the built-in function SCHEMA_NAME is only available since SQL Server 2008. Maybe the function USER_NAME will help: https://social.msdn.microsoft.com/Forums/sqlserver/en-US/135d51e5-2c22-4ce9-a308-fbb958f3362e/how-to-get-schema-name-from-uid-column-in-dbosysobjects-in-sql-server-2000?forum=transactsql