### PR TITLE
[#3170] Adds error to logger and executes stopQuery even on exception.

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -22,6 +22,7 @@ namespace Doctrine\DBAL;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Closure;
+use Doctrine\DBAL\Logging\SQLLogger2;
 use Exception;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
@@ -935,8 +936,8 @@ class Connection implements DriverConnection
                 $stmt = $this->_conn->query($query);
             }
         } catch (Exception $ex) {
-            if ($logger) {
-                $logger->stopQuery($ex);
+            if ($logger && ($logger instanceof SQLLogger2)) {
+                $logger->fail($ex);
             }
 
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));
@@ -1038,8 +1039,8 @@ class Connection implements DriverConnection
         try {
             $statement = $this->_conn->query(...$args);
         } catch (Exception $ex) {
-            if ($logger) {
-                $logger->stopQuery($ex);
+            if ($logger && ($logger instanceof SQLLogger2)) {
+                $logger->fail($ex);
             }
 
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $args[0]);
@@ -1093,8 +1094,8 @@ class Connection implements DriverConnection
                 $result = $this->_conn->exec($query);
             }
         } catch (Exception $ex) {
-            if ($logger) {
-                $logger->stopQuery($ex);
+            if ($logger && ($logger instanceof SQLLogger2)) {
+                $logger->fail($ex);
             }
 
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));
@@ -1128,14 +1129,18 @@ class Connection implements DriverConnection
         try {
             $result = $this->_conn->exec($statement);
         } catch (Exception $ex) {
-            if ($logger) {
-                $logger->stopQuery($ex);
+            if ($logger && ($logger instanceof SQLLogger2)) {
+                $logger->fail($ex);
             }
 
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $statement);
         }
 
         if ($logger) {
+            if ($logger instanceof SQLLogger2) {
+                $logger->countAffectedRows($result);
+            }
+
             $logger->stopQuery();
         }
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -935,6 +935,10 @@ class Connection implements DriverConnection
                 $stmt = $this->_conn->query($query);
             }
         } catch (Exception $ex) {
+            if ($logger) {
+                $logger->stopQuery($ex);
+            }
+
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));
         }
 
@@ -1034,6 +1038,10 @@ class Connection implements DriverConnection
         try {
             $statement = $this->_conn->query(...$args);
         } catch (Exception $ex) {
+            if ($logger) {
+                $logger->stopQuery($ex);
+            }
+
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $args[0]);
         }
 
@@ -1085,6 +1093,10 @@ class Connection implements DriverConnection
                 $result = $this->_conn->exec($query);
             }
         } catch (Exception $ex) {
+            if ($logger) {
+                $logger->stopQuery($ex);
+            }
+
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));
         }
 
@@ -1116,6 +1128,10 @@ class Connection implements DriverConnection
         try {
             $result = $this->_conn->exec($statement);
         } catch (Exception $ex) {
+            if ($logger) {
+                $logger->stopQuery($ex);
+            }
+
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $statement);
         }
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -22,8 +22,8 @@ namespace Doctrine\DBAL;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Closure;
-use Doctrine\DBAL\Logging\SQLLogger2;
 use Exception;
