### PR TITLE
Removed the logic of using BLOB columns for BINARY type of fields

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -102,6 +102,12 @@ The Drizzle project is abandoned and is therefore not supported by Doctrine DBAL
 - `Configuration::getSQLLogger()` does not return `null` anymore, but a `NullLogger` implementation.
 - `Configuration::setSQLLogger()` does not allow `null` anymore.
 
+## BC BREAK: Changes to handling binary fields
+
+- Binary fields whose length exceeds the maximum field size on a given platform are no longer represented as `BLOB`s.
+  Use binary fields of a size which fits all target platforms, or use blob explicitly instead.
+- Binary fields are no longer represented as streams in PHP. They are represented as strings.
+
 # Upgrade to 2.7
 
 ## Doctrine\DBAL\Platforms\AbstractPlatform::DATE_INTERVAL_UNIT_* constants deprecated

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -309,10 +309,6 @@ abstract class AbstractPlatform
 
         $fixed = $field['fixed'] ?? false;
 
-        if ($field['length'] > $this->getBinaryMaxLength()) {
-            return $this->getBlobTypeDeclarationSQL($field);
-        }
-
         return $this->getBinaryTypeDeclarationSQLSnippet($field['length'], $fixed);
     }
 

--- a/lib/Doctrine/DBAL/Types/BinaryType.php
+++ b/lib/Doctrine/DBAL/Types/BinaryType.php
@@ -4,11 +4,9 @@ namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use function fopen;
-use function fseek;
-use function fwrite;
 use function is_resource;
 use function is_string;
