### PR TITLE
Reworked AbstractSchemaManager::extractDoctrineTypeFromComment(), removed ::removeDoctrineTypeFromComment()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK `AbstractSchemaManager::extractDoctrineTypeFromComment()` changed, `::removeDoctrineTypeFromComment()` removed
+
+`AbstractSchemaManager::extractDoctrineTypeFromComment()` made `protected`. It takes the comment by reference, removes the type annotation from it and returns the extracted Doctrine type.
+
 ## BC BREAK `::errorCode()` and `::errorInfo()` removed from `Connection` and `Statement` APIs
 
 The error information is available in `DriverException` trown in case of an error.

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -23,7 +23,6 @@ use function func_get_args;
 use function is_array;
 use function is_callable;
 use function preg_match;
-use function str_replace;
 use function strtolower;
 
 /**
@@ -1099,35 +1098,19 @@ abstract class AbstractSchemaManager
     }
 
     /**
-     * Given a table comment this method tries to extract a typehint for Doctrine Type, or returns
-     * the type given as default.
+     * Given a table comment this method tries to extract a type hint for Doctrine Type. If the type hint is found,
+     * it's removed from the comment.
      *
-     * @param string|null $comment
-     * @param string      $currentType
-     *
-     * @return string
+     * @return string|null The extracted Doctrine type or NULL of the type hint was not found.
      */
-    public function extractDoctrineTypeFromComment($comment, $currentType)
+    final protected function extractDoctrineTypeFromComment(?string &$comment) : ?string
     {
-        if ($comment !== null && preg_match('(\(DC2Type:(((?!\)).)+)\))', $comment, $match)) {
-            return $match[1];
-        }
-
-        return $currentType;
-    }
-
-    /**
-     * @param string|null $comment
-     * @param string|null $type
-     *
-     * @return string|null
-     */
-    public function removeDoctrineTypeFromComment($comment, $type)
-    {
-        if ($comment === null) {
+        if ($comment === null || ! preg_match('/(.*)\(DC2Type:(((?!\)).)+)\)(.*)/', $comment, $match)) {
             return null;
         }
 
-        return str_replace('(DC2Type:' . $type . ')', '', $comment);
+        $comment = $match[1] . $match[4];
+
+        return $match[2];
     }
 }

--- a/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
@@ -56,12 +56,8 @@ class DB2SchemaManager extends AbstractSchemaManager
             $default = trim($tableColumn['default'], "'");
         }
 
-        $type = $this->_platform->getDoctrineTypeMapping($tableColumn['typename']);
-
-        if (isset($tableColumn['comment'])) {
-            $type                   = $this->extractDoctrineTypeFromComment($tableColumn['comment'], $type);
-            $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);
-        }
+        $type = $this->extractDoctrineTypeFromComment($tableColumn['comment'])
+            ?? $this->_platform->getDoctrineTypeMapping($tableColumn['typename']);
 
         switch (strtolower($tableColumn['typename'])) {
             case 'varchar':

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -108,13 +108,8 @@ class MySqlSchemaManager extends AbstractSchemaManager
         $scale     = null;
         $precision = null;
 
-        $type = $this->_platform->getDoctrineTypeMapping($dbType);
-
-        // In cases where not connected to a database DESCRIBE $table does not return 'Comment'
-        if (isset($tableColumn['comment'])) {
-            $type                   = $this->extractDoctrineTypeFromComment($tableColumn['comment'], $type);
-            $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);
-        }
+        $type = $this->extractDoctrineTypeFromComment($tableColumn['comment'])
+            ?? $this->_platform->getDoctrineTypeMapping($dbType);
 
         switch ($dbType) {
             case 'char':

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -160,9 +160,8 @@ class OracleSchemaManager extends AbstractSchemaManager
             $scale = (int) $tableColumn['data_scale'];
         }
 
