### PR TITLE
Reworked the mocks generated by Prophecy using PHPUnit

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Types/DateImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateImmutableTypeTest.php
@@ -9,13 +9,13 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateImmutableType;
 use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Prophecy\ObjectProphecy;
 use function get_class;
 
 class DateImmutableTypeTest extends TestCase
 {
-    /** @var AbstractPlatform|ObjectProphecy */
+    /** @var AbstractPlatform|MockObject */
     private $platform;
 
     /** @var DateImmutableType */
@@ -24,7 +24,7 @@ class DateImmutableTypeTest extends TestCase
     protected function setUp() : void
     {
         $this->type     = Type::getType('date_immutable');
-        $this->platform = $this->prophesize(AbstractPlatform::class);
+        $this->platform = $this->createMock(AbstractPlatform::class);
     }
 
     public function testFactoryCreatesCorrectType() : void
@@ -44,46 +44,53 @@ class DateImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeImmutableInstanceToDatabaseValue() : void
     {
-        $date = $this->prophesize(DateTimeImmutable::class);
+        $date = $this->createMock(DateTimeImmutable::class);
 
-        $this->platform->getDateFormatString()->willReturn('Y-m-d')->shouldBeCalled();
-        $date->format('Y-m-d')->willReturn('2016-01-01')->shouldBeCalled();
+        $this->platform->expects($this->once())
+            ->method('getDateFormatString')
+            ->willReturn('Y-m-d');
+        $date->expects($this->once())
+            ->method('format')
+            ->with('Y-m-d')
+            ->willReturn('2016-01-01');
 
         self::assertSame(
             '2016-01-01',
-            $this->type->convertToDatabaseValue($date->reveal(), $this->platform->reveal())
+            $this->type->convertToDatabaseValue($date, $this->platform)
         );
     }
 
     public function testConvertsNullToDatabaseValue() : void
     {
-        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform->reveal()));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
 
     public function testDoesNotSupportMutableDateTimeToDatabaseValueConversion() : void
     {
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToDatabaseValue(new DateTime(), $this->platform->reveal());
+        $this->type->convertToDatabaseValue(new DateTime(), $this->platform);
     }
 
     public function testConvertsDateTimeImmutableInstanceToPHPValue() : void
     {
         $date = new DateTimeImmutable();
 
-        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform->reveal()));
+        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
     }
 
     public function testConvertsNullToPHPValue() : void
     {
-        self::assertNull($this->type->convertToPHPValue(null, $this->platform->reveal()));
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
     public function testConvertsDateStringToPHPValue() : void
     {
-        $this->platform->getDateFormatString()->willReturn('Y-m-d')->shouldBeCalled();
+        $this->platform->expects($this->once())
+            ->method('getDateFormatString')
+            ->willReturn('Y-m-d');
 
-        $date = $this->type->convertToPHPValue('2016-01-01', $this->platform->reveal());
+        $date = $this->type->convertToPHPValue('2016-01-01', $this->platform);
 
         self::assertInstanceOf(DateTimeImmutable::class, $date);
         self::assertSame('2016-01-01', $date->format('Y-m-d'));
@@ -91,9 +98,11 @@ class DateImmutableTypeTest extends TestCase
 
     public function testResetTimeFractionsWhenConvertingToPHPValue() : void
     {
-        $this->platform->getDateFormatString()->willReturn('Y-m-d');
+        $this->platform->expects($this->any())
+            ->method('getDateFormatString')
+            ->willReturn('Y-m-d');
 
-        $date = $this->type->convertToPHPValue('2016-01-01', $this->platform->reveal());
+        $date = $this->type->convertToPHPValue('2016-01-01', $this->platform);
 
         self::assertSame('2016-01-01 00:00:00.000000', $date->format('Y-m-d H:i:s.u'));
     }
@@ -102,11 +111,11 @@ class DateImmutableTypeTest extends TestCase
     {
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToPHPValue('invalid date string', $this->platform->reveal());
+        $this->type->convertToPHPValue('invalid date string', $this->platform);
     }
 
     public function testRequiresSQLCommentHint() : void
     {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform->reveal()));
+        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTimeImmutableTypeTest.php
@@ -9,13 +9,13 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeImmutableType;
 use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Prophecy\ObjectProphecy;
 use function get_class;
 
 class DateTimeImmutableTypeTest extends TestCase
 {
-    /** @var AbstractPlatform|ObjectProphecy */
+    /** @var AbstractPlatform|MockObject */
     private $platform;
 
     /** @var DateTimeImmutableType */
@@ -24,7 +24,7 @@ class DateTimeImmutableTypeTest extends TestCase
     protected function setUp() : void
     {
         $this->type     = Type::getType('datetime_immutable');
-        $this->platform = $this->prophesize(AbstractPlatform::class);
+        $this->platform = $this->getMockBuilder(AbstractPlatform::class)->getMock();
     }
 
     public function testFactoryCreatesCorrectType() : void
@@ -44,46 +44,53 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeImmutableInstanceToDatabaseValue() : void
     {
-        $date = $this->prophesize(DateTimeImmutable::class);
+        $date = $this->getMockBuilder(DateTimeImmutable::class)->getMock();
 
-        $this->platform->getDateTimeFormatString()->willReturn('Y-m-d H:i:s')->shouldBeCalled();
-        $date->format('Y-m-d H:i:s')->willReturn('2016-01-01 15:58:59')->shouldBeCalled();
+        $this->platform->expects($this->once())
+            ->method('getDateTimeFormatString')
+            ->willReturn('Y-m-d H:i:s');
+        $date->expects($this->once())
+            ->method('format')
+            ->with('Y-m-d H:i:s')
+            ->willReturn('2016-01-01 15:58:59');
 
         self::assertSame(
             '2016-01-01 15:58:59',
-            $this->type->convertToDatabaseValue($date->reveal(), $this->platform->reveal())
+            $this->type->convertToDatabaseValue($date, $this->platform)
         );
     }
 
     public function testConvertsNullToDatabaseValue() : void
     {
-        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform->reveal()));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
 
     public function testDoesNotSupportMutableDateTimeToDatabaseValueConversion() : void
     {
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToDatabaseValue(new DateTime(), $this->platform->reveal());
+        $this->type->convertToDatabaseValue(new DateTime(), $this->platform);
     }
 
     public function testConvertsDateTimeImmutableInstanceToPHPValue() : void
     {
         $date = new DateTimeImmutable();
 
-        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform->reveal()));
+        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
     }
 
     public function testConvertsNullToPHPValue() : void
     {
-        self::assertNull($this->type->convertToPHPValue(null, $this->platform->reveal()));
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
     public function testConvertsDateTimeStringToPHPValue() : void
     {
-        $this->platform->getDateTimeFormatString()->willReturn('Y-m-d H:i:s')->shouldBeCalled();
+        $this->platform->expects($this->once())
+            ->method('getDateTimeFormatString')
+            ->willReturn('Y-m-d H:i:s');
 
-        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59', $this->platform->reveal());
+        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59', $this->platform);
 
         self::assertInstanceOf(DateTimeImmutable::class, $date);
         self::assertSame('2016-01-01 15:58:59', $date->format('Y-m-d H:i:s'));
@@ -94,22 +101,28 @@ class DateTimeImmutableTypeTest extends TestCase
      */
     public function testConvertsDateTimeStringWithMicrosecondsToPHPValue() : void
     {
-        $this->platform->getDateTimeFormatString()->willReturn('Y-m-d H:i:s');
+        $this->platform->expects($this->any())
+            ->method('getDateTimeFormatString')
+            ->willReturn('Y-m-d H:i:s');
 
-        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59.123456', $this->platform->reveal());
+        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59.123456', $this->platform);
 
         self::assertSame('2016-01-01 15:58:59', $date->format('Y-m-d H:i:s'));
     }
 
     public function testThrowsExceptionDuringConversionToPHPValueWithInvalidDateTimeString() : void
     {
+        $this->platform->expects($this->atLeastOnce())
+            ->method('getDateTimeFormatString')
+            ->willReturn('Y-m-d H:i:s');
+
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToPHPValue('invalid datetime string', $this->platform->reveal());
+        $this->type->convertToPHPValue('invalid datetime string', $this->platform);
     }
 
     public function testRequiresSQLCommentHint() : void
     {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform->reveal()));
+        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTimeTzImmutableTypeTest.php
@@ -9,13 +9,13 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeTzImmutableType;
 use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Prophecy\ObjectProphecy;
 use function get_class;
 
 class DateTimeTzImmutableTypeTest extends TestCase
 {
-    /** @var AbstractPlatform|ObjectProphecy */
+    /** @var AbstractPlatform|MockObject */
     private $platform;
 
     /** @var DateTimeTzImmutableType */
@@ -24,7 +24,7 @@ class DateTimeTzImmutableTypeTest extends TestCase
     protected function setUp() : void
     {
         $this->type     = Type::getType('datetimetz_immutable');
-        $this->platform = $this->prophesize(AbstractPlatform::class);
+        $this->platform = $this->createMock(AbstractPlatform::class);
     }
 
     public function testFactoryCreatesCorrectType() : void
@@ -44,46 +44,53 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeImmutableInstanceToDatabaseValue() : void
     {
-        $date = $this->prophesize(DateTimeImmutable::class);
+        $date = $this->createMock(DateTimeImmutable::class);
 
-        $this->platform->getDateTimeTzFormatString()->willReturn('Y-m-d H:i:s T')->shouldBeCalled();
-        $date->format('Y-m-d H:i:s T')->willReturn('2016-01-01 15:58:59 UTC')->shouldBeCalled();
+        $this->platform->expects($this->once())
+            ->method('getDateTimeTzFormatString')
+            ->willReturn('Y-m-d H:i:s T');
+        $date->expects($this->once())
+            ->method('format')
+            ->with('Y-m-d H:i:s T')
+            ->willReturn('2016-01-01 15:58:59 UTC');
 
         self::assertSame(
             '2016-01-01 15:58:59 UTC',
-            $this->type->convertToDatabaseValue($date->reveal(), $this->platform->reveal())
+            $this->type->convertToDatabaseValue($date, $this->platform)
         );
     }
 
     public function testConvertsNullToDatabaseValue() : void
     {
-        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform->reveal()));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
 
     public function testDoesNotSupportMutableDateTimeToDatabaseValueConversion() : void
     {
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToDatabaseValue(new DateTime(), $this->platform->reveal());
+        $this->type->convertToDatabaseValue(new DateTime(), $this->platform);
     }
 
     public function testConvertsDateTimeImmutableInstanceToPHPValue() : void
     {
         $date = new DateTimeImmutable();
 
-        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform->reveal()));
+        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
     }
 
     public function testConvertsNullToPHPValue() : void
     {
-        self::assertNull($this->type->convertToPHPValue(null, $this->platform->reveal()));
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
     public function testConvertsDateTimeWithTimezoneStringToPHPValue() : void
     {
-        $this->platform->getDateTimeTzFormatString()->willReturn('Y-m-d H:i:s T')->shouldBeCalled();
+        $this->platform->expects($this->once())
+            ->method('getDateTimeTzFormatString')
+            ->willReturn('Y-m-d H:i:s T');
 
-        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59 UTC', $this->platform->reveal());
+        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59 UTC', $this->platform);
 
         self::assertInstanceOf(DateTimeImmutable::class, $date);
         self::assertSame('2016-01-01 15:58:59 UTC', $date->format('Y-m-d H:i:s T'));
@@ -91,13 +98,17 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
     public function testThrowsExceptionDuringConversionToPHPValueWithInvalidDateTimeWithTimezoneString() : void
     {
+        $this->platform->expects($this->atLeastOnce())
+            ->method('getDateTimeTzFormatString')
+            ->willReturn('Y-m-d H:i:s T');
+
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToPHPValue('invalid datetime with timezone string', $this->platform->reveal());
+        $this->type->convertToPHPValue('invalid datetime with timezone string', $this->platform);
     }
 
     public function testRequiresSQLCommentHint() : void
     {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform->reveal()));
+        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | build [#545999926](https://travis-ci.org/doctrine/dbal/jobs/545999926#L609)

As of PHP 7.4.0alpha1 `ReflectionType::__toString()` seems to have started triggering deprecation notices however it's deprecated since PHP 7.1. We already reworked the corresponding mocks in #3582 (`develop`), so this is a backport of the relevant changes.