### PR TITLE
Fix typo in AbstractPlatform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3410,7 +3410,7 @@ abstract class AbstractPlatform
 
         if ($offset < 0) {
             throw new DBALException(sprintf(
-                'Offset must be a positive integer of zero, %d given',
+                'Offset must be a positive integer or zero, %d given',
                 $offset
             ));
         }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Just a tiny typo in exception message.