### PR TITLE
Fix the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.9.x-dev",
+            "dev-master": "2.10.x-dev",
             "dev-develop": "3.0.x-dev"
         }
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug (kind of)
| BC Break     | no
| Fixed issues | n/a

#### Summary

Version was bumped to 2.10-dev in 27023276734da75a08cfdd31995884df8030975c but the branch alias was forgotten.
