### PR TITLE
Drop AbstractPlatform::usesSequenceEmulatedIdentityColumns()

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2680,18 +2680,6 @@ abstract class AbstractPlatform
     }
 
     /**
-     * Whether the platform emulates identity columns through sequences.
-     *
-     * Some platforms that do not support identity columns natively
-     * but support sequences can emulate identity columns by using
-     * sequences.
-     */
-    public function usesSequenceEmulatedIdentityColumns() : bool
-    {
-        return false;
-    }
-
-    /**
      * Gets the sequence name prefix based on table information.
      */
     public function getSequencePrefix(string $tableName, ?string $schemaName = null) : string
@@ -2708,8 +2696,6 @@ abstract class AbstractPlatform
 
     /**
      * Returns the name of the sequence for a particular identity column in a particular table.
-     *
-     * @see    usesSequenceEmulatedIdentityColumns
      *
      * @param string $tableName  The name of the table to return the sequence name for.
      * @param string $columnName The name of the identity column in the table to return the sequence name for.

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -940,14 +940,6 @@ SQL
     /**
      * {@inheritdoc}
      */
-    public function usesSequenceEmulatedIdentityColumns() : bool
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getIdentitySequenceName(string $tableName, string $columnName) : string
     {
         $table = new Identifier($tableName);

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -176,14 +176,6 @@ class PostgreSqlPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function usesSequenceEmulatedIdentityColumns() : bool
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getIdentitySequenceName(string $tableName, string $columnName) : string
     {
         return $tableName . '_' . $columnName . '_seq';

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -249,9 +249,9 @@ class WriteTest extends DbalFunctionalTestCase
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        if (! ($platform->supportsIdentityColumns() || $platform->usesSequenceEmulatedIdentityColumns())) {
+        if (! $platform->supportsIdentityColumns()) {
             $this->markTestSkipped(
-                'Test only works on platforms with identity columns or sequence emulated identity columns.'
+                'Test only works on platforms with identity columns.'
             );
         }
 
@@ -268,19 +268,15 @@ class WriteTest extends DbalFunctionalTestCase
             $this->connection->exec($sql);
         }
 
-        $seqName = $platform->usesSequenceEmulatedIdentityColumns()
-            ? $platform->getIdentitySequenceName('test_empty_identity', 'id')
-            : null;
-
         $sql = $platform->getEmptyIdentityInsertSQL('test_empty_identity', 'id');
 
         $this->connection->exec($sql);
 
-        $firstId = $this->lastInsertId($seqName);
+        $firstId = $this->lastInsertId();
 
         $this->connection->exec($sql);
 
-        $secondId = $this->lastInsertId($seqName);
+        $secondId = $this->lastInsertId();
 
         self::assertGreaterThan($firstId, $secondId);
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -818,14 +818,6 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
     /**
      * @group DBAL-563
      */
-    public function testUsesSequenceEmulatedIdentityColumns() : void
-    {
-        self::assertFalse($this->platform->usesSequenceEmulatedIdentityColumns());
-    }
-
-    /**
-     * @group DBAL-563
-     */
     public function testReturnsIdentitySequenceName() : void
     {
         $this->expectException(DBALException::class);

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -575,14 +575,6 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     /**
      * @group DBAL-563
      */
-    public function testUsesSequenceEmulatedIdentityColumns() : void
-    {
-        self::assertTrue($this->platform->usesSequenceEmulatedIdentityColumns());
-    }
-
-    /**
-     * @group DBAL-563
-     */
     public function testReturnsIdentitySequenceName() : void
     {
         self::assertSame('mytable_mycolumn_seq', $this->platform->getIdentitySequenceName('mytable', 'mycolumn'));

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -557,14 +557,6 @@ class OraclePlatformTest extends AbstractPlatformTestCase
 
     /**
      * @group DBAL-563
-     */
-    public function testUsesSequenceEmulatedIdentityColumns() : void
-    {
-        self::assertTrue($this->platform->usesSequenceEmulatedIdentityColumns());
-    }
-
-    /**
-     * @group DBAL-563
      * @group DBAL-831
      */
     public function testReturnsIdentitySequenceName() : void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | N/A

#### Summary

Drops `AbstractPlatform::usesSequenceEmulatedIdentityColumns()`, as suggested in https://github.com/doctrine/dbal/pull/3759#discussion_r353315457.