### PR TITLE
MariaDB improvements, support 10.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -180,6 +180,18 @@ jobs:
         mariadb: 10.2
 
     - stage: Test
+      php: 7.2
+      env: DB=mariadb MARIADB_VERSION=10.3
+      addons:
+          mariadb: 10.3
+
+    - stage: Test
+      php: 7.2
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.3
+      addons:
+          mariadb: 10.3
+
+    - stage: Test
       php: 7.1
       env: DB=pgsql POSTGRESQL_VERSION=9.2 COVERAGE=yes
       services:

--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -37,6 +37,11 @@ MySQL
 -  ``MySQL57Platform`` for version 5.7 (5.7.9 GA) and above.
 -  ``MySQL80Platform`` for version 8.0 (8.0 GA) and above.
 
+MariaDB
+^^^^^
+
+-  ``MariaDb1027Platform`` for version 10.2 (10.2.7 GA) and above.
+
 Oracle
 ^^^^^^
 

--- a/lib/Doctrine/DBAL/Platforms/MariaDb1027Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MariaDb1027Platform.php
@@ -24,21 +24,13 @@ use Doctrine\DBAL\Types\Type;
 /**
  * Provides the behavior, features and SQL dialect of the MariaDB 10.2 (10.2.7 GA) database platform.
  *
- * Note: Should not be used with versions prior ro 10.2.7.
+ * Note: Should not be used with versions prior to 10.2.7.
  *
  * @author Vanvelthem Sébastien
  * @link   www.doctrine-project.org
  */
 final class MariaDb1027Platform extends MySqlPlatform
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function hasNativeJsonType() : bool
-    {
-        return false;
-    }
-
     /**
      * {@inheritdoc}
      *

--- a/tests/Doctrine/Tests/DBAL/Platforms/MariaDb1027PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MariaDb1027PlatformTest.php
@@ -3,8 +3,6 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
-use Doctrine\DBAL\Schema\Comparator;
-use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 
 class MariaDb1027PlatformTest extends AbstractMySQLPlatformTestCase


### PR DESCRIPTION
Support for MariaDB 10.3+

### **Supported Reserved Keywords List Improvements:** (https://mariadb.com/kb/en/library/reserved-words/)

- [x] ~~Remove unsupported reserved keywords by MariaDB 10.2.~~
- [x] ~~Support for MariaDB 10.3 reserved keywords.~~
- [x] Added MariaDB 10.3 in travis (both pdo_mysql and mysqli)

### Native JSON Support (https://github.com/doctrine/dbal/issues/3202) ?

MariaDB still doesn't have native support for the JSON type. I mean that it still an alias for the LONGTEXT type: https://mariadb.com/kb/en/library/json-data-type/

So In fact it still doesn't support a native JSON. Do we need to mark it as native and replace LONGTEXT via JSON ?

### Work In Progress
Please fill free to let me know what I missed or may miss.