### PR TITLE
Schemas with views

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -144,6 +144,24 @@ class Comparator
             $diff->removedSequences[] = $sequence;
         }
 
+        foreach ($toSchema->getViews() as $view) {
+            $viewName = $view->getShortestName($toSchema->getName());
+            if (! $fromSchema->hasView($viewName)) {
+                $diff->newViews[$viewName] = $view;
+            } elseif (! $fromSchema->getView($viewName)->isSameAs($view)) {
+                $diff->changedViews[$viewName] = $view;
+            }
+        }
+
+        foreach ($fromSchema->getViews() as $view) {
+            $viewName = $view->getShortestName($fromSchema->getName());
+            if ($toSchema->hasView($viewName)) {
+                continue;
+            }
+
+            $diff->removedViews[$viewName] = $view;
+        }
+
         return $diff;
     }
 

--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -415,12 +415,7 @@ class Schema extends AbstractAsset
         return $this;
     }
 
-    /**
-     * @param string $viewName
-     *
-     * @return bool
-     */
-    public function hasView($viewName)
+    public function hasView(string $viewName): bool
     {
         $viewName = $this->getFullQualifiedAssetName($viewName);
 
@@ -428,13 +423,9 @@ class Schema extends AbstractAsset
     }
 
     /**
-     * @param string $viewName
-     *
-     * @return View
-     *
      * @throws SchemaException
      */
-    public function getView($viewName)
+    public function getView(string $viewName) : View
     {
         $viewName = $this->getFullQualifiedAssetName($viewName);
         if (! isset($this->_views[$viewName])) {
@@ -445,24 +436,14 @@ class Schema extends AbstractAsset
     }
 
     /**
-     * Gets all views of this schema.
-     *
      * @return View[]
      */
-    public function getViews()
+    public function getViews() : array
     {
         return $this->_views;
     }
 
-    /**
-     * Creates a new view.
-     *
-     * @param string $viewName
-     * @param string $sql
-     *
-     * @return View
-     */
-    public function createView($viewName, $sql)
+    public function createView(string $viewName, string $sql) : View
     {
         $view = new View($viewName, $sql);
         $this->_addView($view);
@@ -470,19 +451,10 @@ class Schema extends AbstractAsset
         return $view;
     }
 
-    /**
-     * Drops a view from the schema.
-     *
-     * @param string $viewName
-     *
-     * @return Schema
-     */
-    public function dropView($viewName)
+    public function dropView(string $viewName) : self
     {
         $viewName = $this->getFullQualifiedAssetName($viewName);
-        if ($this->hasView($viewName)) {
-            unset($this->_views[$viewName]);
-        }
+        unset($this->_views[$viewName]);
 
         return $this;
     }

--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -51,7 +51,7 @@ class Schema extends AbstractAsset
     protected $_sequences = [];
 
     /** @var View[]  */
-    protected $_views = [];
+    private $views = [];
 
     /** @var SchemaConfig */
     protected $_schemaConfig = false;
@@ -89,7 +89,7 @@ class Schema extends AbstractAsset
         }
 
         foreach ($views as $view) {
-            $this->_addView($view);
+            $this->addView($view);
         }
     }
 
@@ -145,16 +145,14 @@ class Schema extends AbstractAsset
     }
 
     /**
-     * @return void
-     *
      * @throws SchemaException
      */
-    protected function _addView(View $view)
+    private function addView(View $view) : void
     {
         $namespaceName = $view->getNamespaceName();
         $viewName      = $view->getFullQualifiedName($this->getName());
 
-        if (isset($this->_views[$viewName])) {
+        if (isset($this->views[$viewName])) {
             throw SchemaException::viewAlreadyExists($viewName);
         }
 
@@ -162,7 +160,7 @@ class Schema extends AbstractAsset
             $this->createNamespace($namespaceName);
         }
 
-        $this->_views[$viewName] = $view;
+        $this->views[$viewName] = $view;
     }
 
     /**
@@ -415,11 +413,11 @@ class Schema extends AbstractAsset
         return $this;
     }
 
-    public function hasView(string $viewName): bool
+    public function hasView(string $viewName) : bool
     {
         $viewName = $this->getFullQualifiedAssetName($viewName);
 
-        return isset($this->_views[$viewName]);
+        return isset($this->views[$viewName]);
     }
 
     /**
@@ -428,11 +426,11 @@ class Schema extends AbstractAsset
     public function getView(string $viewName) : View
     {
         $viewName = $this->getFullQualifiedAssetName($viewName);
-        if (! isset($this->_views[$viewName])) {
+        if (! isset($this->views[$viewName])) {
             throw SchemaException::viewDoesNotExist($viewName);
         }
 
-        return $this->_views[$viewName];
+        return $this->views[$viewName];
     }
 
     /**
@@ -440,21 +438,24 @@ class Schema extends AbstractAsset
      */
     public function getViews() : array
     {
-        return $this->_views;
+        return $this->views;
     }
 
     public function createView(string $viewName, string $sql) : View
     {
         $view = new View($viewName, $sql);
-        $this->_addView($view);
+        $this->addView($view);
 
         return $view;
     }
 