+use Doctrine\DBAL\Logging\SQLLoggerExtended;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\Common\EventManager;
@@ -936,7 +936,7 @@ class Connection implements DriverConnection
                 $stmt = $this->_conn->query($query);
             }
         } catch (Exception $ex) {
-            if ($logger && ($logger instanceof SQLLogger2)) {
+            if ($logger && ($logger instanceof SQLLoggerExtended)) {
                 $logger->fail($ex);
             }
 
@@ -1039,7 +1039,7 @@ class Connection implements DriverConnection
         try {
             $statement = $this->_conn->query(...$args);
         } catch (Exception $ex) {
-            if ($logger && ($logger instanceof SQLLogger2)) {
+            if ($logger && ($logger instanceof SQLLoggerExtended)) {
                 $logger->fail($ex);
             }
 
@@ -1094,7 +1094,7 @@ class Connection implements DriverConnection
                 $result = $this->_conn->exec($query);
             }
         } catch (Exception $ex) {
-            if ($logger && ($logger instanceof SQLLogger2)) {
+            if ($logger && ($logger instanceof SQLLoggerExtended)) {
                 $logger->fail($ex);
             }
 
@@ -1129,7 +1129,7 @@ class Connection implements DriverConnection
         try {
             $result = $this->_conn->exec($statement);
         } catch (Exception $ex) {
-            if ($logger && ($logger instanceof SQLLogger2)) {
+            if ($logger && ($logger instanceof SQLLoggerExtended)) {
                 $logger->fail($ex);
             }
 
@@ -1137,7 +1137,7 @@ class Connection implements DriverConnection
         }
 
         if ($logger) {
-            if ($logger instanceof SQLLogger2) {
+            if ($logger instanceof SQLLoggerExtended) {
                 $logger->countAffectedRows($result);
             }
 

--- a/lib/Doctrine/DBAL/Logging/SQLLogger2.php
+++ b/lib/Doctrine/DBAL/Logging/SQLLogger2.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Logging;
+
+use Exception;
+
+/**
+ * Interface for SQL loggers.
+ *
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author José Carlos Chávez <jcchavezs@gmail.com>
+ */
+interface SQLLogger2 extends SLQLogger
+{
+    /**
+     * Marks the last started query as failed. This can be used for timing of queries and
+     * register errors.
+     *
+     * @param Exception $e
+     * @return void
+     */
+    public function fail(Exception $e);
+
+    /**
+     * Counts the affected rows in the last started query before it is stopped.
+     *
+     * @param $result
+     * @return void
+     */
+    public function countAffectedRows($result);
+}

--- a/lib/Doctrine/DBAL/Logging/SQLLoggerExtended.php
+++ b/lib/Doctrine/DBAL/Logging/SQLLoggerExtended.php
@@ -28,7 +28,7 @@ use Exception;
  * @since  2.0
  * @author José Carlos Chávez <jcchavezs@gmail.com>
  */
-interface SQLLogger2 extends SLQLogger
+interface SQLLoggerExtended extends SQLLogger
 {
     /**
      * Marks the last started query as failed. This can be used for timing of queries and
@@ -42,7 +42,7 @@ interface SQLLogger2 extends SLQLogger
     /**
      * Counts the affected rows in the last started query before it is stopped.
      *
-     * @param $result
+     * @param int $result
      * @return void
      */
     public function countAffectedRows($result);

--- a/lib/Doctrine/DBAL/Logging/SQLLoggerExtended.php
+++ b/lib/Doctrine/DBAL/Logging/SQLLoggerExtended.php
@@ -20,13 +20,12 @@
 namespace Doctrine\DBAL\Logging;
 
 use Exception;
+use Throwable;
 
 /**
  * Interface for SQL loggers.
  *
  * @link   www.doctrine-project.org
- * @since  2.0
- * @author José Carlos Chávez <jcchavezs@gmail.com>
  */
 interface SQLLoggerExtended extends SQLLogger
 {
@@ -34,10 +33,9 @@ interface SQLLoggerExtended extends SQLLogger
      * Marks the last started query as failed. This can be used for timing of queries and
      * register errors.
      *
-     * @param Exception $e
-     * @return void
+     * @return Throwable|Exception void
      */
-    public function fail(Exception $e);
+    public function fail($e);
 
     /**
      * Counts the affected rows in the last started query before it is stopped.

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -169,7 +169,7 @@ class Statement implements \IteratorAggregate, DriverStatement
             $stmt = $this->stmt->execute($params);
         } catch (\Exception $ex) {
             if ($logger) {
-                $logger->stopQuery();
+                $logger->stopQuery($ex);
             }
             throw DBALException::driverExceptionDuringQuery(
                 $this->conn->getDriver(),

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\DBAL;
 
-use Doctrine\DBAL\Logging\SQLLogger2;
+use Doctrine\DBAL\Logging\SQLLoggerExtended;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use function is_array;
@@ -169,8 +169,12 @@ class Statement implements \IteratorAggregate, DriverStatement
         try {
             $stmt = $this->stmt->execute($params);
         } catch (\Exception $ex) {
-            if ($logger && ($logger instanceof SQLLogger2)) {
-                $logger->fail($ex);
+            if ($logger) {
+                if ($logger instanceof SQLLoggerExtended) {
+                    $logger->fail($ex);
+                } else {
+                    $logger->stopQuery();
+                }
             }
             throw DBALException::driverExceptionDuringQuery(
                 $this->conn->getDriver(),

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL;
 
+use Doctrine\DBAL\Logging\SQLLogger2;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use function is_array;
@@ -168,8 +169,8 @@ class Statement implements \IteratorAggregate, DriverStatement
         try {
             $stmt = $this->stmt->execute($params);
         } catch (\Exception $ex) {
-            if ($logger) {
-                $logger->stopQuery($ex);
+            if ($logger && ($logger instanceof SQLLogger2)) {
+                $logger->fail($ex);
             }
             throw DBALException::driverExceptionDuringQuery(
                 $this->conn->getDriver(),

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -171,7 +171,7 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
         // Needed to satisfy construction of DBALException
         $this->conn->expects($this->any())
             ->method('resolveParams')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
 
         $logger->expects($this->once())
             ->method('startQuery');
@@ -181,9 +181,9 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
 
         $this->pdoStatement->expects($this->once())
             ->method('execute')
-            ->will($this->throwException(new \Exception("Mock test exception")));
+            ->will($this->throwException(new \Exception('Mock test exception')));
 
-        $statement = new Statement("", $this->conn);
+        $statement = new Statement('', $this->conn);
         $statement->execute();
     }
 }

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -156,4 +156,34 @@ class StatementTest extends \Doctrine\Tests\DbalTestCase
         $statement = new Statement("", $this->conn);
         $statement->execute();
     }
+
+    /**
+     * @expectedException \Doctrine\DBAL\DBALException
+     */
+    public function testExecuteCallsLoggerExtendedFailsOnException()
+    {
+        $logger = $this->createMock('\Doctrine\DBAL\Logging\SQLLoggerExtended');
+
+        $this->configuration->expects($this->once())
+            ->method('getSQLLogger')
+            ->will($this->returnValue($logger));
+
+        // Needed to satisfy construction of DBALException
+        $this->conn->expects($this->any())
+            ->method('resolveParams')
+            ->will($this->returnValue(array()));
+
+        $logger->expects($this->once())
+            ->method('startQuery');
+
+        $logger->expects($this->once())
+            ->method('fail');
+
+        $this->pdoStatement->expects($this->once())
+            ->method('execute')
+            ->will($this->throwException(new \Exception("Mock test exception")));
+
+        $statement = new Statement("", $this->conn);
+        $statement->execute();
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3170

#### Summary

This PR adds the `stopQuery` error for when the query fails and in that case, pass the exception to the `stopQuery($ex)`.

It is important to mention that this does not break existing clients as the interface remains the same while clients can retrieve the exception by using `func_get_args`.

Ping @morozov
