### PR TITLE
`CREATE_OPTIONS` is nullable in MySQL

### DIFF
--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -312,11 +312,11 @@ class MySqlSchemaManager extends AbstractSchemaManager
     /**
      * @return string[]|true[]
      */
-    private function parseCreateOptions(string $string) : array
+    private function parseCreateOptions(?string $string) : array
     {
         $options = [];
 
-        if ($string === '') {
+        if ($string === null || $string === '') {
             return $options;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -531,4 +531,11 @@ SQL;
         self::assertEquals('', $onlineTable->getOption('comment'));
         self::assertEquals([], $onlineTable->getOption('create_options'));
     }
+
+    public function testParseNullCreateOptions() : void
+    {
+        $table = $this->schemaManager->listTableDetails('sys.processlist');
+
+        self::assertEquals([], $table->getOption('create_options'));
+    }
 }


### PR DESCRIPTION
I haven't found any documentation on when exactly empty `CREATE_OPTIONS` is `NULL` but it looks like it's true for all views and only views.

Fixes https://github.com/doctrine/dbal/issues/3410.
