### PR TITLE
Support for comments on table in all databases

### DIFF
--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -28,6 +28,7 @@ example shows:
     $myTable->addColumn("username", "string", array("length" => 32));
     $myTable->setPrimaryKey(array("id"));
     $myTable->addUniqueIndex(array("username"));
+    $myTable->setComment('Some comment');
     $schema->createSequence("my_table_seq");
 
     $myForeign = $schema->createTable("my_foreign");

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1607,6 +1607,9 @@ abstract class AbstractPlatform
 
         $sql = $this->_getCreateTableSQL($tableName, $columns, $options);
         if ($this->supportsCommentOnStatement()) {
+            if ($table->hasOption('comment')) {
+                $sql[] = $this->getCommentOnTableSQL($tableName, $table->getOption('comment'));
+            }
             foreach ($table->getColumns() as $column) {
                 $comment = $this->getColumnComment($column);
 
@@ -1619,6 +1622,17 @@ abstract class AbstractPlatform
         }
 
         return array_merge($sql, $columnSql);
+    }
+
+    protected function getCommentOnTableSQL(string $tableName, ?string $comment) : string
+    {
+        $tableName = new Identifier($tableName);
+
+        return sprintf(
+            'COMMENT ON TABLE %s IS %s',
+            $tableName->getQuotedName($this),
+            $this->quoteStringLiteral((string) $comment)
+        );
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -900,4 +900,17 @@ class DB2Platform extends AbstractPlatform
     {
         return Keywords\DB2Keywords::class;
     }
+
+    public function getListTableCommentsSQL(string $table) : string
+    {
+        return sprintf(
+            <<<'SQL'
+SELECT REMARKS
+  FROM SYSIBM.SYSTABLES
+  WHERE NAME = UPPER( %s )
+SQL
+            ,
+            $this->quoteStringLiteral($table)
+        );
+    }
 }

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -519,9 +519,7 @@ SQL
 
         // Comment
         if (isset($options['comment'])) {
-            $comment = trim($options['comment'], " '");
-
-            $tableOptions[] = sprintf('COMMENT = %s ', $this->quoteStringLiteral($comment));
+            $tableOptions[] = sprintf('COMMENT = %s ', $this->quoteStringLiteral($options['comment']));
         }
 
         // Row format

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -1182,4 +1182,25 @@ SQL
     {
         return 'BLOB';
     }
+
+    public function getListTableCommentsSQL(string $table, ?string $database = null) : string
+    {
+        $tableCommentsName = 'user_tab_comments';
+        $ownerCondition    = '';
+
+        if ($database !== null && $database !== '/') {
+            $tableCommentsName = 'all_tab_comments';
+            $ownerCondition    = ' AND owner = ' . $this->quoteStringLiteral($this->normalizeIdentifier($database)->getName());
+        }
+
+        return sprintf(
+            <<<'SQL'
+SELECT comments FROM %s WHERE table_name = %s%s
+SQL
+            ,
+            $tableCommentsName,
+            $this->quoteStringLiteral($this->normalizeIdentifier($table)->getName()),
+            $ownerCondition
+        );
+    }
 }

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -1252,4 +1252,19 @@ SQL
     {
         return $columnDiff->fromColumn ? $this->getColumnComment($columnDiff->fromColumn) : null;
     }
+
+    public function getListTableMetadataSQL(string $table, ?string $schema = null) : string
+    {
+        if ($schema !== null) {
+            $table = $schema . '.' . $table;
+        }
+
+        return sprintf(
+            <<<'SQL'
+SELECT obj_description(%s::regclass) AS table_comment;
+SQL
+            ,
+            $this->quoteStringLiteral($table)
+        );
+    }
 }

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -23,6 +23,7 @@ use function str_replace;
 use function strlen;
 use function strpos;
 use function strtolower;
+use function trim;
 
 /**
  * The SqlitePlatform class describes the specifics and dialects of the SQLite
@@ -332,7 +333,14 @@ class SqlitePlatform extends AbstractPlatform
             }
         }
 
-        $query = ['CREATE TABLE ' . $name . ' (' . $queryFields . ')'];
+        $tableComment = '';
+        if (isset($options['comment'])) {
+            $comment = trim($options['comment'], " '");
+
+            $tableComment = $this->getInlineTableCommentSQL($comment);
+        }
+
+        $query = ['CREATE TABLE ' . $name . ' ' . $tableComment . '(' . $queryFields . ')'];
 
         if (isset($options['alter']) && $options['alter'] === true) {
             return $query;
@@ -603,6 +611,11 @@ class SqlitePlatform extends AbstractPlatform
     public function getInlineColumnCommentSQL($comment)
     {
         return '--' . str_replace("\n", "\n--", $comment) . "\n";
+    }
+
+    private function getInlineTableCommentSQL(string $comment) : string
+    {
+        return $this->getInlineColumnCommentSQL($comment);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Types\Type;
 use const CASE_LOWER;
 use function array_change_key_case;
@@ -208,5 +209,19 @@ class DB2SchemaManager extends AbstractSchemaManager
         }
 
         return new View($view['name'], $sql);
+    }
+
+    public function listTableDetails($tableName) : Table
+    {
+        $table = parent::listTableDetails($tableName);
+
+        /** @var DB2Platform $platform */
+        $platform = $this->_platform;
+        $sql      = $platform->getListTableCommentsSQL($tableName);
+
+        $tableOptions = $this->_conn->fetchAssoc($sql);
+        $table->addOption('comment', $tableOptions['REMARKS']);
+
+        return $table;
     }
 }

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -385,4 +385,18 @@ SQL;
             );
         }
     }
