### PR TITLE
[GH-3722] Revert removal of ?? $column breaking named parameters in OCI8

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -278,7 +278,7 @@ class OCI8Statement implements IteratorAggregate, Statement
      */
     public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null)
     {
-        $column = $this->_paramMap[$column];
+        $column = $this->_paramMap[$column] ?? $column;
 
         if ($type === ParameterType::LARGE_OBJECT) {
             $lob = oci_new_descriptor($this->_dbh, OCI_D_LOB);

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/StatementTest.php
@@ -43,9 +43,14 @@ class StatementTest extends DbalFunctionalTestCase
     public static function queryConversionProvider() : iterable
     {
         return [
-            'simple' => [
+            'positional' => [
                 'SELECT ? COL1 FROM DUAL',
                 [1],
+                ['COL1' => 1],
+            ],
+            'named' => [
+                'SELECT :COL1 COL1 FROM DUAL',
+                [':COL1' => 1],
                 ['COL1' => 1],
             ],
             'literal-with-placeholder' => [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3722

#### Summary

This reverts an accidental BC break with OCI8 support breaking named parameters.

Fixes #3722