### PR TITLE
postgres: correctly produce alter table sql comment to update column definition

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -580,11 +580,8 @@ SQL
                 }
             }
 
-            $oldComment = null;
             $newComment = $this->getColumnComment($column);
-            if (null !== $columnDiff->fromColumn) {
-                $oldComment = $this->getColumnComment($columnDiff->fromColumn);
-            }
+            $oldComment = $this->getOldColumnComment($columnDiff);
 
             if ($columnDiff->hasChanged('comment') || ($columnDiff->fromColumn !== null && $oldComment !== $newComment)) {
                 $commentsSQL[] = $this->getCommentOnColumnSQL(
@@ -1253,5 +1250,10 @@ SQL
     private function isNumericType(Type $type) : bool
     {
         return $type instanceof IntegerType || $type instanceof BigIntType;
+    }
+
+    private function getOldColumnComment(ColumnDiff $columnDiff) : ?string
+    {
+        return $columnDiff->fromColumn ? $this->getColumnComment($columnDiff->fromColumn) : null;
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -580,11 +580,17 @@ SQL
                 }
             }
 
-            if ($columnDiff->hasChanged('comment')) {
+            $oldComment = null;
+            $newComment = $this->getColumnComment($column);
+            if (null !== $columnDiff->fromColumn) {
+                $oldComment = $this->getColumnComment($columnDiff->fromColumn);
+            }
+
+            if ($columnDiff->hasChanged('comment') || ($columnDiff->fromColumn !== null && $oldComment !== $newComment)) {
                 $commentsSQL[] = $this->getCommentOnColumnSQL(
                     $diff->getName($this)->getQuotedName($this),
                     $column->getQuotedName($this),
-                    $this->getColumnComment($column)
+                    $newComment
                 );
             }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -854,6 +854,29 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     }
 
     /**
+     * @group 3158
+     */
+    public function testAltersTableColumnCommentIfRequiredByType()
+    {
+        $table1 = new Table('"foo"', [new Column('"bar"', Type::getType('datetime'))]);
+        $table2 = new Table('"foo"', [new Column('"bar"', Type::getType('datetime_immutable'))]);
+
+        $comparator = new Comparator();
+
+        $tableDiff = $comparator->diffTable($table1, $table2);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Schema\TableDiff', $tableDiff);
+        $this->assertSame(
+            [
+                'ALTER TABLE "foo" ALTER "bar" TYPE TIMESTAMP(0) WITHOUT TIME ZONE',
+                'ALTER TABLE "foo" ALTER "bar" DROP DEFAULT',
+                'COMMENT ON COLUMN "foo"."bar" IS \'(DC2Type:datetime_immutable)\'',
+            ],
+            $this->platform->getAlterTableSQL($tableDiff)
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues |

#### Summary

The schema diff for postgres wasn't correctly updating the column comment for an altered column, for example updating a column type from `datetime` to `datetime_immutable`
