### PR TITLE
#2926 Fix backslashes double escaping

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -28,7 +28,6 @@ use function is_bool;
 use function is_numeric;
 use function is_string;
 use function sprintf;
-use function str_replace;
 use function strpos;
 use function strtolower;
 use function trim;
@@ -1197,16 +1196,6 @@ SQL
     public function getBlobTypeDeclarationSQL(array $field)
     {
         return 'BYTEA';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function quoteStringLiteral($str)
-    {
-        $str = str_replace('\\', '\\\\', $str); // PostgreSQL requires backslashes to be escaped aswell.
-
-        return parent::quoteStringLiteral($str);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1584,6 +1584,7 @@ class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
     public function testCanCreateAndRetrieveInfoAboutTypeWithBackslashes()
     {
         Type::addType('Foo\\Bar', BackSlashType::class);
+        $this->connection->getDatabasePlatform()->markDoctrineTypeCommented('Foo\\Bar');
 
         $table = new Table('test_escaping');
         $table->addColumn('column', 'Foo\\Bar');

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -952,7 +952,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
      */
     public function testQuotesTableNameInListTableForeignKeysSQL()
     {
-        self::assertContains("'Foo''Bar\\\\'", $this->platform->getListTableForeignKeysSQL("Foo'Bar\\"), '', true);
+        self::assertContains("'Foo''Bar\\'", $this->platform->getListTableForeignKeysSQL("Foo'Bar\\"), '', true);
     }
 
     /**
@@ -961,7 +961,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     public function testQuotesSchemaNameInListTableForeignKeysSQL()
     {
         self::assertContains(
-            "'Foo''Bar\\\\'",
+            "'Foo''Bar\\'",
             $this->platform->getListTableForeignKeysSQL("Foo'Bar\\.baz_table"),
             '',
             true
@@ -973,7 +973,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
      */
     public function testQuotesTableNameInListTableConstraintsSQL()
     {
-        self::assertContains("'Foo''Bar\\\\'", $this->platform->getListTableConstraintsSQL("Foo'Bar\\"), '', true);
+        self::assertContains("'Foo''Bar\\'", $this->platform->getListTableConstraintsSQL("Foo'Bar\\"), '', true);
     }
 
     /**
@@ -981,7 +981,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
      */
     public function testQuotesTableNameInListTableIndexesSQL()
     {
-        self::assertContains("'Foo''Bar\\\\'", $this->platform->getListTableIndexesSQL("Foo'Bar\\"), '', true);
+        self::assertContains("'Foo''Bar\\'", $this->platform->getListTableIndexesSQL("Foo'Bar\\"), '', true);
     }
 
     /**
@@ -990,7 +990,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     public function testQuotesSchemaNameInListTableIndexesSQL()
     {
         self::assertContains(
-            "'Foo''Bar\\\\'",
+            "'Foo''Bar\\'",
             $this->platform->getListTableIndexesSQL("Foo'Bar\\.baz_table"),
             '',
             true
@@ -1002,7 +1002,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
      */
     public function testQuotesTableNameInListTableColumnsSQL()
     {
-        self::assertContains("'Foo''Bar\\\\'", $this->platform->getListTableColumnsSQL("Foo'Bar\\"), '', true);
+        self::assertContains("'Foo''Bar\\'", $this->platform->getListTableColumnsSQL("Foo'Bar\\"), '', true);
     }
 
     /**
@@ -1011,7 +1011,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     public function testQuotesSchemaNameInListTableColumnsSQL()
     {
         self::assertContains(
-            "'Foo''Bar\\\\'",
+            "'Foo''Bar\\'",
             $this->platform->getListTableColumnsSQL("Foo'Bar\\.baz_table"),
             '',
             true
@@ -1024,7 +1024,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     public function testQuotesDatabaseNameInCloseActiveDatabaseConnectionsSQL()
     {
         self::assertContains(
-            "'Foo''Bar\\\\'",
+            "'Foo''Bar\\'",
             $this->platform->getCloseActiveDatabaseConnectionsSQL("Foo'Bar\\"),
             '',
             true


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #2926 

Seems during #2442 these backslash strategies were added to several DB engines blindly, without verifying if they require such backslashes. What several people experience at least with Postgres then is that DBAL generates SQLs with duplicated backslashes and upon retrieving it from database can't match it with definition (where it's single backslashed).

I can't write backlash specific test case for every single DB operation, but I verified several operations manually (schema, foreign keys, closeActiveDatabaseConnectionsSQL...) and from that I see postgresql does not treat backslash as escape character anywhere. 