### PR TITLE
Index length can be a `string`: ensure that it is an integer when read by the `MySqlSchemaManager`

### DIFF
--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -68,7 +68,7 @@ class MySqlSchemaManager extends AbstractSchemaManager
             } elseif (strpos($v['index_type'], 'SPATIAL') !== false) {
                 $v['flags'] = ['SPATIAL'];
             }
-            $v['length'] = $v['sub_part'] ?? null;
+            $v['length'] = isset($v['sub_part']) ? (int) $v['sub_part'] : null;
 
             $tableIndexes[$k] = $v;
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -107,6 +107,19 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($indexes['s_index']->hasFlag('spatial'));
     }
 
+    public function testIndexWithLength() : void
+    {
+        $table = new Table('index_length');
+        $table->addColumn('text', 'string', ['length' => 255]);
+        $table->addIndex(['text'], 'text_index', [], ['lengths' => [128]]);
+
+        $this->schemaManager->dropAndCreateTable($table);
+
+        $indexes = $this->schemaManager->listTableIndexes('index_length');
+        self::assertArrayHasKey('text_index', $indexes);
+        self::assertSame([128], $indexes['text_index']->getOption('lengths'));
+    }
+
     /**
      * @group DBAL-400
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #3415.

#### Summary

When using MySQL, `AbstractSchemaManager::listTableIndexes()` will return the index length as string, which makes the strict comparison in `Index::hasSameColumnLengths()` fail. `$this->options['length']` will have the index length as string and `$other->options['length']` as integer.

I am not 100% sure if my fix is in the right place, as we could also cast to int in the [_getPortableTableIndexesList()](https://github.com/doctrine/dbal/blob/2.9/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php#L865) method. So feel free to adjust the PR as necessary.