### PR TITLE
WIP - Issue #3631 - fix for Double data type when using MySQLi with languages that do not use '.' for the decimal point

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 
 before_script:
   - if [[ "$DB" == "mysql" || "$DB" == "mysqli" || "$DB" == *"mariadb"* ]]; then mysql < tests/travis/create-mysql-schema.sql; fi;
+  - tests/travis/install-language-de.sh
 
 install:
   - rm composer.lock

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -34,6 +34,7 @@ class MysqliStatement implements IteratorAggregate, Statement
         ParameterType::NULL         => 's',
         ParameterType::INTEGER      => 'i',
         ParameterType::LARGE_OBJECT => 'b',
+        ParameterType::DOUBLE       => 'd',
     ];
 
     /** @var mysqli */

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -26,6 +26,7 @@ class PDOStatement extends \PDOStatement implements Statement
         ParameterType::BINARY       => PDO::PARAM_LOB,
         ParameterType::LARGE_OBJECT => PDO::PARAM_LOB,
         ParameterType::BOOLEAN      => PDO::PARAM_BOOL,
+        ParameterType::DOUBLE       => PDO::PARAM_STR,
     ];
 
     private const FETCH_MODE_MAP = [

--- a/lib/Doctrine/DBAL/ParameterType.php
+++ b/lib/Doctrine/DBAL/ParameterType.php
@@ -50,6 +50,11 @@ final class ParameterType
     public const BINARY = 16;
 
     /**
+     * Represents a double data type.
+     */
+    public const DOUBLE = 17;
+
+    /**
      * This class cannot be instantiated.
      */
     private function __construct()

--- a/lib/Doctrine/DBAL/Types/FloatType.php
+++ b/lib/Doctrine/DBAL/Types/FloatType.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Types;
 
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class FloatType extends Type
@@ -28,5 +29,13 @@ class FloatType extends Type
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         return $value === null ? null : (float) $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBindingType()
+    {
+        return ParameterType::DOUBLE;
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Types/DoubleTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Types/DoubleTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Functional\Types;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalFunctionalTestCase;
+use function abs;
+use function floatval;
+use function is_int;
+use function is_string;
+use function microtime;
+use function sprintf;
+
+class DoubleTest extends DbalFunctionalTestCase
+{
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $table = new Table('double_table');
+        $table->addColumn('id', 'integer');
+        $table->addColumn('val', 'float');
+        $table->setPrimaryKey(['id']);
+
+        $sm = $this->connection->getSchemaManager();
+        $sm->dropAndCreateTable($table);
+    }
+
+    public function testInsertAndSelect() : void
+    {
+        $value1 = 1.1;
+        $value2 = 77.99999999999;
+        $value3 = microtime(true);
+
+        $this->insert(1, $value1);
+        $this->insert(2, $value2);
+        $this->insert(3, $value3);
+
+        $result1 = $this->select(1);
+        $result2 = $this->select(2);
+        $result3 = $this->select(3);
+
+        if (is_string($result1)) {
+            $result1 = floatval($result1);
+            $result2 = floatval($result2);
+            $result3 = floatval($result3);
+        }
+
+        if ($result1 === false) {
+            $this->fail('Expected $result1 to not be false');
+
+            return;
+        }
+        if ($result2 === false) {
+            $this->fail('Expected $result2 to not be false');
+
+            return;
+        }
+        if ($result3 === false) {
+            $this->fail('Expected $result3 to not be false');
+
+            return;
+        }
+
+        $diff1 = abs($result1 - $value1);
+        $diff2 = abs($result2 - $value2);
+        $diff3 = abs($result3 - $value3);
+
+        $this->assertLessThanOrEqual(0.0001, $diff1, sprintf('%f, %f, %f', $diff1, $result1, $value1));
+        $this->assertLessThanOrEqual(0.0001, $diff2, sprintf('%f, %f, %f', $diff2, $result2, $value2));
+        $this->assertLessThanOrEqual(0.0001, $diff3, sprintf('%f, %f, %f', $diff3, $result3, $value3));
+
+        $result1 = $this->selectDouble($value1);
+        $result2 = $this->selectDouble($value2);
+        $result3 = $this->selectDouble($value3);
+
+        $this->assertSame(is_int($result1) ? 1 : '1', $result1);
+        $this->assertSame(is_int($result2) ? 2 : '2', $result2);
+        $this->assertSame(is_int($result3) ? 3 : '3', $result3);
+    }
+
+    private function insert(int $id, float $value) : void
+    {
+        $result = $this->connection->insert('double_table', [
+            'id'  => $id,
+            'val' => $value,
+        ], [
+            ParameterType::INTEGER,
+            ParameterType::DOUBLE,
+        ]);
+
+        self::assertSame(1, $result);
+    }
+
+    /**
+     * @return mixed
+     */
+    private function select(int $id)
+    {
+        return $this->connection->fetchColumn(
+            'SELECT val FROM double_table WHERE id = ?',
+            [$id],
+            0,
+            [ParameterType::INTEGER]
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    private function selectDouble(float $value)
+    {
+        return $this->connection->fetchColumn(
+            'SELECT id FROM double_table WHERE val = ?',
+            [$value],
+            0,
+            [ParameterType::DOUBLE]
+        );
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Types/LanguageDoubleTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Types/LanguageDoubleTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Functional\Types;
+
+use const LC_ALL;
+use function setlocale;
+
+class LanguageDoubleTest extends DoubleTest
+{
+    protected function setUp() : void
+    {
+        setlocale(LC_ALL, 'de_DE.UTF-8', 'de_DE', 'de', 'ge');
+        parent::setUp();
+    }
+}

--- a/tests/travis/install-language-de.sh
+++ b/tests/travis/install-language-de.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Installing language pack de..."
+
+sudo apt -y -q update
+sudo apt install language-pack-de


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3631 

#### Summary

   * Add a special ParameterType for Double
   * Detect floats in MysqliStatement and pass the 'd' as the parameter type (see: [mysqli_stmt::bind-param](https://www.php.net/manual/en/mysqli-stmt.bind-param.php#types))
   * Create two tests cases, one for the standard '.' version, and one that extends the same test case, but switches the language to de_DE and tests the ',' case.
