### PR TITLE
Test SQL Server 17 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -278,6 +278,43 @@ jobs:
         - bash ./tests/travis/install-postgres-10.sh
 
     - stage: Test
+      env: DB=sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mssql-$DB.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: 7.2
+      env: DB=sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mssql-$DB.sh
+        - bash ./tests/travis/install-mssql.sh
+
+    - stage: Test
+      php: 7.1
+      env: DB=pdo_sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mssql-$DB.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: 7.2
+      env: DB=pdo_sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mssql-$DB.sh
+        - bash ./tests/travis/install-mssql.sh
+
+    - stage: Test
       php: 7.1
       env: DB=sqlite DEPENDENCIES=low
       install:

--- a/tests/travis/install-mssql-pdo_sqlsrv.sh
+++ b/tests/travis/install-mssql-pdo_sqlsrv.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Installing extension"
+pecl install pdo_sqlsrv-5.2.0RC1

--- a/tests/travis/install-mssql-sqlsrv.sh
+++ b/tests/travis/install-mssql-sqlsrv.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Installing extension"
+pecl install sqlsrv-5.2.0RC1

--- a/tests/travis/install-mssql.sh
+++ b/tests/travis/install-mssql.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo Installing drivers
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql.list
+sudo apt-get update
+ACCEPT_EULA=Y sudo apt-get install -qy msodbcsql17 mssql-tools unixodbc libssl1.0.0
+
+echo Setting up Microsoft SQL Server
+
+sudo docker pull microsoft/mssql-server-linux:2017-latest
+sudo docker run \
+    -e 'ACCEPT_EULA=Y' \
+    -e 'SA_PASSWORD=Doctrine2018' \
+    -p 127.0.0.1:1433:1433 \
+    --name db \
+    -d \
+    microsoft/mssql-server-linux:2017-latest
+
+
+retries=10
+until (echo quit | /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -l 1 -U sa -P Doctrine2018 &> /dev/null)
+do
+    if [[ "$retries" -le 0 ]]; then
+        echo SQL Server did not start
+        exit 1
+    fi
+
+    retries=$((retries - 1))
+
+    echo Waiting for SQL Server to start...
+
+    sleep 2s
+done
+
+echo SQL Server started

--- a/tests/travis/pdo_sqlsrv.travis.xml
+++ b/tests/travis/pdo_sqlsrv.travis.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         verbose="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnRisky="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+
+        <var name="db_type" value="pdo_sqlsrv"/>
+        <var name="db_host" value="127.0.0.1" />
+        <var name="db_username" value="sa" />
+        <var name="db_password" value="Doctrine2018" />
+        <var name="db_name" value="doctrine" />
+        <var name="db_port" value="1433"/>
+
+        <var name="tmpdb_type" value="pdo_sqlsrv"/>
+        <var name="tmpdb_host" value="127.0.0.1" />
+        <var name="tmpdb_username" value="sa" />
+        <var name="tmpdb_password" value="Doctrine2018" />
+        <var name="tmpdb_port" value="1433"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Doctrine DBAL Test Suite">
+            <directory>../Doctrine/Tests/DBAL</directory>
+        </testsuite>
+    </testsuites>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
+    <groups>
+        <exclude>
+            <group>performance</group>
+            <group>locking_functional</group>
+        </exclude>
+    </groups>
+</phpunit>

--- a/tests/travis/sqlsrv.travis.xml
+++ b/tests/travis/sqlsrv.travis.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         verbose="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnRisky="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+
+        <var name="db_type" value="sqlsrv"/>
+        <var name="db_host" value="127.0.0.1" />
+        <var name="db_username" value="sa" />
+        <var name="db_password" value="Doctrine2018" />
+        <var name="db_name" value="doctrine" />
+        <var name="db_port" value="1433"/>
+
+        <var name="tmpdb_type" value="sqlsrv"/>
+        <var name="tmpdb_host" value="127.0.0.1" />
+        <var name="tmpdb_username" value="sa" />
+        <var name="tmpdb_password" value="Doctrine2018" />
+        <var name="tmpdb_port" value="1433"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Doctrine DBAL Test Suite">
+            <directory>../Doctrine/Tests/DBAL</directory>
+        </testsuite>
+    </testsuites>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
+    <groups>
+        <exclude>
+            <group>performance</group>
+            <group>locking_functional</group>
+        </exclude>
+    </groups>
+</phpunit>


### PR DESCRIPTION
Finally managed to solve the problems with running SQL Server 17 on Travis.

The tests are green for the `pdo_sqlsrv` driver.
Tnere are two failures for the `sqlsrv` driver:
```
1) Doctrine\Tests\DBAL\Functional\PortabilityTest::testFetchAllNullColumn
Failed asserting that Array &0 () is identical to Array &0 (
    0 => null
    1 => null
).
/home/travis/build/Majkl578/doctrine-dbal/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php:194
2) Doctrine\Tests\DBAL\Functional\WriteTest::testEmptyIdentityInsert
Failed asserting that '17' is greater than '17'.
/home/travis/build/Majkl578/doctrine-dbal/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php:289
```
@morozov Do you think you can help with these?

I'm not quite sure if this is legally ok to run it on CI & auto-accept EULA though, any opinions?

Not up to date with master due to  #3049.