### PR TITLE
Fix url resolution for master/slave connections

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -153,7 +153,17 @@ final class DriverManager
             $eventManager = new EventManager();
         }
 
-        $params = self::parseDatabaseUrl($params);
+        if (isset($params['master'])) {
+            $params['master'] = self::parseDatabaseUrl($params['master']);
+
+            if (isset($params['slaves'])) {
+                foreach ($params['slaves'] as $slaveName => $slaveParams) {
+                    $params['slaves'][$slaveName] = self::parseDatabaseUrl($slaveParams);
+                }
+            }
+        } else {
+            $params = self::parseDatabaseUrl($params);
+        }
 
         // check for existing pdo object
         if (isset($params['pdo']) && ! $params['pdo'] instanceof \PDO) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

When using url option for configuring master/slave connection, the url is never parsed and the connection parameters are not filled as they should.
