### PR TITLE
Allow some larger indexes to fulfil another index

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Index.php
+++ b/lib/Doctrine/DBAL/Schema/Index.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function count;
 
 class Index extends AbstractAsset implements Constraint
 {
@@ -200,9 +201,10 @@ class Index extends AbstractAsset implements Constraint
      */
     public function isFullfilledBy(Index $other)
     {
-        // allow the other index to be equally large only. It being larger is an option
-        // but it creates a problem with scenarios of the kind PRIMARY KEY(foo,bar) UNIQUE(foo)
-        if (count($other->getColumns()) != count($this->getColumns())) {
+        // Don't allow the fulfilling index to be larger when our index
+        // is unique, as it will not provide the uniqueness we want.
+        // E.g. PRIMARY KEY(foo,bar) can't fulfil UNIQUE(foo).
+        if (count($other->getColumns()) > count($this->getColumns()) && ($this->isUnique() || $this->isPrimary())) {
             return false;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -412,7 +412,6 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $diff->removedIndexes['index1'] = $table->getIndex('index1');
 
         $sql = array(
-            'DROP INDEX IDX_8D93D64923A0E66',
             'DROP INDEX IDX_8D93D6495A8A6C8D',
             'DROP INDEX IDX_8D93D6493D8E604F',
             'DROP INDEX index1',
@@ -427,7 +426,6 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'INSERT INTO user ("key", article, comment) SELECT id, article, post FROM __temp__user',
             'DROP TABLE __temp__user',
             'ALTER TABLE user RENAME TO client',
-            'CREATE INDEX IDX_8D93D64923A0E66 ON client (article)',
             'CREATE INDEX IDX_8D93D6495A8A6C8D ON client (comment)',
         );
 

--- a/tests/Doctrine/Tests/DBAL/Schema/IndexTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/IndexTest.php
@@ -154,4 +154,14 @@ class IndexTest extends \PHPUnit\Framework\TestCase
         self::assertSame('name IS NULL', $idx2->getOption('WHERE'));
         self::assertSame(array('where' => 'name IS NULL'), $idx2->getOptions());
     }
+
+    public function testFulfilledByLargerIndex()
+    {
+        $largeIdx       = new Index('foo', ['bar', 'baz'], false, false, [], []);
+        $smallIdx       = new Index('foo', ['bar'], false, false, [], []);
+        $smallUniqueIdx = new Index('foo', ['bar'], true, false, [], []);
+
+        self::assertTrue($smallIdx->isFullfilledBy($largeIdx));
+        self::assertFalse($smallUniqueIdx->isFullfilledBy($largeIdx));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -403,7 +403,7 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         $table->addColumn('baz', 'string');
         $table->addColumn('bloo', 'string');
         $table->addIndex(array('baz', 'bar'), 'composite_idx');
-        $table->addIndex(array('bar', 'baz', 'bloo'), 'full_idx');
+        $table->addIndex(['bar', 'bloo', 'baz'], 'full_idx');
 
         $foreignTable = new Table('bar');
         $foreignTable->addColumn('foo', 'integer');
@@ -416,7 +416,7 @@ class TableTest extends \Doctrine\Tests\DbalTestCase
         self::assertTrue($table->hasIndex('full_idx'));
         self::assertTrue($table->hasIndex('idx_8c73652176ff8caa78240498'));
         self::assertSame(array('baz', 'bar'), $table->getIndex('composite_idx')->getColumns());
-        self::assertSame(array('bar', 'baz', 'bloo'), $table->getIndex('full_idx')->getColumns());
+        self::assertSame(['bar', 'bloo', 'baz'], $table->getIndex('full_idx')->getColumns());
         self::assertSame(array('bar', 'baz'), $table->getIndex('idx_8c73652176ff8caa78240498')->getColumns());
     }
 


### PR DESCRIPTION
This allows a larger index to fulfil another index when it doesn't
compromise the uniqueness constraint. This prevents Doctrine from
creating superfluous indexes on foreign keys in some cases. E.g.:

```sql
CREATE TABLE `location_picture` (
  `location_picture_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `location_id` int(10) unsigned NOT NULL,
  `order_id` tinyint(3) unsigned NOT NULL,
  `type` enum('normal','wide') NOT NULL,
  `filename` varchar(255) NOT NULL,
  PRIMARY KEY (`location_picture_id`),
  KEY `location_id_order_id` (`location_id`, `order_id`)
);
```

For the above table, Doctrine would unnecessarily try to create an
index on `location_id` even though it's covered by the existing
`location_id_order_id` index.