### PR TITLE
Fix composer branch aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.8.x-dev"
+            "dev-master": "2.8.x-dev",
+            "dev-develop": "3.0.x-dev"
         }
     },
     "archive": {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

```
$ composer req doctrine/dbal:3.0.x-dev

  [InvalidArgumentException]
  Could not find package doctrine/dbal in a version matching 3.0.x-dev
```

`develop` already specifies an alias, but for dev-master as `3.0.x-dev` - seems wrong.