### PR TITLE
Improve dbal exception class

### DIFF
--- a/lib/Doctrine/DBAL/Cache/CacheException.php
+++ b/lib/Doctrine/DBAL/Cache/CacheException.php
@@ -6,12 +6,16 @@ use Doctrine\DBAL\DBALException;
 
 class CacheException extends DBALException
 {
+    // Exception codes. Dedicated 300-399 numbers
+    public const NO_CACHE_KEY                = 300;
+    public const NO_RESULT_DRIVER_CONFIGURED = 310;
+
     /**
      * @return \Doctrine\DBAL\Cache\CacheException
      */
     public static function noCacheKey()
     {
-        return new self('No cache key was set.');
+        return new self('No cache key was set.', self::NO_CACHE_KEY);
     }
 
     /**
@@ -19,6 +23,9 @@ class CacheException extends DBALException
      */
     public static function noResultDriverConfigured()
     {
-        return new self('Trying to cache a query but no result driver is configured.');
+        return new self(
+            'Trying to cache a query but no result driver is configured.',
+            self::NO_RESULT_DRIVER_CONFIGURED
+        );
     }
 }

--- a/lib/Doctrine/DBAL/ConnectionException.php
+++ b/lib/Doctrine/DBAL/ConnectionException.php
@@ -4,12 +4,21 @@ namespace Doctrine\DBAL;
 
 class ConnectionException extends DBALException
 {
+    // Exception codes. Dedicated 100-199 numbers
+    public const ROLLBACK_ONLY                 = 100;
+    public const NO_ACTIVE_TRANSACTION         = 110;
+    public const SAVE_POINTS_NOT_SUPPORTED     = 120;
+    public const SAVEPOINT_IN_OPEN_TRANSACTION = 130;
+
     /**
      * @return \Doctrine\DBAL\ConnectionException
      */
     public static function commitFailedRollbackOnly()
     {
-        return new self('Transaction commit failed because the transaction has been marked for rollback only.');
+        return new self(
+            'Transaction commit failed because the transaction has been marked for rollback only.',
+            self::ROLLBACK_ONLY
+        );
     }
 
     /**
@@ -17,7 +26,7 @@ class ConnectionException extends DBALException
      */
     public static function noActiveTransaction()
     {
-        return new self('There is no active transaction.');
+        return new self('There is no active transaction.', self::NO_ACTIVE_TRANSACTION);
     }
 
     /**
@@ -25,7 +34,7 @@ class ConnectionException extends DBALException
      */
     public static function savepointsNotSupported()
     {
-        return new self('Savepoints are not supported by this driver.');
+        return new self('Savepoints are not supported by this driver.', self::SAVE_POINTS_NOT_SUPPORTED);
     }
 
     /**
@@ -33,6 +42,9 @@ class ConnectionException extends DBALException
      */
     public static function mayNotAlterNestedTransactionWithSavepointsInTransaction()
     {
-        return new self('May not alter the nested transaction with savepoints behavior while a transaction is open.');
+        return new self(
+            'May not alter the nested transaction with savepoints behavior while a transaction is open.',
+            self::SAVEPOINT_IN_OPEN_TRANSACTION
+        );
     }
 }

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -22,6 +22,9 @@ use function preg_replace;
 use function spl_object_hash;
 use function sprintf;
 
+/**
+ * Exception class responsible for technical errors of DBAL infrastructure
+ */
 class DBALException extends Exception
 {
     // Exception codes. Dedicated 0-99 numbers
@@ -55,6 +58,9 @@ class DBALException extends Exception
         return new self(sprintf("Operation '%s' is not supported by platform.", $method), self::NOT_SUPPORTED_METHOD);
     }
 
