### PR TITLE
2.5.x branch should not contain the PHP 5.5-only ::class syntax

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -34,7 +34,7 @@ class Connection extends PDOConnection implements \Doctrine\DBAL\Driver\Connecti
     public function __construct($dsn, $user = null, $password = null, array $options = null)
     {
         parent::__construct($dsn, $user, $password, $options);
-        $this->setAttribute(\PDO::ATTR_STATEMENT_CLASS, array(Statement::class, array()));
+        $this->setAttribute(\PDO::ATTR_STATEMENT_CLASS, array('Doctrine\DBAL\Driver\PDOSqlsrv\Statement', array()));
     }
 
     /**


### PR DESCRIPTION
Fixes bug #2683 "PDOSqlsrv Connection not compatible with PHP 5.3 - 5.4"