### PR TITLE
Allow setting previous exception in AbstractDriverException

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractDriverException.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractDriverException.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Driver;
 
 use Exception;
+use Throwable;
 
 /**
  * Abstract base implementation of the {@link DriverException} interface.
@@ -27,10 +28,15 @@ abstract class AbstractDriverException extends Exception implements DriverExcept
      * @param string          $message   The driver error message.
      * @param string|null     $sqlState  The SQLSTATE the driver is in at the time the error occurred, if any.
      * @param int|string|null $errorCode The driver specific error code if any.
+     * @param Throwable|null  $previous  The previous exception.
      */
-    public function __construct($message, $sqlState = null, $errorCode = null)
-    {
-        parent::__construct($message);
+    public function __construct(
+        $message,
+        $sqlState = null,
+        $errorCode = null,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, 0, $previous);
 
         $this->errorCode = $errorCode;
         $this->sqlState  = $sqlState;

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverExceptionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Driver;
+
+use Doctrine\DBAL\Driver\AbstractDriverException;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+class AbstractDriverExceptionTest extends TestCase
+{
+    public function testCanSetPreviousException()
+    {
+        $previous = new Exception();
+
+        $abstractDriverException = new class($previous) extends AbstractDriverException {
+            public function __construct(Throwable $previous)
+            {
+                parent::__construct('', null, null, $previous);
+            }
+        };
+
+        $this->assertSame($previous, $abstractDriverException->getPrevious());
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

It is useful to be able to set the previous exception in AbstractDriverException, for logging and debugging purposes. In the case where the doctrine driver is an adapter for the driver of the underlying technology, that driver may have its own exceptions, which are currently lost if they are converted to AbstractDriverException. This change allows the exception from the underlying context to be retrieved.
