### PR TITLE
Default column expressions do not work on SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
-use Doctrine\DBAL\Types;
 use InvalidArgumentException;
 use function array_merge;
 use function array_unique;
@@ -1600,36 +1599,6 @@ SQL
     public function getBlobTypeDeclarationSQL(array $field)
     {
         return 'VARBINARY(MAX)';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDefaultValueDeclarationSQL($field)
-    {
-        if (! isset($field['default'])) {
-            return empty($field['notnull']) ? ' NULL' : '';
-        }
-
-        if (! isset($field['type'])) {
-            return " DEFAULT '" . $field['default'] . "'";
-        }
-
-        $type = $field['type'];
-
-        if ($type instanceof Types\PhpIntegerMappingType) {
-            return ' DEFAULT ' . $field['default'];
-        }
-
-        if ($type instanceof Types\PhpDateTimeMappingType && $field['default'] === $this->getCurrentTimestampSQL()) {
-            return ' DEFAULT ' . $this->getCurrentTimestampSQL();
-        }
-
-        if ($type instanceof Types\BooleanType) {
-            return " DEFAULT '" . $this->convertBooleans($field['default']) . "'";
-        }
-
-        return ' DEFAULT ' . $this->quoteStringLiteral($field['default']);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/DefaultExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/DefaultExpressionTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Functional\Platform;
+
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Tests\DbalFunctionalTestCase;
+use function sprintf;
+
+class DefaultExpressionTest extends DbalFunctionalTestCase
+{
+    public function testCurrentDate() : void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof MySqlPlatform) {
+            self::markTestSkipped('Not supported on MySQL');
+        }
+
+        $this->assertDefaultExpression(Types::DATE_MUTABLE, static function (AbstractPlatform $platform) : string {
+            return $platform->getCurrentDateSQL();
+        });
+    }
+
+    public function testCurrentTime() : void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof MySqlPlatform) {
+            self::markTestSkipped('Not supported on MySQL');
+        }
+
+        if ($platform instanceof OraclePlatform) {
+            self::markTestSkipped('Not supported on Oracle');
+        }
+
+        $this->assertDefaultExpression(Types::TIME_MUTABLE, static function (AbstractPlatform $platform) : string {
+            return $platform->getCurrentTimeSQL();
+        });
+    }
+
+    public function testCurrentTimestamp() : void
+    {
+        $this->assertDefaultExpression(Types::DATETIME_MUTABLE, static function (AbstractPlatform $platform) : string {
+            return $platform->getCurrentTimestampSQL();
+        });
+    }
+
+    private function assertDefaultExpression(string $type, callable $expression) : void
+    {
+        $platform   = $this->connection->getDatabasePlatform();
+        $defaultSql = $expression($platform, $this);
+
+        $table = new Table('default_expr_test');
+        $table->addColumn('actual_value', $type);
+        $table->addColumn('default_value', $type, ['default' => $defaultSql]);
+        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+
+        $this->connection->exec(
+            sprintf(
+                'INSERT INTO default_expr_test (actual_value) VALUES (%s)',
+                $defaultSql
+            )
+        );
+
+        [$actualValue, $defaultValue] = $this->connection->query(
+            'SELECT default_value, actual_value FROM default_expr_test'
+        )->fetch(FetchMode::NUMERIC);
+
+        self::assertEquals($actualValue, $defaultValue);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -54,8 +54,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testDefaultConstraints()
     {
-        $platform = $this->schemaManager->getDatabasePlatform();
-        $table    = new Table('sqlsrv_default_constraints');
+        $table = new Table('sqlsrv_default_constraints');
         $table->addColumn('no_default', 'string');
         $table->addColumn('df_integer', 'integer', ['default' => 666]);
         $table->addColumn('df_string_1', 'string', ['default' => 'foobar']);
@@ -63,8 +62,6 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('df_string_3', 'string', ['default' => 'another default value']);
         $table->addColumn('df_string_4', 'string', ['default' => 'column to rename']);
         $table->addColumn('df_boolean', 'boolean', ['default' => true]);
-        $table->addColumn('df_current_date', 'date', ['default' => $platform->getCurrentDateSQL()]);
-        $table->addColumn('df_current_time', 'time', ['default' => $platform->getCurrentTimeSQL()]);
 
         $this->schemaManager->createTable($table);
         $columns = $this->schemaManager->listTableColumns('sqlsrv_default_constraints');
@@ -75,12 +72,10 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('Doctrine rocks!!!', $columns['df_string_2']->getDefault());
         self::assertEquals('another default value', $columns['df_string_3']->getDefault());
         self::assertEquals(1, $columns['df_boolean']->getDefault());
-        self::assertSame($platform->getCurrentDateSQL(), $columns['df_current_date']->getDefault());
-        self::assertSame($platform->getCurrentTimeSQL(), $columns['df_current_time']->getDefault());
 
         $diff                                = new TableDiff(
             'sqlsrv_default_constraints',
-            [new Column('df_current_timestamp', Type::getType('datetime'), ['default' => 'CURRENT_TIMESTAMP'])],
+            [],
             [
                 'df_integer' => new ColumnDiff(
                     'df_integer',
@@ -126,7 +121,6 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $columns = $this->schemaManager->listTableColumns('sqlsrv_default_constraints');
 
         self::assertNull($columns['no_default']->getDefault());
-        self::assertEquals('CURRENT_TIMESTAMP', $columns['df_current_timestamp']->getDefault());
         self::assertEquals(0, $columns['df_integer']->getDefault());
         self::assertNull($columns['df_string_2']->getDefault());
         self::assertEquals('another default value', $columns['df_string_3']->getDefault());
@@ -140,12 +134,6 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
             'sqlsrv_default_constraints',
             [],
             [
-                'df_current_timestamp' => new ColumnDiff(
-                    'df_current_timestamp',
-                    new Column('df_current_timestamp', Type::getType('datetime')),
-                    ['default'],
-                    new Column('df_current_timestamp', Type::getType('datetime'), ['default' => 'CURRENT_TIMESTAMP'])
-                ),
                 'df_integer' => new ColumnDiff(
                     'df_integer',
                     new Column('df_integer', Type::getType('integer'), ['default' => 666]),
@@ -163,7 +151,6 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->schemaManager->alterTable($diff);
         $columns = $this->schemaManager->listTableColumns('sqlsrv_default_constraints');
 
-        self::assertNull($columns['df_current_timestamp']->getDefault());
         self::assertEquals(666, $columns['df_integer']->getDefault());
     }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1496,7 +1496,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
             ];
 
             self::assertSame(
-                " DEFAULT '" . $currentDateSql . "'",
+                ' DEFAULT CONVERT(date, GETDATE())',
                 $this->platform->getDefaultValueDeclarationSQL($field)
             );
         }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

The combination of #2960 and #3348 helped identify that the SQL Server platform doesn't properly generate DDL for the date/time columns with the default value described as an expression (see the change in `AbstractSQLServerPlatformTestCase`). Instead of using the expression as such, it converts it to a string literal.