### PR TITLE
Added "string" mapping in SqlitePlatform 

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -620,6 +620,7 @@ class SqlitePlatform extends AbstractPlatform
             'real'             => 'float',
             'serial'           => 'integer',
             'smallint'         => 'smallint',
+            'string'           => 'string',
             'text'             => 'text',
             'time'             => 'time',
             'timestamp'        => 'datetime',


### PR DESCRIPTION
  - fix 'Unknown database type string requested, Doctrine\DBAL\Platforms\SqlitePlatform may not support it.' error