### PR TITLE
Add SQL2017 Platform classes + missing NOCHECK reserved keywords

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\SQLServer2005Platform;
 use Doctrine\DBAL\Platforms\SQLServer2008Platform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Doctrine\DBAL\Platforms\SQLServer2017Platform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
@@ -43,6 +44,8 @@ abstract class AbstractSQLServerDriver implements Driver, VersionAwarePlatformDr
         $version      = $majorVersion . '.' . $minorVersion . '.' . $patchVersion . '.' . $buildVersion;
 
         switch(true) {
+            case version_compare($version, '5.7.0.0', '>='):
+                return new SQLServer2017Platform();
             case version_compare($version, '11.00.2100', '>='):
                 return new SQLServer2012Platform();
             case version_compare($version, '10.00.1600', '>='):

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2017Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2017Keywords.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\Keywords;
+
+/**
+ * Microsoft SQL Server 2017 reserved keyword dictionary.
+ *
+ * @license BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link    www.doctrine-project.com
+ */
+class SQLServer2017Keywords extends SQLServer2012Keywords
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'SQLServer2017';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getKeywords()
+    {
+        return array_merge(parent::getKeywords(), [
+            'NOCHECK'
+        ]);
+    }
+}

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2017Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2017Platform.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms;
+
+/**
+ * Platform to ensure compatibility of Doctrine with Microsoft SQL Server 2017 version.
+ *
+ */
+class SQLServer2017Platform extends SQLServer2012Platform
+{
+}

--- a/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
@@ -20,6 +20,7 @@ class ReservedWordsCommand extends Command
         'sqlserver2005' => 'Doctrine\DBAL\Platforms\Keywords\SQLServer2005Keywords',
         'sqlserver2008' => 'Doctrine\DBAL\Platforms\Keywords\SQLServer2008Keywords',
         'sqlserver2012' => 'Doctrine\DBAL\Platforms\Keywords\SQLServer2012Keywords',
+        'sqlserver2017' => 'Doctrine\DBAL\Platforms\Keywords\SQLServer2017Keywords',
         'sqlite'        => 'Doctrine\DBAL\Platforms\Keywords\SQLiteKeywords',
         'pgsql'         => 'Doctrine\DBAL\Platforms\Keywords\PostgreSQLKeywords',
         'pgsql91'       => 'Doctrine\DBAL\Platforms\Keywords\PostgreSQL91Keywords',
@@ -84,6 +85,7 @@ The following keyword lists are currently shipped with Doctrine:
     * sqlserver2005
     * sqlserver2008
     * sqlserver2012
+    * sqlserver2017
     * sqlanywhere
     * sqlanywhere11
     * sqlanywhere12
@@ -114,6 +116,7 @@ EOT
                 'sqlserver2005',
                 'sqlserver2008',
                 'sqlserver2012',
+                'sqlserver2017',
                 'sqlanywhere',
                 'sqlanywhere11',
                 'sqlanywhere12',


### PR DESCRIPTION
Mainly added for date/time format redefined in 2008 (incorect in SQLServerPlatform)

There is no test as this is a simple extend of SQLServer 2012 existing and tested !
