### PR TITLE
Allow build failures for unstable dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -336,3 +336,6 @@ jobs:
       install:
         - composer config minimum-stability dev
         - travis_retry composer update --prefer-dist
+
+  allow_failures:
+    - env: DEPENDENCIES=dev


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | [job #617974029](https://travis-ci.org/doctrine/dbal/jobs/617974029)

Allow build failures for unstable dependencies in order to not have to react to them immediately. We still can see the failures if look at the build results.