### PR TITLE
[SQL Anywhere] Fix bound parameter references in PHP 7

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -59,6 +59,9 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
     /** @var resource The prepared SQL statement to execute. */
     private $stmt;
 
+    /** @var mixed[] The references to bound parameter values. */
+    private $boundValues = [];
+
     /**
      * Prepares given statement for given connection.
      *
@@ -107,6 +110,8 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
             default:
                 throw new SQLAnywhereException('Unknown type: ' . $type);
         }
+
+        $this->boundValues[$column] =& $variable;
 
         if (! sasql_stmt_bind_param_ex($this->stmt, $column - 1, $variable, $type, $variable === null)) {
             throw SQLAnywhereException::fromSQLAnywhereError($this->conn, $this->stmt);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | n/a

#### Summary

The SQL Anywhere driver suffers the same problem that `oci8` did with PHP 7 (See: ae314b137211be8c167250254b06ef388b36c0cc)

Binding multiple parameters in a prepared statement does not work as PHP does not manage the references itself. We have to manage the references to bound parameters ourself, otherwise only the first bound parameter is used and overwritten subsequently.

The tests are revealing the issue already.