### PR TITLE
Fixed query result caching when FetchMode::COLUMN is used

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -167,7 +167,15 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
-        $this->data    = $this->statement->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
+        $data = $this->statement->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
+
+        if ($fetchMode === FetchMode::COLUMN) {
+            foreach ($data as $key => $value) {
+                $data[$key] = [$value];
+            }
+        }
+
+        $this->data    = $data;
         $this->emptied = true;
 
         return $this->data;

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -177,6 +177,22 @@ class ResultCacheTest extends DbalFunctionalTestCase
         self::assertCount(1, $layerCache->fetch('testcachekey'));
     }
 
+    public function testFetchAllColumn() : void
+    {
+        $query = $this->connection->getDatabasePlatform()
+            ->getDummySelectSQL('1');
+
+        $qcp = new QueryCacheProfile(0, 0, new ArrayCache());
+
+        $stmt = $this->connection->executeCacheQuery($query, [], [], $qcp);
+        $stmt->fetchAll(FetchMode::COLUMN);
+        $stmt->closeCursor();
+
+        $stmt = $this->connection->executeCacheQuery($query, [], [], $qcp);
+
+        self::assertEquals([1], $stmt->fetchAll(FetchMode::COLUMN));
+    }
+
     /**
      * @param array<int, array<int, int|string>> $expectedResult
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #3597.

Internally, `ArrayStatement` expects every row to be represented as an array regardless of the fetch mode, however `FetchMode::COLUMN` produces one value per row.

This issue reveals a more fundamental problem: the cached result set is formed from the data represented to the currently used fetch mode and may not contain all the data needed for fetching from the same statement in a different mode. It means that the behavior of the cache may be unpredictable when the original and subsequent fetch modes are different. For example:

1. `SELECT foo, bar FROM table`; `$stmt->fetchAll(FetchMode::COLUMN)`; `$stmt->fetchAll(FetchMode::ASSOC)`. The second query will contain only one column from the cache.
2. `SELECT t1.id, t2.id FROM t1 JOIN t2`; `$stmt->fetchAll(FetchMode::ASSOCIATIVE)`; `$stmt->fetchAll(FetchMode::NUMERIC)`. The second query will contain only one column from the cache.