### PR TITLE
Deprecate the public constants in SQLParserUtils

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,6 +27,10 @@ Some of the constants were renamed in the process:
 
 The  `Doctrine\DBAL\Driver\SQLSrv\SQLSrvStatement::LAST_INSERT_ID_SQL` constant has been deprecated and will be made private in 3.0.
 
+## Deprecated `SQLParserUtils` constants
+
+The constants in `Doctrine\DBAL\SQLParserUtils` have been deprecated and will be made private in 3.0.
+
 # Upgrade to 2.9
 
 ## Deprecated `Statement::fetchColumn()` with an invalid index

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -30,12 +30,12 @@ class SQLParserUtils
      */
     public const POSITIONAL_TOKEN = '\?';
     public const NAMED_TOKEN      = '(?<!:):[a-zA-Z_][a-zA-Z0-9_]*';
-    /**#@-*/
-
     // Quote characters within string literals can be preceded by a backslash.
     public const ESCAPED_SINGLE_QUOTED_TEXT   = "(?:'(?:\\\\\\\\)+'|'(?:[^'\\\\]|\\\\'?|'')*')";
     public const ESCAPED_DOUBLE_QUOTED_TEXT   = '(?:"(?:\\\\\\\\)+"|"(?:[^"\\\\]|\\\\"?)*")';
     public const ESCAPED_BACKTICK_QUOTED_TEXT = '(?:`(?:\\\\\\\\)+`|`(?:[^`\\\\]|\\\\`?)*`)';
+    /**#@-*/
+
     private const ESCAPED_BRACKET_QUOTED_TEXT = '(?<!\b(?i:ARRAY))\[(?:[^\]])*\]';
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | fixes #3539

#### Summary

Deprecate the public constants in SQLParserUtils to prepare for their scope changing to private in Doctrine DBAL 3.0
