### PR TITLE
Removed Driver::getDatabase() in favor of Connection::getDatabase()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade to 3.0
 
+## BC BREAK: Changes in obtaining the currently selected database name
+
+- The `Doctrine\DBAL\Driver::getDatabase()` method has been removed. Please use `Doctrine\DBAL\Connection::getDatabase()` instead.
+- `Doctrine\DBAL\Connection::getDatabase()` will always return the name of the database currently connected to, regardless of the configuration parameters and will initialize a database connection if it's not yet established.
+- A call to `Doctrine\DBAL\Connection::getDatabase()`, when connected to an SQLite database, will no longer return the database file path.
+
 ## BC BREAK: Changes in handling string and binary columns
 
 - When generating schema DDL, DBAL no longer provides the default length for string and binary columns. The application may need to provide the column length if required by the target platform.

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -205,11 +205,23 @@ class Connection implements DriverConnection
     }
 
     /**
-     * Gets the name of the database this Connection is connected to.
+     * Gets the name of the currently selected database.
+     *
+     * @return string|null The name of the database or NULL if a database is not selected.
+     *                     The platforms which don't support the concept of a database (e.g. embedded databases)
+     *                     must always return a string as an indicator of an implicitly selected database.
+     *
+     * @throws DBALException
      */
     public function getDatabase() : ?string
     {
-        return $this->_driver->getDatabase($this);
+        $platform = $this->getDatabasePlatform();
+        $query    = $platform->getDummySelectSQL($platform->getCurrentDatabaseExpression());
+        $database = $this->query($query)->fetchColumn();
+
+        assert(is_string($database) || $database === null);
+
+        return $database;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver.php
+++ b/lib/Doctrine/DBAL/Driver.php
@@ -44,11 +44,4 @@ interface Driver
      * database schema of the platform this driver connects to.
      */
     public function getSchemaManager(Connection $conn) : AbstractSchemaManager;
-
-    /**
-     * Gets the name of the database connected to for this driver.
-     *
-     * @return string|null The name of the database or NULL if no database is currently selected.
-     */
-    public function getDatabase(Connection $conn) : ?string;
 }

