### PR TITLE
Fix compatibility for pre-2.7 DateIntervalType format

### DIFF
--- a/lib/Doctrine/DBAL/Types/DateIntervalType.php
+++ b/lib/Doctrine/DBAL/Types/DateIntervalType.php
@@ -56,10 +56,17 @@ class DateIntervalType extends Type
             return $value;
         }
 
-        try {
-            $interval = new \DateInterval(substr($value, 1));
+        $negative = false;
 
-            if (substr($value, 0, 1) === '-') {
+        if (isset($value[0]) && ($value[0] === '+' || $value[0] === '-')) {
+            $negative = $value[0] === '-';
+            $value    = substr($value, 1);
+        }
+
+        try {
+            $interval = new \DateInterval($value);
+
+            if ($negative) {
                 $interval->invert = 1;
             }
 

--- a/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
@@ -67,6 +67,14 @@ final class DateIntervalTest extends DbalTestCase
         self::assertEquals('-P02Y00M01DT01H02M03S', $interval->format(DateIntervalType::FORMAT));
     }
 
+    public function testDateIntervalFormatWithoutSignConvertsToPHPValue() : void
+    {
+        $interval = $this->type->convertToPHPValue('P02Y00M01DT01H02M03S', $this->platform);
+
+        self::assertInstanceOf(\DateInterval::class, $interval);
+        self::assertEquals('+P02Y00M01DT01H02M03S', $interval->format(DateIntervalType::FORMAT));
+    }
+
     public function testInvalidDateIntervalFormatConversion() : void
     {
         $this->expectException(ConversionException::class);
@@ -77,6 +85,13 @@ final class DateIntervalTest extends DbalTestCase
     public function testDateIntervalNullConversion() : void
     {
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testDateIntervalEmptyStringConversion() : void
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToPHPValue('', $this->platform);
     }
 
     /**


### PR DESCRIPTION
After #2579 DateIntervalType always expects a sign, which is not there for records created by pre-2.7 DBAL.

Fixes #3093.