### PR TITLE
Reorganize Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,6 @@ cache:
         - vendor
         - $HOME/.composer/cache
 
-php:
-  - 7.1
-  - 7.2
-  - 7.3
-  - nightly
-
-env:
-  - DB=sqlite
-  - DB=mysql
-  - DB=mysqli
-
 before_install:
   - |
     if [ "x$COVERAGE" != "xyes" ]; then
@@ -54,53 +43,76 @@ after_script:
 jobs:
   allow_failures:
     - php: nightly
-    - env: DB=pgsql POSTGRESQL_VERSION=11.0
-
-  exclude:
-    - php: 7.1
-      env: DB=sqlite
-    - php: 7.1
-      env: DB=mysql
-    - php: 7.1
-      env: DB=mysqli
-    - php: 7.2
-      env: DB=sqlite
-    - php: 7.2
-      env: DB=mysql
-    - php: 7.2
-      env: DB=mysqli
-    - php: 7.3
-      env: DB=mysql
-    - php: 7.3
-      env: DB=mysqli
-    - php: nightly
-      env: DB=mysql
-    - php: nightly
-      env: DB=mysqli
 
   include:
-    - stage: Test
-      php: 7.1
-      env: DB=sqlite
-
-    - stage: Test
-      php: 7.2
-      env: DB=sqlite COVERAGE=yes
-
-    - stage: Test
-      php: 7.2
-      env: DB=mysql COVERAGE=yes
-
-    - stage: Test
-      php: 7.2
-      env: DB=mysqli COVERAGE=yes
-
     - stage: Test
       php: 7.1
       env: DB=mysql MYSQL_VERSION=5.7
       sudo: required
       before_script:
         - bash ./tests/travis/install-mysql-5.7.sh
+    - stage: Test
+      php: 7.1
+      env: DB=mysqli MYSQL_VERSION=5.7
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-mysql-5.7.sh
+    - stage: Test
+      php: 7.1
+      env: DB=mariadb MARIADB_VERSION=10.3
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: 7.1
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.3
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: 7.1
+      env: DB=pgsql POSTGRESQL_VERSION=11.0
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-postgres-11.sh
+    - stage: Test
+      php: 7.1
+      env: DB=sqlite
+    - stage: Test
+      php: 7.1
+      env: DB=sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mssql-sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: 7.1
+      env: DB=pdo_sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: 7.1
+      env: DB=ibm_db2
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-db2.sh
+        - bash ./tests/travis/install-db2-ibm_db2.sh
+    - stage: Test
+      php: 7.1
+      env: DB=sqlite DEPENDENCIES=low
+      install:
+        - travis_retry composer update --prefer-dist --prefer-lowest
+    - stage: Test
+      php: 7.2
+      env: DB=mysql COVERAGE=yes
     - stage: Test
       php: 7.2
       env: DB=mysql MYSQL_VERSION=5.7 COVERAGE=yes
@@ -108,24 +120,8 @@ jobs:
       before_script:
         - bash ./tests/travis/install-mysql-5.7.sh
     - stage: Test
-      php: 7.3
-      env: DB=mysql MYSQL_VERSION=5.7
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
-    - stage: Test
-      php: nightly
-      env: DB=mysql MYSQL_VERSION=5.7
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
-
-    - stage: Test
-      php: 7.1
-      env: DB=mysqli MYSQL_VERSION=5.7
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
+      php: 7.2
+      env: DB=mysqli COVERAGE=yes
     - stage: Test
       php: 7.2
       env: DB=mysqli MYSQL_VERSION=5.7 COVERAGE=yes
@@ -133,102 +129,45 @@ jobs:
       before_script:
         - bash ./tests/travis/install-mysql-5.7.sh
     - stage: Test
-      php: 7.3
-      env: DB=mysqli MYSQL_VERSION=5.7
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
-    - stage: Test
-      php: nightly
-      env: DB=mysqli MYSQL_VERSION=5.7
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
-
-    - stage: Test
       php: 7.2
       env: DB=mariadb MARIADB_VERSION=10.0 COVERAGE=yes
       addons:
         mariadb: 10.0
-
     - stage: Test
       php: 7.2
       env: DB=mariadb MARIADB_VERSION=10.1 COVERAGE=yes
       addons:
         mariadb: 10.1
