### PR TITLE
fix for pg10 support

### DIFF
--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -21,6 +21,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * PostgreSQL Schema Manager.


### PR DESCRIPTION
In case the db in use is a pg10 the function "_getPortableSequenceDefinition" for retrieving the sequence information won't work.
I've updated the class so it can get the pg version in the constructor and then use in the sequence definition lookup changing the query executed.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | no issue yet

#### Summary

I've created a constructor that gets the version number from prostgresql and then it compares the version in the "_getPortableSequenceDefinition" method.
In case the version is equal or grater to 10 it uses the new view pg_sequences to get the sequence information.
