### PR TITLE
Workaround for the inability to use a post-PHPUnit script on ContinuousPHP

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -21,7 +21,7 @@ before_commands:
 tools:
     external_code_coverage:
         timeout: 3600
-        runs: 20 # 17x Travis (jobs with COVERAGE=yes) + 3x AppVeyor (jobs with coverage=yes)
+        runs: 21 # 17x Travis (jobs with COVERAGE=yes) + 3x AppVeyor (jobs with coverage=yes) + 1x ContinuousPHP
 
 filter:
     excluded_paths:

--- a/tests/continuousphp/bootstrap.php
+++ b/tests/continuousphp/bootstrap.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+(function () : void {
+    $pos = array_search('--coverage-clover', $_SERVER['argv'], true);
+
+    if ($pos === false) {
+        return;
+    }
+
+    $file = $_SERVER['argv'][$pos + 1];
+
+    register_shutdown_function(function () use ($file) : void {
+        $cmd = 'wget https://github.com/scrutinizer-ci/ocular/releases/download/1.5.2/ocular.phar'
+            . ' && php ocular.phar code-coverage:upload --format=php-clover ' . escapeshellarg($file);
+
+        passthru($cmd);
+    });
+})();

--- a/tests/continuousphp/oci8.phpunit.continuousphp.xml
+++ b/tests/continuousphp/oci8.phpunit.continuousphp.xml
@@ -6,6 +6,7 @@
          beStrictAboutTodoAnnotatedTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         bootstrap="bootstrap.php"
 >
   <php>
     <ini name="error_reporting" value="-1" />


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | none

#### Summary

According to the ContinuousPHP support, currently, it's impossible to specify a post-PHPUnit script in the build configuration. A workaround is implemented to do that as part of the PHPUnit run.