### PR TITLE
Implement {Configuration#getSchemaAssetsFilter}

### DIFF
--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -219,18 +219,12 @@ abstract class AbstractSchemaManager
      */
     protected function filterAssetNames($assetNames)
     {
-        $filterExpr = $this->getFilterSchemaAssetsExpression();
-        if (! $filterExpr) {
+        $filter = $this->_conn->getConfiguration()->getSchemaAssetsFilter();
+        if (! $filter) {
             return $assetNames;
         }
 
-        return array_values(
-            array_filter($assetNames, static function ($assetName) use ($filterExpr) {
-                $assetName = $assetName instanceof AbstractAsset ? $assetName->getName() : $assetName;
-
-                return preg_match($filterExpr, $assetName);
-            })
-        );
+        return array_values(array_filter($assetNames, $filter));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
+use function in_array;
 
 /**
  * @covers \Doctrine\DBAL\Schema\DB2SchemaManager
@@ -59,5 +60,140 @@ final class DB2SchemaManagerTest extends TestCase
             ],
             $this->manager->listTableNames()
         );
+    }
+
+    /**
+     * @return void
+     *
+     * @group DBAL-2701
+     */
+    public function testAssetFilteringSetsACallable()
+    {
+        $filterExpression = '/^(?!T_)/';
+        $this->conn->getConfiguration()->setFilterSchemaAssetsExpression($filterExpression);
+        $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue([
+            ['name' => 'FOO'],
+            ['name' => 'T_FOO'],
+            ['name' => 'BAR'],
+            ['name' => 'T_BAR'],
+        ]));
+
+        self::assertSame(
+            [
+                'FOO',
+                'BAR',
+            ],
+            $this->manager->listTableNames()
+        );
+
+        $callable = $this->conn->getConfiguration()->getSchemaAssetsFilter();
+        $this->assertInternalType('callable', $callable);
+
+        // BC check: Test that regexp expression is still preserved & accessible.
+        $this->assertEquals($filterExpression, $this->conn->getConfiguration()->getFilterSchemaAssetsExpression());
+    }
+
+    /**
+     * @return void
+     */
+    public function testListTableNamesFiltersAssetNamesCorrectlyWithCallable()
+    {
+        $accepted = ['T_FOO', 'T_BAR'];
+        $this->conn->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) use ($accepted) {
+            return in_array($assetName, $accepted);
+        });
+        $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue([
+            ['name' => 'FOO'],
+            ['name' => 'T_FOO'],
+            ['name' => 'BAR'],
+            ['name' => 'T_BAR'],
+        ]));
+
+        self::assertSame(
+            [
+                'T_FOO',
+                'T_BAR',
+            ],
+            $this->manager->listTableNames()
+        );
+
+        $this->assertNull($this->conn->getConfiguration()->getFilterSchemaAssetsExpression());
+    }
+
+    /**
+     * @return void
+     */
+    public function testSettingNullExpressionWillResetCallable()
+    {
+        $accepted = ['T_FOO', 'T_BAR'];
+        $this->conn->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) use ($accepted) {
+            return in_array($assetName, $accepted);
+        });
+        $this->conn->expects($this->atLeastOnce())->method('fetchAll')->will($this->returnValue([
+            ['name' => 'FOO'],
+            ['name' => 'T_FOO'],
+            ['name' => 'BAR'],
+            ['name' => 'T_BAR'],
+        ]));
+
+        self::assertSame(
+            [
+                'T_FOO',
+                'T_BAR',
+            ],
+            $this->manager->listTableNames()
+        );
+
+        $this->conn->getConfiguration()->setFilterSchemaAssetsExpression(null);
+
+        self::assertSame(
+            [
+                'FOO',
+                'T_FOO',
+                'BAR',
+                'T_BAR',
+            ],
+            $this->manager->listTableNames()
+        );
+
+        $this->assertNull($this->conn->getConfiguration()->getSchemaAssetsFilter());
+    }
+
+    /**
+     * @return void
+     */
+    public function testSettingNullAsCallableClearsExpression()
+    {
+        $filterExpression = '/^(?!T_)/';
+        $this->conn->getConfiguration()->setFilterSchemaAssetsExpression($filterExpression);
+
+        $this->conn->expects($this->exactly(2))->method('fetchAll')->will($this->returnValue([
+            ['name' => 'FOO'],
+            ['name' => 'T_FOO'],
+            ['name' => 'BAR'],
+            ['name' => 'T_BAR'],
+        ]));
+
+        self::assertSame(
+            [
+                'FOO',
+                'BAR',
+            ],
+            $this->manager->listTableNames()
+        );
+
+        $this->conn->getConfiguration()->setSchemaAssetsFilter(null);
+
+        self::assertSame(
+            [
+                'FOO',
+                'T_FOO',
+                'BAR',
+                'T_BAR',
+            ],
+            $this->manager->listTableNames()
+        );
+
+        $this->assertNull($this->conn->getConfiguration()->getFilterSchemaAssetsExpression());
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #3196

#### Summary

Gives ability to specify a callable to use for filtering schemas by potentially something other than regular expressions. Implements what's laid out by @morozov in his comment: https://github.com/doctrine/dbal/issues/3196#issuecomment-399691227

* [x] Feature implementation
* [x] New tests for the feature
* [x] Pass existing tests