### PR TITLE
Always use phpunit bridge 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpunit/phpunit": "^7.0",
         "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
         "symfony/console": "^2.0.5||^3.0",
-        "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+        "symfony/phpunit-bridge": "^4.0.6"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."


### PR DESCRIPTION
Old versions report annotation assertions as risky.

See https://ci.appveyor.com/project/doctrine/dbal/build/1.0.81/job/utt2h7bq2p2b5jj7#L239