### PR TITLE
Switching Travis CI builds to Ubuntu Xenial Xerus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 sudo: false
-dist: trusty
+dist: xenial
 
 cache:
     directories:
@@ -175,6 +175,8 @@ jobs:
     - stage: Test
       php: 7.4
       env: DB=mysql COVERAGE=yes
+      services:
+        - mysql
     - stage: Test
       php: 7.4
       env: DB=mysql.docker MYSQL_VERSION=5.7 COVERAGE=yes
@@ -192,6 +194,8 @@ jobs:
     - stage: Test
       php: 7.4
       env: DB=mysqli COVERAGE=yes
+      services:
+        - mysql
     - stage: Test
       php: 7.4
       env: DB=mysqli.docker MYSQL_VERSION=5.7 COVERAGE=yes
@@ -208,9 +212,11 @@ jobs:
         - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
       php: 7.4
-      env: DB=mariadb MARIADB_VERSION=10.1 COVERAGE=yes
-      addons:
-        mariadb: 10.1
+      env: DB=mariadb.docker MARIADB_VERSION=10.1 COVERAGE=yes
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mariadb.sh
     - stage: Test
       php: 7.4
       env: DB=mariadb MARIADB_VERSION=10.2 COVERAGE=yes
@@ -223,9 +229,11 @@ jobs:
         mariadb: 10.3
     - stage: Test
       php: 7.4
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.1 COVERAGE=yes
-      addons:
-        mariadb: 10.1
+      env: DB=mariadb.mysqli.docker MARIADB_VERSION=10.1 COVERAGE=yes
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mariadb.sh
     - stage: Test
       php: 7.4
       env: DB=mariadb.mysqli MARIADB_VERSION=10.2 COVERAGE=yes
@@ -239,32 +247,24 @@ jobs:
     - stage: Test
       php: 7.4
       env: DB=pgsql POSTGRESQL_VERSION=9.4 COVERAGE=yes
-      services:
-        - postgresql
       addons:
         postgresql: "9.4"
     - stage: Test
       php: 7.4
       env: DB=pgsql POSTGRESQL_VERSION=9.5 COVERAGE=yes
-      services:
-        - postgresql
       addons:
         postgresql: "9.5"
     - stage: Test
       php: 7.4
       env: DB=pgsql POSTGRESQL_VERSION=9.6 COVERAGE=yes
-      services:
-        - postgresql
       addons:
         postgresql: "9.6"
     - stage: Test
       php: 7.4
       env: DB=pgsql POSTGRESQL_VERSION=10.0 COVERAGE=yes
       sudo: required
-      services:
-        - postgresql
       addons:
-        postgresql: "10.0"
+        postgresql: "10"
       before_script:
         - bash ./tests/travis/install-postgres-10.sh
     - stage: Test

--- a/tests/travis/create-mysql-schema.sql
+++ b/tests/travis/create-mysql-schema.sql
@@ -1,3 +1,6 @@
+DROP USER IF EXISTS 'travis'@'%';
+CREATE USER 'travis'@'%';
+
 CREATE SCHEMA doctrine_tests;
 CREATE SCHEMA test_create_database;
 CREATE SCHEMA test_drop_database;

--- a/tests/travis/install-mariadb.sh
+++ b/tests/travis/install-mariadb.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -ex
+
+sudo docker run \
+    -d \
+    -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+    -e MYSQL_DATABASE=doctrine_tests \
+    -p 33306:3306 \
+    --name mariadb \
+    mariadb:${MARIADB_VERSION}
+
+sudo docker exec -i mariadb bash <<< 'until echo \\q | mysql doctrine_tests > /dev/null 2>&1 ; do sleep 1; done'

--- a/tests/travis/install-sqlsrv-dependencies.sh
+++ b/tests/travis/install-sqlsrv-dependencies.sh
@@ -5,6 +5,6 @@ set -ex
 echo Installing driver dependencies
 
 curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql.list
+curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql.list
 sudo apt-get update
 ACCEPT_EULA=Y sudo apt-get install -qy msodbcsql17 unixodbc unixodbc-dev libssl1.0.0

