### PR TITLE
[SQL Anywhere] Disable exact row count retrieval on SQL Anywhere

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -56,11 +56,6 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
         if (! sasql_set_option($this->connection, 'auto_commit', 'on')) {
             throw SQLAnywhereException::fromSQLAnywhereError($this->connection);
         }
-
-        // Enable exact, non-approximated row count retrieval.
-        if (! sasql_set_option($this->connection, 'row_counts', true)) {
-            throw SQLAnywhereException::fromSQLAnywhereError($this->connection);
-        }
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| BC Break     | no
| Fixed issues | 

#### Summary

SQL Anywhere provides a connection option called `row_counts` which enables exact row count retrieval for `SELECT` queries via `sasql_num_rows()`.
However, setting this option to `On` is problematic as it does not work for every connection. It seems the connection user somehow needs privileges for setting this option to on. The driver unfortunately doesn't give any error information but studying the driver's source code, setting this option to `On` basically is equivalent to executing `SET OPTION ROW_COUNTS = 'on'` which gives more error information:

```
SQLSTATE [55W08] [-757] Modifications not permitted for read-only database
```

Moreover [the documentation says](http://dcx.sybase.com/sa160/en/dbadmin/row-counts-option.html):

> Caution
When row_counts is set to On, it may take significantly longer to execute queries. In fact, it usually causes SQL Anywhere to execute the query twice, doubling the execution time.

Finally the driver is not even using `sasql_num_rows()` at any point, so I think we can safely ignore `row_counts` option.

Not sure if a useful test is possible here but I am open to suggestions if a test is necessary ;)