### PR TITLE
Address issue #3631 by adding support for a float datatype

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,21 +22,21 @@ environment:
     driver: sqlsrv
     db_version: sql2008r2sp2
     coverage: yes
-    php: 7.2
+    php: 7.3
   - db: mssql
     driver: sqlsrv
     db_version: sql2012sp1
-    php: 7.2
+    php: 7.3
     coverage: yes
   - db: mssql
     driver: sqlsrv
     db_version: sql2017
     coverage: no
-    php: 7.2
+    php: 7.3
   - db: mssql
     driver: pdo_sqlsrv
     db_version: sql2017
-    php: 7.2
+    php: 7.3
     coverage: yes
 
 init:
@@ -103,7 +103,7 @@ install:
             New-Item -path c:\tools -name ocular -itemtype directory
           }
           if (!(Test-Path c:\tools\ocular\ocular.phar)) {
-            appveyor-retry appveyor DownloadFile https://github.com/scrutinizer-ci/ocular/releases/download/1.5.2/ocular.phar -Filename C:\tools\ocular\ocular.phar
+            appveyor-retry appveyor DownloadFile https://github.com/scrutinizer-ci/ocular/releases/download/1.6.0/ocular.phar -Filename C:\tools\ocular\ocular.phar
             Set-Content -path 'C:\tools\ocular\ocular.bat' -Value ('@php C:\tools\ocular\ocular.phar %*')
           }
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -21,7 +21,7 @@ before_commands:
 tools:
     external_code_coverage:
         timeout: 3600
-        runs: 30 # 25x Travis (jobs with COVERAGE=yes) + 3x AppVeyor (jobs with coverage=yes) + 2x ContinuousPHP
+        runs: 32 # 27x Travis (jobs with COVERAGE=yes) + 3x AppVeyor (jobs with coverage=yes) + 2x ContinuousPHP
 
 filter:
     excluded_paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,16 +23,22 @@ install:
 
 script:
   - |
+    phpflags=
+    phpexe=
+    if [ "x$LANGUAGE" != "x" ]; then
+       phpflags=-dauto_prepend_file=$PWD/tests/travis/setlocale-de.php
+       phpexe=php
+    fi
     if [ "x$COVERAGE" == "xyes" ]; then
-       ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml --coverage-clover clover.xml
+       $phpexe $phpflags ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml --coverage-clover clover.xml
     else
-       ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml
+       $phpexe $phpflags ./vendor/bin/phpunit --configuration tests/travis/$DB.travis.xml
     fi
 
 after_script:
   - |
     if [ "x$COVERAGE" == "xyes" ]; then
-      travis_retry wget https://github.com/scrutinizer-ci/ocular/releases/download/1.5.2/ocular.phar
+      travis_retry wget https://github.com/scrutinizer-ci/ocular/releases/download/1.6.0/ocular.phar
       travis_retry php ocular.phar code-coverage:upload --format=php-clover clover.xml
     fi
 
@@ -339,3 +345,99 @@ jobs:
       install:
         - composer config minimum-stability dev
         - travis_retry composer update --prefer-dist
+
+    - stage: Test
+      php: 7.2
+      env: LANGUAGE=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 LANG=de_DE.UTF-8 DB=mysqli.docker MYSQL_VERSION=8.0
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-language.sh
+        - bash ./tests/travis/install-mysql-8.0.sh
+
+    - stage: Test
+      php: 7.3
+      env: LANGUAGE=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 LANG=de_DE.UTF-8 DB=mysqli.docker MYSQL_VERSION=8.0 COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-language.sh
+        - bash ./tests/travis/install-mysql-8.0.sh
+
+    - stage: Test
+      php: 7.3
+      env: LANGUAGE=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 LANG=de_DE.UTF-8 DB=mysqli.docker MYSQL_VERSION=5.7
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-language.sh
+        - bash ./tests/travis/install-mysql-5.7.sh
+
+    - stage: Test
+      php: 7.3
+      env: LANGUAGE=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 LANG=de_DE.UTF-8 DB=sqlite COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-language.sh
+
+    - stage: Test
+      php: 7.3
+      env: LANGUAGE=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 LANG=de_DE.UTF-8 DB=pgsql POSTGRESQL_VERSION=10.0
+      sudo: required
+      services:
+        - postgresql
+      addons:
+        postgresql: "9.6"
+      before_script:
+        - bash ./tests/travis/install-language.sh
+        - bash ./tests/travis/install-postgres-10.sh
+
+    - stage: Test
+      php: 7.3
+      env: LANGUAGE=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 LANG=de_DE.UTF-8 DB=pgsql POSTGRESQL_VERSION=11.0
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-language.sh
+        - bash ./tests/travis/install-postgres-11.sh
+
+    - stage: Test
+      php: 7.3
+      env: LANGUAGE=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 LANG=de_DE.UTF-8 DB=sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-language.sh
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
+        - bash ./tests/travis/install-mssql-sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+
+    - stage: Test
+      php: 7.3
+      env: LANGUAGE=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 LANG=de_DE.UTF-8 DB=pdo_sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-language.sh
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
+        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+
+    - stage: Test
+      php: 7.3
+      env: LANGUAGE=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 LANG=de_DE.UTF-8 DB=ibm_db2
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-language.sh
+        - bash ./tests/travis/install-db2.sh
+        - bash ./tests/travis/install-db2-ibm_db2.sh

