### PR TITLE
Adding support for dot character (.) when using parameters

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -29,7 +29,7 @@ namespace Doctrine\DBAL;
 class SQLParserUtils
 {
     const POSITIONAL_TOKEN = '\?';
-    const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
+    const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_.]*';
 
     // Quote characters within string literals can be preceded by a backslash.
     const ESCAPED_SINGLE_QUOTED_TEXT = "(?:'(?:\\\\\\\\)+'|'(?:[^'\\\\]|\\\\'?|'')*')";


### PR DESCRIPTION
The regular expression should have support for dot character (.) when parameters are created.

eg. 
**Query** = SELECT u.user_id, user_email, user_name, user_first_name, user_last_name, user_register_date, user_last_visit_date, user_active, u.media_id, u.user_display_name, u.user_country, user_state, user_phone_number, user_city, user_address, user_birthday, user_gender, user_post_code, u.user_type, g.group_id FROM user u LEFT JOIN group_member g ON u.user_id = g.user_id AND g.group_id = 6 WHERE (user_active <= 2) AND (((user_email LIKE :user_email_0) OR (user_name LIKE :user_name_1) OR (user_first_name LIKE :user_first_name_2) OR (user_last_name LIKE :user_last_name_3) OR (user_active LIKE :user_active_4) OR (u.user_id LIKE :u.user_id_6))) GROUP BY u.user_id ORDER BY u.user_id asc LIMIT 10 OFFSET 0

And the query is preg_matched using 
preg_match_all("/(?<!:):[a-zA-Z_][a-zA-Z0-9_]*/", $input_lines, $output_array);

The result is
array(1
0	=>	array(7
0	=>	:user_email_0
1	=>	:user_name_1
2	=>	:user_first_name_2
3	=>	:user_last_name_3
4	=>	:user_active_4
5	=>	:user_data_5
6	=>	:u
)
)

But when preg_match_all("/(?<!:):[a-zA-Z_][a-zA-Z0-9_.]*/", $input_lines, $output_array); //Added the dot 

The result is 
array(1
0	=>	array(7
0	=>	:user_email_0
1	=>	:user_name_1
2	=>	:user_first_name_2
3	=>	:user_last_name_3
4	=>	:user_active_4
5	=>	:user_data_5
6	=>	:u.user_id_6
)
)

I had run unit test and it seems fine.


