### PR TITLE
When rendering SQL, only render the alias if it's different from the table name

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1120,7 +1120,7 @@ class QueryBuilder
 
         // Loop through all FROM clauses
         foreach ($this->sqlParts['from'] as $from) {
-            if ($from['alias'] === null) {
+            if ($from['alias'] === null || $from['alias'] === $from['table']) {
                 $tableSql = $from['table'];
                 $tableReference = $from['table'];
             } else {
@@ -1179,7 +1179,14 @@ class QueryBuilder
      */
     private function getSQLForUpdate()
     {
-        $table = $this->sqlParts['from']['table'] . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
+        $from = $this->sqlParts['from'];
+
+        if ($from['alias'] === null || $from['alias'] === $from['table']) {
+            $table = $from['table'];
+        } else {
+            $table = $from['table'] . ' ' . $from['alias'];
+        }
+
         $query = 'UPDATE ' . $table
             . ' SET ' . implode(", ", $this->sqlParts['set'])
             . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '');
@@ -1194,7 +1201,14 @@ class QueryBuilder
      */
     private function getSQLForDelete()
     {
-        $table = $this->sqlParts['from']['table'] . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
+        $from = $this->sqlParts['from'];
+
+        if ($from['alias'] === null || $from['alias'] === $from['table']) {
+            $table = $from['table'];
+        } else {
+            $table = $from['table'] . ' ' . $from['alias'];
+        }
+
         $query = 'DELETE FROM ' . $table . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '');
 
         return $query;

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -410,6 +410,16 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
         self::assertEquals('UPDATE users SET foo = ?, bar = ?', (string) $qb);
     }
 
+    public function testUpdateWithMatchingAlias()
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->update('users', 'users')
+           ->set('foo', '?')
+           ->set('bar', '?');
+
+        self::assertEquals('UPDATE users SET foo = ?, bar = ?', (string) $qb);
+    }
+
     public function testUpdateWhere()
     {
         $qb   = new QueryBuilder($this->conn);
@@ -442,6 +452,15 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
     {
         $qb   = new QueryBuilder($this->conn);
         $qb->delete('users');
+
+        self::assertEquals(QueryBuilder::DELETE, $qb->getType());
+        self::assertEquals('DELETE FROM users', (string) $qb);
+    }
+
+    public function testDeleteWithMatchingAlias()
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->delete('users', 'users');
 
         self::assertEquals(QueryBuilder::DELETE, $qb->getType());
         self::assertEquals('DELETE FROM users', (string) $qb);
@@ -772,6 +791,16 @@ class QueryBuilderTest extends \Doctrine\Tests\DbalTestCase
 
         $qb->select('id')
             ->from('users');
+
+        self::assertEquals('SELECT id FROM users', (string) $qb);
+    }
+
+    public function testSimpleSelectWithMatchingTableAlias()
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('id')
+            ->from('users', 'users');
 
         self::assertEquals('SELECT id FROM users', (string) $qb);
     }


### PR DESCRIPTION
When DBAL is used as part of a higher level abstraction where queries are built dynamically, the table name and the alias in `SELECT`, `UPDATE` and `DELETE` queries may be defined independently and may end up being the same. In this case, the resulting SQL contains a redundant alias:
```php
$builder = new QueryBuilder($this->conn);
$builder->select('id')
    ->from('users', 'users');

// SELECT id FROM users users
```
…which is technically valid but not needed. In order to avoid that, the caller needs to compare `$table` and `$alias` before calling `$builder->from()` (in the case above) and pass `null` as the alias in the case if they are equal.

The caller logic could be simplified without an impact on generated SQL if the DBAL itself only rendered the alias if it's different from the table name.