### PR TITLE
ResultCacheStatement lost its cache capability on fetchAll method

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -166,7 +166,10 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
-        return $this->statement->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
+        $this->data    = $this->statement->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
+        $this->emptied = true;
+
+        return $this->data;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -166,6 +166,16 @@ class ResultCacheTest extends DbalFunctionalTestCase
         self::assertCount(2, $this->sqlLogger->queries);
     }
 
+    public function testFetchAllAndFinishSavesCache()
+    {
+        $layerCache = new ArrayCache();
+        $stmt       = $this->connection->executeQuery('SELECT * FROM caching WHERE test_int > 500', [], [], new QueryCacheProfile(10, 'testcachekey', $layerCache));
+        $stmt->fetchAll();
+        $stmt->closeCursor();
+
+        self::assertCount(1, $layerCache->fetch('testcachekey'));
+    }
+
     public function assertCacheNonCacheSelectSameFetchModeAreEqual($expectedResult, $fetchMode)
     {
         $stmt = $this->connection->executeQuery('SELECT * FROM caching ORDER BY test_int ASC', [], [], new QueryCacheProfile(10, 'testcachekey'));


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed Issues | #3383 

#### Summary

ResultCacheStatement is intended to save results to a persistence engine, and in the documentation it is recommended tu call fetchAll() method. To ensure that when calling its self method closeCursor(), the data will be saved.

However, since version 2.9.0, after this commit: https://github.com/doctrine/dbal/commit/e35d5e12eadf567d61e0e8295991d0d8b71deba9

This behavior is broken because ResultCacheStatement fetchAll() does not call its self fetch() method so neither $this->data nor $this->emptied are set.

