### PR TITLE
Fix text column length change

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -469,7 +469,7 @@ class Comparator
             }
         } elseif ($properties1['type'] instanceof Types\TextType) {
             // check if values of length match. There is no default value for all adapters.
-            if ($properties1['length'] !== $properties2['length']) {
+            if ($properties1['length'] != $properties2['length']) {
                 $changedProperties[] = 'length';
             }
         } elseif ($properties1['type'] instanceof Types\DecimalType) {

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -467,6 +467,11 @@ class Comparator
             if ($properties1['fixed'] != $properties2['fixed']) {
                 $changedProperties[] = 'fixed';
             }
+        } elseif ($properties1['type'] instanceof Types\TextType) {
+            // check if values of length match. There is no default value for all adapters.
+            if ($properties1['length'] !== $properties2['length']) {
+                $changedProperties[] = 'length';
+            }
         } elseif ($properties1['type'] instanceof Types\DecimalType) {
             if (($properties1['precision'] ?: 10) != ($properties2['precision'] ?: 10)) {
                 $changedProperties[] = 'precision';

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -1052,6 +1052,28 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         self::assertEquals($expected, Comparator::compareSchemas($oldSchema, $newSchema));
     }
 
+    public function testCompareChangedTextColumn()
+    {
+        $oldSchema = new Schema();
+
+        $tableFoo = $oldSchema->createTable('foo');
+        $tableFoo->addColumn('id', 'text');
+
+        $newSchema = new Schema();
+        $table = $newSchema->createTable('foo');
+        $table->addColumn('id', 'text', array('length' => 16777215 + 1));
+
+        $expected = new SchemaDiff();
+        $expected->fromSchema = $oldSchema;
+        $tableDiff = $expected->changedTables['foo'] = new TableDiff('foo');
+        $tableDiff->fromTable = $tableFoo;
+        $columnDiff = $tableDiff->changedColumns['id'] = new ColumnDiff('id', $table->getColumn('id'));
+        $columnDiff->fromColumn = $tableFoo->getColumn('id');
+        $columnDiff->changedProperties = array('length');
+
+        self::assertEquals($expected, Comparator::compareSchemas($oldSchema, $newSchema));
+    }
+
     /**
      * @group DBAL-617
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2566 

#### Summary

Schema Comparator's diffColumn did not check if the length had changed when the column type was Text. In MySQL it wasn't possible to change between TINYTEXT, TEXT, MEDIUMTEXT and LONGTEXT.
I've added a new check for TextType where i only check if the length property is the same in both columns. I did not append the case with StringType and BinaryType because 'fixed' property doesn't apply to TextType and the default 'length' of 255 feels wrong. 

I've included a test case.
