### PR TITLE
Enforced parameter and return value types in Platform classes

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
@@ -83,7 +83,7 @@ abstract class AbstractSQLiteDriver implements Driver, ExceptionConverterDriver
     {
         $params = $conn->getParams();
 
-        return $params['path'] ?? null;
+        return $params['path'] ?? '';
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -46,6 +46,7 @@ use function implode;
 use function in_array;
 use function is_array;
 use function is_bool;
+use function is_float;
 use function is_int;
 use function is_string;
 use function preg_quote;
@@ -81,7 +82,7 @@ abstract class AbstractPlatform
      */
     protected $doctrineTypeComments = null;
 
-    /** @var EventManager */
+    /** @var EventManager|null */
     protected $_eventManager;
 
     /**
@@ -98,17 +99,15 @@ abstract class AbstractPlatform
     /**
      * Sets the EventManager used by the Platform.
      */
-    public function setEventManager(EventManager $eventManager)
+    public function setEventManager(EventManager $eventManager) : void
     {
         $this->_eventManager = $eventManager;
     }
 
     /**
      * Gets the EventManager used by the Platform.
-     *
-     * @return EventManager
      */
-    public function getEventManager()
+    public function getEventManager() : ?EventManager
     {
         return $this->_eventManager;
     }
@@ -117,61 +116,47 @@ abstract class AbstractPlatform
      * Returns the SQL snippet that declares a boolean column.
      *
      * @param mixed[] $columnDef
-     *
-     * @return string
      */
-    abstract public function getBooleanTypeDeclarationSQL(array $columnDef);
+    abstract public function getBooleanTypeDeclarationSQL(array $columnDef) : string;
 
     /**
      * Returns the SQL snippet that declares a 4 byte integer column.
      *
      * @param mixed[] $columnDef
-     *
-     * @return string
      */
-    abstract public function getIntegerTypeDeclarationSQL(array $columnDef);
+    abstract public function getIntegerTypeDeclarationSQL(array $columnDef) : string;
 
     /**
      * Returns the SQL snippet that declares an 8 byte integer column.
      *
      * @param mixed[] $columnDef
-     *
-     * @return string
      */
-    abstract public function getBigIntTypeDeclarationSQL(array $columnDef);
+    abstract public function getBigIntTypeDeclarationSQL(array $columnDef) : string;
 
     /**
      * Returns the SQL snippet that declares a 2 byte integer column.
      *
      * @param mixed[] $columnDef
-     *
-     * @return string
      */
-    abstract public function getSmallIntTypeDeclarationSQL(array $columnDef);
+    abstract public function getSmallIntTypeDeclarationSQL(array $columnDef) : string;
 
     /**
      * Returns the SQL snippet that declares common properties of an integer column.
      *
      * @param mixed[] $columnDef
-     *
-     * @return string
      */
-    abstract protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef);
+    abstract protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef) : string;
 
     /**
      * Lazy load Doctrine Type Mappings.
-     *
-     * @return void
      */
-    abstract protected function initializeDoctrineTypeMappings();
+    abstract protected function initializeDoctrineTypeMappings() : void;
 
     /**
      * Initializes Doctrine Type Mappings with the platform defaults
      * and with all additional type mappings.
-     *
-     * @return void
      */
