### PR TITLE
fix MySQL build problems with ConnectionException detection

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -90,7 +90,14 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
             case '1429':
             case '2002':
             case '2005':
+            case '2054':
                 return new Exception\ConnectionException($message, $exception);
+		
+            case '2006':
+                if ($exception instanceof Driver\Mysqli\MysqliConnectionException || $exception instanceof PDOConnectionException) {
+                    return new Exception\ConnectionException($message, $exception);
+                }
+                break;
 
             case '1048':
             case '1121':

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnectionException.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnectionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\Mysqli;
+
+/**
+ * Exception thrown in case the mysqli driver errors while connecting.
+ */
+class MysqliConnectionException extends MysqliException
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -28,7 +28,7 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
             $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, [PDOStatement::class, []]);
             $this->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+            throw new PDOConnectionException($exception);
         }
     }
 

--- a/lib/Doctrine/DBAL/Driver/PDOConnectionException.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnectionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\DBAL\Driver;
+
+/**
+ * PDOConnectionException is used to distinguish connection failures from regular PDOExceptions.
+ */
+class PDOConnectionException extends PDOException
+{
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3655 

#### Summary

Over the past few weeks MySQL builds have been randomly failing due to the following sorts of errors (happened with both MySQLi and PDO):

```sh
There was 1 failure:
752
7531) Doctrine\Tests\DBAL\Functional\ExceptionTest::testConnectionException with data set #0 (array('not_existing'))
754Failed asserting that exception of type "Doctrine\DBAL\Exception\DriverException" matches expected exception "Doctrine\DBAL\Exception\ConnectionException". Message was: "An exception occurred in driver: The server requested authentication method unknown to the client" at
755/home/travis/build/doctrine/dbal/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php:71
756/home/travis/build/doctrine/dbal/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php:16
757/home/travis/build/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:354
758/home/travis/build/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:418
759/home/travis/build/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:378
760/home/travis/build/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:322
761/home/travis/build/doctrine/dbal/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php:369
```

This is happening because the test is expecting a ConnectionException, but instead a DriverConnection is incorrectly happening.

*MySQLi driver flaky failed builds:*
https://travis-ci.org/doctrine/dbal/jobs/565778380
https://travis-ci.org/doctrine/dbal/jobs/569139933
https://travis-ci.org/doctrine/dbal/jobs/569146693

*MySQL PDO driver flaky failed builds:*
https://travis-ci.org/doctrine/dbal/jobs/569146680
https://travis-ci.org/doctrine/dbal/jobs/569146690