### PR TITLE
Removed the assertion which doesn't work with a user-provided PDO connection

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1429,7 +1429,6 @@ class Connection implements DriverConnection
     public function getWrappedConnection()
     {
         $this->connect();
-        assert($this->_conn instanceof DriverConnection);
 
         return $this->_conn;
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use Error;
 use Exception;
+use PDO;
 use RuntimeException;
 use Throwable;
 use function in_array;
@@ -310,5 +311,17 @@ class ConnectionTest extends DbalFunctionalTestCase
         self::assertSame($params, $connection->getParams());
 
         $connection->close();
+    }
+
+    /**
+     * @requires extension pdo_sqlite
+     */
+    public function testUserProvidedPDOConnection() : void
+    {
+        self::assertTrue(
+            DriverManager::getConnection([
+                'pdo' => new PDO('sqlite::memory:'),
+            ])->ping()
+        );
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #3487, closes #3544.

For some reason, the currently used version of PHPStan no longer detects the issue which the assertion introduced in #3443 was meant to address. Given that the feature will be removed in `3.0` (#3545), I don't think it makes much sense to spend time on improving the code. We can leave it in the same state it was previously.