### PR TITLE
Introduced binary binding type to support binary parameters on Oracle

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -39,6 +39,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
      */
     protected static $_paramTypeMap = [
         ParameterType::STRING       => 's',
+        ParameterType::BINARY       => 's',
         ParameterType::BOOLEAN      => 'i',
         ParameterType::NULL         => 's',
         ParameterType::INTEGER      => 'i',

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Statement.php
@@ -33,7 +33,9 @@ class Statement extends PDOStatement
      */
     public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null, $driverOptions = null)
     {
-        if ($type === ParameterType::LARGE_OBJECT && $driverOptions === null) {
+        if (($type === ParameterType::LARGE_OBJECT || $type === ParameterType::BINARY)
+            && $driverOptions === null
+        ) {
             $driverOptions = PDO::SQLSRV_ENCODING_BINARY;
         }
 

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -41,6 +41,7 @@ class PDOStatement extends \PDOStatement implements Statement
         ParameterType::NULL         => PDO::PARAM_NULL,
         ParameterType::INTEGER      => PDO::PARAM_INT,
         ParameterType::STRING       => PDO::PARAM_STR,
+        ParameterType::BINARY       => PDO::PARAM_LOB,
         ParameterType::LARGE_OBJECT => PDO::PARAM_LOB,
         ParameterType::BOOLEAN      => PDO::PARAM_BOOL,
     ];

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -132,6 +132,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
 
             case ParameterType::NULL:
             case ParameterType::STRING:
+            case ParameterType::BINARY:
                 $type = 's';
                 break;
 

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -44,6 +44,7 @@ use function sqlsrv_get_field;
 use function sqlsrv_next_result;
 use function sqlsrv_num_fields;
 use function SQLSRV_PHPTYPE_STREAM;
+use function SQLSRV_PHPTYPE_STRING;
 use function sqlsrv_prepare;
 use function sqlsrv_rows_affected;
 use function SQLSRV_SQLTYPE_VARBINARY;
@@ -283,15 +284,27 @@ class SQLSrvStatement implements IteratorAggregate, Statement
         $params = [];
 
         foreach ($this->variables as $column => &$variable) {
-            if ($this->types[$column] === ParameterType::LARGE_OBJECT) {
-                $params[$column - 1] = [
-                    &$variable,
-                    SQLSRV_PARAM_IN,
-                    SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY),
-                    SQLSRV_SQLTYPE_VARBINARY('max'),
-                ];
-            } else {
-                $params[$column - 1] =& $variable;
+            switch ($this->types[$column]) {
+                case ParameterType::LARGE_OBJECT:
+                    $params[$column - 1] = [
+                        &$variable,
+                        SQLSRV_PARAM_IN,
+                        SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY),
+                        SQLSRV_SQLTYPE_VARBINARY('max'),
+                    ];
+                    break;
+
+                case ParameterType::BINARY:
+                    $params[$column - 1] = [
+                        &$variable,
+                        SQLSRV_PARAM_IN,
+                        SQLSRV_PHPTYPE_STRING(SQLSRV_ENC_BINARY),
+                    ];
+                    break;
+
+                default:
+                    $params[$column - 1] =& $variable;
+                    break;
             }
         }
 

--- a/lib/Doctrine/DBAL/ParameterType.php
+++ b/lib/Doctrine/DBAL/ParameterType.php
@@ -43,6 +43,11 @@ final class ParameterType
     public const BOOLEAN = \PDO::PARAM_BOOL;
 
     /**
+     * Represents a binary string data type.
+     */
+    public const BINARY = 16;
+
+    /**
      * This class cannot be instantiated.
      */
     private function __construct()

--- a/lib/Doctrine/DBAL/Types/BinaryType.php
+++ b/lib/Doctrine/DBAL/Types/BinaryType.php
@@ -79,6 +79,6 @@ class BinaryType extends Type
      */
     public function getBindingType()
     {
-        return ParameterType::LARGE_OBJECT;
+        return ParameterType::BINARY;
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Types/BinaryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\DBAL\Functional\Types;
 
 use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
-use Doctrine\DBAL\Driver\OCI8\Driver as OCI8Driver;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\Tests\DbalFunctionalTestCase;
@@ -19,11 +18,6 @@ class BinaryTest extends DbalFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-
-        /** @see https://github.com/doctrine/dbal/issues/2787 */
-        if ($this->_conn->getDriver() instanceof OCI8Driver) {
-            $this->markTestSkipped('Filtering by binary fields is currently not supported on Oracle');
-        }
 
         $table = new Table('binary_table');
         $table->addColumn('id', 'binary', [
@@ -64,8 +58,8 @@ class BinaryTest extends DbalFunctionalTestCase
             'id'  => $id,
             'val' => $value,
         ], [
-            ParameterType::LARGE_OBJECT,
-            ParameterType::LARGE_OBJECT,
+            ParameterType::BINARY,
+            ParameterType::BINARY,
         ]);
 
         self::assertSame(1, $result);
@@ -77,7 +71,7 @@ class BinaryTest extends DbalFunctionalTestCase
             'SELECT val FROM binary_table WHERE id = ?',
             [$id],
             0,
-            [ParameterType::LARGE_OBJECT]
+            [ParameterType::BINARY]
         );
 
         // Currently, `BinaryType` mistakenly converts string values fetched from the DB to a stream.

--- a/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
@@ -32,7 +32,7 @@ class BinaryTest extends \Doctrine\Tests\DbalTestCase
 
     public function testReturnsBindingType()
     {
-        self::assertSame(ParameterType::LARGE_OBJECT, $this->type->getBindingType());
+        self::assertSame(ParameterType::BINARY, $this->type->getBindingType());
     }
 
     public function testReturnsName()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #2787

#### Summary

When binding parameters to a statement, `oci8` requires a special binding type for binary parameters (`OCI_B_BIN`).