+
+    public function listTableDetails($tableName) : Table
+    {
+        $table = parent::listTableDetails($tableName);
+
+        /** @var OraclePlatform $platform */
+        $platform = $this->_platform;
+        $sql      = $platform->getListTableCommentsSQL($tableName);
+
+        $tableOptions = $this->_conn->fetchAssoc($sql);
+        $table->addOption('comment', $tableOptions['COMMENTS']);
+
+        return $table;
+    }
 }

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -489,4 +489,19 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
 
         return str_replace("''", "'", $default);
     }
+
+    public function listTableDetails($tableName) : Table
+    {
+        $table = parent::listTableDetails($tableName);
+
+        /** @var PostgreSqlPlatform $platform */
+        $platform = $this->_platform;
+        $sql      = $platform->getListTableMetadataSQL($tableName);
+
+        $tableOptions = $this->_conn->fetchAssoc($sql);
+
+        $table->addOption('comment', $tableOptions['table_comment']);
+
+        return $table;
+    }
 }

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\Type;
 use PDOException;
 use Throwable;
@@ -324,5 +325,23 @@ class SQLServerSchemaManager extends AbstractSchemaManager
                 $database->getQuotedName($this->_platform)
             )
         );
+    }
+
+    /**
+     * @param string $tableName
+     */
+    public function listTableDetails($tableName) : Table
+    {
+        $table = parent::listTableDetails($tableName);
+
+        /** @var SQLServerPlatform $platform */
+        $platform = $this->_platform;
+        $sql      = $platform->getListTableMetadataSQL($tableName);
+
+        $tableOptions = $this->_conn->fetchAssoc($sql);
+
+        $table->addOption('comment', $tableOptions['table_comment']);
+
+        return $table;
     }
 }

--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -840,4 +840,17 @@ class Table extends AbstractAsset
 
         return $this->trimQuotes(strtolower($identifier));
     }
+
+    public function setComment(?string $comment) : self
+    {
+        // For keeping backward compatibility with MySQL in previous releases, table comments are stored as options.
+        $this->addOption('comment', $comment);
+
+        return $this;
+    }
+
+    public function getComment() : ?string
+    {
+        return $this->_options['comment'] ?? null;
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
@@ -61,4 +61,9 @@ class SQLAnywhereSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertArrayHasKey('test', $columns);
         self::assertTrue($columns['test']->getFixed());
     }
+
+    public function testCommentInTable() : void
+    {
+        self::markTestSkipped('Table level comments are not supported on SQLAnywhere');
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1594,4 +1594,15 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
         $onlineTable = $this->schemaManager->listTableDetails('test_partial_column_index');
         self::assertEquals($expected, $onlineTable->getIndexes());
     }
+
+    public function testCommentInTable() : void
+    {
+        $table = new Table('table_with_comment');
+        $table->addColumn('id', 'integer');
+        $table->setComment('Foo with control characters \'\\');
+        $this->schemaManager->dropAndCreateTable($table);
+
+        $table = $this->schemaManager->listTableDetails('table_with_comment');
+        self::assertSame('Foo with control characters \'\\', $table->getComment());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Schema\Table;
 
 class PostgreSqlPlatformTest extends AbstractPostgreSqlPlatformTestCase
 {
@@ -15,5 +16,20 @@ class PostgreSqlPlatformTest extends AbstractPostgreSqlPlatformTestCase
     public function testSupportsPartialIndexes() : void
     {
         self::assertTrue($this->platform->supportsPartialIndexes());
+    }
+
+    public function testGetCreateTableSQLWithColumnCollation() : void
+    {
+        $table = new Table('foo');
+        $table->addColumn('id', 'string');
+        $table->addOption('comment', 'foo');
+        self::assertSame(
+            [
+                'CREATE TABLE foo (id VARCHAR(255) NOT NULL)',
+                "COMMENT ON TABLE foo IS 'foo'",
+            ],
+            $this->platform->getCreateTableSQL($table),
+            'Comments are added to table.'
+        );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -885,4 +885,13 @@ class TableTest extends DbalTestCase
             ['"FOO"'],
         ];
     }
+
+    public function testTableComment() : void
+    {
+        $table = new Table('bar');
+        self::assertNull($table->getComment());
+
+        $table->setComment('foo');
+        self::assertEquals('foo', $table->getComment());
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

I opened a previous PR to add support for table level comments on PostgreSQL: #3499 

This PR is an attempt to add the same feature on all databases (and not only MySQL / PostgreSQL).

This PR is built on top of #3499 that already adds support to PostgreSQL.

Commit https://github.com/doctrine/dbal/commit/c4d83a7ca3a6abdfb78610a5bc64ce76ca65e182 moves the functional test from PostgreSQL to the abstract functional test case. Obviously, this test will fail as long as all databases do not support table comments.

Closes #3499 