### PR TITLE
Remove temporary SQLite file on teardown

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -15,7 +15,9 @@ use Exception;
 use PDO;
 use RuntimeException;
 use Throwable;
+use function file_exists;
 use function in_array;
+use function unlink;
 
 class ConnectionTest extends DbalFunctionalTestCase
 {
@@ -27,6 +29,10 @@ class ConnectionTest extends DbalFunctionalTestCase
 
     protected function tearDown() : void
     {
+        if (file_exists('/tmp/test_nesting.sqlite')) {
+            unlink('/tmp/test_nesting.sqlite');
+        }
+
         parent::tearDown();
         $this->resetSharedConn();
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

As of #3679, the test suite fails if run consequently in the same environment:
```
phpunit --repeat 2 --filter testTransactionNestingLevelIsResetOnReconnect tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
PHPUnit 8.3.3 by Sebastian Bergmann and contributors.

.E                                                                                  2 / 2 (100%)

Time: 77 ms, Memory: 8.00 MB

There was 1 error:

1) Doctrine\Tests\DBAL\Functional\ConnectionTest::testTransactionNestingLevelIsResetOnReconnect
Exception: [Doctrine\DBAL\Exception\TableExistsException] An exception occurred while executing "CREATE TABLE test_nesting(test int not null)":

SQLSTATE[HY000]: General error: 1 table test_nesting already exists
```