### PR TITLE
Fix constraint name / Index name / Primary Key name not being added to SQL

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -451,6 +451,42 @@ class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
         self::assertFalse($tableIndexes['test_composite_idx']->isPrimary());
     }
 
+    public function testListTableWithUnnamedUniqueIndexCanBeCreated() : void
+    {
+        $table = $this->getTestCompositeTable('list_table_indexes_test');
+        $table->addUniqueIndex(['test'], null);
+
+        $this->schemaManager->dropAndCreateTable($table);
+
+        $tableIndexes = $this->schemaManager->listTableIndexes('list_table_indexes_test');
+
+        self::assertCount(2, $tableIndexes);
+
+        self::assertArrayHasKey('uniq_ee805592d87f7e0c', $tableIndexes);
+        self::assertEquals('uniq_ee805592d87f7e0c', strtolower($tableIndexes['uniq_ee805592d87f7e0c']->getName()));
+        self::assertEquals(['test'], array_map('strtolower', $tableIndexes['uniq_ee805592d87f7e0c']->getColumns()));
+        self::assertTrue($tableIndexes['uniq_ee805592d87f7e0c']->isUnique());
+        self::assertFalse($tableIndexes['uniq_ee805592d87f7e0c']->isPrimary());
+    }
+
+    public function testListTableWithUnnamedCompositeIndexCanBeCreated() : void
+    {
+        $table = $this->getTestCompositeTable('list_table_indexes_test');
+        $table->addIndex(['id', 'test'], null);
+
+        $this->schemaManager->dropAndCreateTable($table);
+
+        $tableIndexes = $this->schemaManager->listTableIndexes('list_table_indexes_test');
+
+        self::assertCount(2, $tableIndexes);
+
+        self::assertArrayHasKey('idx_ee805592bf396750d87f7e0c', $tableIndexes);
+        self::assertEquals('idx_ee805592bf396750d87f7e0c', strtolower($tableIndexes['idx_ee805592bf396750d87f7e0c']->getName()));
+        self::assertEquals(['id', 'test'], array_map('strtolower', $tableIndexes['idx_ee805592bf396750d87f7e0c']->getColumns()));
+        self::assertFalse($tableIndexes['idx_ee805592bf396750d87f7e0c']->isUnique());
+        self::assertFalse($tableIndexes['idx_ee805592bf396750d87f7e0c']->isPrimary());
+    }
+
     public function testDropAndCreateIndex()
     {
         $table = $this->getTestTable('test_create_index');

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -1513,4 +1513,12 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
             $this->platform->modifyLimitQuery($query, null, 0)
         );
     }
+
+    // TODO: These abstract functions can be uncommented once PlatformTestCases have correct inheritance
+//    abstract public function testCreateUnnamedPrimaryKey(): void;
+//    abstract public function testCreateUnnamedNonPrimaryIndex(): void;
+//    abstract public function testCreateUnnamedConstraintName(): void;
+//    abstract public function testCreateNamedPrimaryKey(): void;
+//    abstract public function testCreateNamedNonPrimaryIndex(): void;
+//    abstract public function testCreateNamedConstraintName(): void;
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -1028,6 +1029,85 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
             $this->platform->getCloseActiveDatabaseConnectionsSQL("Foo'Bar\\"),
             '',
             true
