### PR TITLE
add missing exit codes to ensure Symfony 5 compatibility

### DIFF
--- a/lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php
@@ -58,7 +58,7 @@ EOT
         $fileNames = $input->getArgument('file');
 
         if ($fileNames === null) {
-            return null;
+            return 0;
         }
 
         foreach ((array) $fileNames as $fileName) {
@@ -133,6 +133,6 @@ EOT
             }
         }
 
-        return null;
+        return 0;
     }
 }

--- a/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
@@ -68,5 +68,7 @@ EOT
         }
 
         $output->write(Dumper::dump($resultSet, (int) $depth));
+
+        return 0;
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
@@ -70,10 +70,11 @@ class RunSqlCommandTest extends TestCase
     {
         $this->expectConnectionFetchAll();
 
-        $this->commandTester->execute([
+        $exitCode = $this->commandTester->execute([
             'command' => $this->command->getName(),
             'sql' => 'SELECT 1',
         ]);
+        $this->assertSame(0, $exitCode);
 
         self::assertRegExp('@int.*1.*@', $this->commandTester->getDisplay());
         self::assertRegExp('@array.*1.*@', $this->commandTester->getDisplay());


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

While preparing a bundle for Symfony 5 I noticed some issues:

https://travis-ci.org/dmaicher/doctrine-test-bundle/jobs/603592022

```
Return value of "Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunSqlDoctrineCommand::execute()" must be of the type int, NULL returned.
```

So this provides the required exit codes for Symfony 5.