--- a/tests/travis/mariadb.docker.travis.xml
+++ b/tests/travis/mariadb.docker.travis.xml
@@ -10,18 +10,18 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="mysqli"/>
-        <var name="db_host" value="localhost" />
-        <var name="db_username" value="travis" />
+        <var name="db_type" value="pdo_mysql"/>
+        <var name="db_host" value="127.0.0.1" />
+        <var name="db_username" value="root" />
         <var name="db_password" value="" />
         <var name="db_name" value="doctrine_tests" />
-        <var name="db_port" value="3306"/>
+        <var name="db_port" value="33306"/>
 
-        <var name="tmpdb_type" value="mysqli"/>
-        <var name="tmpdb_host" value="localhost" />
-        <var name="tmpdb_username" value="travis" />
+        <var name="tmpdb_type" value="pdo_mysql"/>
+        <var name="tmpdb_host" value="127.0.0.1" />
+        <var name="tmpdb_username" value="root" />
         <var name="tmpdb_password" value="" />
-        <var name="tmpdb_port" value="3306"/>
+        <var name="tmpdb_port" value="33306"/>
     </php>
 
     <testsuites>

--- a/tests/travis/mariadb.mysqli.docker.travis.xml
+++ b/tests/travis/mariadb.mysqli.docker.travis.xml
@@ -11,17 +11,17 @@
         <ini name="error_reporting" value="-1" />
 
         <var name="db_type" value="mysqli"/>
-        <var name="db_host" value="localhost" />
-        <var name="db_username" value="travis" />
+        <var name="db_host" value="127.0.0.1" />
+        <var name="db_username" value="root" />
         <var name="db_password" value="" />
         <var name="db_name" value="doctrine_tests" />
-        <var name="db_port" value="3306"/>
+        <var name="db_port" value="33306"/>
 
         <var name="tmpdb_type" value="mysqli"/>
-        <var name="tmpdb_host" value="localhost" />
-        <var name="tmpdb_username" value="travis" />
+        <var name="tmpdb_host" value="127.0.0.1" />
+        <var name="tmpdb_username" value="root" />
         <var name="tmpdb_password" value="" />
-        <var name="tmpdb_port" value="3306"/>
+        <var name="tmpdb_port" value="33306"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

**Solved issues:**

- [x] ~~PostgreSQL 9.2 service [fails to start](https://travis-ci.org/doctrine/dbal/jobs/523561652#L160-L162) ([not supported](https://docs.travis-ci.com/user/reference/xenial/#databases-and-services)).~~
- [x] ~~PostgreSQL 9.3 service [fails to start](https://travis-ci.org/doctrine/dbal/jobs/523561653#L160-L162) ([not supported](https://docs.travis-ci.com/user/reference/xenial/#databases-and-services)).~~
- [x] MariaDB 10.1 service [fails to start](https://travis-ci.org/doctrine/dbal/jobs/610406446#L226-L229) ([#3151](https://travis-ci.community/t/mariadb-10-1-fails-to-install-on-xenial/3151), https://github.com/travis-ci/travis-cookbooks/pull/1057, [supported until October 2020](https://mariadb.com/kb/en/library/changes-improvements-in-mariadb-101/)).
- [x] PostgreSQL 10.0 [fails to start](https://travis-ci.org/doctrine/dbal/jobs/610395930#L163).

**Summary of the changes:**
1. Request the `mysql` service explicitly when needed ([migration guide](https://docs.travis-ci.com/user/trusty-to-xenial-migration-guide#1-services-support)).
2. Dockerize MariaDB 10.1 since Travis doesn't give a damn about it and it'll be easier for us to transition somewhere else later.
3. Spell the PostgreSQL 10.0 version as 10 to comply with the [naming on Travis](https://docs.travis-ci.com/user/reference/xenial#databases-and-services).
4. Make sure the `travis` user exists on a MySQL-like DB since [Travis doesn't create it consistently](https://travis-ci.community/t/mariadb-build-error-with-xenial/3160).