-        $type                    = $this->_platform->getDoctrineTypeMapping($dbType);
-        $type                    = $this->extractDoctrineTypeFromComment($tableColumn['comments'], $type);
-        $tableColumn['comments'] = $this->removeDoctrineTypeFromComment($tableColumn['comments'], $type);
+        $type = $this->extractDoctrineTypeFromComment($tableColumn['comments'])
+            ?? $this->_platform->getDoctrineTypeMapping($dbType);
 
         switch ($dbType) {
             case 'number':

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -365,9 +365,8 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
             $tableColumn['complete_type'] = $tableColumn['domain_complete_type'];
         }
 
-        $type                   = $this->_platform->getDoctrineTypeMapping($dbType);
-        $type                   = $this->extractDoctrineTypeFromComment($tableColumn['comment'], $type);
-        $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);
+        $type = $this->extractDoctrineTypeFromComment($tableColumn['comment'])
+            ?? $this->_platform->getDoctrineTypeMapping($dbType);
 
         switch ($dbType) {
             case 'smallint':

--- a/lib/Doctrine/DBAL/Schema/SQLAnywhereSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLAnywhereSchemaManager.php
@@ -88,13 +88,13 @@ class SQLAnywhereSchemaManager extends AbstractSchemaManager
      */
     protected function _getPortableTableColumnDefinition($tableColumn)
     {
-        $type                   = $this->_platform->getDoctrineTypeMapping($tableColumn['type']);
-        $type                   = $this->extractDoctrineTypeFromComment($tableColumn['comment'], $type);
-        $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);
-        $precision              = null;
-        $scale                  = null;
-        $fixed                  = false;
-        $default                = null;
+        $type = $this->extractDoctrineTypeFromComment($tableColumn['comment'])
+            ?? $this->_platform->getDoctrineTypeMapping($tableColumn['type']);
+
+        $precision = null;
+        $scale     = null;
+        $fixed     = false;
+        $default   = null;
 
         if ($tableColumn['default'] !== null) {
             // Strip quotes from default value.

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -101,9 +101,8 @@ class SQLServerSchemaManager extends AbstractSchemaManager
             $fixed = true;
         }
 
-        $type                   = $this->_platform->getDoctrineTypeMapping($dbType);
-        $type                   = $this->extractDoctrineTypeFromComment($tableColumn['comment'], $type);
-        $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);
+        $type = $this->extractDoctrineTypeFromComment($tableColumn['comment'])
+            ?? $this->_platform->getDoctrineTypeMapping($dbType);
 
         $options = [
             'length'        => $length === 0 || ! in_array($type, ['text', 'string']) ? null : $length,

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -281,16 +281,10 @@ class SqliteSchemaManager extends AbstractSchemaManager
 
             $comment = $this->parseColumnCommentFromSQL($columnName, $createSql);
 
-            if ($comment === null) {
-                continue;
-            }
+            $type = $this->extractDoctrineTypeFromComment($comment);
 
-            $type = $this->extractDoctrineTypeFromComment($comment, '');
-
-            if ($type !== '') {
+            if ($type !== null) {
                 $column->setType(Type::getType($type));
-
-                $comment = $this->removeDoctrineTypeFromComment($comment, $type);
             }
 
             $column->setComment($comment);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

Currently, `AbstractSchemaManager::extractDoctrineTypeFromComment()` and `::removeDoctrineTypeFromComment()` have to be called separately, one after the other, and duplicate implementation, however they are parts of a single whole: extracting a Doctrine type from the column comment.

The fact that the former requires passing `$currentType` makes it hard to use when the type is not yet known (see `SqliteSchemaManager`) and hard to guess if the type was actually extracted (it takes passing a knowingly wrong type and compare it with the result).

The proposed implementation makes the usage more straightforward. I would like to keep `testExtractDoctrineTypeFromComment` in place but I don't think the method is worth extraction into a separate class. Therefore, reflection is used in the test.

~It's still unclear to me whether column comments should be nullable or not in general (I'd love them to not be), but making a decision requires a larger effort which will be made later.~ It's actually not being currently changed.