### PR TITLE
Ensuring correct ALTER TABLE statement for creation of an AUTO INCREMENT column as new PRIMARY KEY

### DIFF
--- a/.github/ISSUE_TEMPLATE/BC_Break.md
+++ b/.github/ISSUE_TEMPLATE/BC_Break.md
@@ -1,6 +1,6 @@
 ---
 name: 💥 BC Break
-about: Have you encountered an issue during upgrade? 💣
+about: Have you encountered an issue during an upgrade? 💣
 ---
 
 <!--
@@ -18,15 +18,15 @@ Before reporting a BC break, please consult the upgrading document to make sure 
 
 #### Summary
 
-<!-- Provide a summary desciribing the problem you are experiencing. -->
+<!-- Provide a summary describing the problem you are experiencing. -->
 
-#### Previous behavior
+#### Previous behaviour
 
-<!-- What was the previous (working) behavior? -->
+<!-- What was the previous (working) behaviour? -->
 
 #### Current behavior
 
-<!-- What is the current (broken) behavior? -->
+<!-- What is the current (broken) behaviour? -->
 
 #### How to reproduce
 

--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -14,11 +14,11 @@ about: Something is broken? 🔨
 
 #### Summary
 
-<!-- Provide a summary desciribing the problem you are experiencing. -->
+<!-- Provide a summary describing the problem you are experiencing. -->
 
 #### Current behavior
 
-<!-- What is the current (buggy) behavior? -->
+<!-- What is the current (buggy) behaviour? -->
 
 #### How to reproduce
 
@@ -28,7 +28,7 @@ If possible, also add a code snippet with relevant configuration, driver/platfor
 Adding a failing Unit or Functional Test would help us a lot - you can submit one in a Pull Request separately, referencing this bug report.
 -->
 
-#### Expected behavior
+#### Expected behaviour
 
-<!-- What was the expected (correct) behavior? -->
+<!-- What was the expected (correct) behaviour? -->
 

--- a/.github/ISSUE_TEMPLATE/Support_Question.md
+++ b/.github/ISSUE_TEMPLATE/Support_Question.md
@@ -10,7 +10,7 @@ about: Have a problem that you can't figure out? 🤔
 | Version     | x.y.z
 
 <!--
-Before asking question here, please try asking on Gitter or Slack first.
+Before asking a question here, please try asking on Gitter or Slack first.
 Find out more about Doctrine support channels here: https://www.doctrine-project.org/community/
 Keep in mind that GitHub is primarily an issue tracker.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@
 
 #### Summary
 
-<!-- Provide a summary your change. -->
+<!-- Provide a summary of your change. -->

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -51,7 +51,7 @@ class SQLParserUtils
     const ESCAPED_SINGLE_QUOTED_TEXT = "(?:'(?:\\\\\\\\)+'|'(?:[^'\\\\]|\\\\'?|'')*')";
     const ESCAPED_DOUBLE_QUOTED_TEXT = '(?:"(?:\\\\\\\\)+"|"(?:[^"\\\\]|\\\\"?)*")';
     const ESCAPED_BACKTICK_QUOTED_TEXT = '(?:`(?:\\\\\\\\)+`|`(?:[^`\\\\]|\\\\`?)*`)';
-    const ESCAPED_BRACKET_QUOTED_TEXT = '(?<!\bARRAY)\[(?:[^\]])*\]';
+    private const ESCAPED_BRACKET_QUOTED_TEXT = '(?<!\b(?i:ARRAY))\[(?:[^\]])*\]';
 
     /**
      * Gets an array of the placeholders in an sql statements as keys and their positions in the query string.

--- a/lib/Doctrine/DBAL/Schema/Sequence.php
+++ b/lib/Doctrine/DBAL/Schema/Sequence.php
@@ -57,8 +57,8 @@ class Sequence extends AbstractAsset
     public function __construct($name, $allocationSize = 1, $initialValue = 1, $cache = null)
     {
         $this->_setName($name);
-        $this->allocationSize = is_numeric($allocationSize) ? $allocationSize : 1;
-        $this->initialValue   = is_numeric($initialValue) ? $initialValue : 1;
+        $this->setAllocationSize($allocationSize);
+        $this->setInitialValue($initialValue);
         $this->cache          = $cache;
     }
 
@@ -93,7 +93,7 @@ class Sequence extends AbstractAsset
      */
     public function setAllocationSize($allocationSize)
     {
-        $this->allocationSize = is_numeric($allocationSize) ? $allocationSize : 1;
+        $this->allocationSize = is_numeric($allocationSize) ? (int) $allocationSize : 1;
 
         return $this;
     }
