### PR TITLE
[SQL Anywhere] Fix view schema introspection test

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
@@ -24,7 +24,7 @@ class SQLAnywhereSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertCount(1, $views, 'Database has to have one view.');
         self::assertInstanceOf(View::class, $views[$name]);
         self::assertEquals($name, $views[$name]->getName());
-        self::assertEquals($sql, $views[$name]->getSql());
+        self::assertRegExp('/^SELECT \* from "?DBA"?\."?view_test_table"?$/', $views[$name]->getSql());
     }
 
     public function testDropAndCreateAdvancedIndex()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | n/a

#### Summary

This fixes the assertion on the `CREATE VIEW` schema introspection SQL which is returned differently on different SQL Anywhere server versions.

In earlier versions (<= 12 I believe) the identifiers in the returned SQL are returned unquoted while in more recent versions they are quoted:

```
Doctrine\Tests\DBAL\Functional\Schema\SQLAnywhereSchemaManagerTest::testCreateAndListViews
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'SELECT * from DBA.view_test_table'
+'SELECT * from "DBA"."view_test_table"'
```
