### PR TITLE
fix Appveyor builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,21 +22,21 @@ environment:
     driver: sqlsrv
     db_version: sql2008r2sp2
     coverage: yes
-    php: 7.2
+    php: 7.3
   - db: mssql
     driver: sqlsrv
     db_version: sql2012sp1
-    php: 7.2
+    php: 7.3
     coverage: yes
   - db: mssql
     driver: sqlsrv
     db_version: sql2017
     coverage: no
-    php: 7.2
+    php: 7.3
   - db: mssql
     driver: pdo_sqlsrv
     db_version: sql2017
-    php: 7.2
+    php: 7.3
     coverage: yes
 
 init:


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3657

#### Summary

Fix Appveyor builds which just started crashing a week or two ago due to the disappearance of PHP 7.2 from chocolatey.

Upgrades to PHP 7.3 as it's the only version that's available.