### PR TITLE
Upgraded to PHPUnit 8.1.6 and reworked the remaining driver exception mock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "doctrine/coding-standard": "^6.0",
         "jetbrains/phpstorm-stubs": "^2018.1.2",
         "phpstan/phpstan": "^0.11.3",
-        "phpunit/phpunit": "^8.1.5",
+        "phpunit/phpunit": "^8.1.6",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
         "symfony/phpunit-bridge": "^3.4.5|^4.0.5|^5.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c55573f97bd2526e2b02609d5e5290c",
+    "content-hash": "20970a03470d26a047432b1e25bb4a2a",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1788,16 +1788,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.1.5",
+            "version": "8.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "01392d4b5878aa617e8d9bc7a529e5febc8fe956"
+                "reference": "e3c9da6e645492c461e0a11eca117f83f4f4c840"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/01392d4b5878aa617e8d9bc7a529e5febc8fe956",
-                "reference": "01392d4b5878aa617e8d9bc7a529e5febc8fe956",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e3c9da6e645492c461e0a11eca117f83f4f4c840",
+                "reference": "e3c9da6e645492c461e0a11eca117f83f4f4c840",
                 "shasum": ""
             },
             "require": {
@@ -1866,7 +1866,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-05-14T04:57:31+00:00"
+            "time": "2019-05-28T11:53:42+00:00"
         },
         {
             "name": "psr/log",

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
@@ -28,7 +28,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 use Doctrine\Tests\DbalTestCase;
-use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionProperty;
 use function array_merge;
 use function get_class;
@@ -77,40 +77,14 @@ abstract class AbstractDriverTest extends DbalTestCase
             $this->markTestSkipped('This test is only intended for exception converter drivers.');
         }
 
-        $driverException = new class ($errorCode, $sqlState, $message)
-            extends Exception
-            implements DriverExceptionInterface
-        {
-            /** @var mixed */
-            private $errorCode;
-
-            /** @var mixed */
-            private $sqlState;
-
-            public function __construct($errorCode, $sqlState, $message)
-            {
-                parent::__construct($message);
-
-                $this->errorCode = $errorCode;
-                $this->sqlState  = $sqlState;
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            public function getErrorCode()
-            {
-                return $this->errorCode;
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            public function getSQLState()
-            {
-                return $this->sqlState;
-            }
-        };
+        /** @var DriverExceptionInterface|MockObject $driverException */
+        $driverException = $this->getMockBuilder(DriverExceptionInterface::class)
+            ->setConstructorArgs([$message])
+            ->getMock();
+        $driverException->method('getErrorCode')
+            ->willReturn($errorCode);
+        $driverException->method('getSQLState')
+            ->willReturn($sqlState);
 
         $dbalMessage   = 'DBAL exception message';
         $dbalException = $this->driver->convertException($dbalMessage, $driverException);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

This mock couldn't be reworked in #3555 due to https://github.com/sebastianbergmann/phpunit/pull/3694. Hence the PHPUnit constraint bump.