### PR TITLE
Introduce a null SQL logger

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,10 @@ The Doctrine\DBAL\Version class is no longer available: please refrain from chec
 1. The support of `PDO::PARAM_*`, `PDO::FETCH_*`, `PDO::CASE_*` and `PDO::PARAM_INPUT_OUTPUT` constants in the DBAL API is removed.
 2. `\Doctrine\DBAL\Driver\PDOStatement` does not extend `\PDOStatement` anymore.
 
+## BC BREAK: the SQLLogger interface has changed
+
+The methods are the same but use scalar type hints, return types, and non-nullable arrays.
+
 Before:
 
     use Doctrine\DBAL\Portability\Connection;

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,6 +12,7 @@ The Doctrine\DBAL\Version class is no longer available: please refrain from chec
 ## BC BREAK: the SQLLogger interface has changed
 
 The methods are the same but use scalar type hints, return types, and non-nullable arrays.
+SQLLogger implementations are now final.
 
 Before:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,11 +9,6 @@ The Doctrine\DBAL\Version class is no longer available: please refrain from chec
 1. The support of `PDO::PARAM_*`, `PDO::FETCH_*`, `PDO::CASE_*` and `PDO::PARAM_INPUT_OUTPUT` constants in the DBAL API is removed.
 2. `\Doctrine\DBAL\Driver\PDOStatement` does not extend `\PDOStatement` anymore.
 
-## BC BREAK: the SQLLogger interface has changed
-
-The methods are the same but use scalar type hints, return types, and non-nullable arrays.
-SQLLogger implementations are now final.
-
 Before:
 
     use Doctrine\DBAL\Portability\Connection;
@@ -44,6 +39,12 @@ After:
 ## BC BREAK: Removed Drizzle support
 
 The Drizzle project is abandoned and is therefore not supported by Doctrine DBAL anymore.
+
+## BC BREAK: SQLLogger changes
+
+- The SQLLogger interface has changed; the methods are the same but use scalar type hints, return types, and non-nullable arrays.
+- SQLLogger implementations: `DebugStack`, `EchoSQLLogger`, `LoggerChain` are now final.
+- `Configuration::getSQLLogger()` does not return `null` anymore, but a `NullLogger` implementation.
 
 # Upgrade to 2.7
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -42,9 +42,10 @@ The Drizzle project is abandoned and is therefore not supported by Doctrine DBAL
 
 ## BC BREAK: SQLLogger changes
 
-- The SQLLogger interface has changed; the methods are the same but use scalar type hints, return types, and non-nullable arrays.
-- SQLLogger implementations: `DebugStack`, `EchoSQLLogger`, `LoggerChain` are now final.
+- The `SQLLogger` interface has changed; the methods are the same but use scalar type hints, return types, and non-nullable arrays.
+- `SQLLogger` implementations: `DebugStack`, `EchoSQLLogger`, `LoggerChain` are now final.
 - `Configuration::getSQLLogger()` does not return `null` anymore, but a `NullLogger` implementation.
+- `Configuration::setSQLLogger()` does not allow `null` anymore.
 
 # Upgrade to 2.7
 

