### PR TITLE
Excluded tests from Scrutinizer CI analysis

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -26,6 +26,7 @@ tools:
 filter:
     excluded_paths:
         - docs
+        - tests
 
 build_failure_conditions:
     - 'elements.rating(<= C).new.exists'                        # No new classes/methods with a rating of C or worse allowed


### PR DESCRIPTION
1. Judging by the [inspection results](https://scrutinizer-ci.com/g/doctrine/dbal/inspections/e291a0d7-dc12-4a37-b9b2-5fd74c4a5edd/issues/files/tests/Doctrine/Tests/DBAL/Driver/StatementIteratorTest.php?status=failed&conditionIds%5B0%5D=271126), Scrutinizer doesn't understand PHPUnit mocks which unify the type being tested and the mocking API. Adding tests with mocks impacts the code quality metric of the entire project.
2. The issues found in tests should not be considered when the project's code quality is assessed since tests are not used in production.