+use function stream_get_contents;
 
 /**
  * Type that maps ab SQL BINARY/VARBINARY to a PHP resource stream.
@@ -35,14 +33,11 @@ class BinaryType extends Type
             return null;
         }
 
-        if (is_string($value)) {
-            $fp = fopen('php://temp', 'rb+');
-            fwrite($fp, $value);
-            fseek($fp, 0);
-            $value = $fp;
+        if (is_resource($value)) {
+            $value = stream_get_contents($value);
         }
 
-        if ( ! is_resource($value)) {
+        if (! is_string($value)) {
             throw ConversionException::conversionFailed($value, self::BINARY);
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Types/BinaryTest.php
@@ -7,11 +7,10 @@ namespace Doctrine\Tests\DBAL\Functional\Types;
 use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalFunctionalTestCase;
-use function is_resource;
 use function random_bytes;
 use function str_replace;
-use function stream_get_contents;
 
 class BinaryTest extends DbalFunctionalTestCase
 {
@@ -74,14 +73,6 @@ class BinaryTest extends DbalFunctionalTestCase
             [ParameterType::BINARY]
         );
 
-        // Currently, `BinaryType` mistakenly converts string values fetched from the DB to a stream.
-        // It should be the opposite. Streams should be used to represent large objects, not binary
-        // strings. The confusion comes from the PostgreSQL's type system where binary strings and
-        // large objects are represented by the same BYTEA type
-        if (is_resource($value)) {
-            $value = stream_get_contents($value);
-        }
-
-        return $value;
+        return Type::getType('binary')->convertToPHPValue($value, $this->_conn->getDatabasePlatform());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -516,19 +516,24 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
     public function testReturnsBinaryTypeDeclarationSQL()
     {
-        self::assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array()));
-        self::assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 0)));
-        self::assertSame('VARBINARY(65535)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 65535)));
-        self::assertSame('MEDIUMBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 65536)));
-        self::assertSame('MEDIUMBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 16777215)));
-        self::assertSame('LONGBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 16777216)));
+        self::assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL([]));
+        self::assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 0]));
+        self::assertSame('VARBINARY(65535)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 65535]));
+        self::assertSame('VARBINARY(65536)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 65536]));
 
-        self::assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true)));
-        self::assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 0)));
-        self::assertSame('BINARY(65535)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 65535)));
-        self::assertSame('MEDIUMBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 65536)));
-        self::assertSame('MEDIUMBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 16777215)));
-        self::assertSame('LONGBLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 16777216)));
+        self::assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(['fixed' => true]));
+        self::assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 0,
+        ]));
+        self::assertSame('BINARY(65535)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 65535,
+        ]));
+        self::assertSame('BINARY(65536)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 65536,
+        ]));
     }
 
     public function testDoesNotPropagateForeignKeyCreationForNonSupportingEngines()

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -978,15 +978,24 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
 
     public function testReturnsBinaryTypeDeclarationSQL()
     {
-        self::assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array()));
-        self::assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 0)));
-        self::assertSame('VARBINARY(8000)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 8000)));
-        self::assertSame('VARBINARY(MAX)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 8001)));
+        self::assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL([]));
+        self::assertSame('VARBINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 0]));
+        self::assertSame('VARBINARY(8000)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 8000]));
+        self::assertSame('VARBINARY(8001)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 8001]));
 
-        self::assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true)));
-        self::assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 0)));
-        self::assertSame('BINARY(8000)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 8000)));
-        self::assertSame('VARBINARY(MAX)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 8001)));
+        self::assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL(['fixed' => true]));
+        self::assertSame('BINARY(255)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 0,
+        ]));
+        self::assertSame('BINARY(8000)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 8000,
+        ]));
+        self::assertSame('BINARY(8001)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 8001,
+        ]));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -422,11 +422,12 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         self::assertSame('VARCHAR(1) FOR BIT DATA', $this->_platform->getBinaryTypeDeclarationSQL([]));
         self::assertSame('VARCHAR(255) FOR BIT DATA', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 0]));
         self::assertSame('VARCHAR(32704) FOR BIT DATA', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 32704]));
-        self::assertSame('BLOB(1M)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 32705]));
+        self::assertSame('VARCHAR(32705) FOR BIT DATA', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 32705]));
 
         self::assertSame('CHAR(1) FOR BIT DATA', $this->_platform->getBinaryTypeDeclarationSQL(['fixed' => true]));
         self::assertSame('CHAR(254) FOR BIT DATA', $this->_platform->getBinaryTypeDeclarationSQL(['fixed' => true, 'length' => 0]));
-        self::assertSame('BLOB(1M)', $this->_platform->getBinaryTypeDeclarationSQL(['fixed' => true, 'length' => 32705]));
+        self::assertSame('CHAR(254) FOR BIT DATA', $this->_platform->getBinaryTypeDeclarationSQL(['fixed' => true, 'length' => 254]));
+        self::assertSame('CHAR(255) FOR BIT DATA', $this->_platform->getBinaryTypeDeclarationSQL(['fixed' => true, 'length' => 255]));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -443,15 +443,24 @@ class OraclePlatformTest extends AbstractPlatformTestCase
 
     public function testReturnsBinaryTypeDeclarationSQL()
     {
-        self::assertSame('RAW(255)', $this->_platform->getBinaryTypeDeclarationSQL(array()));
-        self::assertSame('RAW(2000)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 0)));
-        self::assertSame('RAW(2000)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 2000)));
-        self::assertSame('BLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 2001)));
+        self::assertSame('RAW(255)', $this->_platform->getBinaryTypeDeclarationSQL([]));
+        self::assertSame('RAW(2000)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 0]));
+        self::assertSame('RAW(2000)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 2000]));
+        self::assertSame('RAW(2001)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 2001]));
 
-        self::assertSame('RAW(255)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true)));
-        self::assertSame('RAW(2000)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 0)));
-        self::assertSame('RAW(2000)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 2000)));
-        self::assertSame('BLOB', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 2001)));
+        self::assertSame('RAW(255)', $this->_platform->getBinaryTypeDeclarationSQL(['fixed' => true]));
+        self::assertSame('RAW(2000)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 0,
+        ]));
+        self::assertSame('RAW(2000)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 2000,
+        ]));
+        self::assertSame('RAW(2001)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 2001,
+        ]));
     }
 
     public function testDoesNotPropagateUnnecessaryTableAlterationOnBinaryType()

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -935,15 +935,24 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
 
     public function testReturnsBinaryTypeDeclarationSQL()
     {
-        self::assertSame('VARBINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(array()));
-        self::assertSame('VARBINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 0)));
-        self::assertSame('VARBINARY(32767)', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 32767)));
-        self::assertSame('LONG BINARY', $this->_platform->getBinaryTypeDeclarationSQL(array('length' => 32768)));
+        self::assertSame('VARBINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL([]));
+        self::assertSame('VARBINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 0]));
+        self::assertSame('VARBINARY(32767)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 32767]));
+        self::assertSame('VARBINARY(32768)', $this->_platform->getBinaryTypeDeclarationSQL(['length' => 32768]));
 
-        self::assertSame('BINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true)));
-        self::assertSame('BINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 0)));
-        self::assertSame('BINARY(32767)', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 32767)));
-        self::assertSame('LONG BINARY', $this->_platform->getBinaryTypeDeclarationSQL(array('fixed' => true, 'length' => 32768)));
+        self::assertSame('BINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL(['fixed' => true]));
+        self::assertSame('BINARY(1)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 0,
+        ]));
+        self::assertSame('BINARY(32767)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 32767,
+        ]));
+        self::assertSame('BINARY(32768)', $this->_platform->getBinaryTypeDeclarationSQL([
+            'fixed' => true,
+            'length' => 32768,
+        ]));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
@@ -5,9 +5,11 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use function array_map;
 use function base64_encode;
 use function fopen;
-use function stream_get_contents;
+use function implode;
+use function range;
 
 class BinaryTest extends \Doctrine\Tests\DbalTestCase
 {
@@ -52,11 +54,10 @@ class BinaryTest extends \Doctrine\Tests\DbalTestCase
 
     public function testBinaryStringConvertsToPHPValue()
     {
-        $databaseValue = 'binary string';
+        $databaseValue = $this->getBinaryString();
         $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
 
-        self::assertInternalType('resource', $phpValue);
-        self::assertEquals($databaseValue, stream_get_contents($phpValue));
+        self::assertSame($databaseValue, $phpValue);
     }
 
     public function testBinaryResourceConvertsToPHPValue()
@@ -64,7 +65,15 @@ class BinaryTest extends \Doctrine\Tests\DbalTestCase
         $databaseValue = fopen('data://text/plain;base64,' . base64_encode('binary string'), 'r');
         $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
 
-        self::assertSame($databaseValue, $phpValue);
+        self::assertSame('binary string', $phpValue);
+    }
+
+    /**
+     * Creates a binary string containing all possible byte values.
+     */
+    private function getBinaryString() : string
+    {
+        return implode(array_map('chr', range(0, 255)));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
@@ -34,37 +34,4 @@ class BlobTest extends \Doctrine\Tests\DbalTestCase
     {
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
-
-    public function testBinaryStringConvertsToPHPValue()
-    {
-        $databaseValue = $this->getBinaryString();
-        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
-
-        self::assertInternalType('resource', $phpValue);
-        self::assertSame($databaseValue, stream_get_contents($phpValue));
-    }
-
-    public function testBinaryResourceConvertsToPHPValue()
-    {
-        $databaseValue = fopen('data://text/plain;base64,' . base64_encode($this->getBinaryString()), 'r');
-        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
-
-        self::assertSame($databaseValue, $phpValue);
-    }
-
-    /**
-     * Creates a binary string containing all possible byte values.
-     *
-     * @return string
-     */
-    private function getBinaryString()
-    {
-        $string = '';
-
-        for ($i = 0; $i < 256; $i++) {
-            $string .= chr($i);
-        }
-
-        return $string;
-    }
 }


### PR DESCRIPTION
In DBAL 2.x, if a `BINARY` column has a length greater than the max size on a given platform, it's represented as a `BLOB`. This idea may be inspired by the type systems of PostgreSQL and SQLite which don't make a difference between `BINARY` columns and `BLOB`s.

On the DBAL level, however, it looks like a bad idea for the following reasons:

1. `BLOB` columns cannot be used in `DISTINCT`, `WHERE`, `ORDER BY` and `GROUP BY` clauses on some platforms (e.g. Oracle, IBM DB2) for a reason. A `BLOB` is just a _large_ piece of binary data which is not supposed to be compared. It should be just exported or imported.
2. The max binary length is inconsistent between platforms: 2K, 4K, 8K, 32K, 64K. It means that depending on the length of a particular field, you'll get it represented as a `BLOB` on some platforms and as a `BINARY` on others.
3. To make `BLOB` and `BINARY` types look alike, DBAL represents `BINARY` columns in PHP as streams. It's pointless because unlike the `BLOB` type which could be used to store images or other media files, `BINARY` columns are used to store values like UUID or hashes like SHA1 and can be used as key columns. You don't want to have your key value as a stream.
4. DBAL doesn't silently convert `(VAR)?CHAR` columns to `TEXT`. The same shouldn't be done for binary columns.

Depending on the purpose of the column, the developer should decide whether it should be a `BINARY` column or a `BLOB` explicitly.