### PR TITLE
Switched from PHPBrew-based configuration to the Docker-based

### DIFF
--- a/tests/continuousphp/install-pdo-oci.sh
+++ b/tests/continuousphp/install-pdo-oci.sh
@@ -2,4 +2,5 @@
 
 set -euo pipefail
 
-phpbrew ext install pdo_oci -- --with-pdo-oci=instantclient,/usr/local/instantclient
+docker-php-ext-configure pdo_oci --with-pdo-oci=instantclient,/usr/local/instantclient
+sudo -E env PHP_INI_DIR=/usr/local/etc/php docker-php-ext-install pdo_oci


### PR DESCRIPTION
Right now, building on `pdo_oci` is disabled due to failures (https://github.com/doctrine/dbal/pull/3712#issuecomment-549175751).

As per the support response, continuousphp switched to building their containers based on the official images from PHP.

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
