### PR TITLE
Implemented support for persistent connections in PDO and mysqli drivers

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -56,6 +56,11 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
 
         $socket = $params['unix_socket'] ?? ini_get('mysqli.default_socket');
         $dbname = $params['dbname'] ?? '';
+        $host   = $params['host'];
+
+        if (! empty($params['persistent'])) {
+            $host = 'p:' . $host;
+        }
 
         $flags = $driverOptions[static::OPTION_FLAGS] ?? 0;
 
@@ -67,7 +72,7 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
         set_error_handler(static function () {
         });
         try {
-            if (! $this->conn->real_connect($params['host'], $username, $password, $dbname, $port, $socket, $flags)) {
+            if (! $this->conn->real_connect($host, $username, $password, $dbname, $port, $socket, $flags)) {
                 throw MysqliException::fromConnectionError($this->conn);
             }
         } finally {

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Driver\PDOConnection;
 use Doctrine\DBAL\Driver\PDOException;
+use PDO;
 
 /**
  * PDO MySql driver.
@@ -19,6 +20,10 @@ class Driver extends AbstractMySQLDriver
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
+        if (! empty($params['persistent'])) {
+            $driverOptions[PDO::ATTR_PERSISTENT] = true;
+        }
+
         try {
             $conn = new PDOConnection(
                 $this->constructPdoDsn($params),

--- a/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
 use Doctrine\DBAL\Driver\PDOConnection;
 use Doctrine\DBAL\Driver\PDOException;
+use PDO;
 
 /**
  * PDO Oracle driver.
@@ -24,6 +25,10 @@ class Driver extends AbstractOracleDriver
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
+        if (! empty($params['persistent'])) {
+            $driverOptions[PDO::ATTR_PERSISTENT] = true;
+        }
+
         try {
             return new PDOConnection(
                 $this->constructPdoDsn($params),

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -21,6 +21,10 @@ class Driver extends AbstractPostgreSQLDriver
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
+        if (! empty($params['persistent'])) {
+            $driverOptions[PDO::ATTR_PERSISTENT] = true;
+        }
+
         try {
             $connection = new PDOConnection(
                 $this->_constructPdoDsn($params),

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
+use PDO;
 use function is_int;
 use function sprintf;
 
@@ -26,6 +27,10 @@ class Driver extends AbstractSQLServerDriver
             } else {
                 $dsnOptions[$option] = $value;
             }
+        }
+
+        if (! empty($params['persistent'])) {
+            $pdoOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
         return new Connection(

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -7,11 +7,16 @@ namespace Doctrine\Tests\DBAL\Functional;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\PDOConnection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\Tests\DbalFunctionalTestCase;
+use Doctrine\Tests\TestUtil;
 use Error;
 use Exception;
+use PDO;
 use RuntimeException;
 use Throwable;
 use function in_array;
@@ -312,5 +317,29 @@ class ConnectionTest extends DbalFunctionalTestCase
         self::assertSame($params, $connection->getParams());
 
         $connection->close();
+    }
+
+    public function testPersistentConnection() : void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SqlitePlatform
+            || $platform instanceof SQLServerPlatform) {
+            self::markTestSkipped('The platform does not support persistent connections');
+        }
+
+        $params               = TestUtil::getConnectionParams();
+        $params['persistent'] = true;
+
+        $connection       = DriverManager::getConnection($params);
+        $driverConnection = $connection->getWrappedConnection();
+
+        if (! $driverConnection instanceof PDOConnection) {
+            self::markTestSkipped('Unable to test if the connection is persistent');
+        }
+
+        $pdo = $driverConnection->getWrappedConnection();
+
+        self::assertTrue($pdo->getAttribute(PDO::ATTR_PERSISTENT));
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #2315

As of #3080, DBAL doesn't use a custom PDO statement class which enables the use of persistent connections with PDO drivers. Additionally, the support for persistent connections has been implemented for the `mysqli` driver.