### PR TITLE
Prepend schema name to ForeignKey foreign_table information in SQLServerSchemaManager

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -148,8 +148,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
             if (! isset($foreignKeys[$tableForeignKey['ForeignKey']])) {
                 $foreignKeys[$tableForeignKey['ForeignKey']] = [
                     'local_columns' => [$tableForeignKey['ColumnName']],
-                    'foreign_table' => $tableForeignKey['ReferenceTableName'],
-                    'foreign_columns' => [$tableForeignKey['ReferenceColumnName']],
+                    'foreign_table' => $tableForeignKey['ReferenceSchemaName'] . '.' . $tableForeignKey['ReferenceTableName'],                    'foreign_columns' => [$tableForeignKey['ReferenceColumnName']],
                     'name' => $tableForeignKey['ForeignKey'],
                     'options' => [
                         'onUpdate' => str_replace('_', ' ', $tableForeignKey['update_referential_action_desc']),


### PR DESCRIPTION
When getting the foreignKey information of a Sql Server table, the
schema name is important information.

This commit prepends the schema name to the `foreign_table` key of the
foreignKey information.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | not sure

#### Summary

When getting the foreignKey information of a Sql Server table it is useful to have to schema name of the table included.
This allows you to build migrations that include the schema.

For example, the https://github.com/Xethron/migrations-generator package loops over the foreignKeys to generate migrations.
The `on` key uses `listTableForeignKeys()` to get the keys and `getForeignTableName()` to get the table name. (see https://github.com/Xethron/migrations-generator/blob/master/src/Xethron/MigrationsGenerator/Generators/ForeignKeyGenerator.php#L33).

Without this merge request, the resulting table does not contain the *schema*, and the migrations are not correct.
