### PR TITLE
Make LoggerChain use constructor to add loggers instead of adder method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -42,6 +42,10 @@ The  `Doctrine\DBAL\Driver\SQLSrv\SQLSrvStatement::LAST_INSERT_ID_SQL` constant 
 
 The constants in `Doctrine\DBAL\SQLParserUtils` have been deprecated and will be made private in 3.0.
 
+## Deprecated `LoggerChain::addLogger` method
+
+The `Doctrine\DBAL\Logging\LoggerChain::addLogger` method has been deprecated. Inject list of loggers via constructor instead.
+
 # Upgrade to 2.9
 
 ## Deprecated `Statement::fetchColumn()` with an invalid index

--- a/lib/Doctrine/DBAL/Logging/LoggerChain.php
+++ b/lib/Doctrine/DBAL/Logging/LoggerChain.php
@@ -11,7 +11,17 @@ class LoggerChain implements SQLLogger
     private $loggers = [];
 
     /**
+     * @param SQLLogger[] $loggers
+     */
+    public function __construct(array $loggers = [])
+    {
+        $this->loggers = $loggers;
+    }
+
+    /**
      * Adds a logger in the chain.
+     *
+     * @deprecated Inject list of loggers via constructor instead
      *
      * @return void
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

This will help us implement configurable list of loggers to inject into LoggerChain on DI level in DoctrineBundle much more easily (then user can just use `!tagged`). Will help us resolve issues like https://github.com/doctrine/DoctrineBundle/pull/692 and https://github.com/doctrine/DoctrineBundle/issues/225

Deprecation was a result of conversation I had with @morozov on Slack.

No test cases because there are none for LoggerChain and this patch seems simple enough for not needing it.

After merging, I will create new PR for `develop` with removed method.

Before:
```php
$chain->addLogger($logger1);
$chain->addLogger($logger2);
```
After:
```php
$chain = new ChainLogger([$logger1, $logger2]);
```