### PR TITLE
fix begin trasaction after reconnect

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -354,6 +354,8 @@ class Connection implements DriverConnection
         $this->_conn       = $this->_driver->connect($this->params, $user, $password, $driverOptions);
         $this->isConnected = true;
 
+        $this->transactionNestingLevel = 0;
+
         if ($this->autoCommit === false) {
             $this->beginTransaction();
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -70,6 +70,40 @@ class ConnectionTest extends DbalFunctionalTestCase
             $this->connection->rollBack();
             self::assertEquals(0, $this->connection->getTransactionNestingLevel());
         }
+
+        $this->connection->beginTransaction();
+        $this->connection->close();
+        $this->connection->beginTransaction();
+        self::assertEquals(1, $this->connection->getTransactionNestingLevel());
+    }
+
+    public function testTransactionNestingLevelIsResetOnReconnect() : void
+    {
+        if ($this->connection->getDatabasePlatform()->getName() === 'sqlite') {
+            $params           = $this->connection->getParams();
+            $params['memory'] = false;
+            $params['path']   = '/tmp/test_nesting.sqlite';
+
+            $connection = DriverManager::getConnection(
+                $params,
+                $this->connection->getConfiguration(),
+                $this->connection->getEventManager()
+            );
+        } else {
+            $connection = $this->connection;
+        }
+
+        $connection->executeQuery('CREATE TABLE test_nesting(test int not null)');
+
+        $this->connection->beginTransaction();
+        $this->connection->beginTransaction();
+        $connection->close(); // connection closed in runtime (for example if lost or another application logic)
+
+        $connection->beginTransaction();
+        $connection->executeQuery('insert into test_nesting values (33)');
+        $connection->rollback();
+
+        self::assertEquals(0, $connection->fetchColumn('select count(*) from test_nesting'));
     }
 
     public function testTransactionNestingBehaviorWithSavepoints() : void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This is a small fix if we lose the connection and work with transactions after reconnect.
The code examples below demonstrate a problem:

```php
/** Doctrine\DBAL\Connection $co */
$co->executeQuery('CREATE TABLE if not exists test11(test int not null)');
$co->executeQuery('truncate table test11');
$co->executeQuery('insert into test11 values (1)');
$co->beginTransaction();
$co->executeQuery('insert into test11 values (2)');
$v = $co->fetchAll('select * from test11');
$co->close(); // here we lost a connection or closed it for some reason
$co->beginTransaction(); /* p1 */
$co->executeQuery('insert into test11 values (33)');
$co->rollback(); /* p2 */
$v = $co->fetchAll('select * from test11'); // I expect the value 33 will not be selected from the table because it was rollbacked. But the transaction was not started on the line "p1" because of nestingLevel had not beed reset after open new connection.
```