### PR TITLE
Consider column lengths when comparing indices

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Index.php
+++ b/lib/Doctrine/DBAL/Schema/Index.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use InvalidArgumentException;
+use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_search;
@@ -211,6 +212,10 @@ class Index extends AbstractAsset implements Constraint
                 return false;
             }
 
+            if (! $this->hasSameColumnLengths($other)) {
+                return false;
+            }
+
             if (! $this->isUnique() && ! $this->isPrimary()) {
                 // this is a special case: If the current key is neither primary or unique, any unique or
                 // primary key will always have the same effect for the index and there cannot be any constraint
@@ -335,5 +340,18 @@ class Index extends AbstractAsset implements Constraint
         }
 
         return ! $this->hasOption('where') && ! $other->hasOption('where');
+    }
+
+    /**
+     * Returns whether the index has the same column lengths as the other
+     */
+    private function hasSameColumnLengths(self $other) : bool
+    {
+        $filter = static function (?int $length) : bool {
+            return $length !== null;
+        };
+
+        return array_filter($this->options['lengths'] ?? [], $filter)
+            === array_filter($other->options['lengths'] ?? [], $filter);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/IndexTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/IndexTest.php
@@ -109,6 +109,36 @@ class IndexTest extends TestCase
     }
 
     /**
+     * @param string[]     $columns
+     * @param int[]|null[] $lengths1
+     * @param int[]|null[] $lengths2
+     *
+     * @dataProvider indexLengthProvider
+     */
+    public function testFulfilledWithLength(array $columns, array $lengths1, array $lengths2, bool $expected) : void
+    {
+        $index1 = new Index('index1', $columns, false, false, [], ['lengths' => $lengths1]);
+        $index2 = new Index('index2', $columns, false, false, [], ['lengths' => $lengths2]);
+
+        self::assertSame($expected, $index1->isFullfilledBy($index2));
+        self::assertSame($expected, $index2->isFullfilledBy($index1));
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public static function indexLengthProvider() : iterable
+    {
+        return [
+            'empty' => [['column'], [], [], true],
+            'same' => [['column'], [64], [64], true],
+            'different' => [['column'], [32], [64], false],
+            'sparse-different-positions' => [['column1', 'column2'], [0 => 32], [1 => 32], false],
+            'sparse-same-positions' => [['column1', 'column2'], [null, 32], [1 => 32], true],
+        ];
+    }
+
+    /**
      * @group DBAL-220
      */
     public function testFlags()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

When comparing indices, compare column lengths as well. Fixes https://github.com/doctrine/dbal/issues/3414.
