### PR TITLE
Use PSR-4 autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,10 @@
         "sort-packages": true
     },
     "autoload": {
-        "psr-0": { "Doctrine\\DBAL\\": "lib/" }
+        "psr-4": { "Doctrine\\DBAL\\": "lib/Doctrine/DBAL" }
     },
     "autoload-dev": {
-        "psr-0": { "Doctrine\\Tests\\": "tests/" }
+        "psr-4": { "Doctrine\\Tests\\": "tests/Doctrine/Tests" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

Use PSR-4 Composer autoloader (**only**). This does NOT change the directory structure in any way. We use PSR-4 autoloader in most Doctrine libraries already.

Related: https://github.com/doctrine/doctrine2/pull/1451 + #621