+    /**
+     * @return $this
+     */
     public function dropView(string $viewName) : self
     {
         $viewName = $this->getFullQualifiedAssetName($viewName);
-        unset($this->_views[$viewName]);
+        unset($this->views[$viewName]);
 
         return $this;
     }
@@ -528,7 +529,7 @@ class Schema extends AbstractAsset
             $sequence->visit($visitor);
         }
 
-        foreach ($this->_views as $view) {
+        foreach ($this->views as $view) {
             $view->visit($visitor);
         }
     }
@@ -546,8 +547,8 @@ class Schema extends AbstractAsset
         foreach ($this->_sequences as $k => $sequence) {
             $this->_sequences[$k] = clone $sequence;
         }
-        foreach ($this->_views as $k => $view) {
-            $this->_views[$k] = clone $view;
+        foreach ($this->views as $k => $view) {
+            $this->views[$k] = clone $view;
         }
     }
 }

--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -60,6 +60,15 @@ class SchemaDiff
     /** @var ForeignKeyConstraint[] */
     public $orphanedForeignKeys = [];
 
+    /** @var View[] */
+    public $newViews = [];
+
+    /** @var View[] */
+    public $changedViews = [];
+
+    /** @var View[] */
+    public $removedViews = [];
+
     /**
      * Constructs an SchemaDiff object.
      *
@@ -133,6 +142,22 @@ class SchemaDiff
 
             foreach ($this->newSequences as $sequence) {
                 $sql[] = $platform->getCreateSequenceSQL($sequence);
+            }
+        }
+
+        if ($platform->supportsViews() === true) {
+            if ($saveMode === false) {
+                foreach ($this->removedViews as $view) {
+                    $sql[] = $platform->getDropViewSQL($view->getName());
+                }
+            }
+            foreach ($this->changedViews as $view) {
+                $sql[] = $platform->getDropViewSQL($view->getName());
+                $sql[] = $platform->getCreateViewSQL($view->getName(), $view->getSql());
+            }
+
+            foreach ($this->newViews as $view) {
+                $sql[] = $platform->getCreateViewSQL($view->getName(), $view->getSql());
             }
         }
 

--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -145,8 +145,8 @@ class SchemaDiff
             }
         }
 
-        if ($platform->supportsViews() === true) {
-            if ($saveMode === false) {
+        if ($platform->supportsViews()) {
+            if (! $saveMode) {
                 foreach ($this->removedViews as $view) {
                     $sql[] = $platform->getDropViewSQL($view->getName());
                 }

--- a/lib/Doctrine/DBAL/Schema/SchemaException.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaException.php
@@ -185,11 +185,17 @@ class SchemaException extends DBALException
 
     public static function viewAlreadyExists(string $viewName)
     {
-        return new self("The view '" . $viewName . "' already exists.", self::VIEW_ALREADY_EXISTS);
+        return new self(
+            sprintf('The view "%s" already exists.', $viewName),
+            self::VIEW_ALREADY_EXISTS
+        );
     }
 
     public static function viewDoesNotExist(string $viewName)
     {
-        return new self("There exists no view with the name '" . $viewName . "'.", self::VIEW_DOENST_EXIST);
+        return new self(
+            sprintf('There exists no view with the name "%s".', $viewName),
+            self::VIEW_DOENST_EXIST
+        );
     }
 }

--- a/lib/Doctrine/DBAL/Schema/SchemaException.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaException.php
@@ -183,22 +183,12 @@ class SchemaException extends DBALException
         );
     }
 
-    /**
-     * @param string $viewName
-     *
-     * @return \Doctrine\DBAL\Schema\SchemaException
-     */
-    public static function viewAlreadyExists($viewName)
+    public static function viewAlreadyExists(string $viewName)
     {
         return new self("The view '" . $viewName . "' already exists.", self::VIEW_ALREADY_EXISTS);
     }
 
