### PR TITLE
Fix numeric comparison for sequence initial value

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -189,11 +189,8 @@ class Comparator
      */
     public function diffSequence(Sequence $sequence1, Sequence $sequence2)
     {
-        if ($sequence1->getAllocationSize() != $sequence2->getAllocationSize()) {
-            return true;
-        }
-
-        return $sequence1->getInitialValue() != $sequence2->getInitialValue();
+        return intval($sequence1->getAllocationSize()) !== intval($sequence2->getAllocationSize())
+            || intval($sequence1->getInitialValue()) !== intval($sequence2->getInitialValue());
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -193,7 +193,7 @@ class Comparator
             return true;
         }
 
-        return $sequence1->getInitialValue() !== $sequence2->getInitialValue();
+        return $sequence1->getInitialValue() != $sequence2->getInitialValue();
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -435,11 +435,15 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $seq1 = new Sequence('foo', 1, 1);
         $seq2 = new Sequence('foo', 1, 2);
         $seq3 = new Sequence('foo', 2, 1);
+        $seq4 = new Sequence('foo', "1", "1");
+        $seq5 = new Sequence('foo', "10", "1");
 
         $c = new Comparator();
 
         self::assertTrue($c->diffSequence($seq1, $seq2));
         self::assertTrue($c->diffSequence($seq1, $seq3));
+        self::assertFalse($c->diffSequence($seq1, $seq4));
+        self::assertTrue($c->diffSequence($seq1, $seq5));
     }
 
     public function testRemovedSequence()

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -435,8 +435,8 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $seq1 = new Sequence('foo', 1, 1);
         $seq2 = new Sequence('foo', 1, 2);
         $seq3 = new Sequence('foo', 2, 1);
-        $seq4 = new Sequence('foo', "1", "1");
-        $seq5 = new Sequence('foo', "10", "1");
+        $seq4 = new Sequence('foo', '1', '1');
+        $seq5 = new Sequence('foo', '10', '1');
 
         $c = new Comparator();
 


### PR DESCRIPTION
Small fix to avoid a diff on sequences cause by a numeric string/integer comparison.