### PR TITLE
Removed DataAccessTest::testFetchColumnNonExistingIndex() since it covers a bug in PDO

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.9
 
+## Deprecated `Statement::fetchColumn()` with an invalid index
+
+Calls to `Statement::fetchColumn()` with an invalid column index currently return `NULL`. In the future, such calls will result in a exception.
+
 ## Deprecated `Configuration::getFilterSchemaAssetsExpression()`, `::setFilterSchemaAssetsExpression()` and `AbstractSchemaManager::getFilterSchemaAssetsExpression()`.
 
 Regular expression-based filters are hard to extend by combining together. Instead, you may use callback-based filers via `::getSchemaAssetsFilter()` and `::getSchemaAssetsFilter()`. Callbacks can use regular expressions internally.

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -891,22 +891,6 @@ class DataAccessTest extends DbalFunctionalTestCase
     /**
      * @group DBAL-1028
      */
-    public function testFetchColumnNonExistingIndex()
-    {
-        if ($this->connection->getDriver()->getName() === 'pdo_sqlsrv') {
-            $this->markTestSkipped(
-                'Test does not work for pdo_sqlsrv driver as it throws a fatal error for a non-existing column index.'
-            );
-        }
-
-        self::assertNull(
-            $this->connection->fetchColumn('SELECT test_int FROM fetch_table WHERE test_int = ?', [1], 1)
-        );
-    }
-
-    /**
-     * @group DBAL-1028
-     */
     public function testFetchColumnNoResult()
     {
         self::assertFalse(


### PR DESCRIPTION
Fixes #3358. I'll add the documentation once we agree on the approach.