### PR TITLE
Add query backtrace logger

### DIFF
--- a/lib/Doctrine/DBAL/Logging/BacktraceLogger.php
+++ b/lib/Doctrine/DBAL/Logging/BacktraceLogger.php
@@ -11,14 +11,6 @@ class BacktraceLogger extends DebugStack
     {
         parent::startQuery($sql, $params, $types);
 
-        $this->queries[$this->currentQuery]['backtrace'] = array_reverse(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function stopQuery()
-    {
-        parent::stopQuery();
+        $this->queries[$this->currentQuery]['backtrace'] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
     }
 }

--- a/lib/Doctrine/DBAL/Logging/BacktraceLogger.php
+++ b/lib/Doctrine/DBAL/Logging/BacktraceLogger.php
@@ -2,6 +2,9 @@
 
 namespace Doctrine\DBAL\Logging;
 
+use const DEBUG_BACKTRACE_IGNORE_ARGS;
+use function debug_backtrace;
+
 class BacktraceLogger extends DebugStack
 {
     /**

--- a/lib/Doctrine/DBAL/Logging/BacktraceLogger.php
+++ b/lib/Doctrine/DBAL/Logging/BacktraceLogger.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\DBAL\Logging;
+
+class BacktraceLogger extends DebugStack
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function startQuery($sql, ?array $params = null, ?array $types = null)
+    {
+        parent::startQuery($sql, $params, $types);
+
+        $this->queries[$this->currentQuery]['backtrace'] = array_reverse(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stopQuery()
+    {
+        parent::stopQuery();
+    }
+}

--- a/lib/Doctrine/DBAL/Logging/BacktraceLogger.php
+++ b/lib/Doctrine/DBAL/Logging/BacktraceLogger.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Logging;
 
 use const DEBUG_BACKTRACE_IGNORE_ARGS;
+use function array_shift;
 use function debug_backtrace;
 
 class BacktraceLogger extends DebugStack
@@ -14,6 +15,11 @@ class BacktraceLogger extends DebugStack
     {
         parent::startQuery($sql, $params, $types);
 
-        $this->queries[$this->currentQuery]['backtrace'] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+
+        // skip first since it's always the current method
+        array_shift($backtrace);
+
+        $this->queries[$this->currentQuery]['backtrace'] = $backtrace;
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Logging/BacktraceLoggerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Logging/BacktraceLoggerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Logging;
+
+use Doctrine\DBAL\Logging\BacktraceLogger;
+use Doctrine\Tests\DbalTestCase;
+
+class BacktraceLoggerTest extends DbalTestCase
+{
+    public function testBacktraceLogged()
+    {
+        $logger = new BacktraceLogger();
+
+        $logger->startQuery('SELECT column FROM table');
+
+        $currentQuery = current($logger->queries);
+
+        self::assertSame('SELECT column FROM table', $currentQuery['sql']);
+        self::assertNull($currentQuery['params']);
+        self::assertNull($currentQuery['types']);
+        self::assertIsArray($currentQuery['backtrace']);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Logging/BacktraceLoggerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Logging/BacktraceLoggerTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Logging;
 
 use Doctrine\DBAL\Logging\BacktraceLogger;
 use Doctrine\Tests\DbalTestCase;
+use function current;
 
 class BacktraceLoggerTest extends DbalTestCase
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | ~

#### Summary
inspired by [doctrine-stats](https://github.com/steevanb/doctrine-stats) I think it'll be nice to log backtrace of each query.

use case with doctrine-bundle:
![image](https://user-images.githubusercontent.com/4582866/56085958-e12f2700-5e4c-11e9-9407-174c9c32186b.png)


[doctrine-bundle pull request](https://github.com/doctrine/DoctrineBundle/pull/954)