### PR TITLE
Updated mariadb 10.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,16 +74,6 @@ jobs:
         - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
       php: 7.2
-      env: DB=mariadb MARIADB_VERSION=10.3
-      addons:
-        mariadb: 10.3
-    - stage: Test
-      php: 7.2
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.3
-      addons:
-        mariadb: 10.3
-    - stage: Test
-      php: 7.2
       env: DB=pgsql POSTGRESQL_VERSION=11.0
       sudo: required
       services:
@@ -169,6 +159,11 @@ jobs:
         mariadb: 10.3
     - stage: Test
       php: 7.3
+      env: DB=mariadb MARIADB_VERSION=10.4 COVERAGE=yes
+      addons:
+        mariadb: 10.4
+    - stage: Test
+      php: 7.3
       env: DB=mariadb.mysqli MARIADB_VERSION=10.0 COVERAGE=yes
       addons:
         mariadb: 10.0
@@ -187,6 +182,11 @@ jobs:
       env: DB=mariadb.mysqli MARIADB_VERSION=10.3 COVERAGE=yes
       addons:
         mariadb: 10.3
+    - stage: Test
+      php: 7.3
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.4 COVERAGE=yes
+      addons:
+        mariadb: 10.4
     - stage: Test
       php: 7.3
       env: DB=pgsql POSTGRESQL_VERSION=9.2 COVERAGE=yes
@@ -290,16 +290,6 @@ jobs:
         - docker
       before_script:
         - bash ./tests/travis/install-mysql-8.0.sh
-    - stage: Test
-      php: 7.4snapshot
-      env: DB=mariadb MARIADB_VERSION=10.3
-      addons:
-        mariadb: 10.3
-    - stage: Test
-      php: 7.4snapshot
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.3
-      addons:
-        mariadb: 10.3
     - stage: Test
       php: 7.4snapshot
       env: DB=pgsql POSTGRESQL_VERSION=11.0

--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -41,6 +41,7 @@ MariaDB
 ^^^^^
 
 -  ``MariaDb1027Platform`` for version 10.2 (10.2.7 GA) and above.
+-  ``MariaDb1043Platform`` for version 10.4 (10.4.3 RC) and above.
 
 Oracle
 ^^^^^^

--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Platforms\MariaDb1043Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
@@ -114,8 +115,13 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
     public function createDatabasePlatformForVersion($version)
     {
         $mariadb = stripos($version, 'mariadb') !== false;
-        if ($mariadb && version_compare($this->getMariaDbMysqlVersionNumber($version), '10.2.7', '>=')) {
-            return new MariaDb1027Platform();
+        if ($mariadb) {
+            if (version_compare($this->getMariaDbMysqlVersionNumber($version), '10.4.3', '>=')) {
+                return new MariaDb1043Platform();
+            }
+            if (version_compare($this->getMariaDbMysqlVersionNumber($version), '10.2.7', '>=')) {
+                return new MariaDb1027Platform();
+            }
         }
 
         if (! $mariadb) {

--- a/lib/Doctrine/DBAL/Platforms/MariaDb1027Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MariaDb1027Platform.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Types\Types;
  *
  * Note: Should not be used with versions prior to 10.2.7.
  */
-final class MariaDb1027Platform extends MySqlPlatform
+class MariaDb1027Platform extends MySqlPlatform
 {
     /**
      * {@inheritdoc}

--- a/lib/Doctrine/DBAL/Platforms/MariaDb1043Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MariaDb1043Platform.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MariaDB 10.4 (10.4.3 RC) database platform.
+ *
+ * Note: Should not be used with versions prior to 10.4.3.
+ */
+final class MariaDb1043Platform extends MariaDb1027Platform
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function hasNativeJsonType() : bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJsonTypeDeclarationSQL(array $field) : string
+    {
+        return 'JSON';
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Platforms\MariaDb1043Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
@@ -80,6 +81,9 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
             ['5.5.5-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
             ['10.2.8-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
             ['10.2.8-MariaDB-1~lenny-log', MariaDb1027Platform::class],
+            ['5.5.5-MariaDB-10.4.3+maria~bionic-log', MariaDb1043Platform::class],
+            ['10.4.3-MariaDB-10.4.3+maria~bionic-log', MariaDb1043Platform::class],
+            ['10.4.3-MariaDB-1~stretch-log', MariaDb1043Platform::class],
         ];
     }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/MariaDb1043PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/MariaDb1043PlatformTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Platforms\MariaDb1043Platform;
+
+class MariaDb1043PlatformTest extends AbstractMySQLPlatformTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createPlatform() : AbstractPlatform
+    {
+        return new MariaDb1043Platform();
+    }
+
+    public function testInheritsMariaDb1027Platform() : void
+    {
+        self::assertInstanceOf(MariaDb1027Platform::class, $this->platform);
+    }
+
+    public function testHasNativeJsonType() : void
+    {
+        self::assertTrue($this->platform->hasNativeJsonType());
+    }
+
+    /**
+     * From MariaDB 10.4.3, the JSON_VALID function is automatically used as a CHECK constraint for the JSON data type
+     * alias in order to ensure that a valid json document is inserted.
+     *
+     * @link https://mariadb.com/kb/en/library/json-data-type/
+     */
+    public function testReturnsJsonTypeDeclarationSQL() : void
+    {
+        self::assertSame('JSON', $this->platform->getJsonTypeDeclarationSQL([]));
+    }
+
+    /**
+     * Overrides and skips AbstractMySQLPlatformTestCase test regarding propagation
+     * of unsupported default values for Blob and Text columns.
+     *
+     * @see AbstractMySQLPlatformTestCase::testDoesNotPropagateDefaultValuesForUnsupportedColumnTypes()
+     */
+    public function testDoesNotPropagateDefaultValuesForUnsupportedColumnTypes() : void
+    {
+        $this->markTestSkipped('MariaDB104Platform support propagation of default values for BLOB and TEXT columns');
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

Since [version 10.4.3](https://mariadb.com/kb/en/library/mariadb-1043-release-notes/), MariaDB uses the `JSON_VALID()` function as a `CHECK` constraint for the JSON data type alias in order to ensure that a valid json document is inserted.

Currently, Doctrine considers MariaDB has no native support for the type JSON type because its an alias of LONGTEXT. However, since the 10.4.3 release adds some constraints to the JSON type alias, I think it's important to use the latter instead of the LONGTEXT type which doesn't add a `CHECK` constraint.