### PR TITLE
Marked connection exception test incomplete on MySQL 8

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -3,14 +3,20 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\DrizzlePlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use Throwable;
 use const PHP_OS;
 use function array_merge;
+use function assert;
 use function chmod;
 use function exec;
 use function file_exists;
@@ -20,6 +26,7 @@ use function sprintf;
 use function sys_get_temp_dir;
 use function touch;
 use function unlink;
+use function version_compare;
 
 class ExceptionTest extends DbalFunctionalTestCase
 {
@@ -289,7 +296,7 @@ class ExceptionTest extends DbalFunctionalTestCase
 
     public function testConnectionExceptionSqLite() : void
     {
-        if ($this->connection->getDatabasePlatform()->getName() !== 'sqlite') {
+        if ($this->connection instanceof SqlitePlatform) {
             $this->markTestSkipped('Only fails this way on sqlite');
         }
 
@@ -343,16 +350,27 @@ EOT
      */
     public function testConnectionException(array $params) : void
     {
-        if ($this->connection->getDatabasePlatform()->getName() === 'sqlite') {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SqlitePlatform) {
             $this->markTestSkipped('Only skipped if platform is not sqlite');
         }
 
-        if ($this->connection->getDatabasePlatform()->getName() === 'drizzle') {
+        if ($platform instanceof DrizzlePlatform) {
             $this->markTestSkipped('Drizzle does not always support authentication');
         }
 
-        if ($this->connection->getDatabasePlatform()->getName() === 'postgresql' && isset($params['password'])) {
+        if ($platform instanceof PostgreSqlPlatform && isset($params['password'])) {
             $this->markTestSkipped('Does not work on Travis');
+        }
+
+        if ($platform instanceof MySqlPlatform && isset($params['user'])) {
+            $wrappedConnection = $this->connection->getWrappedConnection();
+            assert($wrappedConnection instanceof ServerInfoAwareConnection);
+
+            if (version_compare($wrappedConnection->getServerVersion(), '8', '>=')) {
+                $this->markTestIncomplete('PHP currently does not completely support MySQL 8');
+            }
         }
 
         $defaultParams = $this->connection->getParams();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | [job #575597509](https://travis-ci.org/doctrine/dbal/jobs/575597509)

It looks like a MySQL bug or miscommunication between PHP and MySQL 8. I can reproduce it as follows:

1. Start a MySQL 8 container:
   ```bash
   docker run \
       --rm \
       -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
       -p 33306:3306 \
       mysql:8.0 \
       --default-authentication-plugin=mysql_native_password
   ```
2. When the server is ready, run the following script (PHP 7.3.8):
   ```php
   $conn = mysqli_connect('127.0.0.1:33306', 'root', '', 'mysql');
   
   if (!$conn) {
       exit(1);
   }
   
   $query = 'SELECT VERSION()';
   
   $result = mysqli_query($conn, $query);
   
   if (!$result) {
       echo mysqli_error($conn), PHP_EOL;
       exit(1);
   }
   
   echo mysqli_fetch_row($result)[0], PHP_EOL;
   ```
   The expected output is something like `8.0.17`
3. Change the username in the connection parameters to something invalid. Re-run the script. The expected output is:
   >Warning: mysqli_connect(): (HY000/1045): Access denied for user 'anonymous'@'172.17.0.1' (using password: YES)

   The actual output is:
   > Warning: mysqli_connect(): The server requested authentication method unknown to the client [caching_sha2_password]
   > 
   > Warning: mysqli_connect(): (HY000/2054): The server requested authentication method unknown to the client

   At the same time, the server reports its configuration as configured:
   ```
   mysql> show variables like 'default_authentication_plugin';
   +-------------------------------+-----------------------+
   | Variable_name                 | Value                 |
   +-------------------------------+-----------------------+
   | default_authentication_plugin | mysql_native_password |
   +-------------------------------+-----------------------+
   1 row in set (0.01 sec)
   ```

My speculation is that when a connection cannot be established by means of the default `mysql_native_password`, MySQL falls back to `caching_sha2_password` which is not yet supported by PHP. Therefore, instead of error 1045 we're getting 2054.