### PR TITLE
fix MySQL bit type does not support exceptions.

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -1059,6 +1059,7 @@ SQL
             'smallint'      => 'smallint',
             'mediumint'     => 'integer',
             'int'           => 'integer',
+            'bit'           => 'integer',
             'integer'       => 'integer',
             'bigint'        => 'bigint',
             'tinytext'      => 'text',


### PR DESCRIPTION
The following error occurred when I was generating phpdocs.
```
Exception: Unknown database type bit requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it.
Could not analyze class App\Models\UserModel.
```
By checking the source code, I found out that it was a type mapping problem, so I added this line of code.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type            | improvement
| BC Break     | yes
| Fixed issues | fix MySQL bit type does not support exceptions.

#### Summary

<!-- Provide a summary of your change. -->

Type mapping with bit added
