### PR TITLE
Allow getCustomSchemaOption 'using' to be used

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -548,7 +548,7 @@ SQL
                 // here was a server version check before, but DBAL API does not support this anymore.
                 $query = 'ALTER ' . $oldColumnName . ' TYPE ' . $type->getSQLDeclaration($columnDefinition, $this);
                 if ($columnDiff->hasChanged('using')) {
-                    $query = $query . ' USING ' . $column->getCustomSchemaOption('using');
+                    $query .= ' USING ' . $column->getCustomSchemaOption('using');
                 }
                 $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ' . $query;
             }

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -546,7 +546,11 @@ SQL
                 $columnDefinition['autoincrement'] = false;
 
                 // here was a server version check before, but DBAL API does not support this anymore.
-                $query = 'ALTER ' . $oldColumnName . ' TYPE ' . $type->getSQLDeclaration($columnDefinition, $this);
+                $customUsing = '';
+                if ($columnDiff->hasChanged('using')) {
+                    $customUsing = ' USING '.$column->getCustomSchemaOption('using');
+                }
+                $query = 'ALTER ' . $oldColumnName . ' TYPE ' . $type->getSQLDeclaration($columnDefinition, $this) . $customUsing;
                 $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ' . $query;
             }
 

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -548,7 +548,7 @@ SQL
                 // here was a server version check before, but DBAL API does not support this anymore.
                 $customUsing = '';
                 if ($columnDiff->hasChanged('using')) {
-                    $customUsing = ' USING '.$column->getCustomSchemaOption('using');
+                    $customUsing = ' USING ' . $column->getCustomSchemaOption('using');
                 }
                 $query = 'ALTER ' . $oldColumnName . ' TYPE ' . $type->getSQLDeclaration($columnDefinition, $this) . $customUsing;
                 $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ' . $query;

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -546,11 +546,10 @@ SQL
                 $columnDefinition['autoincrement'] = false;
 
                 // here was a server version check before, but DBAL API does not support this anymore.
-                $customUsing = '';
+                $query = 'ALTER ' . $oldColumnName . ' TYPE ' . $type->getSQLDeclaration($columnDefinition, $this);
                 if ($columnDiff->hasChanged('using')) {
-                    $customUsing = ' USING ' . $column->getCustomSchemaOption('using');
+                    $query = $query . ' USING ' . $column->getCustomSchemaOption('using');
                 }
-                $query = 'ALTER ' . $oldColumnName . ' TYPE ' . $type->getSQLDeclaration($columnDefinition, $this) . $customUsing;
                 $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ' . $query;
             }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Schema;
 
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
@@ -14,7 +15,6 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use PHPUnit\Framework\TestCase;
 use function array_keys;
 use function get_class;
@@ -1345,7 +1345,7 @@ class ComparatorTest extends TestCase
             $newTable
         );
 
-        $pgsql  = new \Doctrine\DBAL\Platforms\PostgreSqlPlatform();
+        $pgsql  = new PostgreSqlPlatform();
         $result = $pgsql->getAlterTableSQL($tableDiff);
 
         $expected = [


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | Might fix #2376 

#### Summary

Allow `customSchemaOption` 'using' to be used as an additional SQL to an `ALTER COLUMN`  type change.  This is to allow a way of adding custom SQL that can be used to convert from one type to another.  Mainly used to fix: https://github.com/laravel/framework/issues/28963 with `syntax ->change()->using('special_price::int::numeric(12,4)')`.
