### PR TITLE
Allow windows (userless/passwordless) authentication for SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
@@ -31,8 +31,13 @@ class Driver extends AbstractSQLServerDriver
             $driverOptions['CharacterSet'] = $params['charset'];
         }
 
-        $driverOptions['UID'] = $username;
-        $driverOptions['PWD'] = $password;
+        if ($username !== null) {
+            $driverOptions['UID'] = $username;
+        }
+        
+        if ($password !== null) {
+            $driverOptions['PWD'] = $password;
+        }
 
         if (! isset($driverOptions['ReturnDatesAsStrings'])) {
             $driverOptions['ReturnDatesAsStrings'] = 1;

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
@@ -34,7 +34,7 @@ class Driver extends AbstractSQLServerDriver
         if ($username !== null) {
             $driverOptions['UID'] = $username;
         }
-        
+
         if ($password !== null) {
             $driverOptions['PWD'] = $password;
         }


### PR DESCRIPTION
Adding Windows Authentication compatibility according to http://php.net/manual/en/function.sqlsrv-connect.php
"By default, the connection is attempted using Windows Authentication. To connect using SQL Server Authentication, include "UID" and "PWD" in the connection options array."

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3332 

#### Summary

Simply don't provide useless drivers options.
because [] != ['UID'=>null, 'PWD'=>null]

Thx