--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -90,8 +90,13 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
             case '1429':
             case '2002':
             case '2005':
+            case '2054':
                 return new Exception\ConnectionException($message, $exception);
-
+            case '2006':
+                if ($exception instanceof Driver\Mysqli\MysqliConnectionException || $exception instanceof PDOConnectionException) {
+                    return new Exception\ConnectionException($message, $exception);
+                }
+                break;
             case '1048':
             case '1121':
             case '1138':

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -68,7 +68,7 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
         });
         try {
             if (! $this->conn->real_connect($params['host'], $username, $password, $dbname, $port, $socket, $flags)) {
-                throw new MysqliException($this->conn->connect_error, $this->conn->sqlstate ?? 'HY000', $this->conn->connect_errno);
+                throw new MysqliConnectionException($this->conn->connect_error, $this->conn->sqlstate ?? 'HY000', $this->conn->connect_errno);
             }
         } finally {
             restore_error_handler();

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnectionException.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnectionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\Mysqli;
+
+/**
+ * Exception thrown in case the mysqli driver errors while connecting.
+ */
+class MysqliConnectionException extends MysqliException
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -28,7 +28,7 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
             $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, [PDOStatement::class, []]);
             $this->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+            throw new PDOConnectionException($exception);
         }
     }
 

--- a/lib/Doctrine/DBAL/Driver/PDOConnectionException.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnectionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\DBAL\Driver;
+
+/**
+ * PDOConnectionException is used to distinguish connection failures from regular PDOExceptions.
+ */
+class PDOConnectionException extends PDOException
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -26,6 +26,7 @@ class PDOStatement extends \PDOStatement implements Statement
         ParameterType::BINARY       => PDO::PARAM_LOB,
         ParameterType::LARGE_OBJECT => PDO::PARAM_LOB,
         ParameterType::BOOLEAN      => PDO::PARAM_BOOL,