-    private function initializeAllDoctrineTypeMappings()
+    private function initializeAllDoctrineTypeMappings() : void
     {
         $this->initializeDoctrineTypeMappings();
 
@@ -186,10 +171,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet used to declare a VARCHAR column type.
      *
      * @param mixed[] $field
-     *
-     * @return string
      */
-    public function getVarcharTypeDeclarationSQL(array $field)
+    public function getVarcharTypeDeclarationSQL(array $field) : string
     {
         if (! isset($field['length'])) {
             $field['length'] = $this->getVarcharDefaultLength();
@@ -212,10 +195,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet used to declare a BINARY/VARBINARY column type.
      *
      * @param mixed[] $field The column definition.
-     *
-     * @return string
      */
-    public function getBinaryTypeDeclarationSQL(array $field)
+    public function getBinaryTypeDeclarationSQL(array $field) : string
     {
         if (! isset($field['length'])) {
             $field['length'] = $this->getBinaryDefaultLength();
@@ -233,10 +214,8 @@ abstract class AbstractPlatform
      * special datatypes when the underlying databases support this datatype.
      *
      * @param mixed[] $field
-     *
-     * @return string
      */
-    public function getGuidTypeDeclarationSQL(array $field)
+    public function getGuidTypeDeclarationSQL(array $field) : string
     {
         $field['length'] = 36;
         $field['fixed']  = true;
@@ -251,23 +230,19 @@ abstract class AbstractPlatform
      * special datatypes when the underlying databases support this datatype.
      *
      * @param mixed[] $field
-     *
-     * @return string
      */
-    public function getJsonTypeDeclarationSQL(array $field)
+    public function getJsonTypeDeclarationSQL(array $field) : string
     {
         return $this->getClobTypeDeclarationSQL($field);
     }
 
     /**
-     * @param int  $length
-     * @param bool $fixed
-     *
-     * @return string
+     * @param int  $length The length of the column.
+     * @param bool $fixed  Whether the column length is fixed.
      *
      * @throws DBALException If not supported on this platform.
      */
-    protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getVarcharTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         throw NotSupported::new('VARCHARs not supported by Platform.');
     }
@@ -278,11 +253,9 @@ abstract class AbstractPlatform
      * @param int  $length The length of the column.
      * @param bool $fixed  Whether the column length is fixed.
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getBinaryTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         throw NotSupported::new('BINARY/VARBINARY column types are not supported by this platform.');
     }
@@ -291,36 +264,27 @@ abstract class AbstractPlatform
      * Returns the SQL snippet used to declare a CLOB column type.
      *
      * @param mixed[] $field
-     *
-     * @return string
      */
-    abstract public function getClobTypeDeclarationSQL(array $field);
+    abstract public function getClobTypeDeclarationSQL(array $field) : string;
 
     /**
      * Returns the SQL Snippet used to declare a BLOB column type.
      *
      * @param mixed[] $field
-     *
-     * @return string
      */
-    abstract public function getBlobTypeDeclarationSQL(array $field);
+    abstract public function getBlobTypeDeclarationSQL(array $field) : string;
 
     /**
      * Gets the name of the platform.
-     *
-     * @return string
      */
-    abstract public function getName();
+    abstract public function getName() : string;
 
     /**
      * Registers a doctrine type to be used in conjunction with a column type of this platform.
      *
-     * @param string $dbType
-     * @param string $doctrineType
-     *
      * @throws DBALException If the type is not found.
      */
-    public function registerDoctrineTypeMapping($dbType, $doctrineType)
+    public function registerDoctrineTypeMapping(string $dbType, string $doctrineType) : void
     {
         if ($this->doctrineTypeMapping === null) {
             $this->initializeAllDoctrineTypeMappings();
@@ -345,13 +309,9 @@ abstract class AbstractPlatform
     /**
      * Gets the Doctrine type that is mapped for the given database column type.
      *
-     * @param string $dbType
-     *
-     * @return string
-     *
      * @throws DBALException
      */
-    public function getDoctrineTypeMapping($dbType)
+    public function getDoctrineTypeMapping(string $dbType) : string
     {
         if ($this->doctrineTypeMapping === null) {
             $this->initializeAllDoctrineTypeMappings();
@@ -372,12 +332,8 @@ abstract class AbstractPlatform
 
     /**
      * Checks if a database type is currently supported by this platform.
-     *
-     * @param string $dbType
-     *
-     * @return bool
      */
-    public function hasDoctrineTypeMappingFor($dbType)
+    public function hasDoctrineTypeMappingFor(string $dbType) : bool
     {
         if ($this->doctrineTypeMapping === null) {
             $this->initializeAllDoctrineTypeMappings();
@@ -390,10 +346,8 @@ abstract class AbstractPlatform
 
     /**
      * Initializes the Doctrine Type comments instance variable for in_array() checks.
-     *
-     * @return void
      */
-    protected function initializeCommentedDoctrineTypes()
+    protected function initializeCommentedDoctrineTypes() : void
     {
         $this->doctrineTypeComments = [];
 
@@ -410,10 +364,8 @@ abstract class AbstractPlatform
 
     /**
      * Is it necessary for the platform to add a parsable type comment to allow reverse engineering the given type?
-     *
-     * @return bool
      */
-    public function isCommentedDoctrineType(Type $doctrineType)
+    public function isCommentedDoctrineType(Type $doctrineType) : bool
     {
         if ($this->doctrineTypeComments === null) {
             $this->initializeCommentedDoctrineTypes();
@@ -428,10 +380,8 @@ abstract class AbstractPlatform
      * Marks this type as to be commented in ALTER TABLE and CREATE TABLE statements.
      *
      * @param string|Type $doctrineType
-     *
-     * @return void
      */
-    public function markDoctrineTypeCommented($doctrineType)
+    public function markDoctrineTypeCommented($doctrineType) : void
     {
         if ($this->doctrineTypeComments === null) {
             $this->initializeCommentedDoctrineTypes();
@@ -444,20 +394,16 @@ abstract class AbstractPlatform
 
     /**
      * Gets the comment to append to a column comment that helps parsing this type in reverse engineering.
-     *
-     * @return string
      */
-    public function getDoctrineTypeComment(Type $doctrineType)
+    public function getDoctrineTypeComment(Type $doctrineType) : string
     {
         return '(DC2Type:' . $doctrineType->getName() . ')';
     }
 
     /**
      * Gets the comment of a passed column modified by potential doctrine type comment hints.
-     *
-     * @return string|null
      */
-    protected function getColumnComment(Column $column)
+    protected function getColumnComment(Column $column) : ?string
     {
         $comment = $column->getComment();
 
@@ -470,30 +416,24 @@ abstract class AbstractPlatform
 
     /**
      * Gets the character used for identifier quoting.
-     *
-     * @return string
      */
-    public function getIdentifierQuoteCharacter()
+    public function getIdentifierQuoteCharacter() : string
     {
         return '"';
     }
 
     /**
      * Gets the string portion that starts an SQL comment.
-     *
-     * @return string
      */
-    public function getSqlCommentStartString()
+    public function getSqlCommentStartString() : string
     {
         return '--';
     }
 
     /**
      * Gets the string portion that ends an SQL comment.
-     *
-     * @return string
      */
-    public function getSqlCommentEndString()
+    public function getSqlCommentEndString() : string
     {
         return "\n";
     }
@@ -508,40 +448,32 @@ abstract class AbstractPlatform
 
     /**
      * Gets the maximum length of a varchar field.
-     *
-     * @return int
      */
-    public function getVarcharMaxLength()
+    public function getVarcharMaxLength() : int
     {
         return 4000;
     }
 
     /**
      * Gets the default length of a varchar field.
-     *
-     * @return int
      */
-    public function getVarcharDefaultLength()
+    public function getVarcharDefaultLength() : int
     {
         return 255;
     }
 
     /**
      * Gets the maximum length of a binary field.
-     *
-     * @return int
      */
-    public function getBinaryMaxLength()
+    public function getBinaryMaxLength() : int
     {
         return 4000;
     }
 
     /**
      * Gets the default length of a binary field.
-     *
-     * @return int
      */
-    public function getBinaryDefaultLength()
+    public function getBinaryDefaultLength() : int
     {
         return 255;
     }
@@ -551,7 +483,7 @@ abstract class AbstractPlatform
      *
      * @return string[]
      */
-    public function getWildcards()
+    public function getWildcards() : array
     {
         return ['%', '_'];
     }
@@ -1179,10 +1111,8 @@ abstract class AbstractPlatform
 
     /**
      * Returns the FOR UPDATE expression.
-     *
-     * @return string
      */
-    public function getForUpdateSQL()
+    public function getForUpdateSQL() : string
     {
         return 'FOR UPDATE';
     }
@@ -1193,10 +1123,8 @@ abstract class AbstractPlatform
      * @param string   $fromClause The FROM clause to append the hint for the given lock mode to.
      * @param int|null $lockMode   One of the Doctrine\DBAL\LockMode::* constants. If null is given, nothing will
      *                             be appended to the FROM clause.
-     *
-     * @return string
      */
-    public function appendLockHint($fromClause, $lockMode)
+    public function appendLockHint(string $fromClause, ?int $lockMode) : string
     {
         return $fromClause;
     }
@@ -1206,10 +1134,8 @@ abstract class AbstractPlatform
      *
      * This defaults to the ANSI SQL "FOR UPDATE", which is an exclusive lock (Write). Some database
      * vendors allow to lighten this constraint up to be a real read lock.
-     *
-     * @return string
      */
-    public function getReadLockSQL()
+    public function getReadLockSQL() : string
     {
         return $this->getForUpdateSQL();
     }
@@ -1218,10 +1144,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet to append to any SELECT statement which obtains an exclusive lock on the rows.
      *
      * The semantics of this lock mode should equal the SELECT .. FOR UPDATE of the ANSI SQL standard.
-     *
-     * @return string
      */
-    public function getWriteLockSQL()
+    public function getWriteLockSQL() : string
     {
         return $this->getForUpdateSQL();
     }
@@ -1230,10 +1154,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet to drop an existing database.
      *
      * @param string $database The name of the database that should be dropped.
-     *
-     * @return string
      */
-    public function getDropDatabaseSQL($database)
+    public function getDropDatabaseSQL(string $database) : string
     {
         return 'DROP DATABASE ' . $database;
     }
@@ -1243,11 +1165,9 @@ abstract class AbstractPlatform
      *
      * @param Table|string $table
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getDropTableSQL($table)
+    public function getDropTableSQL($table) : string
     {
         $tableArg = $table;
 
@@ -1281,10 +1201,8 @@ abstract class AbstractPlatform
      * Returns the SQL to safely drop a temporary table WITHOUT implicitly committing an open transaction.
      *
      * @param Table|string $table
-     *
-     * @return string
      */
-    public function getDropTemporaryTableSQL($table)
+    public function getDropTemporaryTableSQL($table) : string
     {
         return $this->getDropTableSQL($table);
     }
@@ -1295,11 +1213,9 @@ abstract class AbstractPlatform
      * @param Index|string $index
      * @param Table|string $table
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getDropIndexSQL($index, $table = null)
+    public function getDropIndexSQL($index, $table = null) : string
     {
         if ($index instanceof Index) {
             $index = $index->getQuotedName($this);
@@ -1315,10 +1231,8 @@ abstract class AbstractPlatform
      *
      * @param Constraint|string $constraint
      * @param Table|string      $table
-     *
-     * @return string
      */
-    public function getDropConstraintSQL($constraint, $table)
+    public function getDropConstraintSQL($constraint, $table) : string
     {
         if (! $constraint instanceof Constraint) {
             $constraint = new Identifier($constraint);
@@ -1339,10 +1253,8 @@ abstract class AbstractPlatform
      *
      * @param ForeignKeyConstraint|string $foreignKey
      * @param Table|string                $table
-     *
-     * @return string
      */
-    public function getDropForeignKeySQL($foreignKey, $table)
+    public function getDropForeignKeySQL($foreignKey, $table) : string
     {
         if (! $foreignKey instanceof ForeignKeyConstraint) {
             $foreignKey = new Identifier($foreignKey);
@@ -1362,19 +1274,12 @@ abstract class AbstractPlatform
      * Returns the SQL statement(s) to create a table with the specified name, columns and constraints
      * on this platform.
      *
-     * @param int $createFlags
-     *
      * @return string[] The sequence of SQL statements.
      *
      * @throws DBALException
-     * @throws InvalidArgumentException
      */
-    public function getCreateTableSQL(Table $table, $createFlags = self::CREATE_INDEXES)
+    public function getCreateTableSQL(Table $table, int $createFlags = self::CREATE_INDEXES) : array
     {
-        if (! is_int($createFlags)) {
-            throw new InvalidArgumentException('Second argument of AbstractPlatform::getCreateTableSQL() has to be an integer.');
-        }
-
         if (count($table->getColumns()) === 0) {
             throw NoColumnsSpecifiedForTable::new($table->getName());
         }
@@ -1468,14 +1373,7 @@ abstract class AbstractPlatform
         return array_merge($sql, $columnSql);
     }
 
-    /**
-     * @param string      $tableName
-     * @param string      $columnName
-     * @param string|null $comment
-     *
-     * @return string
-     */
-    public function getCommentOnColumnSQL($tableName, $columnName, $comment)
+    public function getCommentOnColumnSQL(string $tableName, string $columnName, ?string $comment) : string
     {
         $tableName  = new Identifier($tableName);
         $columnName = new Identifier($columnName);
@@ -1491,31 +1389,26 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to create inline comment on a column.
      *
-     * @param string $comment
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getInlineColumnCommentSQL($comment)
+    public function getInlineColumnCommentSQL(?string $comment) : string
     {
         if (! $this->supportsInlineColumnComments()) {
             throw NotSupported::new(__METHOD__);
         }
 
-        return 'COMMENT ' . $this->quoteStringLiteral($comment);
+        return 'COMMENT ' . $this->quoteStringLiteral((string) $comment);
     }
 
     /**
      * Returns the SQL used to create a table.
      *
-     * @param string    $tableName
      * @param mixed[][] $columns
      * @param mixed[]   $options
      *
      * @return string[]
      */
-    protected function _getCreateTableSQL($tableName, array $columns, array $options = [])
+    protected function _getCreateTableSQL(string $tableName, array $columns, array $options = []) : array
     {
         $columnListSql = $this->getColumnDeclarationListSQL($columns);
 
@@ -1554,10 +1447,7 @@ abstract class AbstractPlatform
         return $sql;
     }
 
-    /**
-     * @return string
-     */
-    public function getCreateTemporaryTableSnippetSQL()
+    public function getCreateTemporaryTableSnippetSQL() : string
     {
         return 'CREATE TEMPORARY TABLE';
     }
@@ -1565,11 +1455,9 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to create a sequence on this platform.
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getCreateSequenceSQL(Sequence $sequence)
+    public function getCreateSequenceSQL(Sequence $sequence) : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -1577,11 +1465,9 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to change a sequence on this platform.
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getAlterSequenceSQL(Sequence $sequence)
+    public function getAlterSequenceSQL(Sequence $sequence) : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -1591,11 +1477,9 @@ abstract class AbstractPlatform
      *
      * @param Table|string $table
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getCreateConstraintSQL(Constraint $constraint, $table)
+    public function getCreateConstraintSQL(Constraint $constraint, $table) : string
     {
         if ($table instanceof Table) {
             $table = $table->getQuotedName($this);
@@ -1632,11 +1516,9 @@ abstract class AbstractPlatform
      *
      * @param Table|string $table The name of the table on which the index is to be created.
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getCreateIndexSQL(Index $index, $table)
+    public function getCreateIndexSQL(Index $index, $table) : string
     {
         if ($table instanceof Table) {
             $table = $table->getQuotedName($this);
@@ -1660,10 +1542,8 @@ abstract class AbstractPlatform
 
     /**
      * Adds condition for partial index.
-     *
-     * @return string
      */
-    protected function getPartialIndexSQL(Index $index)
+    protected function getPartialIndexSQL(Index $index) : string
     {
         if ($this->supportsPartialIndexes() && $index->hasOption('where')) {
             return ' WHERE ' . $index->getOption('where');
@@ -1674,10 +1554,8 @@ abstract class AbstractPlatform
 
     /**
      * Adds additional flags for index generation.
-     *
-     * @return string
      */
-    protected function getCreateIndexSQLFlags(Index $index)
+    protected function getCreateIndexSQLFlags(Index $index) : string
     {
         return $index->isUnique() ? 'UNIQUE ' : '';
     }
@@ -1686,10 +1564,8 @@ abstract class AbstractPlatform
      * Returns the SQL to create an unnamed primary key constraint.
      *
      * @param Table|string $table
-     *
-     * @return string
      */
-    public function getCreatePrimaryKeySQL(Index $index, $table)
+    public function getCreatePrimaryKeySQL(Index $index, $table) : string
     {
         if ($table instanceof Table) {
             $table = $table->getQuotedName($this);
@@ -1701,13 +1577,9 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to create a named schema.
      *
-     * @param string $schemaName
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getCreateSchemaSQL($schemaName)
+    public function getCreateSchemaSQL(string $schemaName) : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -1721,19 +1593,19 @@ abstract class AbstractPlatform
      * you SHOULD use them. In general, they end up causing way more
      * problems than they solve.
      *
-     * @param string $str The identifier name to be quoted.
+     * @param string $identifier The identifier name to be quoted.
      *
      * @return string The quoted identifier string.
      */
-    public function quoteIdentifier($str)
+    public function quoteIdentifier(string $identifier) : string
     {
-        if (strpos($str, '.') !== false) {
-            $parts = array_map([$this, 'quoteSingleIdentifier'], explode('.', $str));
+        if (strpos($identifier, '.') !== false) {
+            $parts = array_map([$this, 'quoteSingleIdentifier'], explode('.', $identifier));
 
             return implode('.', $parts);
         }
 
-        return $this->quoteSingleIdentifier($str);
+        return $this->quoteSingleIdentifier($identifier);
     }
 
     /**
@@ -1743,7 +1615,7 @@ abstract class AbstractPlatform
      *
      * @return string The quoted identifier string.
      */
-    public function quoteSingleIdentifier($str)
+    public function quoteSingleIdentifier(string $str) : string
     {
         $c = $this->getIdentifierQuoteCharacter();
 
@@ -1755,10 +1627,8 @@ abstract class AbstractPlatform
      *
      * @param ForeignKeyConstraint $foreignKey The foreign key constraint.
      * @param Table|string         $table      The name of the table on which the foreign key is to be created.
-     *
-     * @return string
      */
-    public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, $table)
+    public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, $table) : string
     {
         if ($table instanceof Table) {
             $table = $table->getQuotedName($this);
@@ -1776,17 +1646,15 @@ abstract class AbstractPlatform
      *
      * @throws DBALException If not supported on this platform.
      */
-    public function getAlterTableSQL(TableDiff $diff)
+    public function getAlterTableSQL(TableDiff $diff) : array
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
      * @param mixed[] $columnSql
-     *
-     * @return bool
      */
-    protected function onSchemaAlterTableAddColumn(Column $column, TableDiff $diff, &$columnSql)
+    protected function onSchemaAlterTableAddColumn(Column $column, TableDiff $diff, array &$columnSql) : bool
     {
         if ($this->_eventManager === null) {
             return false;
@@ -1806,10 +1674,8 @@ abstract class AbstractPlatform
 
     /**
      * @param string[] $columnSql
-     *
-     * @return bool
      */
-    protected function onSchemaAlterTableRemoveColumn(Column $column, TableDiff $diff, &$columnSql)
+    protected function onSchemaAlterTableRemoveColumn(Column $column, TableDiff $diff, array &$columnSql) : bool
     {
         if ($this->_eventManager === null) {
             return false;
@@ -1829,10 +1695,8 @@ abstract class AbstractPlatform
 
     /**
      * @param string[] $columnSql
-     *
-     * @return bool
      */
-    protected function onSchemaAlterTableChangeColumn(ColumnDiff $columnDiff, TableDiff $diff, &$columnSql)
+    protected function onSchemaAlterTableChangeColumn(ColumnDiff $columnDiff, TableDiff $diff, array &$columnSql) : bool
     {
         if ($this->_eventManager === null) {
             return false;
@@ -1851,12 +1715,9 @@ abstract class AbstractPlatform
     }
 
     /**
-     * @param string   $oldColumnName
      * @param string[] $columnSql
-     *
-     * @return bool
      */
-    protected function onSchemaAlterTableRenameColumn($oldColumnName, Column $column, TableDiff $diff, &$columnSql)
+    protected function onSchemaAlterTableRenameColumn(string $oldColumnName, Column $column, TableDiff $diff, array &$columnSql) : bool
     {
         if ($this->_eventManager === null) {
             return false;
@@ -1876,10 +1737,8 @@ abstract class AbstractPlatform
 
     /**
      * @param string[] $sql
-     *
-     * @return bool
      */
-    protected function onSchemaAlterTable(TableDiff $diff, &$sql)
+    protected function onSchemaAlterTable(TableDiff $diff, array &$sql) : bool
     {
         if ($this->_eventManager === null) {
             return false;
@@ -1900,7 +1759,7 @@ abstract class AbstractPlatform
     /**
      * @return string[]
      */
-    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff)
+    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff) : array
     {
         $tableName = $diff->getName($this)->getQuotedName($this);
 
@@ -1927,7 +1786,7 @@ abstract class AbstractPlatform
     /**
      * @return string[]
      */
-    protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff)
+    protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff) : array
     {
         $sql     = [];
         $newName = $diff->getNewName();
@@ -1976,7 +1835,7 @@ abstract class AbstractPlatform
      *
      * @return string[] The sequence of SQL statements for renaming the given index.
      */
-    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
+    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName) : array
     {
         return [
             $this->getDropIndexSQL($oldIndexName, $tableName),
@@ -1989,7 +1848,7 @@ abstract class AbstractPlatform
      *
      * @return string[]
      */
-    protected function _getAlterTableIndexForeignKeySQL(TableDiff $diff)
+    protected function _getAlterTableIndexForeignKeySQL(TableDiff $diff) : array
     {
         return array_merge($this->getPreAlterTableIndexForeignKeySQL($diff), $this->getPostAlterTableIndexForeignKeySQL($diff));
     }
@@ -2020,10 +1879,8 @@ abstract class AbstractPlatform
      *          Text value with the default COLLATION for this field.
      *      unique
      *          unique constraint
-     *
-     * @return string
      */
-    public function getColumnDeclarationListSQL(array $fields)
+    public function getColumnDeclarationListSQL(array $fields) : string
     {
         $queryFields = [];
 
@@ -2067,7 +1924,7 @@ abstract class AbstractPlatform
      *
      * @return string DBMS specific SQL code portion that should be used to declare the column.
      */
-    public function getColumnDeclarationSQL($name, array $field)
+    public function getColumnDeclarationSQL(string $name, array $field) : string
     {
         if (isset($field['columnDefinition'])) {
             $columnDef = $this->getCustomTypeDeclarationSQL($field);
@@ -2103,10 +1960,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet that declares a floating point column of arbitrary precision.
      *
      * @param mixed[] $columnDef
-     *
-     * @return string
      */
-    public function getDecimalTypeDeclarationSQL(array $columnDef)
+    public function getDecimalTypeDeclarationSQL(array $columnDef) : string
     {
         $columnDef['precision'] = ! isset($columnDef['precision']) || empty($columnDef['precision'])
             ? 10 : $columnDef['precision'];
@@ -2124,7 +1979,7 @@ abstract class AbstractPlatform
      *
      * @return string DBMS specific SQL code portion needed to set a default value.
      */
-    public function getDefaultValueDeclarationSQL($field)
+    public function getDefaultValueDeclarationSQL(array $field) : string
     {
         if (! isset($field['default'])) {
             return empty($field['notnull']) ? ' DEFAULT NULL' : '';
@@ -2158,6 +2013,10 @@ abstract class AbstractPlatform
             return " DEFAULT '" . $this->convertBooleans($default) . "'";
         }
 
+        if (is_int($default) || is_float($default)) {
+            return ' DEFAULT ' . $default;
+        }
+
         return ' DEFAULT ' . $this->quoteStringLiteral($default);
     }
 
@@ -2169,7 +2028,7 @@ abstract class AbstractPlatform
      *
      * @return string DBMS specific SQL code portion needed to set a CHECK constraint.
      */
-    public function getCheckDeclarationSQL(array $definition)
+    public function getCheckDeclarationSQL(array $definition) : string
     {
         $constraints = [];
         foreach ($definition as $field => $def) {
@@ -2180,9 +2039,11 @@ abstract class AbstractPlatform
                     $constraints[] = 'CHECK (' . $field . ' >= ' . $def['min'] . ')';
                 }
 
-                if (isset($def['max'])) {
-                    $constraints[] = 'CHECK (' . $field . ' <= ' . $def['max'] . ')';
+                if (! isset($def['max'])) {
+                    continue;
                 }
+
+                $constraints[] = 'CHECK (' . $field . ' <= ' . $def['max'] . ')';
             }
         }
 
@@ -2200,26 +2061,29 @@ abstract class AbstractPlatform
      *
      * @throws InvalidArgumentException
      */
-    public function getUniqueConstraintDeclarationSQL($name, UniqueConstraint $constraint)
+    public function getUniqueConstraintDeclarationSQL(string $name, UniqueConstraint $constraint) : string
     {
         $columns = $constraint->getColumns();
-        $name    = new Identifier($name);
 
         if (count($columns) === 0) {
             throw new InvalidArgumentException('Incomplete definition. "columns" required.');
         }
 
-        $flags = ['UNIQUE'];
+        $chunks = ['CONSTRAINT'];
 
-        if ($constraint->hasFlag('clustered')) {
-            $flags[] = 'CLUSTERED';
+        if ($name !== '') {
+            $chunks[] = (new Identifier($name))->getQuotedName($this);
         }
 
-        $constraintName  = $name->getQuotedName($this);
-        $constraintName  = ! empty($constraintName) ? $constraintName . ' ' : '';
-        $columnListNames = $this->getIndexFieldDeclarationListSQL($columns);
+        $chunks[] = 'UNIQUE';
 
-        return sprintf('CONSTRAINT %s%s (%s)', $constraintName, implode(' ', $flags), $columnListNames);
+        if ($constraint->hasFlag('clustered')) {
+            $chunks[] = 'CLUSTERED';
+        }
+
+        $chunks[] = sprintf('(%s)', $this->getIndexFieldDeclarationListSQL($columns));
+
+        return implode(' ', $chunks);
     }
 
     /**
@@ -2233,7 +2097,7 @@ abstract class AbstractPlatform
      *
      * @throws InvalidArgumentException
      */
-    public function getIndexDeclarationSQL($name, Index $index)
+    public function getIndexDeclarationSQL(string $name, Index $index) : string
     {
         $columns = $index->getColumns();
         $name    = new Identifier($name);
@@ -2253,10 +2117,8 @@ abstract class AbstractPlatform
      * Only "AUTOINCREMENT" and "PRIMARY KEY" are added if appropriate.
      *
      * @param mixed[] $columnDef
-     *
-     * @return string
      */
-    public function getCustomTypeDeclarationSQL(array $columnDef)
+    public function getCustomTypeDeclarationSQL(array $columnDef) : string
     {
         return $columnDef['columnDefinition'];
     }
@@ -2304,19 +2166,15 @@ abstract class AbstractPlatform
      * @return string The string required to be placed between "CREATE" and "TABLE"
      *                to generate a temporary table, if possible.
      */
-    public function getTemporaryTableSQL()
+    public function getTemporaryTableSQL() : string
     {
         return 'TEMPORARY';
     }
 
     /**
      * Some vendors require temporary table names to be qualified specially.
-     *
-     * @param string $tableName
-     *
-     * @return string
      */
-    public function getTemporaryTableName($tableName)
+    public function getTemporaryTableName(string $tableName) : string
     {
         return $tableName;
     }
@@ -2328,7 +2186,7 @@ abstract class AbstractPlatform
      * @return string DBMS specific SQL code portion needed to set the FOREIGN KEY constraint
      *                of a field declaration.
      */
-    public function getForeignKeyDeclarationSQL(ForeignKeyConstraint $foreignKey)
+    public function getForeignKeyDeclarationSQL(ForeignKeyConstraint $foreignKey) : string
     {
         $sql  = $this->getForeignKeyBaseDeclarationSQL($foreignKey);
         $sql .= $this->getAdvancedForeignKeyOptionsSQL($foreignKey);
@@ -2341,10 +2199,8 @@ abstract class AbstractPlatform
      * as MATCH, INITIALLY DEFERRED, ON UPDATE, ...
      *
      * @param ForeignKeyConstraint $foreignKey The foreign key definition.
-     *
-     * @return string
      */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
+    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey) : string
     {
         $query = '';
         if ($this->supportsForeignKeyOnUpdate() && $foreignKey->hasOption('onUpdate')) {
@@ -2362,11 +2218,9 @@ abstract class AbstractPlatform
      *
      * @param string $action The foreign key referential action.
      *
-     * @return string
-     *
      * @throws InvalidArgumentException If unknown referential action given.
      */
-    public function getForeignKeyReferentialActionSQL($action)
+    public function getForeignKeyReferentialActionSQL(string $action) : string
     {
         $upper = strtoupper($action);
         switch ($upper) {
@@ -2385,14 +2239,12 @@ abstract class AbstractPlatform
      * Obtains DBMS specific SQL code portion needed to set the FOREIGN KEY constraint
      * of a field declaration to be used in statements like CREATE TABLE.
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey)
+    public function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey) : string
     {
         $sql = '';
-        if (strlen($foreignKey->getName())) {
+        if ($foreignKey->getName() !== '') {
             $sql .= 'CONSTRAINT ' . $foreignKey->getQuotedName($this) . ' ';
         }
         $sql .= 'FOREIGN KEY (';
@@ -2420,7 +2272,7 @@ abstract class AbstractPlatform
      * @return string DBMS specific SQL code portion needed to set the UNIQUE constraint
      *                of a field declaration.
      */
-    public function getUniqueFieldDeclarationSQL()
+    public function getUniqueFieldDeclarationSQL() : string
     {
         return 'UNIQUE';
     }
@@ -2434,7 +2286,7 @@ abstract class AbstractPlatform
      * @return string DBMS specific SQL code portion needed to set the CHARACTER SET
      *                of a field declaration.
      */
-    public function getColumnCharsetDeclarationSQL($charset)
+    public function getColumnCharsetDeclarationSQL(string $charset) : string
     {
         return '';
     }
@@ -2448,7 +2300,7 @@ abstract class AbstractPlatform
      * @return string DBMS specific SQL code portion needed to set the COLLATION
      *                of a field declaration.
      */
-    public function getColumnCollationDeclarationSQL($collation)
+    public function getColumnCollationDeclarationSQL(string $collation) : string
     {
         return $this->supportsColumnCollation() ? 'COLLATE ' . $collation : '';
     }
@@ -2456,10 +2308,8 @@ abstract class AbstractPlatform
     /**
      * Whether the platform prefers sequences for ID generation.
      * Subclasses should override this method to return TRUE if they prefer sequences.
-     *
-     * @return bool
      */
-    public function prefersSequences()
+    public function prefersSequences() : bool
     {
         return false;
     }
@@ -2467,10 +2317,8 @@ abstract class AbstractPlatform
     /**
      * Whether the platform prefers identity columns (eg. autoincrement) for ID generation.
      * Subclasses should override this method to return TRUE if they prefer identity columns.
-     *
-     * @return bool
      */
-    public function prefersIdentityColumns()
+    public function prefersIdentityColumns() : bool
     {
         return false;
     }
@@ -2512,12 +2360,14 @@ abstract class AbstractPlatform
      * The default conversion tries to convert value into bool "(bool)$item"
      *
      * @param mixed $item
-     *
-     * @return bool|null
      */
-    public function convertFromBoolean($item)
+    public function convertFromBoolean($item) : ?bool
     {
-        return $item === null ? null: (bool) $item;
+        if ($item === null) {
+            return null;
+        }
+
+        return (bool) $item;
     }
 
     /**
@@ -2537,30 +2387,24 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL specific for the platform to get the current date.
-     *
-     * @return string
      */
-    public function getCurrentDateSQL()
+    public function getCurrentDateSQL() : string
     {
         return 'CURRENT_DATE';
     }
 
     /**
      * Returns the SQL specific for the platform to get the current time.
-     *
-     * @return string
      */
-    public function getCurrentTimeSQL()
+    public function getCurrentTimeSQL() : string
     {
         return 'CURRENT_TIME';
     }
 
     /**
      * Returns the SQL specific for the platform to get the current timestamp
-     *
-     * @return string
      */
-    public function getCurrentTimestampSQL()
+    public function getCurrentTimestampSQL() : string
     {
         return 'CURRENT_TIMESTAMP';
     }
@@ -2568,13 +2412,9 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL for a given transaction isolation level Connection constant.
      *
-     * @param int $level
-     *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    protected function _getTransactionIsolationLevelSQL($level)
+    protected function _getTransactionIsolationLevelSQL(int $level) : string
     {
         switch ($level) {
             case TransactionIsolationLevel::READ_UNCOMMITTED:
@@ -2591,11 +2431,9 @@ abstract class AbstractPlatform
     }
 
     /**
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getListDatabasesSQL()
+    public function getListDatabasesSQL() : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -2603,68 +2441,49 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL statement for retrieving the namespaces defined in the database.
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getListNamespacesSQL()
+    public function getListNamespacesSQL() : string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
-     * @param string $database
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getListSequencesSQL($database)
+    public function getListSequencesSQL(string $database) : string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
-     * @param string $table
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getListTableConstraintsSQL($table)
+    public function getListTableConstraintsSQL(string $table) : string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
-     * @param string      $table
-     * @param string|null $database
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getListTableColumnsSQL($table, $database = null)
+    public function getListTableColumnsSQL(string $table, ?string $database = null) : string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getListTablesSQL()
+    public function getListTablesSQL() : string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getListUsersSQL()
+    public function getListUsersSQL() : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -2672,13 +2491,9 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to list all views of a database or user.
      *
-     * @param string $database
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getListViewsSQL($database)
+    public function getListViewsSQL(string $database) : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -2693,51 +2508,33 @@ abstract class AbstractPlatform
      * are connected with that database. Cross-database information schema
      * requests may be impossible.
      *
-     * @param string $table
-     * @param string $currentDatabase
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getListTableIndexesSQL($table, $currentDatabase = null)
+    public function getListTableIndexesSQL(string $table, ?string $currentDatabase = null) : string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
-     * @param string $table
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getListTableForeignKeysSQL($table)
+    public function getListTableForeignKeysSQL(string $table, ?string $database = null) : string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
-     * @param string $name
-     * @param string $sql
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getCreateViewSQL($name, $sql)
+    public function getCreateViewSQL(string $name, string $sql) : string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
-     * @param string $name
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getDropViewSQL($name)
+    public function getDropViewSQL(string $name) : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -2747,23 +2544,17 @@ abstract class AbstractPlatform
      *
      * @param Sequence|string $sequence
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getDropSequenceSQL($sequence)
+    public function getDropSequenceSQL($sequence) : string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
-     * @param string $sequenceName
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getSequenceNextValSQL($sequenceName)
+    public function getSequenceNextValSQL(string $sequenceName) : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -2773,11 +2564,9 @@ abstract class AbstractPlatform
      *
      * @param string $database The name of the database that should be created.
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getCreateDatabaseSQL($database)
+    public function getCreateDatabaseSQL(string $database) : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -2785,13 +2574,9 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to set the transaction isolation level.
      *
-     * @param int $level
-     *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getSetTransactionIsolationSQL($level)
+    public function getSetTransactionIsolationSQL(int $level) : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -2802,11 +2587,9 @@ abstract class AbstractPlatform
      *
      * @param mixed[] $fieldDeclaration
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -2815,10 +2598,8 @@ abstract class AbstractPlatform
      * Obtains DBMS specific SQL to be used to create datetime with timezone offset fields.
      *
      * @param mixed[] $fieldDeclaration
-     *
-     * @return string
      */
-    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return $this->getDateTimeTypeDeclarationSQL($fieldDeclaration);
     }
@@ -2829,11 +2610,9 @@ abstract class AbstractPlatform
      *
      * @param mixed[] $fieldDeclaration
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getDateTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -2844,21 +2623,17 @@ abstract class AbstractPlatform
      *
      * @param mixed[] $fieldDeclaration
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
      * @param mixed[] $fieldDeclaration
-     *
-     * @return string
      */
-    public function getFloatDeclarationSQL(array $fieldDeclaration)
+    public function getFloatDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DOUBLE PRECISION';
     }
@@ -2870,7 +2645,7 @@ abstract class AbstractPlatform
      *
      * @return int The default isolation level.
      */
-    public function getDefaultTransactionIsolationLevel()
+    public function getDefaultTransactionIsolationLevel() : int
     {
         return TransactionIsolationLevel::READ_COMMITTED;
     }
@@ -2879,10 +2654,8 @@ abstract class AbstractPlatform
 
     /**
      * Whether the platform supports sequences.
-     *
-     * @return bool
      */
-    public function supportsSequences()
+    public function supportsSequences() : bool
     {
         return false;
     }
@@ -2892,10 +2665,8 @@ abstract class AbstractPlatform
      *
      * Identity columns are columns that receive an auto-generated value from the
      * database on insert of a row.
-     *
-     * @return bool
      */
-    public function supportsIdentityColumns()
+    public function supportsIdentityColumns() : bool
     {
         return false;
     }
@@ -2906,23 +2677,16 @@ abstract class AbstractPlatform
      * Some platforms that do not support identity columns natively
      * but support sequences can emulate identity columns by using
      * sequences.
-     *
-     * @return bool
      */
-    public function usesSequenceEmulatedIdentityColumns()
+    public function usesSequenceEmulatedIdentityColumns() : bool
     {
         return false;
     }
 
     /**
      * Gets the sequence name prefix based on table information.
-     *
-     * @param string      $tableName
-     * @param string|null $schemaName
-     *
-     * @return string
      */
-    public function getSequencePrefix($tableName, $schemaName = null)
+    public function getSequencePrefix(string $tableName, ?string $schemaName = null) : string
     {
         if (! $schemaName) {
             return $tableName;
@@ -2942,31 +2706,25 @@ abstract class AbstractPlatform
      * @param string $tableName  The name of the table to return the sequence name for.
      * @param string $columnName The name of the identity column in the table to return the sequence name for.
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getIdentitySequenceName($tableName, $columnName)
+    public function getIdentitySequenceName(string $tableName, string $columnName) : string
     {
         throw NotSupported::new(__METHOD__);
     }
 
     /**
      * Whether the platform supports indexes.
-     *
-     * @return bool
      */
-    public function supportsIndexes()
+    public function supportsIndexes() : bool
     {
         return true;
     }
 
     /**
      * Whether the platform supports partial indexes.
-     *
-     * @return bool
      */
-    public function supportsPartialIndexes()
+    public function supportsPartialIndexes() : bool
     {
         return false;
     }
@@ -2981,80 +2739,64 @@ abstract class AbstractPlatform
 
     /**
      * Whether the platform supports altering tables.
-     *
-     * @return bool
      */
-    public function supportsAlterTable()
+    public function supportsAlterTable() : bool
     {
         return true;
     }
 
     /**
      * Whether the platform supports transactions.
-     *
-     * @return bool
      */
-    public function supportsTransactions()
+    public function supportsTransactions() : bool
     {
         return true;
     }
 
     /**
      * Whether the platform supports savepoints.
-     *
-     * @return bool
      */
-    public function supportsSavepoints()
+    public function supportsSavepoints() : bool
     {
         return true;
     }
 
     /**
      * Whether the platform supports releasing savepoints.
-     *
-     * @return bool
      */
-    public function supportsReleaseSavepoints()
+    public function supportsReleaseSavepoints() : bool
     {
         return $this->supportsSavepoints();
     }
 
     /**
      * Whether the platform supports primary key constraints.
-     *
-     * @return bool
      */
-    public function supportsPrimaryConstraints()
+    public function supportsPrimaryConstraints() : bool
     {
         return true;
     }
 
     /**
      * Whether the platform supports foreign key constraints.
-     *
-     * @return bool
      */
-    public function supportsForeignKeyConstraints()
+    public function supportsForeignKeyConstraints() : bool
     {
         return true;
     }
 
     /**
      * Whether this platform supports onUpdate in foreign key constraints.
-     *
-     * @return bool
      */
-    public function supportsForeignKeyOnUpdate()
+    public function supportsForeignKeyOnUpdate() : bool
     {
         return $this->supportsForeignKeyConstraints();
     }
 
     /**
      * Whether the platform supports database schemas.
-     *
-     * @return bool
      */
-    public function supportsSchemas()
+    public function supportsSchemas() : bool
     {
         return false;
     }
@@ -3065,10 +2807,8 @@ abstract class AbstractPlatform
      * Platforms that either support or emulate schemas don't automatically
      * filter a schema for the namespaced elements in {@link
      * AbstractManager#createSchema}.
-     *
-     * @return bool
      */
-    public function canEmulateSchemas()
+    public function canEmulateSchemas() : bool
     {
         return false;
     }
@@ -3076,11 +2816,9 @@ abstract class AbstractPlatform
     /**
      * Returns the default schema name.
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    public function getDefaultSchemaName()
+    public function getDefaultSchemaName() : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -3089,80 +2827,64 @@ abstract class AbstractPlatform
      * Whether this platform supports create database.
      *
      * Some databases don't allow to create and drop databases at all or only with certain tools.
-     *
-     * @return bool
      */
-    public function supportsCreateDropDatabase()
+    public function supportsCreateDropDatabase() : bool
     {
         return true;
     }
 
     /**
      * Whether the platform supports getting the affected rows of a recent update/delete type query.
-     *
-     * @return bool
      */
-    public function supportsGettingAffectedRows()
+    public function supportsGettingAffectedRows() : bool
     {
         return true;
     }
 
     /**
      * Whether this platform support to add inline column comments as postfix.
-     *
-     * @return bool
      */
-    public function supportsInlineColumnComments()
+    public function supportsInlineColumnComments() : bool
     {
         return false;
     }
 
     /**
      * Whether this platform support the proprietary syntax "COMMENT ON asset".
-     *
-     * @return bool
      */
-    public function supportsCommentOnStatement()
+    public function supportsCommentOnStatement() : bool
     {
         return false;
     }
 
     /**
      * Does this platform have native guid type.
-     *
-     * @return bool
      */
-    public function hasNativeGuidType()
+    public function hasNativeGuidType() : bool
     {
         return false;
     }
 
     /**
      * Does this platform have native JSON type.
-     *
-     * @return bool
      */
-    public function hasNativeJsonType()
+    public function hasNativeJsonType() : bool
     {
         return false;
     }
 
     /**
      * Whether this platform supports views.
-     *
-     * @return bool
      */
-    public function supportsViews()
+    public function supportsViews() : bool
     {
         return true;
     }
 
     /**
      * Does this platform support column collation?
-     *
-     * @return bool
      */
-    public function supportsColumnCollation()
+    public function supportsColumnCollation() : bool
     {
         return false;
     }
@@ -3173,7 +2895,7 @@ abstract class AbstractPlatform
      *
      * @return string The format string.
      */
-    public function getDateTimeFormatString()
+    public function getDateTimeFormatString() : string
     {
         return 'Y-m-d H:i:s';
     }
@@ -3184,7 +2906,7 @@ abstract class AbstractPlatform
      *
      * @return string The format string.
      */
-    public function getDateTimeTzFormatString()
+    public function getDateTimeTzFormatString() : string
     {
         return 'Y-m-d H:i:s';
     }
@@ -3195,7 +2917,7 @@ abstract class AbstractPlatform
      *
      * @return string The format string.
      */
-    public function getDateFormatString()
+    public function getDateFormatString() : string
     {
         return 'Y-m-d';
     }
@@ -3206,7 +2928,7 @@ abstract class AbstractPlatform
      *
      * @return string The format string.
      */
-    public function getTimeFormatString()
+    public function getTimeFormatString() : string
     {
         return 'H:i:s';
     }
@@ -3253,10 +2975,8 @@ abstract class AbstractPlatform
 
     /**
      * Whether the database platform support offsets in modify limit clauses.
-     *
-     * @return bool
      */
-    public function supportsLimitOffset()
+    public function supportsLimitOffset() : bool
     {
         return true;
     }
@@ -3268,7 +2988,7 @@ abstract class AbstractPlatform
      *
      * @return string The column name in the character casing used in SQL result sets.
      */
-    public function getSQLResultCasing($column)
+    public function getSQLResultCasing(string $column) : string
     {
         return $column;
     }
@@ -3276,35 +2996,24 @@ abstract class AbstractPlatform
     /**
      * Makes any fixes to a name of a schema element (table, sequence, ...) that are required
      * by restrictions of the platform, like a maximum length.
-     *
-     * @param string $schemaElementName
-     *
-     * @return string
      */
-    public function fixSchemaElementName($schemaElementName)
+    public function fixSchemaElementName(string $schemaElementName) : string
     {
         return $schemaElementName;
     }
 
     /**
      * Maximum length of any given database identifier, like tables or column names.
-     *
-     * @return int
      */
-    public function getMaxIdentifierLength()
+    public function getMaxIdentifierLength() : int
     {
         return 63;
     }
 
     /**
      * Returns the insert SQL for an empty insert statement.
-     *
-     * @param string $tableName
-     * @param string $identifierColumnName
-     *
-     * @return string
      */
-    public function getEmptyIdentityInsertSQL($tableName, $identifierColumnName)
+    public function getEmptyIdentityInsertSQL(string $tableName, string $identifierColumnName) : string
     {
         return 'INSERT INTO ' . $tableName . ' (' . $identifierColumnName . ') VALUES (null)';
     }
@@ -3314,13 +3023,8 @@ abstract class AbstractPlatform
      *
      * Cascade is not supported on many platforms but would optionally cascade the truncate by
      * following the foreign keys.
-     *
-     * @param string $tableName
-     * @param bool   $cascade
-     *
-     * @return string
      */
-    public function getTruncateTableSQL($tableName, $cascade = false)
+    public function getTruncateTableSQL(string $tableName, bool $cascade = false) : string
     {
         $tableIdentifier = new Identifier($tableName);
 
@@ -3337,36 +3041,24 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL to create a new savepoint.
-     *
-     * @param string $savepoint
-     *
-     * @return string
      */
-    public function createSavePoint($savepoint)
+    public function createSavePoint(string $savepoint) : string
     {
         return 'SAVEPOINT ' . $savepoint;
     }
 
     /**
      * Returns the SQL to release a savepoint.
-     *
-     * @param string $savepoint
-     *
-     * @return string
      */
-    public function releaseSavePoint($savepoint)
+    public function releaseSavePoint(string $savepoint) : string
     {
         return 'RELEASE SAVEPOINT ' . $savepoint;
     }
 
     /**
      * Returns the SQL to rollback a savepoint.
-     *
-     * @param string $savepoint
-     *
-     * @return string
      */
-    public function rollbackSavePoint($savepoint)
+    public function rollbackSavePoint(string $savepoint) : string
     {
         return 'ROLLBACK TO SAVEPOINT ' . $savepoint;
     }
@@ -3374,11 +3066,9 @@ abstract class AbstractPlatform
     /**
      * Returns the keyword list instance of this platform.
      *
-     * @return KeywordList
-     *
      * @throws DBALException If no keyword list is specified.
      */
-    final public function getReservedKeywordsList()
+    final public function getReservedKeywordsList() : KeywordList
     {
         // Check for an existing instantiation of the keywords class.
         if ($this->_keywords) {
@@ -3400,11 +3090,9 @@ abstract class AbstractPlatform
     /**
      * Returns the class name of the reserved keywords list.
      *
-     * @return string
-     *
      * @throws DBALException If not supported on this platform.
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         throw NotSupported::new(__METHOD__);
     }
@@ -3419,7 +3107,7 @@ abstract class AbstractPlatform
      *
      * @return string The quoted literal string.
      */
-    public function quoteStringLiteral($str)
+    public function quoteStringLiteral(string $str) : string
     {
         $c = $this->getStringLiteralQuoteCharacter();
 
@@ -3428,10 +3116,8 @@ abstract class AbstractPlatform
 
     /**
      * Gets the character used for string literal quoting.
-     *
-     * @return string
      */
-    public function getStringLiteralQuoteCharacter()
+    public function getStringLiteralQuoteCharacter() : string
     {
         return "'";
     }

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -33,7 +33,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getBinaryMaxLength()
+    public function getBinaryMaxLength() : int
     {
         return 32704;
     }
@@ -41,7 +41,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getBinaryDefaultLength()
+    public function getBinaryDefaultLength() : int
     {
         return 1;
     }
@@ -49,7 +49,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getVarcharTypeDeclarationSQL(array $field)
+    public function getVarcharTypeDeclarationSQL(array $field) : string
     {
         // for IBM DB2, the CHAR max length is less than VARCHAR default length
         if (! isset($field['length']) && ! empty($field['fixed'])) {
@@ -62,7 +62,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getBlobTypeDeclarationSQL(array $field)
+    public function getBlobTypeDeclarationSQL(array $field) : string
     {
         // todo blob(n) with $field['length'];
         return 'BLOB(1M)';
@@ -71,7 +71,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function initializeDoctrineTypeMappings()
+    public function initializeDoctrineTypeMappings() : void
     {
         $this->doctrineTypeMapping = [
             'bigint'    => 'bigint',
@@ -95,7 +95,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function isCommentedDoctrineType(Type $doctrineType)
+    public function isCommentedDoctrineType(Type $doctrineType) : bool
     {
         if ($doctrineType->getName() === Types::BOOLEAN) {
             // We require a commented boolean type in order to distinguish between boolean and smallint
@@ -109,7 +109,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getVarcharTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return $fixed ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(254)')
                 : ($length ? 'VARCHAR(' . $length . ')' : 'VARCHAR(255)');
@@ -118,7 +118,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getBinaryTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return $this->getVarcharTypeDeclarationSQLSnippet($length, $fixed) . ' FOR BIT DATA';
     }
@@ -126,7 +126,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getClobTypeDeclarationSQL(array $field)
+    public function getClobTypeDeclarationSQL(array $field) : string
     {
         // todo clob(n) with $field['length'];
         return 'CLOB(1M)';
@@ -135,7 +135,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'db2';
     }
@@ -143,7 +143,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getBooleanTypeDeclarationSQL(array $columnDef)
+    public function getBooleanTypeDeclarationSQL(array $columnDef) : string
     {
         return 'SMALLINT';
     }
@@ -151,7 +151,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getIntegerTypeDeclarationSQL(array $columnDef)
+    public function getIntegerTypeDeclarationSQL(array $columnDef) : string
     {
         return 'INTEGER' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
@@ -159,7 +159,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getBigIntTypeDeclarationSQL(array $columnDef)
+    public function getBigIntTypeDeclarationSQL(array $columnDef) : string
     {
         return 'BIGINT' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
@@ -167,7 +167,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getSmallIntTypeDeclarationSQL(array $columnDef)
+    public function getSmallIntTypeDeclarationSQL(array $columnDef) : string
     {
         return 'SMALLINT' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
@@ -175,7 +175,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
+    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef) : string
     {
         $autoinc = '';
         if (! empty($columnDef['autoincrement'])) {
@@ -232,7 +232,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         if (isset($fieldDeclaration['version']) && $fieldDeclaration['version'] === true) {
             return 'TIMESTAMP(0) WITH DEFAULT';
@@ -244,7 +244,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDateTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DATE';
     }
@@ -252,7 +252,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'TIME';
     }
@@ -260,7 +260,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getTruncateTableSQL($tableName, $cascade = false)
+    public function getTruncateTableSQL(string $tableName, bool $cascade = false) : string
     {
         $tableIdentifier = new Identifier($tableName);
 
@@ -269,13 +269,8 @@ class DB2Platform extends AbstractPlatform
 
     /**
      * This code fragment is originally from the Zend_Db_Adapter_Db2 class, but has been edited.
-     *
-     * @param string $table
-     * @param string $database
-     *
-     * @return string
      */
-    public function getListTableColumnsSQL($table, $database = null)
+    public function getListTableColumnsSQL(string $table, ?string $database = null) : string
     {
         $table = $this->quoteStringLiteral($table);
 
@@ -326,7 +321,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTablesSQL()
+    public function getListTablesSQL() : string
     {
         return "SELECT NAME FROM SYSIBM.SYSTABLES WHERE TYPE = 'T'";
     }
@@ -334,7 +329,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListViewsSQL($database)
+    public function getListViewsSQL(string $database) : string
     {
         return 'SELECT NAME, TEXT FROM SYSIBM.SYSVIEWS';
     }
@@ -342,7 +337,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTableIndexesSQL($table, $currentDatabase = null)
+    public function getListTableIndexesSQL(string $table, ?string $currentDatabase = null) : string
     {
         $table = $this->quoteStringLiteral($table);
 
@@ -366,7 +361,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTableForeignKeysSQL($table)
+    public function getListTableForeignKeysSQL(string $table, ?string $database = null) : string
     {
         $table = $this->quoteStringLiteral($table);
 
@@ -400,7 +395,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateViewSQL($name, $sql)
+    public function getCreateViewSQL(string $name, string $sql) : string
     {
         return 'CREATE VIEW ' . $name . ' AS ' . $sql;
     }
@@ -408,7 +403,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDropViewSQL($name)
+    public function getDropViewSQL(string $name) : string
     {
         return 'DROP VIEW ' . $name;
     }
@@ -416,7 +411,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateDatabaseSQL($database)
+    public function getCreateDatabaseSQL(string $database) : string
     {
         return 'CREATE DATABASE ' . $database;
     }
@@ -424,7 +419,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDropDatabaseSQL($database)
+    public function getDropDatabaseSQL(string $database) : string
     {
         return 'DROP DATABASE ' . $database;
     }
@@ -432,7 +427,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsCreateDropDatabase()
+    public function supportsCreateDropDatabase() : bool
     {
         return false;
     }
@@ -440,7 +435,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsReleaseSavepoints()
+    public function supportsReleaseSavepoints() : bool
     {
         return false;
     }
@@ -448,7 +443,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function supportsCommentOnStatement()
+    public function supportsCommentOnStatement() : bool
     {
         return true;
     }
@@ -456,7 +451,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCurrentDateSQL()
+    public function getCurrentDateSQL() : string
     {
         return 'CURRENT DATE';
     }
@@ -464,7 +459,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCurrentTimeSQL()
+    public function getCurrentTimeSQL() : string
     {
         return 'CURRENT TIME';
     }
@@ -472,7 +467,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCurrentTimestampSQL()
+    public function getCurrentTimestampSQL() : string
     {
         return 'CURRENT TIMESTAMP';
     }
@@ -480,7 +475,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getIndexDeclarationSQL($name, Index $index)
+    public function getIndexDeclarationSQL(string $name, Index $index) : string
     {
         // Index declaration in statements like CREATE TABLE is not supported.
         throw NotSupported::new(__METHOD__);
@@ -489,7 +484,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL($tableName, array $columns, array $options = [])
+    protected function _getCreateTableSQL(string $tableName, array $columns, array $options = []) : array
     {
         $indexes = [];
         if (isset($options['indexes'])) {
@@ -509,7 +504,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getAlterTableSQL(TableDiff $diff)
+    public function getAlterTableSQL(TableDiff $diff) : array
     {
         $sql         = [];
         $columnSql   = [];
@@ -628,7 +623,7 @@ class DB2Platform extends AbstractPlatform
      * @param string[]   $sql        The sequence of table alteration statements to fill.
      * @param mixed[]    $queryParts The sequence of column alteration clauses to fill.
      */
-    private function gatherAlterColumnSQL(Identifier $table, ColumnDiff $columnDiff, array &$sql, array &$queryParts)
+    private function gatherAlterColumnSQL(Identifier $table, ColumnDiff $columnDiff, array &$sql, array &$queryParts) : void
     {
         $alterColumnClauses = $this->getAlterColumnClausesSQL($columnDiff);
 
@@ -658,7 +653,7 @@ class DB2Platform extends AbstractPlatform
      *
      * @return string[]
      */
-    private function getAlterColumnClausesSQL(ColumnDiff $columnDiff)
+    private function getAlterColumnClausesSQL(ColumnDiff $columnDiff) : array
     {
         $column = $columnDiff->column->toArray();
 
@@ -701,7 +696,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff)
+    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff) : array
     {
         $sql   = [];
         $table = $diff->getName($this)->getQuotedName($this);
@@ -734,7 +729,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
+    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName) : array
     {
         if (strpos($tableName, '.') !== false) {
             [$schema]     = explode('.', $tableName);
@@ -747,7 +742,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDefaultValueDeclarationSQL($field)
+    public function getDefaultValueDeclarationSQL(array $field) : string
     {
         if (! empty($field['autoincrement'])) {
             return '';
@@ -765,7 +760,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getEmptyIdentityInsertSQL($tableName, $identifierColumnName)
+    public function getEmptyIdentityInsertSQL(string $tableName, string $identifierColumnName) : string
     {
         return 'INSERT INTO ' . $tableName . ' (' . $identifierColumnName . ') VALUES (DEFAULT)';
     }
@@ -773,7 +768,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateTemporaryTableSnippetSQL()
+    public function getCreateTemporaryTableSnippetSQL() : string
     {
         return 'DECLARE GLOBAL TEMPORARY TABLE';
     }
@@ -781,7 +776,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getTemporaryTableName($tableName)
+    public function getTemporaryTableName(string $tableName) : string
     {
         return 'SESSION.' . $tableName;
     }
@@ -840,7 +835,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsIdentityColumns()
+    public function supportsIdentityColumns() : bool
     {
         return true;
     }
@@ -848,7 +843,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function prefersIdentityColumns()
+    public function prefersIdentityColumns() : bool
     {
         return true;
     }
@@ -858,7 +853,7 @@ class DB2Platform extends AbstractPlatform
      *
      * DB2 returns all column names in SQL result sets in uppercase.
      */
-    public function getSQLResultCasing($column)
+    public function getSQLResultCasing(string $column) : string
     {
         return strtoupper($column);
     }
@@ -866,7 +861,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getForUpdateSQL()
+    public function getForUpdateSQL() : string
     {
         return ' WITH RR USE AND KEEP UPDATE LOCKS';
     }
@@ -886,7 +881,7 @@ class DB2Platform extends AbstractPlatform
      *
      * TODO: We have to investigate how to get DB2 up and running with savepoints.
      */
-    public function supportsSavepoints()
+    public function supportsSavepoints() : bool
     {
         return false;
     }
@@ -894,7 +889,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         return Keywords\DB2Keywords::class;
     }

--- a/lib/Doctrine/DBAL/Platforms/Keywords/DB2Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/DB2Keywords.php
@@ -12,7 +12,7 @@ class DB2Keywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'DB2';
     }
@@ -20,7 +20,7 @@ class DB2Keywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    protected function getKeywords()
+    protected function getKeywords() : array
     {
         return [
             'ACTIVATE',

--- a/lib/Doctrine/DBAL/Platforms/Keywords/KeywordList.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/KeywordList.php
@@ -18,12 +18,8 @@ abstract class KeywordList
 
     /**
      * Checks if the given word is a keyword of this dialect/vendor platform.
-     *
-     * @param string $word
-     *
-     * @return bool
      */
-    public function isKeyword($word)
+    public function isKeyword(string $word) : bool
     {
         if ($this->keywords === null) {
             $this->initializeKeywords();
@@ -32,10 +28,7 @@ abstract class KeywordList
         return isset($this->keywords[strtoupper($word)]);
     }
 
-    /**
-     * @return void
-     */
-    protected function initializeKeywords()
+    protected function initializeKeywords() : void
     {
         $this->keywords = array_flip(array_map('strtoupper', $this->getKeywords()));
     }
@@ -45,12 +38,10 @@ abstract class KeywordList
      *
      * @return string[]
      */
-    abstract protected function getKeywords();
+    abstract protected function getKeywords() : array;
 
     /**
      * Returns the name of this keyword list.
-     *
-     * @return string
      */
-    abstract public function getName();
+    abstract public function getName() : string;
 }

--- a/lib/Doctrine/DBAL/Platforms/Keywords/MySQL57Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/MySQL57Keywords.php
@@ -12,7 +12,7 @@ class MySQL57Keywords extends MySQLKeywords
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'MySQL57';
     }
@@ -22,7 +22,7 @@ class MySQL57Keywords extends MySQLKeywords
      *
      * @link http://dev.mysql.com/doc/mysqld-version-reference/en/mysqld-version-reference-reservedwords-5-7.html
      */
-    protected function getKeywords()
+    protected function getKeywords() : array
     {
         return [
             'ACCESSIBLE',

--- a/lib/Doctrine/DBAL/Platforms/Keywords/MySQL80Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/MySQL80Keywords.php
@@ -14,7 +14,7 @@ class MySQL80Keywords extends MySQL57Keywords
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'MySQL80';
     }
@@ -24,7 +24,7 @@ class MySQL80Keywords extends MySQL57Keywords
      *
      * @link https://dev.mysql.com/doc/refman/8.0/en/keywords.html
      */
-    protected function getKeywords()
+    protected function getKeywords() : array
     {
         $keywords = parent::getKeywords();
 

--- a/lib/Doctrine/DBAL/Platforms/Keywords/MySQLKeywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/MySQLKeywords.php
@@ -12,7 +12,7 @@ class MySQLKeywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'MySQL';
     }
@@ -20,7 +20,7 @@ class MySQLKeywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    protected function getKeywords()
+    protected function getKeywords() : array
     {
         return [
             'ACCESSIBLE',

--- a/lib/Doctrine/DBAL/Platforms/Keywords/OracleKeywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/OracleKeywords.php
@@ -12,7 +12,7 @@ class OracleKeywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'Oracle';
     }
@@ -20,7 +20,7 @@ class OracleKeywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    protected function getKeywords()
+    protected function getKeywords() : array
     {
         return [
             'ACCESS',

--- a/lib/Doctrine/DBAL/Platforms/Keywords/PostgreSQL94Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/PostgreSQL94Keywords.php
@@ -15,7 +15,7 @@ class PostgreSQL94Keywords extends PostgreSQLKeywords
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'PostgreSQL94';
     }
@@ -25,7 +25,7 @@ class PostgreSQL94Keywords extends PostgreSQLKeywords
      *
      * @link http://www.postgresql.org/docs/9.4/static/sql-keywords-appendix.html
      */
-    protected function getKeywords()
+    protected function getKeywords() : array
     {
         $parentKeywords = array_diff(parent::getKeywords(), ['OVER']);
 

--- a/lib/Doctrine/DBAL/Platforms/Keywords/PostgreSQLKeywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/PostgreSQLKeywords.php
@@ -12,7 +12,7 @@ class PostgreSQLKeywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'PostgreSQL';
     }
@@ -20,7 +20,7 @@ class PostgreSQLKeywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    protected function getKeywords()
+    protected function getKeywords() : array
     {
         return [
             'ALL',

--- a/lib/Doctrine/DBAL/Platforms/Keywords/ReservedKeywordsValidator.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/ReservedKeywordsValidator.php
@@ -33,17 +33,15 @@ class ReservedKeywordsValidator implements Visitor
     /**
      * @return string[]
      */
-    public function getViolations()
+    public function getViolations() : array
     {
         return $this->violations;
     }
 
     /**
-     * @param string $word
-     *
      * @return string[]
      */
-    private function isReservedWord($word)
+    private function isReservedWord(string $word) : array
     {
         if ($word[0] === '`') {
             $word = str_replace('`', '', $word);
@@ -62,12 +60,9 @@ class ReservedKeywordsValidator implements Visitor
     }
 
     /**
-     * @param string   $asset
      * @param string[] $violatedPlatforms
-     *
-     * @return void
      */
-    private function addViolation($asset, $violatedPlatforms)
+    private function addViolation(string $asset, array $violatedPlatforms) : void
     {
         if (! $violatedPlatforms) {
             return;
@@ -79,7 +74,7 @@ class ReservedKeywordsValidator implements Visitor
     /**
      * {@inheritdoc}
      */
-    public function acceptColumn(Table $table, Column $column)
+    public function acceptColumn(Table $table, Column $column) : void
     {
         $this->addViolation(
             'Table ' . $table->getName() . ' column ' . $column->getName(),
@@ -90,35 +85,35 @@ class ReservedKeywordsValidator implements Visitor
     /**
      * {@inheritdoc}
      */
-    public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint)
+    public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint) : void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function acceptIndex(Table $table, Index $index)
+    public function acceptIndex(Table $table, Index $index) : void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function acceptSchema(Schema $schema)
+    public function acceptSchema(Schema $schema) : void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function acceptSequence(Sequence $sequence)
+    public function acceptSequence(Sequence $sequence) : void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function acceptTable(Table $table)
+    public function acceptTable(Table $table) : void
     {
         $this->addViolation(
             'Table ' . $table->getName(),

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLAnywhereKeywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLAnywhereKeywords.php
@@ -12,7 +12,7 @@ class SQLAnywhereKeywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'SQLAnywhere';
     }
@@ -22,7 +22,7 @@ class SQLAnywhereKeywords extends KeywordList
      *
      * @link http://infocenter.sybase.com/help/topic/com.sybase.dbrfen10/pdf/dbrfen10.pdf?noframes=true
      */
-    protected function getKeywords()
+    protected function getKeywords() : array
     {
         return [
             'ADD',

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2012Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLServer2012Keywords.php
@@ -16,7 +16,7 @@ class SQLServer2012Keywords extends SQLServerKeywords
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'SQLServer2012';
     }
@@ -26,7 +26,7 @@ class SQLServer2012Keywords extends SQLServerKeywords
      *
      * @link http://msdn.microsoft.com/en-us/library/ms189822.aspx
      */
-    protected function getKeywords()
+    protected function getKeywords() : array
     {
         return array_merge(parent::getKeywords(), [
             'SEMANTICKEYPHRASETABLE',

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLServerKeywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLServerKeywords.php
@@ -14,7 +14,7 @@ class SQLServerKeywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'SQLServer';
     }
@@ -24,7 +24,7 @@ class SQLServerKeywords extends KeywordList
      *
      * @link http://msdn.microsoft.com/en-us/library/aa238507%28v=sql.80%29.aspx
      */
-    protected function getKeywords()
+    protected function getKeywords() : array
     {
         return [
             'ADD',

--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLiteKeywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLiteKeywords.php
@@ -12,7 +12,7 @@ class SQLiteKeywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'SQLite';
     }
@@ -20,7 +20,7 @@ class SQLiteKeywords extends KeywordList
     /**
      * {@inheritdoc}
      */
-    protected function getKeywords()
+    protected function getKeywords() : array
     {
         return [
             'ABORT',

--- a/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL57Platform.php
@@ -16,7 +16,7 @@ class MySQL57Platform extends MySqlPlatform
     /**
      * {@inheritdoc}
      */
-    public function hasNativeJsonType()
+    public function hasNativeJsonType() : bool
     {
         return true;
     }
@@ -24,7 +24,7 @@ class MySQL57Platform extends MySqlPlatform
     /**
      * {@inheritdoc}
      */
-    public function getJsonTypeDeclarationSQL(array $field)
+    public function getJsonTypeDeclarationSQL(array $field) : string
     {
         return 'JSON';
     }
@@ -32,7 +32,7 @@ class MySQL57Platform extends MySqlPlatform
     /**
      * {@inheritdoc}
      */
-    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff) : array
     {
         return [];
     }
@@ -40,7 +40,7 @@ class MySQL57Platform extends MySqlPlatform
     /**
      * {@inheritdoc}
      */
-    protected function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    protected function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff) : array
     {
         return [];
     }
@@ -48,7 +48,7 @@ class MySQL57Platform extends MySqlPlatform
     /**
      * {@inheritdoc}
      */
-    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
+    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName) : array
     {
         return ['ALTER TABLE ' . $tableName . ' RENAME INDEX ' . $oldIndexName . ' TO ' . $index->getQuotedName($this)];
     }
@@ -56,7 +56,7 @@ class MySQL57Platform extends MySqlPlatform
     /**
      * {@inheritdoc}
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         return Keywords\MySQL57Keywords::class;
     }
@@ -64,7 +64,7 @@ class MySQL57Platform extends MySqlPlatform
     /**
      * {@inheritdoc}
      */
-    protected function initializeDoctrineTypeMappings()
+    protected function initializeDoctrineTypeMappings() : void
     {
         parent::initializeDoctrineTypeMappings();
 

--- a/lib/Doctrine/DBAL/Platforms/MySQL80Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySQL80Platform.php
@@ -12,7 +12,7 @@ class MySQL80Platform extends MySQL57Platform
     /**
      * {@inheritdoc}
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         return Keywords\MySQL80Keywords::class;
     }

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -66,7 +66,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getIdentifierQuoteCharacter()
+    public function getIdentifierQuoteCharacter() : string
     {
         return '`';
     }
@@ -120,7 +120,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListDatabasesSQL()
+    public function getListDatabasesSQL() : string
     {
         return 'SHOW DATABASES';
     }
@@ -128,7 +128,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTableConstraintsSQL($table)
+    public function getListTableConstraintsSQL(string $table) : string
     {
         return 'SHOW INDEX FROM ' . $table;
     }
@@ -139,7 +139,7 @@ class MySqlPlatform extends AbstractPlatform
      * Two approaches to listing the table indexes. The information_schema is
      * preferred, because it doesn't cause problems with SQL keywords such as "order" or "table".
      */
-    public function getListTableIndexesSQL($table, $currentDatabase = null)
+    public function getListTableIndexesSQL(string $table, ?string $currentDatabase = null) : string
     {
         if ($currentDatabase) {
             $currentDatabase = $this->quoteStringLiteral($currentDatabase);
@@ -158,23 +158,17 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListViewsSQL($database)
+    public function getListViewsSQL(string $database) : string
     {
-        $database = $this->quoteStringLiteral($database);
-
-        return 'SELECT * FROM information_schema.VIEWS WHERE TABLE_SCHEMA = ' . $database;
+        return 'SELECT * FROM information_schema.VIEWS WHERE TABLE_SCHEMA = ' . $this->quoteStringLiteral($database);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getListTableForeignKeysSQL($table, $database = null)
+    public function getListTableForeignKeysSQL(string $table, ?string $database = null) : string
     {
         $table = $this->quoteStringLiteral($table);
-
-        if ($database !== null) {
-            $database = $this->quoteStringLiteral($database);
-        }
 
         $sql = 'SELECT DISTINCT k.`CONSTRAINT_NAME`, k.`COLUMN_NAME`, k.`REFERENCED_TABLE_NAME`, ' .
                'k.`REFERENCED_COLUMN_NAME` /*!50116 , c.update_rule, c.delete_rule */ ' .
@@ -183,7 +177,7 @@ class MySqlPlatform extends AbstractPlatform
                '  c.constraint_name = k.constraint_name AND ' .
                '  c.table_name = ' . $table . ' */ WHERE k.table_name = ' . $table;
 
-        $databaseNameSql = $database ?? 'DATABASE()';
+        $databaseNameSql = $this->getDatabaseNameSql($database);
 
         $sql .= ' AND k.table_schema = ' . $databaseNameSql . ' /*!50116 AND c.constraint_schema = ' . $databaseNameSql . ' */';
         $sql .= ' AND k.`REFERENCED_COLUMN_NAME` is not NULL';
@@ -194,7 +188,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateViewSQL($name, $sql)
+    public function getCreateViewSQL(string $name, string $sql) : string
     {
         return 'CREATE VIEW ' . $name . ' AS ' . $sql;
     }
@@ -202,7 +196,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDropViewSQL($name)
+    public function getDropViewSQL(string $name) : string
     {
         return 'DROP VIEW ' . $name;
     }
@@ -210,7 +204,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getVarcharTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return $fixed ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(255)')
                 : ($length ? 'VARCHAR(' . $length . ')' : 'VARCHAR(255)');
@@ -219,7 +213,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getBinaryTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return $fixed ? 'BINARY(' . ($length ?: 255) . ')' : 'VARBINARY(' . ($length ?: 255) . ')';
     }
@@ -233,7 +227,7 @@ class MySqlPlatform extends AbstractPlatform
      *
      * {@inheritDoc}
      */
-    public function getClobTypeDeclarationSQL(array $field)
+    public function getClobTypeDeclarationSQL(array $field) : string
     {
         if (! empty($field['length']) && is_numeric($field['length'])) {
             $length = $field['length'];
@@ -257,7 +251,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         if (isset($fieldDeclaration['version']) && $fieldDeclaration['version'] === true) {
             return 'TIMESTAMP';
@@ -269,7 +263,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDateTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DATE';
     }
@@ -277,7 +271,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'TIME';
     }
@@ -285,7 +279,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getBooleanTypeDeclarationSQL(array $field)
+    public function getBooleanTypeDeclarationSQL(array $columnDef) : string
     {
         return 'TINYINT(1)';
     }
@@ -296,7 +290,7 @@ class MySqlPlatform extends AbstractPlatform
      * MySql prefers "autoincrement" identity columns since sequences can only
      * be emulated with a table.
      */
-    public function prefersIdentityColumns()
+    public function prefersIdentityColumns() : bool
     {
         return true;
     }
@@ -306,7 +300,7 @@ class MySqlPlatform extends AbstractPlatform
      *
      * MySql supports this through AUTO_INCREMENT columns.
      */
-    public function supportsIdentityColumns()
+    public function supportsIdentityColumns() : bool
     {
         return true;
     }
@@ -314,7 +308,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsInlineColumnComments()
+    public function supportsInlineColumnComments() : bool
     {
         return true;
     }
@@ -322,7 +316,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsColumnCollation()
+    public function supportsColumnCollation() : bool
     {
         return true;
     }
@@ -330,7 +324,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTablesSQL()
+    public function getListTablesSQL() : string
     {
         return "SHOW FULL TABLES WHERE Table_type = 'BASE TABLE'";
     }
@@ -338,21 +332,13 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTableColumnsSQL($table, $database = null)
+    public function getListTableColumnsSQL(string $table, ?string $database = null) : string
     {
-        $table = $this->quoteStringLiteral($table);
-
-        if ($database) {
-            $database = $this->quoteStringLiteral($database);
-        } else {
-            $database = 'DATABASE()';
-        }
-
         return 'SELECT COLUMN_NAME AS Field, COLUMN_TYPE AS Type, IS_NULLABLE AS `Null`, ' .
                'COLUMN_KEY AS `Key`, COLUMN_DEFAULT AS `Default`, EXTRA AS Extra, COLUMN_COMMENT AS Comment, ' .
                'CHARACTER_SET_NAME AS CharacterSet, COLLATION_NAME AS Collation ' .
-               'FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ' . $database . ' AND TABLE_NAME = ' . $table .
-               ' ORDER BY ORDINAL_POSITION ASC';
+               'FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ' . $this->getDatabaseNameSql($database) . ' ' .
+               'AND TABLE_NAME = ' . $this->quoteStringLiteral($table) . ' ORDER BY ORDINAL_POSITION';
     }
 
     public function getListTableMetadataSQL(string $table, ?string $database = null) : string
@@ -372,23 +358,23 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreateDatabaseSQL($name)
+    public function getCreateDatabaseSQL(string $database) : string
     {
-        return 'CREATE DATABASE ' . $name;
+        return 'CREATE DATABASE ' . $database;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getDropDatabaseSQL($name)
+    public function getDropDatabaseSQL(string $database) : string
     {
-        return 'DROP DATABASE ' . $name;
+        return 'DROP DATABASE ' . $database;
     }
 
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL($tableName, array $columns, array $options = [])
+    protected function _getCreateTableSQL(string $tableName, array $columns, array $options = []) : array
     {
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
@@ -441,7 +427,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getDefaultValueDeclarationSQL($field)
+    public function getDefaultValueDeclarationSQL(array $field) : string
     {
         // Unset the default value if the given field definition does not allow default values.
         if ($field['type'] instanceof TextType || $field['type'] instanceof BlobType) {
@@ -455,10 +441,8 @@ SQL
      * Build SQL for table options
      *
      * @param mixed[] $options
-     *
-     * @return string
      */
-    private function buildTableOptions(array $options)
+    private function buildTableOptions(array $options) : string
     {
         if (isset($options['table_options'])) {
             return $options['table_options'];
@@ -511,10 +495,8 @@ SQL
      * Build SQL for partition options.
      *
      * @param mixed[] $options
-     *
-     * @return string
      */
-    private function buildPartitionOptions(array $options)
+    private function buildPartitionOptions(array $options) : string
     {
         return isset($options['partition_options'])
             ? ' ' . $options['partition_options']
@@ -524,7 +506,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getAlterTableSQL(TableDiff $diff)
+    public function getAlterTableSQL(TableDiff $diff) : array
     {
         $columnSql  = [];
         $queryParts = [];
@@ -622,7 +604,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff)
+    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff) : array
     {
         $sql   = [];
         $table = $diff->getName($this)->getQuotedName($this);
@@ -683,7 +665,7 @@ SQL
     /**
      * @return string[]
      */
-    private function getPreAlterTableAlterPrimaryKeySQL(TableDiff $diff, Index $index)
+    private function getPreAlterTableAlterPrimaryKeySQL(TableDiff $diff, Index $index) : array
     {
         $sql = [];
 
@@ -701,7 +683,7 @@ SQL
 
             $column = $diff->fromTable->getColumn($columnName);
 
-            if ($column->getAutoincrement() !== true) {
+            if (! $column->getAutoincrement()) {
                 continue;
             }
 
@@ -722,7 +704,7 @@ SQL
      *
      * @return string[]
      */
-    private function getPreAlterTableAlterIndexForeignKeySQL(TableDiff $diff)
+    private function getPreAlterTableAlterIndexForeignKeySQL(TableDiff $diff) : array
     {
         $sql   = [];
         $table = $diff->getName($this)->getQuotedName($this);
@@ -762,7 +744,7 @@ SQL
      *
      * @return string[]
      */
-    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff) : array
     {
         $sql       = [];
         $tableName = $diff->getName($this)->getQuotedName($this);
@@ -788,7 +770,7 @@ SQL
      *
      * @return ForeignKeyConstraint[]
      */
-    private function getRemainingForeignKeyConstraintsRequiringRenamedIndexes(TableDiff $diff)
+    private function getRemainingForeignKeyConstraintsRequiringRenamedIndexes(TableDiff $diff) : array
     {
         if (empty($diff->renamedIndexes) || ! $diff->fromTable instanceof Table) {
             return [];
@@ -817,7 +799,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff)
+    protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff) : array
     {
         return array_merge(
             parent::getPostAlterTableIndexForeignKeySQL($diff),
@@ -830,7 +812,7 @@ SQL
      *
      * @return string[]
      */
-    protected function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    protected function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff) : array
     {
         $sql     = [];
         $newName = $diff->getNewName();
@@ -855,7 +837,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function getCreateIndexSQLFlags(Index $index)
+    protected function getCreateIndexSQLFlags(Index $index) : string
     {
         $type = '';
         if ($index->isUnique()) {
@@ -872,39 +854,39 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getIntegerTypeDeclarationSQL(array $field)
+    public function getIntegerTypeDeclarationSQL(array $columnDef) : string
     {
-        return 'INT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'INT' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getBigIntTypeDeclarationSQL(array $field)
+    public function getBigIntTypeDeclarationSQL(array $columnDef) : string
     {
-        return 'BIGINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'BIGINT' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getSmallIntTypeDeclarationSQL(array $field)
+    public function getSmallIntTypeDeclarationSQL(array $columnDef) : string
     {
-        return 'SMALLINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'SMALLINT' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getFloatDeclarationSQL(array $field)
+    public function getFloatDeclarationSQL(array $fieldDeclaration) : string
     {
-        return 'DOUBLE PRECISION' . $this->getUnsignedDeclaration($field);
+        return 'DOUBLE PRECISION' . $this->getUnsignedDeclaration($fieldDeclaration);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getDecimalTypeDeclarationSQL(array $columnDef)
+    public function getDecimalTypeDeclarationSQL(array $columnDef) : string
     {
         return parent::getDecimalTypeDeclarationSQL($columnDef) . $this->getUnsignedDeclaration($columnDef);
     }
@@ -913,10 +895,8 @@ SQL
      * Get unsigned declaration for a column.
      *
      * @param mixed[] $columnDef
-     *
-     * @return string
      */
-    private function getUnsignedDeclaration(array $columnDef)
+    private function getUnsignedDeclaration(array $columnDef) : string
     {
         return ! empty($columnDef['unsigned']) ? ' UNSIGNED' : '';
     }
@@ -924,7 +904,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
+    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef) : string
     {
         $autoinc = '';
         if (! empty($columnDef['autoincrement'])) {
@@ -937,7 +917,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getColumnCharsetDeclarationSQL($charset)
+    public function getColumnCharsetDeclarationSQL(string $charset) : string
     {
         return 'CHARACTER SET ' . $charset;
     }
@@ -945,7 +925,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
+    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey) : string
     {
         $query = '';
         if ($foreignKey->hasOption('match')) {
@@ -959,7 +939,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDropIndexSQL($index, $table = null)
+    public function getDropIndexSQL($index, $table = null) : string
     {
         if ($index instanceof Index) {
             $indexName = $index->getQuotedName($this);
@@ -984,12 +964,7 @@ SQL
         return 'DROP INDEX ' . $indexName . ' ON ' . $table;
     }
 
-    /**
-     * @param string $table
-     *
-     * @return string
-     */
-    protected function getDropPrimaryKeySQL($table)
+    protected function getDropPrimaryKeySQL(string $table) : string
     {
         return 'ALTER TABLE ' . $table . ' DROP PRIMARY KEY';
     }
@@ -997,7 +972,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getSetTransactionIsolationSQL($level)
+    public function getSetTransactionIsolationSQL(int $level) : string
     {
         return 'SET SESSION TRANSACTION ISOLATION LEVEL ' . $this->_getTransactionIsolationLevelSQL($level);
     }
@@ -1005,7 +980,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'mysql';
     }
@@ -1013,7 +988,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getReadLockSQL()
+    public function getReadLockSQL() : string
     {
         return 'LOCK IN SHARE MODE';
     }
@@ -1021,7 +996,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function initializeDoctrineTypeMappings()
+    protected function initializeDoctrineTypeMappings() : void
     {
         $this->doctrineTypeMapping = [
             'bigint'     => 'bigint',
@@ -1060,7 +1035,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getVarcharMaxLength()
+    public function getVarcharMaxLength() : int
     {
         return 65535;
     }
@@ -1068,7 +1043,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getBinaryMaxLength()
+    public function getBinaryMaxLength() : int
     {
         return 65535;
     }
@@ -1076,7 +1051,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         return Keywords\MySQLKeywords::class;
     }
@@ -1087,7 +1062,7 @@ SQL
      * MySQL commits a transaction implicitly when DROP TABLE is executed, however not
      * if DROP TEMPORARY TABLE is executed.
      */
-    public function getDropTemporaryTableSQL($table)
+    public function getDropTemporaryTableSQL($table) : string
     {
         if ($table instanceof Table) {
             $table = $table->getQuotedName($this);
@@ -1107,7 +1082,7 @@ SQL
      *
      * {@inheritDoc}
      */
-    public function getBlobTypeDeclarationSQL(array $field)
+    public function getBlobTypeDeclarationSQL(array $field) : string
     {
         if (! empty($field['length']) && is_numeric($field['length'])) {
             $length = $field['length'];
@@ -1131,7 +1106,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function quoteStringLiteral($str)
+    public function quoteStringLiteral(string $str) : string
     {
         $str = str_replace('\\', '\\\\', $str); // MySQL requires backslashes to be escaped aswell.
 
@@ -1141,7 +1116,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getDefaultTransactionIsolationLevel()
+    public function getDefaultTransactionIsolationLevel() : int
     {
         return TransactionIsolationLevel::REPEATABLE_READ;
     }
@@ -1152,5 +1127,19 @@ SQL
     public function supportsColumnLengthIndexes() : bool
     {
         return true;
+    }
+
+    /**
+     * Returns an SQL expression representing the given database name or current database name
+     *
+     * @param string|null $database Database name
+     */
+    private function getDatabaseNameSql(?string $database) : string
+    {
+        if ($database === null) {
+            return 'DATABASE()';
+        }
+
+        return $this->quoteStringLiteral($database);
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -35,11 +35,9 @@ class OraclePlatform extends AbstractPlatform
      *
      * @link http://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements008.htm
      *
-     * @param string $identifier
-     *
      * @throws DBALException
      */
-    public static function assertValidIdentifier($identifier)
+    public static function assertValidIdentifier(string $identifier) : void
     {
         if (! preg_match('(^(([a-zA-Z]{1}[a-zA-Z0-9_$#]{0,})|("[^"]+"))$)', $identifier)) {
             throw new DBALException('Invalid Oracle identifier.');
@@ -61,7 +59,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getNowExpression($type = 'timestamp') : string
+    public function getNowExpression(string $type = 'timestamp') : string
     {
         switch ($type) {
             case 'date':
@@ -163,7 +161,7 @@ class OraclePlatform extends AbstractPlatform
      * Therefore we can use MINVALUE to be able to get a hint what START WITH was for later introspection
      * in {@see listSequences()}
      */
-    public function getCreateSequenceSQL(Sequence $sequence)
+    public function getCreateSequenceSQL(Sequence $sequence) : string
     {
         return 'CREATE SEQUENCE ' . $sequence->getQuotedName($this) .
                ' START WITH ' . $sequence->getInitialValue() .
@@ -175,7 +173,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getAlterSequenceSQL(Sequence $sequence)
+    public function getAlterSequenceSQL(Sequence $sequence) : string
     {
         return 'ALTER SEQUENCE ' . $sequence->getQuotedName($this) .
                ' INCREMENT BY ' . $sequence->getAllocationSize()
@@ -184,10 +182,8 @@ class OraclePlatform extends AbstractPlatform
 
     /**
      * Cache definition for sequences
-     *
-     * @return string
      */
-    private function getSequenceCacheSQL(Sequence $sequence)
+    private function getSequenceCacheSQL(Sequence $sequence) : string
     {
         if ($sequence->getCache() === 0) {
             return ' NOCACHE';
@@ -207,7 +203,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getSequenceNextValSQL($sequenceName)
+    public function getSequenceNextValSQL(string $sequenceName) : string
     {
         return 'SELECT ' . $sequenceName . '.nextval FROM DUAL';
     }
@@ -215,7 +211,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getSetTransactionIsolationSQL($level)
+    public function getSetTransactionIsolationSQL(int $level) : string
     {
         return 'SET TRANSACTION ISOLATION LEVEL ' . $this->_getTransactionIsolationLevelSQL($level);
     }
@@ -223,7 +219,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getTransactionIsolationLevelSQL($level)
+    protected function _getTransactionIsolationLevelSQL(int $level) : string
     {
         switch ($level) {
             case TransactionIsolationLevel::READ_UNCOMMITTED:
@@ -241,7 +237,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getBooleanTypeDeclarationSQL(array $field)
+    public function getBooleanTypeDeclarationSQL(array $columnDef) : string
     {
         return 'NUMBER(1)';
     }
@@ -249,7 +245,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getIntegerTypeDeclarationSQL(array $field)
+    public function getIntegerTypeDeclarationSQL(array $columnDef) : string
     {
         return 'NUMBER(10)';
     }
@@ -257,7 +253,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getBigIntTypeDeclarationSQL(array $field)
+    public function getBigIntTypeDeclarationSQL(array $columnDef) : string
     {
         return 'NUMBER(20)';
     }
@@ -265,7 +261,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getSmallIntTypeDeclarationSQL(array $field)
+    public function getSmallIntTypeDeclarationSQL(array $columnDef) : string
     {
         return 'NUMBER(5)';
     }
@@ -273,7 +269,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'TIMESTAMP(0)';
     }
@@ -281,7 +277,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'TIMESTAMP(0) WITH TIME ZONE';
     }
@@ -289,7 +285,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDateTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DATE';
     }
@@ -297,7 +293,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DATE';
     }
@@ -305,7 +301,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
+    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef) : string
     {
         return '';
     }
@@ -313,7 +309,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getVarcharTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return $fixed ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(2000)')
                 : ($length ? 'VARCHAR2(' . $length . ')' : 'VARCHAR2(4000)');
@@ -322,7 +318,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getBinaryTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return 'RAW(' . ($length ?: $this->getBinaryMaxLength()) . ')';
     }
@@ -330,7 +326,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getBinaryMaxLength()
+    public function getBinaryMaxLength() : int
     {
         return 2000;
     }
@@ -338,7 +334,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getClobTypeDeclarationSQL(array $field)
+    public function getClobTypeDeclarationSQL(array $field) : string
     {
         return 'CLOB';
     }
@@ -346,7 +342,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListDatabasesSQL()
+    public function getListDatabasesSQL() : string
     {
         return 'SELECT username FROM all_users';
     }
@@ -354,19 +350,18 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListSequencesSQL($database)
+    public function getListSequencesSQL(string $database) : string
     {
-        $database = $this->normalizeIdentifier($database);
-        $database = $this->quoteStringLiteral($database->getName());
-
-        return 'SELECT sequence_name, min_value, increment_by FROM sys.all_sequences ' .
-               'WHERE SEQUENCE_OWNER = ' . $database;
+        return 'SELECT SEQUENCE_NAME, MIN_VALUE, INCREMENT_BY FROM SYS.ALL_SEQUENCES WHERE SEQUENCE_OWNER = '
+            . $this->quoteStringLiteral(
+                $this->normalizeIdentifier($database)->getName()
+            );
     }
 
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL($tableName, array $columns, array $options = [])
+    protected function _getCreateTableSQL(string $tableName, array $columns, array $options = []) : array
     {
         $indexes            = $options['indexes'] ?? [];
         $options['indexes'] = [];
@@ -399,7 +394,7 @@ class OraclePlatform extends AbstractPlatform
      *
      * @link http://ezcomponents.org/docs/api/trunk/DatabaseSchema/ezcDbSchemaOracleReader.html
      */
-    public function getListTableIndexesSQL($table, $currentDatabase = null)
+    public function getListTableIndexesSQL(string $table, ?string $currentDatabase = null) : string
     {
         $table = $this->normalizeIdentifier($table);
         $table = $this->quoteStringLiteral($table->getName());
@@ -436,7 +431,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTablesSQL()
+    public function getListTablesSQL() : string
     {
         return 'SELECT * FROM sys.user_tables';
     }
@@ -444,7 +439,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListViewsSQL($database)
+    public function getListViewsSQL(string $database) : string
     {
         return 'SELECT view_name, text FROM sys.user_views';
     }
@@ -452,7 +447,7 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateViewSQL($name, $sql)
+    public function getCreateViewSQL(string $name, string $sql) : string
     {
         return 'CREATE VIEW ' . $name . ' AS ' . $sql;
     }
@@ -460,19 +455,15 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDropViewSQL($name)
+    public function getDropViewSQL(string $name) : string
     {
         return 'DROP VIEW ' . $name;
     }
 
     /**
-     * @param string $name
-     * @param string $table
-     * @param int    $start
-     *
      * @return string[]
      */
-    public function getCreateAutoincrementSql($name, $table, $start = 1)
+    public function getCreateAutoincrementSql(string $name, string $table, int $start = 1) : array
     {
         $tableIdentifier   = $this->normalizeIdentifier($table);
         $quotedTableName   = $tableIdentifier->getQuotedName($this);
@@ -536,7 +527,7 @@ END;';
      *
      * @return string[]
      */
-    public function getDropAutoincrementSql($table)
+    public function getDropAutoincrementSql(string $table) : array
     {
         $table                       = $this->normalizeIdentifier($table);
         $autoincrementIdentifierName = $this->getAutoincrementIdentifierName($table);
@@ -562,7 +553,7 @@ END;';
      *
      * @return Identifier The normalized identifier.
      */
-    private function normalizeIdentifier($name)
+    private function normalizeIdentifier(string $name) : Identifier
     {
         $identifier = new Identifier($name);
 
@@ -576,10 +567,8 @@ END;';
      * if the given table name is quoted by intention.
      *
      * @param Identifier $table The table identifier to return the autoincrement primary key identifier name for.
-     *
-     * @return string
      */
-    private function getAutoincrementIdentifierName(Identifier $table)
+    private function getAutoincrementIdentifierName(Identifier $table) : string
     {
         $identifierName = $table->getName() . '_AI_PK';
 
@@ -591,7 +580,7 @@ END;';
     /**
      * {@inheritDoc}
      */
-    public function getListTableForeignKeysSQL($table)
+    public function getListTableForeignKeysSQL(string $table, ?string $database = null) : string
     {
         $table = $this->normalizeIdentifier($table);
         $table = $this->quoteStringLiteral($table->getName());
@@ -623,7 +612,7 @@ END;';
     /**
      * {@inheritDoc}
      */
-    public function getListTableConstraintsSQL($table)
+    public function getListTableConstraintsSQL(string $table) : string
     {
         $table = $this->normalizeIdentifier($table);
         $table = $this->quoteStringLiteral($table->getName());
@@ -634,7 +623,7 @@ END;';
     /**
      * {@inheritDoc}
      */
-    public function getListTableColumnsSQL($table, $database = null)
+    public function getListTableColumnsSQL(string $table, ?string $database = null) : string
     {
         $table = $this->normalizeIdentifier($table);
         $table = $this->quoteStringLiteral($table->getName());
@@ -678,7 +667,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDropSequenceSQL($sequence)
+    public function getDropSequenceSQL($sequence) : string
     {
         if ($sequence instanceof Sequence) {
             $sequence = $sequence->getQuotedName($this);
@@ -690,7 +679,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDropForeignKeySQL($foreignKey, $table)
+    public function getDropForeignKeySQL($foreignKey, $table) : string
     {
         if (! $foreignKey instanceof ForeignKeyConstraint) {
             $foreignKey = new Identifier($foreignKey);
@@ -709,7 +698,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
+    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey) : string
     {
         $referentialAction = null;
 
@@ -723,7 +712,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getForeignKeyReferentialActionSQL($action)
+    public function getForeignKeyReferentialActionSQL(string $action) : string
     {
         $action = strtoupper($action);
 
@@ -747,7 +736,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDropDatabaseSQL($database)
+    public function getDropDatabaseSQL(string $database) : string
     {
         return 'DROP USER ' . $database . ' CASCADE';
     }
@@ -755,7 +744,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getAlterTableSQL(TableDiff $diff)
+    public function getAlterTableSQL(TableDiff $diff) : array
     {
         $sql         = [];
         $commentsSQL = [];
@@ -886,7 +875,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getColumnDeclarationSQL($name, array $field)
+    public function getColumnDeclarationSQL(string $name, array $field) : string
     {
         if (isset($field['columnDefinition'])) {
             $columnDef = $this->getCustomTypeDeclarationSQL($field);
@@ -915,7 +904,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
+    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName) : array
     {
         if (strpos($tableName, '.') !== false) {
             [$schema]     = explode('.', $tableName);
@@ -928,7 +917,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function prefersSequences()
+    public function prefersSequences() : bool
     {
         return true;
     }
@@ -936,7 +925,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function usesSequenceEmulatedIdentityColumns()
+    public function usesSequenceEmulatedIdentityColumns() : bool
     {
         return true;
     }
@@ -944,7 +933,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getIdentitySequenceName($tableName, $columnName)
+    public function getIdentitySequenceName(string $tableName, string $columnName) : string
     {
         $table = new Identifier($tableName);
 
@@ -963,7 +952,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function supportsCommentOnStatement()
+    public function supportsCommentOnStatement() : bool
     {
         return true;
     }
@@ -971,7 +960,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'oracle';
     }
@@ -1015,7 +1004,7 @@ SQL
      *
      * Oracle returns all column names in SQL result sets in uppercase.
      */
-    public function getSQLResultCasing($column)
+    public function getSQLResultCasing(string $column) : string
     {
         return strtoupper($column);
     }
@@ -1023,7 +1012,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreateTemporaryTableSnippetSQL()
+    public function getCreateTemporaryTableSnippetSQL() : string
     {
         return 'CREATE GLOBAL TEMPORARY TABLE';
     }
@@ -1031,7 +1020,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTzFormatString()
+    public function getDateTimeTzFormatString() : string
     {
         return 'Y-m-d H:i:sP';
     }
@@ -1039,7 +1028,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateFormatString()
+    public function getDateFormatString() : string
     {
         return 'Y-m-d 00:00:00';
     }
@@ -1047,7 +1036,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getTimeFormatString()
+    public function getTimeFormatString() : string
     {
         return '1900-01-01 H:i:s';
     }
@@ -1055,7 +1044,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function fixSchemaElementName($schemaElementName)
+    public function fixSchemaElementName(string $schemaElementName) : string
     {
         if (strlen($schemaElementName) > 30) {
             // Trim it
@@ -1068,7 +1057,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getMaxIdentifierLength()
+    public function getMaxIdentifierLength() : int
     {
         return 30;
     }
@@ -1076,7 +1065,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function supportsSequences()
+    public function supportsSequences() : bool
     {
         return true;
     }
@@ -1084,7 +1073,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function supportsForeignKeyOnUpdate()
+    public function supportsForeignKeyOnUpdate() : bool
     {
         return false;
     }
@@ -1092,7 +1081,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function supportsReleaseSavepoints()
+    public function supportsReleaseSavepoints() : bool
     {
         return false;
     }
@@ -1100,7 +1089,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getTruncateTableSQL($tableName, $cascade = false)
+    public function getTruncateTableSQL(string $tableName, bool $cascade = false) : string
     {
         $tableIdentifier = new Identifier($tableName);
 
@@ -1118,7 +1107,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function initializeDoctrineTypeMappings()
+    protected function initializeDoctrineTypeMappings() : void
     {
         $this->doctrineTypeMapping = [
             'binary_double'  => 'float',
@@ -1150,7 +1139,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function releaseSavePoint($savepoint)
+    public function releaseSavePoint(string $savepoint) : string
     {
         return '';
     }
@@ -1158,7 +1147,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         return Keywords\OracleKeywords::class;
     }
@@ -1166,7 +1155,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getBlobTypeDeclarationSQL(array $field)
+    public function getBlobTypeDeclarationSQL(array $field) : string
     {
         return 'BLOB';
     }

--- a/lib/Doctrine/DBAL/Platforms/PostgreSQL100Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSQL100Platform.php
@@ -19,7 +19,7 @@ class PostgreSQL100Platform extends PostgreSQL94Platform
         return PostgreSQL100Keywords::class;
     }
 
-    public function getListSequencesSQL($database) : string
+    public function getListSequencesSQL(string $database) : string
     {
         return 'SELECT sequence_name AS relname,
                        sequence_schema AS schemaname,

--- a/lib/Doctrine/DBAL/Platforms/PostgreSQL94Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSQL94Platform.php
@@ -13,8 +13,10 @@ class PostgreSQL94Platform extends PostgreSqlPlatform
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
-    public function getJsonTypeDeclarationSQL(array $field)
+    public function getJsonTypeDeclarationSQL(array $field) : string
     {
         if (! empty($field['jsonb'])) {
             return 'JSONB';
@@ -26,7 +28,7 @@ class PostgreSQL94Platform extends PostgreSqlPlatform
     /**
      * {@inheritdoc}
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         return Keywords\PostgreSQL94Keywords::class;
     }
@@ -34,7 +36,7 @@ class PostgreSQL94Platform extends PostgreSqlPlatform
     /**
      * {@inheritdoc}
      */
-    protected function initializeDoctrineTypeMappings()
+    protected function initializeDoctrineTypeMappings() : void
     {
         parent::initializeDoctrineTypeMappings();
 

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms;
 
-use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
@@ -69,12 +68,10 @@ class PostgreSqlPlatform extends AbstractPlatform
      * with regard to how booleans have to be handled.
      *
      * Enables use of 'true'/'false' or otherwise 1 and 0 instead.
-     *
-     * @param bool $flag
      */
-    public function setUseBooleanTrueFalseStrings($flag)
+    public function setUseBooleanTrueFalseStrings(bool $flag) : void
     {
-        $this->useBooleanTrueFalseStrings = (bool) $flag;
+        $this->useBooleanTrueFalseStrings = $flag;
     }
 
     /**
@@ -131,7 +128,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsSequences()
+    public function supportsSequences() : bool
     {
         return true;
     }
@@ -139,7 +136,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsSchemas()
+    public function supportsSchemas() : bool
     {
         return true;
     }
@@ -147,7 +144,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDefaultSchemaName()
+    public function getDefaultSchemaName() : string
     {
         return 'public';
     }
@@ -155,7 +152,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsIdentityColumns()
+    public function supportsIdentityColumns() : bool
     {
         return true;
     }
@@ -163,7 +160,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function supportsPartialIndexes()
+    public function supportsPartialIndexes() : bool
     {
         return true;
     }
@@ -171,7 +168,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function usesSequenceEmulatedIdentityColumns()
+    public function usesSequenceEmulatedIdentityColumns() : bool
     {
         return true;
     }
@@ -179,7 +176,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getIdentitySequenceName($tableName, $columnName)
+    public function getIdentitySequenceName(string $tableName, string $columnName) : string
     {
         return $tableName . '_' . $columnName . '_seq';
     }
@@ -187,7 +184,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsCommentOnStatement()
+    public function supportsCommentOnStatement() : bool
     {
         return true;
     }
@@ -195,7 +192,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function prefersSequences()
+    public function prefersSequences() : bool
     {
         return true;
     }
@@ -203,7 +200,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function hasNativeGuidType()
+    public function hasNativeGuidType() : bool
     {
         return true;
     }
@@ -211,7 +208,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListDatabasesSQL()
+    public function getListDatabasesSQL() : string
     {
         return 'SELECT datname FROM pg_database';
     }
@@ -219,7 +216,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListNamespacesSQL()
+    public function getListNamespacesSQL() : string
     {
         return "SELECT schema_name AS nspname
                 FROM   information_schema.schemata
@@ -230,7 +227,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListSequencesSQL($database)
+    public function getListSequencesSQL(string $database) : string
     {
         return "SELECT sequence_name AS relname,
                        sequence_schema AS schemaname
@@ -242,7 +239,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTablesSQL()
+    public function getListTablesSQL() : string
     {
         return "SELECT quote_ident(table_name) AS table_name,
                        table_schema AS schema_name
@@ -257,7 +254,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListViewsSQL($database)
+    public function getListViewsSQL(string $database) : string
     {
         return 'SELECT quote_ident(table_name) AS viewname,
                        table_schema AS schemaname,
@@ -269,7 +266,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTableForeignKeysSQL($table, $database = null)
+    public function getListTableForeignKeysSQL(string $table, ?string $database = null) : string
     {
         return 'SELECT quote_ident(r.conname) as conname, pg_catalog.pg_get_constraintdef(r.oid, true) as condef
                   FROM pg_catalog.pg_constraint r
@@ -285,7 +282,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateViewSQL($name, $sql)
+    public function getCreateViewSQL(string $name, string $sql) : string
     {
         return 'CREATE VIEW ' . $name . ' AS ' . $sql;
     }
@@ -293,7 +290,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDropViewSQL($name)
+    public function getDropViewSQL(string $name) : string
     {
         return 'DROP VIEW ' . $name;
     }
@@ -301,7 +298,7 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTableConstraintsSQL($table)
+    public function getListTableConstraintsSQL(string $table) : string
     {
         $table = new Identifier($table);
         $table = $this->quoteStringLiteral($table->getName());
@@ -330,7 +327,7 @@ SQL
      *
      * @link http://ezcomponents.org/docs/api/trunk/DatabaseSchema/ezcDbSchemaPgsqlReader.html
      */
-    public function getListTableIndexesSQL($table, $currentDatabase = null)
+    public function getListTableIndexesSQL(string $table, ?string $currentDatabase = null) : string
     {
         return 'SELECT quote_ident(relname) as relname, pg_index.indisunique, pg_index.indisprimary,
                        pg_index.indkey, pg_index.indrelid,
@@ -343,14 +340,7 @@ SQL
                  ) AND pg_index.indexrelid = oid';
     }
 
-    /**
-     * @param string $table
-     * @param string $classAlias
-     * @param string $namespaceAlias
-     *
-     * @return string
-     */
-    private function getTableWhereClause($table, $classAlias = 'c', $namespaceAlias = 'n')
+    private function getTableWhereClause(string $table, string $classAlias = 'c', string $namespaceAlias = 'n') : string
     {
         $whereClause = $namespaceAlias . ".nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast') AND ";
         if (strpos($table, '.') !== false) {
@@ -375,7 +365,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getListTableColumnsSQL($table, $database = null)
+    public function getListTableColumnsSQL(string $table, ?string $database = null) : string
     {
         return "SELECT
                     a.attnum,
@@ -413,9 +403,9 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreateDatabaseSQL($name)
+    public function getCreateDatabaseSQL(string $database) : string
     {
-        return 'CREATE DATABASE ' . $name;
+        return 'CREATE DATABASE ' . $database;
     }
 
     /**
@@ -424,10 +414,8 @@ SQL
      * This is useful to force DROP DATABASE operations which could fail because of active connections.
      *
      * @param string $database The name of the database to disallow new connections for.
-     *
-     * @return string
      */
-    public function getDisallowDatabaseConnectionsSQL($database)
+    public function getDisallowDatabaseConnectionsSQL(string $database) : string
     {
         return "UPDATE pg_database SET datallowconn = 'false' WHERE datname = " . $this->quoteStringLiteral($database);
     }
@@ -438,10 +426,8 @@ SQL
      * This is useful to force DROP DATABASE operations which could fail because of active connections.
      *
      * @param string $database The name of the database to close currently active connections for.
-     *
-     * @return string
      */
-    public function getCloseActiveDatabaseConnectionsSQL($database)
+    public function getCloseActiveDatabaseConnectionsSQL(string $database) : string
     {
         return 'SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '
             . $this->quoteStringLiteral($database);
@@ -450,7 +436,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
+    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey) : string
     {
         $query = '';
 
@@ -478,7 +464,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getAlterTableSQL(TableDiff $diff)
+    public function getAlterTableSQL(TableDiff $diff) : array
     {
         $sql         = [];
         $commentsSQL = [];
@@ -637,7 +623,7 @@ SQL
      *
      * @return bool True if the given column diff is an unchanged binary type column, false otherwise.
      */
-    private function isUnchangedBinaryColumn(ColumnDiff $columnDiff)
+    private function isUnchangedBinaryColumn(ColumnDiff $columnDiff) : bool
     {
         $columnType = $columnDiff->column->getType();
 
@@ -645,9 +631,9 @@ SQL
             return false;
         }
 
-        $fromColumn = $columnDiff->fromColumn instanceof Column ? $columnDiff->fromColumn : null;
+        $fromColumn = $columnDiff->fromColumn;
 
-        if ($fromColumn) {
+        if ($fromColumn !== null) {
             $fromColumnType = $fromColumn->getType();
 
             if (! $fromColumnType instanceof BinaryType && ! $fromColumnType instanceof BlobType) {
@@ -667,7 +653,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
+    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName) : array
     {
         if (strpos($tableName, '.') !== false) {
             [$schema]     = explode('.', $tableName);
@@ -680,7 +666,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getCommentOnColumnSQL($tableName, $columnName, $comment)
+    public function getCommentOnColumnSQL(string $tableName, string $columnName, ?string $comment) : string
     {
         $tableName  = new Identifier($tableName);
         $columnName = new Identifier($columnName);
@@ -697,7 +683,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreateSequenceSQL(Sequence $sequence)
+    public function getCreateSequenceSQL(Sequence $sequence) : string
     {
         return 'CREATE SEQUENCE ' . $sequence->getQuotedName($this) .
             ' INCREMENT BY ' . $sequence->getAllocationSize() .
@@ -709,7 +695,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getAlterSequenceSQL(Sequence $sequence)
+    public function getAlterSequenceSQL(Sequence $sequence) : string
     {
         return 'ALTER SEQUENCE ' . $sequence->getQuotedName($this) .
             ' INCREMENT BY ' . $sequence->getAllocationSize() .
@@ -718,10 +704,8 @@ SQL
 
     /**
      * Cache definition for sequences
-     *
-     * @return string
      */
-    private function getSequenceCacheSQL(Sequence $sequence)
+    private function getSequenceCacheSQL(Sequence $sequence) : string
     {
         if ($sequence->getCache() > 1) {
             return ' CACHE ' . $sequence->getCache();
@@ -733,7 +717,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDropSequenceSQL($sequence)
+    public function getDropSequenceSQL($sequence) : string
     {
         if ($sequence instanceof Sequence) {
             $sequence = $sequence->getQuotedName($this);
@@ -745,7 +729,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreateSchemaSQL($schemaName)
+    public function getCreateSchemaSQL(string $schemaName) : string
     {
         return 'CREATE SCHEMA ' . $schemaName;
     }
@@ -753,7 +737,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDropForeignKeySQL($foreignKey, $table)
+    public function getDropForeignKeySQL($foreignKey, $table) : string
     {
         return $this->getDropConstraintSQL($foreignKey, $table);
     }
@@ -761,7 +745,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL($tableName, array $columns, array $options = [])
+    protected function _getCreateTableSQL(string $tableName, array $columns, array $options = []) : array
     {
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
@@ -803,7 +787,7 @@ SQL
      *
      * @throws UnexpectedValueException
      */
-    private function convertSingleBooleanValue($value, $callback)
+    private function convertSingleBooleanValue($value, callable $callback)
     {
         if ($value === null) {
             return $callback(null);
@@ -846,7 +830,7 @@ SQL
      *
      * @return mixed
      */
-    private function doConvertBooleans($item, $callback)
+    private function doConvertBooleans($item, callable $callback)
     {
         if (is_array($item)) {
             foreach ($item as $key => $value) {
@@ -872,7 +856,7 @@ SQL
 
         return $this->doConvertBooleans(
             $item,
-            static function ($boolean) {
+            static function ($boolean) : string {
                 if ($boolean === null) {
                     return 'NULL';
                 }
@@ -893,7 +877,7 @@ SQL
 
         return $this->doConvertBooleans(
             $item,
-            static function ($boolean) {
+            static function ($boolean) : ?int {
                 return $boolean === null ? null : (int) $boolean;
             }
         );
@@ -902,7 +886,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function convertFromBoolean($item)
+    public function convertFromBoolean($item) : ?bool
     {
         if (in_array($item, $this->booleanLiterals['false'], true)) {
             return false;
@@ -914,7 +898,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getSequenceNextValSQL($sequenceName)
+    public function getSequenceNextValSQL(string $sequenceName) : string
     {
         return "SELECT NEXTVAL('" . $sequenceName . "')";
     }
@@ -922,7 +906,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getSetTransactionIsolationSQL($level)
+    public function getSetTransactionIsolationSQL(int $level) : string
     {
         return 'SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL '
             . $this->_getTransactionIsolationLevelSQL($level);
@@ -931,7 +915,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getBooleanTypeDeclarationSQL(array $field)
+    public function getBooleanTypeDeclarationSQL(array $columnDef) : string
     {
         return 'BOOLEAN';
     }
@@ -939,9 +923,9 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getIntegerTypeDeclarationSQL(array $field)
+    public function getIntegerTypeDeclarationSQL(array $columnDef) : string
     {
-        if (! empty($field['autoincrement'])) {
+        if (! empty($columnDef['autoincrement'])) {
             return 'SERIAL';
         }
 
@@ -951,9 +935,9 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getBigIntTypeDeclarationSQL(array $field)
+    public function getBigIntTypeDeclarationSQL(array $columnDef) : string
     {
-        if (! empty($field['autoincrement'])) {
+        if (! empty($columnDef['autoincrement'])) {
             return 'BIGSERIAL';
         }
 
@@ -963,9 +947,9 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getSmallIntTypeDeclarationSQL(array $field)
+    public function getSmallIntTypeDeclarationSQL(array $columnDef) : string
     {
-        if (! empty($field['autoincrement'])) {
+        if (! empty($columnDef['autoincrement'])) {
             return 'SMALLSERIAL';
         }
 
@@ -975,7 +959,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getGuidTypeDeclarationSQL(array $field)
+    public function getGuidTypeDeclarationSQL(array $field) : string
     {
         return 'UUID';
     }
@@ -983,7 +967,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'TIMESTAMP(0) WITHOUT TIME ZONE';
     }
@@ -991,7 +975,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'TIMESTAMP(0) WITH TIME ZONE';
     }
@@ -999,7 +983,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DATE';
     }
@@ -1007,7 +991,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'TIME(0) WITHOUT TIME ZONE';
     }
@@ -1015,7 +999,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
+    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef) : string
     {
         return '';
     }
@@ -1023,7 +1007,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getVarcharTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return $fixed ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(255)')
             : ($length ? 'VARCHAR(' . $length . ')' : 'VARCHAR(255)');
@@ -1032,7 +1016,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getBinaryTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return 'BYTEA';
     }
@@ -1040,7 +1024,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getClobTypeDeclarationSQL(array $field)
+    public function getClobTypeDeclarationSQL(array $field) : string
     {
         return 'TEXT';
     }
@@ -1048,7 +1032,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'postgresql';
     }
@@ -1058,7 +1042,7 @@ SQL
      *
      * PostgreSQL returns all column names in SQL result sets in lowercase.
      */
-    public function getSQLResultCasing($column)
+    public function getSQLResultCasing(string $column) : string
     {
         return strtolower($column);
     }
@@ -1066,7 +1050,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTzFormatString()
+    public function getDateTimeTzFormatString() : string
     {
         return 'Y-m-d H:i:sO';
     }
@@ -1074,15 +1058,15 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getEmptyIdentityInsertSQL($quotedTableName, $quotedIdentifierColumnName)
+    public function getEmptyIdentityInsertSQL(string $tableName, string $identifierColumnName) : string
     {
-        return 'INSERT INTO ' . $quotedTableName . ' (' . $quotedIdentifierColumnName . ') VALUES (DEFAULT)';
+        return 'INSERT INTO ' . $tableName . ' (' . $identifierColumnName . ') VALUES (DEFAULT)';
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getTruncateTableSQL($tableName, $cascade = false)
+    public function getTruncateTableSQL(string $tableName, bool $cascade = false) : string
     {
         $tableIdentifier = new Identifier($tableName);
         $sql             = 'TRUNCATE ' . $tableIdentifier->getQuotedName($this);
@@ -1097,7 +1081,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getReadLockSQL()
+    public function getReadLockSQL() : string
     {
         return 'FOR SHARE';
     }
@@ -1105,7 +1089,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function initializeDoctrineTypeMappings()
+    protected function initializeDoctrineTypeMappings() : void
     {
         $this->doctrineTypeMapping = [
             'bigint'           => 'bigint',
@@ -1154,7 +1138,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getVarcharMaxLength()
+    public function getVarcharMaxLength() : int
     {
         return 65535;
     }
@@ -1162,7 +1146,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getBinaryMaxLength()
+    public function getBinaryMaxLength() : int
     {
         return 0;
     }
@@ -1170,7 +1154,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getBinaryDefaultLength()
+    public function getBinaryDefaultLength() : int
     {
         return 0;
     }
@@ -1178,7 +1162,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function hasNativeJsonType()
+    public function hasNativeJsonType() : bool
     {
         return true;
     }
@@ -1186,7 +1170,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         return Keywords\PostgreSQLKeywords::class;
     }
@@ -1194,7 +1178,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getBlobTypeDeclarationSQL(array $field)
+    public function getBlobTypeDeclarationSQL(array $field) : string
     {
         return 'BYTEA';
     }
@@ -1202,7 +1186,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getDefaultValueDeclarationSQL($field)
+    public function getDefaultValueDeclarationSQL(array $field) : string
     {
         if ($this->isSerialField($field)) {
             return '';
@@ -1214,7 +1198,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function supportsColumnCollation()
+    public function supportsColumnCollation() : bool
     {
         return true;
     }
@@ -1222,7 +1206,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getColumnCollationDeclarationSQL($collation)
+    public function getColumnCollationDeclarationSQL(string $collation) : string
     {
         return 'COLLATE ' . $this->quoteSingleIdentifier($collation);
     }
@@ -1230,7 +1214,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getJsonTypeDeclarationSQL(array $field)
+    public function getJsonTypeDeclarationSQL(array $field) : string
     {
         return 'JSON';
     }
@@ -1250,7 +1234,7 @@ SQL
      */
     private function typeChangeBreaksDefaultValue(ColumnDiff $columnDiff) : bool
     {
-        if (! $columnDiff->fromColumn) {
+        if ($columnDiff->fromColumn === null) {
             return $columnDiff->hasChanged('type');
         }
 
@@ -1269,6 +1253,10 @@ SQL
 
     private function getOldColumnComment(ColumnDiff $columnDiff) : ?string
     {
-        return $columnDiff->fromColumn ? $this->getColumnComment($columnDiff->fromColumn) : null;
+        if ($columnDiff->fromColumn === null) {
+            return null;
+        }
+
+        return $this->getColumnComment($columnDiff->fromColumn);
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -48,7 +48,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function appendLockHint($fromClause, $lockMode)
+    public function appendLockHint(string $fromClause, ?int $lockMode) : string
     {
         switch (true) {
             case $lockMode === LockMode::NONE:
@@ -70,7 +70,7 @@ class SQLAnywherePlatform extends AbstractPlatform
      *
      * SQL Anywhere supports a maximum length of 128 bytes for identifiers.
      */
-    public function fixSchemaElementName($schemaElementName)
+    public function fixSchemaElementName(string $schemaElementName) : string
     {
         $maxIdentifierLength = $this->getMaxIdentifierLength();
 
@@ -84,7 +84,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
+    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey) : string
     {
         $query = '';
 
@@ -112,7 +112,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getAlterTableSQL(TableDiff $diff)
+    public function getAlterTableSQL(TableDiff $diff) : array
     {
         $sql          = [];
         $columnSql    = [];
@@ -209,10 +209,8 @@ class SQLAnywherePlatform extends AbstractPlatform
      * Returns the SQL clause for creating a column in a table alteration.
      *
      * @param Column $column The column to add.
-     *
-     * @return string
      */
-    protected function getAlterTableAddColumnClause(Column $column)
+    protected function getAlterTableAddColumnClause(Column $column) : string
     {
         return 'ADD ' . $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray());
     }
@@ -221,10 +219,8 @@ class SQLAnywherePlatform extends AbstractPlatform
      * Returns the SQL clause for altering a table.
      *
      * @param Identifier $tableName The quoted name of the table to alter.
-     *
-     * @return string
      */
-    protected function getAlterTableClause(Identifier $tableName)
+    protected function getAlterTableClause(Identifier $tableName) : string
     {
         return 'ALTER TABLE ' . $tableName->getQuotedName($this);
     }
@@ -233,10 +229,8 @@ class SQLAnywherePlatform extends AbstractPlatform
      * Returns the SQL clause for dropping a column in a table alteration.
      *
      * @param Column $column The column to drop.
-     *
-     * @return string
      */
-    protected function getAlterTableRemoveColumnClause(Column $column)
+    protected function getAlterTableRemoveColumnClause(Column $column) : string
     {
         return 'DROP ' . $column->getQuotedName($this);
     }
@@ -246,10 +240,8 @@ class SQLAnywherePlatform extends AbstractPlatform
      *
      * @param string $oldColumnName The quoted name of the column to rename.
      * @param Column $column        The column to rename to.
-     *
-     * @return string
      */
-    protected function getAlterTableRenameColumnClause($oldColumnName, Column $column)
+    protected function getAlterTableRenameColumnClause(string $oldColumnName, Column $column) : string
     {
         $oldColumnName = new Identifier($oldColumnName);
 
@@ -260,10 +252,8 @@ class SQLAnywherePlatform extends AbstractPlatform
      * Returns the SQL clause for renaming a table in a table alteration.
      *
      * @param Identifier $newTableName The quoted name of the table to rename to.
-     *
-     * @return string
      */
-    protected function getAlterTableRenameTableClause(Identifier $newTableName)
+    protected function getAlterTableRenameTableClause(Identifier $newTableName) : string
     {
         return 'RENAME ' . $newTableName->getQuotedName($this);
     }
@@ -275,10 +265,8 @@ class SQLAnywherePlatform extends AbstractPlatform
      * Changes in column comments have to be handled differently.
      *
      * @param ColumnDiff $columnDiff The diff of the column to alter.
-     *
-     * @return string|null
      */
-    protected function getAlterTableChangeColumnClause(ColumnDiff $columnDiff)
+    protected function getAlterTableChangeColumnClause(ColumnDiff $columnDiff) : ?string
     {
         $column = $columnDiff->column;
 
@@ -300,7 +288,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getBigIntTypeDeclarationSQL(array $columnDef)
+    public function getBigIntTypeDeclarationSQL(array $columnDef) : string
     {
         $columnDef['integer_type'] = 'BIGINT';
 
@@ -310,7 +298,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getBinaryDefaultLength()
+    public function getBinaryDefaultLength() : int
     {
         return 1;
     }
@@ -318,7 +306,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getBinaryMaxLength()
+    public function getBinaryMaxLength() : int
     {
         return 32767;
     }
@@ -326,7 +314,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getBlobTypeDeclarationSQL(array $field)
+    public function getBlobTypeDeclarationSQL(array $field) : string
     {
         return 'LONG BINARY';
     }
@@ -339,7 +327,7 @@ class SQLAnywherePlatform extends AbstractPlatform
      * Otherwise by just omitting the NOT NULL clause,
      * SQL Anywhere will declare them NOT NULL nonetheless.
      */
-    public function getBooleanTypeDeclarationSQL(array $columnDef)
+    public function getBooleanTypeDeclarationSQL(array $columnDef) : string
     {
         $nullClause = isset($columnDef['notnull']) && (bool) $columnDef['notnull'] === false ? ' NULL' : '';
 
@@ -349,7 +337,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getClobTypeDeclarationSQL(array $field)
+    public function getClobTypeDeclarationSQL(array $field) : string
     {
         return 'TEXT';
     }
@@ -357,7 +345,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCommentOnColumnSQL($tableName, $columnName, $comment)
+    public function getCommentOnColumnSQL(string $tableName, string $columnName, ?string $comment) : string
     {
         $tableName  = new Identifier($tableName);
         $columnName = new Identifier($columnName);
@@ -382,7 +370,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCreateConstraintSQL(Constraint $constraint, $table)
+    public function getCreateConstraintSQL(Constraint $constraint, $table) : string
     {
         if ($constraint instanceof ForeignKeyConstraint) {
             return $this->getCreateForeignKeySQL($constraint, $table);
@@ -399,7 +387,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCreateDatabaseSQL($database)
+    public function getCreateDatabaseSQL(string $database) : string
     {
         $database = new Identifier($database);
 
@@ -411,7 +399,7 @@ class SQLAnywherePlatform extends AbstractPlatform
      *
      * Appends SQL Anywhere specific flags if given.
      */
-    public function getCreateIndexSQL(Index $index, $table)
+    public function getCreateIndexSQL(Index $index, $table) : string
     {
         return parent::getCreateIndexSQL($index, $table) . $this->getAdvancedIndexOptionsSQL($index);
     }
@@ -419,7 +407,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCreatePrimaryKeySQL(Index $index, $table)
+    public function getCreatePrimaryKeySQL(Index $index, $table) : string
     {
         if ($table instanceof Table) {
             $table = $table->getQuotedName($this);
@@ -431,7 +419,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCreateTemporaryTableSnippetSQL()
+    public function getCreateTemporaryTableSnippetSQL() : string
     {
         return 'CREATE ' . $this->getTemporaryTableSQL() . ' TABLE';
     }
@@ -439,7 +427,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCreateViewSQL($name, $sql)
+    public function getCreateViewSQL(string $name, string $sql) : string
     {
         return 'CREATE VIEW ' . $name . ' AS ' . $sql;
     }
@@ -447,7 +435,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCurrentDateSQL()
+    public function getCurrentDateSQL() : string
     {
         return 'CURRENT DATE';
     }
@@ -455,7 +443,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCurrentTimeSQL()
+    public function getCurrentTimeSQL() : string
     {
         return 'CURRENT TIME';
     }
@@ -463,7 +451,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCurrentTimestampSQL()
+    public function getCurrentTimestampSQL() : string
     {
         return 'CURRENT TIMESTAMP';
     }
@@ -493,7 +481,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDateTimeFormatString()
+    public function getDateTimeFormatString() : string
     {
         return 'Y-m-d H:i:s.u';
     }
@@ -501,7 +489,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DATETIME';
     }
@@ -509,7 +497,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDateTimeTzFormatString()
+    public function getDateTimeTzFormatString() : string
     {
         return 'Y-m-d H:i:s.uP';
     }
@@ -517,7 +505,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDateTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DATE';
     }
@@ -525,7 +513,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDefaultTransactionIsolationLevel()
+    public function getDefaultTransactionIsolationLevel() : int
     {
         return TransactionIsolationLevel::READ_UNCOMMITTED;
     }
@@ -533,7 +521,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDropDatabaseSQL($database)
+    public function getDropDatabaseSQL(string $database) : string
     {
         $database = new Identifier($database);
 
@@ -543,7 +531,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDropIndexSQL($index, $table = null)
+    public function getDropIndexSQL($index, $table = null) : string
     {
         if ($index instanceof Index) {
             $index = $index->getQuotedName($this);
@@ -575,7 +563,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDropViewSQL($name)
+    public function getDropViewSQL(string $name) : string
     {
         return 'DROP VIEW ' . $name;
     }
@@ -583,7 +571,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey)
+    public function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey) : string
     {
         $sql              = '';
         $foreignKeyName   = $foreignKey->getName();
@@ -622,13 +610,11 @@ class SQLAnywherePlatform extends AbstractPlatform
      *
      * @param int $type The foreign key match type
      *
-     * @return string
-     *
      * @throws InvalidArgumentException If unknown match type given.
      */
-    public function getForeignKeyMatchClauseSQL($type)
+    public function getForeignKeyMatchClauseSQL(int $type) : string
     {
-        switch ((int) $type) {
+        switch ($type) {
             case self::FOREIGN_KEY_MATCH_SIMPLE:
                 return 'SIMPLE';
 
@@ -651,7 +637,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getForeignKeyReferentialActionSQL($action)
+    public function getForeignKeyReferentialActionSQL(string $action) : string
     {
         // NO ACTION is not supported, therefore falling back to RESTRICT.
         if (strtoupper($action) === 'NO ACTION') {
@@ -664,7 +650,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getForUpdateSQL()
+    public function getForUpdateSQL() : string
     {
         return '';
     }
@@ -672,7 +658,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getGuidTypeDeclarationSQL(array $field)
+    public function getGuidTypeDeclarationSQL(array $field) : string
     {
         return 'UNIQUEIDENTIFIER';
     }
@@ -680,7 +666,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getIndexDeclarationSQL($name, Index $index)
+    public function getIndexDeclarationSQL(string $name, Index $index) : string
     {
         // Index declaration in statements like CREATE TABLE is not supported.
         throw NotSupported::new(__METHOD__);
@@ -689,7 +675,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getIntegerTypeDeclarationSQL(array $columnDef)
+    public function getIntegerTypeDeclarationSQL(array $columnDef) : string
     {
         $columnDef['integer_type'] = 'INT';
 
@@ -699,7 +685,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getListDatabasesSQL()
+    public function getListDatabasesSQL() : string
     {
         return 'SELECT db_name(number) AS name FROM sa_db_list()';
     }
@@ -707,7 +693,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getListTableColumnsSQL($table, $database = null)
+    public function getListTableColumnsSQL(string $table, ?string $database = null) : string
     {
         $user = 'USER_NAME()';
 
@@ -746,7 +732,7 @@ SQL
      *
      * @todo Where is this used? Which information should be retrieved?
      */
-    public function getListTableConstraintsSQL($table)
+    public function getListTableConstraintsSQL(string $table) : string
     {
         $user = '';
 
@@ -775,7 +761,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getListTableForeignKeysSQL($table)
+    public function getListTableForeignKeysSQL(string $table, ?string $database = null) : string
     {
         $user = '';
 
@@ -868,7 +854,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getListTableIndexesSQL($table, $currentDatabase = null)
+    public function getListTableIndexesSQL(string $table, ?string $currentDatabase = null) : string
     {
         $user = '';
 
@@ -928,7 +914,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getListTablesSQL()
+    public function getListTablesSQL() : string
     {
         return "SELECT   tbl.table_name
                 FROM     SYS.SYSTAB AS tbl
@@ -945,7 +931,7 @@ SQL
      *
      * @todo Where is this used? Which information should be retrieved?
      */
-    public function getListUsersSQL()
+    public function getListUsersSQL() : string
     {
         return 'SELECT * FROM SYS.SYSUSER ORDER BY user_name ASC';
     }
@@ -953,7 +939,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getListViewsSQL($database)
+    public function getListViewsSQL(string $database) : string
     {
         return "SELECT   tbl.table_name, v.view_def
                 FROM     SYS.SYSVIEW v
@@ -979,7 +965,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getMaxIdentifierLength()
+    public function getMaxIdentifierLength() : int
     {
         return 128;
     }
@@ -1003,7 +989,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'sqlanywhere';
     }
@@ -1019,7 +1005,7 @@ SQL
      *
      * @throws InvalidArgumentException If the given index is not a primary key.
      */
-    public function getPrimaryKeyDeclarationSQL(Index $index, $name = null)
+    public function getPrimaryKeyDeclarationSQL(Index $index, ?string $name = null) : string
     {
         if (! $index->isPrimary()) {
             throw new InvalidArgumentException(
@@ -1033,7 +1019,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getSetTransactionIsolationSQL($level)
+    public function getSetTransactionIsolationSQL(int $level) : string
     {
         return 'SET TEMPORARY OPTION isolation_level = ' . $this->_getTransactionIsolationLevelSQL($level);
     }
@@ -1041,7 +1027,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getSmallIntTypeDeclarationSQL(array $columnDef)
+    public function getSmallIntTypeDeclarationSQL(array $columnDef) : string
     {
         $columnDef['integer_type'] = 'SMALLINT';
 
@@ -1058,10 +1044,8 @@ SQL
      * SQL Anywhere does not automatically start a database after creation!
      *
      * @param string $database Name of the database to start.
-     *
-     * @return string
      */
-    public function getStartDatabaseSQL($database)
+    public function getStartDatabaseSQL(string $database) : string
     {
         $database = new Identifier($database);
 
@@ -1077,10 +1061,8 @@ SQL
      * as it has to be explicitly stopped before it can be dropped.
      *
      * @param string $database Name of the database to stop.
-     *
-     * @return string
      */
-    public function getStopDatabaseSQL($database)
+    public function getStopDatabaseSQL(string $database) : string
     {
         $database = new Identifier($database);
 
@@ -1102,7 +1084,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getTemporaryTableSQL()
+    public function getTemporaryTableSQL() : string
     {
         return 'GLOBAL TEMPORARY';
     }
@@ -1110,7 +1092,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getTimeFormatString()
+    public function getTimeFormatString() : string
     {
         return 'H:i:s.u';
     }
@@ -1118,7 +1100,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'TIME';
     }
@@ -1161,7 +1143,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getTruncateTableSQL($tableName, $cascade = false)
+    public function getTruncateTableSQL(string $tableName, bool $cascade = false) : string
     {
         $tableIdentifier = new Identifier($tableName);
 
@@ -1171,7 +1153,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getCreateSequenceSQL(Sequence $sequence)
+    public function getCreateSequenceSQL(Sequence $sequence) : string
     {
         return 'CREATE SEQUENCE ' . $sequence->getQuotedName($this) .
             ' INCREMENT BY ' . $sequence->getAllocationSize() .
@@ -1182,7 +1164,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getAlterSequenceSQL(Sequence $sequence)
+    public function getAlterSequenceSQL(Sequence $sequence) : string
     {
         return 'ALTER SEQUENCE ' . $sequence->getQuotedName($this) .
             ' INCREMENT BY ' . $sequence->getAllocationSize();
@@ -1191,7 +1173,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getDropSequenceSQL($sequence)
+    public function getDropSequenceSQL($sequence) : string
     {
         if ($sequence instanceof Sequence) {
             $sequence = $sequence->getQuotedName($this);
@@ -1203,7 +1185,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getListSequencesSQL($database)
+    public function getListSequencesSQL(string $database) : string
     {
         return 'SELECT sequence_name, increment_by, start_with, min_value FROM SYS.SYSSEQUENCE';
     }
@@ -1211,7 +1193,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getSequenceNextValSQL($sequenceName)
+    public function getSequenceNextValSQL(string $sequenceName) : string
     {
         return 'SELECT ' . $sequenceName . '.NEXTVAL';
     }
@@ -1219,7 +1201,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function supportsSequences()
+    public function supportsSequences() : bool
     {
         return true;
     }
@@ -1227,7 +1209,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'TIMESTAMP WITH TIME ZONE';
     }
@@ -1235,7 +1217,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getVarcharDefaultLength()
+    public function getVarcharDefaultLength() : int
     {
         return 1;
     }
@@ -1243,7 +1225,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getVarcharMaxLength()
+    public function getVarcharMaxLength() : int
     {
         return 32767;
     }
@@ -1251,7 +1233,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function hasNativeGuidType()
+    public function hasNativeGuidType() : bool
     {
         return true;
     }
@@ -1259,7 +1241,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function prefersIdentityColumns()
+    public function prefersIdentityColumns() : bool
     {
         return true;
     }
@@ -1267,7 +1249,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function supportsCommentOnStatement()
+    public function supportsCommentOnStatement() : bool
     {
         return true;
     }
@@ -1275,7 +1257,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function supportsIdentityColumns()
+    public function supportsIdentityColumns() : bool
     {
         return true;
     }
@@ -1283,7 +1265,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
+    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef) : string
     {
         $unsigned      = ! empty($columnDef['unsigned']) ? 'UNSIGNED ' : '';
         $autoincrement = ! empty($columnDef['autoincrement']) ? ' IDENTITY' : '';
@@ -1294,7 +1276,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function _getCreateTableSQL($tableName, array $columns, array $options = [])
+    protected function _getCreateTableSQL(string $tableName, array $columns, array $options = []) : array
     {
         $columnListSql = $this->getColumnDeclarationListSQL($columns);
         $indexSql      = [];
@@ -1343,17 +1325,17 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function _getTransactionIsolationLevelSQL($level)
+    protected function _getTransactionIsolationLevelSQL(int $level) : string
     {
         switch ($level) {
             case TransactionIsolationLevel::READ_UNCOMMITTED:
-                return 0;
+                return '0';
             case TransactionIsolationLevel::READ_COMMITTED:
-                return 1;
+                return '1';
             case TransactionIsolationLevel::REPEATABLE_READ:
-                return 2;
+                return '2';
             case TransactionIsolationLevel::SERIALIZABLE:
-                return 3;
+                return '3';
             default:
                 throw new InvalidArgumentException(sprintf('Invalid isolation level %d.', $level));
         }
@@ -1391,10 +1373,8 @@ SQL
      * SQL Anywhere options.
      *
      * @param Index $index Index definition
-     *
-     * @return string
      */
-    protected function getAdvancedIndexOptionsSQL(Index $index)
+    protected function getAdvancedIndexOptionsSQL(Index $index) : string
     {
         if ($index->hasFlag('with_nulls_distinct') && $index->hasFlag('with_nulls_not_distinct')) {
             throw new UnexpectedValueException(
@@ -1422,7 +1402,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getBinaryTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return $fixed
             ? 'BINARY(' . ($length ?: $this->getBinaryDefaultLength()) . ')'
@@ -1435,11 +1415,9 @@ SQL
      * @param Constraint  $constraint The table constraint to create the SQL snippet for.
      * @param string|null $name       The table constraint name to use if any.
      *
-     * @return string
-     *
      * @throws InvalidArgumentException If the given table constraint type is not supported by this method.
      */
-    protected function getTableConstraintDeclarationSQL(Constraint $constraint, $name = null)
+    protected function getTableConstraintDeclarationSQL(Constraint $constraint, ?string $name = null) : string
     {
         if ($constraint instanceof ForeignKeyConstraint) {
             return $this->getForeignKeyDeclarationSQL($constraint);
@@ -1484,7 +1462,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getCreateIndexSQLFlags(Index $index)
+    protected function getCreateIndexSQLFlags(Index $index) : string
     {
         $type = '';
         if ($index->hasFlag('virtual')) {
@@ -1505,7 +1483,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
+    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName) : array
     {
         return ['ALTER INDEX ' . $oldIndexName . ' ON ' . $tableName . ' RENAME TO ' . $index->getQuotedName($this)];
     }
@@ -1513,7 +1491,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         return Keywords\SQLAnywhereKeywords::class;
     }
@@ -1521,7 +1499,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getVarcharTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return $fixed
             ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(' . $this->getVarcharDefaultLength() . ')')
@@ -1531,7 +1509,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function initializeDoctrineTypeMappings()
+    protected function initializeDoctrineTypeMappings() : void
     {
         $this->doctrineTypeMapping = [
             'bigint'                   => 'bigint',

--- a/lib/Doctrine/DBAL/Platforms/SQLAzurePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAzurePlatform.php
@@ -18,7 +18,7 @@ class SQLAzurePlatform extends SQLServerPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateTableSQL(Table $table, $createFlags = self::CREATE_INDEXES)
+    public function getCreateTableSQL(Table $table, int $createFlags = self::CREATE_INDEXES) : array
     {
         $sql = parent::getCreateTableSQL($table, $createFlags);
 

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -22,7 +22,7 @@ class SQLServer2012Platform extends SQLServerPlatform
     /**
      * {@inheritdoc}
      */
-    public function getAlterSequenceSQL(Sequence $sequence)
+    public function getAlterSequenceSQL(Sequence $sequence) : string
     {
         return 'ALTER SEQUENCE ' . $sequence->getQuotedName($this) .
                ' INCREMENT BY ' . $sequence->getAllocationSize();
@@ -31,7 +31,7 @@ class SQLServer2012Platform extends SQLServerPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCreateSequenceSQL(Sequence $sequence)
+    public function getCreateSequenceSQL(Sequence $sequence) : string
     {
         return 'CREATE SEQUENCE ' . $sequence->getQuotedName($this) .
                ' START WITH ' . $sequence->getInitialValue() .
@@ -42,7 +42,7 @@ class SQLServer2012Platform extends SQLServerPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDropSequenceSQL($sequence)
+    public function getDropSequenceSQL($sequence) : string
     {
         if ($sequence instanceof Sequence) {
             $sequence = $sequence->getQuotedName($this);
@@ -54,7 +54,7 @@ class SQLServer2012Platform extends SQLServerPlatform
     /**
      * {@inheritdoc}
      */
-    public function getListSequencesSQL($database)
+    public function getListSequencesSQL(string $database) : string
     {
         return 'SELECT seq.name,
                        CAST(
@@ -69,7 +69,7 @@ class SQLServer2012Platform extends SQLServerPlatform
     /**
      * {@inheritdoc}
      */
-    public function getSequenceNextValSQL($sequenceName)
+    public function getSequenceNextValSQL(string $sequenceName) : string
     {
         return 'SELECT NEXT VALUE FOR ' . $sequenceName;
     }
@@ -77,7 +77,7 @@ class SQLServer2012Platform extends SQLServerPlatform
     /**
      * {@inheritdoc}
      */
-    public function supportsSequences()
+    public function supportsSequences() : bool
     {
         return true;
     }
@@ -87,7 +87,7 @@ class SQLServer2012Platform extends SQLServerPlatform
      *
      * Returns Microsoft SQL Server 2012 specific keywords class
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         return Keywords\SQLServer2012Keywords::class;
     }

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -46,7 +46,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCurrentDateSQL()
+    public function getCurrentDateSQL() : string
     {
         return $this->getConvertExpression('date', 'GETDATE()');
     }
@@ -54,7 +54,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCurrentTimeSQL()
+    public function getCurrentTimeSQL() : string
     {
         return $this->getConvertExpression('time', 'GETDATE()');
     }
@@ -64,10 +64,8 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * @param string $dataType   The target native data type. Alias data types cannot be used.
      * @param string $expression The SQL expression to convert.
-     *
-     * @return string
      */
-    private function getConvertExpression($dataType, $expression)
+    private function getConvertExpression(string $dataType, string $expression) : string
     {
         return sprintf('CONVERT(%s, %s)', $dataType, $expression);
     }
@@ -100,7 +98,7 @@ class SQLServerPlatform extends AbstractPlatform
      * Microsoft SQL Server prefers "autoincrement" identity columns
      * since sequences can only be emulated with a table.
      */
-    public function prefersIdentityColumns()
+    public function prefersIdentityColumns() : bool
     {
         return true;
     }
@@ -110,7 +108,7 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * Microsoft SQL Server supports this through AUTO_INCREMENT columns.
      */
-    public function supportsIdentityColumns()
+    public function supportsIdentityColumns() : bool
     {
         return true;
     }
@@ -118,7 +116,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsReleaseSavepoints()
+    public function supportsReleaseSavepoints() : bool
     {
         return false;
     }
@@ -126,7 +124,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function supportsSchemas()
+    public function supportsSchemas() : bool
     {
         return true;
     }
@@ -134,7 +132,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDefaultSchemaName()
+    public function getDefaultSchemaName() : string
     {
         return 'dbo';
     }
@@ -142,7 +140,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsColumnCollation()
+    public function supportsColumnCollation() : bool
     {
         return true;
     }
@@ -150,7 +148,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function hasNativeGuidType()
+    public function hasNativeGuidType() : bool
     {
         return true;
     }
@@ -158,23 +156,23 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateDatabaseSQL($name)
+    public function getCreateDatabaseSQL(string $database) : string
     {
-        return 'CREATE DATABASE ' . $name;
+        return 'CREATE DATABASE ' . $database;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getDropDatabaseSQL($name)
+    public function getDropDatabaseSQL(string $database) : string
     {
-        return 'DROP DATABASE ' . $name;
+        return 'DROP DATABASE ' . $database;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function supportsCreateDropDatabase()
+    public function supportsCreateDropDatabase() : bool
     {
         return true;
     }
@@ -182,7 +180,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateSchemaSQL($schemaName)
+    public function getCreateSchemaSQL(string $schemaName) : string
     {
         return 'CREATE SCHEMA ' . $schemaName;
     }
@@ -190,7 +188,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDropForeignKeySQL($foreignKey, $table)
+    public function getDropForeignKeySQL($foreignKey, $table) : string
     {
         if (! $foreignKey instanceof ForeignKeyConstraint) {
             $foreignKey = new Identifier($foreignKey);
@@ -209,7 +207,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDropIndexSQL($index, $table = null)
+    public function getDropIndexSQL($index, $table = null) : string
     {
         if ($index instanceof Index) {
             $index = $index->getQuotedName($this);
@@ -247,7 +245,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL($tableName, array $columns, array $options = [])
+    protected function _getCreateTableSQL(string $tableName, array $columns, array $options = []) : array
     {
         $defaultConstraintsSql = [];
         $commentsSql           = [];
@@ -316,7 +314,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreatePrimaryKeySQL(Index $index, $table)
+    public function getCreatePrimaryKeySQL(Index $index, $table) : string
     {
         if ($table instanceof Table) {
             $identifier = $table->getQuotedName($this);
@@ -347,10 +345,8 @@ SQL
      * @param string      $tableName  The quoted table name to which the column belongs.
      * @param string      $columnName The quoted column name to create the comment for.
      * @param string|null $comment    The column's comment.
-     *
-     * @return string
      */
-    protected function getCreateColumnCommentSQL($tableName, $columnName, $comment)
+    protected function getCreateColumnCommentSQL(string $tableName, string $columnName, ?string $comment) : string
     {
         if (strpos($tableName, '.') !== false) {
             [$schemaSQL, $tableSQL] = explode('.', $tableName);
@@ -379,11 +375,9 @@ SQL
      * @param string  $table  Name of the table to return the default constraint declaration for.
      * @param mixed[] $column Column definition.
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getDefaultConstraintDeclarationSQL($table, array $column)
+    public function getDefaultConstraintDeclarationSQL(string $table, array $column) : string
     {
         if (! isset($column['default'])) {
             throw new InvalidArgumentException('Incomplete column definition. "default" required.');
@@ -400,7 +394,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreateIndexSQL(Index $index, $table)
+    public function getCreateIndexSQL(Index $index, $table) : string
     {
         $constraint = parent::getCreateIndexSQL($index, $table);
 
@@ -414,7 +408,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function getCreateIndexSQLFlags(Index $index)
+    protected function getCreateIndexSQLFlags(Index $index) : string
     {
         $type = '';
         if ($index->isUnique()) {
@@ -432,12 +426,8 @@ SQL
 
     /**
      * Extend unique key constraint with required filters
-     *
-     * @param string $sql
-     *
-     * @return string
      */
-    private function _appendUniqueConstraintDefinition($sql, Index $index)
+    private function _appendUniqueConstraintDefinition(string $sql, Index $index) : string
     {
         $fields = [];
 
@@ -451,7 +441,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getAlterTableSQL(TableDiff $diff)
+    public function getAlterTableSQL(TableDiff $diff) : array
     {
         $queryParts  = [];
         $sql         = [];
@@ -619,10 +609,8 @@ SQL
      *
      * @param string $tableName The name of the table to generate the clause for.
      * @param Column $column    The column to generate the clause for.
-     *
-     * @return string
      */
-    private function getAlterTableAddDefaultConstraintClause($tableName, Column $column)
+    private function getAlterTableAddDefaultConstraintClause(string $tableName, Column $column) : string
     {
         $columnDef         = $column->toArray();
         $columnDef['name'] = $column->getQuotedName($this);
@@ -635,10 +623,8 @@ SQL
      *
      * @param string $tableName  The name of the table to generate the clause for.
      * @param string $columnName The name of the column to generate the clause for.
-     *
-     * @return string
      */
-    private function getAlterTableDropDefaultConstraintClause($tableName, $columnName)
+    private function getAlterTableDropDefaultConstraintClause(string $tableName, string $columnName) : string
     {
         return 'DROP CONSTRAINT ' . $this->generateDefaultConstraintName($tableName, $columnName);
     }
@@ -655,7 +641,7 @@ SQL
      *
      * @return bool True if the column alteration requires dropping its default constraint first, false otherwise.
      */
-    private function alterColumnRequiresDropDefaultConstraint(ColumnDiff $columnDiff)
+    private function alterColumnRequiresDropDefaultConstraint(ColumnDiff $columnDiff) : bool
     {
         // We can only decide whether to drop an existing default constraint
         // if we know the original default value.
@@ -694,10 +680,8 @@ SQL
      * @param string      $tableName  The quoted table name to which the column belongs.
      * @param string      $columnName The quoted column name to alter the comment for.
      * @param string|null $comment    The column's comment.
-     *
-     * @return string
      */
-    protected function getAlterColumnCommentSQL($tableName, $columnName, $comment)
+    protected function getAlterColumnCommentSQL(string $tableName, string $columnName, ?string $comment) : string
     {
         if (strpos($tableName, '.') !== false) {
             [$schemaSQL, $tableSQL] = explode('.', $tableName);
@@ -733,10 +717,8 @@ SQL
      *
      * @param string $tableName  The quoted table name to which the column belongs.
      * @param string $columnName The quoted column name to drop the comment for.
-     *
-     * @return string
      */
-    protected function getDropColumnCommentSQL($tableName, $columnName)
+    protected function getDropColumnCommentSQL(string $tableName, string $columnName) : string
     {
         if (strpos($tableName, '.') !== false) {
             [$schemaSQL, $tableSQL] = explode('.', $tableName);
@@ -761,7 +743,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
+    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName) : array
     {
         return [sprintf(
             "EXEC sp_RENAME N'%s.%s', N'%s', N'INDEX'",
@@ -785,19 +767,17 @@ SQL
      * @param string|null $level1Name The name of the object at level 1 the property belongs to.
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
-     *
-     * @return string
      */
     public function getAddExtendedPropertySQL(
-        $name,
-        $value = null,
-        $level0Type = null,
-        $level0Name = null,
-        $level1Type = null,
-        $level1Name = null,
-        $level2Type = null,
-        $level2Name = null
-    ) {
+        string $name,
+        ?string $value = null,
+        ?string $level0Type = null,
+        ?string $level0Name = null,
+        ?string $level1Type = null,
+        ?string $level1Name = null,
+        ?string $level2Type = null,
+        ?string $level2Name = null
+    ) : string {
         return 'EXEC sp_addextendedproperty ' .
             'N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral((string) $value) . ', ' .
             'N' . $this->quoteStringLiteral((string) $level0Type) . ', ' . $level0Name . ', ' .
@@ -817,18 +797,16 @@ SQL
      * @param string|null $level1Name The name of the object at level 1 the property belongs to.
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
-     *
-     * @return string
      */
     public function getDropExtendedPropertySQL(
-        $name,
-        $level0Type = null,
-        $level0Name = null,
-        $level1Type = null,
-        $level1Name = null,
-        $level2Type = null,
-        $level2Name = null
-    ) {
+        string $name,
+        ?string $level0Type = null,
+        ?string $level0Name = null,
+        ?string $level1Type = null,
+        ?string $level1Name = null,
+        ?string $level2Type = null,
+        ?string $level2Name = null
+    ) : string {
         return 'EXEC sp_dropextendedproperty ' .
             'N' . $this->quoteStringLiteral($name) . ', ' .
             'N' . $this->quoteStringLiteral((string) $level0Type) . ', ' . $level0Name . ', ' .
@@ -849,19 +827,17 @@ SQL
      * @param string|null $level1Name The name of the object at level 1 the property belongs to.
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
-     *
-     * @return string
      */
     public function getUpdateExtendedPropertySQL(
-        $name,
-        $value = null,
-        $level0Type = null,
-        $level0Name = null,
-        $level1Type = null,
-        $level1Name = null,
-        $level2Type = null,
-        $level2Name = null
-    ) {
+        string $name,
+        ?string $value = null,
+        ?string $level0Type = null,
+        ?string $level0Name = null,
+        ?string $level1Type = null,
+        ?string $level1Name = null,
+        ?string $level2Type = null,
+        ?string $level2Name = null
+    ) : string {
         return 'EXEC sp_updateextendedproperty ' .
             'N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral((string) $value) . ', ' .
             'N' . $this->quoteStringLiteral((string) $level0Type) . ', ' . $level0Name . ', ' .
@@ -872,15 +848,15 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getEmptyIdentityInsertSQL($quotedTableName, $quotedIdentifierColumnName)
+    public function getEmptyIdentityInsertSQL(string $tableName, string $identifierColumnName) : string
     {
-        return 'INSERT INTO ' . $quotedTableName . ' DEFAULT VALUES';
+        return 'INSERT INTO ' . $tableName . ' DEFAULT VALUES';
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getListTablesSQL()
+    public function getListTablesSQL() : string
     {
         // "sysdiagrams" table must be ignored as it's internal SQL Server table for Database Diagrams
         // Category 2 must be ignored as it is "MS SQL Server 'pseudo-system' object[s]" for replication
@@ -890,7 +866,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getListTableColumnsSQL($table, $database = null)
+    public function getListTableColumnsSQL(string $table, ?string $database = null) : string
     {
         return "SELECT    col.name,
                           type.name AS type,
@@ -923,7 +899,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getListTableForeignKeysSQL($table, $database = null)
+    public function getListTableForeignKeysSQL(string $table, ?string $database = null) : string
     {
         return 'SELECT f.name AS ForeignKey,
                 SCHEMA_NAME (f.SCHEMA_ID) AS SchemaName,
@@ -945,7 +921,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getListTableIndexesSQL($table, $currentDatabase = null)
+    public function getListTableIndexesSQL(string $table, ?string $currentDatabase = null) : string
     {
         return "SELECT idx.name AS key_name,
                        col.name AS column_name,
@@ -968,7 +944,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreateViewSQL($name, $sql)
+    public function getCreateViewSQL(string $name, string $sql) : string
     {
         return 'CREATE VIEW ' . $name . ' AS ' . $sql;
     }
@@ -976,7 +952,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getListViewsSQL($database)
+    public function getListViewsSQL(string $database) : string
     {
         return "SELECT name FROM sysobjects WHERE type = 'V' ORDER BY name";
     }
@@ -987,10 +963,8 @@ SQL
      * @param string $table        The full qualified name of the table.
      * @param string $schemaColumn The name of the column to compare the schema to in the where clause.
      * @param string $tableColumn  The name of the column to compare the table to in the where clause.
-     *
-     * @return string
      */
-    private function getTableWhereClause($table, $schemaColumn, $tableColumn)
+    private function getTableWhereClause(string $table, string $schemaColumn, string $tableColumn) : string
     {
         if (strpos($table, '.') !== false) {
             [$schema, $table] = explode('.', $table);
@@ -1007,7 +981,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDropViewSQL($name)
+    public function getDropViewSQL(string $name) : string
     {
         return 'DROP VIEW ' . $name;
     }
@@ -1089,7 +1063,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getListDatabasesSQL()
+    public function getListDatabasesSQL() : string
     {
         return 'SELECT * FROM sys.databases';
     }
@@ -1097,7 +1071,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getListNamespacesSQL()
+    public function getListNamespacesSQL() : string
     {
         return "SELECT name FROM sys.schemas WHERE name NOT IN('guest', 'INFORMATION_SCHEMA', 'sys')";
     }
@@ -1125,7 +1099,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getSetTransactionIsolationSQL($level)
+    public function getSetTransactionIsolationSQL(int $level) : string
     {
         return 'SET TRANSACTION ISOLATION LEVEL ' . $this->_getTransactionIsolationLevelSQL($level);
     }
@@ -1133,31 +1107,31 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getIntegerTypeDeclarationSQL(array $field)
+    public function getIntegerTypeDeclarationSQL(array $columnDef) : string
     {
-        return 'INT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'INT' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getBigIntTypeDeclarationSQL(array $field)
+    public function getBigIntTypeDeclarationSQL(array $columnDef) : string
     {
-        return 'BIGINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'BIGINT' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getSmallIntTypeDeclarationSQL(array $field)
+    public function getSmallIntTypeDeclarationSQL(array $columnDef) : string
     {
-        return 'SMALLINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'SMALLINT' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getGuidTypeDeclarationSQL(array $field)
+    public function getGuidTypeDeclarationSQL(array $field) : string
     {
         return 'UNIQUEIDENTIFIER';
     }
@@ -1165,7 +1139,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTzTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DATETIMEOFFSET(6)';
     }
@@ -1173,7 +1147,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getVarcharTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return $fixed ? ($length ? 'NCHAR(' . $length . ')' : 'CHAR(255)') : ($length ? 'NVARCHAR(' . $length . ')' : 'NVARCHAR(255)');
     }
@@ -1181,7 +1155,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getBinaryTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return $fixed ? 'BINARY(' . ($length ?: 255) . ')' : 'VARBINARY(' . ($length ?: 255) . ')';
     }
@@ -1189,7 +1163,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getBinaryMaxLength()
+    public function getBinaryMaxLength() : int
     {
         return 8000;
     }
@@ -1197,7 +1171,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getClobTypeDeclarationSQL(array $field)
+    public function getClobTypeDeclarationSQL(array $field) : string
     {
         return 'VARCHAR(MAX)';
     }
@@ -1205,7 +1179,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
+    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef) : string
     {
         return ! empty($columnDef['autoincrement']) ? ' IDENTITY' : '';
     }
@@ -1213,7 +1187,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         // 3 - microseconds precision length
         // http://msdn.microsoft.com/en-us/library/ms187819.aspx
@@ -1223,7 +1197,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DATE';
     }
@@ -1231,7 +1205,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'TIME(0)';
     }
@@ -1239,7 +1213,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getBooleanTypeDeclarationSQL(array $field)
+    public function getBooleanTypeDeclarationSQL(array $columnDef) : string
     {
         return 'BIT';
     }
@@ -1297,12 +1271,8 @@ SQL
     /**
      * Remove ORDER BY clauses in subqueries - they're not supported by SQL Server.
      * Caveat: will leave ORDER BY in TOP N subqueries.
-     *
-     * @param string $query
-     *
-     * @return string
      */
-    private function scrubInnerOrderBy($query)
+    private function scrubInnerOrderBy(string $query) : string
     {
         $count  = substr_count(strtoupper($query), 'ORDER BY');
         $offset = 0;
@@ -1353,7 +1323,7 @@ SQL
      *
      * @return bool true if ORDER BY is in a TOP N query, false otherwise
      */
-    private function isOrderByInTopNSubquery($query, $currentPosition)
+    private function isOrderByInTopNSubquery(string $query, int $currentPosition) : bool
     {
         // Grab query text on the same nesting level as the ORDER BY clause we're examining.
         $subQueryBuffer = '';
@@ -1380,7 +1350,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function supportsLimitOffset()
+    public function supportsLimitOffset() : bool
     {
         return true;
     }
@@ -1408,7 +1378,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreateTemporaryTableSnippetSQL()
+    public function getCreateTemporaryTableSnippetSQL() : string
     {
         return 'CREATE TABLE';
     }
@@ -1416,7 +1386,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getTemporaryTableName($tableName)
+    public function getTemporaryTableName(string $tableName) : string
     {
         return '#' . $tableName;
     }
@@ -1424,7 +1394,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeFormatString()
+    public function getDateTimeFormatString() : string
     {
         return 'Y-m-d H:i:s.u';
     }
@@ -1432,7 +1402,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateFormatString()
+    public function getDateFormatString() : string
     {
         return 'Y-m-d';
     }
@@ -1440,7 +1410,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getTimeFormatString()
+    public function getTimeFormatString() : string
     {
         return 'H:i:s';
     }
@@ -1448,7 +1418,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTzFormatString()
+    public function getDateTimeTzFormatString() : string
     {
         return 'Y-m-d H:i:s.u P';
     }
@@ -1456,7 +1426,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'mssql';
     }
@@ -1464,7 +1434,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function initializeDoctrineTypeMappings()
+    protected function initializeDoctrineTypeMappings() : void
     {
         $this->doctrineTypeMapping = [
             'bigint'           => 'bigint',
@@ -1502,7 +1472,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function createSavePoint($savepoint)
+    public function createSavePoint(string $savepoint) : string
     {
         return 'SAVE TRANSACTION ' . $savepoint;
     }
@@ -1510,7 +1480,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function releaseSavePoint($savepoint)
+    public function releaseSavePoint(string $savepoint) : string
     {
         return '';
     }
@@ -1518,7 +1488,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function rollbackSavePoint($savepoint)
+    public function rollbackSavePoint(string $savepoint) : string
     {
         return 'ROLLBACK TRANSACTION ' . $savepoint;
     }
@@ -1526,7 +1496,7 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function getForeignKeyReferentialActionSQL($action)
+    public function getForeignKeyReferentialActionSQL(string $action) : string
     {
         // RESTRICT is not supported, therefore falling back to NO ACTION.
         if (strtoupper($action) === 'RESTRICT') {
@@ -1539,7 +1509,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function appendLockHint($fromClause, $lockMode)
+    public function appendLockHint(string $fromClause, ?int $lockMode) : string
     {
         switch (true) {
             case $lockMode === LockMode::NONE:
@@ -1559,7 +1529,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getForUpdateSQL()
+    public function getForUpdateSQL() : string
     {
         return ' ';
     }
@@ -1567,7 +1537,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         return Keywords\SQLServerKeywords::class;
     }
@@ -1575,7 +1545,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function quoteSingleIdentifier($str)
+    public function quoteSingleIdentifier(string $str) : string
     {
         return '[' . str_replace(']', '][', $str) . ']';
     }
@@ -1583,7 +1553,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getTruncateTableSQL($tableName, $cascade = false)
+    public function getTruncateTableSQL(string $tableName, bool $cascade = false) : string
     {
         $tableIdentifier = new Identifier($tableName);
 
@@ -1593,7 +1563,7 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getBlobTypeDeclarationSQL(array $field)
+    public function getBlobTypeDeclarationSQL(array $field) : string
     {
         return 'VARBINARY(MAX)';
     }
@@ -1603,7 +1573,7 @@ SQL
      *
      * Modifies column declaration order as it differs in Microsoft SQL Server.
      */
-    public function getColumnDeclarationSQL($name, array $field)
+    public function getColumnDeclarationSQL(string $name, array $field) : string
     {
         if (isset($field['columnDefinition'])) {
             $columnDef = $this->getCustomTypeDeclarationSQL($field);
@@ -1639,10 +1609,8 @@ SQL
      *
      * @param string $table  Name of the table to generate the unique default constraint name for.
      * @param string $column Name of the column in the table to generate the unique default constraint name for.
-     *
-     * @return string
      */
-    private function generateDefaultConstraintName($table, $column)
+    private function generateDefaultConstraintName(string $table, string $column) : string
     {
         return 'DF_' . $this->generateIdentifierName($table) . '_' . $this->generateIdentifierName($column);
     }
@@ -1651,10 +1619,8 @@ SQL
      * Returns a hash value for a given identifier.
      *
      * @param string $identifier Identifier to generate a hash value for.
-     *
-     * @return string
      */
-    private function generateIdentifierName($identifier)
+    private function generateIdentifierName(string $identifier) : string
     {
         // Always generate name for unquoted identifiers to ensure consistency.
         $identifier = new Identifier($identifier);

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -22,7 +22,6 @@ use function implode;
 use function sprintf;
 use function sqrt;
 use function str_replace;
-use function strlen;
 use function strpos;
 use function strtolower;
 
@@ -45,7 +44,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getNowExpression($type = 'timestamp') : string
+    public function getNowExpression(string $type = 'timestamp') : string
     {
         switch ($type) {
             case 'time':
@@ -154,15 +153,15 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getTransactionIsolationLevelSQL($level)
+    protected function _getTransactionIsolationLevelSQL(int $level) : string
     {
         switch ($level) {
             case TransactionIsolationLevel::READ_UNCOMMITTED:
-                return 0;
+                return '0';
             case TransactionIsolationLevel::READ_COMMITTED:
             case TransactionIsolationLevel::REPEATABLE_READ:
             case TransactionIsolationLevel::SERIALIZABLE:
-                return 1;
+                return '1';
             default:
                 return parent::_getTransactionIsolationLevelSQL($level);
         }
@@ -171,7 +170,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getSetTransactionIsolationSQL($level)
+    public function getSetTransactionIsolationSQL(int $level) : string
     {
         return 'PRAGMA read_uncommitted = ' . $this->_getTransactionIsolationLevelSQL($level);
     }
@@ -179,7 +178,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function prefersIdentityColumns()
+    public function prefersIdentityColumns() : bool
     {
         return true;
     }
@@ -187,7 +186,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getBooleanTypeDeclarationSQL(array $field)
+    public function getBooleanTypeDeclarationSQL(array $columnDef) : string
     {
         return 'BOOLEAN';
     }
@@ -195,28 +194,28 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getIntegerTypeDeclarationSQL(array $field)
+    public function getIntegerTypeDeclarationSQL(array $columnDef) : string
     {
-        return 'INTEGER' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'INTEGER' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getBigIntTypeDeclarationSQL(array $field)
+    public function getBigIntTypeDeclarationSQL(array $columnDef) : string
     {
         //  SQLite autoincrement is implicit for INTEGER PKs, but not for BIGINT fields.
-        if (! empty($field['autoincrement'])) {
-            return $this->getIntegerTypeDeclarationSQL($field);
+        if (! empty($columnDef['autoincrement'])) {
+            return $this->getIntegerTypeDeclarationSQL($columnDef);
         }
 
-        return 'BIGINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'BIGINT' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getTinyIntTypeDeclarationSql(array $field)
+    public function getTinyIntTypeDeclarationSql(array $field) : string
     {
         //  SQLite autoincrement is implicit for INTEGER PKs, but not for TINYINT fields.
         if (! empty($field['autoincrement'])) {
@@ -229,20 +228,20 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getSmallIntTypeDeclarationSQL(array $field)
+    public function getSmallIntTypeDeclarationSQL(array $columnDef) : string
     {
         //  SQLite autoincrement is implicit for INTEGER PKs, but not for SMALLINT fields.
-        if (! empty($field['autoincrement'])) {
-            return $this->getIntegerTypeDeclarationSQL($field);
+        if (! empty($columnDef['autoincrement'])) {
+            return $this->getIntegerTypeDeclarationSQL($columnDef);
         }
 
-        return 'SMALLINT' . $this->_getCommonIntegerTypeDeclarationSQL($field);
+        return 'SMALLINT' . $this->_getCommonIntegerTypeDeclarationSQL($columnDef);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getMediumIntTypeDeclarationSql(array $field)
+    public function getMediumIntTypeDeclarationSql(array $field) : string
     {
         //  SQLite autoincrement is implicit for INTEGER PKs, but not for MEDIUMINT fields.
         if (! empty($field['autoincrement'])) {
@@ -255,7 +254,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DATETIME';
     }
@@ -263,7 +262,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDateTypeDeclarationSQL(array $fieldDeclaration)
+    public function getDateTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'DATE';
     }
@@ -271,7 +270,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getTimeTypeDeclarationSQL(array $fieldDeclaration)
+    public function getTimeTypeDeclarationSQL(array $fieldDeclaration) : string
     {
         return 'TIME';
     }
@@ -279,7 +278,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
+    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef) : string
     {
         // sqlite autoincrement is only possible for the primary key
         if (! empty($columnDef['autoincrement'])) {
@@ -292,7 +291,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getForeignKeyDeclarationSQL(ForeignKeyConstraint $foreignKey)
+    public function getForeignKeyDeclarationSQL(ForeignKeyConstraint $foreignKey) : string
     {
         return parent::getForeignKeyDeclarationSQL(new ForeignKeyConstraint(
             $foreignKey->getQuotedLocalColumns($this),
@@ -306,7 +305,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL($tableName, array $columns, array $options = [])
+    protected function _getCreateTableSQL(string $tableName, array $columns, array $options = []) : array
     {
         $tableName   = str_replace('.', '__', $tableName);
         $queryFields = $this->getColumnDeclarationListSQL($columns);
@@ -372,7 +371,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getVarcharTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return $fixed
             ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(255)')
@@ -382,7 +381,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getBinaryTypeDeclarationSQLSnippet(int $length, bool $fixed) : string
     {
         return 'BLOB';
     }
@@ -390,7 +389,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getBinaryMaxLength()
+    public function getBinaryMaxLength() : int
     {
         return 0;
     }
@@ -398,7 +397,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getBinaryDefaultLength()
+    public function getBinaryDefaultLength() : int
     {
         return 0;
     }
@@ -406,7 +405,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getClobTypeDeclarationSQL(array $field)
+    public function getClobTypeDeclarationSQL(array $field) : string
     {
         return 'CLOB';
     }
@@ -414,7 +413,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTableConstraintsSQL($table)
+    public function getListTableConstraintsSQL(string $table) : string
     {
         $table = str_replace('.', '__', $table);
 
@@ -427,7 +426,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTableColumnsSQL($table, $currentDatabase = null)
+    public function getListTableColumnsSQL(string $table, ?string $database = null) : string
     {
         $table = str_replace('.', '__', $table);
 
@@ -437,7 +436,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTableIndexesSQL($table, $currentDatabase = null)
+    public function getListTableIndexesSQL(string $table, ?string $currentDatabase = null) : string
     {
         $table = str_replace('.', '__', $table);
 
@@ -447,7 +446,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListTablesSQL()
+    public function getListTablesSQL() : string
     {
         return "SELECT name FROM sqlite_master WHERE type = 'table' AND name != 'sqlite_sequence' AND name != 'geometry_columns' AND name != 'spatial_ref_sys' "
              . 'UNION ALL SELECT name FROM sqlite_temp_master '
@@ -457,7 +456,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getListViewsSQL($database)
+    public function getListViewsSQL(string $database) : string
     {
         return "SELECT name, sql FROM sqlite_master WHERE type='view' AND sql NOT NULL";
     }
@@ -465,7 +464,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateViewSQL($name, $sql)
+    public function getCreateViewSQL(string $name, string $sql) : string
     {
         return 'CREATE VIEW ' . $name . ' AS ' . $sql;
     }
@@ -473,7 +472,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDropViewSQL($name)
+    public function getDropViewSQL(string $name) : string
     {
         return 'DROP VIEW ' . $name;
     }
@@ -481,7 +480,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
+    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey) : string
     {
         $query = parent::getAdvancedForeignKeyOptionsSQL($foreignKey);
 
@@ -494,7 +493,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsIdentityColumns()
+    public function supportsIdentityColumns() : bool
     {
         return true;
     }
@@ -502,7 +501,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsColumnCollation()
+    public function supportsColumnCollation() : bool
     {
         return true;
     }
@@ -510,7 +509,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsInlineColumnComments()
+    public function supportsInlineColumnComments() : bool
     {
         return true;
     }
@@ -518,7 +517,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return 'sqlite';
     }
@@ -526,7 +525,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getTruncateTableSQL($tableName, $cascade = false)
+    public function getTruncateTableSQL(string $tableName, bool $cascade = false) : string
     {
         $tableIdentifier = new Identifier($tableName);
         $tableName       = str_replace('.', '__', $tableIdentifier->getQuotedName($this));
@@ -538,35 +537,21 @@ class SqlitePlatform extends AbstractPlatform
      * User-defined function for Sqlite that is used with PDO::sqliteCreateFunction().
      *
      * @param int|float $value
-     *
-     * @return float
      */
-    public static function udfSqrt($value)
+    public static function udfSqrt($value) : float
     {
         return sqrt($value);
     }
 
     /**
      * User-defined function for Sqlite that implements MOD(a, b).
-     *
-     * @param int $a
-     * @param int $b
-     *
-     * @return int
      */
-    public static function udfMod($a, $b)
+    public static function udfMod(int $a, int $b) : int
     {
         return $a % $b;
     }
 
-    /**
-     * @param string $str
-     * @param string $substr
-     * @param int    $offset
-     *
-     * @return int
-     */
-    public static function udfLocate($str, $substr, $offset = 0)
+    public static function udfLocate(string $str, string $substr, int $offset = 0) : int
     {
         // SQL's LOCATE function works on 1-based positions, while PHP's strpos works on 0-based positions.
         // So we have to make them compatible if an offset is given.
@@ -586,7 +571,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getForUpdateSql()
+    public function getForUpdateSql() : string
     {
         return '';
     }
@@ -594,15 +579,19 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getInlineColumnCommentSQL($comment)
+    public function getInlineColumnCommentSQL(?string $comment) : string
     {
+        if ($comment === null || $comment === '') {
+            return '';
+        }
+
         return '--' . str_replace("\n", "\n--", $comment) . "\n";
     }
 
     /**
      * {@inheritDoc}
      */
-    protected function initializeDoctrineTypeMappings()
+    protected function initializeDoctrineTypeMappings() : void
     {
         $this->doctrineTypeMapping = [
             'bigint'           => 'bigint',
@@ -644,7 +633,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass() : string
     {
         return Keywords\SQLiteKeywords::class;
     }
@@ -652,7 +641,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff)
+    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff) : array
     {
         if (! $diff->fromTable instanceof Table) {
             throw new DBALException('Sqlite platform requires for alter table the table diff with reference to original table schema.');
@@ -673,7 +662,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff)
+    protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff) : array
     {
         if (! $diff->fromTable instanceof Table) {
             throw new DBALException('Sqlite platform requires for alter table the table diff with reference to original table schema.');
@@ -712,7 +701,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getBlobTypeDeclarationSQL(array $field)
+    public function getBlobTypeDeclarationSQL(array $field) : string
     {
         return 'BLOB';
     }
@@ -720,7 +709,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getTemporaryTableName($tableName)
+    public function getTemporaryTableName(string $tableName) : string
     {
         $tableName = str_replace('.', '__', $tableName);
 
@@ -736,7 +725,7 @@ class SqlitePlatform extends AbstractPlatform
      * This hack is implemented to be able to use SQLite as testdriver when
      * using schema supporting databases.
      */
-    public function canEmulateSchemas()
+    public function canEmulateSchemas() : bool
     {
         return true;
     }
@@ -744,7 +733,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsForeignKeyConstraints()
+    public function supportsForeignKeyConstraints() : bool
     {
         return false;
     }
@@ -752,7 +741,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreatePrimaryKeySQL(Index $index, $table)
+    public function getCreatePrimaryKeySQL(Index $index, $table) : string
     {
         throw new DBALException('Sqlite platform does not support alter primary key.');
     }
@@ -760,7 +749,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, $table)
+    public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, $table) : string
     {
         throw new DBALException('Sqlite platform does not support alter foreign key.');
     }
@@ -768,7 +757,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDropForeignKeySQL($foreignKey, $table)
+    public function getDropForeignKeySQL($foreignKey, $table) : string
     {
         throw new DBALException('Sqlite platform does not support alter foreign key.');
     }
@@ -776,7 +765,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateConstraintSQL(Constraint $constraint, $table)
+    public function getCreateConstraintSQL(Constraint $constraint, $table) : string
     {
         throw new DBALException('Sqlite platform does not support alter constraint.');
     }
@@ -784,17 +773,15 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateTableSQL(Table $table, $createFlags = null)
+    public function getCreateTableSQL(Table $table, int $createFlags = self::CREATE_INDEXES | self::CREATE_FOREIGNKEYS) : array
     {
-        $createFlags = $createFlags ?? self::CREATE_INDEXES | self::CREATE_FOREIGNKEYS;
-
         return parent::getCreateTableSQL($table, $createFlags);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getListTableForeignKeysSQL($table, $database = null)
+    public function getListTableForeignKeysSQL(string $table, ?string $database = null) : string
     {
         $table = str_replace('.', '__', $table);
 
@@ -804,7 +791,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getAlterTableSQL(TableDiff $diff)
+    public function getAlterTableSQL(TableDiff $diff) : array
     {
         $sql = $this->getSimpleAlterTableSQL($diff);
         if ($sql !== false) {
@@ -1005,7 +992,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * @return string[]
      */
-    private function getColumnNamesInAlteredTable(TableDiff $diff)
+    private function getColumnNamesInAlteredTable(TableDiff $diff) : array
     {
         $columns = [];
 
@@ -1045,7 +1032,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * @return Index[]
      */
-    private function getIndexesInAlteredTable(TableDiff $diff)
+    private function getIndexesInAlteredTable(TableDiff $diff) : array
     {
         $indexes     = $diff->fromTable->getIndexes();
         $columnNames = $this->getColumnNamesInAlteredTable($diff);
@@ -1084,18 +1071,20 @@ class SqlitePlatform extends AbstractPlatform
         }
 
         foreach ($diff->removedIndexes as $index) {
-            $indexName = strtolower($index->getName());
-            if (! strlen($indexName) || ! isset($indexes[$indexName])) {
+            $indexName = $index->getName();
+
+            if ($indexName === '') {
                 continue;
             }
 
-            unset($indexes[$indexName]);
+            unset($indexes[strtolower($indexName)]);
         }
 
         foreach (array_merge($diff->changedIndexes, $diff->addedIndexes, $diff->renamedIndexes) as $index) {
-            $indexName = strtolower($index->getName());
-            if (strlen($indexName)) {
-                $indexes[$indexName] = $index;
+            $indexName = $index->getName();
+
+            if ($indexName !== '') {
+                $indexes[strtolower($indexName)] = $index;
             } else {
                 $indexes[] = $index;
             }
@@ -1107,7 +1096,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * @return ForeignKeyConstraint[]
      */
-    private function getForeignKeysInAlteredTable(TableDiff $diff)
+    private function getForeignKeysInAlteredTable(TableDiff $diff) : array
     {
         $foreignKeys = $diff->fromTable->getForeignKeys();
         $columnNames = $this->getColumnNamesInAlteredTable($diff);
@@ -1142,18 +1131,20 @@ class SqlitePlatform extends AbstractPlatform
                 $constraint = new Identifier($constraint);
             }
 
-            $constraintName = strtolower($constraint->getName());
-            if (! strlen($constraintName) || ! isset($foreignKeys[$constraintName])) {
+            $constraintName = $constraint->getName();
+
+            if ($constraintName === '') {
                 continue;
             }
 
-            unset($foreignKeys[$constraintName]);
+            unset($foreignKeys[strtolower($constraintName)]);
         }
 
         foreach (array_merge($diff->changedForeignKeys, $diff->addedForeignKeys) as $constraint) {
-            $constraintName = strtolower($constraint->getName());
-            if (strlen($constraintName)) {
-                $foreignKeys[$constraintName] = $constraint;
+            $constraintName = $constraint->getName();
+
+            if ($constraintName !== '') {
+                $foreignKeys[strtolower($constraintName)] = $constraint;
             } else {
                 $foreignKeys[] = $constraint;
             }
@@ -1165,7 +1156,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * @return Index[]
      */
-    private function getPrimaryIndexInAlteredTable(TableDiff $diff)
+    private function getPrimaryIndexInAlteredTable(TableDiff $diff) : array
     {
         $primaryIndex = [];
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
@@ -28,6 +28,14 @@ class DriverTest extends AbstractDriverTest
     /**
      * {@inheritdoc}
      */
+    public function testReturnsDatabaseNameWithoutDatabaseNameParameter()
+    {
+        $this->markTestSkipped('SQLite does not support the concept of a database.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function createDriver()
     {
         return new Driver();

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1060,12 +1060,9 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
         $table = new Table('col_def_lifecycle');
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
         $table->addColumn('column1', 'string', ['default' => null]);
-        $table->addColumn('column2', 'string', ['default' => false]);
-        $table->addColumn('column3', 'string', ['default' => true]);
-        $table->addColumn('column4', 'string', ['default' => 0]);
-        $table->addColumn('column5', 'string', ['default' => '']);
-        $table->addColumn('column6', 'string', ['default' => 'def']);
-        $table->addColumn('column7', 'integer', ['default' => 0]);
+        $table->addColumn('column2', 'string', ['default' => '']);
+        $table->addColumn('column3', 'string', ['default' => 'default1']);
+        $table->addColumn('column4', 'integer', ['default' => 0]);
         $table->setPrimaryKey(['id']);
 
         $this->schemaManager->dropAndCreateTable($table);
@@ -1075,21 +1072,15 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
         self::assertNull($columns['id']->getDefault());
         self::assertNull($columns['column1']->getDefault());
         self::assertSame('', $columns['column2']->getDefault());
-        self::assertSame('1', $columns['column3']->getDefault());
+        self::assertSame('default1', $columns['column3']->getDefault());
         self::assertSame('0', $columns['column4']->getDefault());
-        self::assertSame('', $columns['column5']->getDefault());
-        self::assertSame('def', $columns['column6']->getDefault());
-        self::assertSame('0', $columns['column7']->getDefault());
 
         $diffTable = clone $table;
 
-        $diffTable->changeColumn('column1', ['default' => false]);
+        $diffTable->changeColumn('column1', ['default' => '']);
         $diffTable->changeColumn('column2', ['default' => null]);
-        $diffTable->changeColumn('column3', ['default' => false]);
+        $diffTable->changeColumn('column3', ['default' => 'default2']);
         $diffTable->changeColumn('column4', ['default' => null]);
-        $diffTable->changeColumn('column5', ['default' => false]);
-        $diffTable->changeColumn('column6', ['default' => 666]);
-        $diffTable->changeColumn('column7', ['default' => null]);
 
         $comparator = new Comparator();
 
@@ -1099,11 +1090,8 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
 
         self::assertSame('', $columns['column1']->getDefault());
         self::assertNull($columns['column2']->getDefault());
-        self::assertSame('', $columns['column3']->getDefault());
+        self::assertSame('default2', $columns['column3']->getDefault());
         self::assertNull($columns['column4']->getDefault());
-        self::assertSame('', $columns['column5']->getDefault());
-        self::assertSame('666', $columns['column6']->getDefault());
-        self::assertNull($columns['column7']->getDefault());
     }
 
     public function testListTableWithBinary()

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -240,10 +240,10 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
 
     public function testGeneratesForeignKeyCreationSql()
     {
-        $fk = new ForeignKeyConstraint(['fk_name_id'], 'other_table', ['id'], '');
+        $fk = new ForeignKeyConstraint(['fk_name_id'], 'other_table', ['id']);
 
         $sql = $this->platform->getCreateForeignKeySQL($fk, 'test');
-        self::assertEquals($sql, $this->getGenerateForeignKeySql());
+        self::assertEquals($this->getGenerateForeignKeySql(), $sql);
     }
 
     abstract public function getGenerateForeignKeySql();

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1004,9 +1004,9 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
 
         $tableDiff->changedColumns['col_string'] = new ColumnDiff(
             'col_string',
-            new Column('col_string', Type::getType('string'), ['default' => 666, 'fixed' => true]),
+            new Column('col_string', Type::getType('string'), ['default' => 'foo', 'fixed' => true]),
             ['fixed'],
-            new Column('col_string', Type::getType('string'), ['default' => 666])
+            new Column('col_string', Type::getType('string'), ['default' => 'foo'])
         );
 
         $expected = $this->platform->getAlterTableSQL($tableDiff);
@@ -1019,7 +1019,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
                 'ALTER TABLE column_def_change_type ADD CONSTRAINT DF_829302E0_FA2CB292 DEFAULT 666 FOR col_int',
                 'ALTER TABLE column_def_change_type DROP CONSTRAINT DF_829302E0_2725A6D0',
                 'ALTER TABLE column_def_change_type ALTER COLUMN col_string NCHAR(255) NOT NULL',
-                "ALTER TABLE column_def_change_type ADD CONSTRAINT DF_829302E0_2725A6D0 DEFAULT '666' FOR col_string",
+                "ALTER TABLE column_def_change_type ADD CONSTRAINT DF_829302E0_2725A6D0 DEFAULT 'foo' FOR col_string",
             ]
         );
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -221,8 +221,6 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     {
         return [
             [null, ''],
-            [false, ''],
-            [true, ''],
             [LockMode::NONE, ' WITH (NOLOCK)'],
             [LockMode::OPTIMISTIC, ''],
             [LockMode::PESSIMISTIC_READ, ' WITH (UPDLOCK)'],
@@ -725,13 +723,6 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
         );
     }
 
-    public function testCannotGenerateTransactionCommandWithInvalidIsolationLevel()
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->platform->getSetTransactionIsolationSQL('invalid_transaction_isolation_level');
-    }
-
     public function testModifiesLimitQuery()
     {
         self::assertEquals(
@@ -883,10 +874,6 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
         self::assertEquals(
             'SELECT myseq.NEXTVAL',
             $this->platform->getSequenceNextValSQL('myseq')
-        );
-        self::assertEquals(
-            'SELECT sequence_name, increment_by, start_with, min_value FROM SYS.SYSSEQUENCE',
-            $this->platform->getListSequencesSQL(null)
         );
     }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServerPlatformTest.php
@@ -39,8 +39,6 @@ class SQLServerPlatformTest extends AbstractSQLServerPlatformTestCase
     {
         return [
             [null, ''],
-            [false, ''],
-            [true, ''],
             [LockMode::NONE, ' WITH (NOLOCK)'],
             [LockMode::OPTIMISTIC, ''],
             [LockMode::PESSIMISTIC_READ, ' WITH (HOLDLOCK, ROWLOCK)'],

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -663,7 +663,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
 
     protected function getInlineColumnEmptyCommentSQL()
     {
-        return "--\n";
+        return '';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/DateImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateImmutableTypeTest.php
@@ -11,13 +11,13 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateImmutableType;
 use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Prophecy\ObjectProphecy;
 use function get_class;
 
 class DateImmutableTypeTest extends TestCase
 {
-    /** @var AbstractPlatform|ObjectProphecy */
+    /** @var AbstractPlatform|MockObject */
     private $platform;
 
     /** @var DateImmutableType */
@@ -26,7 +26,7 @@ class DateImmutableTypeTest extends TestCase
     protected function setUp() : void
     {
         $this->type     = Type::getType('date_immutable');
-        $this->platform = $this->prophesize(AbstractPlatform::class);
+        $this->platform = $this->getMockForAbstractClass(AbstractPlatform::class);
     }
 
     public function testFactoryCreatesCorrectType()
@@ -48,44 +48,41 @@ class DateImmutableTypeTest extends TestCase
     {
         $date = $this->prophesize(DateTimeImmutable::class);
 
-        $this->platform->getDateFormatString()->willReturn('Y-m-d')->shouldBeCalled();
         $date->format('Y-m-d')->willReturn('2016-01-01')->shouldBeCalled();
 
         self::assertSame(
             '2016-01-01',
-            $this->type->convertToDatabaseValue($date->reveal(), $this->platform->reveal())
+            $this->type->convertToDatabaseValue($date->reveal(), $this->platform)
         );
     }
 
     public function testConvertsNullToDatabaseValue()
     {
-        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform->reveal()));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
 
     public function testDoesNotSupportMutableDateTimeToDatabaseValueConversion()
     {
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToDatabaseValue(new DateTime(), $this->platform->reveal());
+        $this->type->convertToDatabaseValue(new DateTime(), $this->platform);
     }
 
     public function testConvertsDateTimeImmutableInstanceToPHPValue()
     {
         $date = new DateTimeImmutable();
 
-        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform->reveal()));
+        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
     }
 
     public function testConvertsNullToPHPValue()
     {
-        self::assertNull($this->type->convertToPHPValue(null, $this->platform->reveal()));
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
     public function testConvertsDateStringToPHPValue()
     {
-        $this->platform->getDateFormatString()->willReturn('Y-m-d')->shouldBeCalled();
-
-        $date = $this->type->convertToPHPValue('2016-01-01', $this->platform->reveal());
+        $date = $this->type->convertToPHPValue('2016-01-01', $this->platform);
 
         self::assertInstanceOf(DateTimeImmutable::class, $date);
         self::assertSame('2016-01-01', $date->format('Y-m-d'));
@@ -93,9 +90,7 @@ class DateImmutableTypeTest extends TestCase
 
     public function testResetTimeFractionsWhenConvertingToPHPValue()
     {
-        $this->platform->getDateFormatString()->willReturn('Y-m-d');
-
-        $date = $this->type->convertToPHPValue('2016-01-01', $this->platform->reveal());
+        $date = $this->type->convertToPHPValue('2016-01-01', $this->platform);
 
         self::assertSame('2016-01-01 00:00:00.000000', $date->format('Y-m-d H:i:s.u'));
     }
@@ -104,11 +99,11 @@ class DateImmutableTypeTest extends TestCase
     {
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToPHPValue('invalid date string', $this->platform->reveal());
+        $this->type->convertToPHPValue('invalid date string', $this->platform);
     }
 
     public function testRequiresSQLCommentHint()
     {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform->reveal()));
+        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Types/TimeImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/TimeImmutableTypeTest.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\TimeImmutableType;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Prophecy\ObjectProphecy;
 use function get_class;
 
 class TimeImmutableTypeTest extends TestCase
@@ -26,7 +25,7 @@ class TimeImmutableTypeTest extends TestCase
     protected function setUp() : void
     {
         $this->type     = Type::getType('time_immutable');
-        $this->platform = $this->prophesize(AbstractPlatform::class);
+        $this->platform = $this->getMockForAbstractClass(AbstractPlatform::class);
     }
 
     public function testFactoryCreatesCorrectType()
@@ -48,44 +47,41 @@ class TimeImmutableTypeTest extends TestCase
     {
         $date = $this->prophesize(DateTimeImmutable::class);
 
-        $this->platform->getTimeFormatString()->willReturn('H:i:s')->shouldBeCalled();
         $date->format('H:i:s')->willReturn('15:58:59')->shouldBeCalled();
 
         self::assertSame(
             '15:58:59',
-            $this->type->convertToDatabaseValue($date->reveal(), $this->platform->reveal())
+            $this->type->convertToDatabaseValue($date->reveal(), $this->platform)
         );
     }
 
     public function testConvertsNullToDatabaseValue()
     {
-        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform->reveal()));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
 
     public function testDoesNotSupportMutableDateTimeToDatabaseValueConversion()
     {
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToDatabaseValue(new DateTime(), $this->platform->reveal());
+        $this->type->convertToDatabaseValue(new DateTime(), $this->platform);
     }
 
     public function testConvertsDateTimeImmutableInstanceToPHPValue()
     {
         $date = new DateTimeImmutable();
 
-        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform->reveal()));
+        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
     }
 
     public function testConvertsNullToPHPValue()
     {
-        self::assertNull($this->type->convertToPHPValue(null, $this->platform->reveal()));
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
     public function testConvertsTimeStringToPHPValue()
     {
-        $this->platform->getTimeFormatString()->willReturn('H:i:s')->shouldBeCalled();
-
-        $date = $this->type->convertToPHPValue('15:58:59', $this->platform->reveal());
+        $date = $this->type->convertToPHPValue('15:58:59', $this->platform);
 
         self::assertInstanceOf(DateTimeImmutable::class, $date);
         self::assertSame('15:58:59', $date->format('H:i:s'));
@@ -93,9 +89,7 @@ class TimeImmutableTypeTest extends TestCase
 
     public function testResetDateFractionsWhenConvertingToPHPValue()
     {
-        $this->platform->getTimeFormatString()->willReturn('H:i:s');
-
-        $date = $this->type->convertToPHPValue('15:58:59', $this->platform->reveal());
+        $date = $this->type->convertToPHPValue('15:58:59', $this->platform);
 
         self::assertSame('1970-01-01 15:58:59', $date->format('Y-m-d H:i:s'));
     }
@@ -104,11 +98,11 @@ class TimeImmutableTypeTest extends TestCase
     {
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToPHPValue('invalid time string', $this->platform->reveal());
+        $this->type->convertToPHPValue('invalid time string', $this->platform);
     }
 
     public function testRequiresSQLCommentHint()
     {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform->reveal()));
+        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

**Notes:**

1. The nullability of the `$database` argument in `AbstractPlatform` methods is not final. It just reflects the current type. The type can be restricted to a non-nullable `string` in a subsequent PR.
2. Some mocks have been reworked from using the PHPUnit mock API instead of Prophecy because the latter doesn't respect the return types of the mocked methods.