### PR TITLE
Adding the ability to fetch comments from table in PostgreSQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -797,6 +797,12 @@ SQL
             }
         }
 
+        if (isset($options['comment'])) {
+            $comment = trim($options['comment'], " '");
+
+            $sql[] = sprintf('COMMENT ON TABLE %s IS %s', $tableName, $this->quoteStringLiteral($comment));
+        }
+
         return $sql;
     }
 
@@ -1251,5 +1257,20 @@ SQL
     private function getOldColumnComment(ColumnDiff $columnDiff) : ?string
     {
         return $columnDiff->fromColumn ? $this->getColumnComment($columnDiff->fromColumn) : null;
+    }
+
+    public function getListTableMetadataSQL(string $table, ?string $schema = null) : string
+    {
+        if ($schema !== null) {
+            $table = $schema . '.' . $table;
+        }
+
+        return sprintf(
+            <<<'SQL'
+SELECT obj_description(%s::regclass) AS table_comment;
+SQL
+            ,
+            $this->quoteStringLiteral($table)
+        );
     }
 }

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -478,4 +478,19 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
 
         return $defaultValue;
     }
+
+    public function listTableDetails($tableName)
+    {
+        $table = parent::listTableDetails($tableName);
+
+        /** @var PostgreSqlPlatform $platform */
+        $platform = $this->_platform;
+        $sql      = $platform->getListTableMetadataSQL($tableName);
+
+        $tableOptions = $this->_conn->fetchAssoc($sql);
+
+        $table->addOption('comment', $tableOptions['table_comment']);
+
+        return $table;
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/Db2SchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/Db2SchemaManagerTest.php
@@ -31,4 +31,9 @@ class Db2SchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         self::markTestSkipped('Binary data type is currently not supported on DB2 LUW');
     }
+
+    public function testCommentInTable() : void
+    {
+        self::markTestSkipped('Table level comments are not supported on DB2');
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -285,4 +285,9 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         self::markTestSkipped("Skipped for uppercase letters are contained in sequences' names. Fix the schema manager in 3.0.");
     }
+
+    public function testCommentInTable() : void
+    {
+        self::markTestSkipped('Table level comments are not supported on Oracle');
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -514,17 +514,6 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($tableFinal->getColumn('id')->getAutoincrement());
     }
 
-    public function testCommentInTable() : void
-    {
-        $table = new Table('table_with_comment');
-        $table->addColumn('id', 'integer');
-        $table->addOption('comment', 'Foo with control characters \'\\');
-        $this->schemaManager->dropAndCreateTable($table);
-
-        $table = $this->schemaManager->listTableDetails('table_with_comment');
-        self::assertSame('Foo with control characters \'\\', $table->getOption('comment'));
-    }
-
     /**
      * @return mixed[][]
      */

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -517,7 +517,7 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testCommentInTable() : void
     {
         $table = new Table('table_with_comment');
-        $table->addColumn('id', 'int');
+        $table->addColumn('id', 'integer');
         $table->addOption('comment', 'Foo');
         $this->schemaManager->dropAndCreateTable($table);
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -518,11 +518,11 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $table = new Table('table_with_comment');
         $table->addColumn('id', 'integer');
-        $table->addOption('comment', 'Foo');
+        $table->addOption('comment', 'Foo with control characters \'\\');
         $this->schemaManager->dropAndCreateTable($table);
 
         $table = $this->schemaManager->listTableDetails('table_with_comment');
-        self::assertSame('Foo', $table->getOption('comment'));
+        self::assertSame('Foo with control characters \'\\', $table->getOption('comment'));
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -514,6 +514,17 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($tableFinal->getColumn('id')->getAutoincrement());
     }
 
+    public function testCommentInTable() : void
+    {
+        $table = new Table('table_with_comment');
+        $table->addColumn('id', 'int');
+        $table->addOption('comment', 'Foo');
+        $this->schemaManager->dropAndCreateTable($table);
+
+        $table = $this->schemaManager->listTableDetails('table_with_comment');
+        self::assertSame('Foo', $table->getOption('comment'));
+    }
+
     /**
      * @return mixed[][]
      */

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
@@ -61,4 +61,9 @@ class SQLAnywhereSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertArrayHasKey('test', $columns);
         self::assertTrue($columns['test']->getFixed());
     }
+
+    public function testCommentInTable() : void
+    {
+        self::markTestSkipped('Table level comments are not supported on SQLAnywhere');
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -357,4 +357,9 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('colB', $columns[0]);
         self::assertEquals('colA', $columns[1]);
     }
+
+    public function testCommentInTable() : void
+    {
+        self::markTestSkipped('Table level comments are not supported on SQLServer');
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1575,4 +1575,15 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
         $onlineTable = $this->schemaManager->listTableDetails('test_partial_column_index');
         self::assertEquals($expected, $onlineTable->getIndexes());
     }
+
+    public function testCommentInTable() : void
+    {
+        $table = new Table('table_with_comment');
+        $table->addColumn('id', 'integer');
+        $table->addOption('comment', 'Foo with control characters \'\\');
+        $this->schemaManager->dropAndCreateTable($table);
+
+        $table = $this->schemaManager->listTableDetails('table_with_comment');
+        self::assertSame('Foo with control characters \'\\', $table->getOption('comment'));
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -277,4 +277,9 @@ SQL;
         // with an empty table, non autoincrement rowid is always 1
         $this->assertEquals(1, $lastUsedIdAfterDelete);
     }
+
+    public function testCommentInTable() : void
+    {
+        self::markTestSkipped('Table level comments are not supported on Sqlite');
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Schema\Table;
 
 class PostgreSqlPlatformTest extends AbstractPostgreSqlPlatformTestCase
 {
@@ -14,5 +15,20 @@ class PostgreSqlPlatformTest extends AbstractPostgreSqlPlatformTestCase
     public function testSupportsPartialIndexes()
     {
         self::assertTrue($this->platform->supportsPartialIndexes());
+    }
+
+    public function testGetCreateTableSQLWithColumnCollation() : void
+    {
+        $table = new Table('foo');
+        $table->addColumn('id', 'string');
+        $table->addOption('comment', 'foo');
+        self::assertSame(
+            [
+                'CREATE TABLE foo (id VARCHAR(255) NOT NULL)',
+                "COMMENT ON TABLE foo IS 'foo'",
+            ],
+            $this->platform->getCreateTableSQL($table),
+            'Comments are added to table.'
+        );
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

The DBAL MySQL driver supports fetching/setting comments in the table via the options:

```php
$table = new Table('foo');
$table->addOption('comment', 'My comment');
$comment = $table->getOption('comment');
```

However, this is MySQL specific and does not work in PostgreSQL.
(DBAL has native support for column comments for all DBMS but no universal support for table comments)

This PR adds support for the "comment" option in PostgreSQL too.

Note: the PR starts with a failing unit test.