--- a/lib/Doctrine/DBAL/Driver/AbstractDB2Driver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractDB2Driver.php
@@ -19,16 +19,6 @@ abstract class AbstractDB2Driver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function getDatabase(Connection $conn) : ?string
-    {
-        $params = $conn->getParams();
-
-        return $params['dbname'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getDatabasePlatform() : AbstractPlatform
     {
         return new DB2Platform();

--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -195,16 +195,6 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
 
     /**
      * {@inheritdoc}
-     */
-    public function getDatabase(Connection $conn) : ?string
-    {
-        $params = $conn->getParams();
-
-        return $params['dbname'] ?? $conn->query('SELECT DATABASE()')->fetchColumn();
-    }
-
-    /**
-     * {@inheritdoc}
      *
      * @return MySqlPlatform
      */

--- a/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
@@ -66,16 +66,6 @@ abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
     /**
      * {@inheritdoc}
      */
-    public function getDatabase(Connection $conn) : ?string
-    {
-        $params = $conn->getParams();
-
-        return $params['user'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getDatabasePlatform() : AbstractPlatform
     {
         return new OraclePlatform();

--- a/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
@@ -110,16 +110,6 @@ abstract class AbstractPostgreSQLDriver implements Driver, ExceptionConverterDri
     /**
      * {@inheritdoc}
      */
-    public function getDatabase(Connection $conn) : ?string
-    {
-        $params = $conn->getParams();
-
-        return $params['dbname'] ?? $conn->query('SELECT CURRENT_DATABASE()')->fetchColumn();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getDatabasePlatform() : AbstractPlatform
     {
         return new PostgreSqlPlatform();

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
@@ -92,16 +92,6 @@ abstract class AbstractSQLAnywhereDriver implements Driver, ExceptionConverterDr
     /**
      * {@inheritdoc}
      */
-    public function getDatabase(Connection $conn) : ?string
-    {
-        $params = $conn->getParams();
-
-        return $params['dbname'] ?? $conn->query('SELECT DB_NAME()')->fetchColumn();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getDatabasePlatform() : AbstractPlatform
     {
         return new SQLAnywherePlatform();

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
@@ -54,16 +54,6 @@ abstract class AbstractSQLServerDriver implements Driver, VersionAwarePlatformDr
     /**
      * {@inheritdoc}
      */
-    public function getDatabase(Connection $conn) : ?string
-    {
-        $params = $conn->getParams();
-
-        return $params['dbname'] ?? $conn->query('SELECT DB_NAME()')->fetchColumn();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getDatabasePlatform() : AbstractPlatform
     {
         return new SQLServerPlatform();

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
@@ -79,16 +79,6 @@ abstract class AbstractSQLiteDriver implements Driver, ExceptionConverterDriver
     /**
      * {@inheritdoc}
      */
-    public function getDatabase(Connection $conn) : ?string
-    {
-        $params = $conn->getParams();
-
-        return $params['path'] ?? '';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getDatabasePlatform() : AbstractPlatform
     {
         return new SqlitePlatform();

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1113,6 +1113,11 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Returns the SQL expression which represents the currently selected database.
+     */
+    abstract public function getCurrentDatabaseExpression() : string;
+
+    /**
      * Returns the FOR UPDATE expression.
      */
     public function getForUpdateSQL() : string

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -797,6 +797,14 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getCurrentDatabaseExpression() : string
+    {
+        return 'CURRENT_USER';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function supportsIdentityColumns() : bool
     {
         return true;

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -120,6 +120,14 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getCurrentDatabaseExpression() : string
+    {
+        return 'DATABASE()';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getListDatabasesSQL() : string
     {
         return 'SHOW DATABASES';

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -148,6 +148,14 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getCurrentDatabaseExpression() : string
+    {
+        return "SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getBitOrComparisonExpression(string $value1, string $value2) : string
     {
         return '(' . $value1 . '-' .

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -128,6 +128,14 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getCurrentDatabaseExpression() : string
+    {
+        return 'CURRENT_DATABASE()';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function supportsSequences() : bool
     {
         return true;

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -1125,6 +1125,14 @@ SQL
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getCurrentDatabaseExpression() : string
+    {
+        return 'DB_NAME()';
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getTruncateTableSQL(string $tableName, bool $cascade = false) : string

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1100,6 +1100,14 @@ SQL
     /**
      * {@inheritDoc}
      */
+    public function getCurrentDatabaseExpression() : string
+    {
+        return 'DB_NAME()';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getSetTransactionIsolationSQL(int $level) : string
     {
         return 'SET TRANSACTION ISOLATION LEVEL ' . $this->_getTransactionIsolationLevelSQL($level);

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -152,6 +152,19 @@ class SqlitePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * The SQLite platform doesn't support the concept of a database, therefore, it always returns an empty string
+     * as an indicator of an implicitly selected database.
+     *
+     * @see \Doctrine\DBAL\Connection::getDatabase()
+     */
+    public function getCurrentDatabaseExpression() : string
+    {
+        return "''";
+    }
+
+    /**
+     * {@inheritDoc}
      */
     protected function _getTransactionIsolationLevelSQL(int $level) : string
     {

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
@@ -140,23 +140,6 @@ abstract class AbstractDriverTest extends DbalTestCase
         $this->driver->createDatabasePlatformForVersion('foo');
     }
 
-    public function testReturnsDatabaseName() : void
-    {
-        $params = [
-            'user'     => 'foo',
-            'password' => 'bar',
-            'dbname'   => 'baz',
-        ];
-
-        $connection = $this->getConnectionMock();
-
-        $connection->expects($this->once())
-            ->method('getParams')
-            ->will($this->returnValue($params));
-
-        self::assertSame($params['dbname'], $this->driver->getDatabase($connection));
-    }
-
     public function testReturnsDatabasePlatform() : void
     {
         self::assertEquals($this->createPlatform(), $this->driver->getDatabasePlatform());

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\DBAL\Driver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
-use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
@@ -18,35 +17,6 @@ use Doctrine\DBAL\Schema\MySqlSchemaManager;
 
 class AbstractMySQLDriverTest extends AbstractDriverTest
 {
-    public function testReturnsDatabaseName() : void
-    {
-        parent::testReturnsDatabaseName();
-
-        $database = 'bloo';
-        $params   = [
-            'user'     => 'foo',
-            'password' => 'bar',
-        ];
-
-        $statement = $this->createMock(ResultStatement::class);
-
-        $statement->expects($this->once())
-            ->method('fetchColumn')
-            ->will($this->returnValue($database));
-
-        $connection = $this->getConnectionMock();
-
-        $connection->expects($this->once())
-            ->method('getParams')
-            ->will($this->returnValue($params));
-
-        $connection->expects($this->once())
-            ->method('query')
-            ->will($this->returnValue($statement));
-
-        self::assertSame($database, $this->driver->getDatabase($connection));
-    }
-
     protected function createDriver() : Driver
     {
         return $this->getMockForAbstractClass(AbstractMySQLDriver::class);

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractOracleDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractOracleDriverTest.php
@@ -14,42 +14,6 @@ use Doctrine\DBAL\Schema\OracleSchemaManager;
 
 class AbstractOracleDriverTest extends AbstractDriverTest
 {
-    public function testReturnsDatabaseName() : void
-    {
-        $params = [
-            'user'     => 'foo',
-            'password' => 'bar',
-            'dbname'   => 'baz',
-        ];
-
-        $connection = $this->getConnectionMock();
-
-        $connection->expects($this->once())
-            ->method('getParams')
-            ->will($this->returnValue($params));
-
-        self::assertSame($params['user'], $this->driver->getDatabase($connection));
-    }
-
-    public function testReturnsDatabaseNameWithConnectDescriptor() : void
-    {
-        $params = [
-            'user'             => 'foo',
-            'password'         => 'bar',
-            'connectionstring' => '(DESCRIPTION=' .
-                '(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))' .
-                '(CONNECT_DATA=(SERVICE_NAME=baz)))',
-        ];
-
-        $connection = $this->getConnectionMock();
-
-        $connection->expects($this->once())
-            ->method('getParams')
-            ->will($this->returnValue($params));
-
-        self::assertSame($params['user'], $this->driver->getDatabase($connection));
-    }
-
     protected function createDriver() : Driver
     {
         return $this->getMockForAbstractClass(AbstractOracleDriver::class);

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractPostgreSQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractPostgreSQLDriverTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\DBAL\Driver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
-use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
@@ -17,35 +16,6 @@ use Doctrine\DBAL\Schema\PostgreSqlSchemaManager;
 
 class AbstractPostgreSQLDriverTest extends AbstractDriverTest
 {
-    public function testReturnsDatabaseName() : void
-    {
-        parent::testReturnsDatabaseName();
-
-        $database = 'bloo';
-        $params   = [
-            'user'     => 'foo',
-            'password' => 'bar',
-        ];
-
-        $statement = $this->createMock(ResultStatement::class);
-
-        $statement->expects($this->once())
-            ->method('fetchColumn')
-            ->will($this->returnValue($database));
-
-        $connection = $this->getConnectionMock();
-
-        $connection->expects($this->once())
-            ->method('getParams')
-            ->will($this->returnValue($params));
-
-        $connection->expects($this->once())
-            ->method('query')
-            ->will($this->returnValue($statement));
-
-        self::assertSame($database, $this->driver->getDatabase($connection));
-    }
-
     protected function createDriver() : Driver
     {
         return $this->getMockForAbstractClass(AbstractPostgreSQLDriver::class);

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLiteDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLiteDriverTest.php
@@ -14,24 +14,6 @@ use Doctrine\DBAL\Schema\SqliteSchemaManager;
 
 class AbstractSQLiteDriverTest extends AbstractDriverTest
 {
-    public function testReturnsDatabaseName() : void
-    {
-        $params = [
-            'user'     => 'foo',
-            'password' => 'bar',
-            'dbname'   => 'baz',
-            'path'     => 'bloo',
-        ];
-
-        $connection = $this->getConnectionMock();
-
-        $connection->expects($this->once())
-            ->method('getParams')
-            ->will($this->returnValue($params));
-
-        self::assertSame($params['path'], $this->driver->getDatabase($connection));
-    }
-
     protected function createDriver() : Driver
     {
         return $this->getMockForAbstractClass(AbstractSQLiteDriver::class);

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/AbstractDriverTest.php
@@ -58,7 +58,7 @@ abstract class AbstractDriverTest extends DbalFunctionalTestCase
 
         self::assertSame(
             static::getDatabaseNameForConnectionWithoutDatabaseNameParameter(),
-            $this->driver->getDatabase($connection)
+            $connection->getDatabase()
         );
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
@@ -49,7 +49,7 @@ class DriverTest extends AbstractDriverTest
 
         self::assertSame(
             $expectedDatabaseName,
-            $this->driver->getDatabase($connection)
+            $connection->getDatabase()
         );
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverTest.php
@@ -41,7 +41,7 @@ class DriverTest extends AbstractDriverTest
 
         // SQL Anywhere has no "default" database. The name of the default database
         // is defined on server startup and therefore can be arbitrary.
-        self::assertIsString($this->driver->getDatabase($connection));
+        self::assertIsString($connection->getDatabase());
     }
 
     /**

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use InvalidArgumentException;
 use PHPUnit\Framework\Assert;
 use function explode;
@@ -99,7 +100,12 @@ class TestUtil
         $platform = $tmpConn->getDatabasePlatform();
 
         if ($platform->supportsCreateDropDatabase()) {
-            $dbname = $realConn->getDatabase();
+            if (! $platform instanceof OraclePlatform) {
+                $dbname = $realDbParams['dbname'];
+            } else {
+                $dbname = $realDbParams['user'];
+            }
+
             $realConn->close();
 
             if ($dbname === null) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

Fixes: #3592.

1. The changes from the end user perspective are stated in `UPGRADE.md`.
2. Some unit tests have been removed as no longer relevant.
3. The code is still covered by functional tests, specifically the ones which perform schema introspection.
4. I didn't add tests for changing the database on the fly since it's not currently supported by the abstraction. The main goal is to make DBAL not hinder valid scenarios which it doesn't explicitly support.