### PR TITLE
Fix #3082: Add BC for PDO-only fetch modes

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -216,7 +216,13 @@ class PDOStatement extends \PDOStatement implements Statement
     private function convertParamType(int $type) : int
     {
         if (! isset(self::PARAM_TYPE_MAP[$type])) {
-            throw new \InvalidArgumentException('Invalid parameter type: ' . $type);
+            // TODO: next major: throw an exception
+            @trigger_error(sprintf(
+                'Using a PDO parameter type (%d given) is deprecated and will cause an error in Doctrine 3.0',
+                $type
+            ), E_USER_DEPRECATED);
+
+            return $type;
         }
 
         return self::PARAM_TYPE_MAP[$type];

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -22,6 +22,9 @@ namespace Doctrine\DBAL\Driver;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use PDO;
+use const E_USER_DEPRECATED;
+use function sprintf;
+use function trigger_error;
 
 /**
  * The PDO implementation of the Statement interface.
@@ -231,7 +234,14 @@ class PDOStatement extends \PDOStatement implements Statement
         }
 
         if (! isset(self::FETCH_MODE_MAP[$fetchMode])) {
-            throw new \InvalidArgumentException('Invalid fetch mode: ' . $fetchMode);
+            // TODO: next major: throw an exception
+            @trigger_error(sprintf(
+                'Using a PDO fetch mode or their combination (%d given)' .
+                ' is deprecated and will cause an error in Doctrine 3.0',
+                $fetchMode
+            ), E_USER_DEPRECATED);
+
+            return $fetchMode;
         }
 
         return self::FETCH_MODE_MAP[$fetchMode];

--- a/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional;
+
+use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalFunctionalTestCase;
+use PDO;
+use function extension_loaded;
+
+class PDOStatementTest extends DbalFunctionalTestCase
+{
+    protected function setUp()
+    {
+        if (! extension_loaded('pdo')) {
+            $this->markTestSkipped('PDO is not installed');
+        }
+
+        parent::setUp();
+
+        if (! $this->_conn->getWrappedConnection() instanceof PDOConnection) {
+            $this->markTestSkipped('PDO-only test');
+        }
+
+        $table = new Table('stmt_test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'text');
+        $this->_conn->getSchemaManager()->dropAndCreateTable($table);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using a PDO fetch mode or their combination (%d given) is deprecated and will cause an error in Doctrine 3.0
+     */
+    public function testPDOSpecificModeIsAccepted()
+    {
+        $this->_conn->insert('stmt_test', [
+            'id' => 1,
+            'name' => 'Alice',
+        ]);
+        $this->_conn->insert('stmt_test', [
+            'id' => 2,
+            'name' => 'Bob',
+        ]);
+
+        $data = $this->_conn->query('SELECT id, name FROM stmt_test ORDER BY id')
+            ->fetchAll(PDO::FETCH_KEY_PAIR);
+
+        self::assertSame([
+            1 => 'Alice',
+            2 => 'Bob',
+        ], $data);
+    }
+}


### PR DESCRIPTION
The test case covers most of the sane PDO fetch modes that are not availably as DBAL fetch mode. Unfortunately, the fetch mode cannot be read by userland code. We have to trust that they are actually swapped for every method that uses them (well, they are); or use reflection to test the private method `convertFetchMode()`.
closes #3082

Edit by @beberlei:

This deprecation was introduced as part of the removal of Doctrine DBAL API relying on implicit PDO behavior. This was started here https://github.com/doctrine/dbal/pull/2958 and disallows the use of `PDO::PARAM_*` constants in Doctrine DBAL APIs.

Before:
```php
$statement->bindParam(1, $value, PDO::PARAM_INT);
```
After:
```php
$statement->bindParam(1, $value, \Doctrine\DBAL\Types\Types::INTEGER);
```

in addition PDO Fetch modes that are unsupported by Doctrine explictly are disallowed, for example `PDO::FETCH_KEY_PAIR`. Use the new `fetch*()` APIs instead. See https://github.com/doctrine/dbal/pull/4019 for details.