### PR TITLE
Add bin to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 /.gitignore export-ignore
 /.scrutinizer.yml export-ignore
 /.travis.yml export-ignore
+/bin export-ignore
 /build.properties export-ignore
 /build.xml export-ignore
 /composer.lock export-ignore


### PR DESCRIPTION
Needs symfony/console from `require-dev` so most composer includes probably don't want these files :)

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
