### PR TITLE
Remove dependency on doctrine/common

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade to 2.8
 
+## Removed dependency on doctrine/common
+
+The dependency on doctrine/common package has been removed.
+DBAL now depends on doctrine/cache and doctrine/event-manager instead.
+If you are using any other component from doctrine/common package,
+you will have to add an explicit dependency to your composer.json.
+
 ## Corrected exception thrown by ``Doctrine\DBAL\Platforms\SQLAnywhere16Platform::getAdvancedIndexOptionsSQL()``
 
 This method now throws SPL ``UnexpectedValueException`` instead of accidentally throwing ``Doctrine\Common\Proxy\Exception\UnexpectedValueException``.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": "^7.1",
         "ext-pdo": "*",
-        "doctrine/common": "^2.7.1"
+        "doctrine/cache": "^1.0",
+        "doctrine/event-manager": "^1.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^4.0",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues |  #3176

#### Summary

Replace doctrine/common with dependency on doctrine/cache + doctrine/event-manager.

This also drops indirect dependency on:
* doctrine/lexer
* doctrine/collections
* doctrine/annotations
* doctrine/inflector

closes  #3176
