### PR TITLE
Moved rowCount() from Statement to ResultStatement

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK `Statement::rowCount()` is moved.
+
+`Statement::rowCount()` has been moved to the `ResultStatement` interface where it belongs by definition.
+
 ## BC BREAK Transaction-related `Statement` methods return `void`.
 
 `Statement::beginTransaction()`, `::commit()` and `::rollBack()` no longer return a boolean value. They will throw a `DriverException` in case of failure.
@@ -61,7 +65,7 @@ The following classes have been removed:
 
  * `Doctrine\DBAL\Platforms\SQLAnywhere11Platform`
  * `Doctrine\DBAL\Platforms\SQLAnywhere12Platform`
- * `Doctrine\DBAL\Platforms\SQLAnywhere16Platform`  
+ * `Doctrine\DBAL\Platforms\SQLAnywhere16Platform`
  * `Doctrine\DBAL\Platforms\Keywords\SQLAnywhere11Keywords`
  * `Doctrine\DBAL\Platforms\Keywords\SQLAnywhere12Keywords`
  * `Doctrine\DBAL\Platforms\Keywords\SQLAnywhere16Keywords`
@@ -215,7 +219,7 @@ This method now throws SPL ``UnexpectedValueException`` instead of accidentally 
 
 ## Doctrine\DBAL\Connection::TRANSACTION_* constants deprecated
 
-``Doctrine\DBAL\Connection::TRANSACTION_*`` were moved into ``Doctrine\DBAL\TransactionIsolationLevel`` class without the ``TRANSACTION_`` prefix. 
+``Doctrine\DBAL\Connection::TRANSACTION_*`` were moved into ``Doctrine\DBAL\TransactionIsolationLevel`` class without the ``TRANSACTION_`` prefix.
 
 ## DEPRECATION: direct usage of the PDO APIs in the DBAL API
 

--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -60,6 +60,18 @@ class ArrayStatement implements IteratorAggregate, ResultStatement
     /**
      * {@inheritdoc}
      */
+    public function rowCount() : int
+    {
+        if ($this->data === null) {
+            return 0;
+        }
+
+        return count($this->data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setFetchMode($fetchMode, ...$args)
     {
         if (count($args) > 0) {

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -6,14 +6,12 @@ use ArrayIterator;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\ResultStatement;
-use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\FetchMode;
 use InvalidArgumentException;
 use IteratorAggregate;
 use function array_key_exists;
 use function array_merge;
 use function array_values;
-use function assert;
 use function count;
 use function reset;
 
@@ -206,8 +204,6 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
      */
     public function rowCount() : int
     {
-        assert($this->statement instanceof Statement);
-
         return $this->statement->rowCount();
     }
 }

--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -26,6 +26,17 @@ interface ResultStatement extends Traversable
     public function columnCount();
 
     /**
+     * Returns the number of rows affected by the last DELETE, INSERT, or UPDATE statement
+     * executed by the corresponding object.
+     *
+     * If the last SQL statement executed by the associated Statement object was a SELECT statement,
+     * some databases may return the number of rows returned by that statement. However,
+     * this behaviour is not guaranteed for all databases and should not be
+     * relied on for portable applications.
+     */
+    public function rowCount() : int;
+
+    /**
      * Sets the fetch mode to use while iterating this statement.
      *
      * @param int   $fetchMode Controls how the next row will be returned to the caller.

--- a/lib/Doctrine/DBAL/Driver/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/Statement.php
@@ -88,17 +88,4 @@ interface Statement extends ResultStatement
      * @return bool TRUE on success or FALSE on failure.
      */
     public function execute($params = null);
-
-    /**
-     * Returns the number of rows affected by the last DELETE, INSERT, or UPDATE statement
-     * executed by the corresponding object.
-     *
-     * If the last SQL statement executed by the associated Statement object was a SELECT statement,
-     * some databases may return the number of rows returned by that statement. However,
-     * this behaviour is not guaranteed for all databases and should not be
-     * relied on for portable applications.
-     *
-     * @return int The number of rows.
-     */
-    public function rowCount() : int;
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

The issue was discovered using PHPStan as part of [#3436](https://github.com/doctrine/dbal/pull/3436/files#diff-f4ea3306103e9a98e0c10981a495d980R200).