### PR TITLE
Removed errorCode() and errorInfo() methods from Connection and Statement APIs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK `::errorCode()` and `::errorInfo()` removed from `Connection` and `Statement` APIs
+
+The error information is available in `DriverException` trown in case of an error.
+
 ## BC BREAK Changes in driver exceptions
 
 1. The `Doctrine\DBAL\Driver\DriverException::getErrorCode()` method is removed. In order to obtain the driver error code, please use `::getCode()`.

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1066,24 +1066,6 @@ class Connection implements DriverConnection
     }
 
     /**
-     * Fetches the SQLSTATE associated with the last database operation.
-     *
-     * @return string|null The last error code.
-     */
-    public function errorCode()
-    {
-        return $this->getWrappedConnection()->errorCode();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function errorInfo()
-    {
-        return $this->getWrappedConnection()->errorInfo();
-    }
-
-    /**
      * Returns the ID of the last inserted row, or the last value from a sequence object,
      * depending on the underlying driver.
      *

--- a/lib/Doctrine/DBAL/Driver/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/Connection.php
@@ -67,18 +67,4 @@ interface Connection
      * @throws DriverException
      */
     public function rollBack() : void;
-
-    /**
-     * Returns the error code associated with the last operation on the database handle.
-     *
-     * @return string|null The error code, or null if no operation has been run on the database handle.
-     */
-    public function errorCode();
-
-    /**
-     * Returns extended error information associated with the last operation on the database handle.
-     *
-     * @return mixed[]
-     */
-    public function errorInfo();
 }

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -13,8 +13,6 @@ use const DB2_AUTOCOMMIT_OFF;
 use const DB2_AUTOCOMMIT_ON;
 use function db2_autocommit;
 use function db2_commit;
-use function db2_conn_error;
-use function db2_conn_errormsg;
 use function db2_connect;
 use function db2_escape_string;
 use function db2_exec;
