### PR TITLE
#2901: Pass shared cache setting through DSN.

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -61,14 +61,14 @@ class Driver extends AbstractSQLiteDriver
      */
     protected function _constructPdoDsn(array $params)
     {
+        if (isset($params['dsn'])) {
+            return $params['dsn'];
+        }
         $dsn = 'sqlite:';
         if (isset($params['path'])) {
             $dsn .= $params['path'];
         } elseif (isset($params['memory'])) {
             $dsn .= ':memory:';
-            if (isset($params['cache'])) {
-                $dsn .= '?cache=' . $params['cache'];
-            }
         }
 
         return $dsn;

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -66,6 +66,9 @@ class Driver extends AbstractSQLiteDriver
             $dsn .= $params['path'];
         } elseif (isset($params['memory'])) {
             $dsn .= ':memory:';
+            if (isset($params['cache'])) {
+                $dsn .= '?cache=' . $params['cache'];
+            }
         }
 
         return $dsn;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | <!--#2901 - support sqlite shared cache on :memory: -->

#### Summary

<!-- Provide a summary of your change. -->
With this change, 'sqlite:///:memory:?cache=shared' will allow multiple Sqlite connections within a process to share a memory database.