### PR TITLE
[WIP] Index are recreated during a diff even when not changed

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MySqlPlatformTest.php
@@ -3,6 +3,8 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 
 class MySqlPlatformTest extends AbstractMySQLPlatformTestCase
@@ -18,5 +20,12 @@ class MySqlPlatformTest extends AbstractMySQLPlatformTestCase
             TransactionIsolationLevel::REPEATABLE_READ,
             $this->platform->getDefaultTransactionIsolationLevel()
         );
+    }
+
+    public function testPreserveIndexOnAlterTable()
+    {
+        $index = new Index('index_name', ['column']);
+        $diff = new TableDiff('table_name', [], [], [], [], [$index]);
+        $this->assertEquals([], $this->createPlatform()->getAlterTableSQL($diff));
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -398,6 +398,40 @@ class ComparatorTest extends TestCase
         self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
     }
 
+    public function testPreserveIndexesWhenNoChange()
+    {
+        $schema1 = new Schema(
+            [
+                'table' => new Table(
+                    'table',
+                    [
+                        'field' => new Column('field', Type::getType('integer')),
+                    ],
+                    [
+                        'primary' => new Index('primary', ['field']),
+                    ]
+                ),
+            ]
+        );
+        $schema2 = new Schema(
+            [
+                'table' => new Table(
+                    'table',
+                    [
+                        'field' => new Column('field', Type::getType('integer')),
+                    ],
+                    [
+                        'primary' => new Index('primary', ['field']),
+                    ]
+                ),
+            ]
+        );
+
+        $expected = new SchemaDiff();
+        $expected->fromSchema = $schema1;
+        self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
+    }
+
     public function testCompareChangedIndexFieldPositions()
     {
         $schema1 = new Schema([


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3780

#### Summary

This PR adds the steps to reproduce for #3780
When generating a diff (using DoctrineMigration package) for a table containing an index, the index is always dropped and then recreated.

I wrote a test in the `Comparator` to see if it could be the source, but he seems to work properly. So I just added a test on the `MysqlPlatform` (the place where I got the error). 

I will try to work on a patch when I get the time, unless someone fixes it before.

**Note:** This seems to be a **regression** introduced in `2.9.2`, since it worked in `<=2.9.1`. 

**TODO**

- [X] Step to reproduce 
- [ ] Provide a fix

![image](https://user-images.githubusercontent.com/1745744/52796196-547d0e00-3041-11e9-8c5b-4d1c2e9d1fd7.png)
