### PR TITLE
Relax statement type declaration

### DIFF
--- a/lib/Doctrine/DBAL/Driver/StatementIterator.php
+++ b/lib/Doctrine/DBAL/Driver/StatementIterator.php
@@ -6,10 +6,10 @@ use IteratorAggregate;
 
 class StatementIterator implements IteratorAggregate
 {
-    /** @var Statement */
+    /** @var ResultStatement */
     private $statement;
 
-    public function __construct(Statement $statement)
+    public function __construct(ResultStatement $statement)
     {
         $this->statement = $statement;
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

`fetch()` is part of the `ResultStatement` interface. Using `Statement` as a
type declaration needlessly constrains people to use this class only
with implementations of Statement.

See https://github.com/doctrine/dbal/blob/b0726e7aab01080fc385599a88491a0ccdbd9417/lib/Doctrine/DBAL/Driver/ResultStatement.php#L65