+        ParameterType::DOUBLE       => PDO::PARAM_STR,
     ];
 
     private const FETCH_MODE_MAP = [

--- a/lib/Doctrine/DBAL/ParameterType.php
+++ b/lib/Doctrine/DBAL/ParameterType.php
@@ -50,6 +50,11 @@ final class ParameterType
     public const BINARY = 16;
 
     /**
+     * Represents a double data type.
+     */
+    public const DOUBLE = 17;
+
+    /**
      * This class cannot be instantiated.
      */
     private function __construct()

--- a/lib/Doctrine/DBAL/Types/FloatType.php
+++ b/lib/Doctrine/DBAL/Types/FloatType.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Types;
 
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class FloatType extends Type
@@ -28,5 +29,13 @@ class FloatType extends Type
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         return $value === null ? null : (float) $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBindingType()
+    {
+        return ParameterType::DOUBLE;
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
@@ -53,7 +53,7 @@ class MysqliConnectionTest extends DbalFunctionalTestCase
             new MysqliConnection(['host' => '255.255.255.255'], 'user', 'pass');
             self::fail('An exception was supposed to be raised');
         } catch (MysqliException $e) {
-            self::assertSame('Network is unreachable', $e->getMessage());
+            self::assertSame(2002, $e->getErrorCode());
         }
 
         self::assertSame($handler, set_error_handler($default_handler), 'Restoring error handler failed.');

--- a/tests/Doctrine/Tests/DBAL/Functional/Types/DoubleTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Types/DoubleTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Functional\Types;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalFunctionalTestCase;
+use function abs;
+use function floatval;
+use function is_int;
+use function is_string;
+use function microtime;
+use function sprintf;
+
+class DoubleTest extends DbalFunctionalTestCase
+{
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $table = new Table('double_table');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('val', 'float');
+        $table->setPrimaryKey(['id']);
+
+        $sm = $this->connection->getSchemaManager();
+        $sm->dropAndCreateTable($table);
+    }
+
+    public function testInsertAndSelect() : void
+    {
+        $value1 = 1.1;
+        $value2 = 77.99999999999;
+        $value3 = microtime(true);
+
+        $this->insert(1, $value1);
+        $this->insert(2, $value2);
+        $this->insert(3, $value3);
+
+        $result1 = $this->select(1);
+        $result2 = $this->select(2);
+        $result3 = $this->select(3);
+
+        if (is_string($result1)) {
+            $result1 = floatval($result1);
+            $result2 = floatval($result2);
+            $result3 = floatval($result3);
+        }
+
+        if ($result1 === false) {
+            $this->fail('Expected $result1 to not be false');
+
+            return;
+        }
+        if ($result2 === false) {
+            $this->fail('Expected $result2 to not be false');
+
+            return;
+        }
+        if ($result3 === false) {
+            $this->fail('Expected $result3 to not be false');
+
+            return;
+        }
+
+        $diff1 = abs($result1 - $value1);
+        $diff2 = abs($result2 - $value2);
+        $diff3 = abs($result3 - $value3);
+
+        $this->assertLessThanOrEqual(0.0001, $diff1, sprintf('%f, %f, %f', $diff1, $result1, $value1));
+        $this->assertLessThanOrEqual(0.0001, $diff2, sprintf('%f, %f, %f', $diff2, $result2, $value2));
+        $this->assertLessThanOrEqual(0.0001, $diff3, sprintf('%f, %f, %f', $diff3, $result3, $value3));
+
+        $result1 = $this->selectDouble($value1);
+        $result2 = $this->selectDouble($value2);
+        $result3 = $this->selectDouble($value3);
+
+        $this->assertSame(is_int($result1) ? 1 : '1', $result1);
+        $this->assertSame(is_int($result2) ? 2 : '2', $result2);
+        $this->assertSame(is_int($result3) ? 3 : '3', $result3);
+    }
+
+    private function insert(int $id, float $value) : void
+    {
+        $result = $this->connection->insert('double_table', [
+            'id'  => $id,
+            'val' => $value,
+        ], [
+            ParameterType::INTEGER,
+            ParameterType::DOUBLE,
+        ]);
+
+        self::assertSame(1, $result);
+    }
+
+    /**
+     * @return mixed
+     */
+    private function select(int $id)
+    {
+        return $this->connection->fetchColumn(
+            'SELECT val FROM double_table WHERE id = ?',
+            [$id],
+            0,
+            [ParameterType::INTEGER]
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    private function selectDouble(float $value)
+    {
+        return $this->connection->fetchColumn(
+            'SELECT id FROM double_table WHERE val = ?',
+            [$value],
+            0,
+            [ParameterType::DOUBLE]
+        );
+    }
+}

--- a/tests/continuousphp/bootstrap.php
+++ b/tests/continuousphp/bootstrap.php
@@ -23,7 +23,7 @@ use Doctrine\DBAL\DriverManager;
     $file = $_SERVER['argv'][$pos + 1];
 
     register_shutdown_function(static function () use ($file) : void {
-        $cmd = 'wget https://github.com/scrutinizer-ci/ocular/releases/download/1.5.2/ocular.phar'
+        $cmd = 'wget https://github.com/scrutinizer-ci/ocular/releases/download/1.6.0/ocular.phar'
             . ' && php ocular.phar code-coverage:upload --format=php-clover ' . escapeshellarg($file);
 
         passthru($cmd);

--- a/tests/travis/install-db2-ibm_db2.sh
+++ b/tests/travis/install-db2-ibm_db2.sh
@@ -5,6 +5,7 @@ set -ex
 echo "Installing extension"
 (
     # updating APT packages as per support recommendation
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
     sudo apt -y -q update
     sudo apt install ksh
 

--- a/tests/travis/install-language.sh
+++ b/tests/travis/install-language.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Installing language pack..."
+
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
+sudo apt -y -q update
+sudo apt install language-pack-de

--- a/tests/travis/install-mysql-8.0.sh
+++ b/tests/travis/install-mysql-8.0.sh
@@ -12,6 +12,7 @@ sudo docker run \
     -p 33306:3306 \
     --name mysql80 \
     mysql:8.0 \
+    mysqld \
     --default-authentication-plugin=mysql_native_password
 
 sudo docker exec -i mysql80 bash <<< 'until echo \\q | mysql doctrine_tests > /dev/null 2>&1 ; do sleep 1; done'

--- a/tests/travis/setlocale-de.php
+++ b/tests/travis/setlocale-de.php
@@ -1,0 +1,3 @@
+<?php
+
+setlocale(LC_ALL, 'de_DE.UTF-8', 'de_DE', 'de', 'ge');


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3631 

#### Summary

Create a new DOUBLE type to satisfy the 'd' type necessary for full Mysqli compatibility as referenced here: [mysqli_stmt::bind_param](https://www.php.net/manual/en/mysqli-stmt.bind-param.php).

(NOTE: new PR b/c rebase didn't work on PR #3639).