@@ -105,7 +105,7 @@ class Sequence extends AbstractAsset
      */
     public function setInitialValue($initialValue)
     {
-        $this->initialValue = is_numeric($initialValue) ? $initialValue : 1;
+        $this->initialValue = is_numeric($initialValue) ? (int) $initialValue : 1;
 
         return $this;
     }

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -38,7 +38,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    public const VERSION = '2.8.0-DEV';
+    public const VERSION = '2.8.0';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -38,7 +38,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    public const VERSION = '2.8.0';
+    public const VERSION = '2.8.1-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL2807Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL2807Test.php
@@ -6,8 +6,11 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\Tests\DbalFunctionalTestCase;
 
-final class DBALxxxTest extends DbalFunctionalTestCase
+final class DBAL2807Test extends DbalFunctionalTestCase
 {
+    /**
+     * {@inheritDoc}
+     */
     public function setUp()
     {
         parent::setUp();
@@ -20,6 +23,13 @@ final class DBALxxxTest extends DbalFunctionalTestCase
         }
     }
 
+    /**
+     * Ensures that the primary key is created within the same "alter table" statement that an auto-increment column
+     * is added to the table as part of the new primary key.
+     *
+     * Before the fix for this problem this resulted in a database error:
+     * SQLSTATE[42000]: Syntax error or access violation: 1075 Incorrect table definition; there can be only one auto column and it must be defined as a key
+     */
     public function testAlterPrimaryKeyToAutoIncrementColumn()
     {
         $table = new Table('my_table');

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBALxxxTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBALxxxTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Ticket;
+
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+final class DBALxxxTest extends DbalFunctionalTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (!in_array($this->getPlatform()->getName(), ['mysql']))
+        {
+            $this->markTestSkipped('Restricted to MySQL.');
+
+            return;
+        }
+    }
+
+    public function testAlterPrimaryKeyToAutoIncrementColumn()
+    {
+        $table = new Table('my_table');
+        $table->addColumn('initial_id', 'integer');
+        $table->setPrimaryKey(['initial_id']);
+
+        $newTable = clone $table;
+        $newTable->addColumn('new_id', 'integer', ['autoincrement' => true]);
+        $newTable->dropPrimaryKey();
+        $newTable->setPrimaryKey(['new_id']);
+
+        $diff = (new Comparator())->diffTable($table, $newTable);
+
+        $this->assertSame(
+            ['ALTER TABLE my_table ADD new_id INT AUTO_INCREMENT NOT NULL, DROP PRIMARY KEY, ADD PRIMARY KEY (new_id)',],
+            $this->getPlatform()->getAlterTableSQL($diff)
+        );
+    }
+
+    protected function getPlatform()
+    {
+        return $this->_conn->getDatabasePlatform();
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -55,7 +55,8 @@ class SQLParserUtilsTest extends \Doctrine\Tests\DbalTestCase
             array('SELECT foo::date as date FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(46 => 'start_date', 68 =>  'start_date')), // Ticket GH-259
             array('SELECT `d.ns:col_name` FROM my_table d WHERE `d.date` >= :param1', false, array(57 => 'param1')), // Ticket DBAL-552
             array('SELECT [d.ns:col_name] FROM my_table d WHERE [d.date] >= :param1', false, array(57 => 'param1')), // Ticket DBAL-552
-            array('SELECT * FROM foo WHERE jsonb_exists_any(foo.bar, ARRAY[:foo])', false, array(56 => 'foo')), // Ticket GH-2295
+            ['SELECT * FROM foo WHERE jsonb_exists_any(foo.bar, ARRAY[:foo])', false, [56 => 'foo']], // Ticket GH-2295
+            ['SELECT * FROM foo WHERE jsonb_exists_any(foo.bar, array[:foo])', false, [56 => 'foo']],
             array(
 <<<'SQLDATA'
 SELECT * FROM foo WHERE 

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -435,11 +435,13 @@ class ComparatorTest extends \PHPUnit\Framework\TestCase
         $seq1 = new Sequence('foo', 1, 1);
         $seq2 = new Sequence('foo', 1, 2);
         $seq3 = new Sequence('foo', 2, 1);
+        $seq4 = new Sequence('foo', '1', '1');
 
         $c = new Comparator();
 
         self::assertTrue($c->diffSequence($seq1, $seq2));
         self::assertTrue($c->diffSequence($seq1, $seq3));
+        self::assertFalse($c->diffSequence($seq1, $seq4));
     }
 
     public function testRemovedSequence()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2807 

#### Summary

Ensures that the primary key is created within the same "alter table" statement that an auto-increment column is added to the table as part of the new primary key.

Before the fix for this problem this resulted in a database error:
> SQLSTATE[42000]: Syntax error or access violation: 1075 Incorrect table definition; there can be only one auto column and it must be defined as a key