### PR TITLE
Temporarily disable the usage of PHPUnit 8.4 due to a regression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "doctrine/coding-standard": "^6.0",
         "jetbrains/phpstorm-stubs": "^2019.1",
         "phpstan/phpstan": "^0.11.3",
-        "phpunit/phpunit": "^8.3.3",
+        "phpunit/phpunit": "^8.3.3, <8.4.0",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d397d6d064efda6d4150edce78e283a",
+    "content-hash": "7502364f1cb482daff6265017e5e9f4f",
     "packages": [
         {
             "name": "doctrine/cache",


### PR DESCRIPTION
See https://github.com/sebastianbergmann/phpunit/issues/3879

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Fixes #3687.
