### PR TITLE
Add Failing test using getTruncateTableSQL

### DIFF
--- a/.github/ISSUE_TEMPLATE/BC_Break.md
+++ b/.github/ISSUE_TEMPLATE/BC_Break.md
@@ -1,6 +1,6 @@
 ---
 name: 💥 BC Break
-about: Have you encountered an issue during upgrade? 💣
+about: Have you encountered an issue during an upgrade? 💣
 ---
 
 <!--
@@ -18,15 +18,15 @@ Before reporting a BC break, please consult the upgrading document to make sure 
 
 #### Summary
 
-<!-- Provide a summary desciribing the problem you are experiencing. -->
+<!-- Provide a summary describing the problem you are experiencing. -->
 
-#### Previous behavior
+#### Previous behaviour
 
-<!-- What was the previous (working) behavior? -->
+<!-- What was the previous (working) behaviour? -->
 
 #### Current behavior
 
-<!-- What is the current (broken) behavior? -->
+<!-- What is the current (broken) behaviour? -->
 
 #### How to reproduce
 

--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -14,11 +14,11 @@ about: Something is broken? 🔨
 
 #### Summary
 
-<!-- Provide a summary desciribing the problem you are experiencing. -->
+<!-- Provide a summary describing the problem you are experiencing. -->
 
 #### Current behavior
 
-<!-- What is the current (buggy) behavior? -->
+<!-- What is the current (buggy) behaviour? -->
 
 #### How to reproduce
 
@@ -28,7 +28,7 @@ If possible, also add a code snippet with relevant configuration, driver/platfor
 Adding a failing Unit or Functional Test would help us a lot - you can submit one in a Pull Request separately, referencing this bug report.
 -->
 
-#### Expected behavior
+#### Expected behaviour
 
-<!-- What was the expected (correct) behavior? -->
+<!-- What was the expected (correct) behaviour? -->
 

--- a/.github/ISSUE_TEMPLATE/Support_Question.md
+++ b/.github/ISSUE_TEMPLATE/Support_Question.md
@@ -10,7 +10,7 @@ about: Have a problem that you can't figure out? 🤔
 | Version     | x.y.z
 
 <!--
-Before asking question here, please try asking on Gitter or Slack first.
+Before asking a question here, please try asking on Gitter or Slack first.
 Find out more about Doctrine support channels here: https://www.doctrine-project.org/community/
 Keep in mind that GitHub is primarily an issue tracker.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@
 
 #### Summary
 
-<!-- Provide a summary your change. -->
+<!-- Provide a summary of your change. -->

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -38,7 +38,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    public const VERSION = '2.8.0-DEV';
+    public const VERSION = '2.8.0';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -38,7 +38,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    public const VERSION = '2.8.0';
+    public const VERSION = '2.8.1-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1523,21 +1523,21 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
      */
     public function testTruncatePrimaryKeyNoAutoIncrement()
     {
-        $table = new Table('test_pk_auto_increment');
+        $table = new Table('test_pk_no_auto_increment');
         $table->addColumn('id', 'integer');
         $table->addColumn('text', 'text');
         $table->setPrimaryKey(['id']);
         $this->_sm->dropAndCreateTable($table);
 
-        $this->_conn->insert('test_pk_auto_increment', ['text' => '1']);
+        $this->_conn->insert('test_pk_no_auto_increment', ['text' => '1']);
 
         // Get platform parameters
         $platform = $this->_conn->getDatabasePlatform();
         $this->_conn->executeUpdate($platform->getTruncateTableSQL($table->getName(), true));
 
-        $this->_conn->insert('test_pk_auto_increment', ['text' => '2']);
+        $this->_conn->insert('test_pk_no_auto_increment', ['text' => '2']);
 
-        $query = $this->_conn->query('SELECT id FROM test_pk_auto_increment WHERE text = "2"');
+        $query = $this->_conn->query('SELECT id FROM test_pk_no_auto_increment WHERE text = "2"');
         $query->execute();
         $lastUsedIdAfterTruncate = (int) $query->fetchColumn();
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

The test ``testTruncatePrimaryKeyAutoIncrement`` is currently failing with SQLITE because TRUNCATE doesn't exists with this platform. Using DELETE in replacement of TRUNCATE doesn't reset the PK with autoincrement. This issue happens on 2.8.x because of the merge of the following PR https://github.com/doctrine/dbal/commit/51358603bba352e46d56310125d68430342ed26a#diff-3fa09ba089913d40a1fbeb10b8cb8536

Before, all PK were created without autoincrement (by default rowid are automatically incremented in SQLITE if not specified explicitely when inserting data). On delete the rowid was reset so it was OK for this use case.

I'm not sure how to fix this issue because the best would be to reset the linked sequence, a bit like in this PR https://github.com/doctrine/dbal/pull/3243 but currently there is another side effect.

Maybe the best solution would be to revert the following 5135860 because autoincrement is not recommended (https://www.sqlite.org/autoinc.html) on SQLITE and by default the rowid automatically increments if not specified. Currently when you run a test suite (generally with sqlite) it fails because rowid is not reset between each unit tests when using the ORMPurger. So it's a big issue.
