### PR TITLE
Fix of branch names for doctrine website config

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -7,13 +7,13 @@
     "versions": [
         {
             "name": "3.0",
-            "branchName": "develop",
+            "branchName": "master",
             "slug": "latest",
             "upcoming": true
         },
         {
             "name": "2.10",
-            "branchName": "master",
+            "branchName": "2.10",
             "slug": "2.10",
             "current": true,
             "aliases": [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

This should fix the dbal version infos on the doctrine website about what's an upcoming version and what's the current supported version.