### PR TITLE
Add test case for issue #2880

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1281,6 +1281,26 @@ class SchemaManagerFunctionalTestCase extends \Doctrine\Tests\DbalFunctionalTest
     }
 
     /**
+     * @group ????
+     */
+    public function testComparatorShouldReturnFalseWhenLegacyJsonArrayColumnHasCommentAndHasBeenRemoved() : void
+    {
+        $table = new Table('json_array_test');
+        $table->addColumn('parameters', 'json_array');
+
+        $this->_sm->createTable($table);
+
+        $table->changeColumn('parameters', [
+            'type' => Type::STRING
+        ]);
+
+        $comparator = new Comparator();
+        $tableDiff  = $comparator->diffTable($this->_sm->listTableDetails('json_array_test'), $table);
+
+        self::assertFalse($tableDiff);
+    }
+
+    /**
      * @group 2782
      * @group 6654
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2880

#### Summary

Adds a test case to cover specific situation : adding a `json_array` column to a table, executing changes, changing the `json_array` to a `string` still show a schema diff.
