### PR TITLE
Ignore code coverage of private constructors of static classes

### DIFF
--- a/lib/Doctrine/DBAL/ColumnCase.php
+++ b/lib/Doctrine/DBAL/ColumnCase.php
@@ -25,6 +25,8 @@ final class ColumnCase
 
     /**
      * This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -77,6 +77,8 @@ final class DriverManager
 
     /**
      * Private constructor. This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/Events.php
+++ b/lib/Doctrine/DBAL/Events.php
@@ -11,6 +11,8 @@ final class Events
 {
     /**
      * Private constructor. This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/FetchMode.php
+++ b/lib/Doctrine/DBAL/FetchMode.php
@@ -64,6 +64,8 @@ final class FetchMode
 
     /**
      * This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/LockMode.php
+++ b/lib/Doctrine/DBAL/LockMode.php
@@ -14,6 +14,8 @@ class LockMode
 
     /**
      * Private constructor. This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     final private function __construct()
     {

--- a/lib/Doctrine/DBAL/ParameterType.php
+++ b/lib/Doctrine/DBAL/ParameterType.php
@@ -51,6 +51,8 @@ final class ParameterType
 
     /**
      * This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/Platforms/DateIntervalUnit.php
+++ b/lib/Doctrine/DBAL/Platforms/DateIntervalUnit.php
@@ -22,6 +22,9 @@ final class DateIntervalUnit
 
     public const YEAR = 'YEAR';
 
+    /**
+     * @codeCoverageIgnore
+     */
     private function __construct()
     {
     }

--- a/lib/Doctrine/DBAL/Platforms/TrimMode.php
+++ b/lib/Doctrine/DBAL/Platforms/TrimMode.php
@@ -14,6 +14,9 @@ final class TrimMode
 
     public const BOTH = 3;
 
+    /**
+     * @codeCoverageIgnore
+     */
     private function __construct()
     {
     }

--- a/lib/Doctrine/DBAL/Tools/Dumper.php
+++ b/lib/Doctrine/DBAL/Tools/Dumper.php
@@ -40,6 +40,8 @@ final class Dumper
 {
     /**
      * Private constructor (prevents instantiation).
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/TransactionIsolationLevel.php
+++ b/lib/Doctrine/DBAL/TransactionIsolationLevel.php
@@ -26,6 +26,9 @@ final class TransactionIsolationLevel
      */
     public const SERIALIZABLE = 4;
 
+    /**
+     * @codeCoverageIgnore
+     */
     private function __construct()
     {
     }

--- a/lib/Doctrine/DBAL/Types/Types.php
+++ b/lib/Doctrine/DBAL/Types/Types.php
@@ -37,6 +37,9 @@ final class Types
     /** @deprecated json_array type is deprecated, use {@see self::JSON} instead. */
     public const JSON_ARRAY = 'json_array';
 
+    /**
+     * @codeCoverageIgnore
+     */
     private function __construct()
     {
     }


### PR DESCRIPTION
According to Scrutinizer, static classes have 0% code coverage since the only their executable code (constructor) is not executed. But it's not supposed to since it's just a way to prevent class instantiation.

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

Static class constructors are marked as `@codeCoverageIgnore`.
