### PR TITLE
Allow Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,8 @@
         "jetbrains/phpstorm-stubs": "^2018.1.2",
         "phpstan/phpstan": "^0.11.3",
         "phpunit/phpunit": "^8.1.5",
-        "symfony/console": "^2.0.5|^3.0|^4.0",
-        "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+        "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
+        "symfony/phpunit-bridge": "^3.4.5|^4.0.5|^5.0"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07e2f7f05586700d8d7bde1f2fd023e6",
+    "content-hash": "7c55573f97bd2526e2b02609d5e5290c",
     "packages": [
         {
             "name": "doctrine/cache",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Sibling of https://github.com/doctrine/DoctrineBundle/pull/975
Not strictly required as it doesn't block the Symfony 5 CI. Yet will help ensure Symfony 5 is compatible.