### PR TITLE
Issue #950: Fixed cardinality issue where subquery could return more than one row

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -287,7 +287,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     {
         return "SELECT quote_ident(r.conname) as conname, pg_catalog.pg_get_constraintdef(r.oid, true) as condef
                   FROM pg_catalog.pg_constraint r
-                  WHERE r.conrelid =
+                  WHERE r.conrelid IN
                   (
                       SELECT c.oid
                       FROM pg_catalog.pg_class c, pg_catalog.pg_namespace n


### PR DESCRIPTION
Fixed cardinality issue where subquery could return more than than one row in getListTableForeignKeysSQL function

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #950 

#### Summary

Replaced "=" with "IN" in the query in the PostgreSqlPlatform->getListTableForeignKeysSQL() function to avoid getting a cardinality violation error thrown