### PR TITLE
Connection parameters are cached hashed

### DIFF
--- a/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
+++ b/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
@@ -20,18 +20,19 @@
 namespace Doctrine\DBAL\Cache;
 
 use Doctrine\Common\Cache\Cache;
+use function hash;
+use function serialize;
+use function sha1;
 
 /**
  * Query Cache Profile handles the data relevant for query caching.
  *
  * It is a value object, setter methods return NEW instances.
- *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
 class QueryCacheProfile
 {
     /**
-     * @var \Doctrine\Common\Cache\Cache|null
+     * @var Cache|null
      */
     private $resultCacheDriver;
 
@@ -46,19 +47,18 @@ class QueryCacheProfile
     private $cacheKey;
 
     /**
-     * @param int                               $lifetime
-     * @param string|null                       $cacheKey
-     * @param \Doctrine\Common\Cache\Cache|null $resultCache
+     * @param int         $lifetime
+     * @param string|null $cacheKey
      */
-    public function __construct($lifetime = 0, $cacheKey = null, Cache $resultCache = null)
+    public function __construct($lifetime = 0, $cacheKey = null, ?Cache $resultCache = null)
     {
-        $this->lifetime = $lifetime;
-        $this->cacheKey = $cacheKey;
+        $this->lifetime          = $lifetime;
+        $this->cacheKey          = $cacheKey;
         $this->resultCacheDriver = $resultCache;
     }
 
     /**
-     * @return \Doctrine\Common\Cache\Cache|null
+     * @return Cache|null
      */
     public function getResultCacheDriver()
     {
@@ -76,7 +76,7 @@ class QueryCacheProfile
     /**
      * @return string
      *
-     * @throws \Doctrine\DBAL\Cache\CacheException
+     * @throws CacheException
      */
     public function getCacheKey()
     {
@@ -102,7 +102,7 @@ class QueryCacheProfile
         $realCacheKey = 'query=' . $query .
             '&params=' . serialize($params) .
             '&types=' . serialize($types) .
-            '&connectionParams=' . serialize($connectionParams);
+            '&connectionParams=' . hash('sha256', serialize($connectionParams));
 
         // should the key be automatically generated using the inputs or is the cache key set?
         if ($this->cacheKey === null) {
@@ -111,11 +111,10 @@ class QueryCacheProfile
             $cacheKey = $this->cacheKey;
         }
 
-        return array($cacheKey, $realCacheKey);
+        return [$cacheKey, $realCacheKey];
     }
 
     /**
-     * @param \Doctrine\Common\Cache\Cache $cache
      *
      * @return \Doctrine\DBAL\Cache\QueryCacheProfile
      */


### PR DESCRIPTION
As per https://github.com/doctrine/doctrine2/issues/7086 (I didn't know it was related to dbal and not doctrine2), parameters should be hashed because they can have passwords inside.