### PR TITLE
Fixed empty defaults (In MySqlSchemaManager.php line 223: Notice: Uni…

### DIFF
--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -217,7 +217,7 @@ class MySqlSchemaManager extends AbstractSchemaManager
      */
     private function getMariaDb1027ColumnDefault(MariaDb1027Platform $platform, ?string $columnDefault) : ?string
     {
-        if ($columnDefault === 'NULL' || $columnDefault === null) {
+        if ($columnDefault === 'NULL' || $columnDefault === null || $columnDefault === '') {
             return null;
         }
         if ($columnDefault[0] === "'") {

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL3691Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL3691Test.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Ticket;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Schema\MySqlSchemaManager;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * @group DBAL-3691
+ */
+class DBAL3691Test extends TestCase
+{
+    public function testIssue()
+    {
+        $conn     = $this->createMock(Connection::class);
+        $platform = new MariaDb1027Platform();
+
+        $schemaManager = new MySqlSchemaManager($conn, $platform);
+
+        $reflectionMethod = new ReflectionMethod($schemaManager, '_getPortableTableColumnDefinition');
+        $reflectionMethod->setAccessible(true);
+
+        $column = $reflectionMethod->invoke($schemaManager, [
+            'field' => 'string_empty_by_default',
+            'type' => 'varchar',
+            'length' => 255,
+            'default' => '',
+            'notnull' => true,
+            'extra' => false,
+            'null' => false,
+        ]);
+
+        $this->assertEquals(null, $column->getDefault());
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | `null`

#### Summary

Fixes following error which happens when the default is an empty string:
```
In MySqlSchemaManager.php line 223:                                    
  Notice: Uninitialized string offset: 0  
```
