### PR TITLE
Exception for UPDATE, DELETE, and INSERT with JOIN

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -214,6 +214,8 @@ class QueryBuilder
      * </code>
      *
      * @return string The SQL query string.
+     *
+     * @throws QueryException
      */
     public function getSQL()
     {
@@ -1174,6 +1176,10 @@ class QueryBuilder
      */
     private function getSQLForInsert()
     {
+        if ($this->usesJoin()) {
+            throw QueryException::joinNotAllowed('INSERT');
+        }
+
         return 'INSERT INTO ' . $this->sqlParts['from']['table'] .
         ' (' . implode(', ', array_keys($this->sqlParts['values'])) . ')' .
         ' VALUES(' . implode(', ', $this->sqlParts['values']) . ')';
@@ -1183,9 +1189,14 @@ class QueryBuilder
      * Converts this instance into an UPDATE string in SQL.
      *
      * @return string
+     *
+     * @throws QueryException
      */
     private function getSQLForUpdate()
     {
+        if ($this->usesJoin()) {
+            throw QueryException::joinNotAllowed('UPDATE');
+        }
         $table = $this->sqlParts['from']['table'] . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
 
         return 'UPDATE ' . $table
@@ -1197,12 +1208,26 @@ class QueryBuilder
      * Converts this instance into a DELETE string in SQL.
      *
      * @return string
+     *
+     * @throws QueryException
      */
     private function getSQLForDelete()
     {
+        if ($this->usesJoin()) {
+            throw QueryException::joinNotAllowed('DELETE');
+        }
+
         $table = $this->sqlParts['from']['table'] . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
 
         return 'DELETE FROM ' . $table . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '');
+    }
+
+    /**
+     * @return bool
+     */
+    private function usesJoin(): bool
+    {
+        return !empty($this->sqlParts['join']);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1222,12 +1222,9 @@ class QueryBuilder
         return 'DELETE FROM ' . $table . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '');
     }
 
-    /**
-     * @return bool
-     */
-    private function usesJoin(): bool
+    private function usesJoin() : bool
     {
-        return !empty($this->sqlParts['join']);
+        return ! empty($this->sqlParts['join']);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Query/QueryException.php
+++ b/lib/Doctrine/DBAL/Query/QueryException.php
@@ -32,4 +32,14 @@ class QueryException extends DBALException
             'in FROM and JOIN clause table. The currently registered ' .
             'aliases are: ' . implode(', ', $registeredAliases) . '.');
     }
+
+    /**
+     * @param string $action
+     *
+     * @return \Doctrine\DBAL\Query\QueryException
+     */
+    public static function joinNotAllowed(string $action): self
+    {
+        return new self('JOIN is not allowed for ' . $action);
+    }
 }

--- a/lib/Doctrine/DBAL/Query/QueryException.php
+++ b/lib/Doctrine/DBAL/Query/QueryException.php
@@ -38,7 +38,7 @@ class QueryException extends DBALException
      *
      * @return \Doctrine\DBAL\Query\QueryException
      */
-    public static function joinNotAllowed(string $action): self
+    public static function joinNotAllowed(string $action) : self
     {
         return new self('JOIN is not allowed for ' . $action);
     }

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -900,10 +900,7 @@ class QueryBuilderTest extends DbalTestCase
         $qb->getSQL();
     }
 
-    /**
-     * @return void
-     */
-    public function testUpdateWithJoin(): void
+    public function testUpdateWithJoin() : void
     {
         $qb   = new QueryBuilder($this->conn);
         $expr = $qb->expr();
@@ -918,10 +915,7 @@ class QueryBuilderTest extends DbalTestCase
         $qb->getSQL();
     }
 
-    /**
-     * @return void
-     */
-    public function testDeleteWithJoin(): void
+    public function testDeleteWithJoin() : void
     {
         $qb   = new QueryBuilder($this->conn);
         $expr = $qb->expr();
@@ -934,12 +928,9 @@ class QueryBuilderTest extends DbalTestCase
         $qb->getSQL();
     }
 
-    /**
-     * @return void
-     */
-    public function testInsertWithJoin(): void
+    public function testInsertWithJoin() : void
     {
-        $qb = new QueryBuilder($this->conn);
+        $qb   = new QueryBuilder($this->conn);
         $expr = $qb->expr();
 
         $qb->insert('users')

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -899,4 +899,60 @@ class QueryBuilderTest extends DbalTestCase
 
         $qb->getSQL();
     }
+
+    /**
+     * @return void
+     */
+    public function testUpdateWithJoin(): void
+    {
+        $qb   = new QueryBuilder($this->conn);
+        $expr = $qb->expr();
+
+        $qb->update('users', 'u')
+            ->join('u', 'phones', 'p', $expr->eq('p.user_id', 'u.id'))
+            ->set('u.foo', '?')
+            ->set('u.bar', '?');
+
+        $this->expectException(QueryException::class);
+
+        $qb->getSQL();
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeleteWithJoin(): void
+    {
+        $qb   = new QueryBuilder($this->conn);
+        $expr = $qb->expr();
+
+        $qb->delete('users', 'u')
+            ->join('u', 'phones', 'p', $expr->eq('p.user_id', 'u.id'));
+
+        $this->expectException(QueryException::class);
+
+        $qb->getSQL();
+    }
+
+    /**
+     * @return void
+     */
+    public function testInsertWithJoin(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $expr = $qb->expr();
+
+        $qb->insert('users')
+            ->join('u', 'phones', 'p', $expr->eq('p.user_id', 'u.id'))
+            ->values(
+                [
+                    'foo' => '?',
+                    'bar' => '?',
+                ]
+            );
+
+        $this->expectException(QueryException::class);
+
+        $qb->getSQL();
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #2716

#### Summary

The `QueryBuilder` will throw an exception now, if you use `UPDATE`, `DELETE`
or `INSERT` with `JOINS`, as soon as the `getSQL()` method is called, to point
out that these actions are not allowed together.
Currently the `QueryBuilder` is just ignoring the `JOIN`. This could lead to unexpected behaviour because someone doesn't know, that the `QueryBuilder` doesn't support it.
