### PR TITLE
Replaced call_user_func_array() of a fixed method with the usage of variadic arguments

### DIFF
--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -27,7 +27,6 @@ use const DB2_CHAR;
 use const DB2_LONG;
 use const DB2_PARAM_IN;
 use function array_change_key_case;
-use function call_user_func_array;
 use function db2_bind_param;
 use function db2_execute;
 use function db2_fetch_array;

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -25,7 +25,6 @@ use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use function array_combine;
 use function array_fill;
-use function call_user_func_array;
 use function count;
 use function str_repeat;
 
@@ -172,7 +171,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
                     throw new MysqliException($this->_stmt->error, $this->_stmt->errno);
                 }
             } else {
-                if (!call_user_func_array([$this->_stmt, 'bind_param'], [$this->types] + $this->_bindedValues)) {
+                if (! $this->_stmt->bind_param($this->types, ...$this->_bindedValues)) {
                     throw new MysqliException($this->_stmt->error, $this->_stmt->sqlstate, $this->_stmt->errno);
                 }
             }
@@ -221,7 +220,7 @@ class MysqliStatement implements \IteratorAggregate, Statement
                 $refs[$key] =& $value;
             }
 
-            if (!call_user_func_array([$this->_stmt, 'bind_result'], $refs)) {
+            if (! $this->_stmt->bind_result(...$refs)) {
                 throw new MysqliException($this->_stmt->error, $this->_stmt->sqlstate, $this->_stmt->errno);
             }
         }
@@ -242,13 +241,12 @@ class MysqliStatement implements \IteratorAggregate, Statement
     {
         $params = [];
         $types = str_repeat('s', count($values));
-        $params[0] = $types;
 
         foreach ($values as &$v) {
             $params[] =& $v;
         }
 
-        return call_user_func_array([$this->_stmt, 'bind_param'], $params);
+        return $this->_stmt->bind_param($types, ...$params);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -26,7 +26,6 @@ use Doctrine\DBAL\ParameterType;
 use IteratorAggregate;
 use const SASQL_BOTH;
 use function array_key_exists;
-use function call_user_func_array;
 use function func_get_args;
 use function func_num_args;
 use function gettype;
@@ -280,7 +279,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
 
         switch ($fetchMode) {
             case FetchMode::CUSTOM_OBJECT:
-                while ($row = call_user_func_array([$this, 'fetch'], func_get_args())) {
+                while ($row = $this->fetch(...func_get_args())) {
                     $rows[] = $row;
                 }
                 break;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

The regular `$object->method(...$arguments)` syntax is cleaner and more friendly to SA.