-    /**
-     * @param string $viewName
-     *
-     * @return \Doctrine\DBAL\Schema\SchemaException
-     */
-    public static function viewDoesNotExist($viewName)
+    public static function viewDoesNotExist(string $viewName)
     {
         return new self("There exists no view with the name '" . $viewName . "'.", self::VIEW_DOENST_EXIST);
     }

--- a/lib/Doctrine/DBAL/Schema/SchemaException.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaException.php
@@ -19,6 +19,8 @@ class SchemaException extends DBALException
     public const INDEX_INVALID_NAME       = 90;
     public const FOREIGNKEY_DOESNT_EXIST  = 100;
     public const NAMESPACE_ALREADY_EXISTS = 110;
+    public const VIEW_DOENST_EXIST        = 120;
+    public const VIEW_ALREADY_EXISTS      = 130;
 
     /**
      * @param string $tableName
@@ -179,5 +181,25 @@ class SchemaException extends DBALException
         return new self(
             sprintf("Alter table change not supported, given '%s'", $changeName)
         );
+    }
+
+    /**
+     * @param string $viewName
+     *
+     * @return \Doctrine\DBAL\Schema\SchemaException
+     */
+    public static function viewAlreadyExists($viewName)
+    {
+        return new self("The view '" . $viewName . "' already exists.", self::VIEW_ALREADY_EXISTS);
+    }
+
+    /**
+     * @param string $viewName
+     *
+     * @return \Doctrine\DBAL\Schema\SchemaException
+     */
+    public static function viewDoesNotExist($viewName)
+    {
+        return new self("There exists no view with the name '" . $viewName . "'.", self::VIEW_DOENST_EXIST);
     }
 }

--- a/lib/Doctrine/DBAL/Schema/View.php
+++ b/lib/Doctrine/DBAL/Schema/View.php
@@ -19,21 +19,21 @@ class View extends AbstractAsset
         $this->sql = $sql;
     }
 
-    public function getSql(): string
+    public function getSql() : string
     {
         return $this->sql;
     }
 
-    public function visit(Visitor $visitor): void
+    public function visit(Visitor $visitor) : void
     {
-        if (! ($visitor instanceof ViewVisitor)) {
+        if (! $visitor instanceof ViewVisitor) {
             return;
         }
 
         $visitor->acceptView($this);
     }
 
-    public function isSameAs(View $anotherView): bool
+    public function isSameAs(View $anotherView) : bool
     {
         return $anotherView->getSql() === $this->getSql();
     }

--- a/lib/Doctrine/DBAL/Schema/View.php
+++ b/lib/Doctrine/DBAL/Schema/View.php
@@ -13,28 +13,18 @@ class View extends AbstractAsset
     /** @var string */
     private $sql;
 
-    /**
-     * @param string $name
-     * @param string $sql
-     */
-    public function __construct($name, $sql)
+    public function __construct(string $name, string $sql)
     {
         $this->_setName($name);
         $this->sql = $sql;
     }
 
-    /**
-     * @return string
-     */
-    public function getSql()
+    public function getSql(): string
     {
         return $this->sql;
     }
 
-    /**
-     * @return void
-     */
-    public function visit(Visitor $visitor)
+    public function visit(Visitor $visitor): void
     {
         if (! ($visitor instanceof ViewVisitor)) {
             return;
@@ -43,7 +33,7 @@ class View extends AbstractAsset
         $visitor->acceptView($this);
     }
 
-    public function isSameAs(View $anotherView)
+    public function isSameAs(View $anotherView): bool
     {
         return $anotherView->getSql() === $this->getSql();
     }

--- a/lib/Doctrine/DBAL/Schema/View.php
+++ b/lib/Doctrine/DBAL/Schema/View.php
@@ -2,6 +2,9 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Schema\Visitor\ViewVisitor;
+use Doctrine\DBAL\Schema\Visitor\Visitor;
+
 /**
  * Representation of a Database View.
  */
@@ -26,5 +29,22 @@ class View extends AbstractAsset
     public function getSql()
     {
         return $this->sql;
+    }
+
+    /**
+     * @return void
+     */
+    public function visit(Visitor $visitor)
+    {
+        if (! ($visitor instanceof ViewVisitor)) {
+            return;
+        }
+
+        $visitor->acceptView($this);
+    }
+
+    public function isSameAs(View $anotherView)
+    {
+        return $anotherView->getSql() === $this->getSql();
     }
 }

--- a/lib/Doctrine/DBAL/Schema/Visitor/AbstractVisitor.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/AbstractVisitor.php
@@ -46,7 +46,7 @@ class AbstractVisitor implements Visitor, NamespaceVisitor, ViewVisitor
     {
     }
 
-    public function acceptView(View $view)
+    public function acceptView(View $view) : void
     {
     }
 }

