### PR TITLE
Add MySQL 8 reserved keywords

### DIFF
--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -35,6 +35,7 @@ MySQL
 
 -  ``MySqlPlatform`` for version 5.0 and above.
 -  ``MySQL57Platform`` for version 5.7 (5.7.9 GA) and above.
+-  ``MySQL80Platform`` for version 8.0 (8.0 GA) and above.
 
 Oracle
 ^^^^^^

--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\MySqlSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
@@ -137,8 +138,14 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
             return new MariaDb1027Platform();
         }
 
-        if ( ! $mariadb && version_compare($this->getOracleMysqlVersionNumber($version), '5.7.9', '>=')) {
-            return new MySQL57Platform();
+        if (! $mariadb) {
+            $oracleMysqlVersion = $this->getOracleMysqlVersionNumber($version);
+            if (version_compare($oracleMysqlVersion, '8', '>=')) {
+                return new MySQL80Platform();
+            }
+            if (version_compare($oracleMysqlVersion, '5.7.9', '>=')) {
+                return new MySQL57Platform();
+            }
         }
 
         return $this->getDatabasePlatform();

--- a/lib/Doctrine/DBAL/Platforms/Keywords/MySQL80Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/MySQL80Keywords.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Platforms\Keywords;
+
+use function array_merge;
+
+/**
+ * MySQL 8.0 reserved keywords list.
+ *
+ * @link   www.doctrine-project.org
+ */
+class MySQL80Keywords extends MySQL57Keywords
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'MySQL80';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @link https://dev.mysql.com/doc/refman/8.0/en/keywords.html
+     */
+    protected function getKeywords()
+    {
+        $keywords = parent::getKeywords();
+
+        $keywords = array_merge($keywords, [
+            'ADMIN',
+            'CUBE',
+            'CUME_DIST',
+            'DENSE_RANK',
+            'EMPTY',
+            'EXCEPT',
+            'FIRST_VALUE',
+            'FUNCTION',
+            'GROUPING',
+            'GROUPS',
+            'JSON_TABLE',
+            'LAG',
+            'LAST_VALUE',
+            'LEAD',
+            'NTH_VALUE',
+            'NTILE',
+            'OF',
+            'OVER',
+            'PERCENT_RANK',
+            'PERSIST',
+            'PERSIST_ONLY',
+            'RANK',
+            'RECURSIVE',
+            'ROW',
+            'ROWS',
+            'ROW_NUMBER',
+            'SYSTEM',
+            'WINDOW',
+        ]);
+
+        return $keywords;
+    }
+}

--- a/lib/Doctrine/DBAL/Platforms/MySQL80Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL80Platform.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Platforms;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MySQL 8.0 (8.0 GA) database platform.
+ *
+ * @link   www.doctrine-project.org
+ */
+class MySQL80Platform extends MySQL57Platform
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getReservedKeywordsClass()
+    {
+        return Keywords\MySQL80Keywords::class;
+    }
+}

--- a/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
@@ -36,6 +36,7 @@ class ReservedWordsCommand extends Command
     private $keywordListClasses = [
         'mysql'         => 'Doctrine\DBAL\Platforms\Keywords\MySQLKeywords',
         'mysql57'       => 'Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords',
+        'mysql80'       => 'Doctrine\DBAL\Platforms\Keywords\MySQL80Keywords',
         'sqlserver'     => 'Doctrine\DBAL\Platforms\Keywords\SQLServerKeywords',
         'sqlserver2005' => 'Doctrine\DBAL\Platforms\Keywords\SQLServer2005Keywords',
         'sqlserver2008' => 'Doctrine\DBAL\Platforms\Keywords\SQLServer2008Keywords',
@@ -96,6 +97,7 @@ The following keyword lists are currently shipped with Doctrine:
 
     * mysql
     * mysql57
+    * mysql80
     * pgsql
     * pgsql92
     * sqlite
@@ -126,6 +128,7 @@ EOT
             $keywordLists = [
                 'mysql',
                 'mysql57',
+                'mysql80',
                 'pgsql',
                 'pgsql92',
                 'sqlite',

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL\Driver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\MySqlSchemaManager;
 
@@ -63,6 +64,9 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
             ['5.7.8', MySqlPlatform::class],
             ['5.7.9', MySQL57Platform::class],
             ['5.7.10', MySQL57Platform::class],
+            ['8', MySQL80Platform::class],
+            ['8.0', MySQL80Platform::class],
+            ['8.0.11', MySQL80Platform::class],
             ['6', MySQL57Platform::class],
             ['10.0.15-MariaDB-1~wheezy', MySqlPlatform::class],
             ['5.5.5-10.1.25-MariaDB', MySqlPlatform::class],


### PR DESCRIPTION
MySQL 8 added a few reserved keywords.
Comparing https://dev.mysql.com/doc/refman/8.0/en/keywords.html with [MySQL57Keywords.php](https://github.com/doctrine/dbal/blob/e4af109a206352e27c1ddab0d438c8e5f3a80d1c/lib/Doctrine/DBAL/Platforms/Keywords/MySQL57Keywords.php) here's the list of the new keywords:

- `ADMIN`
- `CUBE`
- `CUME_DIST`
- `DENSE_RANK`
- `EMPTY`
- `EXCEPT`
- `FIRST_VALUE`
- `FUNCTION`
- `GROUPING`
- `GROUPS`
- `JSON_TABLE`
- `LAG`
- `LAST_VALUE`
- `LEAD`
- `NTH_VALUE`
- `NTILE`
- `OF`
- `OVER`
- `PERCENT_RANK`
- `PERSIST`
- `PERSIST_ONLY`
- `RANK`
- `RECURSIVE`
- `ROW`
- `ROWS`
- `ROW_NUMBER`
- `SYSTEM`
- `WINDOW`

What should I write in the `@since` phodoc?

PS: it would be nice to add this to the 2.5.x series, for projects using PHP older than 7.1