### PR TITLE
Lost parameters: wrong ESCAPED_BRACKET_QUOTED_TEXT

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -14,6 +14,7 @@ use function is_int;
 use function key;
 use function ksort;
 use function preg_match_all;
+use function sprintf;
 use function strlen;
 use function strpos;
 use function substr;
@@ -199,11 +200,13 @@ class SQLParserUtils
      */
     private static function getUnquotedStatementFragments($statement)
     {
-        $literal = self::ESCAPED_SINGLE_QUOTED_TEXT . '|' .
-                   self::ESCAPED_DOUBLE_QUOTED_TEXT . '|' .
-                   self::ESCAPED_BACKTICK_QUOTED_TEXT . '|' .
-                   self::ESCAPED_BRACKET_QUOTED_TEXT;
-        preg_match_all('/([^\'"`\[]+)(?:' . $literal . ')?/s', $statement, $fragments, PREG_OFFSET_CAPTURE);
+        $literal    = self::ESCAPED_SINGLE_QUOTED_TEXT . '|' .
+            self::ESCAPED_DOUBLE_QUOTED_TEXT . '|' .
+            self::ESCAPED_BACKTICK_QUOTED_TEXT . '|' .
+            self::ESCAPED_BRACKET_QUOTED_TEXT;
+        $expression = sprintf('/((.+(?i:ARRAY)\\[.+\\])|([^\'"`\\[]+))(?:%s)?/s', $literal);
+
+        preg_match_all($expression, $statement, $fragments, PREG_OFFSET_CAPTURE);
 
         return $fragments[1];
     }

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -59,6 +59,10 @@ class SQLParserUtilsTest extends DbalTestCase
             ['SELECT [d.ns:col_name] FROM my_table d WHERE [d.date] >= :param1', false, [57 => 'param1']], // Ticket DBAL-552
             ['SELECT * FROM foo WHERE jsonb_exists_any(foo.bar, ARRAY[:foo])', false, [56 => 'foo']], // Ticket GH-2295
             ['SELECT * FROM foo WHERE jsonb_exists_any(foo.bar, array[:foo])', false, [56 => 'foo']],
+            ['SELECT table.field1, ARRAY[\'3\'] FROM schema.table table WHERE table.f1 = :foo AND ARRAY[\'3\']', false, [73 => 'foo']],
+            ['SELECT table.field1, ARRAY[\'3\']::integer[] FROM schema.table table WHERE table.f1 = :foo AND ARRAY[\'3\']::integer[]', false, [84 => 'foo']],
+            ['SELECT table.field1, ARRAY[:foo] FROM schema.table table WHERE table.f1 = :bar AND ARRAY[\'3\']', false, [27 => 'foo', 74 => 'bar']],
+            ['SELECT table.field1, ARRAY[:foo]::integer[] FROM schema.table table WHERE table.f1 = :bar AND ARRAY[\'3\']::integer[]', false, [27 => 'foo', 85 => 'bar']],
             [
                 <<<'SQLDATA'
 SELECT * FROM foo WHERE 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #3140 

#### Summary

The first capturing group of the parser regex was stopping from the moment it would find a `[` character. I expanded the original capturing group to include `ARRAY[.*]` as a capturable expression.