### PR TITLE
Fix executing insert() with empty data

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -785,7 +785,7 @@ class Connection implements DriverConnection
     public function insert($tableExpression, array $data, array $types = [])
     {
         if (empty($data)) {
-            return $this->executeUpdate('INSERT INTO ' . $tableExpression . ' ()' . ' VALUES ()');
+            return 0;
         }
 
         $columns = [];

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -324,15 +324,11 @@ class ConnectionTest extends \Doctrine\Tests\DbalTestCase
         self::assertFalse($conn->isTransactionActive());
     }
 
-    public function testEmptyInsert()
+    public function testEmptyInsert() : void
     {
         $conn = $this->getExecuteUpdateMockConnection();
 
-        $conn->expects($this->once())
-            ->method('executeUpdate')
-            ->with('INSERT INTO footable () VALUES ()');
-
-        $conn->insert('footable', array());
+        self::assertSame(0, $conn->insert('footable', []));
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Before this change it run query with invalid syntax. Now `insert()` with empty data returns 0 rows.
