### PR TITLE
Remove old comment from MysqliStatement

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -42,8 +42,6 @@ class MysqliStatement implements \IteratorAggregate, Statement
         ParameterType::BOOLEAN      => 'i',
         ParameterType::NULL         => 's',
         ParameterType::INTEGER      => 'i',
-
-        // TODO Support LOB bigger then max package size
         ParameterType::LARGE_OBJECT => 's',
     ];
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

As discussed in #3217 (see https://github.com/doctrine/dbal/pull/3217#issuecomment-419673323 in particular), there is no way in MySQL to get around the `max_allowed_packet` limitation.