### PR TITLE
Documentation: Warn against using object fields in MySQL and MariaDB

### DIFF
--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -481,6 +481,14 @@ using deserialization or ``null`` if no data is present.
 
 .. warning::
 
+    While the built-in ``text`` type of MySQL and MariaDB can store binary data,
+    ``mysqldump`` cannot properly export ``text`` fields containing binary data.
+    This will cause creating and restoring of backups fail silently. A workaround is
+    to ``serialize()``/``unserialize()`` and ``base64_encode()``/``base64_decode()``
+    PHP objects and store them into a ``text`` field manually.
+
+.. warning::
+
     Because the built-in ``text`` type of PostgreSQL does not support NULL bytes,
     the object type will cause deserialization errors on PostgreSQL. A workaround is
     to ``serialize()``/``unserialize()`` and ``base64_encode()``/``base64_decode()`` PHP objects and store


### PR DESCRIPTION
While `types.rst` warns against using `object` in PostgreSQL, it does not warn against using it in MySQL. This PR adds a warning against it, since using object fields will cause backups to silently fail. Based on previous PRs and issues, fixing this would break backward compatibility.