### PR TITLE
Fix2.9 tests

### DIFF
--- a/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
@@ -64,5 +64,7 @@ EOT
         }
 
         $output->write(Dumper::dump($resultSet, (int) $depth));
+
+        return 0;
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | Bug
| BC Break     | no
| Fixed issues | #3776 

#### Summary

Return 0 from RunSqlCommand to fix Travis tests with Symfony 4.4 Console component.

Fixes #3776 