### PR TITLE
Fix incorrect exception thrown from SQLAnywhere16Platform

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,9 @@
+# Upgrade to 2.8
+
+## Corrected exception thrown by ``Doctrine\DBAL\Platforms\SQLAnywhere16Platform::getAdvancedIndexOptionsSQL()``
+
+This method now throws SPL ``UnexpectedValueException`` instead of accidentally throwing ``Doctrine\Common\Proxy\Exception\UnexpectedValueException``.
+
 # Upgrade to 2.7
 
 ## Doctrine\DBAL\Platforms\AbstractPlatform::DATE_INTERVAL_UNIT_* constants deprecated

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywhere16Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywhere16Platform.php
@@ -19,8 +19,8 @@
 
 namespace Doctrine\DBAL\Platforms;
 
-use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use Doctrine\DBAL\Schema\Index;
+use UnexpectedValueException;
 
 /**
  * The SQLAnywhere16Platform provides the behavior, features and SQL dialect of the


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | maybe?

#### Summary

SQLAnywhere16Platform was throwing exception from doctrine/common's Proxy.