### PR TITLE
fixed a typo in PoolingShardConnection phpdoc

### DIFF
--- a/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
@@ -26,7 +26,7 @@ use function is_string;
  * - By default, the global shard is selected. If no global shard is configured
  *   an exception is thrown on access.
  * - Selecting a shard by distribution value delegates the mapping
- *   "distributionValue" => "client" to the ShardChooser interface.
+ *   "distributionValue" => "client" to the ShardChoser interface.
  * - An exception is thrown if trying to switch shards during an open
  *   transaction.
  *


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

PHPDocs refers to ShardChoser Interface but named "ShardChooser". This change prevents a little confustion.
