### PR TITLE
Removed some unused code bits

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -60,9 +60,6 @@ class OCI8Statement implements IteratorAggregate, Statement
     /** @var OCI8Connection */
     protected $_conn;
 
-    /** @var string */
-    protected static $_PARAM = ':param';
-
     /** @var int[] */
     protected static $fetchModeMap = [
         FetchMode::MIXED       => OCI_BOTH,

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1844,16 +1844,6 @@ abstract class AbstractPlatform
     }
 
     /**
-     * Common code for alter table statement generation that updates the changed Index and Foreign Key definitions.
-     *
-     * @return string[]
-     */
-    protected function _getAlterTableIndexForeignKeySQL(TableDiff $diff) : array
-    {
-        return array_merge($this->getPreAlterTableIndexForeignKeySQL($diff), $this->getPostAlterTableIndexForeignKeySQL($diff));
-    }
-
-    /**
      * Gets declaration of a number of fields in bulk.
      *
      * @param mixed[][] $fields A multidimensional array.

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Sharding\Exception\MissingDefaultFederationName;
 use Doctrine\DBAL\Sharding\Exception\MissingDistributionType;
 use Doctrine\DBAL\Sharding\ShardingException;
 use Doctrine\DBAL\Sharding\ShardManager;
-use Doctrine\DBAL\Types\Type;
 use RuntimeException;
 use function sprintf;
 
@@ -192,8 +191,6 @@ class SQLAzureShardManager implements ShardManager
      */
     public function splitFederation($splitDistributionValue) : void
     {
-        $type = Type::getType($this->distributionType);
-
         $sql = 'ALTER FEDERATION ' . $this->getFederationName() . ' ' .
                'SPLIT AT (' . $this->getDistributionKey() . ' = ' .
                $this->conn->quote($splitDistributionValue) . ')';


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

1. `OCI8Statement::$_PARAM`. Was never used since its introduction.
2. `AbstractPlatform::_getAlterTableIndexForeignKeySQL()` is unused since #700 (`v2.5.0`).
3. The `$type` variable in `SQLAzureShardManager::splitFederation()` is unused since #3488.

**TODO:**
- [x] Document deprecations in `master` once accepted (#3598).