### PR TITLE
Fix getTruncateTableSQL for Sqlite platform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -558,7 +558,7 @@ class SqlitePlatform extends AbstractPlatform
         $tableIdentifier = new Identifier($tableName);
         $tableName = str_replace('.', '__', $tableIdentifier->getQuotedName($this));
 
-        return 'DELETE FROM ' . $tableName;
+        return 'DELETE FROM ' . $tableName . '; UPDATE SQLITE_SEQUENCE SET SEQ=0 WHERE NAME="' . $tableName . '";';
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes

#### Summary

Reset sequence when calling getTruncateTableSQL as if it was a real truncate.

Currently if you have a table with auto-increment primary key, the sequence is not reset when using the ORMPurger with ``PURGE_MODE_TRUNCATE`` for sqlite databases.

The behaviour was different in ``doctrine/dbal: 2.7.2`` because the keys where reset when calling only DELETE (as the field was not created with autoincrement). This have been changed by the following commit (which is BC BREAK) https://github.com/doctrine/dbal/commit/51358603bba352e46d56310125d68430342ed26a#diff-3fa09ba089913d40a1fbeb10b8cb8536