--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -28,8 +28,6 @@ class Configuration
 
     /**
      * Sets the SQL logger to use.
-     *
-     * @param SQLLogger $logger
      */
     public function setSQLLogger(SQLLogger $logger) : void
     {

--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -27,13 +27,11 @@ class Configuration
     protected $_attributes = [];
 
     /**
-     * Sets the SQL logger to use. Defaults to NULL which means SQL logging is disabled.
+     * Sets the SQL logger to use.
      *
-     * @param \Doctrine\DBAL\Logging\SQLLogger|null $logger
-     *
-     * @return void
+     * @param SQLLogger $logger
      */
-    public function setSQLLogger(SQLLogger $logger = null)
+    public function setSQLLogger(SQLLogger $logger) : void
     {
         $this->_attributes['sqlLogger'] = $logger;
     }

--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -45,11 +45,7 @@ class Configuration
      */
     public function getSQLLogger() : SQLLogger
     {
-        if (! isset($this->_attributes['sqlLogger'])) {
-            $this->_attributes['sqlLogger'] = new NullLogger();
-        }
-
-        return $this->_attributes['sqlLogger'];
+        return $this->_attributes['sqlLogger'] ?? $this->_attributes['sqlLogger'] = new NullLogger();
     }
 
     /**

--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL;
 
+use Doctrine\DBAL\Logging\NullLogger;
 use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\Common\Cache\Cache;
 
@@ -40,11 +41,15 @@ class Configuration
     /**
      * Gets the SQL logger that is used.
      *
-     * @return \Doctrine\DBAL\Logging\SQLLogger|null
+     * @return \Doctrine\DBAL\Logging\SQLLogger
      */
-    public function getSQLLogger()
+    public function getSQLLogger() : SQLLogger
     {
-        return $this->_attributes['sqlLogger'] ?? null;
+        if (! isset($this->_attributes['sqlLogger'])) {
+            $this->_attributes['sqlLogger'] = new NullLogger();
+        }
+
+        return $this->_attributes['sqlLogger'];
     }
 
     /**

--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -40,8 +40,6 @@ class Configuration
 
     /**
      * Gets the SQL logger that is used.
-     *
-     * @return \Doctrine\DBAL\Logging\SQLLogger
      */
     public function getSQLLogger() : SQLLogger
     {

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -892,9 +892,7 @@ class Connection implements DriverConnection
         $this->connect();
 
         $logger = $this->_config->getSQLLogger();
-        if ($logger) {
-            $logger->startQuery($query, $params, $types);
-        }
+        $logger->startQuery($query, $params, $types);
 
         try {
             if ($params) {
@@ -916,9 +914,7 @@ class Connection implements DriverConnection
 
         $stmt->setFetchMode($this->defaultFetchMode);
 
-        if ($logger) {
-            $logger->stopQuery();
-        }
+        $logger->stopQuery();
 
         return $stmt;
     }
@@ -1003,9 +999,7 @@ class Connection implements DriverConnection
         $args = func_get_args();
 
         $logger = $this->_config->getSQLLogger();
-        if ($logger) {
-            $logger->startQuery($args[0]);
-        }
+        $logger->startQuery($args[0]);
 
         try {
             $statement = $this->_conn->query(...$args);
@@ -1015,9 +1009,7 @@ class Connection implements DriverConnection
 
         $statement->setFetchMode($this->defaultFetchMode);
 
-        if ($logger) {
-            $logger->stopQuery();
-        }
+        $logger->stopQuery();
 
         return $statement;
     }
@@ -1041,9 +1033,7 @@ class Connection implements DriverConnection
         $this->connect();
 
         $logger = $this->_config->getSQLLogger();
-        if ($logger) {
-            $logger->startQuery($query, $params, $types);
-        }
+        $logger->startQuery($query, $params, $types);
 
         try {
             if ($params) {
@@ -1064,9 +1054,7 @@ class Connection implements DriverConnection
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));
         }
 
-        if ($logger) {
-            $logger->stopQuery();
-        }
+        $logger->stopQuery();
 
         return $result;
     }
@@ -1085,9 +1073,7 @@ class Connection implements DriverConnection
         $this->connect();
 
         $logger = $this->_config->getSQLLogger();
-        if ($logger) {
-            $logger->startQuery($statement);
-        }
+        $logger->startQuery($statement);
 
         try {
             $result = $this->_conn->exec($statement);
@@ -1095,9 +1081,7 @@ class Connection implements DriverConnection
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $statement);
         }
 
-        if ($logger) {
-            $logger->stopQuery();
-        }
+        $logger->stopQuery();
 
         return $result;
     }
