### PR TITLE
Throw ConversionException when unserialization fail for array and object types

### DIFF
--- a/lib/Doctrine/DBAL/Types/ConversionException.php
+++ b/lib/Doctrine/DBAL/Types/ConversionException.php
@@ -120,4 +120,13 @@ class ConversionException extends \Doctrine\DBAL\DBALException
             $error
         ));
     }
+
+    public static function conversionFailedUnserialization(string $format, string $error) : self
+    {
+        return new self(sprintf(
+            "Could not convert database value to '%s' as an error was triggered by the unserialization: '%s'",
+            $format,
+            $error
+        ));
+    }
 }

--- a/lib/Doctrine/DBAL/Types/ObjectType.php
+++ b/lib/Doctrine/DBAL/Types/ObjectType.php
@@ -21,7 +21,9 @@ namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use function is_resource;
+use function restore_error_handler;
 use function serialize;
+use function set_error_handler;
 use function stream_get_contents;
 use function unserialize;
 
@@ -58,12 +60,16 @@ class ObjectType extends Type
         }
 
         $value = (is_resource($value)) ? stream_get_contents($value) : $value;
-        $val = unserialize($value);
-        if ($val === false && $value !== 'b:0;') {
-            throw ConversionException::conversionFailed($value, $this->getName());
-        }
 
-        return $val;
+        set_error_handler(function (int $code, string $message) : void {
+            throw ConversionException::conversionFailedUnserialization($this->getName(), $message);
+        });
+
+        try {
+            return unserialize($value);
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
@@ -5,9 +5,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
-use const E_ALL;
-use const E_STRICT;
-use function error_reporting;
 use function serialize;
 
 class ArrayTest extends \Doctrine\Tests\DbalTestCase
@@ -28,12 +25,6 @@ class ArrayTest extends \Doctrine\Tests\DbalTestCase
         $this->_type = Type::getType('array');
     }
 
-    protected function tearDown()
-    {
-        error_reporting(-1); // reactive all error levels
-    }
-
-
     public function testArrayConvertsToDatabaseValue()
     {
         self::assertInternalType(
@@ -52,8 +43,8 @@ class ArrayTest extends \Doctrine\Tests\DbalTestCase
 
     public function testConversionFailure()
     {
-        error_reporting( (E_ALL | E_STRICT) - \E_NOTICE );
         $this->expectException('Doctrine\DBAL\Types\ConversionException');
+        $this->expectExceptionMessage("Could not convert database value to 'array' as an error was triggered by the unserialization: 'unserialize(): Error at offset 0 of 7 bytes'");
         $this->_type->convertToPHPValue('abcdefg', $this->_platform);
     }
 

--- a/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
@@ -4,9 +4,6 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
-use const E_ALL;
-use const E_STRICT;
-use function error_reporting;
 use function serialize;
 
 class ObjectTest extends \Doctrine\Tests\DbalTestCase
@@ -27,11 +24,6 @@ class ObjectTest extends \Doctrine\Tests\DbalTestCase
         $this->_type = Type::getType('object');
     }
 
-    protected function tearDown()
-    {
-        error_reporting(-1); // reactive all error levels
-    }
-
     public function testObjectConvertsToDatabaseValue()
     {
         self::assertInternalType('string', $this->_type->convertToDatabaseValue(new \stdClass(), $this->_platform));
@@ -44,8 +36,8 @@ class ObjectTest extends \Doctrine\Tests\DbalTestCase
 
     public function testConversionFailure()
     {
-        error_reporting( (E_ALL | E_STRICT) - \E_NOTICE );
         $this->expectException('Doctrine\DBAL\Types\ConversionException');
+        $this->expectExceptionMessage("Could not convert database value to 'object' as an error was triggered by the unserialization: 'unserialize(): Error at offset 0 of 7 bytes'");
         $this->_type->convertToPHPValue('abcdefg', $this->_platform);
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| BC Break     | no

#### Summary

**Problem:** Converting invalid data with ArrayType/ObjectType throws PHP notice error.

**Solution:** inside convert method unserialize notice error can be suppressed since a proper exception (ConversionException) will be thrown right after that. No need to deal with error reporting.
