### PR TITLE
Set Appveyor to use PHP 7.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,9 +9,9 @@ clone_depth: 1
 cache:
   - C:\ProgramData\chocolatey\bin -> .appveyor.yml
   - C:\ProgramData\chocolatey\lib -> .appveyor.yml
-  - c:\tools\php -> .appveyor.yml
+  - C:\tools\php72 -> .appveyor.yml
   - composer.phar
-  - '%LOCALAPPDATA%\Composer\files'
+  - '%LOCALAPPDATA%\Composer'
   #- vendor
 
 ## Build matrix for lowest and highest possible targets

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ clone_depth: 1
 cache:
   - C:\ProgramData\chocolatey\bin -> .appveyor.yml
   - C:\ProgramData\chocolatey\lib -> .appveyor.yml
-  - C:\tools\php72 -> .appveyor.yml
+  - C:\tools\php -> .appveyor.yml
   - composer.phar
   - '%LOCALAPPDATA%\Composer'
   #- vendor

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ cache:
   - C:\ProgramData\chocolatey\lib -> .appveyor.yml
   - C:\tools\php -> .appveyor.yml
   - composer.phar
-  - '%LOCALAPPDATA%\Composer'
+  - '%LOCALAPPDATA%\Composer\files'
   #- vendor
 
 ## Build matrix for lowest and highest possible targets

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,19 +20,19 @@ environment:
   - db: mssql
     driver: sqlsrv
     db_version: sql2008r2sp2
-    php: 7.1
+    php: 7.2
   - db: mssql
     driver: sqlsrv
     db_version: sql2012sp1
-    php: 7.1
+    php: 7.2
   - db: mssql
     driver: sqlsrv
     db_version: sql2017
-    php: 7.1
+    php: 7.2
   - db: mssql
     driver: pdo_sqlsrv
     db_version: sql2017
-    php: 7.1
+    php: 7.2
 
 init:
   - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
@@ -60,24 +60,22 @@ install:
           Add-Content php.ini "`n extension=php_pdo_sqlite.dll"
           Add-Content php.ini "`n extension=php_sqlite3.dll"
 
-          # If needed get the MSSQL DLL's
-          if ($env:db -eq "mssql") {
-            $DLLVersion = "5.2.0rc1"
-            cd c:\tools\php\ext
-            $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc14-x64.zip"
-            $destination = "c:\tools\php\ext\php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc14-x64.zip"
-            Invoke-WebRequest $source -OutFile $destination
-            7z x -y php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc14-x64.zip > $null
-            $source = "https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($DLLVersion)/php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc14-x64.zip"
-            $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc14-x64.zip"
-            Invoke-WebRequest $source -OutFile $destination
-            7z x -y php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc14-x64.zip > $null
-            Remove-Item c:\tools\php\* -include .zip
-            cd c:\tools\php
-            Add-Content php.ini "`nextension=php_sqlsrv.dll"
-            Add-Content php.ini "`nextension=php_pdo_sqlsrv.dll"
-            Add-Content php.ini "`n"
-          }
+          # Get and install the MSSQL DLL's
+          $DLLVersion = "5.2.0rc1"
+          cd c:\tools\php\ext
+          $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
+          $destination = "c:\tools\php\ext\php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
+          Invoke-WebRequest $source -OutFile $destination
+          7z x -y php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip > $null
+          $source = "https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($DLLVersion)/php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
+          $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
+          Invoke-WebRequest $source -OutFile $destination
+          7z x -y php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip > $null
+          Remove-Item c:\tools\php\* -include .zip
+          cd c:\tools\php
+          Add-Content php.ini "`nextension=php_sqlsrv.dll"
+          Add-Content php.ini "`nextension=php_pdo_sqlsrv.dll"
+          Add-Content php.ini "`n"
 
           cd c:\projects\dbal
 


### PR DESCRIPTION
This makes it so the SQLSVR DLL packages install the correct version to work with PHP 7.2

In #2617 it appeared like there was a limitation preventing testing with PHP 7.2, That was based on an oversite in the appveyor set up vs the PHP packages. This addresses that oversite and allows testing on PHP 7.2