### PR TITLE
SQLSRV / MSSQL / TSQL - Fix default CLOB type from varchar(max) to nchar(max) & nvarchar(max)

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2005Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2005Platform.php
@@ -48,7 +48,13 @@ class SQLServer2005Platform extends SQLServerPlatform
      */
     public function getClobTypeDeclarationSQL(array $field)
     {
-        return 'VARCHAR(MAX)';
+        $fixed = $field['fixed'] ?? false;
+
+        if ($fixed) {
+            return 'NCHAR(MAX)';
+        }
+
+        return 'NVARCHAR(MAX)';
     }
 
     /**


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #2323, #1182, #1351

#### Summary

Modifies SQL Server (MSSQL, TSQL) VARCHAR column type to be NVARCHAR, to better handle unicode.

Initial breaking change: #451.
