### PR TITLE
CS bump to 4.0, imports for global functions & constants

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -84,6 +84,7 @@ install:
           }
         }
     # install composer dependencies
+    - rm composer.lock
     - appveyor-retry php composer.phar self-update
     - appveyor-retry php composer.phar install --no-progress --profile
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@ build.xml export-ignore
 phpunit.xml.dist export-ignore
 run-all.sh export-ignore
 /phpcs.xml.dist export-ignore
+/composer.lock export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ dist/
 download/
 vendor/
 *.phpunit.xml
-composer.lock
 /phpunit.xml
 /.phpcs-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ before_script:
   - if [[ "$DB" == "mysql" || "$DB" == "mysqli" || "$DB" == *"mariadb"* ]]; then mysql < tests/travis/create-mysql-schema.sql; fi;
 
 install:
-  - travis_retry composer -n install
+  - rm composer.lock
+  - travis_retry composer -n update --prefer-dist
 
 script: ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml
 
@@ -343,6 +344,7 @@ jobs:
     - stage: Pull request coding standard
       if: type = pull_request
       php: 7.1
+      install: travis_retry composer install --prefer-dist
       script:
         - |
           if [ $TRAVIS_BRANCH != "master" ]; then
@@ -356,5 +358,6 @@ jobs:
     - stage: Coding standard
       if: NOT type = pull_request
       php: 7.1
+      install: travis_retry composer install --prefer-dist
       script:
         - ./vendor/bin/phpcs

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/common": "^2.7.1"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^3.0",
+        "doctrine/coding-standard": "^4.0",
         "phpunit/phpunit": "^7.0",
         "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
         "symfony/console": "^2.0.5||^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2393 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a408facf78f3db3aa10aca1da0473202",
+    "packages": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-12-06T07:11:42+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/b3217d58609e9c8e661cd41357a54d926c4a2a1a",
+                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^5.7",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2017-08-25T07:02:50+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2017-07-22T10:37:32+00:00"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "f68c297ce6455e8fd794aa8ffaf9fa458f6ade66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/f68c297ce6455e8fd794aa8ffaf9fa458f6ade66",
+                "reference": "f68c297ce6455e8fd794aa8ffaf9fa458f6ade66",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": "~7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2017-08-31T08:43:38+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5527a48b7313d15261292c149e55e26eae771b0a",
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string"
+            ],
+            "time": "2018-01-09T20:05:19+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09T13:34:57+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "wimg/php-compatibility": "^8.0"
+            },
+            "suggest": {
+                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "f.nijhof@dealerdirect.nl",
+                    "homepage": "http://workingatdealerdirect.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://workingatdealerdirect.eu",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2017-12-06T16:27:17+00:00"
+        },
+        {
+            "name": "doctrine/coding-standard",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/coding-standard.git",
+                "reference": "0469c18a1a4724c278f2879c0dd7b1fa860b52de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/0469c18a1a4724c278f2879c0dd7b1fa860b52de",
+                "reference": "0469c18a1a4724c278f2879c0dd7b1fa860b52de",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
+                "php": "^7.1",
+                "slevomat/coding-standard": "^4.5.0",
+                "squizlabs/php_codesniffer": "^3.2.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Sniffs\\": "lib/Doctrine/Sniffs"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Steve Müller",
+                    "email": "st.mueller@dzh-online.de"
+                }
+            ],
+            "description": "Doctrine Coding Standard",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "code",
+                "coding",
+                "cs",
+                "doctrine",
+                "sniffer",
+                "standard",
+                "style"
+            ],
+            "time": "2018-03-03T23:49:15+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2017-07-22T11:58:36+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-09-11T18:02:19+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-11-30T07:14:17+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-07-14T14:27:02+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2018-02-19T10:16:54+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2018-02-02T07:01:41+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2017-11-27T13:52:08+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2018-02-01T13:07:23+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2018-02-01T13:16:43+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "7.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "536f4d853c12d8189963435088e8ff7c0daeab2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/536f4d853c12d8189963435088e8ff7c0daeab2e",
+                "reference": "536f4d853c12d8189963435088e8ff7c0daeab2e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0.1",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.0",
+                "phpunit/phpunit-mock-objects": "^6.0",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2018-03-26T07:36:48+00:00"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2018-02-15T05:27:38+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2018-02-01T13:46:46+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "time": "2018-02-01T13:45:15+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2017-07-01T08:51:00+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2017-04-03T13:19:02+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2017-04-27T15:39:26+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2017-03-03T06:23:57+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "4.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "1e609159241fa90d5a429f185b2ea9b881340a7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/1e609159241fa90d5a429f185b2ea9b881340a7c",
+                "reference": "1e609159241fa90d5a429f185b2ea9b881340a7c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "squizlabs/php_codesniffer": "^3.2.3"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "1.0.0",
+                "phing/phing": "2.16",
+                "phpstan/phpstan": "0.9.2",
+                "phpstan/phpstan-phpunit": "0.9.4",
+                "phpstan/phpstan-strict-rules": "0.9",
+                "phpunit/php-code-coverage": "6.0.1",
+                "phpunit/phpunit": "7.0.2"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "time": "2018-03-08T08:14:33+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-02-20T21:35:23+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v3.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "067339e9b8ec30d5f19f5950208893ff026b94f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/067339e9b8ec30d5f19f5950208893ff026b94f7",
+                "reference": "067339e9b8ec30d5f19f5950208893ff026b94f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/debug": "~2.8|~3.0|~4.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.3|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.3|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-02-26T15:46:28+00:00"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "1721e4e7effb23480966690cdcdc7d2a4152d489"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/1721e4e7effb23480966690cdcdc7d2a4152d489",
+                "reference": "1721e4e7effb23480966690cdcdc7d2a4152d489",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": "<3.4"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "~3.4|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-02-28T21:50:02+00:00"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "14ffbbe2a72d0f6339b24eb830dd38cf63ba6630"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/14ffbbe2a72d0f6339b24eb830dd38cf63ba6630",
+                "reference": "14ffbbe2a72d0f6339b24eb830dd38cf63ba6630",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "suggest": {
+                "ext-zip": "Zip support is required when using bin/simple-phpunit",
+                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                },
+                "thanks": {
+                    "name": "phpunit/phpunit",
+                    "url": "https://github.com/sebastianbergmann/phpunit"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2018-02-19T16:50:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-01-30T19:27:44+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2018-01-29T19:49:41+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^7.1",
+        "ext-pdo": "*"
+    },
+    "platform-dev": []
+}

