### PR TITLE
Transpose PostgreSqlPlatform::$booleanLiterals for optimization

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -23,7 +23,6 @@ use function array_values;
 use function count;
 use function explode;
 use function implode;
-use function in_array;
 use function is_array;
 use function is_bool;
 use function is_numeric;
@@ -43,24 +42,21 @@ class PostgreSqlPlatform extends AbstractPlatform
     /** @var bool */
     private $useBooleanTrueFalseStrings = true;
 
-    /** @var string[][] PostgreSQL booleans literals */
+    /** @var bool[] PostgreSQL booleans literals */
     private $booleanLiterals = [
-        'true' => [
-            't',
-            'true',
-            'y',
-            'yes',
-            'on',
-            '1',
-        ],
-        'false' => [
-            'f',
-            'false',
-            'n',
-            'no',
-            'off',
-            '0',
-        ],
+        't'     => true,
+        'true'  => true,
+        'y'     => true,
+        'yes'   => true,
+        'on'    => true,
+        '1'     => true,
+
+        'f'     => false,
+        'false' => false,
+        'n'     => false,
+        'no'    => false,
+        'off'   => false,
+        '0'     => false,
     ];
 
     /**
@@ -809,15 +805,9 @@ SQL
             return $callback(true);
         }
 
-        /**
-         * Better safe than sorry: http://php.net/in_array#106319
-         */
-        if (in_array(strtolower(trim($value)), $this->booleanLiterals['false'], true)) {
-            return $callback(false);
-        }
-
-        if (in_array(strtolower(trim($value)), $this->booleanLiterals['true'], true)) {
-            return $callback(true);
+        $boolean = $this->booleanLiterals[strtolower(trim($value))] ?? null;
+        if ($boolean !== null) {
+            return $callback($boolean);
         }
 
         throw new UnexpectedValueException(sprintf(
@@ -896,7 +886,7 @@ SQL
      */
     public function convertFromBoolean($item) : ?bool
     {
-        if (in_array($item, $this->booleanLiterals['false'], true)) {
+        if (($this->booleanLiterals[$item] ?? null) === false) {
             return false;
         }
 

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -39,11 +39,7 @@ use function trim;
  */
 class PostgreSqlPlatform extends AbstractPlatform
 {
-    /** @var bool */
-    private $useBooleanTrueFalseStrings = true;
-
-    /** @var bool[] PostgreSQL booleans literals */
-    private $booleanLiterals = [
+    private const BOOLEAN_LITERALS = [
         't'     => true,
         'true'  => true,
         'y'     => true,
@@ -58,6 +54,9 @@ class PostgreSqlPlatform extends AbstractPlatform
         'off'   => false,
         '0'     => false,
     ];
+
+    /** @var bool */
+    private $useBooleanTrueFalseStrings = true;
 
     /**
      * PostgreSQL has different behavior with some drivers
@@ -805,7 +804,7 @@ SQL
             return $callback(true);
         }
 
-        $boolean = $this->booleanLiterals[strtolower(trim($value))] ?? null;
+        $boolean = self::BOOLEAN_LITERALS[strtolower(trim($value))] ?? null;
         if ($boolean !== null) {
             return $callback($boolean);
         }
@@ -886,7 +885,7 @@ SQL
      */
     public function convertFromBoolean($item) : ?bool
     {
-        if (($this->booleanLiterals[$item] ?? null) === false) {
+        if ((self::BOOLEAN_LITERALS[$item] ?? null) === false) {
             return false;
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

Searching by key instead in_array works twice faster on this array.

##### Original version
real	0m0.804s
user	0m0.799s
sys	0m0.004s
```
$booleanLiterals = [
    'true' => [
        't',
        'true',
        'y',
        'yes',
        'on',
        '1',
    ],
    'false' => [
        'f',
        'false',
        'n',
        'no',
        'off',
        '0',
    ],
];

$value = 'true';
for($i = 0; $i < 10000000; $i++) {
    in_array(strtolower(trim($value)), $booleanLiterals['false'], true);
}
```
##### Transposed version
real	0m0.470s
user	0m0.462s
sys	0m0.008s
```
$booleanLiterals = [
    't' => true,
    'true' => true,
    'y' => true,
    'yes' => true,
    'on' => true,
    '1' => true,
    'f' => false,
    'false => false,
    'n' => false,
    'no' => false,
    'off' => false,
    '0' => false,
];

$value = 'true';
for($i = 0; $i < 10000000; $i++) {
    $booleanLiterals[strtolower(trim($value))];
}
```
