### PR TITLE
Fix "Unknown database type binary requested" for SQLite

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -642,6 +642,7 @@ class SqlitePlatform extends AbstractPlatform
             'decimal'          => 'decimal',
             'numeric'          => 'decimal',
             'blob'             => 'blob',
+            'binary'           => 'blob',
         ];
     }
 


### PR DESCRIPTION
Hello!

Currently there is no type mapping for binary that is cause of error: Unknown database type binary requested, Doctrine\DBAL\Platforms\SqlitePlatform

This PR fix it