--- a/lib/Doctrine/DBAL/Schema/Visitor/AbstractVisitor.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/AbstractVisitor.php
@@ -8,11 +8,12 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\View;
 
 /**
  * Abstract Visitor with empty methods for easy extension.
  */
-class AbstractVisitor implements Visitor, NamespaceVisitor
+class AbstractVisitor implements Visitor, NamespaceVisitor, ViewVisitor
 {
     public function acceptSchema(Schema $schema)
     {
@@ -42,6 +43,10 @@ class AbstractVisitor implements Visitor, NamespaceVisitor
     }
 
     public function acceptSequence(Sequence $sequence)
+    {
+    }
+
+    public function acceptView(View $view)
     {
     }
 }

--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -77,7 +77,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
     /**
      * {@inheritdoc}
      */
-    public function acceptView(View $view)
+    public function acceptView(View $view) : void
     {
         $this->createViewQueries[] = $this->platform->getCreateViewSQL($view->getName(), $view->getSql());
     }

--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\View;
 use function array_merge;
 
 class CreateSchemaSqlCollector extends AbstractVisitor
@@ -21,6 +22,9 @@ class CreateSchemaSqlCollector extends AbstractVisitor
 
     /** @var string[] */
     private $createFkConstraintQueries = [];
+
+    /** @var string[] */
+    private $createViewQueries = [];
 
     /** @var AbstractPlatform */
     private $platform = null;
@@ -71,6 +75,14 @@ class CreateSchemaSqlCollector extends AbstractVisitor
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function acceptView(View $view)
+    {
+        $this->createViewQueries[] = $this->platform->getCreateViewSQL($view->getName(), $view->getSql());
+    }
+
+    /**
      * @return void
      */
     public function resetQueries()
@@ -79,6 +91,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
         $this->createTableQueries        = [];
         $this->createSequenceQueries     = [];
         $this->createFkConstraintQueries = [];
+        $this->createViewQueries         = [];
     }
 
     /**
@@ -92,7 +105,8 @@ class CreateSchemaSqlCollector extends AbstractVisitor
             $this->createNamespaceQueries,
             $this->createTableQueries,
             $this->createSequenceQueries,
-            $this->createFkConstraintQueries
+            $this->createFkConstraintQueries,
+            $this->createViewQueries
         );
     }
 }

--- a/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\View;
 use SplObjectStorage;
 use function strlen;
 
@@ -23,6 +24,9 @@ class DropSchemaSqlCollector extends AbstractVisitor
 
     /** @var SplObjectStorage */
     private $tables;
+
+    /** @var SplObjectStorage<View> */
+    private $views;
 
     /** @var AbstractPlatform */
     private $platform;
@@ -62,6 +66,14 @@ class DropSchemaSqlCollector extends AbstractVisitor
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function acceptView(View $view)
+    {
+        $this->views->attach($view);
+    }
+
+    /**
      * @return void
      */
     public function clearQueries()
@@ -69,6 +81,7 @@ class DropSchemaSqlCollector extends AbstractVisitor
         $this->constraints = new SplObjectStorage();
         $this->sequences   = new SplObjectStorage();
         $this->tables      = new SplObjectStorage();
