### PR TITLE
Fix support for URL to account for master-slave and pooling-shard connections

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -155,6 +155,28 @@ final class DriverManager
 
         $params = self::parseDatabaseUrl($params);
 
+        // URL support for MasterSlaveConnection
+        if (isset($params['master'])) {
+            $params['master'] = self::parseDatabaseUrl($params['master']);
+        }
+
+        if (isset($params['slaves'])) {
+            foreach ($params['slaves'] as $key => $slaveParams) {
+                $params['slaves'][$key] = self::parseDatabaseUrl($slaveParams);
+            }
+        }
+
+        // URL support for PoolingShardConnection
+        if (isset($params['global'])) {
+            $params['global'] = self::parseDatabaseUrl($params['global']);
+        }
+
+        if (isset($params['shards'])) {
+            foreach ($params['shards'] as $key => $shardParams) {
+                $params['shards'][$key] = self::parseDatabaseUrl($shardParams);
+            }
+        }
+
         // check for existing pdo object
         if (isset($params['pdo']) && ! $params['pdo'] instanceof \PDO) {
             throw DBALException::invalidPdoInstance();

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -2,12 +2,15 @@
 
 namespace Doctrine\Tests\DBAL;
 
+use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver as DrizzlePDOMySqlDriver;
 use Doctrine\DBAL\Driver\PDOMySql\Driver as PDOMySQLDriver;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver as PDOSqliteDriver;
 use Doctrine\DBAL\Driver\SQLSrv\Driver as SQLSrvDriver;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Sharding\PoolingShardConnection;
+use Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 use Doctrine\Tests\DbalTestCase;
 use Doctrine\Tests\Mocks\ConnectionMock;
@@ -131,6 +134,74 @@ class DriverManagerTest extends DbalTestCase
 
         $conn = DriverManager::getConnection($options);
         self::assertInstanceOf(PDOMySQLDriver::class, $conn->getDriver());
+    }
+
+    public function testDatabaseUrlMasterSlave()
+    {
+        $options = [
+            'driver' => 'pdo_mysql',
+            'master' => ['url' => 'mysql://foo:bar@localhost:11211/baz'],
+            'slaves' => [
+                'slave1' => ['url' => 'mysql://foo:bar@localhost:11211/baz_slave'],
+            ],
+            'wrapperClass' => MasterSlaveConnection::class,
+        ];
+
+        $conn = DriverManager::getConnection($options);
+
+        $params = $conn->getParams();
+        self::assertInstanceOf(PDOMySQLDriver::class, $conn->getDriver());
+
+        $expected = [
+            'user'     => 'foo',
+            'password' => 'bar',
+            'host'     => 'localhost',
+            'port'     => 11211,
+        ];
+
+        foreach ($expected as $key => $value) {
+            self::assertEquals($value, $params['master'][$key]);
+            self::assertEquals($value, $params['slaves']['slave1'][$key]);
+        }
+
+        self::assertEquals('baz', $params['master']['dbname']);
+        self::assertEquals('baz_slave', $params['slaves']['slave1']['dbname']);
+    }
+
+    public function testDatabaseUrlShard()
+    {
+        $options = [
+            'driver' => 'pdo_mysql',
+            'shardChoser' => MultiTenantShardChoser::class,
+            'global' => ['url' => 'mysql://foo:bar@localhost:11211/baz'],
+            'shards' => [
+                [
+                    'id' => 1,
+                    'url' => 'mysql://foo:bar@localhost:11211/baz_slave',
+                ],
+            ],
+            'wrapperClass' => PoolingShardConnection::class,
+        ];
+
+        $conn = DriverManager::getConnection($options);
+
+        $params = $conn->getParams();
+        self::assertInstanceOf(PDOMySQLDriver::class, $conn->getDriver());
+
+        $expected = [
+            'user'     => 'foo',
+            'password' => 'bar',
+            'host'     => 'localhost',
+            'port'     => 11211,
+        ];
+
+        foreach ($expected as $key => $value) {
+            self::assertEquals($value, $params['global'][$key]);
+            self::assertEquals($value, $params['shards'][0][$key]);
+        }
+
+        self::assertEquals('baz', $params['global']['dbname']);
+        self::assertEquals('baz_slave', $params['shards'][0]['dbname']);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/feature
| BC Break     | no
| Fixed issues | 

#### Summary

When adding support for url-based configuration, it was implemented at the DriverManager level rather than at the Connection level (which indeed has a bunch of advantages). Due to that, MasterSlaveConnection and PoolingShardConnection were missing support for the URL because the params are not at the top-level, but in sub-keys.
Moving the parsing of the URL to the connection itself when dealing with params would probably require much more work than making DriverManager aware of the config structure for these 2 special connections. 

I would consider it as a bugfix for the URL support (and so I hope it gets cherry-picked at least in 2.7), but that's your choice.
