### PR TITLE
Test case and fix for issue #3740

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1420,7 +1420,7 @@ class Connection implements DriverConnection
         // Check whether parameters are positional or named. Mixing is not allowed, just like in PDO.
         if (is_int(key($params))) {
             // Positional parameters
-            $typeOffset = array_key_exists(0, $types) ? -1 : 0;
+            $typeOffset = array_key_exists(0, $params) ? -1 : 0;
             $bindIndex  = 1;
             foreach ($params as $value) {
                 $typeIndex = $bindIndex + $typeOffset;

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1352,7 +1352,7 @@ class Connection implements DriverConnection
         // Check whether parameters are positional or named. Mixing is not allowed, just like in PDO.
         if (is_int(key($params))) {
             // Positional parameters
-            $typeOffset = array_key_exists(0, $types) ? -1 : 0;
+            $typeOffset = array_key_exists(0, $params) ? -1 : 0;
             $bindIndex  = 1;
             foreach ($params as $value) {
                 $typeIndex = $bindIndex + $typeOffset;

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -383,12 +383,7 @@ class ConnectionTest extends DbalFunctionalTestCase
      */
     public function testTypeConversionWithNumericalParams() : void
     {
-        $table = new Table('users');
-        $table->addColumn('name', Types::STRING, ['length' => 40]);
-        $table->addColumn('last_login', Types::DATETIME_MUTABLE);
-        $this->connection->getSchemaManager()->createTable($table);
-
-        $query = 'INSERT INTO users (name, last_login) VALUES(?, ?)';
+        $query = $this->connection->getDatabasePlatform()->getDummySelectSQL('?, ?');
 
         $params = [
             0 => 'John Smith',

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -390,6 +390,6 @@ class ConnectionTest extends DbalFunctionalTestCase
 
         $types = [1 => 'datetime'];
 
-        $this->connection->executeUpdate($query, $params, $types);
+        $this->connection->executeQuery($query, $params, $types);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -13,6 +13,8 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use Doctrine\Tests\TestUtil;
 use Error;
@@ -381,7 +383,12 @@ class ConnectionTest extends DbalFunctionalTestCase
      */
     public function testTypeConversionWithNumericalParams() : void
     {
-        $query = $this->connection->getDatabasePlatform()->getDummySelectSQL('?, ?');
+        $table = new Table('users');
+        $table->addColumn('name', Types::STRING, ['length' => 40]);
+        $table->addColumn('last_login', Types::DATETIME_MUTABLE);
+        $this->connection->getSchemaManager()->createTable($table);
+
+        $query = 'INSERT INTO users (name, last_login) VALUES(?, ?)';
 
         $params = [
             0 => 'John Smith',
@@ -390,6 +397,6 @@ class ConnectionTest extends DbalFunctionalTestCase
 
         $types = [1 => 'datetime'];
 
-        $this->connection->executeQuery($query, $params, $types);
+        $this->connection->executeUpdate($query, $params, $types);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\DBAL\Functional;
 
+use DateTime;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
@@ -383,13 +384,14 @@ class ConnectionTest extends DbalFunctionalTestCase
         $this->connection->executeQuery('CREATE TABLE users(name varchar not null, last_login datetime not null)');
 
         $query = 'INSERT INTO users (name, last_login) VALUES(?, ?)';
+
         $params = [
             0 => 'John Smith',
-            1 => new \DateTime()
+            1 => new DateTime(),
         ];
 
         $types = [
-            1 => 'datetime'
+            1 => 'datetime',
         ];
 
         $this->connection->executeUpdate($query, $params, $types);

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -381,7 +381,7 @@ class ConnectionTest extends DbalFunctionalTestCase
      */
     public function testTypeConversionWithNumericalParams() : void
     {
-        $this->connection->executeQuery('CREATE TABLE users(name varchar not null, last_login datetime not null)');
+        $this->connection->executeQuery('CREATE TABLE users(name varchar(40) not null, last_login datetime not null)');
 
         $query = 'INSERT INTO users (name, last_login) VALUES(?, ?)';
 
@@ -390,9 +390,7 @@ class ConnectionTest extends DbalFunctionalTestCase
             1 => new DateTime(),
         ];
 
-        $types = [
-            1 => 'datetime',
-        ];
+        $types = [1 => 'datetime'];
 
         $this->connection->executeUpdate($query, $params, $types);
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -374,4 +374,24 @@ class ConnectionTest extends DbalFunctionalTestCase
 
         self::assertTrue($pdo->getAttribute(PDO::ATTR_PERSISTENT));
     }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testTypeConversionWithNumericalParams() : void
+    {
+        $this->connection->executeQuery('CREATE TABLE users(name varchar not null, last_login datetime not null)');
+
+        $query = 'INSERT INTO users (name, last_login) VALUES(?, ?)';
+        $params = [
+            0 => 'John Smith',
+            1 => new \DateTime()
+        ];
+
+        $types = [
+            1 => 'datetime'
+        ];
+
+        $this->connection->executeUpdate($query, $params, $types);
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -13,8 +13,6 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
-use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use Doctrine\Tests\TestUtil;
 use Error;

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -13,6 +13,8 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use Doctrine\Tests\TestUtil;
 use Error;
@@ -381,7 +383,10 @@ class ConnectionTest extends DbalFunctionalTestCase
      */
     public function testTypeConversionWithNumericalParams() : void
     {
-        $this->connection->executeQuery('CREATE TABLE users(name varchar(40) not null, last_login datetime not null)');
+        $table = new Table('users');
+        $table->addColumn('name', Types::STRING, ['length' => 40]);
+        $table->addColumn('last_login', Types::DATETIME_MUTABLE);
+        $this->connection->getSchemaManager()->createTable($table);
 
         $query = 'INSERT INTO users (name, last_login) VALUES(?, ?)';
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3740

#### Summary

Not sure if I've put this test case in a proper place, but I hope it's good enough to illustrate the bug.

A fix is to check if we need to use an offset for types by looking at the first key of params array. It's the only way to know what kind of positioning is used - starting from 0 or 1. 
