### PR TITLE
Enforce parameter and return value types in the codebase

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade to 3.0
 
+## BC BREAK: Changes in the `Doctrine\DBAL\Schema` API
+
+- Column precision no longer defaults to 10. The default value is NULL.
+- Asset names are no longer nullable. An empty asset name should be represented as an empty string.
+- `Doctrine\DBAL\Schema\AbstractSchemaManager::_getPortableTriggersList()` and `::_getPortableTriggerDefinition()` have been removed.
+
 ## BC BREAK: Changes in the `Doctrine\DBAL\Event` API
 
 - `SchemaAlterTableAddColumnEventArgs::addSql()` and the same method in other `SchemaEventArgs`-based classes no longer accept an array of SQL statements. They accept a variadic string.

--- a/lib/Doctrine/DBAL/Schema/AbstractAsset.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractAsset.php
@@ -25,7 +25,7 @@ use function substr;
 abstract class AbstractAsset
 {
     /** @var string */
-    protected $_name;
+    protected $_name = '';
 
     /**
      * Namespace of the asset. If none isset the default namespace is assumed.
@@ -138,7 +138,7 @@ abstract class AbstractAsset
             return $this->_namespace . '.' . $this->_name;
         }
 
-        return $this->_name ?? '';
+        return $this->_name;
     }
 
     /**
@@ -167,7 +167,7 @@ abstract class AbstractAsset
      */
     protected function _generateIdentifierName(array $columnNames, string $prefix = '', int $maxSize = 30) : string
     {
-        $hash = implode('', array_map(static function ($column) {
+        $hash = implode('', array_map(static function ($column) : string {
             return dechex(crc32($column));
         }, $columnNames));
 

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -223,7 +223,7 @@ abstract class AbstractSchemaManager
      *
      * @return array<int, mixed>
      */
-    protected function filterAssetNames(array $assetNames)
+    protected function filterAssetNames(array $assetNames) : array
     {
         $filter = $this->_conn->getConfiguration()->getSchemaAssetsFilter();
         if (! $filter) {
@@ -603,35 +603,6 @@ abstract class AbstractSchemaManager
     protected function getPortableNamespaceDefinition(array $namespace) : string
     {
         return array_shift($namespace);
-    }
-
-    /**
-     * @param array<int, array<int, mixed>> $triggers
-     *
-     * @return array<int, string>
-     */
-    protected function _getPortableTriggersList(array $triggers)
-    {
-        $list = [];
-        foreach ($triggers as $value) {
-            $value = $this->_getPortableTriggerDefinition($value);
-
-            if (! $value) {
-                continue;
-            }
-
-            $list[] = $value;
-        }
-
-        return $list;
-    }
-
-    /**
-     * @param array<string|int, mixed> $trigger
-     */
-    protected function _getPortableTriggerDefinition(array $trigger) : string
-    {
-        return array_shift($trigger);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/Column.php
+++ b/lib/Doctrine/DBAL/Schema/Column.php
@@ -23,7 +23,7 @@ class Column extends AbstractAsset
     protected $_length;
 
     /** @var int|null */
-    protected $_precision = 10;
+    protected $_precision;
 
     /** @var int */
     protected $_scale = 0;
@@ -106,10 +106,6 @@ class Column extends AbstractAsset
 
     public function setPrecision(?int $precision) : self
     {
-        if ($precision === null) {
-            $precision = 10; // defaults to 10 when no precision is given.
-        }
-
         $this->_precision = $precision;
 
         return $this;
@@ -195,7 +191,7 @@ class Column extends AbstractAsset
         return $this->_precision;
     }
 
-    public function getScale() : ?int
+    public function getScale() : int
     {
         return $this->_scale;
     }

--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -59,14 +59,12 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * @param array<int, string>   $localColumnNames   Names of the referencing table columns.
      * @param Table|string         $foreignTableName   Referenced table.
      * @param array<int, string>   $foreignColumnNames Names of the referenced table columns.
-     * @param string|null          $name               Name of the foreign key constraint.
+     * @param string               $name               Name of the foreign key constraint.
      * @param array<string, mixed> $options            Options associated with the foreign key constraint.
      */
-    public function __construct(array $localColumnNames, $foreignTableName, array $foreignColumnNames, $name = null, array $options = [])
+    public function __construct(array $localColumnNames, $foreignTableName, array $foreignColumnNames, string $name = '', array $options = [])
     {
-        if ($name !== null) {
-            $this->_setName($name);
-        }
+        $this->_setName($name);
 
         $this->_localColumnNames = $this->createIdentifierMap($localColumnNames);
 

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -92,7 +92,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         $names = $this->getSchemaNames();
         $paths = $this->getSchemaSearchPaths();
 
-        $this->existingSchemaPaths = array_filter($paths, static function ($v) use ($names) {
+        $this->existingSchemaPaths = array_filter($paths, static function ($v) use ($names) : bool {
             return in_array($v, $names);
         });
     }
@@ -159,14 +159,6 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
             $tableForeignKey['conname'],
             ['onUpdate' => $onUpdate, 'onDelete' => $onDelete]
         );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _getPortableTriggerDefinition(array $trigger) : string
-    {
-        return $trigger['trigger_name'];
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/SQLAnywhereSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLAnywhereSchemaManager.php
@@ -45,13 +45,13 @@ class SQLAnywhereSchemaManager extends AbstractSchemaManager
         parent::dropDatabase($database);
     }
 
-    public function startDatabase(string $database)
+    public function startDatabase(string $database) : void
     {
         assert($this->_platform instanceof SQLAnywherePlatform);
         $this->_execSql($this->_platform->getStartDatabaseSQL($database));
     }
 
-    public function stopDatabase(string $database)
+    public function stopDatabase(string $database) : void
     {
         assert($this->_platform instanceof SQLAnywherePlatform);
         $this->_execSql($this->_platform->getStopDatabaseSQL($database));

--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -408,8 +408,6 @@ class Schema extends AbstractAsset
 
     /**
      * Cloning a Schema triggers a deep clone of all related assets.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -120,7 +120,7 @@ class SchemaDiff
             }
         }
 
-        if ($platform->supportsSequences() === true) {
+        if ($platform->supportsSequences()) {
             foreach ($this->changedSequences as $sequence) {
                 $sql[] = $platform->getAlterSequenceSQL($sequence);
             }

--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -460,7 +460,7 @@ class Table extends AbstractAsset
 
         $colNames = array_unique(array_merge($pkCols, $fkCols, array_keys($columns)));
 
-        uksort($columns, static function ($a, $b) use ($colNames) {
+        uksort($columns, static function ($a, $b) use ($colNames) : bool {
             return array_search($a, $colNames) >= array_search($b, $colNames);
         });
 
@@ -578,7 +578,7 @@ class Table extends AbstractAsset
      *
      * @return array<string, ForeignKeyConstraint>
      */
-    public function getForeignKeys()
+    public function getForeignKeys() : array
     {
         return $this->_fkConstraints;
     }
@@ -623,8 +623,6 @@ class Table extends AbstractAsset
 
     /**
      * Clone of a Table triggers a deep clone of all affected assets.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/lib/Doctrine/DBAL/Schema/Visitor/SchemaDiffVisitor.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/SchemaDiffVisitor.php
@@ -17,25 +17,25 @@ interface SchemaDiffVisitor
     /**
      * Visit an orphaned foreign key whose table was deleted.
      */
-    public function visitOrphanedForeignKey(ForeignKeyConstraint $foreignKey);
+    public function visitOrphanedForeignKey(ForeignKeyConstraint $foreignKey) : void;
 
     /**
      * Visit a sequence that has changed.
      */
-    public function visitChangedSequence(Sequence $sequence);
+    public function visitChangedSequence(Sequence $sequence) : void;
 
     /**
      * Visit a sequence that has been removed.
      */
-    public function visitRemovedSequence(Sequence $sequence);
+    public function visitRemovedSequence(Sequence $sequence) : void;
 
-    public function visitNewSequence(Sequence $sequence);
+    public function visitNewSequence(Sequence $sequence) : void;
 
-    public function visitNewTable(Table $table);
+    public function visitNewTable(Table $table) : void;
 
-    public function visitNewTableForeignKey(Table $table, ForeignKeyConstraint $foreignKey);
+    public function visitNewTableForeignKey(Table $table, ForeignKeyConstraint $foreignKey) : void;
 
-    public function visitRemovedTable(Table $table);
+    public function visitRemovedTable(Table $table) : void;
 
-    public function visitChangedTable(TableDiff $tableDiff);
+    public function visitChangedTable(TableDiff $tableDiff) : void;
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,14 +20,6 @@
         <exclude name="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants.DisallowedLateStaticBindingForConstant"/>
     </rule>
 
-    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint">
-        <exclude-pattern>*/lib/*</exclude-pattern>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint">
-        <exclude-pattern>*/lib/*</exclude-pattern>
-    </rule>
-
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractOracleDriver/EasyConnectStringTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractOracleDriver/EasyConnectStringTest.php
@@ -22,7 +22,7 @@ class EasyConnectStringTest extends TestCase
     }
 
     /**
-     * @return mixed[]
+     * @return iterable<string, array<int, mixed>>
      */
     public static function connectionParametersProvider() : iterable
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -251,17 +251,6 @@ class ConnectionTest extends DbalFunctionalTestCase
         self::assertEquals(42, $res);
     }
 
-    /**
-     * Tests that the quote function accepts DBAL and PDO types.
-     */
-    public function testQuote() : void
-    {
-        self::assertEquals(
-            $this->connection->quote('foo'),
-            $this->connection->quote('foo')
-        );
-    }
-
     public function testPingDoesTriggersConnect() : void
     {
         $this->connection->close();

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -512,11 +512,9 @@ class DataAccessTest extends DbalFunctionalTestCase
     }
 
     /**
-     * @param string|false $char
-     *
      * @dataProvider getTrimExpressionData
      */
-    public function testTrimExpression(string $value, int $position, $char, string $expectedResult) : void
+    public function testTrimExpression(string $value, int $position, ?string $char, string $expectedResult) : void
     {
         $sql = 'SELECT ' .
             $this->connection->getDatabasePlatform()->getTrimExpression($value, $position, $char) . ' AS trimmed ' .

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -293,54 +293,54 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
 
         self::assertArrayHasKey('test', $columns);
         self::assertEquals(1, array_search('test', $columnsKeys));
-        self::assertEquals('test', strtolower($columns['test']->getname()));
-        self::assertInstanceOf(StringType::class, $columns['test']->gettype());
-        self::assertEquals(255, $columns['test']->getlength());
-        self::assertEquals(false, $columns['test']->getfixed());
-        self::assertEquals(false, $columns['test']->getnotnull());
-        self::assertEquals('expected default', $columns['test']->getdefault());
+        self::assertEquals('test', strtolower($columns['test']->getName()));
+        self::assertInstanceOf(StringType::class, $columns['test']->getType());
+        self::assertEquals(255, $columns['test']->getLength());
+        self::assertEquals(false, $columns['test']->getFixed());
+        self::assertEquals(false, $columns['test']->getNotnull());
+        self::assertEquals('expected default', $columns['test']->getDefault());
         self::assertIsArray($columns['test']->getPlatformOptions());
 
-        self::assertEquals('foo', strtolower($columns['foo']->getname()));
+        self::assertEquals('foo', strtolower($columns['foo']->getName()));
         self::assertEquals(2, array_search('foo', $columnsKeys));
-        self::assertInstanceOf(TextType::class, $columns['foo']->gettype());
-        self::assertEquals(false, $columns['foo']->getunsigned());
-        self::assertEquals(false, $columns['foo']->getfixed());
-        self::assertEquals(true, $columns['foo']->getnotnull());
-        self::assertEquals(null, $columns['foo']->getdefault());
+        self::assertInstanceOf(TextType::class, $columns['foo']->getType());
+        self::assertEquals(false, $columns['foo']->getUnsigned());
+        self::assertEquals(false, $columns['foo']->getFixed());
+        self::assertEquals(true, $columns['foo']->getNotnull());
+        self::assertEquals(null, $columns['foo']->getDefault());
         self::assertIsArray($columns['foo']->getPlatformOptions());
 
-        self::assertEquals('bar', strtolower($columns['bar']->getname()));
+        self::assertEquals('bar', strtolower($columns['bar']->getName()));
         self::assertEquals(3, array_search('bar', $columnsKeys));
-        self::assertInstanceOf(DecimalType::class, $columns['bar']->gettype());
-        self::assertEquals(null, $columns['bar']->getlength());
-        self::assertEquals(10, $columns['bar']->getprecision());
-        self::assertEquals(4, $columns['bar']->getscale());
-        self::assertEquals(false, $columns['bar']->getunsigned());
-        self::assertEquals(false, $columns['bar']->getfixed());
-        self::assertEquals(false, $columns['bar']->getnotnull());
-        self::assertEquals(null, $columns['bar']->getdefault());
+        self::assertInstanceOf(DecimalType::class, $columns['bar']->getType());
+        self::assertEquals(null, $columns['bar']->getLength());
+        self::assertEquals(10, $columns['bar']->getPrecision());
+        self::assertEquals(4, $columns['bar']->getScale());
+        self::assertEquals(false, $columns['bar']->getUnsigned());
+        self::assertEquals(false, $columns['bar']->getFixed());
+        self::assertEquals(false, $columns['bar']->getNotnull());
+        self::assertEquals(null, $columns['bar']->getDefault());
         self::assertIsArray($columns['bar']->getPlatformOptions());
 
-        self::assertEquals('baz1', strtolower($columns['baz1']->getname()));
+        self::assertEquals('baz1', strtolower($columns['baz1']->getName()));
         self::assertEquals(4, array_search('baz1', $columnsKeys));
-        self::assertInstanceOf(DateTimeType::class, $columns['baz1']->gettype());
-        self::assertEquals(true, $columns['baz1']->getnotnull());
-        self::assertEquals(null, $columns['baz1']->getdefault());
+        self::assertInstanceOf(DateTimeType::class, $columns['baz1']->getType());
+        self::assertEquals(true, $columns['baz1']->getNotnull());
+        self::assertEquals(null, $columns['baz1']->getDefault());
         self::assertIsArray($columns['baz1']->getPlatformOptions());
 
-        self::assertEquals('baz2', strtolower($columns['baz2']->getname()));
+        self::assertEquals('baz2', strtolower($columns['baz2']->getName()));
         self::assertEquals(5, array_search('baz2', $columnsKeys));
-        self::assertContains($columns['baz2']->gettype()->getName(), ['time', 'date', 'datetime']);
-        self::assertEquals(true, $columns['baz2']->getnotnull());
-        self::assertEquals(null, $columns['baz2']->getdefault());
+        self::assertContains($columns['baz2']->getType()->getName(), ['time', 'date', 'datetime']);
+        self::assertEquals(true, $columns['baz2']->getNotnull());
+        self::assertEquals(null, $columns['baz2']->getDefault());
         self::assertIsArray($columns['baz2']->getPlatformOptions());
 
-        self::assertEquals('baz3', strtolower($columns['baz3']->getname()));
+        self::assertEquals('baz3', strtolower($columns['baz3']->getName()));
         self::assertEquals(6, array_search('baz3', $columnsKeys));
-        self::assertContains($columns['baz3']->gettype()->getName(), ['time', 'date', 'datetime']);
-        self::assertEquals(true, $columns['baz3']->getnotnull());
-        self::assertEquals(null, $columns['baz3']->getdefault());
+        self::assertContains($columns['baz3']->getType()->getName(), ['time', 'date', 'datetime']);
+        self::assertEquals(true, $columns['baz3']->getNotnull());
+        self::assertEquals(null, $columns['baz3']->getDefault());
         self::assertIsArray($columns['baz3']->getPlatformOptions());
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -154,7 +154,6 @@ class WriteTest extends DbalFunctionalTestCase
         self::assertEquals(1, $this->connection->insert('write_table', ['test_int' => 2, 'test_string' => 'bar']));
         $num = $this->lastInsertId();
 
-        self::assertNotNull($num, 'LastInsertId() should not be null.');
         self::assertGreaterThan(0, $num, 'LastInsertId() should be non-negative number.');
     }
 
@@ -343,11 +342,9 @@ class WriteTest extends DbalFunctionalTestCase
      * Returns the ID of the last inserted row or skips the test if the currently used driver
      * doesn't support this feature
      *
-     * @return string|false
-     *
      * @throws DriverException
      */
-    private function lastInsertId(?string $name = null)
+    private function lastInsertId(?string $name = null) : string
     {
         try {
             return $this->connection->lastInsertId($name);

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -426,16 +426,14 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     }
 
     /**
-     * @param string|bool $databaseValue
-     *
      * @group DBAL-457
      * @dataProvider pgBooleanProvider
      */
     public function testConvertBooleanAsLiteralStrings(
-        $databaseValue,
+        string $databaseValue,
         string $preparedStatementValue,
-        ?int $integerValue,
-        ?bool $booleanValue
+        int $integerValue,
+        bool $booleanValue
     ) : void {
         $platform = $this->createPlatform();
 
@@ -458,16 +456,14 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     }
 
     /**
-     * @param string|bool $databaseValue
-     *
      * @group DBAL-630
      * @dataProvider pgBooleanProvider
      */
     public function testConvertBooleanAsDatabaseValueStrings(
-        $databaseValue,
+        string $databaseValue,
         string $preparedStatementValue,
-        ?int $integerValue,
-        ?bool $booleanValue
+        int $integerValue,
+        bool $booleanValue
     ) : void {
         $platform = $this->createPlatform();
 
@@ -487,11 +483,9 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     }
 
     /**
-     * @param string|bool $databaseValue
-     *
      * @dataProvider pgBooleanProvider
      */
-    public function testConvertFromBoolean($databaseValue, string $prepareStatementValue, ?int $integerValue, ?bool $booleanValue) : void
+    public function testConvertFromBoolean(string $databaseValue, string $prepareStatementValue, int $integerValue, bool $booleanValue) : void
     {
         $platform = $this->createPlatform();
 
@@ -730,7 +724,6 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     {
         return [
             // Database value, prepared statement value, boolean integer value, boolean value.
-            [true, 'true', 1, true],
             ['t', 'true', 1, true],
             ['true', 'true', 1, true],
             ['y', 'true', 1, true],
@@ -738,15 +731,12 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
             ['on', 'true', 1, true],
             ['1', 'true', 1, true],
 
-            [false, 'false', 0, false],
             ['f', 'false', 0, false],
             ['false', 'false', 0, false],
             [ 'n', 'false', 0, false],
             ['no', 'false', 0, false],
             ['off', 'false', 0, false],
             ['0', 'false', 0, false],
-
-            [null, 'NULL', null, null],
         ];
     }
 
@@ -809,14 +799,6 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     protected function getQuotesDropForeignKeySQL() : string
     {
         return 'ALTER TABLE "table" DROP CONSTRAINT "select"';
-    }
-
-    public function testGetNullCommentOnColumnSQL() : void
-    {
-        self::assertEquals(
-            'COMMENT ON COLUMN mytable.id IS NULL',
-            $this->platform->getCommentOnColumnSQL('mytable', 'id', null)
-        );
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -246,7 +246,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
      */
     public function testGeneratesAdvancedForeignKeyOptionsSQL(array $options, string $expectedSql) : void
     {
-        $foreignKey = new ForeignKeyConstraint(['foo'], 'foreign_table', ['bar'], null, $options);
+        $foreignKey = new ForeignKeyConstraint(['foo'], 'foreign_table', ['bar'], '', $options);
 
         self::assertSame($expectedSql, $this->platform->getAdvancedForeignKeyOptionsSQL($foreignKey));
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -234,11 +234,9 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
-     * @param int|bool|null $lockMode
-     *
      * @dataProvider getLockHints
      */
-    public function testAppendsLockHint($lockMode, string $lockHint) : void
+    public function testAppendsLockHint(?int $lockMode, string $lockHint) : void
     {
         $fromClause     = 'FROM users';
         $expectedResult = $fromClause . $lockHint;

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -16,12 +16,10 @@ class SQLServerPlatformTest extends AbstractSQLServerPlatformTestCase
     }
 
     /**
-     * @param int|bool|null $lockMode
-     *
      * @group DDC-2310
      * @dataProvider getLockHints
      */
-    public function testAppendsLockHint($lockMode, string $lockHint) : void
+    public function testAppendsLockHint(?int $lockMode, string $lockHint) : void
     {
         $fromClause     = 'FROM users';
         $expectedResult = $fromClause . $lockHint;
@@ -33,7 +31,7 @@ class SQLServerPlatformTest extends AbstractSQLServerPlatformTestCase
      * @group DBAL-2408
      * @dataProvider getModifyLimitQueries
      */
-    public function testScrubInnerOrderBy(string $query, int $limit, ?int $offset, string $expectedResult) : void
+    public function testScrubInnerOrderBy(string $query, int $limit, int $offset, string $expectedResult) : void
     {
         self::assertSame($expectedResult, $this->platform->modifyLimitQuery($query, $limit, $offset));
     }

--- a/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardConnectionTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Sharding\ShardingException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use function array_merge;
 
 /**
  * @requires extension pdo_sqlite
@@ -19,8 +20,7 @@ class PoolingShardConnectionTest extends TestCase
 {
     public function testConnect() : void
     {
-        $conn = DriverManager::getConnection([
-            'wrapperClass' => PoolingShardConnection::class,
+        $conn = $this->createConnection([
             'driver' => 'pdo_sqlite',
             'global' => ['memory' => true],
             'shards' => [
@@ -56,8 +56,7 @@ class PoolingShardConnectionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Connection Parameters require "global" and "shards" configurations.');
 
-        DriverManager::getConnection([
-            'wrapperClass' => PoolingShardConnection::class,
+        $this->createConnection([
             'driver' => 'pdo_sqlite',
             'shards' => [
                 ['id' => 1, 'memory' => true],
@@ -72,8 +71,7 @@ class PoolingShardConnectionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Connection Parameters require "global" and "shards" configurations.');
 
-        DriverManager::getConnection([
-            'wrapperClass' => PoolingShardConnection::class,
+        $this->createConnection([
             'driver' => 'pdo_sqlite',
             'global' => ['memory' => true],
             'shardChoser' => MultiTenantShardChoser::class,
@@ -85,8 +83,7 @@ class PoolingShardConnectionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Missing Shard Choser configuration "shardChoser".');
 
-        DriverManager::getConnection([
-            'wrapperClass' => PoolingShardConnection::class,
+        $this->createConnection([
             'driver' => 'pdo_sqlite',
             'global' => ['memory' => true],
             'shards' => [
@@ -101,8 +98,7 @@ class PoolingShardConnectionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The "shardChoser" configuration is not a valid instance of Doctrine\DBAL\Sharding\ShardChoser\ShardChoser');
 
-        DriverManager::getConnection([
-            'wrapperClass' => PoolingShardConnection::class,
+        $this->createConnection([
             'driver' => 'pdo_sqlite',
             'global' => ['memory' => true],
             'shards' => [
@@ -118,8 +114,7 @@ class PoolingShardConnectionTest extends TestCase
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Shard Id has to be a non-negative number.');
 
-        DriverManager::getConnection([
-            'wrapperClass' => PoolingShardConnection::class,
+        $this->createConnection([
             'driver' => 'pdo_sqlite',
             'global' => ['memory' => true],
             'shards' => [
@@ -134,8 +129,7 @@ class PoolingShardConnectionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Missing "id" for one configured shard. Please specify a unique shard-id.');
 
-        DriverManager::getConnection([
-            'wrapperClass' => PoolingShardConnection::class,
+        $this->createConnection([
             'driver' => 'pdo_sqlite',
             'global' => ['memory' => true],
             'shards' => [
@@ -150,8 +144,7 @@ class PoolingShardConnectionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Shard "1" is duplicated in the configuration.');
 
-        DriverManager::getConnection([
-            'wrapperClass' => PoolingShardConnection::class,
+        $this->createConnection([
             'driver' => 'pdo_sqlite',
             'global' => ['memory' => true],
             'shards' => [
@@ -164,8 +157,7 @@ class PoolingShardConnectionTest extends TestCase
 
     public function testSwitchShardWithOpenTransactionException() : void
     {
-        $conn = DriverManager::getConnection([
-            'wrapperClass' => PoolingShardConnection::class,
+        $conn = $this->createConnection([
             'driver' => 'pdo_sqlite',
             'global' => ['memory' => true],
             'shards' => [
@@ -183,8 +175,7 @@ class PoolingShardConnectionTest extends TestCase
 
     public function testGetActiveShardId() : void
     {
-        $conn = DriverManager::getConnection([
-            'wrapperClass' => PoolingShardConnection::class,
+        $conn = $this->createConnection([
             'driver' => 'pdo_sqlite',
             'global' => ['memory' => true],
             'shards' => [
@@ -207,8 +198,7 @@ class PoolingShardConnectionTest extends TestCase
 
     public function testGetParamsOverride() : void
     {
-        $conn = DriverManager::getConnection([
-            'wrapperClass' => PoolingShardConnection::class,
+        $conn = $this->createConnection([
             'driver' => 'pdo_sqlite',
             'global' => ['memory' => true, 'host' => 'localhost'],
             'shards' => [
@@ -242,5 +232,16 @@ class PoolingShardConnectionTest extends TestCase
             'memory' => true,
             'host' => 'foo',
         ], $conn->getParams());
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function createConnection(array $parameters) : PoolingShardConnection
+    {
+        return DriverManager::getConnection(array_merge(
+            ['wrapperClass' => PoolingShardConnection::class],
+            $parameters
+        ));
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | none

Enabled `SlevomatCodingStandard.TypeHints.TypeHintDeclaration.Missing{Parameter,Return}TypeHint` sniffs across the codebase.