### PR TITLE
Fixed inconsistency in calculating date difference between platforms

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -160,14 +160,10 @@ class OraclePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
-     *
-     * Note: Since Oracle timestamp differences are calculated down to the microsecond we have to truncate
-     * them to the difference in days. This is obviously a restriction of the original functionality, but we
-     * need to make this a portable function.
      */
     public function getDateDiffExpression($date1, $date2)
     {
-        return "TRUNC(TO_NUMBER(SUBSTR((" . $date1 . "-" . $date2 . "), 1, INSTR(" . $date1 . "-" . $date2 .", ' '))))";
+        return sprintf('TRUNC(%s) - TRUNC(%s)', $date1, $date2);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -174,7 +174,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getDateDiffExpression($date1, $date2)
     {
-        return 'ROUND(JULIANDAY('.$date1 . ')-JULIANDAY('.$date2.'))';
+        return sprintf("JULIANDAY(%s, 'start of day') - JULIANDAY(%s, 'start of day')", $date1, $date2);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -5,7 +5,6 @@ namespace Doctrine\Tests\DBAL\Functional;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\TrimMode;
 use Doctrine\DBAL\Types\Type;
 use const CASE_LOWER;
@@ -531,7 +530,6 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
     {
         $p = $this->_conn->getDatabasePlatform();
         $sql = 'SELECT ';
-        $sql .= $p->getDateDiffExpression('test_datetime', $p->getCurrentTimestampSQL()) .' AS diff, ';
         $sql .= $p->getDateAddSecondsExpression('test_datetime', 1) .' AS add_seconds, ';
         $sql .= $p->getDateSubSecondsExpression('test_datetime', 1) .' AS sub_seconds, ';
         $sql .= $p->getDateAddMinutesExpression('test_datetime', 5) .' AS add_minutes, ';
@@ -553,8 +551,6 @@ class DataAccessTest extends \Doctrine\Tests\DbalFunctionalTestCase
         $row = $this->_conn->fetchAssoc($sql);
         $row = array_change_key_case($row, CASE_LOWER);
 
-        $diff = (strtotime('2010-01-01') - strtotime(date('Y-m-d'))) / 3600 / 24;
-        self::assertEquals($diff, $row['diff'], "Date difference should be approx. ".$diff." days.", 1);
         self::assertEquals('2010-01-01 10:10:11', date('Y-m-d H:i:s', strtotime($row['add_seconds'])), "Adding second should end up on 2010-01-01 10:10:11");
         self::assertEquals('2010-01-01 10:10:09', date('Y-m-d H:i:s', strtotime($row['sub_seconds'])), "Subtracting second should end up on 2010-01-01 10:10:09");
         self::assertEquals('2010-01-01 10:15:10', date('Y-m-d H:i:s', strtotime($row['add_minutes'])), "Adding minutes should end up on 2010-01-01 10:15:10");

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/DateExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/DateExpressionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Platform;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalFunctionalTestCase;
+use function sprintf;
+
+class DateExpressionTest extends DbalFunctionalTestCase
+{
+    /**
+     * @dataProvider differenceProvider
+     */
+    public function testDifference(string $date1, string $date2, int $expected) : void
+    {
+        $table = new Table('date_expr_test');
+        $table->addColumn('date1', 'date');
+        $table->addColumn('date2', 'date');
+        $this->_conn->getSchemaManager()->dropAndCreateTable($table);
+        $this->_conn->insert('date_expr_test', [
+            'date1' => $date1,
+            'date2' => $date2,
+        ]);
+
+        $platform = $this->_conn->getDatabasePlatform();
+
+        $sql  = sprintf('SELECT %s FROM date_expr_test', $platform->getDateDiffExpression('date1', 'date2'));
+        $diff = $this->_conn->query($sql)->fetchColumn();
+
+        self::assertEquals($expected, $diff);
+    }
+
+    /**
+     * @return string[][]|int[][]
+     */
+    public static function differenceProvider() : iterable
+    {
+        $date1    = new DateTimeImmutable();
+        $date2    = new DateTimeImmutable('2018-04-10 10:10:10');
+        $expected = $date1->modify('midnight')->diff(
+            $date2->modify('midnight')
+        )->days;
+
+        return [
+            'dynamic'  => [
+                $date1->format('Y-m-d H:i:s'),
+                $date2->format('Y-m-d H:i:s'),
+                $expected,
+            ],
+            'same day' => ['2018-04-14 23:59:59', '2018-04-14 00:00:00', 0],
+            'midnight' => ['2018-04-14 00:00:00', '2018-04-13 23:59:59', 1],
+        ];
+    }
+}


### PR DESCRIPTION
**Original symptom**: the test fails on SQLite depending on the current time and timezone:
```
↪ php -r "echo date('r'), PHP_EOL;"
Sat, 14 Apr 2018 18:26:33 -0700

↪ phpunit --filter testDateArithmetics tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.phpPHPUnit 7.1.3 by Sebastian Bergmann and contributors.

Testing Doctrine\Tests\DBAL\Functional\DataAccessTest
F                                                                                   1 / 1 (100%)

Time: 84 ms, Memory: 6.00MB

There was 1 failure:

1) Doctrine\Tests\DBAL\Functional\DataAccessTest::testDateArithmetics
Date difference should be approx. -3024.9583333333 days.
Failed asserting that '-3026.0' matches expected -3024.9583333333335.

tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php:557

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

**Reason**:

The test relies upon `date('Y-m-d')` and `AbstractPlatform:::getCurrentTimestampSQL()` always producing dates in the same day. It's not true in case of SQLite whose `CURRENT_TIMESTAMP` is always in UTC or in general if the DB timezone is different from the PHPs.

**Additional issue**:
```php
function diff(string $date1, string $date2) {
    $conn = \Doctrine\DBAL\DriverManager::getConnection([
        'driver' => 'pdo_sqlite',
        'memory' => true,
    ]);

    $platform = $conn->getDatabasePlatform();
    $sql = 'SELECT ' . $platform->getDateDiffExpression('?', '?');

    return $conn->executeQuery(
        $sql,
        [$date1, $date2]
    )->fetchColumn();
}

// two close enough dates on the same day
echo diff('2018-04-14 18:00:00', '2018-04-14 08:00:00'), PHP_EOL; // 0.0, correct

// two not close enough dates on the same day
echo diff('2018-04-14 18:00:00', '2018-04-14 06:00:00'), PHP_EOL; // 1.0, incorrect

// two close enough dates on subsequent days
echo diff('2018-04-15 02:00:00', '2018-04-14 22:00:00'), PHP_EOL; // 0.0, incorrect
```

**Reason**:

The Oracle and SQLite platforms, instead of comparing days of the dates, compare the datetimes and round the result. Instead, they should extract days from the datetimes and compare them.