### PR TITLE
[Docs] wrong charset in mysql example

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -66,12 +66,12 @@ For example, to connect to a "foo" MySQL DB using the ``pdo_mysql``
 driver on localhost port 4486 with the charset set to UTF-8, you
 would use the following URL::
 
-    mysql://localhost:4486/foo?charset=UTF-8
+    mysql://localhost:4486/foo?charset=utf8
 
 This is identical to the following connection string using the
 full driver name::
 
-    pdo-mysql://localhost:4486/foo?charset=UTF-8
+    pdo-mysql://localhost:4486/foo?charset=utf8
 
 If you wanted to use the ``drizzle_pdo__mysql`` driver instead::
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     |  no

#### Summary

I think the name of the UTF-8 Charset in mysql is utf8 not UTF-8, right?