@@ -164,24 +162,5 @@ class DB2Connection implements Connection, ServerInfoAwareConnection
         if (! db2_autocommit($this->conn, DB2_AUTOCOMMIT_ON)) {
             throw DB2Exception::fromConnectionError($this->conn);
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorCode()
-    {
-        return db2_conn_error($this->conn);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorInfo()
-    {
-        return [
-            0 => db2_conn_errormsg($this->conn),
-            1 => $this->errorCode(),
-        ];
     }
 }

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -32,8 +32,6 @@ use function db2_fetch_object;
 use function db2_free_result;
 use function db2_num_fields;
 use function db2_num_rows;
-use function db2_stmt_error;
-use function db2_stmt_errormsg;
 use function error_get_last;
 use function fclose;
 use function fwrite;
@@ -163,25 +161,6 @@ class DB2Statement implements IteratorAggregate, Statement
     public function columnCount()
     {
         return db2_num_fields($this->stmt) ?: 0;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorCode()
-    {
-        return db2_stmt_error();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorInfo()
-    {
-        return [
-            db2_stmt_errormsg(),
-            db2_stmt_error(),
-        ];
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -199,22 +199,6 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function errorCode()
-    {
-        return $this->conn->errno;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorInfo()
-    {
-        return $this->conn->error;
-    }
-
-    /**
      * Apply the driver options to the connection.
      *
      * @param mixed[] $driverOptions

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -391,22 +391,6 @@ class MysqliStatement implements IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function errorCode()
-    {
-        return $this->_stmt->errno;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorInfo()
-    {
-        return $this->_stmt->error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function closeCursor() : void
     {
         $this->_stmt->free_result();

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -199,31 +199,4 @@ class OCI8Connection implements Connection, ServerInfoAwareConnection
 
         $this->executeMode = OCI_COMMIT_ON_SUCCESS;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorCode()
-    {
-        $error = oci_error($this->dbh);
-        if ($error !== false) {
-            $error = $error['code'];
-        }
-
-        return $error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorInfo()
-    {
-        $error = oci_error($this->dbh);
-
-        if ($error === false) {
-            return [];
-        }
-
-        return $error;
-    }
 }

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -345,33 +345,6 @@ class OCI8Statement implements IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function errorCode()
-    {
-        $error = oci_error($this->_sth);
-        if ($error !== false) {
-            $error = $error['code'];
-        }
-
-        return $error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorInfo()
-    {
-        $error = oci_error($this->_sth);
-
-        if ($error === false) {
-            return [];
-        }
-
-        return $error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function execute($params = null) : void
     {
         if ($params) {

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -148,22 +148,6 @@ class PDOConnection implements Connection, ServerInfoAwareConnection
         $this->connection->rollBack();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function errorCode()
-    {
-        return $this->connection->errorCode();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function errorInfo()
-    {
-        return $this->connection->errorInfo();
-    }
-
     public function getWrappedConnection() : PDO
     {
         return $this->connection;

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -116,22 +116,6 @@ class PDOStatement implements IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function errorCode()
-    {
-        return $this->stmt->errorCode();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorInfo()
-    {
-        return $this->stmt->errorInfo();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function execute($params = null) : void
     {
         try {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -14,8 +14,6 @@ use function is_string;
 use function sasql_affected_rows;
 use function sasql_commit;
 use function sasql_connect;
-use function sasql_error;
-use function sasql_errorcode;
 use function sasql_escape_string;
 use function sasql_insert_id;
 use function sasql_pconnect;
@@ -82,22 +80,6 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
         }
 
         $this->endTransaction();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorCode()
-    {
-        return sasql_errorcode($this->connection);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorInfo()
-    {
-        return sasql_error($this->connection);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -30,8 +30,6 @@ use function sasql_fetch_row;
 use function sasql_prepare;
 use function sasql_stmt_affected_rows;
 use function sasql_stmt_bind_param_ex;
-use function sasql_stmt_errno;
-use function sasql_stmt_error;
 use function sasql_stmt_execute;
 use function sasql_stmt_field_count;
 use function sasql_stmt_reset;
@@ -142,22 +140,6 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
     public function columnCount()
     {
         return sasql_stmt_field_count($this->stmt);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorCode()
-    {
-        return sasql_stmt_errno($this->stmt);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorInfo()
-    {
-        return sasql_stmt_error($this->stmt);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -8,12 +8,10 @@ use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
-use const SQLSRV_ERR_ERRORS;
 use function sqlsrv_begin_transaction;
 use function sqlsrv_commit;
 use function sqlsrv_configure;
 use function sqlsrv_connect;
-use function sqlsrv_errors;
 use function sqlsrv_query;
 use function sqlsrv_rollback;
 use function sqlsrv_rows_affected;
@@ -161,26 +159,5 @@ class SQLSrvConnection implements Connection, ServerInfoAwareConnection
         if (! sqlsrv_rollback($this->conn)) {
             throw SQLSrvException::fromSqlSrvErrors();
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function errorCode()
-    {
-        $errors = sqlsrv_errors(SQLSRV_ERR_ERRORS);
-        if ($errors) {
-            return $errors[0]['code'];
-        }
-
-        return false;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function errorInfo()
-    {
-        return (array) sqlsrv_errors(SQLSRV_ERR_ERRORS);
     }
 }

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use IteratorAggregate;
 use const SQLSRV_ENC_BINARY;
-use const SQLSRV_ERR_ERRORS;
 use const SQLSRV_FETCH_ASSOC;
 use const SQLSRV_FETCH_BOTH;
 use const SQLSRV_FETCH_NUMERIC;
@@ -21,7 +20,6 @@ use function count;
 use function in_array;
 use function is_int;
 use function is_numeric;
-use function sqlsrv_errors;
 use function sqlsrv_execute;
 use function sqlsrv_fetch;
 use function sqlsrv_fetch_array;
@@ -205,27 +203,6 @@ class SQLSrvStatement implements IteratorAggregate, Statement
         }
 
         return sqlsrv_num_fields($this->stmt) ?: 0;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorCode()
-    {
-        $errors = sqlsrv_errors(SQLSRV_ERR_ERRORS);
-        if ($errors) {
-            return $errors[0]['code'];
-        }
-
-        return false;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorInfo()
-    {
-        return (array) sqlsrv_errors(SQLSRV_ERR_ERRORS);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/Statement.php
@@ -60,22 +60,6 @@ interface Statement extends ResultStatement
     public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null) : void;
 
     /**
-     * Fetches the SQLSTATE associated with the last operation on the statement handle.
-     *
-     * @see Doctrine_Adapter_Interface::errorCode()
-     *
-     * @return string|int|bool The error code string.
-     */
-    public function errorCode();
-
-    /**
-     * Fetches extended error information associated with the last operation on the statement handle.
-     *
-     * @return mixed[] The error info array.
-     */
-    public function errorInfo();
-
-    /**
      * Executes a prepared statement
      *
      * If the prepared statement included parameter markers, you must either:

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -83,26 +83,6 @@ class Statement implements IteratorAggregate, DriverStatement
     /**
      * {@inheritdoc}
      */
-    public function errorCode()
-    {
-        assert($this->stmt instanceof DriverStatement);
-
-        return $this->stmt->errorCode();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function errorInfo()
-    {
-        assert($this->stmt instanceof DriverStatement);
-
-        return $this->stmt->errorInfo();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function execute($params = null) : void
     {
         assert($this->stmt instanceof DriverStatement);

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -180,24 +180,6 @@ class Statement implements IteratorAggregate, DriverStatement
     }
 
     /**
-     * Fetches the SQLSTATE associated with the last operation on the statement.
-     *
-     * @return string|int|bool
-     */
-    public function errorCode()
-    {
-        return $this->stmt->errorCode();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function errorInfo()
-    {
-        return $this->stmt->errorInfo();
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function setFetchMode($fetchMode, ...$args) : void

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,7 +26,6 @@ parameters:
         - '~^Method Doctrine\\DBAL\\Schema\\(Oracle|PostgreSql|SQLServer)SchemaManager::_getPortableTableDefinition\(\) should return array but returns string\.\z~'
         - '~^Method Doctrine\\DBAL\\Platforms\\(|SQLAnywhere|Sqlite)Platform::_getTransactionIsolationLevelSQL\(\) should return string but returns int\.\z~'
         - '~^Method Doctrine\\DBAL\\Driver\\OCI8\\OCI8Connection::lastInsertId\(\) should return string but returns (int|false)\.\z~'
-        - '~^Method Doctrine\\DBAL\\Driver\\SQLSrv\\SQLSrvConnection::errorCode\(\) should return string\|null but returns false\.\z~'
 
         # http://php.net/manual/en/pdo.sqlitecreatefunction.php
         - '~^Call to an undefined method PDO::sqliteCreateFunction\(\)\.\z~'

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\OCI8\OCI8Connection;
 use Doctrine\DBAL\Driver\OCI8\OCI8Exception;
 use Doctrine\DBAL\Driver\OCI8\OCI8Statement;
 use Doctrine\Tests\DbalTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionProperty;
 use const OCI_NO_AUTO_COMMIT;
 use function extension_loaded;
@@ -39,8 +40,9 @@ class OCI8StatementTest extends DbalTestCase
      */
     public function testExecute(array $params)
     {
+        /** @var OCI8Statement|MockObject $statement */
         $statement = $this->getMockBuilder(OCI8Statement::class)
-            ->setMethods(['bindValue', 'errorInfo'])
+            ->setMethods(['bindValue'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -56,10 +58,7 @@ class OCI8StatementTest extends DbalTestCase
 
         // can't pass to constructor since we don't have a real database handle,
         // but execute must check the connection for the executeMode
-        $conn = $this->getMockBuilder(OCI8Connection::class)
-            ->setMethods(['getExecuteMode'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $conn = $this->createMock(OCI8Connection::class);
         $conn->expects($this->once())
             ->method('getExecuteMode')
             ->willReturn(OCI_NO_AUTO_COMMIT);

--- a/tests/Doctrine/Tests/DBAL/Portability/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Portability/StatementTest.php
@@ -85,29 +85,7 @@ class StatementTest extends DbalTestCase
         self::assertSame($columnCount, $this->stmt->columnCount());
     }
 
-    public function testErrorCode()
-    {
-        $errorCode = '666';
-
-        $this->wrappedStmt->expects($this->once())
-            ->method('errorCode')
-            ->will($this->returnValue($errorCode));
-
-        self::assertSame($errorCode, $this->stmt->errorCode());
-    }
-
-    public function testErrorInfo()
-    {
-        $errorInfo = ['666', 'Evil error.'];
-
-        $this->wrappedStmt->expects($this->once())
-            ->method('errorInfo')
-            ->will($this->returnValue($errorInfo));
-
-        self::assertSame($errorInfo, $this->stmt->errorInfo());
-    }
-
-    public function testExecute()
+    public function testExecute() : void
     {
         $params = [
             'foo',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

The reasons or removal are:

1. It's an archaism inherited from PDO and relevant only for the procedural type of API (`do_stuff()`, `get_last_error()`) which was only relevant for the `PDO::ERRMODE_WARNING` mode.
2. The current implementation is not portable: for DB2, the meaning of the code is SQLState, for MySQL it's the driver error code. Unlike others drivers where the error info is a tuple of error code and message, `sqlsrv` returns a list of such tuples.
3. This API is not covered with integration tests which proves #‌2.
4. Tuples are not supported natively by PHP which makes it harder to analyze these methods statically.