### PR TITLE
Allow add previous exception in ConversionException

### DIFF
--- a/lib/Doctrine/DBAL/Types/ConversionException.php
+++ b/lib/Doctrine/DBAL/Types/ConversionException.php
@@ -26,11 +26,11 @@ class ConversionException extends DBALException
      *
      * @return \Doctrine\DBAL\Types\ConversionException
      */
-    public static function conversionFailed($value, $toType)
+    public static function conversionFailed($value, $toType, ?Throwable $previous = null)
     {
         $value = strlen($value) > 32 ? substr($value, 0, 20) . '...' : $value;
 
-        return new self('Could not convert database value "' . $value . '" to Doctrine Type ' . $toType);
+        return new self('Could not convert database value "' . $value . '" to Doctrine Type ' . $toType, 0, $previous);
     }
 
     /**
@@ -64,8 +64,12 @@ class ConversionException extends DBALException
      *
      * @return \Doctrine\DBAL\Types\ConversionException
      */
-    public static function conversionFailedInvalidType($value, $toType, array $possibleTypes)
-    {
+    public static function conversionFailedInvalidType(
+        $value,
+        $toType,
+        array $possibleTypes,
+        ?Throwable $previous = null
+    ) {
         $actualType = is_object($value) ? get_class($value) : gettype($value);
 
         if (is_scalar($value)) {
@@ -75,7 +79,7 @@ class ConversionException extends DBALException
                 $actualType,
                 $toType,
                 implode(', ', $possibleTypes)
-            ));
+            ), 0, $previous);
         }
 
         return new self(sprintf(
@@ -83,7 +87,7 @@ class ConversionException extends DBALException
             $actualType,
             $toType,
             implode(', ', $possibleTypes)
-        ));
+        ), 0, $previous);
     }
 
     public static function conversionFailedSerialization($value, $format, $error)

--- a/tests/Doctrine/Tests/DBAL/Types/ConversionExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ConversionExceptionTest.php
@@ -3,13 +3,23 @@
 namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Types\ConversionException;
-use Exception;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Throwable;
 use function tmpfile;
 
 class ConversionExceptionTest extends TestCase
 {
+    public function testConversionFailedPreviousException() : void
+    {
+        $previous = $this->createMock(Throwable::class);
+
+        $exception = ConversionException::conversionFailed('foo', 'foo', $previous);
+
+        self::assertInstanceOf(ConversionException::class, $exception);
+        self::assertSame($previous, $exception->getPrevious());
+    }
+
     /**
      * @param mixed $scalarValue
      *
@@ -44,9 +54,19 @@ class ConversionExceptionTest extends TestCase
         );
     }
 
+    public function testConversionFailedInvalidTypePreviousException() : void
+    {
+        $previous = $this->createMock(Throwable::class);
+
+        $exception = ConversionException::conversionFailedInvalidType('foo', 'foo', ['bar', 'baz'], $previous);
+
+        self::assertInstanceOf(ConversionException::class, $exception);
+        self::assertSame($previous, $exception->getPrevious());
+    }
+
     public function testConversionFailedFormatPreservesPreviousException() : void
     {
-        $previous = new Exception();
+        $previous = $this->createMock(Throwable::class);
 
         $exception = ConversionException::conversionFailedFormat('foo', 'bar', 'baz', $previous);
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | - <!-- use #NUM format to reference an issue -->

#### Summary

I often use Value Object, and the code of DBAL type looks something like this:

```php
final class MoneyType extends Type
{
    public function convertToPHPValue($value, AbstractPlatform $platform)
    {
        if ($value === null || $value instanceof Money) {
            return $value;
        }

        try {
            return new Money($value, new Currency('EUR'));
        } catch (\Exception $e) {
            throw ConversionException::conversionFailed($value, $this->getName());
        }
    }

    // ...

}
```

In this case, it would be convenient to add the previous exception to `ConversionException`.
