### PR TITLE
Removed hard-coded configuration filenames from the test runner

### DIFF
--- a/run-all.sh
+++ b/run-all.sh
@@ -1,22 +1,9 @@
 #!/bin/bash
 
 # This script is a small convenience wrapper for running the doctrine testsuite against a large bunch of databases.
-# Just create the phpunit.xmls as described in the array below and configure the specific files <php /> section
-# to connect to that database. Just omit a file if you dont have that database and the tests will be skipped.
+# Create *.phpunit.xml files and specify database connection parameters in the <php /> section.
 
-configs[1]="mysql.phpunit.xml"
-configs[2]='postgres.phpunit.xml'
-configs[3]='sqlite.phpunit.xml'
-configs[4]='oracle.phpunit.xml'
-configs[5]='db2.phpunit.xml'
-configs[6]='pdo-ibm.phpunit.xml'
-configs[7]='sqlsrv.phpunit.xml'
-configs[8]='sqlanywhere.phpunit.xml'
-
-for i in "${configs[@]}"; do
-    if [ -f "$i" ];
-    then
-        echo "RUNNING TESTS WITH CONFIG $i"
-        phpunit -c "$i" "$@"
-    fi;
+for i in *.phpunit.xml; do
+    echo "RUNNING TESTS WITH CONFIG $i"
+    vendor/bin/phpunit -c "$i" "$@"
 done


### PR DESCRIPTION
Currently, `run-all.sh` contains hard-coded configuration file names some of which are obsolete (`pdo-ibm`) and some are missing (`pdo-pgsql`).