### PR TITLE
Don't use the RC versions of sqlsrv/pdo_sqlsrv in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -83,9 +83,6 @@ install:
           Install-PhpExtension -Extension xdebug -DontEnable
           Write-Host "xdebug version: $((Get-PhpExtension | Where-Object { $_.Handle -eq 'xdebug' }).Version)"
 
-          # install sqlite
-          appveyor-retry cinst -y sqlite
-
           # download Composer
           if (!(Test-Path C:\tools\composer)) {
             New-Item -Path c:\tools -Name composer -ItemType Directory | Out-Null

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ clone_depth: 2
 cache:
   - C:\ProgramData\chocolatey\bin -> .appveyor.yml
   - C:\ProgramData\chocolatey\lib -> .appveyor.yml
+  - '%ProgramFiles%\WindowsPowerShell\Modules\PhpManager -> .appveyor.yml'
   - C:\tools\php -> .appveyor.yml
   - C:\tools\composer -> .appveyor.yml
   - C:\tools\ocular -> .appveyor.yml
@@ -46,16 +47,16 @@ init:
 ## Install PHP and composer, and run the appropriate composer command
 install:
     - ps: |
-        # Check if installation is cached
-        if (!(Test-Path c:\tools\php)) {
-
-          # install PhpManager
+        # install PhpManager
+        if (-Not(Get-Module -Name PhpManager -ListAvailable)) {
           if (-Not(Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue | Where-Object { $_.Version -ge '2.8.5.201'})) {
             Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
           }
-          if (-Not(Get-Module -ListAvailable | Where-Object { $_.Name -eq 'PhpManager' })) {
-            Install-Module -Name PhpManager -Force -SkipPublisherCheck
-          }
+          Install-Module -Name PhpManager -Force -SkipPublisherCheck
+        }
+
+        # Check if installation is cached
+        if (!(Test-Path c:\tools\php)) {
 
           # install PHP
           Install-Php -Version $env:php -Architecture $env:platform -ThreadSafe $false -Path c:\tools\php -TimeZone UTC -AddToPath System -InitialPhpIni Production
@@ -79,7 +80,7 @@ install:
           Write-Host "sqlsrv version: $((Get-PhpExtension | Where-Object { $_.Handle -eq 'sqlsrv' }).Version)"
           Install-PhpExtension -Extension pdo_sqlsrv
           Write-Host "pdo_sqlsrv version: $((Get-PhpExtension | Where-Object { $_.Handle -eq 'pdo_sqlsrv' }).Version)"
-          Install-PhpExtension -Extension xdebug
+          Install-PhpExtension -Extension xdebug -DontEnable
           Write-Host "xdebug version: $((Get-PhpExtension | Where-Object { $_.Handle -eq 'xdebug' }).Version)"
 
           # install sqlite
@@ -127,7 +128,9 @@ test_script:
       }
   - ps: >-
       if ($env:coverage -eq "yes") {
+        Enable-PhpExtension -Extension xdebug
         vendor\bin\phpunit -c $($env:phpunit_config) --coverage-clover clover.xml
+        Disable-PhpExtension -Extension xdebug
         appveyor-retry ocular code-coverage:upload --format=php-clover clover.xml
       } else {
         vendor\bin\phpunit -c $($env:phpunit_config)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,6 @@ cache:
   - C:\ProgramData\chocolatey\bin -> .appveyor.yml
   - C:\ProgramData\chocolatey\lib -> .appveyor.yml
   - C:\tools\php -> .appveyor.yml
-  - C:\tools\cacert -> .appveyor.yml
   - C:\tools\composer -> .appveyor.yml
   - C:\tools\ocular -> .appveyor.yml
   - '%LOCALAPPDATA%\Composer\files -> composer.json'
@@ -49,50 +48,46 @@ install:
     - ps: |
         # Check if installation is cached
         if (!(Test-Path c:\tools\php)) {
-          appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+
+          # install PhpManager
+          if (-Not(Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue | Where-Object { $_.Version -ge '2.8.5.201'})) {
+            Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
+          }
+          if (-Not(Get-Module -ListAvailable | Where-Object { $_.Name -eq 'PhpManager' })) {
+            Install-Module -Name PhpManager -Force -SkipPublisherCheck
+          }
+
+          # install PHP
+          Install-Php -Version $env:php -Architecture $env:platform -ThreadSafe $false -Path c:\tools\php -TimeZone UTC -AddToPath System -InitialPhpIni Production
+
+          # download and configure CA bundle
+          Update-PhpCAInfo
+
+          # configure PHP
+          Set-PhpIniKey -Key memory_limit -Value 1G
+
+          # enable PHP extensions
+          Enable-PhpExtension -Extension openssl
+          Enable-PhpExtension -Extension mbstring
+          Enable-PhpExtension -Extension fileinfo
+          Enable-PhpExtension -Extension pdo_sqlite
+          Enable-PhpExtension -Extension sqlite3
+          Enable-PhpExtension -Extension curl
+
+          # download and enable PHP extensions
+          Install-PhpExtension -Extension sqlsrv
+          Write-Host "sqlsrv version: $((Get-PhpExtension | Where-Object { $_.Handle -eq 'sqlsrv' }).Version)"
+          Install-PhpExtension -Extension pdo_sqlsrv
+          Write-Host "pdo_sqlsrv version: $((Get-PhpExtension | Where-Object { $_.Handle -eq 'pdo_sqlsrv' }).Version)"
+          Install-PhpExtension -Extension xdebug
+          Write-Host "xdebug version: $((Get-PhpExtension | Where-Object { $_.Handle -eq 'xdebug' }).Version)"
+
           # install sqlite
           appveyor-retry cinst -y sqlite
-          Get-ChildItem -Path c:\tools\php
-          cd c:\tools\php
-
-          # Set PHP environment items that are always needed
-          copy php.ini-production php.ini
-          Add-Content php.ini "`n date.timezone=UTC"
-          Add-Content php.ini "`n extension_dir=ext"
-          Add-Content php.ini "`n memory_limit=1G"
-          Add-Content php.ini "`n extension=php_openssl.dll"
-          Add-Content php.ini "`n extension=php_mbstring.dll"
-          Add-Content php.ini "`n extension=php_fileinfo.dll"
-          Add-Content php.ini "`n extension=php_pdo_sqlite.dll"
-          Add-Content php.ini "`n extension=php_sqlite3.dll"
-          Add-Content php.ini "`n extension=php_curl.dll"
-          Add-Content php.ini "`n curl.cainfo=C:\tools\cacert\bundle.pem"
-
-          # Get and install the MSSQL DLL's
-          $DLLVersion = "5.2.0rc1"
-          cd c:\tools\php\ext
-          $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
-          $destination = "c:\tools\php\ext\php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
-          Invoke-WebRequest $source -OutFile $destination
-          7z x -y php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip > $null
-          $source = "https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($DLLVersion)/php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
-          $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
-          Invoke-WebRequest $source -OutFile $destination
-          7z x -y php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip > $null
-          $DLLVersion = "2.6.0"
-          $source = "https://xdebug.org/files/php_xdebug-$($DLLVersion)-$($env:php)-vc15-nts-x86_64.dll"
-          $destination = "c:\tools\php\ext\php_xdebug.dll"
-          Invoke-WebRequest $source -OutFile $destination
-          Remove-Item c:\tools\php\* -include .zip
-          cd c:\tools\php
-          Add-Content php.ini "`nextension=php_sqlsrv.dll"
-          Add-Content php.ini "`nextension=php_pdo_sqlsrv.dll"
-          Add-Content php.ini "`nzend_extension=php_xdebug.dll"
-          Add-Content php.ini "`n"
 
           # download Composer
           if (!(Test-Path C:\tools\composer)) {
-            New-Item -path c:\tools -name composer -itemtype directory
+            New-Item -Path c:\tools -Name composer -ItemType Directory | Out-Null
           }
           if (!(Test-Path c:\tools\composer\composer.phar)) {
             appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar -Filename C:\tools\composer\composer.phar
@@ -101,19 +96,11 @@ install:
 
           # download Scrutinizer's Ocular
           if (!(Test-Path C:\tools\ocular)) {
-            New-Item -path c:\tools -name ocular -itemtype directory
+            New-Item -Path c:\tools -Name ocular -ItemType Directory | Out-Null
           }
           if (!(Test-Path c:\tools\ocular\ocular.phar)) {
             appveyor-retry appveyor DownloadFile https://github.com/scrutinizer-ci/ocular/releases/download/1.5.2/ocular.phar -Filename C:\tools\ocular\ocular.phar
             Set-Content -path 'C:\tools\ocular\ocular.bat' -Value ('@php C:\tools\ocular\ocular.phar %*')
-          }
-
-          # download CA bundle
-          if (!(Test-Path C:\tools\cacert)) {
-            New-Item -path c:\tools\ -name cacert -itemtype directory
-          }
-          if (!(Test-Path c:\tools\cacert\bundle.pem)) {
-            appveyor-retry appveyor DownloadFile https://curl.haxx.se/ca/cacert.pem -Filename C:\tools\cacert\bundle.pem
           }
         }
     # install composer dependencies

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,24 +82,24 @@ install:
           Write-Host "pdo_sqlsrv version: $((Get-PhpExtension | Where-Object { $_.Handle -eq 'pdo_sqlsrv' }).Version)"
           Install-PhpExtension -Extension xdebug -DontEnable
           Write-Host "xdebug version: $((Get-PhpExtension | Where-Object { $_.Handle -eq 'xdebug' }).Version)"
+        }
 
-          # download Composer
-          if (!(Test-Path C:\tools\composer)) {
-            New-Item -Path c:\tools -Name composer -ItemType Directory | Out-Null
-          }
-          if (!(Test-Path c:\tools\composer\composer.phar)) {
-            appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar -Filename C:\tools\composer\composer.phar
-            Set-Content -path 'C:\tools\composer\composer.bat' -Value ('@php C:\tools\composer\composer.phar %*')
-          }
+        # download Composer
+        if (!(Test-Path C:\tools\composer)) {
+          New-Item -Path c:\tools -Name composer -ItemType Directory | Out-Null
+        }
+        if (!(Test-Path c:\tools\composer\composer.phar)) {
+          appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar -Filename C:\tools\composer\composer.phar
+          Set-Content -path 'C:\tools\composer\composer.bat' -Value ('@php C:\tools\composer\composer.phar %*')
+        }
 
-          # download Scrutinizer's Ocular
-          if (!(Test-Path C:\tools\ocular)) {
-            New-Item -Path c:\tools -Name ocular -ItemType Directory | Out-Null
-          }
-          if (!(Test-Path c:\tools\ocular\ocular.phar)) {
-            appveyor-retry appveyor DownloadFile https://github.com/scrutinizer-ci/ocular/releases/download/1.5.2/ocular.phar -Filename C:\tools\ocular\ocular.phar
-            Set-Content -path 'C:\tools\ocular\ocular.bat' -Value ('@php C:\tools\ocular\ocular.phar %*')
-          }
+        # download Scrutinizer's Ocular
+        if (!(Test-Path C:\tools\ocular)) {
+          New-Item -Path c:\tools -Name ocular -ItemType Directory | Out-Null
+        }
+        if (!(Test-Path c:\tools\ocular\ocular.phar)) {
+          appveyor-retry appveyor DownloadFile https://github.com/scrutinizer-ci/ocular/releases/download/1.5.2/ocular.phar -Filename C:\tools\ocular\ocular.phar
+          Set-Content -path 'C:\tools\ocular\ocular.bat' -Value ('@php C:\tools\ocular\ocular.phar %*')
         }
     # install composer dependencies
     - cd C:\projects\dbal


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

AppVeyor is currently configured to test the 5.2.0rc1 versions of the `sqlsrv`/`pdo_sqlsrv` PHP extensions.
BTW the very latest version is now [5.2.0](https://github.com/Microsoft/msphpsql/releases): let's use it.
This is done by using the [PhpManager](https://github.com/mlocati/powershell-phpmanager) PowerShell module, that's able to automatically install the most recent stable version of PHP extensions, without the need of manually specifying their download URL and version.