### PR TITLE
Phpstan fix backport

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -77,5 +77,6 @@
     <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.IncorrectReturnTypeHint">
         <exclude-pattern>lib/Doctrine/DBAL/Types/ArrayType.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/DBAL/Types/ObjectType.php</exclude-pattern>
+        <exclude-pattern>tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
@@ -44,7 +44,7 @@ class MysqliConnectionTest extends DbalFunctionalTestCase
 
     public function testRestoresErrorHandlerOnException() : void
     {
-        $handler         = static function () : void {
+        $handler         = static function () : bool {
             self::fail('Never expected this to be called');
         };
         $default_handler = set_error_handler($handler);

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -296,7 +296,7 @@ class ExceptionTest extends DbalFunctionalTestCase
 
     public function testConnectionExceptionSqLite() : void
     {
-        if ($this->connection instanceof SqlitePlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
             $this->markTestSkipped('Only fails this way on sqlite');
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Without these changes, PHPStan produces the following errors on `develop`:
```
------ ---------------------------------------------------------------------------------- 
  Line   tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php                  
 ------ ---------------------------------------------------------------------------------- 
  52     Parameter #1 $error_handler of function set_error_handler expects (callable(int,  
         string, string, int, array): bool)|null, Closure(): void given.                   
  61     Parameter #1 $error_handler of function set_error_handler expects (callable(int,  
         string, string, int, array): bool)|null, Closure(): void given.                   
 ------ ---------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------- 
  Line   tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php                                  
 ------ ---------------------------------------------------------------------------------------- 
  300    Instanceof between Doctrine\DBAL\Connection and Doctrine\DBAL\Platforms\SqlitePlatform  
         will always evaluate to false.                                                          
 ------ ----------------------------------------------------------------------------------------
```
Currently, we do not run PHPStan on `tests/` in master and doing so would require a lot of effort since many existing issues are by design.