### PR TITLE
Revert complex type specification in Connection

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -882,7 +882,7 @@ class Connection implements DriverConnection
      *
      * @param string                 $query  The SQL query to execute.
      * @param mixed[]                $params The parameters to bind to the query, if any.
-     * @param (int|string|Type)[]    $types  The types the previous parameters are in.
+     * @param int[]|string[]|Type[]  $types  The types the previous parameters are in.
      * @param QueryCacheProfile|null $qcp    The query cache profile, optional.
      *
      * @throws DBALException
@@ -926,10 +926,10 @@ class Connection implements DriverConnection
     /**
      * Executes a caching query.
      *
-     * @param string              $query  The SQL query to execute.
-     * @param mixed[]             $params The parameters to bind to the query, if any.
-     * @param (int|string)|Type[] $types  The types the previous parameters are in.
-     * @param QueryCacheProfile   $qcp    The query cache profile.
+     * @param string                $query  The SQL query to execute.
+     * @param mixed[]               $params The parameters to bind to the query, if any.
+     * @param int[]|string[]|Type[] $types  The types the previous parameters are in.
+     * @param QueryCacheProfile     $qcp    The query cache profile.
      *
      * @throws DBALException
      */
@@ -1016,9 +1016,9 @@ class Connection implements DriverConnection
      *
      * This method supports PDO binding types as well as DBAL mapping types.
      *
-     * @param string              $query  The SQL query.
-     * @param mixed[]             $params The query parameters.
-     * @param (int|string|Type)[] $types  The parameter types.
+     * @param string                $query  The SQL query.
+     * @param mixed[]               $params The query parameters.
+     * @param int[]|string[]|Type[] $types  The parameter types.
      *
      * @throws DBALException
      */
@@ -1460,9 +1460,9 @@ class Connection implements DriverConnection
      * Binds a set of parameters, some or all of which are typed with a PDO binding type
      * or DBAL mapping type, to a given statement.
      *
-     * @param DriverStatement     $stmt   The statement to bind the values to.
-     * @param mixed[]             $params The map/list of named/positional parameters.
-     * @param (int|string|Type)[] $types  The parameter types.
+     * @param DriverStatement       $stmt   The statement to bind the values to.
+     * @param mixed[]               $params The map/list of named/positional parameters.
+     * @param int[]|string[]|Type[] $types  The parameter types.
      */
     private function _bindTypedValues(DriverStatement $stmt, array $params, array $types) : void
     {


### PR DESCRIPTION
This reverts non-standard type specification using parenthesis.
Such format is not supported by any tools or IDEs, PHPStan likely being the sole exception in the PHP ecosystem. It breaks type inspection in IDEs etc.
Additionally it has no standard to support this (the syntax is currently just a PHPStan made-up).

Note that this is not even part of PSR-5 proposal.

Follow-up from https://github.com/doctrine/dbal/pull/3080#discussion_r181420821 and https://github.com/doctrine/dbal/pull/3025#discussion_r168909829.