### PR TITLE
PingableConnection and ServerInfoAwareConnection now extend Connection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK: PingableConnection and ServerInfoAwareConnection interfaces now extends Connection
+
+All implementations of the `PingableConnection` and `ServerInfoAwareConnection` interfaces have to implement the methods defined in the `Connection` interface as well.
+
 ## BC BREAK: VersionAwarePlatformDriver interface now extends Driver
 
 All implementations of the `VersionAwarePlatformDriver` interface have to implement the methods defined in the `Driver` interface as well.

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -4,7 +4,6 @@ declare(strict_types=0);
 
 namespace Doctrine\DBAL\Driver\IBMDB2;
 
-use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
@@ -23,7 +22,7 @@ use function db2_prepare;
 use function db2_rollback;
 use function db2_server_info;
 
-class DB2Connection implements Connection, ServerInfoAwareConnection
+class DB2Connection implements ServerInfoAwareConnection
 {
     /** @var resource */
     private $conn = null;

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\Mysqli;
 
-use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Mysqli\Exception\ConnectionError;
 use Doctrine\DBAL\Driver\PingableConnection;
 use Doctrine\DBAL\Driver\ResultStatement;
@@ -28,7 +27,7 @@ use function set_error_handler;
 use function sprintf;
 use function stripos;
 
-class MysqliConnection implements Connection, PingableConnection, ServerInfoAwareConnection
+class MysqliConnection implements PingableConnection, ServerInfoAwareConnection
 {
     /**
      * Name of the option to set connection flags

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -12,7 +12,7 @@ use function assert;
  *
  * Used by all PDO-based drivers.
  */
-class PDOConnection implements Connection, ServerInfoAwareConnection
+class PDOConnection implements ServerInfoAwareConnection
 {
     /** @var PDO */
     private $connection;

--- a/lib/Doctrine/DBAL/Driver/PingableConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PingableConnection.php
@@ -7,7 +7,7 @@ namespace Doctrine\DBAL\Driver;
 /**
  * An interface for connections which support a "native" ping method.
  */
-interface PingableConnection
+interface PingableConnection extends Connection
 {
     /**
      * Pings the database server to determine if the connection is still

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\SQLAnywhere;
 
-use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
@@ -24,7 +23,7 @@ use function sasql_set_option;
 /**
  * SAP Sybase SQL Anywhere implementation of the Connection interface.
  */
-class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
+class SQLAnywhereConnection implements ServerInfoAwareConnection
 {
     /** @var resource The SQL Anywhere connection resource. */
     private $connection;

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\SQLSrv;
 
-use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
@@ -21,7 +20,7 @@ use function str_replace;
 /**
  * SQL Server implementation for the Connection interface.
  */
-class SQLSrvConnection implements Connection, ServerInfoAwareConnection
+class SQLSrvConnection implements ServerInfoAwareConnection
 {
     /** @var resource */
     protected $conn;

--- a/lib/Doctrine/DBAL/Driver/ServerInfoAwareConnection.php
+++ b/lib/Doctrine/DBAL/Driver/ServerInfoAwareConnection.php
@@ -7,7 +7,7 @@ namespace Doctrine\DBAL\Driver;
 /**
  * Contract for a connection that is able to provide information about the server it is connected to.
  */
-interface ServerInfoAwareConnection
+interface ServerInfoAwareConnection extends Connection
 {
     /**
      * Returns the version number of the database server connected to.

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -676,7 +676,7 @@ class ConnectionTest extends DbalTestCase
         $driverMock = $this->createMock(VersionAwarePlatformDriver::class);
 
         /** @var DriverConnection|ServerInfoAwareConnection|MockObject $driverConnectionMock */
-        $driverConnectionMock = $this->createMock([DriverConnection::class, ServerInfoAwareConnection::class]);
+        $driverConnectionMock = $this->createMock(ServerInfoAwareConnection::class);
 
         /** @var AbstractPlatform|MockObject $platformMock */
         $platformMock = $this->getMockForAbstractClass(AbstractPlatform::class);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | [job #617974029](https://travis-ci.org/doctrine/dbal/jobs/617974029)

The `PingableConnection` and `ServerInfoAwareConnection` interfaces should extend `Connection`, same as in #3746.