### PR TITLE
Add support for multi table truncate when possible (Postgres as example)

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3103,6 +3103,16 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Whether the platform supports multi table truncate.
+     *
+     * @return bool
+     */
+    public function supportsTruncateMultiTable()
+    {
+        return false;
+    }
+
+    /**
      * Whether the platform supports partial indexes.
      *
      * @return bool
@@ -3476,6 +3486,22 @@ abstract class AbstractPlatform
     public function getEmptyIdentityInsertSQL($tableName, $identifierColumnName)
     {
         return 'INSERT INTO ' . $tableName . ' (' . $identifierColumnName . ') VALUES (null)';
+    }
+
+    /**
+     * Generates a Truncate Table SQL statement for the given list of tables.
+     *
+     * Cascade is not supported on many platforms but would optionally cascade the truncate by
+     * following the foreign keys.
+     *
+     * @param string[] $tableNames
+     * @param bool     $cascade
+     *
+     * @return string
+     */
+    public function getTruncateMultiTableSQL(array $tableNames, $cascade = false)
+    {
+        throw DBALException::notSupported(__METHOD__);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -1094,6 +1094,43 @@ SQL
     }
 
     /**
+     * Whether the platform supports multi table truncate.
+     *
+     * @return bool
+     */
+    public function supportsTruncateMultiTable()
+    {
+        return true;
+    }
+
+    /**
+     * Generates a Truncate Table SQL statement for the given list of tables.
+     *
+     * Cascade is not supported on many platforms but would optionally cascade the truncate by
+     * following the foreign keys.
+     *
+     * @param string[] $tableNames
+     * @param bool     $cascade
+     *
+     * @return string
+     */
+    public function getTruncateMultiTableSQL(array $tableNames, $cascade = false)
+    {
+        $quotedTableNames = [];
+        foreach ($tableNames as $tableName) {
+            $tableIdentifier    = new Identifier($tableName);
+            $quotedTableNames[] = $tableIdentifier->getQuotedName($this);
+        }
+        $sql = 'TRUNCATE ' . implode(', ', $quotedTableNames);
+
+        if ($cascade) {
+            $sql .= ' CASCADE';
+        }
+
+        return $sql;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getTruncateTableSQL($tableName, $cascade = false)

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -60,6 +60,11 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
         return 'ALTER TABLE test ADD FOREIGN KEY (fk_name_id) REFERENCES other_table (id) NOT DEFERRABLE INITIALLY IMMEDIATE';
     }
 
+    public function testSupportsTruncateMultiTable() : void
+    {
+        self::assertTrue($this->platform->supportsTruncateMultiTable());
+    }
+
     public function testGeneratesForeignKeySqlForNonStandardOptions() : void
     {
         $foreignKey = new ForeignKeyConstraint(
@@ -945,6 +950,14 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL() : array
     {
         return ['ALTER INDEX idx_foo RENAME TO idx_foo_renamed'];
+    }
+
+    public function testGetTruncateMultiTableSQL() : void
+    {
+        self::assertSame(
+            'TRUNCATE foo, foo.bar, "default" CASCADE',
+            $this->platform->getTruncateMultiTableSQL(['foo', 'foo.bar', 'default'], true)
+        );
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | - 

#### Summary

Hi,
this PR allows to truncate multiple tables with a single query when supported (postgres as example).

It allowed us to have a test suite running in ~20s instead of 6m. I'm open for suggestions on how to improve it.

This PR is a follow up on https://github.com/doctrine/data-fixtures/pull/314

Is this solution acceptable?