### PR TITLE
Add .doctrine-project.json to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /.appveyor.yml export-ignore
+/.doctrine-project.json export-ignore
 /.gitattributes export-ignore
 /.github export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Stops .doctrine-project.json being brought in when including via composer
