### PR TITLE
Refactor usage of MockBuilder's deprecated setMethods()

### DIFF
--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -67,7 +67,7 @@ class ConnectionTest extends DbalTestCase
         $platform = $this->getMockForAbstractClass(AbstractPlatform::class);
 
         return $this->getMockBuilder(Connection::class)
-            ->setMethods(['executeUpdate'])
+            ->onlyMethods(['executeUpdate'])
             ->setConstructorArgs([['platform' => $platform], $driverMock])
             ->getMock();
     }
@@ -145,8 +145,8 @@ class ConnectionTest extends DbalTestCase
 
     public function testConnectDispatchEvent() : void
     {
-        $listenerMock = $this->getMockBuilder('ConnectDispatchEventListener')
-            ->setMethods(['postConnect'])
+        $listenerMock = $this->getMockBuilder($this->getMockClass('ConnectDispatchEventListener'))
+            ->addMethods(['postConnect'])
             ->getMock();
         $listenerMock->expects($this->once())->method('postConnect');
 
@@ -566,7 +566,7 @@ class ConnectionTest extends DbalTestCase
 
         /** @var Connection|MockObject $conn */
         $conn = $this->getMockBuilder(Connection::class)
-            ->setMethods(['executeQuery'])
+            ->onlyMethods(['executeQuery'])
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
 
@@ -602,7 +602,7 @@ class ConnectionTest extends DbalTestCase
 
         /** @var Connection|MockObject $conn */
         $conn = $this->getMockBuilder(Connection::class)
-            ->setMethods(['executeQuery'])
+            ->onlyMethods(['executeQuery'])
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
 
@@ -639,7 +639,7 @@ class ConnectionTest extends DbalTestCase
 
         /** @var Connection|MockObject $conn */
         $conn = $this->getMockBuilder(Connection::class)
-            ->setMethods(['executeQuery'])
+            ->onlyMethods(['executeQuery'])
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
 
@@ -674,7 +674,7 @@ class ConnectionTest extends DbalTestCase
 
         /** @var Connection|MockObject $conn */
         $conn = $this->getMockBuilder(Connection::class)
-            ->setMethods(['executeQuery'])
+            ->onlyMethods(['executeQuery'])
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
 
@@ -756,7 +756,7 @@ class ConnectionTest extends DbalTestCase
 
         $conn = $this->getMockBuilder(Connection::class)
             ->setConstructorArgs([['pdo' => $pdoMock, 'platform' => $platformMock], $driverMock])
-            ->setMethods(['connect'])
+            ->onlyMethods(['connect'])
             ->getMock();
 
         $conn->expects($this->once())->method('connect');

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -36,7 +36,7 @@ class OCI8StatementTest extends DbalTestCase
     public function testExecute(array $params) : void
     {
         $statement = $this->getMockBuilder(OCI8Statement::class)
-            ->setMethods(['bindValue', 'errorInfo'])
+            ->onlyMethods(['bindValue', 'errorInfo'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -67,7 +67,7 @@ class OCI8StatementTest extends DbalTestCase
         // can't pass to constructor since we don't have a real database handle,
         // but execute must check the connection for the executeMode
         $conn = $this->getMockBuilder(OCI8Connection::class)
-            ->setMethods(['getExecuteMode'])
+            ->onlyMethods(['getExecuteMode'])
             ->disableOriginalConstructor()
             ->getMock();
         $conn->expects($this->once())

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -367,10 +367,10 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
 
         $this->schemaManager->dropAndCreateTable($table);
 
-        $listenerMock = $this
-            ->getMockBuilder('ListTableColumnsDispatchEventListener')
-            ->setMethods(['onSchemaColumnDefinition'])
+        $listenerMock = $this->getMockBuilder($this->getMockClass('ListTableColumnsDispatchEventListener'))
+            ->addMethods(['onSchemaColumnDefinition'])
             ->getMock();
+
         $listenerMock
             ->expects($this->exactly(7))
             ->method('onSchemaColumnDefinition');
@@ -395,9 +395,8 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
 
         $this->schemaManager->dropAndCreateTable($table);
 
-        $listenerMock = $this
-            ->getMockBuilder('ListTableIndexesDispatchEventListener')
-            ->setMethods(['onSchemaIndexDefinition'])
+        $listenerMock = $this->getMockBuilder($this->getMockClass('ListTableIndexesDispatchEventListener'))
+            ->addMethods(['onSchemaIndexDefinition'])
             ->getMock();
         $listenerMock
             ->expects($this->exactly(3))

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -380,8 +380,8 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
 
     public function testGetCreateTableSqlDispatchEvent() : void
     {
-        $listenerMock = $this->getMockBuilder('GetCreateTableSqlDispatchEvenListener')
-            ->setMethods(['onSchemaCreateTable', 'onSchemaCreateTableColumn'])
+        $listenerMock = $this->getMockBuilder($this->getMockClass('GetCreateTableSqlDispatchEvenListener'))
+            ->addMethods(['onSchemaCreateTable', 'onSchemaCreateTableColumn'])
             ->getMock();
         $listenerMock
             ->expects($this->once())
@@ -404,8 +404,8 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
 
     public function testGetDropTableSqlDispatchEvent() : void
     {
-        $listenerMock = $this->getMockBuilder('GetDropTableSqlDispatchEventListener')
-            ->setMethods(['onSchemaDropTable'])
+        $listenerMock = $this->getMockBuilder($this->getMockClass('GetDropTableSqlDispatchEventListener'))
+            ->addMethods(['onSchemaDropTable'])
             ->getMock();
         $listenerMock
             ->expects($this->once())
@@ -429,8 +429,8 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
             'onSchemaAlterTableRenameColumn',
         ];
 
-        $listenerMock = $this->getMockBuilder('GetAlterTableSqlDispatchEvenListener')
-            ->setMethods($events)
+        $listenerMock = $this->getMockBuilder($this->getMockClass('GetAlterTableSqlDispatchEvenListener'))
+            ->addMethods($events)
             ->getMock();
         $listenerMock
             ->expects($this->once())

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -617,7 +617,7 @@ class ComparatorTest extends TestCase
         $c    = new Comparator();
         $diff = $c->compare($schemaA, $schemaB);
 
-        self::assertSchemaTableChangeCount($diff, 1, 0, 1);
+        $this->assertSchemaTableChangeCount($diff, 1, 0, 1);
     }
 
     public function testSequencesCaseInsensitive() : void
@@ -637,7 +637,7 @@ class ComparatorTest extends TestCase
         $c    = new Comparator();
         $diff = $c->compare($schemaA, $schemaB);
 
-        self::assertSchemaSequenceChangeCount($diff, 1, 0, 1);
+        $this->assertSchemaSequenceChangeCount($diff, 1, 0, 1);
     }
 
     public function testCompareColumnCompareCaseInsensitive() : void

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -1172,10 +1172,10 @@ class ComparatorTest extends TestCase
     {
         $comparator = new Comparator();
         $fromSchema = $this->getMockBuilder(Schema::class)
-            ->setMethods(['getNamespaces', 'hasNamespace'])
+            ->onlyMethods(['getNamespaces', 'hasNamespace'])
             ->getMock();
         $toSchema   = $this->getMockBuilder(Schema::class)
-            ->setMethods(['getNamespaces', 'hasNamespace'])
+            ->onlyMethods(['getNamespaces', 'hasNamespace'])
             ->getMock();
 
         $fromSchema->expects($this->once())

--- a/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
@@ -30,7 +30,7 @@ final class DB2SchemaManagerTest extends TestCase
         $platform      = $this->createMock(DB2Platform::class);
         $this->conn    = $this
             ->getMockBuilder(Connection::class)
-            ->setMethods(['fetchAll', 'quote'])
+            ->onlyMethods(['fetchAll', 'quote'])
             ->setConstructorArgs([['platform' => $platform], $driverMock, new Configuration(), $eventManager])
             ->getMock();
         $this->manager = new DB2SchemaManager($this->conn);

--- a/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
@@ -27,7 +27,7 @@ class MySqlSchemaManagerTest extends TestCase
         $driverMock    = $this->createMock(Driver::class);
         $platform      = $this->createMock(MySqlPlatform::class);
         $this->conn    = $this->getMockBuilder(Connection::class)
-            ->setMethods(['fetchAll'])
+            ->onlyMethods(['fetchAll'])
             ->setConstructorArgs([['platform' => $platform], $driverMock, new Configuration(), $eventManager])
             ->getMock();
         $this->manager = new MySqlSchemaManager($this->conn);

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -26,7 +26,7 @@ class CreateSchemaSqlCollectorTest extends TestCase
         parent::setUp();
 
         $this->platformMock = $this->getMockBuilder(AbstractPlatform::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getCreateForeignKeySQL',
                     'getCreateSchemaSQL',

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/DropSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/DropSchemaSqlCollectorTest.php
@@ -23,7 +23,7 @@ class DropSchemaSqlCollectorTest extends TestCase
         $keyConstraintTwo = $this->getStubKeyConstraint('second');
 
         $platform = $this->getMockBuilder(AbstractPlatform::class)
-            ->setMethods(['getDropForeignKeySQL'])
+            ->onlyMethods(['getDropForeignKeySQL'])
             ->getMockForAbstractClass();
 
         $collector = new DropSchemaSqlCollector($platform);

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
@@ -11,7 +11,7 @@ class SchemaSqlCollectorTest extends TestCase
     public function testCreateSchema() : void
     {
         $platformMock = $this->getMockBuilder(MySqlPlatform::class)
-            ->setMethods(['getCreateTableSql', 'getCreateSequenceSql', 'getCreateForeignKeySql'])
+            ->onlyMethods(['getCreateTableSql', 'getCreateSequenceSql', 'getCreateForeignKeySql'])
             ->getMock();
         $platformMock->expects($this->exactly(2))
                      ->method('getCreateTableSql')
@@ -33,7 +33,7 @@ class SchemaSqlCollectorTest extends TestCase
     public function testDropSchema() : void
     {
         $platformMock = $this->getMockBuilder(MySqlPlatform::class)
-            ->setMethods(['getDropTableSql', 'getDropSequenceSql', 'getDropForeignKeySql'])
+            ->onlyMethods(['getDropTableSql', 'getDropSequenceSql', 'getDropForeignKeySql'])
             ->getMock();
         $platformMock->expects($this->exactly(2))
                      ->method('getDropTableSql')

--- a/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
@@ -16,7 +16,7 @@ class PoolingShardManagerTest extends TestCase
     private function createConnectionMock() : PoolingShardConnection
     {
         return $this->getMockBuilder(PoolingShardConnection::class)
-            ->setMethods(['connect', 'getParams', 'fetchAll'])
+            ->onlyMethods(['connect', 'getParams', 'fetchAll'])
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/SQLAzureShardManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/SQLAzureShardManagerTest.php
@@ -85,7 +85,7 @@ class SQLAzureShardManagerTest extends TestCase
     private function createConnection(array $params) : Connection
     {
         $conn = $this->getMockBuilder(Connection::class)
-            ->setMethods(['getParams', 'exec', 'isTransactionActive'])
+            ->onlyMethods(['getParams', 'exec', 'isTransactionActive'])
             ->disableOriginalConstructor()
             ->getMock();
         $conn->expects($this->at(0))->method('getParams')->will($this->returnValue($params));

--- a/tests/Doctrine/Tests/DBAL/Sharding/ShardChoser/MultiTenantShardChoserTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/ShardChoser/MultiTenantShardChoserTest.php
@@ -20,7 +20,7 @@ class MultiTenantShardChoserTest extends TestCase
     private function createConnectionMock() : PoolingShardConnection
     {
         return $this->getMockBuilder(PoolingShardConnection::class)
-            ->setMethods(['connect', 'getParams', 'fetchAll'])
+            ->onlyMethods(['connect', 'getParams', 'fetchAll'])
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -28,7 +28,7 @@ class StatementTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->pdoStatement = $this->getMockBuilder(PDOStatement::class)
-            ->setMethods(['execute', 'bindParam', 'bindValue'])
+            ->onlyMethods(['execute', 'bindParam', 'bindValue'])
             ->getMock();
 
         $driverConnection = $this->createMock(DriverConnection::class);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

- `setMethods()` has been deprecated ([ref](https://github.com/sebastianbergmann/phpunit/blob/b61d4d78a2657f5c65a296ffc86944b473211c88/src/Framework/MockObject/MockBuilder.php#L195)) in `PHPUnit\Framework\MockObject\MockBuilder` (https://github.com/sebastianbergmann/phpunit/commit/d618fa3fda437421264dcfa1413a474f306f79c4)

  - Mocking nonexistent classes requires
    ```
    $this->getMockBuilder('Foo')
    ```
    to be refactored into
    ```
    $this->getMockBuilder($this->getMockClass('Foo'))
    ```
    and then set the mock methods with [`addMethods()`](https://github.com/sebastianbergmann/phpunit/blob/b61d4d78a2657f5c65a296ffc86944b473211c88/src/Framework/MockObject/MockBuilder.php#L259-L266)

  - Mocking existing classes requires existing methods to be set with [`onlyMethods()`](https://github.com/sebastianbergmann/phpunit/blob/b61d4d78a2657f5c65a296ffc86944b473211c88/src/Framework/MockObject/MockBuilder.php#L206-L213)
- In 2 occurrances a class was calling its own dynamic method in a static way. Changed this to use `$this` instead of `self::`