### PR TITLE
Remove Doctrine\DBAL\Types\Type::getDefaultLength()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK: `Doctrine\DBAL\Types\Type::getDefaultLength()` removed
+
+The `Doctrine\DBAL\Types\Type::getDefaultLength()` method has been removed as it served no purpose.
+
 ## BC BREAK: `Doctrine\DBAL\Types\Type::__toString()` removed
 
 Relying on string representation was discouraged and has been removed.

--- a/lib/Doctrine/DBAL/Types/StringType.php
+++ b/lib/Doctrine/DBAL/Types/StringType.php
@@ -22,14 +22,6 @@ class StringType extends Type
     /**
      * {@inheritdoc}
      */
-    public function getDefaultLength(AbstractPlatform $platform)
-    {
-        return $platform->getVarcharDefaultLength();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         return Type::STRING;

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -123,20 +123,6 @@ abstract class Type
     }
 
     /**
-     * Gets the default length of this type.
-     *
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     *
-     * @return int|null
-     *
-     * @todo Needed?
-     */
-    public function getDefaultLength(AbstractPlatform $platform)
-    {
-        return null;
-    }
-
-    /**
      * Gets the SQL declaration snippet for a field of this type.
      *
      * @param array                                     $fieldDeclaration The field declaration.

--- a/tests/Doctrine/Tests/DBAL/Types/StringTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/StringTest.php
@@ -28,11 +28,6 @@ class StringTest extends \Doctrine\Tests\DbalTestCase
         self::assertEquals("DUMMYVARCHAR()", $this->_type->getSqlDeclaration(array(), $this->_platform));
     }
 
-    public function testReturnsDefaultLengthFromPlatformVarchar()
-    {
-        self::assertEquals(255, $this->_type->getDefaultLength($this->_platform));
-    }
-
     public function testConvertToPHPValue()
     {
         self::assertInternalType("string", $this->_type->convertToPHPValue("foo", $this->_platform));


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

#### Summary

Not used by DBAL itself, only overridden by StringType. Some other types (DateIntervalType) hardcode limits in `getSQLDeclaration()` directly.

1st step towards #2841 (_Refactoring type system_).