### PR TITLE
add sql type parameter to connection project function

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -968,13 +968,14 @@ class Connection implements DriverConnection
      * @param Closure $function The transformation function that is applied on each row.
      *                           The function receives a single parameter, an array, that
      *                           represents a row of the result set.
+     * @param mixed[] $types    The types the previous parameters are in.
      *
      * @return mixed[] The projected result of the query.
      */
-    public function project($query, array $params, Closure $function)
+    public function project($query, array $params, Closure $function, array $types = [])
     {
         $result = [];
-        $stmt   = $this->executeQuery($query, $params);
+        $stmt   = $this->executeQuery($query, $params, $types);
 
         while ($row = $stmt->fetch()) {
             $result[] = $function($row);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | none

#### Summary

I've added the missing sql-type parameter to the project wrapper function.
