### PR TITLE
Drop PCRE x modifier in SqliteSchemaManager (#2885 rework)

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -439,7 +439,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     private function parseColumnCollationFromSQL(string $column, string $sql) : ?string
     {
         $pattern = '{(?:\W' . preg_quote($column) . '\W|\W' . preg_quote($this->_platform->quoteSingleIdentifier($column))
-                 . '\W)[^,(]+(?:\([^()]+\)[^,]*)?(?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*COLLATE\s+["\']?([^\s,"\')]+)}isx';
+            . '\W)[^,(]+(?:\([^()]+\)[^,]*)?(?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*COLLATE\s+["\']?([^\s,"\')]+)}is';
 
         if (preg_match($pattern, $sql, $match) !== 1) {
             return null;
@@ -451,7 +451,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     private function parseColumnCommentFromSQL(string $column, string $sql) : ?string
     {
         $pattern = '{[\s(,](?:\W' . preg_quote($this->_platform->quoteSingleIdentifier($column)) . '\W|\W' . preg_quote($column)
-                 . '\W)(?:\(.*?\)|[^,(])*?,?((?:(?!\n))(?:\s*--[^\n]*\n?)+)}ix';
+            . '\W)(?:\(.*?\)|[^,(])*?,?((?:(?!\n))(?:\s*--[^\n]*\n?)+)}i';
 
         if (preg_match($pattern, $sql, $match) !== 1) {
             return null;

--- a/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaManagerTest.php
@@ -36,6 +36,14 @@ class SqliteSchemaManagerTest extends \PHPUnit\Framework\TestCase
             ['BINARY', 'b', 'CREATE TABLE "a" (bb TEXT COLLATE RTRIM, b VARCHAR(42) NOT NULL COLLATE BINARY)'],
             ['BINARY', 'b', 'CREATE TABLE "a" (bbb TEXT COLLATE NOCASE, bb TEXT COLLATE RTRIM, b VARCHAR(42) NOT NULL COLLATE BINARY)'],
             ['BINARY', 'b', 'CREATE TABLE "a" (b VARCHAR(42) NOT NULL COLLATE BINARY, bb TEXT COLLATE RTRIM)'],
+            ['utf-8', 'bar#', 'CREATE TABLE dummy_table (id INTEGER NOT NULL, foo VARCHAR(255) COLLATE "utf-8" NOT NULL, "bar#" VARCHAR(255) COLLATE "utf-8" NOT NULL, baz VARCHAR(255) COLLATE "utf-8" NOT NULL, PRIMARY KEY(id))'],
+            [null,    'bar#', 'CREATE TABLE dummy_table (id INTEGER NOT NULL, foo VARCHAR(255) NOT NULL, "bar#" VARCHAR(255) NOT NULL, baz VARCHAR(255) NOT NULL, PRIMARY KEY(id))'],
+            ['utf-8', 'baz',  'CREATE TABLE dummy_table (id INTEGER NOT NULL, foo VARCHAR(255) COLLATE "utf-8" NOT NULL, "bar#" INTEGER NOT NULL, baz VARCHAR(255) COLLATE "utf-8" NOT NULL, PRIMARY KEY(id))'],
+            [null,    'baz',  'CREATE TABLE dummy_table (id INTEGER NOT NULL, foo VARCHAR(255) NOT NULL, "bar#" INTEGER NOT NULL, baz VARCHAR(255) NOT NULL, PRIMARY KEY(id))'],
+            ['utf-8', 'bar/', 'CREATE TABLE dummy_table (id INTEGER NOT NULL, foo VARCHAR(255) COLLATE "utf-8" NOT NULL, "bar/" VARCHAR(255) COLLATE "utf-8" NOT NULL, baz VARCHAR(255) COLLATE "utf-8" NOT NULL, PRIMARY KEY(id))'],
+            [null,    'bar/', 'CREATE TABLE dummy_table (id INTEGER NOT NULL, foo VARCHAR(255) NOT NULL, "bar/" VARCHAR(255) NOT NULL, baz VARCHAR(255) NOT NULL, PRIMARY KEY(id))'],
+            ['utf-8', 'baz',  'CREATE TABLE dummy_table (id INTEGER NOT NULL, foo VARCHAR(255) COLLATE "utf-8" NOT NULL, "bar/" INTEGER NOT NULL, baz VARCHAR(255) COLLATE "utf-8" NOT NULL, PRIMARY KEY(id))'],
+            [null,    'baz',  'CREATE TABLE dummy_table (id INTEGER NOT NULL, foo VARCHAR(255) NOT NULL, "bar/" INTEGER NOT NULL, baz VARCHAR(255) NOT NULL, PRIMARY KEY(id))'],
         ];
     }
 
@@ -96,6 +104,148 @@ class SqliteSchemaManagerTest extends \PHPUnit\Framework\TestCase
                 '(DC2Type:guid)', 'c', 'CREATE TABLE "b" ("a" NUMERIC(10, 0) NOT NULL, "b" CLOB NOT NULL --(DC2Type:array)
 , "c" CHAR(36) NOT NULL --(DC2Type:guid)
 )',
+            ],
+            'Column with numeric but no comment 4' => [
+                '(DC2Type:array)',
+                'b',
+                'CREATE TABLE "b" ("a" NUMERIC(10, 0) NOT NULL,
+                    "b" CLOB NOT NULL, --(DC2Type:array)
+                    "c" CHAR(36) NOT NULL --(DC2Type:guid)
+                )',
+            ],
+            'Column "bar", select "bar" with no comment' => [
+                null,
+                'bar',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar" VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    PRIMARY KEY(id)
+                )',
+            ],
+            'Column "bar", select "bar" with type comment' => [
+                '(DC2Type:x)',
+                'bar',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar" VARCHAR(255) COLLATE "utf-8" NOT NULL, --(DC2Type:x)
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL, --(DC2Type:y)
+                    PRIMARY KEY(id)
+                )',
+            ],
+            'Column "bar", select "baz" with no comment' => [
+                null,
+                'baz',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar" INTEGER NOT NULL,
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    PRIMARY KEY(id)
+                )',
+            ],
+            'Column "bar", select "baz" with type comment' => [
+                '(DC2Type:y)',
+                'baz',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar" INTEGER NOT NULL, --(DC2Type:x)
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL, --(DC2Type:y)
+                    PRIMARY KEY(id)
+                )',
+            ],
+
+            'Column "bar#", select "bar#" with no comment' => [
+                null,
+                'bar#',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar#" VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    PRIMARY KEY(id)
+                )',
+            ],
+            'Column "bar#", select "bar#" with type comment' => [
+                '(DC2Type:x)',
+                'bar#',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar#" VARCHAR(255) COLLATE "utf-8" NOT NULL, --(DC2Type:x)
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL, --(DC2Type:y)
+                    PRIMARY KEY(id)
+                )',
+            ],
+            'Column "bar#", select "baz" with no comment' => [
+                null,
+                'baz',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar#" INTEGER NOT NULL,
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    PRIMARY KEY(id)
+                )',
+            ],
+            'Column "bar#", select "baz" with type comment' => [
+                '(DC2Type:y)',
+                'baz',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar#" INTEGER NOT NULL, --(DC2Type:x)
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL, --(DC2Type:y)
+                    PRIMARY KEY(id)
+                )',
+            ],
+
+            'Column "bar/", select "bar/" with no comment' => [
+                null,
+                'bar/',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar/" VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    PRIMARY KEY(id)
+                    )',
+            ],
+            'Column "bar/", select "bar/" with type comment' => [
+                '(DC2Type:x)',
+                'bar/',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar/" VARCHAR(255) COLLATE "utf-8" NOT NULL, --(DC2Type:x)
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL, --(DC2Type:y)
+                    PRIMARY KEY(id)
+                )',
+            ],
+            'Column "bar/", select "baz" with no comment' => [
+                null,
+                'baz',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar/" INTEGER NOT NULL,
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    PRIMARY KEY(id)
+                )',
+            ],
+            'Column "bar/", select "baz" with type comment' => [
+                '(DC2Type:y)',
+                'baz',
+                'CREATE TABLE dummy_table (
+                    id INTEGER NOT NULL,
+                    foo VARCHAR(255) COLLATE "utf-8" NOT NULL,
+                    "bar/" INTEGER COLLATE "utf-8" NOT NULL, --(DC2Type:x)
+                    baz VARCHAR(255) COLLATE "utf-8" NOT NULL, --(DC2Type:y)
+                    PRIMARY KEY(id)
+                )',
             ],
         ];
     }


### PR DESCRIPTION
Simplified version of #2885.

Tests are taken from there (and expectedly failing without the fix), but the approach is different - instead of fixing PHP bugs conditionally, just dropping the `x` modifier altogether.

Closes #2885.
Fixes #2881.