### PR TITLE
Updated Jetbrains PhpStorm stubs to 2019.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^6.0",
-        "jetbrains/phpstorm-stubs": "^2018.1.2",
+        "jetbrains/phpstorm-stubs": "^2019.1",
         "phpstan/phpstan": "^0.11.3",
         "phpunit/phpunit": "^8.1.6",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20970a03470d26a047432b1e25bb4a2a",
+    "content-hash": "9612eb03f704eeb9e5e8099f7e096443",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -436,20 +436,21 @@
         },
         {
             "name": "jetbrains/phpstorm-stubs",
-            "version": "v2018.1.2",
+            "version": "v2019.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "d5fd088949a717b477a08ed8e24e7e64a814ae10"
+                "reference": "9e309771f362e979ecfb429303ad7a402c657234"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/d5fd088949a717b477a08ed8e24e7e64a814ae10",
-                "reference": "d5fd088949a717b477a08ed8e24e7e64a814ae10",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/9e309771f362e979ecfb429303ad7a402c657234",
+                "reference": "9e309771f362e979ecfb429303ad7a402c657234",
                 "shasum": ""
             },
             "require-dev": {
                 "nikic/php-parser": "v4.0.1",
+                "php": "^7.1",
                 "phpdocumentor/reflection-docblock": "^4.3",
                 "phpunit/phpunit": "7.1.4"
             },
@@ -470,7 +471,7 @@
                 "stubs",
                 "type"
             ],
-            "time": "2018-04-25T12:26:46+00:00"
+            "time": "2019-03-25T16:59:23+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2931,7 +2932,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -28,11 +28,8 @@ parameters:
         - '~^Method Doctrine\\DBAL\\Driver\\OCI8\\OCI8Connection::lastInsertId\(\) should return string but returns (int|false)\.\z~'
         - '~^Method Doctrine\\DBAL\\Driver\\SQLSrv\\SQLSrvConnection::errorCode\(\) should return string\|null but returns false\.\z~'
 
-        # http://php.net/manual/en/pdo.sqlitecreatefunction.php
+        # https://bugs.php.net/bug.php?id=78126
         - '~^Call to an undefined method Doctrine\\DBAL\\Driver\\PDOConnection::sqliteCreateFunction\(\)\.\z~'
-
-        # https://github.com/JetBrains/phpstorm-stubs/pull/488
-        - '~^Parameter #1 \$byteCount of function SQLSRV_SQLTYPE_VARBINARY expects int, string given\.\z~'
 
         # https://github.com/phpstan/phpstan/issues/1847
         - '~^Parameter #2 \$registeredAliases of static method Doctrine\\DBAL\\Query\\QueryException::unknownAlias\(\) expects array<string>, array<int, int|string> given\.\z~'
@@ -42,7 +39,7 @@ parameters:
         - '~^Method Doctrine\\DBAL\\Platforms\\AbstractPlatform::escapeStringForLike\(\) should return string but returns string|null\.\z~'
 
         # legacy variadic-like signature
-        - '~^Method Doctrine\\DBAL\\Driver\\Connection::query\(\) invoked with \d+ parameters?, 0 required\.\z~'
+        - '~^Method Doctrine\\DBAL(\\.*)?Connection::query\(\) invoked with \d+ parameters?, 0 required\.\z~'
 
         # some drivers actually do accept 2nd parameter...
         - '~^Method Doctrine\\DBAL\\Platforms\\AbstractPlatform::getListTableForeignKeysSQL\(\) invoked with \d+ parameters, 1 required\.\z~'
@@ -54,8 +51,8 @@ parameters:
         # inheritance variance inference issue
         - '~^Method Doctrine\\DBAL\\Driver\\PDOConnection::\w+\(\) should return Doctrine\\DBAL\\Driver\\Statement but returns PDOStatement\.\z~'
 
-        # may not exist when pdo_sqlsrv is not loaded
+        # may not exist when pdo_sqlsrv is not loaded but PDO is
         - '~^Access to undefined constant PDO::SQLSRV_ENCODING_BINARY\.\z~'
 
-        # weird class name, doesn't exist in stubs either
+        # weird class name, represented in stubs as OCI_(Lob|Collection)
         - '~unknown class OCI-(Lob|Collection)~'


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

I was hoping https://github.com/JetBrains/phpstorm-stubs/pull/393 would fix the issue about having to suppress `PDOConnection::sqliteCreateFunction()` as well but it didn't due to PHP [bug #78126](https://bugs.php.net/bug.php?id=78126).