### PR TITLE
Resolve an issue where ServerVersion could not be obtained correctly

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -467,6 +467,10 @@ class Connection implements DriverConnection
             return $this->_conn->getServerVersion();
         }
 
+        if ($this->_conn instanceof \PDO) {
+            return $this->_conn->getAttribute(\PDO::ATTR_SERVER_VERSION);
+        }
+
         // Unable to detect platform version.
         return null;
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 1. \PDO instance gets ServerVersion

#### Summary

During use, I found that when `$this->_conn` is a `\PDO` instance,
this method can't get the MySQL version of the server correctly,
so  can't select the correct Platform, which leads to some unexpected
situations. 

eg:

When I use \PDO as the connection, there is a json type field in a table in my database.
At this point my MySQL database version is 8.0+ , But it doesn't work

```
Unknown database type json requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it.
```
This patch is to solve this problem, I am using this problem found in `laravel-ide-helper`.
