### PR TITLE
Add IfExists and IfNotExists convenience methods to Schema and Table

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Schema.php
+++ b/lib/Doctrine/DBAL/Schema/Schema.php
@@ -304,6 +304,15 @@ class Schema extends AbstractAsset
         return $this;
     }
 
+    public function createNamespaceIfNotExists(string $namespaceName) : self
+    {
+        if ($this->hasNamespace($namespaceName)) {
+            return $this;
+        }
+
+        return $this->createNamespace($namespaceName);
+    }
+
     /**
      * Creates a new table.
      *
@@ -321,6 +330,15 @@ class Schema extends AbstractAsset
         }
 
         return $table;
+    }
+
+    public function createTableIfNotExists(string $tableName) : Table
+    {
+        if ($this->hasTable($tableName)) {
+            return $this->getTable($tableName);
+        }
+
+        return $this->createTable($tableName);
     }
 
     /**
@@ -358,6 +376,15 @@ class Schema extends AbstractAsset
         return $this;
     }
 
+    public function dropTableIfExists(string $tableName) : self
+    {
+        if (! $this->hasTable($tableName)) {
+            return $this;
+        }
+
+        return $this->dropTable($tableName);
+    }
+
     /**
      * Creates a new sequence.
      *
@@ -375,6 +402,18 @@ class Schema extends AbstractAsset
         return $seq;
     }
 
+    public function createSequenceIfNotExists(
+        string $sequenceName,
+        int $allocationSize = 1,
+        int $initialValue = 1
+    ) : Sequence {
+        if ($this->hasSequence($sequenceName)) {
+            return $this->getSequence($sequenceName);
+        }
+
+        return $this->createSequence($sequenceName, $allocationSize, $initialValue);
+    }
+
     /**
      * @param string $sequenceName
      *
@@ -386,6 +425,15 @@ class Schema extends AbstractAsset
         unset($this->_sequences[$sequenceName]);
 
         return $this;
+    }
+
+    public function dropSequenceIfExists(string $sequenceName) : self
+    {
+        if (! $this->hasSequence($sequenceName)) {
+            return $this;
+        }
+
+        return $this->dropSequence($sequenceName);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
@@ -90,6 +90,20 @@ class SchemaTest extends TestCase
         self::assertFalse($schema->hasTable('foo'));
     }
 
+    public function testDropTableIfExists() : void
+    {
+        $table  = new Table('foo');
+        $schema = new Schema([$table]);
+
+        self::assertTrue($schema->hasTable('foo'));
+
+        $schema->dropTableIfExists('foo');
+
+        self::assertFalse($schema->hasTable('foo'));
+
+        $schema->dropTableIfExists('foo');
+    }
+
     public function testCreateTable()
     {
         $schema = new Schema();
@@ -101,6 +115,15 @@ class SchemaTest extends TestCase
         self::assertInstanceOf(Table::class, $table);
         self::assertEquals('foo', $table->getName());
         self::assertTrue($schema->hasTable('foo'));
+    }
+
+    public function testCreateTableIfNotExists() : void
+    {
+        $schema = new Schema();
+
+        $table = $schema->createTableIfNotExists('foo');
+
+        self::assertSame($table, $schema->createTableIfNotExists('foo'));
     }
 
     public function testAddSequences()
@@ -154,6 +177,14 @@ class SchemaTest extends TestCase
         self::assertArrayHasKey('public.a_seq', $sequences);
     }
 
+    public function testCreateSequenceIfNotExists() : void
+    {
+        $schema   = new Schema();
+        $sequence = $schema->createSequenceIfNotExists('a_seq', 10, 20);
+
+        self::assertSame($sequence, $schema->createSequenceIfNotExists('a_seq', 10, 20));
+    }
+
     public function testDropSequence()
     {
         $sequence = new Sequence('a_seq', 1, 1);
@@ -162,6 +193,19 @@ class SchemaTest extends TestCase
 
         $schema->dropSequence('a_seq');
         self::assertFalse($schema->hasSequence('a_seq'));
+    }
+
+    public function testDropSequenceIfExists() : void
+    {
+        $sequence = new Sequence('a_seq', 1, 1);
+
+        $schema = new Schema([], [$sequence]);
+
+        $schema->dropSequenceIfExists('a_seq');
+
+        self::assertFalse($schema->hasSequence('a_seq'));
+
+        $schema->dropSequenceIfExists('a_seq');
     }
 
     public function testAddSequenceTwiceThrowsException()
@@ -354,6 +398,20 @@ class SchemaTest extends TestCase
 
         self::assertTrue($schema->hasNamespace('baz'));
         self::assertFalse($schema->hasNamespace('moo'));
+    }
+
+    public function testCreateNamespaceIfNotExists() : void
+    {
+        $schema = new Schema();
+
+        $schema->createNamespaceIfNotExists('namespace');
+
+        self::assertTrue($schema->hasNamespace('namespace'));
+        self::assertCount(1, $schema->getNamespaces());
+
+        $schema->createNamespaceIfNotExists('namespace');
+
+        self::assertCount(1, $schema->getNamespaces());
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -882,4 +882,105 @@ class TableTest extends DbalTestCase
             ['"FOO"'],
         ];
     }
+
+    public function testRemoveForeignKeyIfExists() : void
+    {
+        $table =  new Table('foo');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('foo', 'integer');
+
+        $foreignTable = new Table('bar');
+        $foreignTable->addColumn('id', 'integer');
+
+        $table->addForeignKeyConstraint($foreignTable, ['foo'], ['id'], [], 'testfk');
+
+        self::assertTrue($table->hasForeignKey('testfk'));
+
+        $table->removeForeignKeyIfExists('testfk');
+
+        self::assertFalse($table->hasForeignKey('testfk'));
+
+        $table->removeForeignKeyIfExists('testfk');
+    }
+
+    public function testAddIndexIfNotExists() : void
+    {
+        $table = new Table('foo');
+        $table->addColumn('bar', 'string');
+
+        $table->addIndexIfNotExists(['bar'], 'test_foo_idx');
+
+        self::assertTrue($table->hasIndex('test_foo_idx'));
+
+        $table->addIndexIfNotExists(['bar'], 'test_foo_idx');
+    }
+
+    public function testAddUniqueIndexIfNotExists() : void
+    {
+        $table = new Table('foo');
+        $table->addColumn('bar', 'string');
+
+        $table->addUniqueIndexIfNotExists(['bar'], 'test_foo_uniq');
+
+        self::assertTrue($table->hasIndex('test_foo_uniq'));
+
+        $table->addUniqueIndexIfNotExists(['bar'], 'test_foo_uniq');
+    }
+
+    public function testDropIndexIfExists() : void
+    {
+        $table = new Table('foo');
+        $table->addColumn('bar', 'string');
+
+        $table->addIndex(['bar'], 'test_foo_idx');
+
+        self::assertTrue($table->hasIndex('test_foo_idx'));
+
+        $table->dropIndexIfExists('test_foo_idx');
+
+        self::assertFalse($table->hasIndex('test_foo_idx'));
+
+        $table->dropIndexIfExists('test_foo_idx');
+    }
+
+    public function testAddColumnIfNotExists() : void
+    {
+        $table  = new Table('foo');
+        $column = $table->addColumnIfNotExists('bar', 'string');
+
+        self::assertSame('bar', $column->getName());
+        self::assertTrue($table->hasColumn('bar'));
+
+        self::assertSame($column, $table->addColumnIfNotExists('bar', 'string'));
+    }
+
+    public function testDropColumnIfExists() : void
+    {
+        $table = new Table('foo');
+        $table->addColumn('bar', 'string');
+
+        self::assertTrue($table->hasColumn('bar'));
+
+        $table->dropColumnIfExists('bar');
+
+        self::assertFalse($table->hasColumn('bar'));
+
+        $table->dropColumnIfExists('bar');
+    }
+
+    public function testAddForeignKeyConstraintIfNotExists() : void
+    {
+        $table =  new Table('foo');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('foo', 'integer');
+
+        $foreignTable = new Table('bar');
+        $foreignTable->addColumn('id', 'integer');
+
+        $table->addForeignKeyConstraintIfNotExists($foreignTable, ['foo'], ['id'], [], 'testfk');
+
+        self::assertTrue($table->hasForeignKey('testfk'));
+
+        $table->addForeignKeyConstraint($foreignTable, ['foo'], ['id'], [], 'testfk');
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | fixes #3529 

#### Summary

Add IfExists and IfNotExists convenience methods to Schema and Table public API:

- Schema::createNamespaceIfNotExists
- Schema::createTableIfNotExists
- Schema::dropTableIfExists
- Schema::createSequenceIfNotExists
- Schema::dropSequenceIfExists
- Table::addIndexIfNotExists
- Table::addUniqueIndexIfNotExists
- Table::dropIndexIfExists
- Table::addColumnIfNotExists
- Table::dropColumnIfExists
- Table::addForeignKeyConstraintIfNotExists
- Table::removeForeignKeyIfExists

#### Notes

- `addForeignKeyConstraint` and `removeForeignKey` method names are not consistent. Should we make this consistent in 3.0? Either both with `Constraint` suffix or not.
