### PR TITLE
PHPStan Level 5

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -12,6 +12,7 @@ use IteratorAggregate;
 use PDO;
 use function array_merge;
 use function array_values;
+use function assert;
 use function reset;
 
 /**
@@ -41,7 +42,7 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
     /** @var int */
     private $lifetime;
 
-    /** @var Statement */
+    /** @var ResultStatement */
     private $statement;
 
     /**
@@ -62,7 +63,7 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
      * @param string $realKey
      * @param int    $lifetime
      */
-    public function __construct(Statement $stmt, Cache $resultCache, $cacheKey, $realKey, $lifetime)
+    public function __construct(ResultStatement $stmt, Cache $resultCache, $cacheKey, $realKey, $lifetime)
     {
         $this->statement   = $stmt;
         $this->resultCache = $resultCache;
@@ -196,6 +197,8 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
      */
     public function rowCount()
     {
+        assert($this->statement instanceof Statement);
+
         return $this->statement->rowCount();
     }
 }

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -128,11 +128,10 @@ class DBALException extends Exception
     }
 
     /**
-     * @param Exception $driverEx
-     * @param string    $sql
-     * @param mixed[]   $params
+     * @param string  $sql
+     * @param mixed[] $params
      *
-     * @return \Doctrine\DBAL\DBALException
+     * @return self
      */
     public static function driverExceptionDuringQuery(Driver $driver, Throwable $driverEx, $sql, array $params = [])
     {
@@ -146,9 +145,7 @@ class DBALException extends Exception
     }
 
     /**
-     * @param Exception $driverEx
-     *
-     * @return \Doctrine\DBAL\DBALException
+     * @return self
      */
     public static function driverException(Driver $driver, Throwable $driverEx)
     {
@@ -156,9 +153,7 @@ class DBALException extends Exception
     }
 
     /**
-     * @param Exception $driverEx
-     *
-     * @return \Doctrine\DBAL\DBALException
+     * @return self
      */
     private static function wrapException(Driver $driver, Throwable $driverEx, $msg)
     {

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -240,7 +240,7 @@ class OCI8Statement implements IteratorAggregate, Statement
      * where the token was found.
      *
      * @param string $statement The SQL statement to parse
-     * @param string $offset    The offset to start searching from
+     * @param int    $offset    The offset to start searching from
      * @param string $regex     The regex containing token pattern
      *
      * @return string|null Token or NULL if not found

--- a/lib/Doctrine/DBAL/Event/SchemaCreateTableEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaCreateTableEventArgs.php
@@ -3,7 +3,6 @@
 namespace Doctrine\DBAL\Event;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use function array_merge;
 use function is_array;
@@ -16,7 +15,7 @@ class SchemaCreateTableEventArgs extends SchemaEventArgs
     /** @var Table */
     private $table;
 
-    /** @var Column[] */
+    /** @var mixed[][] */
     private $columns;
 
     /** @var mixed[] */
@@ -29,8 +28,8 @@ class SchemaCreateTableEventArgs extends SchemaEventArgs
     private $sql = [];
 
     /**
-     * @param Column[] $columns
-     * @param mixed[]  $options
+     * @param mixed[][] $columns
+     * @param mixed[]   $options
      */
     public function __construct(Table $table, array $columns, array $options, AbstractPlatform $platform)
     {
@@ -49,7 +48,7 @@ class SchemaCreateTableEventArgs extends SchemaEventArgs
     }
 
     /**
-     * @return Column[]
+     * @return mixed[][]
      */
     public function getColumns()
     {

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Portability;
 
+use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\Driver\StatementIterator;
 use Doctrine\DBAL\FetchMode;
@@ -9,6 +10,7 @@ use Doctrine\DBAL\ParameterType;
 use IteratorAggregate;
 use PDO;
 use function array_change_key_case;
+use function assert;
 use function is_string;
 use function rtrim;
 
@@ -20,7 +22,7 @@ class Statement implements IteratorAggregate, DriverStatement
     /** @var int */
     private $portability;
 
-    /** @var DriverStatement */
+    /** @var DriverStatement|ResultStatement */
     private $stmt;
 
     /** @var int */
@@ -32,7 +34,7 @@ class Statement implements IteratorAggregate, DriverStatement
     /**
      * Wraps <tt>Statement</tt> and applies portability measures.
      *
-     * @param DriverStatement $stmt
+     * @param DriverStatement|ResultStatement $stmt
      */
     public function __construct($stmt, Connection $conn)
     {
@@ -46,6 +48,8 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null)
     {
+        assert($this->stmt instanceof DriverStatement);
+
         return $this->stmt->bindParam($column, $variable, $type, $length);
     }
 
@@ -54,6 +58,8 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function bindValue($param, $value, $type = ParameterType::STRING)
     {
+        assert($this->stmt instanceof DriverStatement);
+
         return $this->stmt->bindValue($param, $value, $type);
     }
 
@@ -78,6 +84,8 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function errorCode()
     {
+        assert($this->stmt instanceof DriverStatement);
+
         return $this->stmt->errorCode();
     }
 
@@ -86,6 +94,8 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function errorInfo()
     {
+        assert($this->stmt instanceof DriverStatement);
+
         return $this->stmt->errorInfo();
     }
 
@@ -94,6 +104,8 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function execute($params = null)
     {
+        assert($this->stmt instanceof DriverStatement);
+
         return $this->stmt->execute($params);
     }
 
@@ -228,6 +240,8 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function rowCount()
     {
+        assert($this->stmt instanceof DriverStatement);
+
         return $this->stmt->rowCount();
     }
 }

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -286,8 +286,8 @@ class ExpressionBuilder
     /**
      * Quotes a given input parameter.
      *
-     * @param mixed       $input The parameter to be quoted.
-     * @param string|null $type  The type of the parameter.
+     * @param mixed    $input The parameter to be quoted.
+     * @param int|null $type  The type of the parameter.
      *
      * @return string
      */

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -36,13 +36,13 @@ class SQLParserUtils
     /**
      * Gets an array of the placeholders in an sql statements as keys and their positions in the query string.
      *
-     * Returns an integer => integer pair (indexed from zero) for a positional statement
-     * and a string => int[] pair for a named statement.
+     * For a statement with positional parameters, returns a zero-indexed list of placeholder position.
+     * For a statement with named parameters, returns a map of placeholder positions to their parameter names.
      *
      * @param string $statement
      * @param bool   $isPositional
      *
-     * @return int[]
+     * @return int[]|string[]
      */
     public static function getPlaceholderPositions($statement, $isPositional = true)
     {

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -268,7 +268,7 @@ abstract class AbstractSchemaManager
         }
         $indexes = $this->listTableIndexes($tableName);
 
-        return new Table($tableName, $columns, $indexes, $foreignKeys, false, []);
+        return new Table($tableName, $columns, $indexes, $foreignKeys);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -216,7 +216,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
     protected function _getPortableViewDefinition($view)
     {
         // @todo
-        return new View($view['name'], null);
+        return new View($view['name'], '');
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -283,9 +283,9 @@ class SqliteSchemaManager extends AbstractSchemaManager
                 continue;
             }
 
-            $type = $this->extractDoctrineTypeFromComment($comment, null);
+            $type = $this->extractDoctrineTypeFromComment($comment, '');
 
-            if ($type !== null) {
+            if ($type !== '') {
                 $column->setType(Type::getType($type));
 
                 $comment = $this->removeDoctrineTypeFromComment($comment, $type);

--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -425,7 +425,7 @@ class Table extends AbstractAsset
 
     /**
      * @param string $name
-     * @param string $value
+     * @param mixed  $value
      *
      * @return self
      */

--- a/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
@@ -78,15 +78,18 @@ class DropSchemaSqlCollector extends AbstractVisitor
     {
         $sql = [];
 
+        /** @var ForeignKeyConstraint $fkConstraint */
         foreach ($this->constraints as $fkConstraint) {
             $localTable = $this->constraints[$fkConstraint];
             $sql[]      = $this->platform->getDropForeignKeySQL($fkConstraint, $localTable);
         }
 
+        /** @var Sequence $sequence */
         foreach ($this->sequences as $sequence) {
             $sql[] = $this->platform->getDropSequenceSQL($sequence);
         }
 
+        /** @var Table $table */
         foreach ($this->tables as $table) {
             $sql[] = $this->platform->getDropTableSQL($table);
         }

--- a/lib/Doctrine/DBAL/Schema/Visitor/Graphviz.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/Graphviz.php
@@ -8,8 +8,6 @@ use Doctrine\DBAL\Schema\Table;
 use function current;
 use function file_put_contents;
 use function in_array;
-use function mt_rand;
-use function sha1;
 use function strtolower;
 
 /**
@@ -41,7 +39,7 @@ class Graphviz extends AbstractVisitor
      */
     public function acceptSchema(Schema $schema)
     {
-        $this->output  = 'digraph "' . sha1(mt_rand()) . '" {' . "\n";
+        $this->output  = 'digraph "' . $schema->getName() . '" {' . "\n";
         $this->output .= 'splines = true;' . "\n";
         $this->output .= 'overlap = false;' . "\n";
         $this->output .= 'outputorder=edgesfirst;' . "\n";

--- a/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
@@ -205,7 +205,7 @@ class PoolingShardConnection extends Connection
     /**
      * Connects to a specific connection.
      *
-     * @param string $shardId
+     * @param string|int $shardId
      *
      * @return \Doctrine\DBAL\Driver\Connection
      */

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 4
+    level: 5
     paths:
         - %currentWorkingDirectory%/lib
     autoload_files:
@@ -25,6 +25,9 @@ parameters:
 
         # http://php.net/manual/en/pdo.sqlitecreatefunction.php
         - '~^Call to an undefined method Doctrine\\DBAL\\Driver\\PDOConnection::sqliteCreateFunction\(\)\.\z~'
+
+        # https://github.com/JetBrains/phpstorm-stubs/pull/488
+        - '~^Parameter #1 \$byteCount of function SQLSRV_SQLTYPE_VARBINARY expects int, string given\.\z~'
 
         # legacy variadic-like signature
         - '~^Method Doctrine\\DBAL\\Driver\\Connection::query\(\) invoked with \d+ parameters?, 0 required\.\z~'


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

On level 5, things are getting a bit awkward. Fixing some issues the right way would cause a BC break.

1. The `rowCount()` method logically belongs to `ResultStatement`, however, it's declared in the `Statement` class. This issue has manifested in `ResultCacheStatement`.
2. The same should be applicable to `errorCode()` and `errorInfo()`. The error is a _result_ of statement execution, not an intent to execute it. See `Portability\Statement`.
3. Additionally, some methods of `Portability\Statement` requires a `Statement` while the others require a `ResultStatement`. Probably it could be split into two classes and represent two interfaces independently.
4. Type-wise, `SQLParserUtils::getPlaceholderPositions()` should be split into two methods for the statements with positional and named parameters.
5. PHPStan doesn't seem to understand property annotations like `SplObjectStorage|T[]` or `SplObjectStorage<T>`. That's why the annotations are added inline. See https://github.com/phpstan/phpstan/issues/1838.
6. `sha1(mt_rand())` has been removed from the `Graphviz` visitor since the object name is optional and it cannot be referenced from outside.