### PR TITLE
Travis CI tests on MySQL 8.0

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -21,7 +21,7 @@ before_commands:
 tools:
     external_code_coverage:
         timeout: 3600
-        runs: 28 # 23x Travis (jobs with COVERAGE=yes) + 3x AppVeyor (jobs with coverage=yes) + 2x ContinuousPHP
+        runs: 30 # 25x Travis (jobs with COVERAGE=yes) + 3x AppVeyor (jobs with coverage=yes) + 2x ContinuousPHP
 
 filter:
     excluded_paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,16 +47,18 @@ jobs:
   include:
     - stage: Test
       php: 7.1
-      env: DB=mysql MYSQL_VERSION=5.7
+      env: DB=mysql MYSQL_VERSION=8.0
+      dist: xenial
       sudo: required
       before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
+        - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
       php: 7.1
-      env: DB=mysqli MYSQL_VERSION=5.7
+      env: DB=mysqli MYSQL_VERSION=8.0
+      dist: xenial
       sudo: required
       before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
+        - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
       php: 7.1
       env: DB=mariadb MARIADB_VERSION=10.3
@@ -121,6 +123,13 @@ jobs:
         - bash ./tests/travis/install-mysql-5.7.sh
     - stage: Test
       php: 7.2
+      env: DB=mysql MYSQL_VERSION=8.0 COVERAGE=yes
+      dist: xenial
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-mysql-8.0.sh
+    - stage: Test
+      php: 7.2
       env: DB=mysqli COVERAGE=yes
     - stage: Test
       php: 7.2
@@ -128,6 +137,13 @@ jobs:
       sudo: required
       before_script:
         - bash ./tests/travis/install-mysql-5.7.sh
+    - stage: Test
+      php: 7.2
+      env: DB=mysqli MYSQL_VERSION=8.0 COVERAGE=yes
+      dist: xenial
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
       php: 7.2
       env: DB=mariadb MARIADB_VERSION=10.0 COVERAGE=yes
@@ -304,16 +320,18 @@ jobs:
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
       php: nightly
-      env: DB=mysql MYSQL_VERSION=5.7
+      env: DB=mysql MYSQL_VERSION=8.0
+      dist: xenial
       sudo: required
       before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
+        - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
       php: nightly
-      env: DB=mysqli MYSQL_VERSION=5.7
+      env: DB=mysqli MYSQL_VERSION=8.0
+      dist: xenial
       sudo: required
       before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
+        - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
       php: nightly
       env: DB=mariadb MARIADB_VERSION=10.3

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -158,7 +158,8 @@ class MySqlPlatform extends AbstractPlatform
                    'SEQ_IN_INDEX AS Seq_in_index, COLUMN_NAME AS Column_Name, COLLATION AS Collation, ' .
                    'CARDINALITY AS Cardinality, SUB_PART AS Sub_Part, PACKED AS Packed, ' .
                    'NULLABLE AS `Null`, INDEX_TYPE AS Index_Type, COMMENT AS Comment ' .
-                   'FROM information_schema.STATISTICS WHERE TABLE_NAME = ' . $table . ' AND TABLE_SCHEMA = ' . $currentDatabase;
+                   'FROM information_schema.STATISTICS WHERE TABLE_NAME = ' . $table . ' AND TABLE_SCHEMA = ' . $currentDatabase .
+                   ' ORDER BY SEQ_IN_INDEX ASC';
         }
 
         return 'SHOW INDEX FROM ' . $table;
@@ -376,7 +377,8 @@ class MySqlPlatform extends AbstractPlatform
         return 'SELECT COLUMN_NAME AS Field, COLUMN_TYPE AS Type, IS_NULLABLE AS `Null`, ' .
                'COLUMN_KEY AS `Key`, COLUMN_DEFAULT AS `Default`, EXTRA AS Extra, COLUMN_COMMENT AS Comment, ' .
                'CHARACTER_SET_NAME AS CharacterSet, COLLATION_NAME AS Collation ' .
-               'FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ' . $database . ' AND TABLE_NAME = ' . $table;
+               'FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ' . $database . ' AND TABLE_NAME = ' . $table .
+               ' ORDER BY ORDINAL_POSITION ASC';
     }
 
     public function getListTableMetadataSQL(string $table, ?string $database = null) : string

--- a/tests/travis/install-mysql-8.0.sh
+++ b/tests/travis/install-mysql-8.0.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Installing MySQL 8.0..."
+
+echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+wget https://dev.mysql.com/get/mysql-apt-config_0.8.10-1_all.deb
+sudo dpkg --install mysql-apt-config_0.8.10-1_all.deb
+sudo apt-get update -q
+sudo apt-get install -q -y --force-yes -o Dpkg::Options::=--force-confnew mysql-server
+echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password" | sudo tee --append /etc/mysql/my.cnf
+sudo /etc/init.d/mysql start
+sudo mysql_upgrade
+
+mysql --version


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

MySQL 8.0 has been out for some time, yet Doctrine DBAL is not tested against this version right now.

Following the rules edicted in #3347 and #3365, PHP `7.1`, <s>`7.3`</s>① and `nightly` are now only tested against the latest version, MySQL 8.0.

① **Edit:** MySQL 8.0 requires Xenial, and Travis CI does not support PHP 7.3 on Xenial yet. PHP 7.3 tests are therefore kept on MySQL 5.7 for the time being.