+        $this->views       = new SplObjectStorage();
     }
 
     /**
@@ -89,6 +102,10 @@ class DropSchemaSqlCollector extends AbstractVisitor
 
         foreach ($this->tables as $table) {
             $sql[] = $this->platform->getDropTableSQL($table);
+        }
+
+        foreach ($this->views as $view) {
+            $sql[] = $this->platform->getDropViewSQL($view->getName());
         }
 
         return $sql;

--- a/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
@@ -68,7 +68,7 @@ class DropSchemaSqlCollector extends AbstractVisitor
     /**
      * {@inheritdoc}
      */
-    public function acceptView(View $view)
+    public function acceptView(View $view) : void
     {
         $this->views->attach($view);
     }

--- a/lib/Doctrine/DBAL/Schema/Visitor/RemoveNamespacedAssets.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/RemoveNamespacedAssets.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\View;
 
 /**
  * Removes assets from a schema that are not in the default namespace.
@@ -53,6 +54,18 @@ class RemoveNamespacedAssets extends AbstractVisitor
         }
 
         $this->schema->dropSequence($sequence->getName());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function acceptView(View $view)
+    {
+        if ($view->isInDefaultNamespace($this->schema->getName())) {
+            return;
+        }
+
+        $this->schema->dropView($view->getName());
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/Visitor/RemoveNamespacedAssets.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/RemoveNamespacedAssets.php
@@ -59,7 +59,7 @@ class RemoveNamespacedAssets extends AbstractVisitor
     /**
      * {@inheritdoc}
      */
-    public function acceptView(View $view)
+    public function acceptView(View $view) : void
     {
         if ($view->isInDefaultNamespace($this->schema->getName())) {
             return;

--- a/lib/Doctrine/DBAL/Schema/Visitor/ViewVisitor.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/ViewVisitor.php
@@ -6,13 +6,8 @@ use Doctrine\DBAL\Schema\View;
 
 /**
  * Visitor that can visit views.
- *
- * @link   www.doctrine-project.org
  */
 interface ViewVisitor
 {
-    /**
-     * @return void
-     */
-    public function acceptView(View $view);
+    public function acceptView(View $view) : void;
 }

--- a/lib/Doctrine/DBAL/Schema/Visitor/ViewVisitor.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/ViewVisitor.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\DBAL\Schema\Visitor;
+
+use Doctrine\DBAL\Schema\View;
+
+/**
+ * Visitor that can visit views.
+ *
+ * @link   www.doctrine-project.org
+ */
+interface ViewVisitor
+{
+    /**
+     * @return void
+     */
+    public function acceptView(View $view);
+}

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Schema\View;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 use PHPUnit\Framework\TestCase;
 
@@ -19,7 +20,21 @@ class SchemaDiffTest extends TestCase
 
         $sql = $diff->toSql($platform);
 
-        $expected = ['create_schema', 'drop_orphan_fk', 'alter_seq', 'drop_seq', 'create_seq', 'create_table', 'create_foreign_key', 'drop_table', 'alter_table'];
+        $expected = [
+            'create_schema',
+            'drop_orphan_fk',
+            'alter_seq',
+            'drop_seq',
+            'create_seq',
+            'drop_view',
+            'change_view_drop',
+            'change_view_add',
+            'create_view',
+            'create_table',
+            'create_foreign_key',
+            'drop_table',
+            'alter_table',
+        ];
 
         self::assertEquals($expected, $sql);
     }
@@ -31,7 +46,17 @@ class SchemaDiffTest extends TestCase
 
         $sql = $diff->toSaveSql($platform);
 
-        $expected = ['create_schema', 'alter_seq', 'create_seq', 'create_table', 'create_foreign_key', 'alter_table'];
+        $expected = [
+            'create_schema',
+            'alter_seq',
+            'create_seq',
+            'change_view_drop',
+            'change_view_add',
+            'create_view',
+            'create_table',
+            'create_foreign_key',
+            'alter_table',
+        ];
 
         self::assertEquals($expected, $sql);
     }
@@ -57,6 +82,37 @@ class SchemaDiffTest extends TestCase
                  ->method('getCreateSequenceSql')
                  ->with($this->isInstanceOf(Sequence::class))
                  ->will($this->returnValue('create_seq'));
