### PR TITLE
Deprecated Driver::getName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.10
 
+## Deprecated `Doctrine\DBAL\Driver::getName()`
+
+Relying on the name of the driver is discouraged. For referencing the driver, use its class name.
+
 ## Deprecated usage of user-provided `PDO` instance
 
 The usage of user-provided `PDO` instance is deprecated. The known use cases are:

--- a/lib/Doctrine/DBAL/Driver.php
+++ b/lib/Doctrine/DBAL/Driver.php
@@ -42,6 +42,8 @@ interface Driver
     /**
      * Gets the name of the driver.
      *
+     * @deprecated
+     *
      * @return string The name of the driver.
      */
     public function getName();

--- a/lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Driver.php
@@ -49,6 +49,8 @@ class Driver extends \Doctrine\DBAL\Driver\PDOMySql\Driver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Driver.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Driver.php
@@ -39,6 +39,8 @@ class DB2Driver extends AbstractDB2Driver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {

--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -44,6 +44,8 @@ class Driver extends AbstractOracleDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {

--- a/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
@@ -49,6 +49,8 @@ class Driver extends AbstractDB2Driver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -62,6 +62,8 @@ class Driver extends AbstractMySQLDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -108,6 +108,8 @@ class Driver extends AbstractPostgreSQLDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -73,6 +73,8 @@ class Driver extends AbstractSQLiteDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
@@ -83,6 +83,8 @@ class Driver extends AbstractSQLServerDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -40,6 +40,8 @@ class Driver extends AbstractSQLAnywhereDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
@@ -48,6 +48,8 @@ class Driver extends AbstractSQLServerDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -40,6 +40,7 @@ use function current;
 use function end;
 use function explode;
 use function in_array;
+use function sprintf;
 use function str_replace;
 use function strcasecmp;
 use function strlen;
@@ -130,8 +131,12 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
      */
     public function testDropAndCreateSequence()
     {
-        if (! $this->connection->getDatabasePlatform()->supportsSequences()) {
-            $this->markTestSkipped($this->connection->getDriver()->getName() . ' does not support sequences.');
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $platform->supportsSequences()) {
+            $this->markTestSkipped(
+                sprintf('The "%s" platform does not support sequences.', $platform->getName())
+            );
         }
 
         $name = 'dropcreate_sequences_test_seq';
@@ -158,8 +163,12 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
 
     public function testListSequences()
     {
-        if (! $this->connection->getDatabasePlatform()->supportsSequences()) {
-            $this->markTestSkipped($this->connection->getDriver()->getName() . ' does not support sequences.');
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $platform->supportsSequences()) {
+            $this->markTestSkipped(
+                sprintf('The "%s" platform does not support sequences.', $platform->getName())
+            );
         }
 
         $sequence = new Sequence('list_sequences_test_seq', 20, 10);


### PR DESCRIPTION
The method is not used for anything else than skipping tests for specific drivers. Cross-driver portability should be established by drivers, not outside of them based on their name. The method has been removed in #3553.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no
