### PR TITLE
ResultStatement::fetchColumn() can return null if the result set is empty

### DIFF
--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -109,7 +109,7 @@ interface ResultStatement extends \Traversable
      *                         If no value is supplied, PDOStatement->fetchColumn()
      *                         fetches the first column.
      *
-     * @return string|boolean A single column in the next row of a result set, or FALSE if there are no more rows.
+     * @return string|boolean|null A single column in the next row of a result set, or FALSE if there are no more rows.
      */
     public function fetchColumn($columnIndex = 0);
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

For PHPStan to stop complaining when the result is compared against `null`, I added `null` to the return typehint of this method. It can return null when the result set is empty.