### PR TITLE
Marked some test classes abstract

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -46,7 +46,7 @@ use function strlen;
 use function strtolower;
 use function substr;
 
-class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
+abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
 {
     /** @var AbstractSchemaManager */
     protected $schemaManager;

--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -18,7 +18,7 @@ use function is_scalar;
 use function strpos;
 use function var_export;
 
-class DbalFunctionalTestCase extends DbalTestCase
+abstract class DbalFunctionalTestCase extends DbalTestCase
 {
     /**
      * Shared connection when a TestCase is run alone (outside of it's functional suite)

--- a/tests/Doctrine/Tests/DbalPerformanceTestCase.php
+++ b/tests/Doctrine/Tests/DbalPerformanceTestCase.php
@@ -11,7 +11,7 @@ use function microtime;
  * and stopTiming at the end of all tests. Tests that do not start or stop
  * timing will fail.
  */
-class DbalPerformanceTestCase extends DbalFunctionalTestCase
+abstract class DbalPerformanceTestCase extends DbalFunctionalTestCase
 {
     /**
      * time the test started


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. `SchemaManagerFunctionalTestCase` can be run only via an extending class. Otherwise, it skips all the tests. If the test case is represented as an abstract class, PhpStorm will offer a choice of concrete classes which is very handy when debugging test failures.
   ![screenshot from 2019-02-22 16-39-55](https://user-images.githubusercontent.com/59683/53279074-66565500-36c2-11e9-9e76-f22353b7e247.png)

2. `DbalFunctionalTestCase` and `DbalPerformanceTestCase` are meant to be used as base classes and don't contain any tests.
