### PR TITLE
Fix like escape for sqlite

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -48,9 +48,9 @@ class SQLParserUtils
     const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
 
     // Quote characters within string literals can be preceded by a backslash.
-    const ESCAPED_SINGLE_QUOTED_TEXT = "(?:'(?:\\\\\\\\)+'|'(?:[^'\\\\]|\\\\'?|'')*')";
-    const ESCAPED_DOUBLE_QUOTED_TEXT = '(?:"(?:\\\\\\\\)+"|"(?:[^"\\\\]|\\\\"?)*")';
-    const ESCAPED_BACKTICK_QUOTED_TEXT = '(?:`(?:\\\\\\\\)+`|`(?:[^`\\\\]|\\\\`?)*`)';
+    const ESCAPED_SINGLE_QUOTED_TEXT = "(?:'(?:\\\\\\\\)+'|(?<=ESCAPE\\s)'(?:\\\\)+'|'(?:[^'\\\\]|\\\\'?|'')*')";
+    const ESCAPED_DOUBLE_QUOTED_TEXT = '(?:"(?:\\\\\\\\)+"|(?<=ESCAPE\\s)"(?:\\\\)+"|"(?:[^"\\\\]|\\\\"?)*")';
+    const ESCAPED_BACKTICK_QUOTED_TEXT = '(?:`(?:\\\\\\\\)+`|(?<=ESCAPE\\s)`(?:\\\\)+`|`(?:[^`\\\\]|\\\\`?)*`)';
     const ESCAPED_BRACKET_QUOTED_TEXT = '(?<!\bARRAY)\[(?:[^\]])*\]';
 
     /**

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -68,11 +68,11 @@ OR bar=:a_param3
 SQLDATA
                 , false, array(74 => 'a_param1', 91 => 'a_param2', 190 => 'a_param3')
             ),
-            array("SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE '\\\\') AND (data.description LIKE :condition_1 ESCAPE '\\\\') ORDER BY id ASC", false, array(121 => 'condition_0', 174 => 'condition_1')),
-            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE "\\\\") AND (data.description LIKE :condition_1 ESCAPE "\\\\") ORDER BY id ASC', false, array(121 => 'condition_0', 174 => 'condition_1')),
-            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE "\\\\") AND (data.description LIKE :condition_1 ESCAPE \'\\\\\') ORDER BY id ASC', false, array(121 => 'condition_0', 174 => 'condition_1')),
-            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE `\\\\`) AND (data.description LIKE :condition_1 ESCAPE `\\\\`) ORDER BY id ASC', false, array(121 => 'condition_0', 174 => 'condition_1')),
-            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE \'\\\\\') AND (data.description LIKE :condition_1 ESCAPE `\\\\`) ORDER BY id ASC', false, array(121 => 'condition_0', 174 => 'condition_1')),
+            array("SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE '\\') AND (data.description LIKE :condition_1 ESCAPE '\\') ORDER BY id ASC", false, array(121 => 'condition_0', 173 => 'condition_1')),
+            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE "\\") AND (data.description LIKE :condition_1 ESCAPE "\\") ORDER BY id ASC', false, array(121 => 'condition_0', 173 => 'condition_1')),
+            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE "\\") AND (data.description LIKE :condition_1 ESCAPE \'\\\') ORDER BY id ASC', false, array(121 => 'condition_0', 173 => 'condition_1')),
+            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE `\\`) AND (data.description LIKE :condition_1 ESCAPE `\\`) ORDER BY id ASC', false, array(121 => 'condition_0', 173 => 'condition_1')),
+            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE \'\\\') AND (data.description LIKE :condition_1 ESCAPE `\\`) ORDER BY id ASC', false, array(121 => 'condition_0', 173 => 'condition_1')),
 
         );
     }

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -70,9 +70,7 @@ SQLDATA
             ),
             array("SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE '\\') AND (data.description LIKE :condition_1 ESCAPE '\\') ORDER BY id ASC", false, array(121 => 'condition_0', 173 => 'condition_1')),
             array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE "\\") AND (data.description LIKE :condition_1 ESCAPE "\\") ORDER BY id ASC', false, array(121 => 'condition_0', 173 => 'condition_1')),
-            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE "\\") AND (data.description LIKE :condition_1 ESCAPE \'\\\') ORDER BY id ASC', false, array(121 => 'condition_0', 173 => 'condition_1')),
-            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE `\\`) AND (data.description LIKE :condition_1 ESCAPE `\\`) ORDER BY id ASC', false, array(121 => 'condition_0', 173 => 'condition_1')),
-            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE \'\\\') AND (data.description LIKE :condition_1 ESCAPE `\\`) ORDER BY id ASC', false, array(121 => 'condition_0', 173 => 'condition_1')),
+            array('SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE \'\\\') AND (data.description LIKE :condition_1 ESCAPE \'\\\') ORDER BY id ASC', false, array(121 => 'condition_0', 173 => 'condition_1')),
 
         );
     }


### PR DESCRIPTION
Follow up to #2720 from @mondrake approved by @deeky666 (["I simply trust you guys on this one" 😿](https://github.com/doctrine/dbal/pull/2720#pullrequestreview-38390044))

Not sure if that is also the case for other DBs, but at least for SQLite `ESCAPE "…"` must only contain one char. So that is `ESCAPE "\\"` in php. The unit test accidently used `ESCAPE "\\\\"` and therefor didn't match the actual syntax and broke for SQLite.

In case `ESCAPE "\\\\"` is needed for another DB, we should just add both unit tests.

