### PR TITLE
Add MySQL bit type support 

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -1028,6 +1028,7 @@ SQL
             'tinyint'       => 'boolean',
             'smallint'      => 'smallint',
             'mediumint'     => 'integer',
+            'bit'           => 'integer',
             'int'           => 'integer',
             'integer'       => 'integer',
             'bigint'        => 'bigint',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | add MySQL bit type support.

#### Summary

This is a [#3693](https://github.com/doctrine/dbal/pull/3693) resubmit because I realized that I submitted the wrong branch before.

The following error occurred when I was generating phpdocs.
```
Exception: Unknown database type bit requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it.
Could not analyze class App\Models\UserModel.
```
By checking the source code, I found out that it was a type mapping problem, so I added this line of code.