@@ -1243,21 +1227,13 @@ class Connection implements DriverConnection
         $logger = $this->_config->getSQLLogger();
 
         if ($this->_transactionNestingLevel == 1) {
-            if ($logger) {
-                $logger->startQuery('"START TRANSACTION"');
-            }
+            $logger->startQuery('"START TRANSACTION"');
             $this->_conn->beginTransaction();
-            if ($logger) {
-                $logger->stopQuery();
-            }
+            $logger->stopQuery();
         } elseif ($this->_nestTransactionsWithSavepoints) {
-            if ($logger) {
-                $logger->startQuery('"SAVEPOINT"');
-            }
+            $logger->startQuery('"SAVEPOINT"');
             $this->createSavepoint($this->_getNestedTransactionSavePointName());
-            if ($logger) {
-                $logger->stopQuery();
-            }
+            $logger->stopQuery();
         }
     }
 
@@ -1283,21 +1259,13 @@ class Connection implements DriverConnection
         $logger = $this->_config->getSQLLogger();
 
         if ($this->_transactionNestingLevel == 1) {
-            if ($logger) {
-                $logger->startQuery('"COMMIT"');
-            }
+            $logger->startQuery('"COMMIT"');
             $this->_conn->commit();
-            if ($logger) {
-                $logger->stopQuery();
-            }
+            $logger->stopQuery();
         } elseif ($this->_nestTransactionsWithSavepoints) {
-            if ($logger) {
-                $logger->startQuery('"RELEASE SAVEPOINT"');
-            }
+            $logger->startQuery('"RELEASE SAVEPOINT"');
             $this->releaseSavepoint($this->_getNestedTransactionSavePointName());
-            if ($logger) {
-                $logger->stopQuery();
-            }
+            $logger->stopQuery();
         }
 
         --$this->_transactionNestingLevel;
@@ -1341,28 +1309,20 @@ class Connection implements DriverConnection
         $logger = $this->_config->getSQLLogger();
 
         if ($this->_transactionNestingLevel == 1) {
-            if ($logger) {
-                $logger->startQuery('"ROLLBACK"');
-            }
+            $logger->startQuery('"ROLLBACK"');
             $this->_transactionNestingLevel = 0;
             $this->_conn->rollBack();
             $this->_isRollbackOnly = false;
-            if ($logger) {
-                $logger->stopQuery();
-            }
+            $logger->stopQuery();
 
             if (false === $this->autoCommit) {
                 $this->beginTransaction();
             }
         } elseif ($this->_nestTransactionsWithSavepoints) {
-            if ($logger) {
-                $logger->startQuery('"ROLLBACK TO SAVEPOINT"');
-            }
+            $logger->startQuery('"ROLLBACK TO SAVEPOINT"');
             $this->rollbackSavepoint($this->_getNestedTransactionSavePointName());
             --$this->_transactionNestingLevel;
-            if ($logger) {
-                $logger->stopQuery();
-            }
+            $logger->stopQuery();
         } else {
             $this->_isRollbackOnly = true;
             --$this->_transactionNestingLevel;

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -349,15 +349,11 @@ class MasterSlaveConnection extends Connection
         $args = func_get_args();
 
         $logger = $this->getConfiguration()->getSQLLogger();
-        if ($logger) {
-            $logger->startQuery($args[0]);
-        }
+        $logger->startQuery($args[0]);
 
         $statement = $this->_conn->query(...$args);
 
-        if ($logger) {
-            $logger->stopQuery();
-        }
+        $logger->stopQuery();
 
         return $statement;
     }

--- a/lib/Doctrine/DBAL/Logging/DebugStack.php
+++ b/lib/Doctrine/DBAL/Logging/DebugStack.php
@@ -12,7 +12,7 @@ namespace Doctrine\DBAL\Logging;
  * @author Jonathan Wage <jonwage@gmail.com>
  * @author Roman Borschel <roman@code-factory.org>
  */
