### PR TITLE
Fix breaks named parameters in Oracle

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/StatementTest.php
@@ -38,14 +38,38 @@ class StatementTest extends DbalFunctionalTestCase
     }
 
     /**
+     * Low-level approach to working with parameter binding
+     *
+     * @param mixed[] $params
+     * @param mixed[] $expected
+     *
+     * @dataProvider queryConversionProvider
+     */
+    public function testStatementBindParameters(string $query, array $params, array $expected) : void
+    {
+        $stmt = $this->connection->prepare($query);
+        $stmt->execute($params);
+
+        self::assertEquals(
+            $expected,
+            $stmt->fetch()
+        );
+    }
+
+    /**
      * @return array<string, array<int, mixed>>
      */
     public static function queryConversionProvider() : iterable
     {
         return [
-            'simple' => [
+            'positional' => [
                 'SELECT ? COL1 FROM DUAL',
                 [1],
+                ['COL1' => 1],
+            ],
+            'named' => [
+                'SELECT :COL COL1 FROM DUAL',
+                [':COL' => 1],
                 ['COL1' => 1],
             ],
             'literal-with-placeholder' => [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes

Fixes #3722
Closes #3779

#### Summary

Fix breaks named parameters in Oracle ( see issue  #3722 )