+        if ($unsafe) {
+            $platform->expects($this->exactly(2))
+                ->method('getDropViewSQL')
+                ->with($this->logicalOr(
+                    $this->equalTo('bar_view'),
+                    $this->equalTo('baz_view')
+                ))
+                ->will($this->returnCallback(static function ($arg) {
+                    return [
+                        'bar_view' => 'drop_view',
+                        'baz_view' => 'change_view_drop',
+                    ][$arg] ?? null;
+                }));
+        } else {
+            $platform->expects($this->exactly(1))
+                ->method('getDropViewSQL')
+                ->with($this->equalTo('baz_view'))
+                ->will($this->returnValue('change_view_drop'));
+        }
+        $platform->expects($this->exactly(2))
+            ->method('getCreateViewSQL')
+            ->with($this->logicalOr(
+                $this->equalTo('baz_view'),
+                $this->equalTo('foo_view')
+            ), '')
+            ->will($this->returnCallback(static function ($arg) {
+                return [
+                    'baz_view' => 'change_view_add',
+                    'foo_view' => 'create_view',
+                ][$arg] ?? null;
+            }));
         if ($unsafe) {
             $platform->expects($this->exactly(1))
                      ->method('getDropTableSql')
@@ -90,6 +146,9 @@ class SchemaDiffTest extends TestCase
         $platform->expects($this->exactly(1))
                 ->method('supportsSequences')
                 ->will($this->returnValue(true));
+        $platform->expects($this->exactly(1))
+                ->method('supportsViews')
+                ->will($this->returnValue(true));
         $platform->expects($this->exactly(2))
                 ->method('supportsForeignKeyConstraints')
                 ->will($this->returnValue(true));
@@ -104,6 +163,9 @@ class SchemaDiffTest extends TestCase
         $diff->changedSequences['foo_seq'] = new Sequence('foo_seq');
         $diff->newSequences['bar_seq']     = new Sequence('bar_seq');
         $diff->removedSequences['baz_seq'] = new Sequence('baz_seq');
+        $diff->newViews['foo_view']        = new View('foo_view', '');
+        $diff->removedViews['bar_view']    = new View('bar_view', '');
+        $diff->changedViews['baz_view']    = new View('baz_view', '');
         $diff->newTables['foo_table']      = new Table('foo_table');
         $diff->removedTables['bar_table']  = new Table('bar_table');
         $diff->changedTables['baz_table']  = new TableDiff('baz_table');

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
@@ -396,7 +396,7 @@ class SchemaTest extends TestCase
         $visitor->expects($this->exactly(2))
             ->method('acceptSequence');
 
-        $this->assertNull($schema->visit($visitor));
+        self::assertNull($schema->visit($visitor));
     }
 
     /**
@@ -473,12 +473,12 @@ class SchemaTest extends TestCase
 
         $schema = new Schema([], [], null, [], [$view]);
 
-        $this->assertTrue($schema->hasView($viewName));
+        self::assertTrue($schema->hasView($viewName));
 
         $views = $schema->getViews();
-        $this->assertTrue(isset($views[$viewName]));
-        $this->assertSame($view, $views[$viewName]);
-        $this->assertSame($view, $schema->getView($viewName));
+        self::assertArrayHasKey($viewName, $views);
+        self::assertSame($view, $views[$viewName]);
+        self::assertSame($view, $schema->getView($viewName));
     }
 
     public function testViewMatchingCaseInsensitive()
@@ -486,12 +486,12 @@ class SchemaTest extends TestCase
         $view = new View('Foo', 'SELECT * FROM `bar`');
 
         $schema = new Schema([], [], null, [], [$view]);
-        $this->assertTrue($schema->hasView('foo'));
-        $this->assertTrue($schema->hasView('FOO'));
+        self::assertTrue($schema->hasView('foo'));
+        self::assertTrue($schema->hasView('FOO'));
 
-        $this->assertSame($view, $schema->getView('FOO'));
-        $this->assertSame($view, $schema->getView('foo'));
-        $this->assertSame($view, $schema->getView('Foo'));
+        self::assertSame($view, $schema->getView('FOO'));
+        self::assertSame($view, $schema->getView('foo'));
+        self::assertSame($view, $schema->getView('Foo'));
     }
 
     /**
@@ -512,32 +512,32 @@ class SchemaTest extends TestCase
         $view     = new View($viewName, 'SELECT * FROM `bar`');
         $views    = [$view, $view];
 
-        $schema = new Schema([], [], null, [], $views);
+        new Schema([], [], null, [], $views);
     }
 
     public function testHasView()
     {
         $schema = new Schema();
 
-        $this->assertFalse($schema->hasView('foo'));
+        self::assertFalse($schema->hasView('foo'));
 
         $schema->createView('foo', 'SELECT * FROM `bar`');
 
-        $this->assertTrue($schema->hasView('foo'));
+        self::assertTrue($schema->hasView('foo'));
     }
 
     public function testCreatesView()
     {
         $schema = new Schema();
 
-        $this->assertFalse($schema->hasView('foo'));
+        self::assertFalse($schema->hasView('foo'));
 
         $view = $schema->createView('foo', 'SELECT * FROM `bar`');
 
-        $this->assertInstanceOf('Doctrine\DBAL\Schema\View', $view);
-        $this->assertEquals('foo', $view->getName());
-        $this->assertEquals('SELECT * FROM `bar`', $view->getSql());
-        $this->assertTrue($schema->hasView('foo'));
+        self::assertInstanceOf('Doctrine\DBAL\Schema\View', $view);
+        self::assertEquals('foo', $view->getName());
+        self::assertEquals('SELECT * FROM `bar`', $view->getSql());
+        self::assertTrue($schema->hasView('foo'));
     }
 
     public function testDropView()
@@ -545,11 +545,11 @@ class SchemaTest extends TestCase
         $schema = new Schema();
 
         $schema->dropView('foo');
-        $this->assertFalse($schema->hasView('foo'));
+        self::assertFalse($schema->hasView('foo'));
 
         $schema->createView('foo', 'SELECT * FROM `bar`');
 
         $schema->dropView('foo');
-        $this->assertFalse($schema->hasView('foo'));
+        self::assertFalse($schema->hasView('foo'));
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/ViewTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ViewTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\View;
+use Doctrine\Tests\DbalTestCase;
+
+class ViewTest extends DbalTestCase
+{
+    public function testComparision()
+    {
+        $view1 = new View('foo', 'bar');
+        $view2 = new View('foo', 'baz');
+
+        self::assertFalse($view1->isSameAs($view2));
+        self::assertTrue($view1->isSameAs($view1));
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/DropSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/DropSchemaSqlCollectorTest.php
@@ -6,7 +6,9 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\View;
 use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -29,7 +31,7 @@ class DropSchemaSqlCollectorTest extends TestCase
         $collector = new DropSchemaSqlCollector($platform);
 
         $platform->expects($this->exactly(2))
-            ->method('getDropForeignKeySQL');
+             ->method('getDropForeignKeySQL');
 
         $platform->expects($this->at(0))
             ->method('getDropForeignKeySQL')
@@ -82,5 +84,35 @@ class DropSchemaSqlCollectorTest extends TestCase
 
         $this->expectException(SchemaException::class);
         $collector->acceptForeignKey($this->getTableMock(), $this->getStubKeyConstraint(''));
+    }
+
+    public function testAcceptsView()
+    {
+        $platform = $this->getMockBuilder('Doctrine\DBAL\Platforms\AbstractPlatform')
+            ->setMethods(['getDropViewSQL'])
+            ->getMockForAbstractClass();
+
+        $collector = new DropSchemaSqlCollector($platform);
+
+        $view = $this->createViewMock();
+
+        $platform->expects($this->exactly(1))
+            ->method('getDropViewSQL');
+
+        $platform->expects($this->at(0))
+            ->method('getDropViewSQL');
+
+        $collector->acceptView($view);
+        $collector->getQueries();
+    }
+
+    /**
+     * @return View|MockObject
+     */
+    private function createViewMock()
+    {
+        return $this->getMockBuilder('Doctrine\DBAL\Schema\View')
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | Partially #1798

#### Summary

This PR adds ability to define views using schema manager. This is small rework of #2510

```php
$schema->createView('my_view', 'SELECT * FROM some_table');
if ($schema->hasView('my_view')) {
    $view = $schema->getView('my_view');
    $schema->dropView('my_view');    
}
```

 - [x] Base implementation
 - [ ] Update docs 