### PR TITLE
Update deprecation messages to refer to DBAL

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -195,7 +195,7 @@ class PDOStatement extends \PDOStatement implements Statement
         if (! isset(self::PARAM_TYPE_MAP[$type])) {
             // TODO: next major: throw an exception
             @trigger_error(sprintf(
-                'Using a PDO parameter type (%d given) is deprecated and will cause an error in Doctrine 3.0',
+                'Using a PDO parameter type (%d given) is deprecated and will cause an error in Doctrine DBAL 3.0',
                 $type
             ), E_USER_DEPRECATED);
 
@@ -216,7 +216,7 @@ class PDOStatement extends \PDOStatement implements Statement
             // TODO: next major: throw an exception
             @trigger_error(sprintf(
                 'Using a PDO fetch mode or their combination (%d given)' .
-                ' is deprecated and will cause an error in Doctrine 3.0',
+                ' is deprecated and will cause an error in Doctrine DBAL 3.0',
                 $fetchMode
             ), E_USER_DEPRECATED);
 

--- a/lib/Doctrine/DBAL/Schema/Column.php
+++ b/lib/Doctrine/DBAL/Schema/Column.php
@@ -80,7 +80,7 @@ class Column extends AbstractAsset
                 // next major: throw an exception
                 @trigger_error(sprintf(
                     'The "%s" column option is not supported,' .
-                    ' setting it is deprecated and will cause an error in Doctrine 3.0',
+                    ' setting it is deprecated and will cause an error in Doctrine DBAL 3.0',
                     $name
                 ), E_USER_DEPRECATED);
 

--- a/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
@@ -30,7 +30,7 @@ class PDOStatementTest extends DbalFunctionalTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Using a PDO fetch mode or their combination (%d given) is deprecated and will cause an error in Doctrine 3.0
+     * @expectedDeprecation Using a PDO fetch mode or their combination (%d given) is deprecated and will cause an error in Doctrine DBAL 3.0
      */
     public function testPDOSpecificModeIsAccepted() : void
     {

--- a/tests/Doctrine/Tests/DBAL/Schema/ColumnTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ColumnTest.php
@@ -62,7 +62,7 @@ class ColumnTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The "unknown_option" column option is not supported, setting it is deprecated and will cause an error in Doctrine 3.0
+     * @expectedDeprecation The "unknown_option" column option is not supported, setting it is deprecated and will cause an error in Doctrine DBAL 3.0
      */
     public function testSettingUnknownOptionIsStillSupported() : void
     {
@@ -73,7 +73,7 @@ class ColumnTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The "unknown_option" column option is not supported, setting it is deprecated and will cause an error in Doctrine 3.0
+     * @expectedDeprecation The "unknown_option" column option is not supported, setting it is deprecated and will cause an error in Doctrine DBAL 3.0
      */
     public function testOptionsShouldNotBeIgnored() : void
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

This updates the deprecation messages to refer to "DBAL 3.0" instead of just "Doctrine 3.0". This is important for people to distinguish the messages from DBAL and ORM and know which package is deprecating functionality.