### PR TITLE
fix_begin_transaction_after_reconnect

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -358,6 +358,8 @@ class Connection implements DriverConnection
             $this->_params['password'] : null;
 
         $this->_conn = $this->_driver->connect($this->_params, $user, $password, $driverOptions);
+        
+        $this->_transactionNestingLevel = 0;
         $this->_isConnected = true;
 
         if (null === $this->platform) {

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -62,6 +62,18 @@ class ConnectionTest extends \Doctrine\Tests\DbalFunctionalTestCase
         }
     }
 
+    public function testTransactionNestingLevelIsResetOnReconnect()
+    {
+        $this->connection->beginTransaction();
+        $this->connection->beginTransaction();
+        self::assertEquals(2, $this->connection->getTransactionNestingLevel());
+        $this->connection->close(); // connection is lost
+        $this->connection->beginTransaction(); // should connect, reset nesting level and increase it once
+        self::assertEquals(1, $this->connection->getTransactionNestingLevel());
+        $this->connection->commit();
+        self::assertEquals(0, $this->connection->getTransactionNestingLevel());
+    }
+
     public function testTransactionNestingBehaviorWithSavepoints()
     {
         if (!$this->_conn->getDatabasePlatform()->supportsSavepoints()) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->



|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary
This is a small fix if we lose the connection and work with transactions after reconnect.
The code examples below demonstrate a problem:
/** Doctrine\DBAL\Connection $co */
This is a small fix if we lose the connection and work with transactions after reconnect.
The code examples below demonstrate a problem:
/** Doctrine\DBAL\Connection $co */
$co->executeQuery('CREATE TABLE if not exists test11(test int not null)');
         $co->executeQuery('truncate table test11');
         $co->executeQuery('insert into test11 values (1)');
         $co->beginTransaction();
         $co->executeQuery('insert into test11 values (2)');
         $v = $co->fetchAll('select * from test11');
         $co->close(); // here we lost a connection or closed it for some reason
         $co->beginTransaction(); /* p1 */
         $co->executeQuery('insert into test11 values (33)');
         $co->rollback(); /* p2 */
        $v = $co->fetchAll('select * from test11'); // I expect the value 33 will not be selected from the table because it was rollbacked. But the transaction was not started on the line "p1" because of nestingLevel had not beed reset after open new connection.