### PR TITLE
Remove Doctrine\DBAL\Types\Type::__toString()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK: `Doctrine\DBAL\Types\Type::__toString()` removed
+
+Relying on string representation was discouraged and has been removed.
+
 ## BC BREAK: The `NULL` value of `$offset` in LIMIT queries is not allowed
 
 The `NULL` value of the `$offset` argument in `AbstractPlatform::(do)?ModifyLimitQuery()` methods is no longer allowed. The absence of the offset should be indicated with a `0` which is now the default value.

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -256,16 +256,6 @@ abstract class Type
     }
 
     /**
-     * @return string
-     */
-    public function __toString()
-    {
-        $e = explode('\\', get_class($this));
-
-        return str_replace('Type', '', end($e));
-    }
-
-    /**
      * Does working with this column require SQL conversion functions?
      *
      * This is a metadata function that is required for example in the ORM.


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

#### Summary

Relying on __toString() internally was already removed in #2835, it's not obsolete and untested API.

1st step towards #2841 (_Refactoring type system_).