### PR TITLE
Reworked SQL Server installer on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,7 @@ jobs:
       services:
         - docker
       before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
         - bash ./tests/travis/install-mssql-sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
@@ -109,6 +110,7 @@ jobs:
       services:
         - docker
       before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
         - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
@@ -245,6 +247,7 @@ jobs:
       services:
         - docker
       before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
         - bash ./tests/travis/install-mssql-sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
@@ -254,6 +257,7 @@ jobs:
       services:
         - docker
       before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
         - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
@@ -314,6 +318,7 @@ jobs:
       services:
         - docker
       before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
         - bash ./tests/travis/install-mssql-sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
@@ -323,6 +328,7 @@ jobs:
       services:
         - docker
       before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
         - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
 

--- a/tests/travis/install-mssql.sh
+++ b/tests/travis/install-mssql.sh
@@ -2,12 +2,6 @@
 
 set -ex
 
-echo Installing drivers
-curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql.list
-sudo apt-get update
-ACCEPT_EULA=Y sudo apt-get install -qy msodbcsql17 mssql-tools unixodbc libssl1.0.0
-
 echo Setting up Microsoft SQL Server
 
 sudo docker pull microsoft/mssql-server-linux:2017-latest
@@ -15,24 +9,10 @@ sudo docker run \
     -e 'ACCEPT_EULA=Y' \
     -e 'SA_PASSWORD=Doctrine2018' \
     -p 127.0.0.1:1433:1433 \
-    --name db \
+    --name mssql \
     -d \
     microsoft/mssql-server-linux:2017-latest
 
-
-retries=10
-until (echo quit | /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -l 1 -U sa -P Doctrine2018 &> /dev/null)
-do
-    if [[ "$retries" -le 0 ]]; then
-        echo SQL Server did not start
-        exit 1
-    fi
-
-    retries=$((retries - 1))
-
-    echo Waiting for SQL Server to start...
-
-    sleep 2s
-done
+sudo docker exec -i mssql bash <<< 'until echo quit | /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -l 1 -U sa -P Doctrine2018 > /dev/null 2>&1 ; do sleep 1; done'
 
 echo SQL Server started

--- a/tests/travis/install-sqlsrv-dependencies.sh
+++ b/tests/travis/install-sqlsrv-dependencies.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo Installing driver dependencies
+
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql.list
+sudo apt-get update
+ACCEPT_EULA=Y sudo apt-get install -qy msodbcsql17 unixodbc unixodbc-dev libssl1.0.0


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The existing implementation has a couple of issues:

1. The installer scripts are executed in the following order:
   https://github.com/doctrine/dbal/blob/74a2714de32d7de161790d0f54561c5b2b3e4e4b/.travis.yml#L103-L104

   Which means that a PHP extension is installed first, and then its dependencies are installed. Not sure how it works with `dist: trusty` but it [won't work](https://travis-ci.org/doctrine/dbal/jobs/523284700#L462) with `dist: xenial`. Also, the script is missing the `unixodbc-dev` package which is needed to be able to compile the extension and is probably included into the VM image.
2. The scripts install the `mssql-tools` package only in order to be able to connect to the DB from outside the container, however, it can be done from within the container which we do with [MySQL](https://github.com/doctrine/dbal/blob/9b75cd5febbca8591075157046e739b8ab655f6b/tests/travis/install-mysql-8.0.sh#L19) and [PostgreSQL](https://github.com/doctrine/dbal/blob/master/tests/travis/install-postgres-11.sh#L10).