### PR TITLE
MasterSlaveConnection::ping() throws PDOException

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Cache\CacheException;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Cache\ResultCacheStatement;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\PDOException;
 use Doctrine\DBAL\Driver\PingableConnection;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
@@ -1671,7 +1672,7 @@ class Connection implements DriverConnection
             $this->query($this->getDatabasePlatform()->getDummySelectSQL());
 
             return true;
-        } catch (DBALException $e) {
+        } catch (PDOException | DBALException $e) {
             return false;
         }
     }

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -5,11 +5,13 @@ namespace Doctrine\DBAL\Connections;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Events;
 use InvalidArgumentException;
+use Throwable;
 use function array_rand;
 use function count;
 use function func_get_args;
@@ -352,7 +354,11 @@ class MasterSlaveConnection extends Connection
             $logger->startQuery($args[0]);
         }
 
-        $statement = $this->_conn->query(...$args);
+        try {
+            $statement = $this->_conn->query(...$args);
+        } catch (Throwable $e) {
+            throw DBALException::driverExceptionDuringQuery($this->_driver, $e, $args[0]);
+        }
 
         if ($logger) {
             $logger->stopQuery();

--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -189,4 +189,14 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
         $conn->connect('master');
         self::assertTrue($conn->isConnectedToMaster());
     }
+
+    public function testPingDoesTriggersConnect()
+    {
+        $conn = $this->createMasterSlaveConnection();
+
+        $conn->connect('master');
+
+        self::assertTrue($conn->ping());
+        self::assertTrue($conn->isConnectedToMaster());
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | https://github.com/doctrine/dbal/issues/3118 https://github.com/doctrine/dbal/issues/2769 

#### Summary

Fix existing issue with uncaught exception in the `MasterSlaveConnection::query`.
Also looks like `ping` method in the MasterSlaveConnection class will send pings to the slave connection:
https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php#L124-L133

I've marked it as BC Break as `ping` method will change it behavior in the `MasterSlaveConnection` and will ping master instead of slave

p.s. this PR covers 2 issues: https://github.com/doctrine/dbal/issues/3118 and https://github.com/doctrine/dbal/issues/2769 