### PR TITLE
[SQL Anywhere] Fix query limit values "0" and "null"

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -1308,25 +1308,20 @@ SQL
      */
     protected function doModifyLimitQuery($query, $limit, $offset)
     {
-        $limitOffsetClause = '';
+        $limitOffsetClause = $this->getTopClauseSQL($limit, $offset);
 
-        if ($limit > 0) {
-            $limitOffsetClause = 'TOP ' . $limit . ' ';
-        }
+        return $limitOffsetClause === ''
+            ? $query
+            : preg_replace('/^\s*(SELECT\s+(DISTINCT\s+)?)/i', '\1' . $limitOffsetClause . ' ', $query);
+    }
 
+    private function getTopClauseSQL(?int $limit, ?int $offset) : string
+    {
         if ($offset > 0) {
-            if ($limit === 0) {
-                $limitOffsetClause = 'TOP ALL ';
-            }
-
-            $limitOffsetClause .= 'START AT ' . ($offset + 1) . ' ';
+            return sprintf('TOP %s START AT %d', $limit ?? 'ALL', $offset + 1);
         }
 
-        if ($limitOffsetClause) {
-            return preg_replace('/^\s*(SELECT\s+(DISTINCT\s+)?)/i', '\1' . $limitOffsetClause, $query);
-        }
-
-        return $query;
+        return $limit === null ? '' : 'TOP ' . $limit;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -646,7 +646,7 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
             $this->platform->modifyLimitQuery('SELECT * FROM user', 10, 5)
         );
         self::assertEquals(
-            'SELECT TOP ALL START AT 6 * FROM user',
+            'SELECT TOP 0 START AT 6 * FROM user',
             $this->platform->modifyLimitQuery('SELECT * FROM user', 0, 5)
         );
     }
@@ -656,6 +656,14 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
         self::assertEquals(
             'SELECT TOP 10 * FROM (SELECT u.id as uid, u.name as uname FROM user) AS doctrine_tbl',
             $this->platform->modifyLimitQuery('SELECT * FROM (SELECT u.id as uid, u.name as uname FROM user) AS doctrine_tbl', 10)
+        );
+    }
+
+    public function testModifiesLimitQueryWithoutLimit()
+    {
+        self::assertEquals(
+            'SELECT TOP ALL START AT 11 n FROM Foo',
+            $this->platform->modifyLimitQuery('SELECT n FROM Foo', null, 10)
         );
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | n/a

#### Summary

Integration tests on SQL Anywhere revealed that the platform doesn't handle `$limit = null` when rewriting `SELECT` statements for LIMIT/OFFSET.
Also handling of `$limit = 0` was wrong as it was selecting ALL results instead of NONE.

Reference: http://dcx.sybase.com/1200/en/dbreference/select-statement.html
