### PR TITLE
Modified subquery in PostgreSqlPlatform->getListTableForeignKeysSQL()

### DIFF
--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -98,6 +98,18 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
     }
 
     /**
+     * Lists the foreign keys for the given table in a given schema.
+     *
+     * @param string $tableWithSchema The name of the table prefixed with the schema (i.e. 'some_schema.some_table').
+     *
+     * @return array<int|string, ForeignKeyConstraint>
+     */
+    public function listTableForeignKeys(string $tableWithSchema, ?string $database = null) : array
+    {
+        return parent::listTableForeignKeys($tableWithSchema, $database);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function dropDatabase(string $database) : void

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -961,7 +961,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     {
         self::assertStringContainsStringIgnoringCase(
             "'Foo''Bar\\'",
-            $this->platform->getListTableForeignKeysSQL("Foo'Bar\\")
+            $this->platform->getListTableForeignKeysSQL("public.Foo'Bar\\")
         );
     }
 
@@ -994,7 +994,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     {
         self::assertStringContainsStringIgnoringCase(
             "'Foo''Bar\\'",
-            $this->platform->getListTableIndexesSQL("Foo'Bar\\")
+            $this->platform->getListTableIndexesSQL("public.Foo'Bar\\")
         );
     }
 
@@ -1016,7 +1016,7 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     {
         self::assertStringContainsStringIgnoringCase(
             "'Foo''Bar\\'",
-            $this->platform->getListTableColumnsSQL("Foo'Bar\\")
+            $this->platform->getListTableColumnsSQL("public.Foo'Bar\\")
         );
     }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/PostgreSqlListTableFunctionsTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/PostgreSqlListTableFunctionsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Schema;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\Tests\DbalFunctionalTestCase;
+use function extension_loaded;
+use function in_array;
+
+class PostgreSqlListTableFunctionsTest extends DbalFunctionalTestCase
+{
+    protected function setUp() : void
+    {
+        if (! extension_loaded('pdo_pgsql')) {
+            $this->markTestSkipped('pdo_pgsql is not loaded.');
+
+            return;
+        }
+
+        parent::setUp();
+
+        if (! in_array('pdo_pgsql', DriverManager::getAvailableDrivers())) {
+            $this->markTestSkipped('PostgreSQL driver not available');
+
+            return;
+        }
+
+        if (! $this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+            $this->markTestSkipped('PostgreSQL Only test.');
+
+            return;
+        }
+
+        $this->connection->executeQuery('CREATE SCHEMA test_schema1;');
+        $this->connection->executeQuery('CREATE SCHEMA test_schema2;');
+        $this->connection->executeQuery('set search_path = "test_schema1", "test_schema2";');
+        $this->connection->executeQuery('CREATE TABLE test_schema1.test_foreign1 ( id integer PRIMARY KEY );');
+        $this->connection->executeQuery('CREATE TABLE test_schema1.test_table ( test_column1 varchar(5), test_foreign1_id integer constraint fk_test_foreign1 references test_schema1.test_foreign1 (id) );');
+        $this->connection->executeQuery('CREATE INDEX idx_test_column1 ON test_schema1.test_table (test_column1);');
+        $this->connection->executeQuery('CREATE TABLE test_schema2.test_foreign2 ( id integer PRIMARY KEY );');
+        $this->connection->executeQuery('CREATE TABLE test_schema2.test_table ( test_column2 varchar(5), test_foreign2_id integer constraint fk_test_foreign2 references test_schema2.test_foreign2 (id) );');
+        $this->connection->executeQuery('CREATE INDEX idx_test_column2 ON test_schema2.test_table (test_column2);');
+    }
+
+    public function testListTableFunctions() : void
+    {
+        $foreignKeys = $this->connection->getSchemaManager()->listTableForeignKeys('test_table');
+        $this->assertNotEmpty($foreignKeys);
+        $foreignKeys = $this->connection->getSchemaManager()->listTableForeignKeys('test_schema1.test_table');
+        $columns     = isset($foreignKeys[0]) ? $foreignKeys[0]->getColumns() : [];
+        $this->assertContains('test_foreign1_id', $columns);
+        $foreignKeys = $this->connection->getSchemaManager()->listTableForeignKeys('test_schema2.test_table');
+        $columns     = isset($foreignKeys[0]) ? $foreignKeys[0]->getColumns() : [];
+        $this->assertContains('test_foreign2_id', $columns);
+
+        $columns = $this->connection->getSchemaManager()->listTableColumns('test_table');
+        $this->assertNotEmpty($columns);
+        $columns = $this->connection->getSchemaManager()->listTableColumns('test_schema1.test_table');
+        $this->assertArrayHasKey('test_column1', $columns);
+        $columns = $this->connection->getSchemaManager()->listTableColumns('test_schema2.test_table');
+        $this->assertArrayHasKey('test_column2', $columns);
+
+        $indexes = $this->connection->getSchemaManager()->listTableIndexes('test_table');
+        $this->assertNotEmpty($indexes);
+        $indexes = $this->connection->getSchemaManager()->listTableIndexes('test_schema1.test_table');
+        $this->assertArrayHasKey('idx_test_column1', $indexes);
+        $indexes = $this->connection->getSchemaManager()->listTableIndexes('test_schema2.test_table');
+        $this->assertArrayHasKey('idx_test_column2', $indexes);
+    }
+}


### PR DESCRIPTION
Fixed cardinality issue where subquery could return more than than one row in getListTableForeignKeysSQL function

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #950 

#### Summary

The cardinality error would happen when the schema wasn't prefixed in the $table parameter. As the subquery in the `WHERE =` clause would return more than one result if there was the same table name in two different schemas. (This is specific to postgres only.)

This adds:

- `LIMIT 1` to the subquery of the `WHERE = (SELECT ...)` clause
- A clearer parameter name `$tableWithSchema` and doc blocks to convey what's expected for this function
- A deprecation message for when the schema is not included