### PR TITLE
Grouped PHPStan and PHP_CodeSniffer for parallel execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -320,12 +320,11 @@ jobs:
 
     - stage: Code Quality
       php: 7.2
-      env: DB=none STATIC_ANALYSIS
+      env: PHPStan
       install: travis_retry composer install --prefer-dist
       script: vendor/bin/phpstan analyse
-
-    - stage: Coding standard
+    - stage: Code Quality
       php: 7.2
+      env: PHP_CodeSniffer
       install: travis_retry composer install --prefer-dist
-      script:
-        - ./vendor/bin/phpcs
+      script: vendor/bin/phpcs


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Parallel execution of PHPStan and PHP_CodeSniffer should make builds one minute faster.