### PR TITLE
Avoid database connection from PHPUnit data providers

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/AbstractDriverTest.php
@@ -55,7 +55,7 @@ abstract class AbstractDriverTest extends DbalFunctionalTestCase
         );
 
         self::assertSame(
-            $this->getDatabaseNameForConnectionWithoutDatabaseNameParameter(),
+            static::getDatabaseNameForConnectionWithoutDatabaseNameParameter(),
             $this->driver->getDatabase($connection)
         );
     }
@@ -65,10 +65,7 @@ abstract class AbstractDriverTest extends DbalFunctionalTestCase
      */
     abstract protected function createDriver();
 
-    /**
-     * @return string|null
-     */
-    protected function getDatabaseNameForConnectionWithoutDatabaseNameParameter()
+    protected static function getDatabaseNameForConnectionWithoutDatabaseNameParameter() : ?string
     {
         return null;
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
@@ -50,9 +50,12 @@ class DriverTest extends AbstractDriverTest
         );
     }
 
-    public function getDatabaseParameter()
+    /**
+     * @return mixed[][]
+     */
+    public static function getDatabaseParameter() : iterable
     {
-        $params            = TestUtil::getConnection()->getParams();
+        $params            = TestUtil::getConnectionParams();
         $realDatabaseName  = $params['dbname'] ?? '';
         $dummyDatabaseName = $realDatabaseName . 'a';
 
@@ -61,7 +64,7 @@ class DriverTest extends AbstractDriverTest
             [$realDatabaseName, null, $realDatabaseName],
             [$realDatabaseName, $dummyDatabaseName, $realDatabaseName],
             [null, $realDatabaseName, $realDatabaseName],
-            [null, null, $this->getDatabaseNameForConnectionWithoutDatabaseNameParameter()],
+            [null, null, static::getDatabaseNameForConnectionWithoutDatabaseNameParameter()],
         ];
     }
 
@@ -108,7 +111,7 @@ class DriverTest extends AbstractDriverTest
     /**
      * {@inheritdoc}
      */
-    protected function getDatabaseNameForConnectionWithoutDatabaseNameParameter()
+    protected static function getDatabaseNameForConnectionWithoutDatabaseNameParameter() : ?string
     {
         return 'postgres';
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
@@ -36,7 +36,7 @@ class DriverTest extends AbstractDriverTest
     /**
      * {@inheritdoc}
      */
-    protected function getDatabaseNameForConnectionWithoutDatabaseNameParameter()
+    protected static function getDatabaseNameForConnectionWithoutDatabaseNameParameter() : ?string
     {
         return 'master';
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/DriverTest.php
@@ -34,7 +34,7 @@ class DriverTest extends AbstractDriverTest
     /**
      * {@inheritdoc}
      */
-    protected function getDatabaseNameForConnectionWithoutDatabaseNameParameter()
+    protected static function getDatabaseNameForConnectionWithoutDatabaseNameParameter() : ?string
     {
         return 'master';
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Fixes #3471.

The data provider `PDOPgSql\DriverTest::getDatabaseParameter()` triggers a database connection in order to obtain the configured database name. Under certain circumstances, this connection may fail and invalidate the entire test suite. What are those circumstances?

1. PostgreSQL running in a Docker container:
   ```bash
   docker run -d -p 5432:5432 --name pgsql postgres:11.1
   docker exec -i pgsql bash <<< 'until pg_isready -U postgres > /dev/null 2>&1 ; do sleep 1; done'
   php -r 'try {new PDO("pgsql:host=127.0.0.1;port=5432", "postgres", "");} catch (PDOException $e) {echo $e->getMessage(), PHP_EOL;}'

   # SQLSTATE[08006] [7] server closed the connection unexpectedly
   #     This probably means the server terminated abnormally
   #     before or while processing the request.
   ```
   This failure [happens](https://travis-ci.org/doctrine/dbal/jobs/498266025) inconsistently, one of a few times.
2. MySQL running in a Docker container without an explicitly created database. Even if the test is going to be skipped, the data provider is still executed:
   ```bash
   docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 33306:3306 --name mysql mysql:5.7
   docker exec -i mysql bash <<< 'until mysql -e "show databases"; do sleep 1; done'
   php -r 'try {new PDO("mysql:host=127.0.0.1;port=33306", "root", "");} catch (PDOException $e) {echo $e->getMessage(), PHP_EOL;}'

   # SQLSTATE[HY000] [2006] MySQL server has gone away
   ```
   This failure [happens](https://travis-ci.org/doctrine/dbal/jobs/496130765) in 100% of the cases.

The solution is to expose `TestUtil::getConnectionParams()` to the test suite in order to let it get the parameters from configuration instead of connection. The logic from `TestUtil::getSpecifiedConnectionParams()` has been worked into `TestUtil::initializeDatabase()` in order to avoid side effects in `TestUtil::getConnectionParams()`.

This way, until we find a better solution, at least the MySQL jobs will not be impacted by an issue in PostgreSQL tests.