### PR TITLE
provide custom socket path through dsn

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -103,6 +103,10 @@ class Driver extends AbstractPostgreSQLDriver
             $dsn .= 'application_name=' . $params['application_name'] . ';';
         }
 
+        if (isset($params['unix_socket'])) {
+            $dsn .= 'unix_socket=' . $params['unix_socket'] . ';';
+        }
+
         return $dsn;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature/improvement
| BC Break     | no
| Fixed issues | #3624

#### Summary

If `unix_socket` is passed through params, add it to the dsn.