-
     - stage: Test
       php: 7.2
       env: DB=mariadb MARIADB_VERSION=10.2 COVERAGE=yes
       addons:
         mariadb: 10.2
-
+    - stage: Test
+      php: 7.2
+      env: DB=mariadb MARIADB_VERSION=10.3 COVERAGE=yes
+      addons:
+        mariadb: 10.3
     - stage: Test
       php: 7.2
       env: DB=mariadb.mysqli MARIADB_VERSION=10.0 COVERAGE=yes
       addons:
-          mariadb: 10.0
-
+        mariadb: 10.0
     - stage: Test
       php: 7.2
       env: DB=mariadb.mysqli MARIADB_VERSION=10.1 COVERAGE=yes
       addons:
-          mariadb: 10.1
-
+        mariadb: 10.1
     - stage: Test
       php: 7.2
       env: DB=mariadb.mysqli MARIADB_VERSION=10.2 COVERAGE=yes
       addons:
         mariadb: 10.2
-
-    - stage: Test
-      php: 7.1
-      env: DB=mariadb MARIADB_VERSION=10.3
-      addons:
-          mariadb: 10.3
-
-    - stage: Test
-      php: 7.2
-      env: DB=mariadb MARIADB_VERSION=10.3 COVERAGE=yes
-      addons:
-          mariadb: 10.3
-
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb MARIADB_VERSION=10.3
-      addons:
-          mariadb: 10.3
-
-    - stage: Test
-      php: nightly
-      env: DB=mariadb MARIADB_VERSION=10.3
-      addons:
-          mariadb: 10.3
-
-    - stage: Test
-      php: 7.1
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.3
-      addons:
-          mariadb: 10.3
-
     - stage: Test
       php: 7.2
       env: DB=mariadb.mysqli MARIADB_VERSION=10.3 COVERAGE=yes
       addons:
-          mariadb: 10.3
-
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.3
-      addons:
-          mariadb: 10.3
-
-    - stage: Test
-      php: nightly
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.3
-      addons:
-          mariadb: 10.3
-
+        mariadb: 10.3
     - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=9.2 COVERAGE=yes
@@ -236,7 +175,6 @@ jobs:
         - postgresql
       addons:
         postgresql: "9.2"
-
     - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=9.3 COVERAGE=yes
@@ -244,7 +182,6 @@ jobs:
         - postgresql
       addons:
         postgresql: "9.3"
-
     - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=9.4 COVERAGE=yes
@@ -252,7 +189,6 @@ jobs:
         - postgresql
       addons:
         postgresql: "9.4"
-
     - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=9.5 COVERAGE=yes
@@ -260,7 +196,6 @@ jobs:
         - postgresql
       addons:
         postgresql: "9.5"
-
     - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=9.6 COVERAGE=yes
@@ -268,7 +203,6 @@ jobs:
         - postgresql
       addons:
         postgresql: "9.6"
-
     - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=10.0 COVERAGE=yes
@@ -279,15 +213,6 @@ jobs:
         postgresql: "9.6"
       before_script:
         - bash ./tests/travis/install-postgres-10.sh
-
-    - stage: Test
-      php: 7.1
-      env: DB=pgsql POSTGRESQL_VERSION=11.0
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-postgres-11.sh
     - stage: Test
       php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=11.0 COVERAGE=yes
@@ -297,31 +222,8 @@ jobs:
       before_script:
         - bash ./tests/travis/install-postgres-11.sh
     - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=11.0
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-postgres-11.sh
-    - stage: Test
-      php: nightly
-      env: DB=pgsql POSTGRESQL_VERSION=11.0
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-postgres-11.sh
-
-    - stage: Test
-      php: 7.1
-      env: DB=sqlsrv
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-mssql-$DB.sh
-        - bash ./tests/travis/install-mssql.sh
+      php: 7.2
+      env: DB=sqlite COVERAGE=yes
     - stage: Test
       php: 7.2
       env: DB=sqlsrv COVERAGE=yes
@@ -329,35 +231,7 @@ jobs:
       services:
         - docker
       before_script:
-        - bash ./tests/travis/install-mssql-$DB.sh
-        - bash ./tests/travis/install-mssql.sh
-    - stage: Test
-      php: 7.3
-      env: DB=sqlsrv
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-mssql-$DB.sh
-        - bash ./tests/travis/install-mssql.sh
-    - stage: Test
-      php: nightly
-      env: DB=sqlsrv
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-mssql-$DB.sh
-        - bash ./tests/travis/install-mssql.sh
-
-    - stage: Test
-      php: 7.1
-      env: DB=pdo_sqlsrv
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-mssql-$DB.sh
+        - bash ./tests/travis/install-mssql-sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
       php: 7.2
@@ -366,36 +240,8 @@ jobs:
       services:
         - docker
       before_script:
-        - bash ./tests/travis/install-mssql-$DB.sh
+        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
-    - stage: Test
-      php: 7.3
-      env: DB=pdo_sqlsrv
-      sudo: required
-      services:
-      - docker
-      before_script:
-      - bash ./tests/travis/install-mssql-$DB.sh
-      - bash ./tests/travis/install-mssql.sh
-    - stage: Test
-      php: nightly
-      env: DB=pdo_sqlsrv
-      sudo: required
-      services:
-      - docker
-      before_script:
-      - bash ./tests/travis/install-mssql-$DB.sh
-      - bash ./tests/travis/install-mssql.sh
-
-    - stage: Test
-      php: 7.1
-      env: DB=ibm_db2
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-db2.sh
-        - bash ./tests/travis/install-db2-$DB.sh
     - stage: Test
       php: 7.2
       env: DB=ibm_db2 COVERAGE=yes
@@ -404,13 +250,109 @@ jobs:
         - docker
       before_script:
         - bash ./tests/travis/install-db2.sh
-        - bash ./tests/travis/install-db2-$DB.sh
-
+        - bash ./tests/travis/install-db2-ibm_db2.sh
     - stage: Test
-      php: 7.1
-      env: DB=sqlite DEPENDENCIES=low
-      install:
-        - travis_retry composer update --prefer-dist --prefer-lowest
+      php: 7.3
+      env: DB=mysql MYSQL_VERSION=5.7
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-mysql-5.7.sh
+    - stage: Test
+      php: 7.3
+      env: DB=mysqli MYSQL_VERSION=5.7
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-mysql-5.7.sh
+    - stage: Test
+      php: 7.3
+      env: DB=mariadb MARIADB_VERSION=10.3
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: 7.3
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.3
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: 7.3
+      env: DB=pgsql POSTGRESQL_VERSION=11.0
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-postgres-11.sh
+    - stage: Test
+      php: 7.3
+      env: DB=sqlite
+    - stage: Test
+      php: 7.3
+      env: DB=sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mssql-sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: 7.3
+      env: DB=pdo_sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: nightly
+      env: DB=mysql MYSQL_VERSION=5.7
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-mysql-5.7.sh
+    - stage: Test
+      php: nightly
+      env: DB=mysqli MYSQL_VERSION=5.7
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-mysql-5.7.sh
+    - stage: Test
+      php: nightly
+      env: DB=mariadb MARIADB_VERSION=10.3
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: nightly
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.3
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: nightly
+      env: DB=pgsql POSTGRESQL_VERSION=11.0
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-postgres-11.sh
+    - stage: Test
+      php: nightly
+      env: DB=sqlite
+    - stage: Test
+      php: nightly
+      env: DB=sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mssql-sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: nightly
+      env: DB=pdo_sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
 
     - stage: Test
       if: type = cron


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

This is a follow-up to #3347. This PR reorganizes the Travix CI matrix so that:

### Every job is explicitly created via `jobs.include`

So far, a few jobs were created by a matrix created by the `php` and `env` configs, but most of them were excluded in `jobs.exclude`.

The `php`, `env` and `jobs.exclude` are now unnecessary, everything is explicitly listed in `jobs.include`.

### Jobs are consistently ordered

1. PHP version
2. Driver
3. Platform version

### Output can be automated

[A script is available](https://gist.github.com/BenMorel/67e5d94c864af9b9ae1d3a1db8010b98) to generated the jobs matrix, respecting the points above and the algorithm suggested by @morozov in #3347:

- the latest stable PHP version is tested against all drivers and platform versions, and used for code coverage analysis
- other PHP versions are only tested against the latest version of the platform for each driver, with no code coverage

This PR should output the exact same Travis CI jobs as the latest master, in a different order.