### PR TITLE
fix type : simpleArrayType, empty set will make mistake

### DIFF
--- a/lib/Doctrine/DBAL/Types/SimpleArrayType.php
+++ b/lib/Doctrine/DBAL/Types/SimpleArrayType.php
@@ -60,7 +60,7 @@ class SimpleArrayType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return [];
         }
 

--- a/tests/Doctrine/Tests/DBAL/Types/SimpleArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/SimpleArrayTest.php
@@ -15,26 +15,21 @@ class SimpleArrayTest extends \Doctrine\Tests\DbalTestCase
     /**
      * @var AbstractPlatform
      */
-    protected $_platform;
+    private $platform;
 
     /**
      * @var Type
      */
-    protected $_type;
+    private $type;
 
     protected function setUp()
     {
-        $this->_platform = new MockPlatform();
-        $this->_type = Type::getType('simple_array');
-    }
-
-    protected function tearDown()
-    {
-        error_reporting(-1); // reactive all error levels
+        $this->platform = new MockPlatform();
+        $this->type = Type::getType('simple_array');
     }
 
     public function testNullConversion()
     {
-        self::assertEquals([], $this->_type->convertToPHPValue("", $this->_platform));
+        self::assertEquals([], $this->type->convertToPHPValue("", $this->platform));
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Types/SimpleArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/SimpleArrayTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use const E_ALL;
+use const E_STRICT;
+use function error_reporting;
+use function serialize;
+
+class SimpleArrayTest extends \Doctrine\Tests\DbalTestCase
+{
+    /**
+     * @var AbstractPlatform
+     */
+    protected $_platform;
+
+    /**
+     * @var Type
+     */
+    protected $_type;
+
+    protected function setUp()
+    {
+        $this->_platform = new MockPlatform();
+        $this->_type = Type::getType('simple_array');
+    }
+
+    protected function tearDown()
+    {
+        error_reporting(-1); // reactive all error levels
+    }
+
+    public function testNullConversion()
+    {
+        self::assertEquals([], $this->_type->convertToPHPValue("", $this->_platform));
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

If mysql type was **SET**, and mapping to the doctrine entity will be **simpleArray**, and if the set was empty, the value passed to the **convertToPHPValue** was '', the origin code would return [''], the correct result should be [].

<!-- Provide a summary of your change. -->