+        );
+    }
+
+    public function testCreateUnnamedPrimaryKey() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->setPrimaryKey(['id']);
+
+        self::assertEquals(
+            ['CREATE TABLE test (id INT NOT NULL, name VARCHAR(50) NOT NULL, PRIMARY KEY(id))'],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateUnnamedNonPrimaryIndex() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->addIndex(['name']);
+
+        self::assertEquals(
+            [
+                'CREATE TABLE test (id INT NOT NULL, name VARCHAR(50) NOT NULL)',
+                'CREATE INDEX IDX_D87F7E0C5E237E06 ON test (name)',
+            ],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateUnnamedConstraintName() : void
+    {
+        self::assertEquals(
+            'ALTER TABLE foo ADD PRIMARY KEY (a, b)',
+            $this->platform->getCreatePrimaryKeySQL(
+                new Index(null, ['a', 'b'], false, false),
+                'foo'
+            )
+        );
+    }
+
+    public function testCreateNamedPrimaryKey() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->setPrimaryKey(['id'], 'primary_key_name');
+
+        self::assertEquals(
+            ['CREATE TABLE test (id INT NOT NULL, PRIMARY KEY(id))'],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateNamedNonPrimaryIndex() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->addIndex(['name'], 'named_index');
+
+        self::assertEquals(
+            [
+                'CREATE TABLE test (id INT NOT NULL, name VARCHAR(50) NOT NULL)',
+                'CREATE INDEX named_index ON test (name)',
+            ],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateNamedConstraintName() : void
+    {
+        self::assertEquals(
+            'ALTER TABLE foo ADD CONSTRAINT constraint_name PRIMARY KEY (a, b)',
+            $this->platform->getCreatePrimaryKeySQL(
+                new Index('constraint_name', ['a', 'b']),
+                'foo'
+            )
         );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MariaDb1027PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MariaDb1027PlatformTest.php
@@ -3,6 +3,8 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 
 class MariaDb1027PlatformTest extends AbstractMySQLPlatformTestCase
@@ -45,5 +47,78 @@ class MariaDb1027PlatformTest extends AbstractMySQLPlatformTestCase
     public function testDoesNotPropagateDefaultValuesForUnsupportedColumnTypes() : void
     {
         $this->markTestSkipped('MariaDB102Platform support propagation of default values for BLOB and TEXT columns');
+    }
+
+    public function testCreateUnnamedPrimaryKey() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->setPrimaryKey(['id']);
+
+        self::assertEquals(
+            ['CREATE TABLE test (id INT NOT NULL, name VARCHAR(50) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB'],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateUnnamedNonPrimaryIndex() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->addIndex(['name']);
+
+        self::assertEquals(
+            ['CREATE TABLE test (id INT NOT NULL, name VARCHAR(50) NOT NULL, INDEX IDX_D87F7E0C5E237E06 (name)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB'],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateUnnamedConstraintName() : void
+    {
+        self::assertEquals(
+            'ALTER TABLE foo ADD PRIMARY KEY (a, b)',
+            $this->platform->getCreatePrimaryKeySQL(
+                new Index(null, ['a', 'b'], false, false),
+                'foo'
+            )
+        );
+    }
+
+    public function testCreateNamedPrimaryKey() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->setPrimaryKey(['id'], 'primary_key_name');
+
+        self::assertEquals(
+            ['CREATE TABLE test (id INT NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB'],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateNamedNonPrimaryIndex() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->addIndex(['name'], 'named_index');
+
+        self::assertEquals(
+            ['CREATE TABLE test (id INT NOT NULL, name VARCHAR(50) NOT NULL, INDEX named_index (name)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB'],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateNamedConstraintName() : void
+    {
+        self::assertEquals(
+            'ALTER TABLE foo ADD CONSTRAINT constraint_name PRIMARY KEY (a, b)',
+            $this->platform->getCreatePrimaryKeySQL(
+                new Index('constraint_name', ['a', 'b']),
+                'foo'
+            )
+        );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -916,5 +917,84 @@ SQL
     public function testQuotesDatabaseNameInListTableColumnsSQL()
     {
         self::assertContains("'Foo''Bar\\'", $this->platform->getListTableColumnsSQL('foo_table', "Foo'Bar\\"), '', true);
+    }
+
+    public function testCreateUnnamedPrimaryKey() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->setPrimaryKey(['id']);
+
+        self::assertEquals(
+            ['CREATE TABLE test (id NUMBER(10) NOT NULL, name VARCHAR2(50) NOT NULL, PRIMARY KEY(id))'],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateUnnamedNonPrimaryIndex() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->addIndex(['name']);
+
+        self::assertEquals(
+            [
+                'CREATE TABLE test (id NUMBER(10) NOT NULL, name VARCHAR2(50) NOT NULL)',
+                'CREATE INDEX IDX_D87F7E0C5E237E06 ON test (name)',
+            ],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateUnnamedConstraintName() : void
+    {
+        self::assertEquals(
+            'ALTER TABLE foo ADD PRIMARY KEY (a, b)',
+            $this->platform->getCreatePrimaryKeySQL(
+                new Index(null, ['a', 'b'], false, false),
+                'foo'
+            )
+        );
+    }
+
+    public function testCreateNamedPrimaryKey() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->setPrimaryKey(['id'], 'primary_key_name');
+
+        self::assertEquals(
+            ['CREATE TABLE test (id NUMBER(10) NOT NULL, PRIMARY KEY(id))'],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateNamedNonPrimaryIndex() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->addIndex(['name'], 'named_index');
+
+        self::assertEquals(
+            [
+                'CREATE TABLE test (id NUMBER(10) NOT NULL, name VARCHAR2(50) NOT NULL)',
+                'CREATE INDEX named_index ON test (name)',
+            ],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateNamedConstraintName() : void
+    {
+        self::assertEquals(
+            'ALTER TABLE foo ADD CONSTRAINT constraint_name PRIMARY KEY (a, b)',
+            $this->platform->getCreatePrimaryKeySQL(
+                new Index('constraint_name', ['a', 'b']),
+                'foo'
+            )
+        );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL92PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL92PlatformTest.php
@@ -3,6 +3,8 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\PostgreSQL92Platform;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 
 class PostgreSQL92PlatformTest extends AbstractPostgreSqlPlatformTestCase
@@ -66,6 +68,85 @@ class PostgreSQL92PlatformTest extends AbstractPostgreSqlPlatformTestCase
         self::assertSame(
             "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'foo'",
             $this->platform->getCloseActiveDatabaseConnectionsSQL('foo')
+        );
+    }
+
+    public function testCreateUnnamedPrimaryKey() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->setPrimaryKey(['id']);
+
+        self::assertEquals(
+            ['CREATE TABLE test (id INT NOT NULL, name VARCHAR(50) NOT NULL, PRIMARY KEY(id))'],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateUnnamedNonPrimaryIndex() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->addIndex(['name']);
+
+        self::assertEquals(
+            [
+                'CREATE TABLE test (id INT NOT NULL, name VARCHAR(50) NOT NULL)',
+                'CREATE INDEX IDX_D87F7E0C5E237E06 ON test (name)',
+            ],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateUnnamedConstraintName() : void
+    {
+        self::assertEquals(
+            'ALTER TABLE foo ADD PRIMARY KEY (a, b)',
+            $this->platform->getCreatePrimaryKeySQL(
+                new Index(null, ['a', 'b'], false, false),
+                'foo'
+            )
+        );
+    }
+
+    public function testCreateNamedPrimaryKey() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->setPrimaryKey(['id'], 'primary_key_name');
+
+        self::assertEquals(
+            ['CREATE TABLE test (id INT NOT NULL, PRIMARY KEY(id))'],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateNamedNonPrimaryIndex() : void
+    {
+        $table = new Table('test');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->addIndex(['name'], 'named_index');
+
+        self::assertEquals(
+            [
+                'CREATE TABLE test (id INT NOT NULL, name VARCHAR(50) NOT NULL)',
+                'CREATE INDEX named_index ON test (name)',
+            ],
+            $this->platform->getCreateTableSQL($table)
+        );
+    }
+
+    public function testCreateNamedConstraintName() : void
+    {
+        self::assertEquals(
+            'ALTER TABLE foo ADD CONSTRAINT constraint_name PRIMARY KEY (a, b)',
+            $this->platform->getCreatePrimaryKeySQL(
+                new Index('constraint_name', ['a', 'b']),
+                'foo'
+            )
         );
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

When adding a named primary key to a table, or a named primary key directly to a column, the name was not being outputted when DBAL generated the SQL.


