### PR TITLE
Update OCI8Statement.php

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -299,7 +299,7 @@ class OCI8Statement implements IteratorAggregate, Statement
 
             case ParameterType::LARGE_OBJECT:
                 return OCI_B_BLOB;
-                
+
             case ParameterType::INTEGER:
                 return SQLT_INT;
 

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -299,6 +299,9 @@ class OCI8Statement implements IteratorAggregate, Statement
 
             case ParameterType::LARGE_OBJECT:
                 return OCI_B_BLOB;
+                
+            case ParameterType::INTEGER:
+                return SQLT_INT;
 
             default:
                 return SQLT_CHR;

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -301,7 +301,7 @@ class OCI8Statement implements IteratorAggregate, Statement
                 return OCI_B_BLOB;
 
             case ParameterType::INTEGER:
-                return SQLT_INT;
+                return OCI_B_INT;
 
             default:
                 return SQLT_CHR;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no


#### Summary

Converting ParameterType::Integer to SQLT_INT

Requires for "insert into xxx returning id into :id" statements
otherwise a numeric id will be casted to string.

Example: Saved entity will genertate an ID from a sequence, lets say 1234567890

Before this change this will return a '1' 
After this chang this will return 1234567890

See: https://stackoverflow.com/questions/1710617/oci-bind-by-name-returning-into-truncates-value