### PR TITLE
Remove phpunit-bridge specific annotations

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
@@ -28,10 +28,6 @@ class PDOStatementTest extends DbalFunctionalTestCase
         $this->connection->getSchemaManager()->dropAndCreateTable($table);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Using a PDO fetch mode or their combination (%d given) is deprecated and will cause an error in Doctrine 3.0.
-     */
     public function testPDOSpecificModeIsAccepted() : void
     {
         $this->connection->insert('stmt_test', [

--- a/tests/Doctrine/Tests/DBAL/Schema/ColumnTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ColumnTest.php
@@ -62,10 +62,6 @@ class ColumnTest extends TestCase
         self::assertEquals($expected, $this->createColumn()->toArray());
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The "unknown_option" column option is not supported, setting it is deprecated and will cause an error in Doctrine 3.0
-     */
     public function testSettingUnknownOptionIsStillSupported() : void
     {
         $this->expectNotToPerformAssertions();
@@ -73,10 +69,6 @@ class ColumnTest extends TestCase
         new Column('foo', $this->createMock(Type::class), ['unknown_option' => 'bar']);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The "unknown_option" column option is not supported, setting it is deprecated and will cause an error in Doctrine 3.0
-     */
     public function testOptionsShouldNotBeIgnored() : void
     {
         $col1 = new Column('bar', Type::getType(Types::INTEGER), ['unknown_option' => 'bar', 'notnull' => true]);


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | pedantic
| BC Break     | no
| Fixed issues | n/a

#### Summary

The phpunit-bridge has been removed in #3643, so these no longer serve
any purpose. The tests themselves are kept since they check that there
is no crash when using an unknown option, and do not need a phpunit
assertion to do so.
