### PR TITLE
Fixed parsing MySQL create table flags (options without a value)

### DIFF
--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -18,7 +18,6 @@ use function stripslashes;
 use function strpos;
 use function strtok;
 use function strtolower;
-use function trim;
 
 /**
  * Schema manager for the MySql RDBMS.
@@ -305,25 +304,28 @@ class MySqlSchemaManager extends AbstractSchemaManager
             $table->addOption('autoincrement', $tableOptions['AUTO_INCREMENT']);
         }
         $table->addOption('comment', $tableOptions['TABLE_COMMENT']);
-
-        if ($tableOptions['CREATE_OPTIONS'] === null) {
-            return $table;
-        }
-
-        $createOptionsString = trim($tableOptions['CREATE_OPTIONS']);
-
-        $createOptions = [];
-
-        if ($createOptionsString !== '') {
-            foreach (explode(' ', $createOptionsString) as $option) {
-                [$createOption, $value] = explode('=', $option);
-
-                $createOptions[$createOption] = $value;
-            }
-        }
-
-        $table->addOption('create_options', $createOptions);
+        $table->addOption('create_options', $this->parseCreateOptions($tableOptions['CREATE_OPTIONS']));
 
         return $table;
+    }
+
+    /**
+     * @return string[]|true[]
+     */
+    private function parseCreateOptions(string $string) : array
+    {
+        $options = [];
+
+        if ($string === '') {
+            return $options;
+        }
+
+        foreach (explode(' ', $string) as $pair) {
+            $parts = explode('=', $pair, 2);
+
+            $options[$parts[0]] = $parts[1] ?? true;
+        }
+
+        return $options;
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -502,6 +502,7 @@ ENGINE InnoDB
 ROW_FORMAT COMPRESSED
 COMMENT 'This is a test'
 AUTO_INCREMENT=42
+PARTITION BY HASH (col1)
 SQL;
 
         $this->connection->query($sql);
@@ -511,7 +512,10 @@ SQL;
         self::assertEquals('utf8_general_ci', $onlineTable->getOption('collation'));
         self::assertEquals(42, $onlineTable->getOption('autoincrement'));
         self::assertEquals('This is a test', $onlineTable->getOption('comment'));
-        self::assertEquals(['row_format' => 'COMPRESSED'], $onlineTable->getOption('create_options'));
+        self::assertEquals([
+            'row_format' => 'COMPRESSED',
+            'partitioned' => true,
+        ], $onlineTable->getOption('create_options'));
     }
 
     public function testEnsureTableWithoutOptionsAreReflectedInMetadata() : void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #3384.