--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -21,6 +21,10 @@ namespace Doctrine\DBAL\Cache;
 
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\FetchMode;
+use function array_merge;
+use function array_values;
+use function count;
+use function reset;
 
 class ArrayStatement implements \IteratorAggregate, ResultStatement
 {

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -23,6 +23,9 @@ use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\DBAL\FetchMode;
+use function array_merge;
+use function array_values;
+use function reset;
 
 /**
  * Cache statement for SQL results.

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -32,6 +32,13 @@ use Doctrine\DBAL\Cache\ArrayStatement;
 use Doctrine\DBAL\Cache\CacheException;
 use Doctrine\DBAL\Driver\PingableConnection;
 use Throwable;
+use function array_key_exists;
+use function array_merge;
+use function func_get_args;
+use function implode;
+use function is_int;
+use function is_string;
+use function key;
 
 /**
  * A wrapper around a Doctrine\DBAL\Driver\Connection that adds features like

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -25,6 +25,9 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Events;
+use function array_rand;
+use function count;
+use function func_get_args;
 
 /**
  * Master-Slave Connection

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -23,6 +23,14 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function array_map;
+use function bin2hex;
+use function implode;
+use function is_resource;
+use function is_string;
+use function json_encode;
+use function sprintf;
+use function str_split;
 
 class DBALException extends \Exception
 {

--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -27,6 +27,9 @@ use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\MySqlSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
+use function preg_match;
+use function stripos;
+use function version_compare;
 
 /**
  * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for MySQL based drivers.

--- a/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
@@ -29,6 +29,9 @@ use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\PostgreSqlSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
+use function preg_match;
+use function strpos;
+use function version_compare;
 
 /**
  * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for PostgreSQL based drivers.

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
@@ -28,6 +28,8 @@ use Doctrine\DBAL\Platforms\SQLAnywhere16Platform;
 use Doctrine\DBAL\Platforms\SQLAnywherePlatform;
 use Doctrine\DBAL\Schema\SQLAnywhereSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
+use function preg_match;
+use function version_compare;
 
 /**
  * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for SAP Sybase SQL Anywhere based drivers.

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
@@ -27,6 +27,8 @@ use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
+use function preg_match;
+use function version_compare;
 
 /**
  * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for Microsoft SQL Server based drivers.

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
@@ -23,6 +23,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\SqliteSchemaManager;
+use function strpos;
 
 /**
  * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for SQLite based drivers.

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -22,6 +22,23 @@ namespace Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
+use const DB2_AUTOCOMMIT_OFF;
+use const DB2_AUTOCOMMIT_ON;
+use function db2_autocommit;
+use function db2_commit;
+use function db2_conn_error;
+use function db2_conn_errormsg;
+use function db2_connect;
+use function db2_escape_string;
+use function db2_exec;
+use function db2_last_insert_id;
+use function db2_num_rows;
+use function db2_pconnect;
+use function db2_prepare;
+use function db2_rollback;
+use function db2_server_info;
+use function db2_stmt_errormsg;
+use function func_get_args;
 
 class DB2Connection implements Connection, ServerInfoAwareConnection
 {

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -23,6 +23,30 @@ use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Driver\StatementIterator;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
+use const DB2_CHAR;
+use const DB2_LONG;
+use const DB2_PARAM_IN;
+use function array_change_key_case;
+use function call_user_func_array;
+use function db2_bind_param;
+use function db2_execute;
+use function db2_fetch_array;
+use function db2_fetch_assoc;
+use function db2_fetch_both;
+use function db2_fetch_object;
+use function db2_free_result;
+use function db2_num_fields;
+use function db2_num_rows;
+use function db2_stmt_error;
+use function db2_stmt_errormsg;
+use function func_get_args;
+use function func_num_args;
+use function gettype;
+use function is_object;
+use function is_string;
+use function ksort;
+use function sprintf;
+use function strtolower;
 
 class DB2Statement implements \IteratorAggregate, Statement
 {

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -23,6 +23,19 @@ use Doctrine\DBAL\Driver\Connection as Connection;
 use Doctrine\DBAL\Driver\PingableConnection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
+use function defined;
+use function floor;
+use function func_get_args;
+use function in_array;
+use function ini_get;
+use function mysqli_errno;
+use function mysqli_error;
+use function mysqli_init;
+use function mysqli_options;
+use function restore_error_handler;
+use function set_error_handler;
+use function sprintf;
+use function stripos;
 
 /**
  * @author Kim Hemsø Rasmussen <kimhemsoe@gmail.com>

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -23,6 +23,11 @@ use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Driver\StatementIterator;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
+use function array_combine;
+use function array_fill;
+use function call_user_func_array;
+use function count;
+use function str_repeat;
 
 /**
  * @author Kim Hemsø Rasmussen <kimhemsoe@gmail.com>

--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -21,6 +21,7 @@ namespace Doctrine\DBAL\Driver\OCI8;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
+use const OCI_DEFAULT;
 
 /**
  * A Doctrine DBAL driver for the Oracle OCI8 PHP extensions.

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -22,6 +22,24 @@ namespace Doctrine\DBAL\Driver\OCI8;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
+use const OCI_COMMIT_ON_SUCCESS;
+use const OCI_DEFAULT;
+use const OCI_NO_AUTO_COMMIT;
+use function addcslashes;
+use function define;
+use function defined;
+use function func_get_args;
+use function is_float;
+use function is_int;
+use function oci_commit;
+use function oci_connect;
+use function oci_error;
+use function oci_pconnect;
+use function oci_rollback;
+use function oci_server_version;
+use function preg_match;
+use function sprintf;
+use function str_replace;
 
 /**
  * OCI8 implementation of the Connection interface.

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -24,6 +24,36 @@ use Doctrine\DBAL\Driver\StatementIterator;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use IteratorAggregate;
+use const OCI_ASSOC;
+use const OCI_B_BLOB;
+use const OCI_BOTH;
+use const OCI_D_LOB;
+use const OCI_FETCHSTATEMENT_BY_COLUMN;
+use const OCI_FETCHSTATEMENT_BY_ROW;
+use const OCI_NUM;
+use const OCI_RETURN_LOBS;
+use const OCI_RETURN_NULLS;
+use const OCI_TEMP_BLOB;
+use const PREG_OFFSET_CAPTURE;
+use function array_key_exists;
+use function count;
+use function implode;
+use function is_numeric;
+use function oci_bind_by_name;
+use function oci_cancel;
+use function oci_error;
+use function oci_execute;
+use function oci_fetch_all;
+use function oci_fetch_array;
+use function oci_fetch_object;
+use function oci_new_descriptor;
+use function oci_num_fields;
+use function oci_num_rows;
+use function oci_parse;
+use function preg_match;
+use function preg_quote;
+use function sprintf;
+use function substr;
 
 /**
  * The OCI8 implementation of the Statement interface.

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -21,6 +21,8 @@ namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\ParameterType;
 use PDO;
+use function count;
+use function func_get_args;
 
 /**
  * PDO implementation of the Connection interface.

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Driver\PDOConnection;
 use Doctrine\DBAL\DBALException;
 use PDOException;
 use PDO;
+use function defined;
 
 /**
  * Driver that connects through pdo_pgsql.

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -23,6 +23,7 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use Doctrine\DBAL\Driver\PDOConnection;
 use PDOException;
+use function array_merge;
 
 /**
  * The PDO Sqlite driver.

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -21,6 +21,8 @@ namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
 use Doctrine\DBAL\Driver\PDOConnection;
 use Doctrine\DBAL\ParameterType;
+use function strpos;
+use function substr;
 
 /**
  * Sqlsrv Connection implementation.

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -21,6 +21,9 @@ namespace Doctrine\DBAL\Driver\SQLAnywhere;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractSQLAnywhereDriver;
+use function array_keys;
+use function array_map;
+use function implode;
 
 /**
  * A Doctrine DBAL driver for the SAP Sybase SQL Anywhere PHP extension.

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -22,6 +22,21 @@ namespace Doctrine\DBAL\Driver\SQLAnywhere;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
+use function func_get_args;
+use function is_float;
+use function is_int;
+use function is_resource;
+use function sasql_affected_rows;
+use function sasql_commit;
+use function sasql_connect;
+use function sasql_error;
+use function sasql_errorcode;
+use function sasql_escape_string;
+use function sasql_insert_id;
+use function sasql_pconnect;
+use function sasql_real_query;
+use function sasql_rollback;
+use function sasql_set_option;
 
 /**
  * SAP Sybase SQL Anywhere implementation of the Connection interface.

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereException.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereException.php
@@ -20,6 +20,12 @@
 namespace Doctrine\DBAL\Driver\SQLAnywhere;
 
 use Doctrine\DBAL\Driver\AbstractDriverException;
+use function is_resource;
+use function sasql_error;
+use function sasql_errorcode;
+use function sasql_sqlstate;
+use function sasql_stmt_errno;
+use function sasql_stmt_error;
 
 /**
  * SAP Sybase SQL Anywhere driver exception.

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -24,6 +24,31 @@ use Doctrine\DBAL\Driver\StatementIterator;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use IteratorAggregate;
+use const SASQL_BOTH;
+use function array_key_exists;
+use function call_user_func_array;
+use function func_get_args;
+use function func_num_args;
+use function gettype;
+use function is_array;
+use function is_numeric;
+use function is_object;
+use function is_resource;
+use function is_string;
+use function sasql_fetch_array;
+use function sasql_fetch_assoc;
+use function sasql_fetch_object;
+use function sasql_fetch_row;
+use function sasql_prepare;
+use function sasql_stmt_affected_rows;
+use function sasql_stmt_bind_param_ex;
+use function sasql_stmt_errno;
+use function sasql_stmt_error;
+use function sasql_stmt_execute;
+use function sasql_stmt_field_count;
+use function sasql_stmt_reset;
+use function sasql_stmt_result_metadata;
+use function sprintf;
 
 /**
  * SAP SQL Anywhere implementation of the Statement interface.

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -22,6 +22,21 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
+use const SQLSRV_ERR_ERRORS;
+use function func_get_args;
+use function is_float;
+use function is_int;
+use function sprintf;
+use function sqlsrv_begin_transaction;
+use function sqlsrv_commit;
+use function sqlsrv_configure;
+use function sqlsrv_connect;
+use function sqlsrv_errors;
+use function sqlsrv_query;
+use function sqlsrv_rollback;
+use function sqlsrv_rows_affected;
+use function sqlsrv_server_info;
+use function str_replace;
 
 /**
  * SQL Server implementation for the Connection interface.

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvException.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvException.php
@@ -21,6 +21,9 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 
 
 use Doctrine\DBAL\Driver\AbstractDriverException;
+use const SQLSRV_ERR_ERRORS;
+use function rtrim;
+use function sqlsrv_errors;
 
 class SQLSrvException extends AbstractDriverException
 {

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -24,7 +24,30 @@ use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use IteratorAggregate;
 use Doctrine\DBAL\Driver\Statement;
+use const SQLSRV_ENC_BINARY;
+use const SQLSRV_ERR_ERRORS;
+use const SQLSRV_FETCH_ASSOC;
+use const SQLSRV_FETCH_BOTH;
+use const SQLSRV_FETCH_NUMERIC;
+use const SQLSRV_PARAM_IN;
+use function array_key_exists;
+use function count;
 use function func_get_args;
+use function in_array;
+use function is_numeric;
+use function sqlsrv_errors;
+use function sqlsrv_execute;
+use function sqlsrv_fetch;
+use function sqlsrv_fetch_array;
+use function sqlsrv_fetch_object;
+use function sqlsrv_get_field;
+use function sqlsrv_next_result;
+use function sqlsrv_num_fields;
+use function SQLSRV_PHPTYPE_STREAM;
+use function sqlsrv_prepare;
+use function sqlsrv_rows_affected;
+use function SQLSRV_SQLTYPE_VARBINARY;
+use function stripos;
 
 /**
  * SQL Server Statement.

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -20,6 +20,18 @@
 namespace Doctrine\DBAL;
 
 use Doctrine\Common\EventManager;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function class_implements;
+use function in_array;
+use function is_subclass_of;
+use function parse_str;
+use function parse_url;
+use function preg_replace;
+use function str_replace;
+use function strpos;
+use function substr;
 
 /**
  * Factory for creating Doctrine\DBAL\Connection instances.

--- a/lib/Doctrine/DBAL/Event/Listeners/OracleSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/OracleSessionInit.php
@@ -22,6 +22,10 @@ namespace Doctrine\DBAL\Event\Listeners;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Events;
 use Doctrine\Common\EventSubscriber;
+use function array_change_key_case;
+use function array_merge;
+use function count;
+use function implode;
 
 /**
  * Should be used when Oracle Server default environment does not match the Doctrine requirements.

--- a/lib/Doctrine/DBAL/Event/SchemaAlterTableAddColumnEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaAlterTableAddColumnEventArgs.php
@@ -22,6 +22,8 @@ namespace Doctrine\DBAL\Event;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\TableDiff;
+use function array_merge;
+use function is_array;
 
 /**
  * Event Arguments used when SQL queries for adding table columns are generated inside Doctrine\DBAL\Platform\*Platform.

--- a/lib/Doctrine/DBAL/Event/SchemaAlterTableChangeColumnEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaAlterTableChangeColumnEventArgs.php
@@ -22,6 +22,8 @@ namespace Doctrine\DBAL\Event;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\TableDiff;
+use function array_merge;
+use function is_array;
 
 /**
  * Event Arguments used when SQL queries for changing table columns are generated inside Doctrine\DBAL\Platform\*Platform.

--- a/lib/Doctrine/DBAL/Event/SchemaAlterTableEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaAlterTableEventArgs.php
@@ -21,6 +21,8 @@ namespace Doctrine\DBAL\Event;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\TableDiff;
+use function array_merge;
+use function is_array;
 
 /**
  * Event Arguments used when SQL queries for creating tables are generated inside Doctrine\DBAL\Platform\*Platform.

--- a/lib/Doctrine/DBAL/Event/SchemaAlterTableRemoveColumnEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaAlterTableRemoveColumnEventArgs.php
@@ -22,6 +22,8 @@ namespace Doctrine\DBAL\Event;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\TableDiff;
+use function array_merge;
+use function is_array;
 
 /**
  * Event Arguments used when SQL queries for removing table columns are generated inside Doctrine\DBAL\Platform\*Platform.

--- a/lib/Doctrine/DBAL/Event/SchemaAlterTableRenameColumnEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaAlterTableRenameColumnEventArgs.php
@@ -22,6 +22,8 @@ namespace Doctrine\DBAL\Event;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\TableDiff;
+use function array_merge;
+use function is_array;
 
 /**
  * Event Arguments used when SQL queries for renaming table columns are generated inside Doctrine\DBAL\Platform\*Platform.

--- a/lib/Doctrine/DBAL/Event/SchemaCreateTableColumnEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaCreateTableColumnEventArgs.php
@@ -22,6 +22,8 @@ namespace Doctrine\DBAL\Event;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
+use function array_merge;
+use function is_array;
 
 /**
  * Event Arguments used when SQL queries for creating table columns are generated inside Doctrine\DBAL\Platform\AbstractPlatform.

--- a/lib/Doctrine/DBAL/Event/SchemaCreateTableEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaCreateTableEventArgs.php
@@ -21,6 +21,8 @@ namespace Doctrine\DBAL\Event;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Table;
+use function array_merge;
+use function is_array;
 
 /**
  * Event Arguments used when SQL queries for creating tables are generated inside Doctrine\DBAL\Platform\AbstractPlatform.

--- a/lib/Doctrine/DBAL/Event/SchemaDropTableEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaDropTableEventArgs.php
@@ -21,6 +21,7 @@ namespace Doctrine\DBAL\Event;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Table;
+use function is_string;
 
 /**
  * Event Arguments used when the SQL query for dropping tables are generated inside Doctrine\DBAL\Platform\AbstractPlatform.

--- a/lib/Doctrine/DBAL/Id/TableGenerator.php
+++ b/lib/Doctrine/DBAL/Id/TableGenerator.php
@@ -23,6 +23,8 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\LockMode;
+use const CASE_LOWER;
+use function array_change_key_case;
 
 /**
  * Table ID Generator for those poor languages that are missing sequences.

--- a/lib/Doctrine/DBAL/Logging/DebugStack.php
+++ b/lib/Doctrine/DBAL/Logging/DebugStack.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\DBAL\Logging;
 
+use function microtime;
+
 /**
  * Includes executed SQLs in a Debug Stack.
  *

--- a/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
+++ b/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\DBAL\Logging;
 
+use const PHP_EOL;
+use function var_dump;
+
 /**
  * A SQL logger that logs to the standard output using echo/var_dump.
  *

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -43,10 +43,29 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
 use function addcslashes;
+use function array_map;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function count;
+use function explode;
+use function func_get_args;
+use function get_class;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_bool;
+use function is_int;
+use function is_string;
+use function join;
 use function preg_quote;
 use function preg_replace;
 use function sprintf;
+use function str_replace;
 use function strlen;
+use function strpos;
+use function strtolower;
+use function strtoupper;
 
 /**
  * Base class for all DatabasePlatforms. The DatabasePlatforms are the central

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -26,6 +26,14 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
+use function array_merge;
+use function count;
+use function current;
+use function explode;
+use function implode;
+use function sprintf;
+use function strpos;
+use function strtoupper;
 
 class DB2Platform extends AbstractPlatform
 {

--- a/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
@@ -24,6 +24,19 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\BinaryType;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function count;
+use function func_get_args;
+use function implode;
+use function is_array;
+use function is_bool;
+use function is_numeric;
+use function is_string;
+use function join;
+use function sprintf;
+use function trim;
 
 /**
  * Drizzle platform

--- a/lib/Doctrine/DBAL/Platforms/Keywords/KeywordList.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/KeywordList.php
@@ -19,6 +19,10 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use function array_flip;
+use function array_map;
+use function strtoupper;
+
 /**
  * Abstract interface for a SQL reserved keyword dictionary.
  *

--- a/lib/Doctrine/DBAL/Platforms/Keywords/PostgreSQL92Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/PostgreSQL92Keywords.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use function array_merge;
+
 /**
  * PostgreSQL 9.2 reserved keywords list.
  *

--- a/lib/Doctrine/DBAL/Platforms/Keywords/PostgreSQL94Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/PostgreSQL94Keywords.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use function array_diff;
+use function array_merge;
+
 /**
  * PostgreSQL 9.4 reserved keywords list.
  *

--- a/lib/Doctrine/DBAL/Platforms/Keywords/ReservedKeywordsValidator.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/ReservedKeywordsValidator.php
@@ -26,6 +26,8 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Index;
+use function implode;
+use function str_replace;
 
 class ReservedKeywordsValidator implements Visitor
 {

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLAnywhere11Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLAnywhere11Keywords.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use function array_diff;
+use function array_merge;
+
 /**
  * SAP Sybase SQL Anywhere 11 reserved keywords list.
  *

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLAnywhere12Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLAnywhere12Keywords.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use function array_diff;
+use function array_merge;
+
 /**
  * SAP Sybase SQL Anywhere 12 reserved keywords list.
  *

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLAnywhere16Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLAnywhere16Keywords.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use function array_merge;
+
 /**
  * SAP Sybase SQL Anywhere 16 reserved keywords list.
  *

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2005Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2005Keywords.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use function array_diff;
+use function array_merge;
+
 /**
  * Microsoft SQL Server 2005 reserved keyword dictionary.
  *

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2008Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2008Keywords.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use function array_merge;
+
 /**
  * Microsoft SQL Server 2008 reserved keyword dictionary.
  *

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2012Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2012Keywords.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use function array_merge;
+
 /**
  * Microsoft SQL Server 2012 reserved keyword dictionary.
  *

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -26,6 +26,21 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\TextType;
+use function array_diff_key;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function count;
+use function func_get_args;
+use function implode;
+use function in_array;
+use function is_numeric;
+use function is_string;
+use function join;
+use function sprintf;
+use function str_replace;
+use function strtoupper;
+use function trim;
 
 /**
  * The MySqlPlatform provides the behavior, features and SQL dialect of the

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -28,6 +28,17 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\BinaryType;
+use function array_merge;
+use function count;
+use function explode;
+use function implode;
+use function preg_match;
+use function sprintf;
+use function str_replace;
+use function strlen;
+use function strpos;
+use function strtoupper;
+use function substr;
 
 /**
  * OraclePlatform.

--- a/lib/Doctrine/DBAL/Platforms/PostgreSQL91Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSQL91Platform.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use function explode;
+
 /**
  * Provides the behavior, features and SQL dialect of the PostgreSQL 9.1 database platform.
  *

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -30,6 +30,22 @@ use Doctrine\DBAL\Types\BigIntType;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\Type;
+use function array_diff;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function count;
+use function explode;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_bool;
+use function is_numeric;
+use function is_string;
+use function str_replace;
+use function strpos;
+use function strtolower;
+use function trim;
 
 /**
  * PostgreSqlPlatform.

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -30,6 +30,20 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function count;
+use function explode;
+use function func_get_args;
+use function get_class;
+use function implode;
+use function is_string;
+use function preg_replace;
+use function strlen;
+use function strpos;
+use function strtoupper;
+use function substr;
 
 /**
  * The SQLAnywherePlatform provides the behavior, features and SQL dialect of the

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -20,6 +20,10 @@
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Schema\Sequence;
+use const PREG_OFFSET_CAPTURE;
+use function preg_match;
+use function preg_match_all;
+use function substr_count;
 
 /**
  * Platform to ensure compatibility of Doctrine with Microsoft SQL Server 2012 version.

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -28,10 +28,31 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function count;
+use function crc32;
+use function dechex;
 use function explode;
+use function func_get_args;
 use function implode;
+use function is_array;
+use function is_bool;
+use function is_null;
+use function is_numeric;
+use function is_string;
+use function preg_match;
+use function preg_replace;
 use function sprintf;
+use function str_replace;
+use function stripos;
+use function stristr;
+use function strlen;
 use function strpos;
+use function strtoupper;
+use function substr;
+use function substr_count;
 
 /**
  * The SQLServerPlatform provides the behavior, features and SQL dialect of the

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -29,6 +29,17 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function implode;
+use function is_numeric;
+use function sprintf;
+use function sqrt;
+use function str_replace;
+use function strlen;
+use function strpos;
+use function strtolower;
 
 /**
  * The SqlitePlatform class describes the specifics and dialects of the SQLite

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -21,6 +21,9 @@ namespace Doctrine\DBAL\Portability;
 
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\ColumnCase;
+use const CASE_LOWER;
+use const CASE_UPPER;
+use function func_get_args;
 
 /**
  * Portability wrapper for a Connection.

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -21,6 +21,10 @@ namespace Doctrine\DBAL\Portability;
 
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
+use function array_change_key_case;
+use function is_null;
+use function is_string;
+use function rtrim;
 
 /**
  * Portability wrapper for a Statement.

--- a/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
+++ b/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\DBAL\Query\Expression;
 
+use function count;
+use function implode;
+
 /**
  * Composite expression is responsible to build a group of similar expression.
  *

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -21,7 +21,9 @@ namespace Doctrine\DBAL\Query\Expression;
 
 use Doctrine\DBAL\Connection;
 use function func_get_arg;
+use function func_get_args;
 use function func_num_args;
+use function implode;
 use function sprintf;
 
 /**

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -22,6 +22,18 @@ namespace Doctrine\DBAL\Query;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Connection;
+use function array_key_exists;
+use function array_keys;
+use function array_unshift;
+use function func_get_args;
+use function func_num_args;
+use function implode;
+use function is_array;
+use function is_null;
+use function is_object;
+use function key;
+use function strtoupper;
+use function substr;
 
 /**
  * QueryBuilder class is responsible to dynamically create SQL queries.

--- a/lib/Doctrine/DBAL/Query/QueryException.php
+++ b/lib/Doctrine/DBAL/Query/QueryException.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Query;
 
 use Doctrine\DBAL\DBALException;
+use function implode;
 
 /**
  * @since 2.1.4

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -19,6 +19,22 @@
 
 namespace Doctrine\DBAL;
 
+use const PREG_OFFSET_CAPTURE;
+use function array_fill;
+use function array_key_exists;
+use function array_merge;
+use function array_slice;
+use function array_values;
+use function count;
+use function implode;
+use function is_int;
+use function key;
+use function ksort;
+use function preg_match_all;
+use function strlen;
+use function strpos;
+use function substr;
+
 /**
  * Utility class that parses sql statements with regard to types and parameters.
  *

--- a/lib/Doctrine/DBAL/SQLParserUtilsException.php
+++ b/lib/Doctrine/DBAL/SQLParserUtilsException.php
@@ -21,6 +21,8 @@
 
 namespace Doctrine\DBAL;
 
+use function sprintf;
+
 /**
  * Doctrine\DBAL\ConnectionException
  *

--- a/lib/Doctrine/DBAL/Schema/AbstractAsset.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractAsset.php
@@ -20,6 +20,16 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function array_map;
+use function crc32;
+use function dechex;
+use function explode;
+use function implode;
+use function str_replace;
+use function strpos;
+use function strtolower;
+use function strtoupper;
+use function substr;
 
 /**
  * The abstract asset allows to reset the name of all assets without publishing this to the public userland.

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -24,6 +24,17 @@ use Doctrine\DBAL\Event\SchemaColumnDefinitionEventArgs;
 use Doctrine\DBAL\Event\SchemaIndexDefinitionEventArgs;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function array_filter;
+use function array_map;
+use function array_values;
+use function call_user_func_array;
+use function count;
+use function func_get_args;
+use function is_array;
+use function is_null;
+use function preg_match;
+use function str_replace;
+use function strtolower;
 
 /**
  * Base class for schema managers. Schema managers are used to inspect and/or

--- a/lib/Doctrine/DBAL/Schema/Column.php
+++ b/lib/Doctrine/DBAL/Schema/Column.php
@@ -20,6 +20,12 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Types\Type;
+use const E_USER_DEPRECATED;
+use function array_merge;
+use function is_numeric;
+use function method_exists;
+use function sprintf;
+use function trigger_error;
 
 /**
  * Object representation of a database column.

--- a/lib/Doctrine/DBAL/Schema/ColumnDiff.php
+++ b/lib/Doctrine/DBAL/Schema/ColumnDiff.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use function in_array;
+
 /**
  * Represents the change of a column.
  *

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -20,6 +20,15 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Types;
+use function array_intersect_key;
+use function array_key_exists;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function array_shift;
+use function array_unique;
+use function count;
+use function strtolower;
 
 /**
  * Compares two Schemas and return an instance of SchemaDiff.

--- a/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
@@ -19,6 +19,13 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use function array_change_key_case;
+use function is_resource;
+use function strpos;
+use function strtolower;
+use function substr;
+use function trim;
+
 /**
  * IBM Db2 Schema Manager.
  *

--- a/lib/Doctrine/DBAL/Schema/DrizzleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DrizzleSchemaManager.php
@@ -20,6 +20,9 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Types\Type;
+use function explode;
+use function strtolower;
+use function trim;
 
 /**
  * Schema manager for the Drizzle RDBMS.

--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -20,6 +20,14 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function array_combine;
+use function array_keys;
+use function array_map;
+use function end;
+use function explode;
+use function in_array;
+use function strtolower;
+use function strtoupper;
 
 /**
  * An abstraction class for a foreign key constraint.

--- a/lib/Doctrine/DBAL/Schema/Index.php
+++ b/lib/Doctrine/DBAL/Schema/Index.php
@@ -20,6 +20,12 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function array_keys;
+use function array_map;
+use function array_search;
+use function count;
+use function is_string;
+use function strtolower;
 
 class Index extends AbstractAsset implements Constraint
 {

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -22,6 +22,18 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Types\Type;
+use const CASE_LOWER;
+use function array_change_key_case;
+use function array_shift;
+use function array_values;
+use function end;
+use function preg_match;
+use function preg_replace;
+use function str_replace;
+use function stripslashes;
+use function strpos;
+use function strtok;
+use function strtolower;
 
 /**
  * Schema manager for the MySql RDBMS.

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -22,6 +22,16 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Types\Type;
+use const CASE_LOWER;
+use function array_change_key_case;
+use function array_values;
+use function is_null;
+use function preg_match;
+use function sprintf;
+use function strpos;
+use function strtolower;
+use function strtoupper;
+use function trim;
 
 /**
  * Oracle Schema Manager.

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -21,6 +21,23 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Types\Type;
+use const CASE_LOWER;
+use function array_change_key_case;
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_shift;
+use function explode;
+use function in_array;
+use function join;
+use function preg_match;
+use function preg_replace;
+use function str_replace;
+use function stripos;
+use function strlen;
+use function strpos;
+use function strtolower;
+use function trim;
 
 /**
  * PostgreSQL Schema Manager.

--- a/lib/Doctrine/DBAL/Schema/SQLAnywhereSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLAnywhereSchemaManager.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Types\Type;
+use function preg_replace;
 
 /**
  * SAP Sybase SQL Anywhere schema manager.

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -22,6 +22,14 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Types\Type;
+use function count;
+use function in_array;
+use function preg_replace;
+use function sprintf;
+use function str_replace;
+use function strpos;
+use function strtok;
+use function trim;
 
 /**
  * SQL Server Schema Manager.

--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -24,6 +24,9 @@ use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
 use Doctrine\DBAL\Schema\Visitor\NamespaceVisitor;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function array_keys;
+use function strpos;
+use function strtolower;
 
 /**
  * Object representation of a database schema.

--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use \Doctrine\DBAL\Platforms\AbstractPlatform;
+use function array_merge;
 
 /**
  * Schema Diff.

--- a/lib/Doctrine/DBAL/Schema/SchemaException.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaException.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use function implode;
+use function sprintf;
+
 class SchemaException extends \Doctrine\DBAL\DBALException
 {
     const TABLE_DOESNT_EXIST = 10;

--- a/lib/Doctrine/DBAL/Schema/Sequence.php
+++ b/lib/Doctrine/DBAL/Schema/Sequence.php
@@ -20,6 +20,9 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Visitor\Visitor;
+use function count;
+use function is_numeric;
+use function sprintf;
 
 /**
  * Sequence structure.

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -24,6 +24,25 @@ use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
+use const CASE_LOWER;
+use function array_change_key_case;
+use function array_map;
+use function array_reverse;
+use function array_values;
+use function explode;
+use function file_exists;
+use function preg_match;
+use function preg_match_all;
+use function preg_quote;
+use function preg_replace;
+use function rtrim;
+use function sprintf;
+use function str_replace;
+use function strpos;
+use function strtolower;
+use function trim;
+use function unlink;
+use function usort;
 
 /**
  * Sqlite SchemaManager.

--- a/lib/Doctrine/DBAL/Schema/Synchronizer/SingleDatabaseSynchronizer.php
+++ b/lib/Doctrine/DBAL/Schema/Synchronizer/SingleDatabaseSynchronizer.php
@@ -23,6 +23,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
+use function count;
 
 /**
  * Schema Synchronizer for Default DBAL Connection.

--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -22,6 +22,15 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 use Doctrine\DBAL\DBALException;
+use const ARRAY_FILTER_USE_KEY;
+use function array_filter;
+use function array_merge;
+use function in_array;
+use function is_numeric;
+use function is_string;
+use function preg_match;
+use function strlen;
+use function strtolower;
 
 /**
  * Object Representation of a table.

--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -23,6 +23,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
+use function array_merge;
 
 class CreateSchemaSqlCollector extends AbstractVisitor
 {

--- a/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\SchemaException;
+use function strlen;
 
 /**
  * Gathers SQL statements that allow to completely drop the current schema.

--- a/lib/Doctrine/DBAL/Schema/Visitor/Graphviz.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/Graphviz.php
@@ -22,6 +22,12 @@ namespace Doctrine\DBAL\Schema\Visitor;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use function current;
+use function file_put_contents;
+use function in_array;
+use function mt_rand;
+use function sha1;
+use function strtolower;
 
 /**
  * Create a Graphviz output of a Schema.

--- a/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
@@ -26,6 +26,9 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Events;
 use Doctrine\DBAL\Sharding\ShardChoser\ShardChoser;
+use function array_merge;
+use function is_numeric;
+use function is_string;
 
 /**
  * Sharding implementation that pools many different connections

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizer.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizer.php
@@ -26,6 +26,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Schema\Synchronizer\AbstractSchemaSynchronizer;
 use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer;
 use Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer;
+use function array_merge;
 
 /**
  * SQL Azure Schema Synchronizer.

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
@@ -23,6 +23,9 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Sharding\ShardingException;
 use Doctrine\DBAL\Sharding\ShardManager;
 use Doctrine\DBAL\Types\Type;
+use function is_bool;
+use function is_scalar;
+use function sprintf;
 
 /**
  * Sharding using the SQL Azure Federations support.

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/Schema/MultiTenantVisitor.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/Schema/MultiTenantVisitor.php
@@ -26,6 +26,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Index;
+use function in_array;
 
 /**
  * Converts a single tenant schema into a multi-tenant schema for SQL Azure

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -21,6 +21,8 @@ namespace Doctrine\DBAL;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
+use function is_array;
+use function is_string;
 
 /**
  * A thin wrapper around a Doctrine\DBAL\Driver\Statement that adds support

--- a/lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php
@@ -23,6 +23,12 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use const PHP_EOL;
+use function file_exists;
+use function file_get_contents;
+use function is_readable;
+use function realpath;
+use function sprintf;
 
 /**
  * Task for executing arbitrary SQL that can come from a file or directly from

--- a/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
@@ -24,6 +24,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function array_keys;
+use function count;
+use function implode;
 
 class ReservedWordsCommand extends Command
 {

--- a/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
@@ -24,6 +24,10 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use function is_numeric;
+use function ob_get_clean;
+use function ob_start;
+use function stripos;
 
 /**
  * Task for executing arbitrary SQL that can come from a file or directly from

--- a/lib/Doctrine/DBAL/Types/ArrayType.php
+++ b/lib/Doctrine/DBAL/Types/ArrayType.php
@@ -20,6 +20,10 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function is_resource;
+use function serialize;
+use function stream_get_contents;
+use function unserialize;
 
 /**
  * Type that maps a PHP array to a clob SQL type.

--- a/lib/Doctrine/DBAL/Types/BinaryType.php
+++ b/lib/Doctrine/DBAL/Types/BinaryType.php
@@ -21,6 +21,11 @@ namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function fopen;
+use function fseek;
+use function fwrite;
+use function is_resource;
+use function is_string;
 
 /**
  * Type that maps ab SQL BINARY/VARBINARY to a PHP resource stream.

--- a/lib/Doctrine/DBAL/Types/BlobType.php
+++ b/lib/Doctrine/DBAL/Types/BlobType.php
@@ -21,6 +21,11 @@ namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function fopen;
+use function fseek;
+use function fwrite;
+use function is_resource;
+use function is_string;
 
 /**
  * Type that maps an SQL BLOB to a PHP resource stream.

--- a/lib/Doctrine/DBAL/Types/ConversionException.php
+++ b/lib/Doctrine/DBAL/Types/ConversionException.php
@@ -29,6 +29,15 @@
  */
 namespace Doctrine\DBAL\Types;
 
+use function get_class;
+use function gettype;
+use function implode;
+use function is_object;
+use function is_scalar;
+use function sprintf;
+use function strlen;
+use function substr;
+
 class ConversionException extends \Doctrine\DBAL\DBALException
 {
     /**

--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function date_create;
 
 /**
  * Type that maps an SQL DATETIME/TIMESTAMP to a PHP DateTime object.

--- a/lib/Doctrine/DBAL/Types/JsonArrayType.php
+++ b/lib/Doctrine/DBAL/Types/JsonArrayType.php
@@ -20,6 +20,9 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function is_resource;
+use function json_decode;
+use function stream_get_contents;
 
 /**
  * Array Type which can be used to generate json arrays.

--- a/lib/Doctrine/DBAL/Types/JsonType.php
+++ b/lib/Doctrine/DBAL/Types/JsonType.php
@@ -20,6 +20,13 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use const JSON_ERROR_NONE;
+use function is_resource;
+use function json_decode;
+use function json_encode;
+use function json_last_error;
+use function json_last_error_msg;
+use function stream_get_contents;
 
 /**
  * Type generating json objects values

--- a/lib/Doctrine/DBAL/Types/ObjectType.php
+++ b/lib/Doctrine/DBAL/Types/ObjectType.php
@@ -20,6 +20,10 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function is_resource;
+use function serialize;
+use function stream_get_contents;
+use function unserialize;
 
 /**
  * Type that maps a PHP object to a clob SQL type.

--- a/lib/Doctrine/DBAL/Types/SimpleArrayType.php
+++ b/lib/Doctrine/DBAL/Types/SimpleArrayType.php
@@ -20,6 +20,10 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function explode;
+use function implode;
+use function is_resource;
+use function stream_get_contents;
 
 /**
  * Array Type which can be used for simple values.

--- a/lib/Doctrine/DBAL/Types/TextType.php
+++ b/lib/Doctrine/DBAL/Types/TextType.php
@@ -20,6 +20,8 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function is_resource;
+use function stream_get_contents;
 
 /**
  * Type that maps an SQL CLOB to a PHP string.

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -22,6 +22,10 @@ namespace Doctrine\DBAL\Types;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\DBALException;
+use function end;
+use function explode;
+use function get_class;
+use function str_replace;
 
 /**
  * The base class for so-called Doctrine mapping types.

--- a/lib/Doctrine/DBAL/Types/VarDateTimeImmutableType.php
+++ b/lib/Doctrine/DBAL/Types/VarDateTimeImmutableType.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function date_create_immutable;
 
 /**
  * Immutable type of {@see VarDateTimeType}.

--- a/lib/Doctrine/DBAL/Types/VarDateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/VarDateTimeType.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function date_create;
 
 /**
  * Variable DateTime Type using date_create() instead of DateTime::createFromFormat().

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -19,6 +19,10 @@
 
 namespace Doctrine\DBAL;
 
+use function str_replace;
+use function strtolower;
+use function version_compare;
+
 /**
  * Class to store and retrieve the version of Doctrine.
  *

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,10 +4,10 @@
     <arg name="extensions" value="php"/>
     <arg name="parallel" value="80"/>
     <arg name="cache" value=".phpcs-cache"/>
-    <arg name="colors" />
+    <arg name="colors"/>
 
-    <!-- Ignore warnings and show progress of the run -->
-    <arg value="np"/>
+    <!-- Ignore warnings, show progress of the run and show sniff names -->
+    <arg value="nps"/>
 
     <file>lib</file>
     <file>tests</file>
@@ -16,6 +16,8 @@
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Tests\Mocks\DriverMock;
 use Doctrine\Tests\Mocks\VersionAwarePlatformDriverMock;
+use function call_user_func_array;
 
 /**
  * @requires extension pdo_mysql

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -7,6 +7,9 @@ use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Driver\DriverException as InnerDriverException;
 use Doctrine\Tests\DbalTestCase;
 use Doctrine\DBAL\Driver;
+use function chr;
+use function fopen;
+use function sprintf;
 
 class DBALExceptionTest extends DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
@@ -7,6 +7,8 @@ use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 use Doctrine\Tests\DbalTestCase;
+use function get_class;
+use function sprintf;
 
 abstract class AbstractDriverTest extends DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Driver/IBMDB2/DB2ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/IBMDB2/DB2ConnectionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Driver\IBMDB2;
 
 use Doctrine\Tests\DbalTestCase;
+use function extension_loaded;
 
 class DB2ConnectionTest extends DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
@@ -6,6 +6,9 @@ use Doctrine\DBAL\Driver\Mysqli\MysqliConnection;
 use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\Tests\DbalFunctionalTestCase;
+use function extension_loaded;
+use function restore_error_handler;
+use function set_error_handler;
 
 class MysqliConnectionTest extends DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8ConnectionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Driver\OCI8;
 
 use Doctrine\Tests\DbalTestCase;
+use function extension_loaded;
 
 class OCI8ConnectionTest extends DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL;
 use Doctrine\DBAL\Driver\OCI8\OCI8Exception;
 use Doctrine\DBAL\Driver\OCI8\OCI8Statement;
 use Doctrine\Tests\DbalTestCase;
+use function extension_loaded;
 
 class OCI8StatementTest extends DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Driver/PDOExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDOExceptionTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Driver;
 
 use Doctrine\DBAL\Driver\PDOException;
 use Doctrine\Tests\DbalTestCase;
+use function extension_loaded;
 
 class PDOExceptionTest extends DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDOPgSql/DriverTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\PDOPgSql\Driver;
 use Doctrine\Tests\DBAL\Driver\AbstractPostgreSQLDriverTest;
 use PDO;
 use PDOException;
+use function defined;
 
 class DriverTest extends AbstractPostgreSQLDriverTest
 {

--- a/tests/Doctrine/Tests/DBAL/Driver/SQLAnywhere/SQLAnywhereConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/SQLAnywhere/SQLAnywhereConnectionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Driver\SQLAnywhere;
 
 use Doctrine\Tests\DbalTestCase;
+use function extension_loaded;
 
 class SQLAnywhereConnectionTest extends DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Driver/SQLSrv/SQLSrvConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/SQLSrv/SQLSrvConnectionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Driver\SQLSrv;
 
 use Doctrine\Tests\DbalTestCase;
+use function extension_loaded;
 
 class SQLSrvConnectionTest extends DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -13,6 +13,9 @@ use Doctrine\Tests\DbalTestCase;
 use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Mocks\DriverMock;
 use stdClass;
+use function extension_loaded;
+use function in_array;
+use function is_array;
 
 class DriverManagerTest extends DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Events/OracleSessionInitTest.php
+++ b/tests/Doctrine/Tests/DBAL/Events/OracleSessionInitTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Event\Listeners\OracleSessionInit;
 use Doctrine\DBAL\Events;
 use Doctrine\Tests\DbalTestCase;
+use function sprintf;
 
 class OracleSessionInitTest extends DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
@@ -4,6 +4,9 @@ namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
+use const CASE_LOWER;
+use function array_change_key_case;
+use function stream_get_contents;
 
 /**
  * @group DBAL-6

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use function in_array;
 
 class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -8,6 +8,18 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\TrimMode;
 use Doctrine\DBAL\Types\Type;
+use const CASE_LOWER;
+use const PHP_EOL;
+use function array_change_key_case;
+use function array_filter;
+use function array_keys;
+use function count;
+use function date;
+use function implode;
+use function is_numeric;
+use function json_encode;
+use function property_exists;
+use function strtotime;
 
 class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/DB2DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/DB2DriverTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\IBMDB2;
 
 use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+use function extension_loaded;
 
 class DB2DriverTest extends AbstractDriverTest
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/DB2StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/DB2StatementTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use PHPUnit\Framework\Error\Notice;
+use function extension_loaded;
 
 class DB2StatementTest extends DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/ConnectionTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Doctrine\Tests\DBAL\Functional\Driver\Mysqli;
+use function extension_loaded;
 
 class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/DriverTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\Mysqli\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+use function extension_loaded;
 
 class DriverTest extends AbstractDriverTest
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/DriverTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\OCI8;
 
 use Doctrine\DBAL\Driver\OCI8\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+use function extension_loaded;
 
 class DriverTest extends AbstractDriverTest
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/OCI8ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/OCI8ConnectionTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\OCI8;
 use Doctrine\DBAL\Driver\OCI8\Driver;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\Tests\DbalFunctionalTestCase;
+use function extension_loaded;
 
 class OCI8ConnectionTest extends DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/StatementTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\OCI8;
 
 use Doctrine\DBAL\Driver\OCI8\Driver;
 use Doctrine\Tests\DbalFunctionalTestCase;
+use function extension_loaded;
 
 class StatementTest extends DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOConnectionTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\Tests\DBAL\Functional\Driver;
 
 use Doctrine\DBAL\Driver\PDOConnection;
 use Doctrine\Tests\DbalFunctionalTestCase;
+use function extension_loaded;
+use function sprintf;
 
 class PDOConnectionTest extends DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOMySql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOMySql/DriverTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDOMySql;
 
 use Doctrine\DBAL\Driver\PDOMySql\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+use function extension_loaded;
 
 class DriverTest extends AbstractDriverTest
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOOracle/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOOracle/DriverTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDOOracle;
 
 use Doctrine\DBAL\Driver\PDOOracle\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+use function extension_loaded;
 
 class DriverTest extends AbstractDriverTest
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
@@ -6,6 +6,10 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\PDOPgSql\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 use Doctrine\Tests\TestUtil;
+use function array_key_exists;
+use function extension_loaded;
+use function microtime;
+use function sprintf;
 
 class DriverTest extends AbstractDriverTest
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgsqlConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgsqlConnectionTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\Tests\DbalFunctionalTestCase;
+use function extension_loaded;
 
 class PDOPgsqlConnectionTest extends DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDOSqlite;
 
 use Doctrine\DBAL\Driver\PDOSqlite\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+use function extension_loaded;
 
 class DriverTest extends AbstractDriverTest
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/Driver.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/Driver.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDOSqlsrv;
 
 use Doctrine\DBAL\Driver\PDOSqlsrv\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+use function extension_loaded;
 
 class DriverTest extends AbstractDriverTest
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/ConnectionTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
 
 use Doctrine\DBAL\Driver\SQLAnywhere\Driver;
 use Doctrine\DBAL\DriverManager;
+use function extension_loaded;
 
 class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\SQLAnywhere\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+use function extension_loaded;
 
 class DriverTest extends AbstractDriverTest
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/StatementTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
 
 use Doctrine\DBAL\Driver\SQLAnywhere\Driver;
 use Doctrine\DBAL\DriverManager;
+use function extension_loaded;
 
 class StatementTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/Driver.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/Driver.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\SQLSrv;
 
 use Doctrine\DBAL\Driver\SQLSrv\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+use function extension_loaded;
 
 class DriverTest extends AbstractDriverTest
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/StatementTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\SQLSrv;
 use Doctrine\DBAL\Driver\SQLSrv\Driver;
 use Doctrine\DBAL\Driver\SQLSrv\SQLSrvException;
 use Doctrine\Tests\DbalFunctionalTestCase;
+use function extension_loaded;
 
 class StatementTest extends DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -4,6 +4,14 @@ namespace Doctrine\Tests\DBAL\Functional;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Table;
+use function array_merge;
+use function chmod;
+use function defined;
+use function file_exists;
+use function sprintf;
+use function sys_get_temp_dir;
+use function touch;
+use function unlink;
 
 class ExceptionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -5,6 +5,12 @@ namespace Doctrine\Tests\DBAL\Functional;
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\Tests\DbalFunctionalTestCase;
+use const CASE_LOWER;
+use function array_change_key_case;
+use function sprintf;
+use function strlen;
+use function strtolower;
+use function substr;
 
 /**
  * @group DBAL-20

--- a/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ModifyLimitQueryTest.php
@@ -1,6 +1,9 @@
 <?php
 
 namespace Doctrine\Tests\DBAL\Functional;
+use const CASE_LOWER;
+use function array_change_key_case;
+use function count;
 
 class ModifyLimitQueryTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
+use const CASE_LOWER;
+use function array_change_key_case;
 
 /**
  * @group DDC-1372

--- a/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Portability\Connection as ConnectionPortability;
+use function strlen;
 
 /**
  * @group DBAL-56

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -5,6 +5,12 @@ namespace Doctrine\Tests\DBAL\Functional;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Logging\DebugStack;
+use const CASE_LOWER;
+use function array_change_key_case;
+use function array_merge;
+use function array_shift;
+use function array_values;
+use function is_array;
 
 /**
  * @group DDC-217

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\Types\MySqlPointType;
+use function implode;
 
 class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\TestUtil;
+use function array_map;
 
 class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -9,6 +9,10 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
+use function array_map;
+use function array_pop;
+use function count;
+use function strtolower;
 
 class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
+use function current;
 
 class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -14,6 +14,20 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_search;
+use function count;
+use function current;
+use function end;
+use function explode;
+use function get_class;
+use function in_array;
+use function str_replace;
+use function strlen;
+use function strtolower;
+use function substr;
 
 class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -4,6 +4,10 @@ namespace Doctrine\Tests\DBAL\Functional\Schema;
 
 use Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Types\Type;
+use function array_map;
+use function dirname;
+use function extension_loaded;
+use function version_compare;
 
 class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
@@ -7,6 +7,8 @@ use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
+use function base64_decode;
+use function stream_get_contents;
 
 class StatementTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL421Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL421Test.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace Doctrine\Tests\DBAL\Functional\Ticket;
+use function in_array;
+use function preg_match;
 
 /**
  * @group DBAL-421

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL\Functional\Ticket;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\ParameterType;
 use PDO;
+use function in_array;
 
 /**
  * @group DBAL-630

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL752Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL752Test.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Doctrine\Tests\DBAL\Functional\Ticket;
+use function in_array;
 
 /**
  * @group DBAL-752

--- a/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\Types\Type;
+use function str_repeat;
 
 class TypeConversionTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
+use function array_filter;
+use function strtolower;
 
 class WriteTest extends \Doctrine\Tests\DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
+use function array_shift;
 
 abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -14,6 +14,10 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\Types\CommentedType;
+use function get_class;
+use function implode;
+use function sprintf;
+use function str_repeat;
 
 abstract class AbstractPlatformTestCase extends \Doctrine\Tests\DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -10,6 +10,10 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Type;
+use function array_walk;
+use function preg_replace;
+use function strtoupper;
+use function uniqid;
 
 class OraclePlatformTest extends AbstractPlatformTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -16,6 +16,9 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Type;
+use function mt_rand;
+use function strlen;
+use function substr;
 
 class SQLAnywherePlatformTest extends AbstractPlatformTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -31,6 +31,7 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
+use function array_keys;
 
 /**
  * @license http://www.opensource.org/licenses/lgpl-license.php LGPL

--- a/tests/Doctrine/Tests/DBAL/Schema/MySqlInheritCharsetTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/MySqlInheritCharsetTest.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\MySqlSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
+use function array_merge;
 
 class MySqlInheritCharsetTest extends TestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL\Schema;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Schema\MySqlSchemaManager;
+use function array_map;
 
 class MySqlSchemaManagerTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
@@ -5,6 +5,8 @@ namespace Doctrine\Tests\DBAL\Schema;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
+use function current;
+use function strlen;
 
 class SchemaTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
+use function array_shift;
+use function current;
 
 class TableTest extends \Doctrine\Tests\DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/RemoveNamespacedAssetsTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/RemoveNamespacedAssetsTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets;
+use function array_keys;
 
 class RemoveNamespacedAssetsTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/AbstractTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/AbstractTestCase.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL\Sharding\SQLAzure;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Sharding\SQLAzure\SQLAzureShardManager;
+use function strpos;
 
 abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/FunctionalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/FunctionalTest.php
@@ -2,6 +2,7 @@
 namespace Doctrine\Tests\DBAL\Sharding\SQLAzure;
 
 use Doctrine\DBAL\Sharding\SQLAzure\SQLAzureFederationsSynchronizer;
+use function count;
 
 class FunctionalTest extends AbstractTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
@@ -5,6 +5,10 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use const E_ALL;
+use const E_STRICT;
+use function error_reporting;
+use function serialize;
 
 class ArrayTest extends \Doctrine\Tests\DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/BaseDateTypeTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BaseDateTypeTestCase.php
@@ -3,6 +3,8 @@
 namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use function date_default_timezone_get;
+use function date_default_timezone_set;
 
 abstract class BaseDateTypeTestCase extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
@@ -5,6 +5,9 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use function base64_encode;
+use function fopen;
+use function stream_get_contents;
 
 class BinaryTest extends \Doctrine\Tests\DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
@@ -4,6 +4,10 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use function base64_encode;
+use function chr;
+use function fopen;
+use function stream_get_contents;
 
 class BlobTest extends \Doctrine\Tests\DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/ConversionExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ConversionExceptionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Types\ConversionException;
+use function tmpfile;
 
 class ConversionExceptionTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/DateImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateImmutableTypeTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateImmutableType;
 use Doctrine\DBAL\Types\Type;
+use function get_class;
 
 class DateImmutableTypeTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/DateTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Types\Type;
+use function date_default_timezone_set;
 
 class DateTest extends BaseDateTypeTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTimeImmutableTypeTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeImmutableType;
 use Doctrine\DBAL\Types\Type;
+use function get_class;
 
 class DateTimeImmutableTypeTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTimeTzImmutableTypeTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeTzImmutableType;
 use Doctrine\DBAL\Types\Type;
+use function get_class;
 
 class DateTimeTzImmutableTypeTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/GuidTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/GuidTypeTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use function get_class;
 
 class GuidTest extends \Doctrine\Tests\DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
@@ -5,6 +5,9 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use function base64_encode;
+use function fopen;
+use function json_encode;
 
 class JsonArrayTest extends \Doctrine\Tests\DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/JsonTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonTest.php
@@ -5,6 +5,9 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use function base64_encode;
+use function fopen;
+use function json_encode;
 
 class JsonTest extends \Doctrine\Tests\DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
@@ -4,6 +4,10 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use const E_ALL;
+use const E_STRICT;
+use function error_reporting;
+use function serialize;
 
 class ObjectTest extends \Doctrine\Tests\DbalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/Types/TimeImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/TimeImmutableTypeTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\TimeImmutableType;
 use Doctrine\DBAL\Types\Type;
+use function get_class;
 
 class TimeImmutableTypeTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -1,6 +1,16 @@
 <?php
 
 namespace Doctrine\Tests;
+use const PHP_EOL;
+use function array_map;
+use function array_reverse;
+use function count;
+use function get_class;
+use function implode;
+use function is_object;
+use function is_scalar;
+use function strpos;
+use function var_export;
 
 class DbalFunctionalTestCase extends DbalTestCase
 {

--- a/tests/Doctrine/Tests/DbalPerformanceTestCase.php
+++ b/tests/Doctrine/Tests/DbalPerformanceTestCase.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Doctrine\Tests;
+use function microtime;
 
 /**
  * Base class for all DBAL performance tests.

--- a/tests/Doctrine/Tests/DbalPerformanceTestListener.php
+++ b/tests/Doctrine/Tests/DbalPerformanceTestListener.php
@@ -5,6 +5,9 @@ namespace Doctrine\Tests;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestListenerDefaultImplementation;
+use function get_class;
+use function printf;
+use function str_replace;
 
 /**
  * Listener for collecting and reporting results of performance tests

--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Doctrine\Tests\Mocks;
+use function is_string;
 
 class ConnectionMock extends \Doctrine\DBAL\Connection
 {

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -5,6 +5,9 @@ namespace Doctrine\Tests;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use PHPUnit\Framework\Assert;
+use function explode;
+use function extension_loaded;
+use function unlink;
 
 /**
  * TestUtil is a class with static utility methods used during tests.

--- a/tests/Doctrine/Tests/Types/CommentedType.php
+++ b/tests/Doctrine/Tests/Types/CommentedType.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use function strtoupper;
 
 class CommentedType extends Type
 {

--- a/tests/Doctrine/Tests/Types/MySqlPointType.php
+++ b/tests/Doctrine/Tests/Types/MySqlPointType.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use function strtoupper;
 
 class MySqlPointType extends Type
 {


### PR DESCRIPTION
CS is a simple bump (no change required since we use incremental diffs here).

Had to hack some sniffs to:
* only add imports for functions/constants (and not classes as well)
* to re-order only functions/constants (and not classes as well)

Would love to see this in 2.7, but not a dealbreaker.