### PR TITLE
Use newer PHPUnit to prevent crashes on failures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^4.0",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.1.2",
         "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
         "symfony/console": "^2.0.5||^3.0",
         "symfony/phpunit-bridge": "^3.4.5|^4.0.5"


### PR DESCRIPTION
Fixes #3049.
Related: symfony/symfony#26861, https://github.com/sebastianbergmann/phpunit/commit/9b58a4f41d91a20bc9c7c3aae94e74ac61e530b2