### PR TITLE
In Schema Diff, ignore default value alteration for MySQL TEXT and BLOB types

### DIFF
--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -168,7 +168,12 @@ class MySqlSchemaManager extends AbstractSchemaManager
         if ($this->_platform instanceof MariaDb1027Platform) {
             $columnDefault = $this->getMariaDb1027ColumnDefault($this->_platform, $tableColumn['default']);
         } else {
-            $columnDefault = $tableColumn['default'];
+            if ($dbType === 'text' || $dbType === 'blob') {
+                // MySQL (all versions) and MariaDB (<10.2.1) does not support default value for TEXT and BLOB types
+                $columnDefault = null;
+            } else {
+                $columnDefault = $tableColumn['default'];
+            }
         }
 
         $options = [

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -345,7 +345,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         );
     }
 
-    public function testDefaultConstraintsForTextAndBlobAreIgnoredInSchemaDiff()
+    public function testDefaultConstraintsForTextAndBlobAreIgnoredInSchemaAndTableDiff()
     {
         $tableName = 'default_constraints_text_and_blob';
         $table     = new Table($tableName);
@@ -365,9 +365,13 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $platform    = $this->schemaManager->getDatabasePlatform();
         $onlineTable = $this->schemaManager->listTableDetails($tableName);
         $comparator  = new Comparator();
-        $diff        = $comparator->compare(new Schema([$onlineTable]), new Schema([$table]));
 
-        self::assertCount(0, $diff->toSql($platform), 'nothing to update');
+        $diff = $comparator->compare(new Schema([$onlineTable]), new Schema([$table]));
+        self::assertCount(0, $diff->toSql($platform), 'nothing to update - correct');
+
+        $tableDiff = $comparator->diffTable($onlineTable, $table);
+        // $tableDiff is not empty because Comparator has no idea which DB Platform it compares for :(
+        self::assertFalse($tableDiff, 'nothing to update, so table diff should be empty');
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -345,6 +345,31 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         );
     }
 
+    public function testDefaultConstraintsForTextAndBlobAreIgnoredInSchemaDiff()
+    {
+        $tableName = 'default_constraints_text_and_blob';
+        $table     = new Table($tableName);
+        $table->addColumn('no_default', 'string');
+        $table->addColumn('df_string', 'string', ['default' => 'foobar']);
+        $table->addColumn('df_text', 'text', ['default' => 'Doctrine rocks!!!']);
+        $table->addColumn('df_blob', 'blob', ['default' => 'another default value']);
+
+        $this->schemaManager->dropAndCreateTable($table);
+        $onlineColumns = $this->schemaManager->listTableColumns($tableName);
+
+        self::assertNull($onlineColumns['no_default']->getDefault());
+        self::assertEquals('foobar', $onlineColumns['df_string']->getDefault());
+        self::assertNull($onlineColumns['df_text']->getDefault());
+        self::assertNull($onlineColumns['df_blob']->getDefault());
+
+        $platform    = $this->schemaManager->getDatabasePlatform();
+        $onlineTable = $this->schemaManager->listTableDetails($tableName);
+        $comparator  = new Comparator();
+        $diff        = $comparator->compare(new Schema([$onlineTable]), new Schema([$table]));
+
+        self::assertCount(0, $diff->toSql($platform), 'nothing to update');
+    }
+
     /**
      * @group DBAL-423
      */


### PR DESCRIPTION
MySQL (all versions) and MariaDB (<10.2.1) does not support default value for TEXT and BLOB types.

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #514 

#### Summary

If you look at #514 Doctrine already ignores those, but if you run schema diff you can still see that default value for these columns is altered.

See: https://github.com/bolt/bolt/pull/7477

I am not sure if this is best place to fix it. Any better proposals are more than welcomed :)