### PR TITLE
Adds generation expression to MySQL57 getListTableColumns method

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
@@ -92,4 +92,24 @@ class MySQL57Platform extends MySqlPlatform
 
         $this->doctrineTypeMapping['json'] = Type::JSON;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getListTableColumnsSQL($table, $database = null)
+    {
+        $table = $this->quoteStringLiteral($table);
+
+        if ($database) {
+            $database = $this->quoteStringLiteral($database);
+        } else {
+            $database = 'DATABASE()';
+        }
+
+        return 'SELECT COLUMN_NAME AS Field, COLUMN_TYPE AS Type, IS_NULLABLE AS `Null`, ' .
+            'COLUMN_KEY AS `Key`, COLUMN_DEFAULT AS `Default`, EXTRA AS Extra,' .
+            'GENERATION_EXPRESSION AS GenerationExpression, COLUMN_COMMENT AS Comment, ' .
+            'CHARACTER_SET_NAME AS CharacterSet, COLLATION_NAME AS Collation ' .
+            'FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ' . $database . ' AND TABLE_NAME = ' . $table;
+    }
 }

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -22,6 +22,9 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Types\Type;
+use function strpos;
+use function strstr;
+use function strtoupper;
 
 /**
  * Schema manager for the MySql RDBMS.
@@ -202,6 +205,21 @@ class MySqlSchemaManager extends AbstractSchemaManager
 
         if (isset($tableColumn['collation'])) {
             $column->setPlatformOption('collation', $tableColumn['collation']);
+        }
+
+        // MySQL 5.7 specific https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html
+        if (strpos($tableColumn['extra'], 'GENERATED') !== false) {
+            // extra's syntax in the case of a generated column:
+            // <UPPERCASE_GENERATION_TYPE> GENERATED
+            $generationType = strstr($tableColumn['extra'], ' ', true);
+            $column->setPlatformOption(
+                'generationType',
+                strtoupper($generationType)
+            );
+            $column->setPlatformOption(
+                'generationExpression',
+                $tableColumn['generationexpression']
+            );
         }
 
         return $column;


### PR DESCRIPTION
The generation expression is very important for the table columns, it is actually the definition of virtual columns.

https://www.percona.com/blog/2016/03/04/virtual-columns-in-mysql-and-mariadb/