### PR TITLE
Fix Fetch mode query in MasterSlaveConnection

### DIFF
--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -354,6 +354,8 @@ class MasterSlaveConnection extends Connection
 
         $statement = $this->_conn->query(...$args);
 
+        $statement->setFetchMode($this->defaultFetchMode);
+
         if ($logger) {
             $logger->stopQuery();
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
+use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Table;
@@ -188,5 +189,55 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
 
         $conn->connect('master');
         self::assertTrue($conn->isConnectedToMaster());
+    }
+
+    public function testQueryOnMaster()
+    {
+        $conn = $this->createMasterSlaveConnection();
+
+        $query = 'SELECT count(*) as num FROM master_slave_table';
+
+        $statement = $conn->query($query);
+
+        self::assertInstanceOf(Statement::class, $statement);
+
+        //Query must be executed only on Master
+        self::assertTrue($conn->isConnectedToMaster());
+
+        $data = $statement->fetchAll();
+
+        //Default fetchmode is FetchMode::ASSOCIATIVE
+        self::assertArrayHasKey(0, $data);
+        self::assertArrayHasKey('num', $data[0]);
+
+        //Could be set in other fetchmodes
+        self::assertArrayNotHasKey(0, $data[0]);
+        self::assertEquals(1, $data[0]['num']);
+    }
+
+    public function testQueryOnSlave()
+    {
+        $conn = $this->createMasterSlaveConnection();
+        $conn->connect('slave');
+
+        $query = 'SELECT count(*) as num FROM master_slave_table';
+
+        $statement = $conn->query($query);
+
+        self::assertInstanceOf(Statement::class, $statement);
+
+        //Query must be executed only on Master, even when we connect to the slave
+        self::assertTrue($conn->isConnectedToMaster());
+
+        $data = $statement->fetchAll();
+
+        //Default fetchmode is FetchMode::ASSOCIATIVE
+        self::assertArrayHasKey(0, $data);
+        self::assertArrayHasKey('num', $data[0]);
+
+        //Could be set in other fetchmodes
+        self::assertArrayNotHasKey(0, $data[0]);
+
+        self::assertEquals(1, $data[0]['num']);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

The `Doctrine\DBAL\Connections\MasterSlaveConnection` class doesn't set the default fetchmode when using die `query()` method.

The issue came up when we were migrating a normal connection to master/slave. First we got a FETCH_ASSOC and after the config change we had FETCH_BOTH.