### PR TITLE
Fetch all should use the driver statement's fetchAll method

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -166,12 +166,7 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
-        $rows = [];
-        while ($row = $this->fetch($fetchMode)) {
-            $rows[] = $row;
-        }
-
-        return $rows;
+        return $this->statement->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

At the moment it just loops over calling fetch instead of calling fetchAll on the ResultStatement which may mean losing performance gains implemented in fetchAll.