### PR TITLE
Removed DB2SchemaManager::_getPortableForeignKeyRuleDef()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK `DB2SchemaManager::_getPortableForeignKeyRuleDef()` removed
+
+The method was used internally and is no longer needed.
+
 ## BC BREAK `AbstractPlatform::get*Expression()` methods no loner accept integer values as arguments
 
 The following methods' arguments do not longer accept integer value:

--- a/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
@@ -178,22 +178,6 @@ class DB2SchemaManager extends AbstractSchemaManager
     /**
      * {@inheritdoc}
      */
-    protected function _getPortableForeignKeyRuleDef($def)
-    {
-        if ($def === 'C') {
-            return 'CASCADE';
-        }
-
-        if ($def === 'N') {
-            return 'SET NULL';
-        }
-
-        return null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function _getPortableViewDefinition($view)
     {
         $view = array_change_key_case($view, CASE_LOWER);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

The method is unused since #447 (`v2.5.0-BETA2`). Its logic is still implemented in `DB2Platform::getListTableForeignKeysSQL()` and is covered by `SchemaManagerFunctionalTestCase::testListForeignKeys()`.