### PR TITLE
Remove redundant implements

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -11,7 +11,7 @@ use function substr;
 /**
  * Sqlsrv Connection implementation.
  */
-class Connection extends PDOConnection implements \Doctrine\DBAL\Driver\Connection
+class Connection extends PDOConnection
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

`Driver\PDOSqlsrv\Connection` extends `Driver\PDOConnection`, which already implements `Driver\Connection`, therefore the `implements` is redundant and can be safely removed.