### PR TITLE
Don't catch `Exception` anymore, as `Throwable` is already handled

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1151,7 +1151,6 @@ class Connection implements DriverConnection
      *
      * @return mixed The value returned by $func
      *
-     * @throws Exception
      * @throws Throwable
      */
     public function transactional(Closure $func)
@@ -1161,9 +1160,6 @@ class Connection implements DriverConnection
             $res = $func($this);
             $this->commit();
             return $res;
-        } catch (Exception $e) {
-            $this->rollBack();
-            throw $e;
         } catch (Throwable $e) {
             $this->rollBack();
             throw $e;


### PR DESCRIPTION
This was only needed for PHP 5.x.