### PR TITLE
Fix quotes in single-line comments breaking parameters

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -254,7 +254,7 @@ class SQLParserUtils
         $expression = sprintf('/(?:[\s]*--.*?\n)|((.+(?i:ARRAY)\\[.+\\])|([^-\'"`\\[]+))(?:%s)?/s', $literal);
         preg_match_all($expression, $statement, $fragments, PREG_OFFSET_CAPTURE);
 
-        return array_filter($fragments[1], static function ($match) {
+        return array_filter($fragments[1], static function (string $match) : bool {
             return $match !== '';
         });
     }

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL;
 
 use const PREG_OFFSET_CAPTURE;
 use function array_fill;
+use function array_filter;
 use function array_key_exists;
 use function array_merge;
 use function array_slice;
@@ -250,11 +251,12 @@ class SQLParserUtils
             self::ESCAPED_DOUBLE_QUOTED_TEXT . '|' .
             self::ESCAPED_BACKTICK_QUOTED_TEXT . '|' .
             self::ESCAPED_BRACKET_QUOTED_TEXT;
-        $expression = sprintf('/((.+(?i:ARRAY)\\[.+\\])|([^\'"`\\[]+))(?:%s)?/s', $literal);
-
+        $expression = sprintf('/(?:[\s]*--.*?\n)|((.+(?i:ARRAY)\\[.+\\])|([^-\'"`\\[]+))(?:%s)?/s', $literal);
         preg_match_all($expression, $statement, $fragments, PREG_OFFSET_CAPTURE);
 
-        return $fragments[1];
+        return array_filter($fragments[1], static function ($match) {
+            return $match !== '';
+        });
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -86,6 +86,25 @@ SQLDATA
             ['SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE "\\\\") AND (data.description LIKE :condition_1 ESCAPE \'\\\\\') ORDER BY id ASC', false, [121 => 'condition_0', 174 => 'condition_1']],
             ['SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE `\\\\`) AND (data.description LIKE :condition_1 ESCAPE `\\\\`) ORDER BY id ASC', false, [121 => 'condition_0', 174 => 'condition_1']],
             ['SELECT data.age AS age, data.id AS id, data.name AS name, data.id AS id FROM test_data data WHERE (data.description LIKE :condition_0 ESCAPE \'\\\\\') AND (data.description LIKE :condition_1 ESCAPE `\\\\`) ORDER BY id ASC', false, [121 => 'condition_0', 174 => 'condition_1']],
+            // Named parameter containing comment(s) with odd number of single quotes
+            [
+                <<<'SQLDATA'
+SELECT * FROM foo WHERE 
+bar=:a_param1
+-- Oops! Perfectly normal comment but it's got an odd number of apostrophes
+OR bar=':not_a_param1'
+OR bar=:a_param2
+OR bar=:a_param3
+OR bar=':not_a_param2'
+SQLDATA
+                ,
+                false,
+                [
+                    29 => 'a_param1',
+                    145 => 'a_param2',
+                    162 => 'a_param3',
+                ],
+            ],
 
         ];
     }

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -105,6 +105,23 @@ SQLDATA
                     162 => 'a_param3',
                 ],
             ],
+            // Check comments in strings don't reverse it either
+            [
+                <<<'SQLDATA'
+INSERT INTO foo VALUES
+('
+-- Not a comment
+Hello, world! 
+',
+:a_param1
+':not_a_param1')
+SQLDATA
+                ,
+                false,
+                [
+                    61 => 'a_param1',
+                ],
+            ],
 
         ];
     }

--- a/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
+++ b/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php
@@ -118,9 +118,19 @@ Hello, world!
 SQLDATA
                 ,
                 false,
-                [
-                    61 => 'a_param1',
-                ],
+                [ 61 => 'a_param1' ],
+            ],
+            // And with comment on same line as quote
+            [
+                <<<'SQLDATA'
+INSERT INTO foo VALUES
+('
+-- Not a comment Hello, world! ', :a_param1
+':not_a_param1')
+SQLDATA
+                ,
+                false,
+                [ 60 => 'a_param1' ],
             ],
 
         ];


### PR DESCRIPTION
An odd number of quotes in comments would cause getUnquotedStatementFragments to start returning the inside of strings, rather than the outside.
Ignore comment lines to solve this problem.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Could not find existing issue

#### Summary

This PR ensures that comments are ignored when breaking a query into fragments. Without this PR, comments with quotes **(including apostrophes in words)** can arbitrarily break parameter substitution.
While ideal production code does not include comments, test code can, and will confuse people if something breaks because they're present.

When trying to test a query locally, I got an SQLSTATE error indicating there was a mismatch between positional parameters and the parameters provided.
Inspecting the query just before execution, I noted that not all of the parameters had been substituted, it seemed that the ones that were later in the query had not.
After stepping through, I found the culprit to be getUnquotedSegmentFragments, later on in the query it was returning short fragments such as "variable_foo" etc. (I recognised these as names of json fields that I was accessing)
**I realised that the pattern was such that it broke my comments into fragments, and then encountered the final quote in a comment and continued searching for its pair, then treating every following _opening_ quote as a _closing_ one!**

This is fixable by adding syntax for comments to the beginning of the RegEx, so they are skipped if found.
I also needed to add the "-" character to the list of banned characters preceding a quote, so that it would be interrupted by a comment. This doesn't seem to prevent important edge cases, but I'm happy if one is found to prove me wrong.