### PR TITLE
Extract constants for built-in types from Type to Types

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,16 @@
+# Upgrade to 2.10
+
+## Deprecated `Type::*` constants
+
+The constants for built-in types have been moved from `Doctrine\DBAL\Types\Type` to a separate class `Doctrine\DBAL\Types\Types`.
+
+Some of the constants were renamed in the process:
+* `TARRAY`-> `ARRAY`
+* `DATE` -> `DATE_MUTABLE`
+* `DATETIME` -> `DATETIME_MUTABLE`
+* `DATETIMETZ` -> `DATETIMETZ_MUTABLE`
+* `TIME` -> `TIME_MUTABLE`
+
 # Upgrade to 2.9
 
 ## Deprecated `Statement::fetchColumn()` with an invalid index

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use function array_merge;
 use function count;
 use function current;
@@ -96,7 +97,7 @@ class DB2Platform extends AbstractPlatform
      */
     public function isCommentedDoctrineType(Type $doctrineType)
     {
-        if ($doctrineType->getName() === Type::BOOLEAN) {
+        if ($doctrineType->getName() === Types::BOOLEAN) {
             // We require a commented boolean type in order to distinguish between boolean and smallint
             // as both (have to) map to the same native type.
             return true;

--- a/lib/Doctrine/DBAL/Platforms/MariaDb1027Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MariaDb1027Platform.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 /**
  * Provides the behavior, features and SQL dialect of the MariaDB 10.2 (10.2.7 GA) database platform.
@@ -36,6 +36,6 @@ final class MariaDb1027Platform extends MySqlPlatform
     {
         parent::initializeDoctrineTypeMappings();
 
-        $this->doctrineTypeMapping['json'] = Type::JSON;
+        $this->doctrineTypeMapping['json'] = Types::JSON;
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 /**
  * Provides the behavior, features and SQL dialect of the MySQL 5.7 (5.7.9 GA) database platform.
@@ -66,6 +66,6 @@ class MySQL57Platform extends MySqlPlatform
     {
         parent::initializeDoctrineTypeMappings();
 
-        $this->doctrineTypeMapping['json'] = Type::JSON;
+        $this->doctrineTypeMapping['json'] = Types::JSON;
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/PostgreSQL92Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSQL92Platform.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use function sprintf;
 
 /**
@@ -53,7 +53,7 @@ class PostgreSQL92Platform extends PostgreSQL91Platform
     {
         parent::initializeDoctrineTypeMappings();
 
-        $this->doctrineTypeMapping['json'] = Type::JSON;
+        $this->doctrineTypeMapping['json'] = Types::JSON;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/PostgreSQL94Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSQL94Platform.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 /**
  * Provides the behavior, features and SQL dialect of the PostgreSQL 9.4 database platform.
@@ -36,6 +36,6 @@ class PostgreSQL94Platform extends PostgreSQL92Platform
     {
         parent::initializeDoctrineTypeMappings();
 
-        $this->doctrineTypeMapping['jsonb'] = Type::JSON;
+        $this->doctrineTypeMapping['jsonb'] = Types::JSON;
     }
 }

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use const CASE_LOWER;
 use function array_change_key_case;
 use function array_filter;
@@ -456,7 +457,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
             $column->setPlatformOption('collation', $tableColumn['collation']);
         }
 
-        if (in_array($column->getType()->getName(), [Type::JSON_ARRAY, Type::JSON], true)) {
+        if (in_array($column->getType()->getName(), [Types::JSON_ARRAY, Types::JSON], true)) {
             $column->setPlatformOption('jsonb', $jsonb);
         }
 

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizer.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizer.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Schema\Synchronizer\AbstractSchemaSynchronizer;
 use Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer;
 use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use RuntimeException;
 use function array_merge;
 
@@ -240,12 +241,12 @@ class SQLAzureFederationsSynchronizer extends AbstractSchemaSynchronizer
         $federationType = Type::getType($this->shardManager->getDistributionType());
 
         switch ($federationType->getName()) {
-            case Type::GUID:
+            case Types::GUID:
                 $defaultValue = '00000000-0000-0000-0000-000000000000';
                 break;
-            case Type::INTEGER:
-            case Type::SMALLINT:
-            case Type::BIGINT:
+            case Types::INTEGER:
+            case Types::SMALLINT:
+            case Types::BIGINT:
                 $defaultValue = '0';
                 break;
             default:

--- a/lib/Doctrine/DBAL/Types/ArrayType.php
+++ b/lib/Doctrine/DBAL/Types/ArrayType.php
@@ -59,7 +59,7 @@ class ArrayType extends Type
      */
     public function getName()
     {
-        return Type::TARRAY;
+        return Types::ARRAY;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/BigIntType.php
+++ b/lib/Doctrine/DBAL/Types/BigIntType.php
@@ -15,7 +15,7 @@ class BigIntType extends Type implements PhpIntegerMappingType
      */
     public function getName()
     {
-        return Type::BIGINT;
+        return Types::BIGINT;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/BinaryType.php
+++ b/lib/Doctrine/DBAL/Types/BinaryType.php
@@ -42,7 +42,7 @@ class BinaryType extends Type
         }
 
         if (! is_resource($value)) {
-            throw ConversionException::conversionFailed($value, self::BINARY);
+            throw ConversionException::conversionFailed($value, Types::BINARY);
         }
 
         return $value;
@@ -53,7 +53,7 @@ class BinaryType extends Type
      */
     public function getName()
     {
-        return Type::BINARY;
+        return Types::BINARY;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/BlobType.php
+++ b/lib/Doctrine/DBAL/Types/BlobType.php
@@ -42,7 +42,7 @@ class BlobType extends Type
         }
 
         if (! is_resource($value)) {
-            throw ConversionException::conversionFailed($value, self::BLOB);
+            throw ConversionException::conversionFailed($value, Types::BLOB);
         }
 
         return $value;
@@ -53,7 +53,7 @@ class BlobType extends Type
      */
     public function getName()
     {
-        return Type::BLOB;
+        return Types::BLOB;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/BooleanType.php
+++ b/lib/Doctrine/DBAL/Types/BooleanType.php
@@ -39,7 +39,7 @@ class BooleanType extends Type
      */
     public function getName()
     {
-        return Type::BOOLEAN;
+        return Types::BOOLEAN;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/DateImmutableType.php
+++ b/lib/Doctrine/DBAL/Types/DateImmutableType.php
@@ -15,7 +15,7 @@ class DateImmutableType extends DateType
      */
     public function getName()
     {
-        return Type::DATE_IMMUTABLE;
+        return Types::DATE_IMMUTABLE;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/DateIntervalType.php
+++ b/lib/Doctrine/DBAL/Types/DateIntervalType.php
@@ -19,7 +19,7 @@ class DateIntervalType extends Type
      */
     public function getName()
     {
-        return Type::DATEINTERVAL;
+        return Types::DATEINTERVAL;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/DateTimeImmutableType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeImmutableType.php
@@ -16,7 +16,7 @@ class DateTimeImmutableType extends DateTimeType
      */
     public function getName()
     {
-        return Type::DATETIME_IMMUTABLE;
+        return Types::DATETIME_IMMUTABLE;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/DateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeType.php
@@ -17,7 +17,7 @@ class DateTimeType extends Type implements PhpDateTimeMappingType
      */
     public function getName()
     {
-        return Type::DATETIME;
+        return Types::DATETIME_MUTABLE;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/DateTimeTzImmutableType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeTzImmutableType.php
@@ -15,7 +15,7 @@ class DateTimeTzImmutableType extends DateTimeTzType
      */
     public function getName()
     {
-        return Type::DATETIMETZ_IMMUTABLE;
+        return Types::DATETIMETZ_IMMUTABLE;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/DateTimeTzType.php
+++ b/lib/Doctrine/DBAL/Types/DateTimeTzType.php
@@ -29,7 +29,7 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
      */
     public function getName()
     {
-        return Type::DATETIMETZ;
+        return Types::DATETIMETZ_MUTABLE;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/DateType.php
+++ b/lib/Doctrine/DBAL/Types/DateType.php
@@ -16,7 +16,7 @@ class DateType extends Type
      */
     public function getName()
     {
-        return Type::DATE;
+        return Types::DATE_MUTABLE;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/DecimalType.php
+++ b/lib/Doctrine/DBAL/Types/DecimalType.php
@@ -14,7 +14,7 @@ class DecimalType extends Type
      */
     public function getName()
     {
-        return Type::DECIMAL;
+        return Types::DECIMAL;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/FloatType.php
+++ b/lib/Doctrine/DBAL/Types/FloatType.php
@@ -11,7 +11,7 @@ class FloatType extends Type
      */
     public function getName()
     {
-        return Type::FLOAT;
+        return Types::FLOAT;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/GuidType.php
+++ b/lib/Doctrine/DBAL/Types/GuidType.php
@@ -22,7 +22,7 @@ class GuidType extends StringType
      */
     public function getName()
     {
-        return Type::GUID;
+        return Types::GUID;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/IntegerType.php
+++ b/lib/Doctrine/DBAL/Types/IntegerType.php
@@ -15,7 +15,7 @@ class IntegerType extends Type implements PhpIntegerMappingType
      */
     public function getName()
     {
-        return Type::INTEGER;
+        return Types::INTEGER;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/JsonArrayType.php
+++ b/lib/Doctrine/DBAL/Types/JsonArrayType.php
@@ -33,7 +33,7 @@ class JsonArrayType extends JsonType
      */
     public function getName()
     {
-        return Type::JSON_ARRAY;
+        return Types::JSON_ARRAY;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/JsonType.php
+++ b/lib/Doctrine/DBAL/Types/JsonType.php
@@ -69,7 +69,7 @@ class JsonType extends Type
      */
     public function getName()
     {
-        return Type::JSON;
+        return Types::JSON;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/ObjectType.php
+++ b/lib/Doctrine/DBAL/Types/ObjectType.php
@@ -58,7 +58,7 @@ class ObjectType extends Type
      */
     public function getName()
     {
-        return Type::OBJECT;
+        return Types::OBJECT;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/SimpleArrayType.php
+++ b/lib/Doctrine/DBAL/Types/SimpleArrayType.php
@@ -54,7 +54,7 @@ class SimpleArrayType extends Type
      */
     public function getName()
     {
-        return Type::SIMPLE_ARRAY;
+        return Types::SIMPLE_ARRAY;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/SmallIntType.php
+++ b/lib/Doctrine/DBAL/Types/SmallIntType.php
@@ -15,7 +15,7 @@ class SmallIntType extends Type implements PhpIntegerMappingType
      */
     public function getName()
     {
-        return Type::SMALLINT;
+        return Types::SMALLINT;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/StringType.php
+++ b/lib/Doctrine/DBAL/Types/StringType.php
@@ -30,6 +30,6 @@ class StringType extends Type
      */
     public function getName()
     {
-        return Type::STRING;
+        return Types::STRING;
     }
 }

--- a/lib/Doctrine/DBAL/Types/TextType.php
+++ b/lib/Doctrine/DBAL/Types/TextType.php
@@ -32,6 +32,6 @@ class TextType extends Type
      */
     public function getName()
     {
-        return Type::TEXT;
+        return Types::TEXT;
     }
 }

--- a/lib/Doctrine/DBAL/Types/TimeImmutableType.php
+++ b/lib/Doctrine/DBAL/Types/TimeImmutableType.php
@@ -15,7 +15,7 @@ class TimeImmutableType extends TimeType
      */
     public function getName()
     {
-        return Type::TIME_IMMUTABLE;
+        return Types::TIME_IMMUTABLE;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/TimeType.php
+++ b/lib/Doctrine/DBAL/Types/TimeType.php
@@ -16,7 +16,7 @@ class TimeType extends Type
      */
     public function getName()
     {
-        return Type::TIME;
+        return Types::TIME_MUTABLE;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -18,61 +18,110 @@ use function substr;
  */
 abstract class Type
 {
-    public const BIGINT               = 'bigint';
-    public const BINARY               = 'binary';
-    public const BLOB                 = 'blob';
-    public const BOOLEAN              = 'boolean';
-    public const DATE                 = 'date';
-    public const DATE_IMMUTABLE       = 'date_immutable';
-    public const DATEINTERVAL         = 'dateinterval';
-    public const DATETIME             = 'datetime';
-    public const DATETIME_IMMUTABLE   = 'datetime_immutable';
-    public const DATETIMETZ           = 'datetimetz';
-    public const DATETIMETZ_IMMUTABLE = 'datetimetz_immutable';
-    public const DECIMAL              = 'decimal';
-    public const FLOAT                = 'float';
-    public const GUID                 = 'guid';
-    public const INTEGER              = 'integer';
-    public const JSON                 = 'json';
-    public const JSON_ARRAY           = 'json_array';
-    public const OBJECT               = 'object';
-    public const SIMPLE_ARRAY         = 'simple_array';
-    public const SMALLINT             = 'smallint';
-    public const STRING               = 'string';
-    public const TARRAY               = 'array';
-    public const TEXT                 = 'text';
-    public const TIME                 = 'time';
-    public const TIME_IMMUTABLE       = 'time_immutable';
+    /** @deprecated Use {@see DefaultTypes::BIGINT} instead. */
+    public const BIGINT = Types::BIGINT;
+
+    /** @deprecated Use {@see DefaultTypes::BINARY} instead. */
+    public const BINARY = Types::BINARY;
+
+    /** @deprecated Use {@see DefaultTypes::BLOB} instead. */
+    public const BLOB = Types::BLOB;
+
+    /** @deprecated Use {@see DefaultTypes::BOOLEAN} instead. */
+    public const BOOLEAN = Types::BOOLEAN;
+
+    /** @deprecated Use {@see DefaultTypes::DATE_MUTABLE} instead. */
+    public const DATE = Types::DATE_MUTABLE;
+
+    /** @deprecated Use {@see DefaultTypes::DATE_IMMUTABLE} instead. */
+    public const DATE_IMMUTABLE = Types::DATE_IMMUTABLE;
+
+    /** @deprecated Use {@see DefaultTypes::DATEINTERVAL} instead. */
+    public const DATEINTERVAL = Types::DATEINTERVAL;
+
+    /** @deprecated Use {@see DefaultTypes::DATETIME_MUTABLE} instead. */
+    public const DATETIME = Types::DATETIME_MUTABLE;
+
+    /** @deprecated Use {@see DefaultTypes::DATETIME_IMMUTABLE} instead. */
+    public const DATETIME_IMMUTABLE = Types::DATETIME_IMMUTABLE;
+
+    /** @deprecated Use {@see DefaultTypes::DATETIMETZ_MUTABLE} instead. */
+    public const DATETIMETZ = Types::DATETIMETZ_MUTABLE;
+
+    /** @deprecated Use {@see DefaultTypes::DATETIMETZ_IMMUTABLE} instead. */
+    public const DATETIMETZ_IMMUTABLE = Types::DATETIMETZ_IMMUTABLE;
+
+    /** @deprecated Use {@see DefaultTypes::DECIMAL} instead. */
+    public const DECIMAL = Types::DECIMAL;
+
+    /** @deprecated Use {@see DefaultTypes::FLOAT} instead. */
+    public const FLOAT = Types::FLOAT;
+
+    /** @deprecated Use {@see DefaultTypes::GUID} instead. */
+    public const GUID = Types::GUID;
+
+    /** @deprecated Use {@see DefaultTypes::INTEGER} instead. */
+    public const INTEGER = Types::INTEGER;
+
+    /** @deprecated Use {@see DefaultTypes::JSON} instead. */
+    public const JSON = Types::JSON;
+
+    /** @deprecated Use {@see DefaultTypes::JSON_ARRAY} instead. */
+    public const JSON_ARRAY = Types::JSON_ARRAY;
+
+    /** @deprecated Use {@see DefaultTypes::OBJECT} instead. */
+    public const OBJECT = Types::OBJECT;
+
+    /** @deprecated Use {@see DefaultTypes::SIMPLE_ARRAY} instead. */
+    public const SIMPLE_ARRAY = Types::SIMPLE_ARRAY;
+
+    /** @deprecated Use {@see DefaultTypes::SMALLINT} instead. */
+    public const SMALLINT = Types::SMALLINT;
+
+    /** @deprecated Use {@see DefaultTypes::STRING} instead. */
+    public const STRING = Types::STRING;
+
+    /** @deprecated Use {@see DefaultTypes::ARRAY} instead. */
+    public const TARRAY = Types::ARRAY;
+
+    /** @deprecated Use {@see DefaultTypes::TEXT} instead. */
+    public const TEXT = Types::TEXT;
+
+    /** @deprecated Use {@see DefaultTypes::TIME_MUTABLE} instead. */
+    public const TIME = Types::TIME_MUTABLE;
+
+    /** @deprecated Use {@see DefaultTypes::TIME_IMMUTABLE} instead. */
+    public const TIME_IMMUTABLE = Types::TIME_IMMUTABLE;
 
     /**
      * The map of supported doctrine mapping types.
      */
     private const BUILTIN_TYPES_MAP = [
-        self::BIGINT               => BigIntType::class,
-        self::BINARY               => BinaryType::class,
-        self::BLOB                 => BlobType::class,
-        self::BOOLEAN              => BooleanType::class,
-        self::DATE                 => DateType::class,
-        self::DATE_IMMUTABLE       => DateImmutableType::class,
-        self::DATEINTERVAL         => DateIntervalType::class,
-        self::DATETIME             => DateTimeType::class,
-        self::DATETIME_IMMUTABLE   => DateTimeImmutableType::class,
-        self::DATETIMETZ           => DateTimeTzType::class,
-        self::DATETIMETZ_IMMUTABLE => DateTimeTzImmutableType::class,
-        self::DECIMAL              => DecimalType::class,
-        self::FLOAT                => FloatType::class,
-        self::GUID                 => GuidType::class,
-        self::INTEGER              => IntegerType::class,
-        self::JSON                 => JsonType::class,
-        self::JSON_ARRAY           => JsonArrayType::class,
-        self::OBJECT               => ObjectType::class,
-        self::SIMPLE_ARRAY         => SimpleArrayType::class,
-        self::SMALLINT             => SmallIntType::class,
-        self::STRING               => StringType::class,
-        self::TARRAY               => ArrayType::class,
-        self::TEXT                 => TextType::class,
-        self::TIME                 => TimeType::class,
-        self::TIME_IMMUTABLE       => TimeImmutableType::class,
+        Types::ARRAY                => ArrayType::class,
+        Types::BIGINT               => BigIntType::class,
+        Types::BINARY               => BinaryType::class,
+        Types::BLOB                 => BlobType::class,
+        Types::BOOLEAN              => BooleanType::class,
+        Types::DATE_MUTABLE         => DateType::class,
+        Types::DATE_IMMUTABLE       => DateImmutableType::class,
+        Types::DATEINTERVAL         => DateIntervalType::class,
+        Types::DATETIME_MUTABLE     => DateTimeType::class,
+        Types::DATETIME_IMMUTABLE   => DateTimeImmutableType::class,
+        Types::DATETIMETZ_MUTABLE   => DateTimeTzType::class,
+        Types::DATETIMETZ_IMMUTABLE => DateTimeTzImmutableType::class,
+        Types::DECIMAL              => DecimalType::class,
+        Types::FLOAT                => FloatType::class,
+        Types::GUID                 => GuidType::class,
+        Types::INTEGER              => IntegerType::class,
+        Types::JSON                 => JsonType::class,
+        Types::JSON_ARRAY           => JsonArrayType::class,
+        Types::OBJECT               => ObjectType::class,
+        Types::SIMPLE_ARRAY         => SimpleArrayType::class,
+        Types::SMALLINT             => SmallIntType::class,
+        Types::STRING               => StringType::class,
+        Types::TEXT                 => TextType::class,
+        Types::TIME_MUTABLE         => TimeType::class,
+        Types::TIME_IMMUTABLE       => TimeImmutableType::class,
     ];
 
     /** @var TypeRegistry|null */

--- a/lib/Doctrine/DBAL/Types/Types.php
+++ b/lib/Doctrine/DBAL/Types/Types.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types;
+
+/**
+ * Default built-in types provided by Doctrine DBAL.
+ */
+final class Types
+{
+    public const ARRAY                = 'array';
+    public const BIGINT               = 'bigint';
+    public const BINARY               = 'binary';
+    public const BLOB                 = 'blob';
+    public const BOOLEAN              = 'boolean';
+    public const DATE_MUTABLE         = 'date';
+    public const DATE_IMMUTABLE       = 'date_immutable';
+    public const DATEINTERVAL         = 'dateinterval';
+    public const DATETIME_MUTABLE     = 'datetime';
+    public const DATETIME_IMMUTABLE   = 'datetime_immutable';
+    public const DATETIMETZ_MUTABLE   = 'datetimetz';
+    public const DATETIMETZ_IMMUTABLE = 'datetimetz_immutable';
+    public const DECIMAL              = 'decimal';
+    public const FLOAT                = 'float';
+    public const GUID                 = 'guid';
+    public const INTEGER              = 'integer';
+    public const JSON                 = 'json';
+    public const OBJECT               = 'object';
+    public const SIMPLE_ARRAY         = 'simple_array';
+    public const SMALLINT             = 'smallint';
+    public const STRING               = 'string';
+    public const TEXT                 = 'text';
+    public const TIME_MUTABLE         = 'time';
+    public const TIME_IMMUTABLE       = 'time_immutable';
+
+    /** @deprecated json_array type is deprecated, use {@see DefaultTypes::JSON} instead. */
+    public const JSON_ARRAY = 'json_array';
+
+    private function __construct()
+    {
+    }
+}

--- a/lib/Doctrine/DBAL/Types/VarDateTimeImmutableType.php
+++ b/lib/Doctrine/DBAL/Types/VarDateTimeImmutableType.php
@@ -16,7 +16,7 @@ class VarDateTimeImmutableType extends VarDateTimeType
      */
     public function getName()
     {
-        return Type::DATETIME_IMMUTABLE;
+        return Types::DATETIME_IMMUTABLE;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use Error;
 use Exception;
@@ -252,7 +252,7 @@ class ConnectionTest extends DbalFunctionalTestCase
     public function testQuote()
     {
         self::assertEquals(
-            $this->connection->quote('foo', Type::STRING),
+            $this->connection->quote('foo', Types::STRING),
             $this->connection->quote('foo', ParameterType::STRING)
         );
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -16,7 +16,7 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\TrimMode;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Statement;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use PDO;
 use const CASE_LOWER;
@@ -225,7 +225,11 @@ class DataAccessTest extends DbalFunctionalTestCase
         $datetime       = new DateTime($datetimeString);
 
         $sql  = 'SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?';
-        $data = $this->connection->fetchAll($sql, [1, $datetime], [ParameterType::STRING, Type::DATETIME]);
+        $data = $this->connection->fetchAll(
+            $sql,
+            [1, $datetime],
+            [ParameterType::STRING, Types::DATETIME_MUTABLE]
+        );
 
         self::assertCount(1, $data);
 
@@ -297,7 +301,11 @@ class DataAccessTest extends DbalFunctionalTestCase
         $datetime       = new DateTime($datetimeString);
 
         $sql = 'SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?';
-        $row = $this->connection->fetchAssoc($sql, [1, $datetime], [ParameterType::STRING, Type::DATETIME]);
+        $row = $this->connection->fetchAssoc(
+            $sql,
+            [1, $datetime],
+            [ParameterType::STRING, Types::DATETIME_MUTABLE]
+        );
 
         self::assertNotFalse($row);
 
@@ -338,7 +346,11 @@ class DataAccessTest extends DbalFunctionalTestCase
         $datetime       = new DateTime($datetimeString);
 
         $sql = 'SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?';
-        $row = $this->connection->fetchArray($sql, [1, $datetime], [ParameterType::STRING, Type::DATETIME]);
+        $row = $this->connection->fetchArray(
+            $sql,
+            [1, $datetime],
+            [ParameterType::STRING, Types::DATETIME_MUTABLE]
+        );
 
         self::assertNotFalse($row);
 
@@ -383,7 +395,12 @@ class DataAccessTest extends DbalFunctionalTestCase
         $datetime       = new DateTime($datetimeString);
 
         $sql    = 'SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?';
-        $column = $this->connection->fetchColumn($sql, [1, $datetime], 1, [ParameterType::STRING, Type::DATETIME]);
+        $column = $this->connection->fetchColumn(
+            $sql,
+            [1, $datetime],
+            1,
+            [ParameterType::STRING, Types::DATETIME_MUTABLE]
+        );
 
         self::assertNotFalse($column);
 
@@ -415,7 +432,7 @@ class DataAccessTest extends DbalFunctionalTestCase
         $stmt = $this->connection->executeQuery(
             $sql,
             [1 => new DateTime('2010-01-01 10:10:10')],
-            [1 => Type::DATETIME]
+            [1 => Types::DATETIME_MUTABLE]
         );
 
         self::assertEquals(1, $stmt->fetchColumn());
@@ -436,14 +453,14 @@ class DataAccessTest extends DbalFunctionalTestCase
         ], [
             1 => ParameterType::INTEGER,
             2 => ParameterType::STRING,
-            3 => Type::DATETIME,
+            3 => Types::DATETIME_MUTABLE,
         ]);
 
         self::assertEquals(1, $affectedRows);
         self::assertEquals(1, $this->connection->executeQuery(
             'SELECT count(*) AS c FROM fetch_table WHERE test_datetime = ?',
             [1 => $datetime],
-            [1 => Type::DATETIME]
+            [1 => Types::DATETIME_MUTABLE]
         )->fetchColumn());
     }
 
@@ -454,7 +471,7 @@ class DataAccessTest extends DbalFunctionalTestCase
     {
         $sql  = 'SELECT count(*) AS c FROM fetch_table WHERE test_datetime = ?';
         $stmt = $this->connection->prepare($sql);
-        $stmt->bindValue(1, new DateTime('2010-01-01 10:10:10'), Type::DATETIME);
+        $stmt->bindValue(1, new DateTime('2010-01-01 10:10:10'), Types::DATETIME_MUTABLE);
         $stmt->execute();
 
         self::assertEquals(1, $stmt->fetchColumn());

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\Types\MySqlPointType;
 use function implode;
 use function sprintf;
@@ -415,7 +416,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $columns = $this->schemaManager->listTableColumns('test_mysql_json');
 
-        self::assertSame(Type::JSON, $columns['col_json']->getType()->getName());
+        self::assertSame(Types::JSON, $columns['col_json']->getType()->getName());
     }
 
     public function testColumnDefaultCurrentTimestamp() : void

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\DBAL\Functional\Schema;
 use Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\BinaryType;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\TestUtil;
 use function array_map;
 
@@ -232,7 +232,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->schemaManager->dropAndCreateTable($table);
 
         $otherTable = new Table($table->getName());
-        $otherTable->addColumn('id', Type::STRING);
+        $otherTable->addColumn('id', Types::STRING);
         TestUtil::getTempConnection()->getSchemaManager()->dropAndCreateTable($otherTable);
 
         $columns = $this->schemaManager->listTableColumns($table->getName(), $this->connection->getUsername());

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\DecimalType;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use function array_map;
 use function array_pop;
 use function count;
@@ -410,8 +411,8 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function jsonbColumnTypeProvider() : array
     {
         return [
-            [Type::JSON],
-            [Type::JSON_ARRAY],
+            [Types::JSON],
+            [Types::JSON_ARRAY],
         ];
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use SQLite3;
 use function array_map;
 use function dirname;
@@ -206,8 +207,8 @@ SQL;
         self::assertArrayHasKey('foo', $columns);
         self::assertArrayHasKey('bar', $columns);
 
-        self::assertSame(Type::getType(Type::STRING), $columns['foo']->getType());
-        self::assertSame(Type::getType(Type::TEXT), $columns['bar']->getType());
+        self::assertSame(Type::getType(Types::STRING), $columns['foo']->getType());
+        self::assertSame(Type::getType(Types::TEXT), $columns['bar']->getType());
 
         self::assertSame(64, $columns['foo']->getLength());
         self::assertSame(100, $columns['bar']->getLength());

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 class DB2PlatformTest extends AbstractPlatformTestCase
 {
@@ -279,7 +280,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     {
         $data = parent::getIsCommentedDoctrineType();
 
-        $data[Type::BOOLEAN] = [Type::getType(Type::BOOLEAN), true];
+        $data[Types::BOOLEAN] = [Type::getType(Types::BOOLEAN), true];
 
         return $data;
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/MariaDb1027PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MariaDb1027PlatformTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 class MariaDb1027PlatformTest extends AbstractMySQLPlatformTestCase
 {
@@ -33,7 +33,7 @@ class MariaDb1027PlatformTest extends AbstractMySQLPlatformTestCase
     public function testInitializesJsonTypeMapping() : void
     {
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('json'));
-        self::assertSame(Type::JSON, $this->platform->getDoctrineTypeMapping('json'));
+        self::assertSame(Types::JSON, $this->platform->getDoctrineTypeMapping('json'));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySQL57PlatformTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\MySQL57Platform;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 class MySQL57PlatformTest extends AbstractMySQLPlatformTestCase
 {
@@ -28,7 +28,7 @@ class MySQL57PlatformTest extends AbstractMySQLPlatformTestCase
     public function testInitializesJsonTypeMapping()
     {
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('json'));
-        self::assertSame(Type::JSON, $this->platform->getDoctrineTypeMapping('json'));
+        self::assertSame(Types::JSON, $this->platform->getDoctrineTypeMapping('json'));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL92PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL92PlatformTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\PostgreSQL92Platform;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 class PostgreSQL92PlatformTest extends AbstractPostgreSqlPlatformTestCase
 {
@@ -55,7 +55,7 @@ class PostgreSQL92PlatformTest extends AbstractPostgreSqlPlatformTestCase
     public function testInitializesJsonTypeMapping()
     {
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('json'));
-        self::assertEquals(Type::JSON, $this->platform->getDoctrineTypeMapping('json'));
+        self::assertEquals(Types::JSON, $this->platform->getDoctrineTypeMapping('json'));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL94PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL94PlatformTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 class PostgreSQL94PlatformTest extends PostgreSQL92PlatformTest
 {
@@ -26,6 +26,6 @@ class PostgreSQL94PlatformTest extends PostgreSQL92PlatformTest
     {
         parent::testInitializesJsonTypeMapping();
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('jsonb'));
-        self::assertEquals(Type::JSON, $this->platform->getDoctrineTypeMapping('jsonb'));
+        self::assertEquals(Types::JSON, $this->platform->getDoctrineTypeMapping('jsonb'));
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/ColumnDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ColumnDiffTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL\Schema;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 class ColumnDiffTest extends TestCase
@@ -14,8 +15,8 @@ class ColumnDiffTest extends TestCase
      */
     public function testPreservesOldColumnNameQuotation()
     {
-        $fromColumn = new Column('"foo"', Type::getType(Type::INTEGER));
-        $toColumn   = new Column('bar', Type::getType(Type::INTEGER));
+        $fromColumn = new Column('"foo"', Type::getType(Types::INTEGER));
+        $toColumn   = new Column('bar', Type::getType(Types::INTEGER));
 
         $columnDiff = new ColumnDiff('"foo"', $toColumn, []);
         self::assertTrue($columnDiff->getOldColumnName()->isQuoted());

--- a/tests/Doctrine/Tests/DBAL/Schema/ColumnTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ColumnTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 class ColumnTest extends TestCase
@@ -74,10 +75,10 @@ class ColumnTest extends TestCase
      */
     public function testOptionsShouldNotBeIgnored() : void
     {
-        $col1 = new Column('bar', Type::getType(Type::INTEGER), ['unknown_option' => 'bar', 'notnull' => true]);
+        $col1 = new Column('bar', Type::getType(Types::INTEGER), ['unknown_option' => 'bar', 'notnull' => true]);
         self::assertTrue($col1->getNotnull());
 
-        $col2 = new Column('bar', Type::getType(Type::INTEGER), ['unknown_option' => 'bar', 'notnull' => false]);
+        $col2 = new Column('bar', Type::getType(Types::INTEGER), ['unknown_option' => 'bar', 'notnull' => false]);
         self::assertFalse($col2->getNotnull());
     }
 

--- a/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use function base64_encode;
@@ -37,7 +38,7 @@ class BinaryTest extends DbalTestCase
 
     public function testReturnsName()
     {
-        self::assertSame(Type::BINARY, $this->type->getName());
+        self::assertSame(Types::BINARY, $this->type->getName());
     }
 
     public function testReturnsSQLDeclaration()

--- a/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\JsonArrayType;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use function base64_encode;
@@ -36,7 +37,7 @@ class JsonArrayTest extends DbalTestCase
 
     public function testReturnsName()
     {
-        self::assertSame(Type::JSON_ARRAY, $this->type->getName());
+        self::assertSame(Types::JSON_ARRAY, $this->type->getName());
     }
 
     public function testReturnsSQLDeclaration()

--- a/tests/Doctrine/Tests/DBAL/Types/JsonTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use function base64_encode;
@@ -37,7 +38,7 @@ class JsonTest extends DbalTestCase
 
     public function testReturnsName()
     {
-        self::assertSame(Type::JSON, $this->type->getName());
+        self::assertSame(Types::JSON, $this->type->getName());
     }
 
     public function testReturnsSQLDeclaration()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Deprecations | yes
| Related issues | #2841

#### Summary

Move constants for built-in types to a separate constant-only class.

Some constants were renamed for clarity:
* `TARRAY`-> `ARRAY` (this was [due to a PHP 5 limitation](https://3v4l.org/Qaj1T))
* `DATE` -> `DATE_MUTABLE`
* `DATETIME` -> `DATETIME_MUTABLE`
* `DATETIMETZ` -> `DATETIMETZ_MUTABLE`
* `TIME` -> `TIME_MUTABLE`

Old constants are now deprecated.

##### Naming

I originally used `BuiltinTypes`, but it seemed strange, so I decided for `DefaultTypes`. Thoughts?