### PR TITLE
Force Sequence::$initialValue type

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Sequence.php
+++ b/lib/Doctrine/DBAL/Schema/Sequence.php
@@ -57,8 +57,8 @@ class Sequence extends AbstractAsset
     public function __construct($name, $allocationSize = 1, $initialValue = 1, $cache = null)
     {
         $this->_setName($name);
-        $this->allocationSize = is_numeric($allocationSize) ? $allocationSize : 1;
-        $this->initialValue   = is_numeric($initialValue) ? $initialValue : 1;
+        $this->setAllocationSize($allocationSize);
+        $this->setInitialValue($initialValue);
         $this->cache          = $cache;
     }
 
@@ -93,7 +93,7 @@ class Sequence extends AbstractAsset
      */
     public function setAllocationSize($allocationSize)
     {
-        $this->allocationSize = is_numeric($allocationSize) ? $allocationSize : 1;
+        $this->allocationSize = is_numeric($allocationSize) ? (int) $allocationSize : 1;
 
         return $this;
     }
@@ -105,7 +105,7 @@ class Sequence extends AbstractAsset
      */
     public function setInitialValue($initialValue)
     {
-        $this->initialValue = is_numeric($initialValue) ? $initialValue : 1;
+        $this->initialValue = is_numeric($initialValue) ? (int) $initialValue : 1;
 
         return $this;
     }

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -435,11 +435,13 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $seq1 = new Sequence('foo', 1, 1);
         $seq2 = new Sequence('foo', 1, 2);
         $seq3 = new Sequence('foo', 2, 1);
+        $seq4 = new Sequence('foo', '1', '1');
 
         $c = new Comparator();
 
         self::assertTrue($c->diffSequence($seq1, $seq2));
         self::assertTrue($c->diffSequence($seq1, $seq3));
+        self::assertFalse($c->diffSequence($seq1, $seq4));
     }
 
     public function testRemovedSequence()


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3267

#### Summary
`Schema\Sequence`:  

 - Deduplicated setters code
 - Forced int type for numeric values
