### PR TITLE
Remove PHP 7.4 from `allow_failures` #3683

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ after_script:
     fi
 
 jobs:
-  allow_failures:
-    - php: 7.4snapshot
-
   include:
 
     - stage: Smoke Testing


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3683 

#### Summary

Removed PHP 7.4 From `allow_failures`
