### PR TITLE
Set wait_timeout for MySQL in travis tests to prevent timeouts

### DIFF
--- a/tests/travis/install-mysql-5.7.sh
+++ b/tests/travis/install-mysql-5.7.sh
@@ -18,5 +18,11 @@ sudo apt-get install -q -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options
 sudo mysql_upgrade
 
 echo "Restart mysql..."
-sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
+sudo mysql -e "
+    use mysql;
+    update user set authentication_string=PASSWORD('') where User='root';
+    update user set plugin='mysql_native_password';
+    FLUSH PRIVILEGES;
+    SET @@GLOBAL.wait_timeout=3600;
+"
 

--- a/tests/travis/install-mysql-8.0.sh
+++ b/tests/travis/install-mysql-8.0.sh
@@ -16,4 +16,5 @@ sudo docker run \
     --name mysql80 \
     mysql:8.0
 
-sudo docker exec -i mysql80 bash <<< 'until echo \\q | mysql doctrine_tests > /dev/null 2>&1 ; do sleep 1; done'
+sudo docker exec -i mysql80 bash <<< 'until echo \\q | mysql doctrine_tests > /dev/null 2>&1; do sleep 1; done'
+sudo docker exec -i mysql80 mysql -e 'SET @@GLOBAL.wait_timeout=3600;' > /dev/null

--- a/tests/travis/mariadb.mysqli.travis.xml
+++ b/tests/travis/mariadb.mysqli.travis.xml
@@ -2,7 +2,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
-         bootstrap="../../vendor/autoload.php"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          failOnRisky="true"


### PR DESCRIPTION
Also remove redundant bootstrap option in mariadb tests config

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | none

#### Summary

This patch should fix issues like this one https://travis-ci.org/doctrine/dbal/jobs/476488849 . After a quick research this seems like a solution to these kinds of errors on Travis CI.
