### PR TITLE
Travis CI: PHP 7.3 tests on MySQL 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -207,16 +207,18 @@ jobs:
         - travis_retry composer update --prefer-dist --prefer-lowest
     - stage: Test
       php: 7.3
-      env: DB=mysql MYSQL_VERSION=5.7
+      env: DB=mysql MYSQL_VERSION=8.0
+      dist: xenial
       sudo: required
       before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
+        - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
       php: 7.3
-      env: DB=mysqli MYSQL_VERSION=5.7
+      env: DB=mysqli MYSQL_VERSION=8.0
+      dist: xenial
       sudo: required
       before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
+        - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
       php: 7.3
       env: DB=mariadb MARIADB_VERSION=10.3


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

This is a follow up to #3372. We did not test PHP 7.3 on MySQL 8.0 as we should have according to [Morozov's Law](https://github.com/doctrine/dbal/pull/3347#issuecomment-439231396), because Travis CI did not support PHP 7.3 on Xenial.

It does now: https://travis-ci.community/t/please-add-php-7-3-on-xenial/1238/13

So this PR changes PHP 7.3 tests to run on MySQL 8.0 instead of 5.7 as they should.