### PR TITLE
Allow to specify arbitrary SQL expression in AbstractPlatform::getDummySelectSQL()

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -49,7 +49,9 @@ use function array_unique;
 use function array_values;
 use function count;
 use function explode;
+use function func_get_arg;
 use function func_get_args;
+use function func_num_args;
 use function get_class;
 use function implode;
 use function in_array;
@@ -3499,7 +3501,9 @@ abstract class AbstractPlatform
      */
     public function getDummySelectSQL()
     {
-        return 'SELECT 1';
+        $expression = func_num_args() > 0 ? func_get_arg(0) : '1';
+
+        return sprintf('SELECT %s', $expression);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -30,6 +30,8 @@ use function array_merge;
 use function count;
 use function current;
 use function explode;
+use function func_get_arg;
+use function func_num_args;
 use function implode;
 use function sprintf;
 use function strpos;
@@ -863,7 +865,9 @@ class DB2Platform extends AbstractPlatform
      */
     public function getDummySelectSQL()
     {
-        return 'SELECT 1 FROM sysibm.sysdummy1';
+        $expression = func_num_args() > 0 ? func_get_arg(0) : '1';
+
+        return sprintf('SELECT %s FROM sysibm.sysdummy1', $expression);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -31,6 +31,8 @@ use Doctrine\DBAL\Types\BinaryType;
 use function array_merge;
 use function count;
 use function explode;
+use function func_get_arg;
+use function func_num_args;
 use function implode;
 use function preg_match;
 use function sprintf;
@@ -1120,7 +1122,9 @@ END;';
      */
     public function getDummySelectSQL()
     {
-        return 'SELECT 1 FROM DUAL';
+        $expression = func_num_args() > 0 ? func_get_arg(0) : '1';
+
+        return sprintf('SELECT %s FROM DUAL', $expression);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/LikeWildcardsEscapingTest.php
@@ -13,16 +13,16 @@ final class LikeWildcardsEscapingTest extends DbalFunctionalTestCase
         $string           = '_25% off_ your next purchase \o/ [$̲̅(̲̅5̲̅)̲̅$̲̅] (^̮^)';
         $escapeChar       = '!';
         $databasePlatform = $this->_conn->getDatabasePlatform();
-        $stmt             = $this->_conn->prepare(str_replace(
-            '1',
-            sprintf(
-                "(CASE WHEN '%s' LIKE '%s' ESCAPE '%s' THEN 1 ELSE 0 END)",
-                $string,
-                $databasePlatform->escapeStringForLike($string, $escapeChar),
-                $escapeChar
-            ),
-            $databasePlatform->getDummySelectSQL()
-        ));
+        $stmt             = $this->_conn->prepare(
+            $databasePlatform->getDummySelectSQL(
+                sprintf(
+                    "(CASE WHEN '%s' LIKE '%s' ESCAPE '%s' THEN 1 ELSE 0 END)",
+                    $string,
+                    $databasePlatform->escapeStringForLike($string, $escapeChar),
+                    $escapeChar
+                )
+            )
+        );
         $stmt->execute();
         $this->assertTrue((bool) $stmt->fetchColumn());
     }


### PR DESCRIPTION
For testing purposes and not only, it may be needed to evaluate an arbitrary SQL expression (see https://github.com/doctrine/dbal/pull/3013, https://github.com/doctrine/dbal/pull/3108). Instead of doing `str_replace()` on an expected string, one could specify the expression explicitly.