### PR TITLE
Replaced Xdebug with PCOV for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,14 @@ cache:
         - $HOME/.composer/cache
 
 before_install:
+  - phpenv config-rm xdebug.ini || true
   - |
-    if [ "x$COVERAGE" != "xyes" ]; then
-      mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || true
+    if [ "x$COVERAGE" == "xyes" ]; then
+      pecl install pcov-1.0.0
     fi
 
 before_script:
   - if [[ "$DB" == "mysql" || "$DB" == "mysqli" || "$DB" == *"mariadb"* ]]; then mysql < tests/travis/create-mysql-schema.sql; fi;
-  - |
-    if [ "x$COVERAGE" == "xyes" ] && [[ ! $(php -m | grep -si xdebug) ]]; then
-      echo "xdebug is required for coverage"
-      exit 1
-    fi
 
 install:
   - rm composer.lock


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

On the SQLite build with code coverage enabled, the test run with PCOV takes [~20 seconds](https://travis-ci.org/doctrine/dbal/jobs/497330533#L731) comparing to more than [1½ minutes](https://travis-ci.org/doctrine/dbal/jobs/497267081#L575) with Xdebug.