### PR TITLE
Use locked version of PHPStan to avoid accidental build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -427,7 +427,7 @@ jobs:
 
     - stage: Code Quality
       env: DB=none STATIC_ANALYSIS
-      install: travis_retry composer update --prefer-dist
+      install: travis_retry composer install --prefer-dist
       script: vendor/bin/phpstan analyse
 
     - stage: Coding standard


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

This patch fixes unexpected build failures caused by changes in patch versions of PHPStan (e.g.  [job #6264.59](https://travis-ci.org/doctrine/dbal/jobs/444781800) on `master` and [job #6263.56](https://travis-ci.org/doctrine/dbal/jobs/444346736) on `2.8`).