### PR TITLE
Deprecated regex-based asset filters

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.9
 
+## Deprecated `Configuration::getFilterSchemaAssetsExpression()`, `::setFilterSchemaAssetsExpression()` and `AbstractSchemaManager::getFilterSchemaAssetsExpression()`.
+
+Regular expression-based filters are hard to extend by combining together. Instead, you may use callback-based filers via `::getSchemaAssetsFilter()` and `::getSchemaAssetsFilter()`. Callbacks can use regular expressions internally.
+
 ## Deprecated `Doctrine\DBAL\Types\Type::getDefaultLength()`
 
 This method was never used by DBAL internally. It is now deprecated and will be removed in DBAL 3.0.

--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -70,6 +70,8 @@ class Configuration
      * schema instances generated for the active connection when calling
      * {AbstractSchemaManager#createSchema()}.
      *
+     * @deprecated Use Configuration::setSchemaAssetsFilter() instead
+     *
      * @param string $filterExpression
      *
      * @return void
@@ -86,6 +88,8 @@ class Configuration
 
     /**
      * Returns filter schema assets expression.
+     *
+     * @deprecated Use Configuration::getSchemaAssetsFilter() instead
      *
      * @return string|null
      */

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -228,6 +228,8 @@ abstract class AbstractSchemaManager
     }
 
     /**
+     * @deprecated Use Configuration::getSchemaAssetsFilter() instead
+     *
      * @return string|null
      */
     protected function getFilterSchemaAssetsExpression()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

As of #3308, callback-based asset filters are available. They provide the same functionality as the regex-based ones but are better extensible. There's no need to keep the old API.

Before:
```php
$this->connection->getConfiguration()->setFilterSchemaAssetsExpression('#^dbal204_#');
```
After:
```php
$this->connection->getConfiguration()->setSchemaAssetsFilter(function ($assetName) {
    return preg_match('#^dbal204_#', $assetName);
});
```