### PR TITLE
Extract type factory and registry from Type into TypeRegistry

### DIFF
--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\DriverException as DriverExceptionInterface;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
 use Exception;
 use Throwable;
 use function array_map;
@@ -18,6 +19,7 @@ use function is_resource;
 use function is_string;
 use function json_encode;
 use function preg_replace;
+use function spl_object_hash;
 use function sprintf;
 
 class DBALException extends Exception
@@ -276,5 +278,17 @@ class DBALException extends Exception
     public static function typeNotFound($name)
     {
         return new self('Type to be overwritten ' . $name . ' does not exist.');
+    }
+
+    public static function typeNotRegistered(Type $type) : self
+    {
+        return new self(sprintf('Type of the class %s@%s is not registered.', get_class($type), spl_object_hash($type)));
+    }
+
+    public static function typeAlreadyRegistered(Type $type) : self
+    {
+        return new self(
+            sprintf('Type of the class %s@%s is already registered.', get_class($type), spl_object_hash($type))
+        );
     }
 }

--- a/lib/Doctrine/DBAL/Types/TypeRegistry.php
+++ b/lib/Doctrine/DBAL/Types/TypeRegistry.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\DBALException;
+use function array_search;
+use function in_array;
+
+/**
+ * The type registry is responsible for holding a map of all known DBAL types.
+ * The types are stored using the flyweight pattern so that one type only exists as exactly one instance.
+ *
+ * @internal TypeRegistry exists for forward compatibility, its API should not be considered stable.
+ */
+final class TypeRegistry
+{
+    /** @var array<string, Type> Map of type names and their corresponding flyweight objects. */
+    private $instances = [];
+
+    /**
+     * Finds a type by the given name.
+     *
+     * @throws DBALException
+     */
+    public function get(string $name) : Type
+    {
+        if (! isset($this->instances[$name])) {
+            throw DBALException::unknownColumnType($name);
+        }
+
+        return $this->instances[$name];
+    }
+
+    /**
+     * Finds a name for the given type.
+     *
+     * @throws DBALException
+     */
+    public function lookupName(Type $type) : string
+    {
+        $name = $this->findTypeName($type);
+
+        if ($name === null) {
+            throw DBALException::typeNotRegistered($type);
+        }
+
+        return $name;
+    }
+
+    /**
+     * Checks if there is a type of the given name.
+     */
+    public function has(string $name) : bool
+    {
+        return isset($this->instances[$name]);
+    }
+
+    /**
+     * Registers a custom type to the type map.
+     *
+     * @throws DBALException
+     */
+    public function register(string $name, Type $type) : void
+    {
+        if (isset($this->instances[$name])) {
+            throw DBALException::typeExists($name);
+        }
+
+        if ($this->findTypeName($type) !== null) {
+            throw DBALException::typeAlreadyRegistered($type);
+        }
+
+        $this->instances[$name] = $type;
+    }
+
+    /**
+     * Overrides an already defined type to use a different implementation.
+     *
+     * @throws DBALException
+     */
+    public function override(string $name, Type $type) : void
+    {
+        if (! isset($this->instances[$name])) {
+            throw DBALException::typeNotFound($name);
+        }
+
+        if (! in_array($this->findTypeName($type), [$name, null], true)) {
+            throw DBALException::typeAlreadyRegistered($type);
+        }
+
+        $this->instances[$name] = $type;
+    }
+
+    /**
+     * Gets the map of all registered types and their corresponding type instances.
+     *
+     * @internal
+     *
+     * @return array<string, Type>
+     */
+    public function getMap() : array
+    {
+        return $this->instances;
+    }
+
+    private function findTypeName(Type $type) : ?string
+    {
+        $name = array_search($type, $this->instances, true);
+
+        if ($name === false) {
+            return null;
+        }
+
+        return $name;
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Types/TypeRegistryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/TypeRegistryTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Types;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Types\BinaryType;
+use Doctrine\DBAL\Types\BlobType;
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\TextType;
+use Doctrine\DBAL\Types\TypeRegistry;
+use PHPUnit\Framework\TestCase;
+
+class TypeRegistryTest extends TestCase
+{
+    private const TEST_TYPE_NAME       = 'test';
+    private const OTHER_TEST_TYPE_NAME = 'other';
+
+    /** @var TypeRegistry */
+    private $registry;
+
+    /** @var BlobType */
+    private $testType;
+
+    /** @var BinaryType */
+    private $otherTestType;
+
+    protected function setUp() : void
+    {
+        $this->testType      = new BlobType();
+        $this->otherTestType = new BinaryType();
+
+        $this->registry = new TypeRegistry();
+        $this->registry->register(self::TEST_TYPE_NAME, $this->testType);
+        $this->registry->register(self::OTHER_TEST_TYPE_NAME, $this->otherTestType);
+    }
+
+    public function testGet() : void
+    {
+        self::assertSame($this->testType, $this->registry->get(self::TEST_TYPE_NAME));
+        self::assertSame($this->otherTestType, $this->registry->get(self::OTHER_TEST_TYPE_NAME));
+
+        $this->expectException(DBALException::class);
+        $this->registry->get('unknown');
+    }
+
+    public function testGetReturnsSameInstances() : void
+    {
+        self::assertSame(
+            $this->registry->get(self::TEST_TYPE_NAME),
+            $this->registry->get(self::TEST_TYPE_NAME)
+        );
+    }
+
+    public function testLookupName() : void
+    {
+        self::assertSame(
+            self::TEST_TYPE_NAME,
+            $this->registry->lookupName($this->testType)
+        );
+        self::assertSame(
+            self::OTHER_TEST_TYPE_NAME,
+            $this->registry->lookupName($this->otherTestType)
+        );
+
+        $this->expectException(DBALException::class);
+        $this->registry->lookupName(new TextType());
+    }
+
+    public function testHas() : void
+    {
+        self::assertTrue($this->registry->has(self::TEST_TYPE_NAME));
+        self::assertTrue($this->registry->has(self::OTHER_TEST_TYPE_NAME));
+        self::assertFalse($this->registry->has('unknown'));
+    }
+
+    public function testRegister() : void
+    {
+        $newType = new TextType();
+
+        $this->registry->register('some', $newType);
+
+        self::assertTrue($this->registry->has('some'));
+        self::assertSame($newType, $this->registry->get('some'));
+    }
+
+    public function testRegisterWithAlradyRegisteredName() : void
+    {
+        $this->registry->register('some', new TextType());
+
+        $this->expectException(DBALException::class);
+        $this->registry->register('some', new TextType());
+    }
+
+    public function testRegisterWithAlreadyRegisteredInstance() : void
+    {
+        $newType = new TextType();
+
+        $this->registry->register('some', $newType);
+
+        $this->expectException(DBALException::class);
+        $this->registry->register('other', $newType);
+    }
+
+    public function testOverride() : void
+    {
+        $baseType     = new TextType();
+        $overrideType = new StringType();
+
+        $this->registry->register('some', $baseType);
+        $this->registry->override('some', $overrideType);
+
+        self::assertSame($overrideType, $this->registry->get('some'));
+    }
+
+    public function testOverrideAllowsExistingInstance() : void
+    {
+        $type = new TextType();
+
+        $this->registry->register('some', $type);
+        $this->registry->override('some', $type);
+
+        self::assertSame($type, $this->registry->get('some'));
+    }
+
+    public function testOverrideWithAlreadyRegisteredInstance() : void
+    {
+        $newType = new TextType();
+
+        $this->registry->register('first', $newType);
+        $this->registry->register('second', new StringType());
+
+        $this->expectException(DBALException::class);
+        $this->registry->override('second', $newType);
+    }
+
+    public function testOverrideWithUnknownType() : void
+    {
+        $this->expectException(DBALException::class);
+        $this->registry->override('unknown', new TextType());
+    }
+
+    public function testGetMap() : void
+    {
+        $registeredTypes = $this->registry->getMap();
+
+        self::assertCount(2, $registeredTypes);
+        self::assertArrayHasKey(self::TEST_TYPE_NAME, $registeredTypes);
+        self::assertArrayHasKey(self::OTHER_TEST_TYPE_NAME, $registeredTypes);
+        self::assertSame($this->testType, $registeredTypes[self::TEST_TYPE_NAME]);
+        self::assertSame($this->otherTestType, $registeredTypes[self::OTHER_TEST_TYPE_NAME]);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Types/TypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/TypeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Types;
+
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class TypeTest extends TestCase
+{
+    /**
+     * @dataProvider defaultTypesProvider()
+     */
+    public function testDefaultTypesAreRegistered(string $name) : void
+    {
+        self::assertTrue(Type::hasType($name));
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function defaultTypesProvider() : iterable
+    {
+        foreach ((new ReflectionClass(Type::class))->getReflectionConstants() as $constant) {
+            if (! $constant->isPublic()) {
+                continue;
+            }
+
+            yield [$constant->getValue()];
+        }
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Related issues | #2841

#### Summary

This PR splits Type factory, registry and abstract ancestor for all implementors.
Factory and registry stuff is moved to new TypeRegistry which holds no default types on its own.

##### TODO
* [x] Make `addType()` and `overrideType()` accept instances or factories instead of class name strings? This would remove internal API dependency on `Type`'s constructor and allow users use it.

##### Further scope
* Add support type aliases on registry level (internally one level of indirection, not leaked outside registry).
* Make TypeRegistry per-connection, so different platforms may declare different types.
* Eliminate static access to `Type::*()` registry methods.
* Deprecate and remove `Type::getName()` and leverage ~`TypeRegistry::getName()`~`TypeRegistry::lookupName()` instead.
* Un`@internal`ize TypeRegistry.

cc @greg0ire