### PR TITLE
Compare type class when comparing columns.

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -12,6 +12,7 @@ use function array_shift;
 use function array_unique;
 use function assert;
 use function count;
+use function get_class;
 use function strtolower;
 
 /**
@@ -421,7 +422,11 @@ class Comparator
 
         $changedProperties = [];
 
-        foreach (['type', 'notnull', 'unsigned', 'autoincrement'] as $property) {
+        if (get_class($properties1['type']) !== get_class($properties2['type'])) {
+            $changedProperties[] = 'type';
+        }
+
+        foreach (['notnull', 'unsigned', 'autoincrement'] as $property) {
             if ($properties1[$property] === $properties2[$property]) {
                 continue;
             }

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
 use function array_keys;
+use function get_class;
 
 class ComparatorTest extends TestCase
 {
@@ -191,6 +192,36 @@ class ComparatorTest extends TestCase
         $c = new Comparator();
         self::assertEquals(['type'], $c->diffColumn($column1, $column2));
         self::assertEquals([], $c->diffColumn($column1, $column1));
+    }
+
+    public function testCompareColumnsMultipleTypeInstances() : void
+    {
+        $integerType1 = Type::getType('integer');
+        Type::overrideType('integer', get_class($integerType1));
+        $integerType2 = Type::getType('integer');
+
+        $column1 = new Column('integerfield1', $integerType1);
+        $column2 = new Column('integerfield1', $integerType2);
+
+        $c = new Comparator();
+        self::assertEquals([], $c->diffColumn($column1, $column2));
+    }
+
+    public function testCompareColumnsOverriddenType() : void
+    {
+        $oldStringInstance = Type::getType('string');
+        $integerType       = Type::getType('integer');
+
+        Type::overrideType('string', get_class($integerType));
+        $overriddenStringType = Type::getType('string');
+
+        Type::overrideType('string', get_class($oldStringInstance));
+
+        $column1 = new Column('integerfield1', $integerType);
+        $column2 = new Column('integerfield1', $overriddenStringType);
+
+        $c = new Comparator();
+        self::assertEquals([], $c->diffColumn($column1, $column2));
     }
 
     public function testCompareChangedColumnsChangeCustomSchemaOption() : void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3427 <!-- use #NUM format to reference an issue -->

#### Summary
Comparing columns that have different instances of the same type no longer detects a difference in type.

I'm a little hesitant to override a type in a test, but I don't know of a better way to get two instances of a type.

<!-- Provide a summary of your change. -->
