### PR TITLE
Enabled the build against IBM DB2 on PHP 7.3 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -257,7 +257,7 @@ jobs:
         - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
-      php: 7.2
+      php: 7.3
       env: DB=ibm_db2 COVERAGE=yes
       sudo: required
       services:


### PR DESCRIPTION
`ibm_db2` supports PHP 7.3 since [2.0.7](https://pecl.php.net/package-info.php?package=ibm_db2&version=2.0.7).