### PR TITLE
Add missing MySQL 8.0 reserved keywords

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/Keywords/MySQL80Keywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/MySQL80Keywords.php
@@ -28,6 +28,7 @@ class MySQL80Keywords extends MySQL57Keywords
 
         $keywords = array_merge($keywords, [
             'ADMIN',
+            'ARRAY',
             'CUBE',
             'CUME_DIST',
             'DENSE_RANK',
@@ -40,7 +41,9 @@ class MySQL80Keywords extends MySQL57Keywords
             'JSON_TABLE',
             'LAG',
             'LAST_VALUE',
+            'LATERAL',
             'LEAD',
+            'MEMBER',
             'NTH_VALUE',
             'NTILE',
             'OF',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3673, contao/contao#727

#### Summary

This PR adds three reserved keywords currently missing from the `MySQL80Keywords` class, taken from [the official MySQL docs](https://dev.mysql.com/doc/refman/8.0/en/keywords.html).

Those keywords are:

Keyword | MySQL Version
-|-
`LATERAL` | 8.0.14
`ARRAY` | 8.0.17
`MEMBER` | 8.0.17
