### PR TITLE
Fix column name type hint

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -100,8 +100,8 @@ class Table extends AbstractAsset
     /**
      * Sets the Primary Key.
      *
-     * @param mixed[][]   $columns
-     * @param string|bool $indexName
+     * @param string[]|mixed[][] $columns
+     * @param string|bool        $indexName
      *
      * @return self
      */
@@ -118,10 +118,10 @@ class Table extends AbstractAsset
     }
 
     /**
-     * @param mixed[][]   $columnNames
-     * @param string|null $indexName
-     * @param string[]    $flags
-     * @param mixed[]     $options
+     * @param string[]|mixed[][] $columnNames
+     * @param string|null        $indexName
+     * @param string[]           $flags
+     * @param mixed[]            $options
      *
      * @return self
      */
@@ -168,9 +168,9 @@ class Table extends AbstractAsset
     }
 
     /**
-     * @param mixed[][]   $columnNames
-     * @param string|null $indexName
-     * @param mixed[]     $options
+     * @param string[]|mixed[][] $columnNames
+     * @param string|null        $indexName
+     * @param mixed[]            $options
      *
      * @return self
      */
@@ -236,7 +236,7 @@ class Table extends AbstractAsset
     /**
      * Checks if an index begins in the order of the given columns.
      *
-     * @param mixed[][] $columnsNames
+     * @param string[]|mixed[][] $columnsNames
      *
      * @return bool
      */
@@ -253,12 +253,12 @@ class Table extends AbstractAsset
     }
 
     /**
-     * @param mixed[][] $columnNames
-     * @param string    $indexName
-     * @param bool      $isUnique
-     * @param bool      $isPrimary
-     * @param string[]  $flags
-     * @param mixed[]   $options
+     * @param string[]|mixed[][] $columnNames
+     * @param string             $indexName
+     * @param bool               $isUnique
+     * @param bool               $isPrimary
+     * @param string[]           $flags
+     * @param mixed[]            $options
      *
      * @return Index
      *


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

The type hint changes in #3306 triggered some PHPStan failures for me (https://github.com/libero/content-api-bundle/pull/15#issuecomment-445270367) as they no longer declare a simple list of strings is allowed.

There's some other usages of `mixed[][]` in the codebase, haven't looked to see if they have similar problems.