### PR TITLE
Using command line options to configure MySQL 8 instead of mounting a config file

### DIFF
--- a/tests/travis/install-mysql-8.0.sh
+++ b/tests/travis/install-mysql-8.0.sh
@@ -4,16 +4,14 @@ set -ex
 
 echo "Starting MySQL 8.0..."
 
-echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password" > /tmp/mysql-auth.cnf
-
 sudo docker pull mysql:8.0
 sudo docker run \
     -d \
     -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
     -e MYSQL_DATABASE=doctrine_tests \
-    -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro \
     -p 33306:3306 \
     --name mysql80 \
-    mysql:8.0
+    mysql:8.0 \
+    --default-authentication-plugin=mysql_native_password
 
 sudo docker exec -i mysql80 bash <<< 'until echo \\q | mysql doctrine_tests > /dev/null 2>&1 ; do sleep 1; done'


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | [build #567372184](https://travis-ci.org/doctrine/dbal/builds/567372184)

Some builds fail on MySQL 8 with the following error message:

> SQLSTATE[HY000] [2054] The server requested authentication method unknown to the client

however, this issue should have been mitigated by the additional server configuration:

https://github.com/doctrine/dbal/blob/b9d7a36604d43a466b24d63da02982f05356dd91/tests/travis/install-mysql-8.0.sh#L7

According to the current [documentation](https://hub.docker.com/_/mysql#configuration-without-a-cnf-file), the needed configuration may be specified using a command-line switch w/o mounting a file. Judging by the error message, the mounted file is not taken into account for some reason.