### PR TITLE
Fixed test failures on PHP 7.4

### DIFF
--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -309,13 +309,20 @@ class MySqlSchemaManager extends AbstractSchemaManager
 
         $tableOptions = $this->_conn->fetchAssoc($sql);
 
+        if ($tableOptions === false) {
+            return $table;
+        }
+
         $table->addOption('engine', $tableOptions['ENGINE']);
+
         if ($tableOptions['TABLE_COLLATION'] !== null) {
             $table->addOption('collation', $tableOptions['TABLE_COLLATION']);
         }
+
         if ($tableOptions['AUTO_INCREMENT'] !== null) {
             $table->addOption('autoincrement', $tableOptions['AUTO_INCREMENT']);
         }
+
         $table->addOption('comment', $tableOptions['TABLE_COMMENT']);
         $table->addOption('create_options', $this->parseCreateOptions($tableOptions['CREATE_OPTIONS']));
 

--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -34,7 +34,9 @@ class Table extends AbstractAsset
     protected $_fkConstraints = [];
 
     /** @var mixed[] */
-    protected $_options = [];
+    protected $_options = [
+        'create_options' => [],
+    ];
 
     /** @var SchemaConfig|null */
     protected $_schemaConfig = null;
@@ -69,7 +71,7 @@ class Table extends AbstractAsset
             $this->_addForeignKeyConstraint($constraint);
         }
 
-        $this->_options = $options;
+        $this->_options = array_merge($this->_options, $options);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -59,6 +59,11 @@ class OCI8StatementTest extends DbalTestCase
                 $this->equalTo($params[2])
             );
 
+        // the return value is irrelevant to the test
+        // but it has to be compatible with the method signature
+        $statement->method('errorInfo')
+            ->willReturn(false);
+
         // can't pass to constructor since we don't have a real database handle,
         // but execute must check the connection for the executeMode
         $conn = $this->getMockBuilder(OCI8Connection::class)

--- a/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
@@ -47,6 +47,10 @@ class PoolingShardManagerTest extends TestCase
     {
         $conn = $this->createConnectionMock();
         $conn->expects($this->once())->method('connect')->with($this->equalTo(0));
+        $conn->method('getParams')
+            ->willReturn([
+                'shardChoser' => $this->createMock(ShardChoser::class),
+            ]);
 
         $shardManager = new PoolingShardManager($conn);
         $shardManager->selectGlobal();


### PR DESCRIPTION
The failures are caused by the changes in PHP according to [PHP RFC: E_WARNING for invalid container read array-access](https://wiki.php.net/rfc/notice-for-non-valid-array-container).

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | [build #567162538](https://travis-ci.org/doctrine/dbal/builds/567162538)
