### PR TITLE
Test against Postgres 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ jobs:
   allow_failures:
     - php: nightly
     - stage: Coding standard
+    - env: DB=pgsql POSTGRESQL_VERSION=11.0
 
   exclude:
     - php: 7.1
@@ -318,6 +319,31 @@ jobs:
         postgresql: "9.6"
       before_script:
         - bash ./tests/travis/install-postgres-10.sh
+
+    - stage: Test
+      php: 7.1
+      env: DB=pgsql POSTGRESQL_VERSION=11.0
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-postgres-11.sh
+    - stage: Test
+      php: 7.2
+      env: DB=pgsql POSTGRESQL_VERSION=11.0
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-postgres-11.sh
+    - stage: Test
+      php: nightly
+      env: DB=pgsql POSTGRESQL_VERSION=11.0
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-postgres-11.sh
 
     - stage: Test
       env: DB=sqlsrv COVERAGE=yes

--- a/tests/travis/Dockerfile-postgres11
+++ b/tests/travis/Dockerfile-postgres11
@@ -1,0 +1,15 @@
+FROM debian:experimental-20180426
+
+RUN apt-get update && \
+    apt-get install -y -t experimental --no-install-recommends \
+    postgresql-11 \
+    postgresql-client-11 \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN echo "host all all all trust" >> /etc/postgresql/11/main/pg_hba.conf
+RUN echo "listen_addresses='*'" >> /etc/postgresql/11/main/conf.d/listen.conf
+
+EXPOSE 5432
+
+CMD ["sleep", "inf"]

--- a/tests/travis/install-postgres-11.sh
+++ b/tests/travis/install-postgres-11.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Preparing Postgres 11"
+
+sudo service postgresql stop || true
+
+sudo docker build -t postgres11 - < tests/travis/Dockerfile-postgres11
+sudo docker run -d --name postgres11 -p 5432:5432 postgres11
+sudo docker exec postgres11 service postgresql start
+sudo docker exec -i postgres11 su -c psql postgres <<<"create database doctrine_tests"
+
+echo "Postgres 11 ready"


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

PostgreSQL 11 beta 1 [will be released tomorrow](https://www.postgresql.org/message-id/12B4300D-2171-4690-A020-E9852797F478%40excoventures.com). It's already tagged and available through Debian experimental, so let's use it on CI for preliminary testing and spotting possible breakages.