### PR TITLE
Removed NOW() from QueryBuilder usage examples

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -552,9 +552,9 @@ class QueryBuilder
      *
      * <code>
      *     $qb = $conn->createQueryBuilder()
-     *         ->update('users', 'u')
-     *         ->set('u.last_login', 'NOW()')
-     *         ->where('u.id = ?');
+     *         ->update('counters', 'c')
+     *         ->set('c.value', 'c.value + 1')
+     *         ->where('c.id = ?');
      * </code>
      *
      * @param string $update The table whose rows are subject to the update.
@@ -745,9 +745,9 @@ class QueryBuilder
      *
      * <code>
      *     $qb = $conn->createQueryBuilder()
-     *         ->update('users', 'u')
-     *         ->set('u.last_login', 'NOW()')
-     *         ->where('u.id = ?');
+     *         ->update('counters', 'c')
+     *         ->set('c.value', 'c.value + 1')
+     *         ->where('c.id = ?');
      * </code>
      *
      * @param string $key   The column to set.
@@ -766,19 +766,19 @@ class QueryBuilder
      *
      * <code>
      *     $qb = $conn->createQueryBuilder()
-     *         ->select('u.name')
-     *         ->from('users', 'u')
-     *         ->where('u.id = ?');
+     *         ->select('c.value')
+     *         ->from('counters', 'c')
+     *         ->where('c.id = ?');
      *
      *     // You can optionally programatically build and/or expressions
      *     $qb = $conn->createQueryBuilder();
      *
      *     $or = $qb->expr()->orx();
-     *     $or->add($qb->expr()->eq('u.id', 1));
-     *     $or->add($qb->expr()->eq('u.id', 2));
+     *     $or->add($qb->expr()->eq('c.id', 1));
+     *     $or->add($qb->expr()->eq('c.id', 2));
      *
-     *     $qb->update('users', 'u')
-     *         ->set('u.last_login', 'NOW()')
+     *     $qb->update('counters', 'c')
+     *         ->set('c.value', 'c.value + 1')
      *         ->where($or);
      * </code>
      *


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

The `QueryBuilder` API documentation contains usages of the `NOW()` function. It's not the best idea for the following reasons:
1. This function is non-portable. Therefore, users who are not enough familiar with the supported platforms may be tricked into using this function in production code as recommended.
2. It promotes sourcing dates from the DB platform which may lead to data inconsistency between app-generated and DB-generated dates.