### PR TITLE
Implemented proper escaping of string literals in platforms and schema managers

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
@@ -326,15 +326,15 @@ class DrizzlePlatform extends AbstractPlatform
     public function getListTableColumnsSQL($table, $database = null)
     {
         if ($database) {
-            $database = "'" . $database . "'";
+            $databaseSQL = $this->quoteStringLiteral($database);
         } else {
-            $database = 'DATABASE()';
+            $databaseSQL = 'DATABASE()';
         }
 
         return 'SELECT COLUMN_NAME, DATA_TYPE, COLUMN_COMMENT, IS_NULLABLE, IS_AUTO_INCREMENT, CHARACTER_MAXIMUM_LENGTH, COLUMN_DEFAULT,' .
                ' NUMERIC_PRECISION, NUMERIC_SCALE, COLLATION_NAME' .
                ' FROM DATA_DICTIONARY.COLUMNS' .
-               ' WHERE TABLE_SCHEMA=' . $database . " AND TABLE_NAME = '" . $table . "'";
+               ' WHERE TABLE_SCHEMA=' . $databaseSQL . ' AND TABLE_NAME = ' . $this->quoteStringLiteral($table);
     }
 
     /**
@@ -343,14 +343,14 @@ class DrizzlePlatform extends AbstractPlatform
     public function getListTableForeignKeysSQL($table, $database = null)
     {
         if ($database) {
-            $database = "'" . $database . "'";
+            $databaseSQL = $this->quoteStringLiteral($database);
         } else {
-            $database = 'DATABASE()';
+            $databaseSQL = 'DATABASE()';
         }
 
         return 'SELECT CONSTRAINT_NAME, CONSTRAINT_COLUMNS, REFERENCED_TABLE_NAME, REFERENCED_TABLE_COLUMNS, UPDATE_RULE, DELETE_RULE' .
                ' FROM DATA_DICTIONARY.FOREIGN_KEYS' .
-               ' WHERE CONSTRAINT_SCHEMA=' . $database . " AND CONSTRAINT_TABLE='" . $table . "'";
+               ' WHERE CONSTRAINT_SCHEMA=' . $databaseSQL . ' AND CONSTRAINT_TABLE=' . $this->quoteStringLiteral($table);
     }
 
     /**
@@ -359,14 +359,14 @@ class DrizzlePlatform extends AbstractPlatform
     public function getListTableIndexesSQL($table, $database = null)
     {
         if ($database) {
-            $database = "'" . $database . "'";
+            $databaseSQL = $this->quoteStringLiteral($database);
         } else {
-            $database = 'DATABASE()';
+            $databaseSQL = 'DATABASE()';
         }
 
         return "SELECT INDEX_NAME AS 'key_name', COLUMN_NAME AS 'column_name', IS_USED_IN_PRIMARY AS 'primary', IS_UNIQUE=0 AS 'non_unique'" .
                ' FROM DATA_DICTIONARY.INDEX_PARTS' .
-               ' WHERE TABLE_SCHEMA=' . $database . " AND TABLE_NAME='" . $table . "'";
+               ' WHERE TABLE_SCHEMA=' . $databaseSQL . ' AND TABLE_NAME=' . $this->quoteStringLiteral($table);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -439,7 +439,7 @@ SQL
      */
     public function getDisallowDatabaseConnectionsSQL($database)
     {
-        return "UPDATE pg_database SET datallowconn = 'false' WHERE datname = '" . $database . "'";
+        return "UPDATE pg_database SET datallowconn = 'false' WHERE datname = " . $this->quoteStringLiteral($database);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
@@ -27,7 +27,7 @@ class DB2SchemaManager extends AbstractSchemaManager
     public function listTableNames()
     {
         $sql  = $this->_platform->getListTablesSQL();
-        $sql .= " AND CREATOR = UPPER('" . $this->_conn->getUsername() . "')";
+        $sql .= ' AND CREATOR = UPPER(' . $this->_conn->quote($this->_conn->getUsername()) . ')';
 
         $tables = $this->_conn->fetchAll($sql);
 

--- a/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
@@ -30,7 +30,7 @@ final class DB2SchemaManagerTest extends TestCase
         $platform      = $this->createMock(DB2Platform::class);
         $this->conn    = $this
             ->getMockBuilder(Connection::class)
-            ->setMethods(['fetchAll'])
+            ->setMethods(['fetchAll', 'quote'])
             ->setConstructorArgs([['platform' => $platform], $driverMock, new Configuration(), $eventManager])
             ->getMock();
         $this->manager = new DB2SchemaManager($this->conn);
@@ -102,6 +102,7 @@ final class DB2SchemaManagerTest extends TestCase
         $this->conn->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) use ($accepted) {
             return in_array($assetName, $accepted);
         });
+        $this->conn->expects($this->any())->method('quote');
         $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
@@ -129,6 +130,7 @@ final class DB2SchemaManagerTest extends TestCase
         $this->conn->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) use ($accepted) {
             return in_array($assetName, $accepted);
         });
+        $this->conn->expects($this->any())->method('quote');
         $this->conn->expects($this->atLeastOnce())->method('fetchAll')->will($this->returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

Some SQL queries used internally in DBAL wrap string literals in quotes w/o doing proper escaping. While it doubtfully can be considered a security issue on its own, it still makes sense to fix them at least in order to set a proper example of writing SQL queries.