### PR TITLE
Postgres, Oracle and SQL Server Sequence increment_by & min_value as int

### DIFF
--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -303,8 +303,8 @@ class OracleSchemaManager extends AbstractSchemaManager
 
         return new Sequence(
             $this->getQuotedIdentifierName($sequence['sequence_name']),
-            $sequence['increment_by'],
-            $sequence['min_value']
+            (int) $sequence['increment_by'],
+            (int) $sequence['min_value']
         );
     }
 

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -311,7 +311,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
             $sequence += $data;
         }
 
-        return new Sequence($sequenceName, $sequence['increment_by'], $sequence['min_value']);
+        return new Sequence($sequenceName, (int) $sequence['increment_by'], (int) $sequence['min_value']);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -76,7 +76,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
      */
     protected function _getPortableSequenceDefinition($sequence)
     {
-        return new Sequence($sequence['name'], $sequence['increment'], $sequence['start_value']);
+        return new Sequence($sequence['name'], (int) $sequence['increment'], (int) $sequence['start_value']);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/Sequence.php
+++ b/lib/Doctrine/DBAL/Schema/Sequence.php
@@ -58,8 +58,8 @@ class Sequence extends AbstractAsset
     {
         $this->_setName($name);
         $this->allocationSize = is_numeric($allocationSize) ? $allocationSize : 1;
-        $this->initialValue = is_numeric($initialValue) ? $initialValue : 1;
-        $this->cache = $cache;
+        $this->initialValue   = is_numeric($initialValue) ? $initialValue : 1;
+        $this->cache          = $cache;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -123,7 +123,7 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
 
         $name = 'dropcreate_sequences_test_seq';
 
-        $this->_sm->dropAndCreateSequence(new \Doctrine\DBAL\Schema\Sequence($name, 20, 10));
+        $this->_sm->dropAndCreateSequence(new Sequence($name, 20, 10));
 
         self::assertTrue($this->hasElementWithName($this->_sm->listSequences(), $name));
     }
@@ -142,11 +142,11 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
 
     public function testListSequences()
     {
-        if(!$this->_conn->getDatabasePlatform()->supportsSequences()) {
-            $this->markTestSkipped($this->_conn->getDriver()->getName().' does not support sequences.');
+        if (! $this->_conn->getDatabasePlatform()->supportsSequences()) {
+            $this->markTestSkipped($this->_conn->getDriver()->getName() . ' does not support sequences.');
         }
 
-        $sequence = new \Doctrine\DBAL\Schema\Sequence('list_sequences_test_seq', 20, 10);
+        $sequence = new Sequence('list_sequences_test_seq', 20, 10);
         $this->_sm->createSequence($sequence);
 
         $sequences = $this->_sm->listSequences();
@@ -154,16 +154,18 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
         self::assertInternalType('array', $sequences, 'listSequences() should return an array.');
 
         $foundSequence = null;
-        foreach($sequences as $sequence) {
-            self::assertInstanceOf('Doctrine\DBAL\Schema\Sequence', $sequence, 'Array elements of listSequences() should be Sequence instances.');
-            if(strtolower($sequence->getName()) == 'list_sequences_test_seq') {
-                $foundSequence = $sequence;
+        foreach ($sequences as $sequence) {
+            self::assertInstanceOf(Sequence::class, $sequence, 'Array elements of listSequences() should be Sequence instances.');
+            if (strtolower($sequence->getName()) !== 'list_sequences_test_seq') {
+                continue;
             }
+
+            $foundSequence = $sequence;
         }
 
         self::assertNotNull($foundSequence, "Sequence with name 'list_sequences_test_seq' was not found.");
-        self::assertEquals(20, $foundSequence->getAllocationSize(), "Allocation Size is expected to be 20.");
-        self::assertEquals(10, $foundSequence->getInitialValue(), "Initial Value is expected to be 10.");
+        self::assertSame(20, $foundSequence->getAllocationSize(), 'Allocation Size is expected to be 20.');
+        self::assertSame(10, $foundSequence->getInitialValue(), 'Initial Value is expected to be 10.');
     }
 
     public function testListDatabases()


### PR DESCRIPTION
When comparing schema, it causes problem at https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Schema/Comparator.php#L196 where `$initialValue` is int in first case and string in second case and therefore `schema:validate` command never passes as `--dump-sql` always generates statements like:

```sql
ALTER SEQUENCE asequence_id_seq INCREMENT BY 1;
```