### PR TITLE
Implemented comparison of default values as strings regardless of their PHP types

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -432,12 +432,10 @@ class Comparator
             $changedProperties[] = 'comment';
         }
 
-        if ($properties1['default'] !== $properties2['default'] ||
-            // Null values need to be checked additionally as they tell whether to create or drop a default value.
-            // null != 0, null != false, null != '' etc. This affects platform's table alteration SQL generation.
-            ($properties1['default'] === null && $properties2['default'] !== null) ||
-            ($properties2['default'] === null && $properties1['default'] !== null)
-        ) {
+        // Null values need to be checked additionally as they tell whether to create or drop a default value.
+        // null != 0, null != false, null != '' etc. This affects platform's table alteration SQL generation.
+        if (($properties1['default'] === null) !== ($properties2['default'] === null)
+            || (string) $properties1['default'] !== (string) $properties2['default']) {
             $changedProperties[] = 'default';
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/ComparatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Functional\Schema;
+
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+class ComparatorTest extends DbalFunctionalTestCase
+{
+    /** @var AbstractSchemaManager */
+    private $schemaManager;
+
+    /** @var Comparator */
+    private $comparator;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->schemaManager = $this->connection->getSchemaManager();
+        $this->comparator    = new Comparator();
+    }
+
+    public function testDefaultValueComparison()
+    {
+        $table = new Table('default_value');
+        $table->addColumn('id', 'integer', ['default' => 1]);
+
+        $this->schemaManager->createTable($table);
+
+        $onlineTable = $this->schemaManager->listTableDetails('default_value');
+
+        self::assertFalse($this->comparator->diffTable($table, $onlineTable));
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -23,6 +23,8 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
             return;
         }
 
+        $this->resetSharedConn();
+
         Type::addType('point', MySqlPointType::class);
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3336

Compare default values as strings (as they appear in SQL and introspected schema) regardless of their PHP types.