### PR TITLE
Change fetchAll typehint

### DIFF
--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -70,7 +70,7 @@ interface ResultStatement extends Traversable
      * @param int|null     $fetchMode     Controls how the next row will be returned to the caller.
      *                                    The value must be one of the {@link \Doctrine\DBAL\FetchMode} constants,
      *                                    defaulting to {@link \Doctrine\DBAL\FetchMode::MIXED}.
-     * @param int|null     $fetchArgument This argument has a different meaning depending on the value of the $fetchMode parameter:
+     * @param mixed|null   $fetchArgument This argument has a different meaning depending on the value of the $fetchMode parameter:
      *                                    * {@link \Doctrine\DBAL\FetchMode::COLUMN}:
      *                                      Returns the indicated 0-indexed column.
      *                                    * {@link \Doctrine\DBAL\FetchMode::CUSTOM_OBJECT}:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | no issue

#### Summary

i hope i didn't get this wrong, but i think the type hint for the `$fetchArgument` argument in `fetchAll` method is wrong, at least in case you are using PDO. The argument `$fetchArgument` may also be a string when `$fetchMode` is set to `\Doctrine\DBAL\FetchMode::CUSTOM_OBJECT`