### PR TITLE
Update releases documentation

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -15,17 +15,17 @@
             "name": "2.10",
             "branchName": "master",
             "slug": "2.10",
-            "upcoming": true
-        },
-        {
-            "name": "2.9",
-            "branchName": "2.9",
-            "slug": "2.9",
             "current": true,
             "aliases": [
                 "current",
                 "stable"
             ]
+        },
+        {
+            "name": "2.9",
+            "branchName": "2.9",
+            "slug": "2.9",
+            "maintained": false
         },
         {
             "name": "2.8",


### PR DESCRIPTION
`v2.10` is the `current` one now.

|      Q       |   A
|------------- | -----------
| Type         | documentation
| BC Break     | no
| Fixed issues | - 