### PR TITLE
Add $statement parameter to PDOConnection::query()

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -67,7 +67,7 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
     /**
      * {@inheritdoc}
      */
-    public function query()
+    public function query($statement = null)
     {
         $args = func_get_args();
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug-ish
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

PHP 8 updates the signature to `PDO::query(string $statement)`, so change `PDOConnection` to be compatible with that (but also older versions).

This doesn't seem relevant for version 3.x anymore (which does not extend PDO), but this should allow testing current Symfony and Laravel versions under PHP 8.
