### PR TITLE
Introduced a PSR-3 logger adapter

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,11 @@
+# Upgrade to 2.8
+
+## Deprecated logger implementations
+
+With the introduction of the [PSR-3](https://www.php-fig.org/psr/psr-3/) logger interface standard, we can focus on implementing DBAL-specific features and delegate to [other libraries](https://packagist.org/providers/psr/log-implementation).
+
+`Doctrine\DBAL\Logging\EchoSQLLogger` has been deprecated. Please use `Doctrine\DBAL\Logging\PsrAdapter` and a PSR-3 compatible implementation instead.
+
 # Upgrade to 2.7
 
 ## Doctrine\DBAL\Platforms\AbstractPlatform::DATE_INTERVAL_UNIT_* constants deprecated

--- a/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
+++ b/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
@@ -31,6 +31,8 @@ use function var_dump;
  * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author Jonathan Wage <jonwage@gmail.com>
  * @author Roman Borschel <roman@code-factory.org>
+ *
+ * @deprecated
  */
 class EchoSQLLogger implements SQLLogger
 {

--- a/lib/Doctrine/DBAL/Logging/PsrAdapter.php
+++ b/lib/Doctrine/DBAL/Logging/PsrAdapter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Doctrine\DBAL\Logging;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Logs every query as a debug message
+ */
+final class PsrAdapter implements SQLLogger
+{
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function startQuery($sql, array $params = null, array $types = null)
+    {
+        $this->logger->debug($sql, [
+            'params' => $params,
+            'types' => $types,
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function stopQuery()
+    {
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -196,6 +196,7 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
      * Pretty dumb test, however we want to check that the EchoSQLLogger correctly implements the interface.
      *
      * @group DBAL-11
+     * @group legacy
      */
     public function testEchoSQLLogger()
     {

--- a/tests/Doctrine/Tests/DBAL/Logging/PsrAdapterTest.php
+++ b/tests/Doctrine/Tests/DBAL/Logging/PsrAdapterTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\DBAL\Logging;
+
+use Doctrine\DBAL\ParameterType;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use function interface_exists;
+
+class PsrAdapterTest extends TestCase
+{
+    public function testLogging()
+    {
+        if (! interface_exists(LoggerInterface::class)) {
+            $this->markTestSkipped('PSR-3 LoggerInterface is unavailable');
+        }
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('debug')
+            ->with('SELECT name FROM users WHERE id = ?', [
+                'params' => [1],
+                'types' => [ParameterType::INTEGER],
+            ]);
+
+        $adapter = new PsrAdapter($logger);
+        $adapter->startQuery('SELECT name FROM users WHERE id = ?', [1], [ParameterType::INTEGER]);
+    }
+}


### PR DESCRIPTION
1. Introduced a PSR-3 logger adapter as per https://github.com/doctrine/dbal/pull/2911#issuecomment-343755819.
2. Deprecated `EchoSQLLogger` as per https://github.com/doctrine/dbal/pull/2911#issuecomment-343755494.

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none