### PR TITLE
Maintain platform parameter in connection params

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -200,7 +200,6 @@ class Connection implements DriverConnection
             }
 
             $this->platform = $params['platform'];
-            unset($this->params['platform']);
         }
 
         // Create default config and event manager if none given
@@ -932,7 +931,10 @@ class Connection implements DriverConnection
             throw CacheException::noResultDriverConfigured();
         }
 
-        [$cacheKey, $realKey] = $qcp->generateCacheKeys($query, $params, $types, $this->getParams());
+        $connectionParams = $this->getParams();
+        unset($connectionParams['platform']);
+
+        [$cacheKey, $realKey] = $qcp->generateCacheKeys($query, $params, $types, $connectionParams);
 
         // fetch the row pointers entry
         $data = $resultCache->fetch($cacheKey);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3194

#### Summary

Maintain platform parameter in connection params but remove it before using params in query cache key generation.

We still have the same issue with the `pdo` parameter being unset in `Connection::__construct()` but we're not going to deal with that in this PR.