### PR TITLE
Use latest stable versions of sqlsrv and pdo_sqlsrv on CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -68,8 +68,7 @@ install:
           Add-Content php.ini "`n extension=php_curl.dll"
           Add-Content php.ini "`n curl.cainfo=C:\tools\cacert\bundle.pem"
 
-          # Get and install the latest stable sqlsrv DLL's
-          $DLLVersion = (Invoke-WebRequest "https://pecl.php.net/rest/r/sqlsrv/stable.txt").Content
+          $DLLVersion = "5.5.0preview"
           cd c:\tools\php\ext
           $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
           $destination = "c:\tools\php\ext\php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
@@ -79,7 +78,7 @@ install:
           $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
           Invoke-WebRequest $source -OutFile $destination
           7z x -y php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip > $null
-          $DLLVersion = "2.6.0"
+          $DLLVersion = (Invoke-WebRequest "https://pecl.php.net/rest/r/xdebug/stable.txt").Content
           $source = "https://xdebug.org/files/php_xdebug-$($DLLVersion)-$($env:php)-vc15-nts-x86_64.dll"
           $destination = "c:\tools\php\ext\php_xdebug.dll"
           Invoke-WebRequest $source -OutFile $destination

--- a/tests/travis/install-mssql-pdo_sqlsrv.sh
+++ b/tests/travis/install-mssql-pdo_sqlsrv.sh
@@ -4,8 +4,4 @@ set -ex
 
 echo "Installing extension"
 
-if [ "$TRAVIS_PHP_VERSION" == "7.3" ] || [ "$TRAVIS_PHP_VERSION" == "nightly" ] ; then
-  pecl install pdo_sqlsrv-5.4.0preview
-else
-  pecl install pdo_sqlsrv
-fi
+pecl install pdo_sqlsrv

--- a/tests/travis/install-mssql-sqlsrv.sh
+++ b/tests/travis/install-mssql-sqlsrv.sh
@@ -4,8 +4,4 @@ set -ex
 
 echo "Installing extension"
 
-if [ "$TRAVIS_PHP_VERSION" == "7.3" ] || [ "$TRAVIS_PHP_VERSION" == "nightly" ] ; then
-  pecl install sqlsrv-5.4.0preview
-else
-  pecl install sqlsrv
-fi
+pecl install sqlsrv


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. [`sqlsrv` and `pdo_sqlsrv` v5.6.0](https://github.com/Microsoft/msphpsql/releases/tag/v5.6.0) are compatible with all supported PHP versions.
2. [`xdebug` v2.7.0](https://github.com/xdebug/xdebug/releases/tag/2.7.0) is available.
3. `sqlsrv` on AppVeyor is temporarily rolled back to `5.5.0preview` due to (https://github.com/Microsoft/msphpsql/issues/955).