+    /**
+     * @return DBALException
+     */
     public static function invalidPlatformSpecified() : self
     {
         return new self(
@@ -65,6 +71,8 @@ class DBALException extends Exception
 
     /**
      * @param mixed $invalidPlatform
+     *
+     * @return DBALException
      */
     public static function invalidPlatformType($invalidPlatform) : self
     {
@@ -111,7 +119,7 @@ class DBALException extends Exception
     }
 
     /**
-     * @return \Doctrine\DBAL\DBALException
+     * @return DBALException
      */
     public static function invalidPdoInstance()
     {
@@ -125,7 +133,7 @@ class DBALException extends Exception
     /**
      * @param string|null $url The URL that was provided in the connection parameters (if any).
      *
-     * @return \Doctrine\DBAL\DBALException
+     * @return DBALException
      */
     public static function driverRequired($url = null)
     {
@@ -151,7 +159,7 @@ class DBALException extends Exception
      * @param string   $unknownDriverName
      * @param string[] $knownDrivers
      *
-     * @return \Doctrine\DBAL\DBALException
+     * @return DBALException
      */
     public static function unknownDriver($unknownDriverName, array $knownDrivers)
     {
@@ -166,7 +174,7 @@ class DBALException extends Exception
      * @param string  $sql
      * @param mixed[] $params
      *
-     * @return self
+     * @return DBALException|DriverException|Throwable
      */
     public static function driverExceptionDuringQuery(Driver $driver, Throwable $driverEx, $sql, array $params = [])
     {
@@ -180,7 +188,10 @@ class DBALException extends Exception
     }
 
     /**
-     * @return self
+     * @param Driver    $driver
+     * @param Throwable $driverEx
+     *
+     * @return DBALException|DriverException|Throwable
      */
     public static function driverException(Driver $driver, Throwable $driverEx)
     {
@@ -193,7 +204,12 @@ class DBALException extends Exception
     }
 
     /**
-     * @return self
+     * @param Driver    $driver
+     * @param Throwable $driverEx
+     * @param string    $msg
+     * @param int       $code
+     *
+     * @return DBALException|DriverException|Throwable
      */
     private static function wrapException(Driver $driver, Throwable $driverEx, $msg, $code = 0)
     {
@@ -236,7 +252,7 @@ class DBALException extends Exception
     /**
      * @param string $wrapperClass
      *
-     * @return \Doctrine\DBAL\DBALException
+     * @return DBALException
      */
     public static function invalidWrapperClass($wrapperClass)
     {
@@ -249,7 +265,7 @@ class DBALException extends Exception
     /**
      * @param string $driverClass
      *
-     * @return \Doctrine\DBAL\DBALException
+     * @return DBALException
      */
     public static function invalidDriverClass($driverClass)
     {
@@ -262,7 +278,7 @@ class DBALException extends Exception
     /**
      * @param string $tableName
      *
-     * @return \Doctrine\DBAL\DBALException
+     * @return DBALException
      */
     public static function invalidTableName($tableName)
     {
@@ -272,7 +288,7 @@ class DBALException extends Exception
     /**
      * @param string $tableName
      *
-     * @return \Doctrine\DBAL\DBALException
+     * @return DBALException
      */
     public static function noColumnsSpecifiedForTable($tableName)
     {
@@ -280,7 +296,7 @@ class DBALException extends Exception
     }
 
     /**
-     * @return \Doctrine\DBAL\DBALException
+     * @return DBALException
      */
     public static function limitOffsetInvalid()
     {
@@ -293,7 +309,7 @@ class DBALException extends Exception
     /**
      * @param string $name
      *
-     * @return \Doctrine\DBAL\DBALException
+     * @return DBALException
      */
     public static function typeExists($name)
     {
@@ -303,7 +319,7 @@ class DBALException extends Exception
     /**
      * @param string $name
      *
-     * @return \Doctrine\DBAL\DBALException
+     * @return DBALException
      */
     public static function unknownColumnType($name)
     {
@@ -322,13 +338,18 @@ class DBALException extends Exception
     /**
      * @param string $name
      *
-     * @return \Doctrine\DBAL\DBALException
+     * @return DBALException
      */
     public static function typeNotFound($name)
     {
         return new self('Type to be overwritten ' . $name . ' does not exist.', self::TYPE_NOT_FOUND);
     }
 
+    /**
+     * @param Type $type
+     *
+     * @return DBALException
+     */
     public static function typeNotRegistered(Type $type) : self
     {
         return new self(
@@ -337,6 +358,11 @@ class DBALException extends Exception
         );
     }
 
+    /**
+     * @param Type $type
+     *
+     * @return DBALException
+     */
     public static function typeAlreadyRegistered(Type $type) : self
     {
         return new self(

--- a/lib/Doctrine/DBAL/SQLParserUtilsException.php
+++ b/lib/Doctrine/DBAL/SQLParserUtilsException.php
@@ -9,6 +9,10 @@ use function sprintf;
  */
 class SQLParserUtilsException extends DBALException
 {
+    // Exception codes. Dedicated 200-299 numbers
+    public const MISSING_PARAMS = 200;
+    public const MISSING_TYPE   = 210;
+
     /**
      * @param string $paramName
      *
@@ -16,7 +20,10 @@ class SQLParserUtilsException extends DBALException
      */
     public static function missingParam($paramName)
     {
-        return new self(sprintf('Value for :%1$s not found in params array. Params array key should be "%1$s"', $paramName));
+        return new self(
+            sprintf('Value for :%1$s not found in params array. Params array key should be "%1$s"', $paramName),
+            self::MISSING_PARAMS
+        );
     }
 
     /**
@@ -26,6 +33,9 @@ class SQLParserUtilsException extends DBALException
      */
     public static function missingType($typeName)
     {
-        return new self(sprintf('Value for :%1$s not found in types array. Types array key should be "%1$s"', $typeName));
+        return new self(
+            sprintf('Value for :%1$s not found in types array. Types array key should be "%1$s"', $typeName),
+            self::MISSING_TYPE
+        );
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -1301,7 +1301,7 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
 
         $this->expectException(DBALException::class);
         $this->expectExceptionMessage("Operation 'Doctrine\\DBAL\\Platforms\\AbstractPlatform::getInlineColumnCommentSQL' is not supported by platform.");
-        $this->expectExceptionCode(0);
+        $this->expectExceptionCode(DBALException::NOT_SUPPORTED_METHOD);
 
         $this->platform->getInlineColumnCommentSQL('unsupported');
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

**Added error codes to exception classes**

There are exception classes in the repository that can be thrown for various reasons. For example, class `DBALException` may throw 19 errors for various reasons. Therefore, error codes were added to this class (also in 3 other classes):
 - DBALException
 - ConnectionException
 - DBALException
 - SQLParserUtilsException

_Also added technical comments to `DBALException` class_