-class DebugStack implements SQLLogger
+final class DebugStack implements SQLLogger
 {
     /**
      * Executed SQL queries.

--- a/lib/Doctrine/DBAL/Logging/DebugStack.php
+++ b/lib/Doctrine/DBAL/Logging/DebugStack.php
@@ -41,7 +41,7 @@ class DebugStack implements SQLLogger
     /**
      * {@inheritdoc}
      */
-    public function startQuery($sql, array $params = null, array $types = null)
+    public function startQuery(string $sql, array $params = [], array $types = []) : void
     {
         if ($this->enabled) {
             $this->start = microtime(true);
@@ -52,7 +52,7 @@ class DebugStack implements SQLLogger
     /**
      * {@inheritdoc}
      */
-    public function stopQuery()
+    public function stopQuery() : void
     {
         if ($this->enabled) {
             $this->queries[$this->currentQuery]['executionMS'] = microtime(true) - $this->start;

--- a/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
+++ b/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
@@ -12,7 +12,7 @@ namespace Doctrine\DBAL\Logging;
  * @author Jonathan Wage <jonwage@gmail.com>
  * @author Roman Borschel <roman@code-factory.org>
  */
-class EchoSQLLogger implements SQLLogger
+final class EchoSQLLogger implements SQLLogger
 {
     /**
      * {@inheritdoc}

--- a/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
+++ b/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
@@ -17,7 +17,7 @@ class EchoSQLLogger implements SQLLogger
     /**
      * {@inheritdoc}
      */
-    public function startQuery($sql, array $params = null, array $types = null)
+    public function startQuery(string $sql, array $params = [], array $types = []) : void
     {
         echo $sql . PHP_EOL;
 
@@ -33,7 +33,7 @@ class EchoSQLLogger implements SQLLogger
     /**
      * {@inheritdoc}
      */
-    public function stopQuery()
+    public function stopQuery() : void
     {
     }
 }

--- a/lib/Doctrine/DBAL/Logging/LoggerChain.php
+++ b/lib/Doctrine/DBAL/Logging/LoggerChain.php
@@ -9,7 +9,7 @@ namespace Doctrine\DBAL\Logging;
  * @since  2.2
  * @author Christophe Coevoet <stof@notk.org>
  */
-class LoggerChain implements SQLLogger
+final class LoggerChain implements SQLLogger
 {
     /**
      * @var \Doctrine\DBAL\Logging\SQLLogger[]

--- a/lib/Doctrine/DBAL/Logging/LoggerChain.php
+++ b/lib/Doctrine/DBAL/Logging/LoggerChain.php
@@ -23,7 +23,7 @@ class LoggerChain implements SQLLogger
      *
      * @return void
      */
-    public function addLogger(SQLLogger $logger)
+    public function addLogger(SQLLogger $logger) : void
     {
         $this->loggers[] = $logger;
     }
@@ -31,7 +31,7 @@ class LoggerChain implements SQLLogger
     /**
      * {@inheritdoc}
      */
-    public function startQuery($sql, array $params = null, array $types = null)
+    public function startQuery(string $sql, array $params = [], array $types = []) : void
     {
         foreach ($this->loggers as $logger) {
             $logger->startQuery($sql, $params, $types);
@@ -41,7 +41,7 @@ class LoggerChain implements SQLLogger
     /**
      * {@inheritdoc}
      */
-    public function stopQuery()
+    public function stopQuery() : void
     {
         foreach ($this->loggers as $logger) {
             $logger->stopQuery();

--- a/lib/Doctrine/DBAL/Logging/NullLogger.php
+++ b/lib/Doctrine/DBAL/Logging/NullLogger.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL\Logging;
 /**
  * A SQL logger that does nothing.
  */
-class NullLogger implements SQLLogger
+final class NullLogger implements SQLLogger
 {
     /**
      * {@inheritdoc}

--- a/lib/Doctrine/DBAL/Logging/NullLogger.php
+++ b/lib/Doctrine/DBAL/Logging/NullLogger.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\DBAL\Logging;
+
+/**
+ * A SQL logger that does nothing.
+ */
+class NullLogger implements SQLLogger
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function startQuery($sql, array $params = null, array $types = null)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stopQuery()
+    {
+    }
+}

--- a/lib/Doctrine/DBAL/Logging/NullLogger.php
+++ b/lib/Doctrine/DBAL/Logging/NullLogger.php
@@ -4,6 +4,8 @@ namespace Doctrine\DBAL\Logging;
 
 /**
  * A SQL logger that does nothing.
+ *
+ * @codeCoverageIgnore
  */
 final class NullLogger implements SQLLogger
 {

--- a/lib/Doctrine/DBAL/Logging/NullLogger.php
+++ b/lib/Doctrine/DBAL/Logging/NullLogger.php
@@ -10,14 +10,14 @@ final class NullLogger implements SQLLogger
     /**
      * {@inheritdoc}
      */
-    public function startQuery($sql, array $params = null, array $types = null)
+    public function startQuery(string $sql, array $params = [], array $types = []) : void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function stopQuery()
+    public function stopQuery() : void
     {
     }
 }

--- a/lib/Doctrine/DBAL/Logging/SQLLogger.php
+++ b/lib/Doctrine/DBAL/Logging/SQLLogger.php
@@ -17,18 +17,18 @@ interface SQLLogger
     /**
      * Logs a SQL statement somewhere.
      *
-     * @param string     $sql    The SQL to be executed.
-     * @param array|null $params The SQL parameters.
-     * @param array|null $types  The SQL parameter types.
+     * @param string $sql    The SQL to be executed.
+     * @param array  $params The SQL parameters.
+     * @param array  $types  The SQL parameter types.
      *
      * @return void
      */
-    public function startQuery($sql, array $params = null, array $types = null);
+    public function startQuery(string $sql, array $params = [], array $types = []) : void;
 
     /**
      * Marks the last started query as stopped. This can be used for timing of queries.
      *
      * @return void
      */
-    public function stopQuery();
+    public function stopQuery() : void;
 }

--- a/lib/Doctrine/DBAL/Logging/SQLLogger.php
+++ b/lib/Doctrine/DBAL/Logging/SQLLogger.php
@@ -17,9 +17,9 @@ interface SQLLogger
     /**
      * Logs a SQL statement somewhere.
      *
-     * @param string $sql    The SQL to be executed.
-     * @param array  $params The SQL parameters.
-     * @param array  $types  The SQL parameter types.
+     * @param string   $sql    The SQL to be executed.
+     * @param mixed[]  $params The SQL parameters.
+     * @param string[] $types  The SQL parameter types.
      *
      * @return void
      */

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -142,16 +142,12 @@ class Statement implements \IteratorAggregate, DriverStatement
         }
 
         $logger = $this->conn->getConfiguration()->getSQLLogger();
-        if ($logger) {
-            $logger->startQuery($this->sql, $this->params, $this->types);
-        }
+        $logger->startQuery($this->sql, $this->params, $this->types);
 
         try {
             $stmt = $this->stmt->execute($params);
         } catch (\Exception $ex) {
-            if ($logger) {
-                $logger->stopQuery();
-            }
+            $logger->stopQuery();
             throw DBALException::driverExceptionDuringQuery(
                 $this->conn->getDriver(),
                 $ex,
@@ -160,9 +156,7 @@ class Statement implements \IteratorAggregate, DriverStatement
             );
         }
 
-        if ($logger) {
-            $logger->stopQuery();
-        }
+        $logger->stopQuery();
         $this->params = [];
         $this->types = [];
 

--- a/tests/Doctrine/Tests/DBAL/Logging/DebugStackTest.php
+++ b/tests/Doctrine/Tests/DBAL/Logging/DebugStackTest.php
@@ -21,8 +21,8 @@ class DebugStackTest extends \Doctrine\Tests\DbalTestCase
             array(
                 1 => array(
                     'sql' => 'SELECT column FROM table',
-                    'params' => null,
-                    'types' => null,
+                    'params' => [],
+                    'types' => [],
                     'executionMS' => 0,
                 ),
             ),


### PR DESCRIPTION
As suggested by @morozov in [#634](https://github.com/doctrine/dbal/pull/634#discussion_r172039417), this adds a null SQL logger and avoids wrapping every `start|stopQuery()` call in a `if ($logger)` condition.

I extracted this in a separate PR to avoid polluting too much the Transaction object PR.