### PR TITLE
Introduced a smoke testing phase on Travis to run SQLite tests and CS checks first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,21 @@ jobs:
     - php: nightly
 
   include:
+
+    - stage: Smoke Testing
+      php: 7.2
+      env: DB=sqlite COVERAGE=yes
+    - stage: Smoke Testing
+      php: 7.2
+      env: PHPStan
+      install: travis_retry composer install --prefer-dist
+      script: vendor/bin/phpstan analyse
+    - stage: Smoke Testing
+      php: 7.2
+      env: PHP_CodeSniffer
+      install: travis_retry composer install --prefer-dist
+      script: vendor/bin/phpcs
+
     - stage: Test
       php: 7.2
       env: DB=mysql COVERAGE=yes
@@ -170,9 +185,6 @@ jobs:
         - docker
       before_script:
         - bash ./tests/travis/install-postgres-11.sh
-    - stage: Test
-      php: 7.2
-      env: DB=sqlite COVERAGE=yes
     - stage: Test
       php: 7.2
       env: DB=sqlsrv COVERAGE=yes
@@ -319,14 +331,3 @@ jobs:
       install:
         - composer config minimum-stability dev
         - travis_retry composer update --prefer-dist
-
-    - stage: Code Quality
-      php: 7.2
-      env: PHPStan
-      install: travis_retry composer install --prefer-dist
-      script: vendor/bin/phpstan analyse
-    - stage: Code Quality
-      php: 7.2
-      env: PHP_CodeSniffer
-      install: travis_retry composer install --prefer-dist
-      script: vendor/bin/phpcs


### PR DESCRIPTION
Sometimes, the CS verification is the only failing stage of the build (especially, if CS is not verified locally before submitting the patch). In this case, after fixing the CS issue, it'd be very convenient to get immediate feedback instead of waiting 15-20 minutes until all test builds finish first.

A solution could be to introduce a "smoke testing" stage which would precede the testing one and include the following:

1. Testing against SQLite to find non-platform-specific issues since it's the fastest platform.
2. Code style verification.