### PR TITLE
[GH-1204] Add Platform flag for FK constraints through emulation

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3148,6 +3148,16 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Wheather the platform can support foreign key constraints through emulation using triggers.
+     *
+     * @return bool
+     */
+    public function supportsForeignKeyConstraintsThroughEmulation() : bool
+    {
+        return false;
+    }
+
+    /**
      * Whether this platform supports onUpdate in foreign key constraints.
      *
      * @return bool

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -752,6 +752,14 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function supportsForeignKeyConstraintsThroughEmulation() : bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getCreatePrimaryKeySQL(Index $index, $table)
     {
         throw new DBALException('Sqlite platform does not support alter primary key.');

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -263,7 +263,7 @@ abstract class AbstractSchemaManager
     {
         $columns     = $this->listTableColumns($tableName);
         $foreignKeys = [];
-        if ($this->_platform->supportsForeignKeyConstraints()) {
+        if ($this->_platform->supportsForeignKeyConstraints() || $this->_platform->supportsForeignKeyConstraintsThroughEmulation()) {
             $foreignKeys = $this->listTableForeignKeys($tableName);
         }
         $indexes = $this->listTableIndexes($tableName);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1204 doctrine/orm#7841

#### Summary

`SchemaManager::listTableDetails` checks for foreign key support, which SQLite emulates but still responds false to. This leads to bugs in ORMs SchemaTool where it always finds foreign keys are added and thus it re-creates the tables.

We can't change `supportsForeignKeyConstraints()` to true, because `getForeignKeyConstraintCreateSql()` throws an exception that its not supported.