### PR TITLE
BUGFIX: Fix to handle default values in columnDefinition

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -14,6 +14,7 @@ use function assert;
 use function count;
 use function get_class;
 use function strtolower;
+use function preg_match;
 
 /**
  * Compares two Schemas and return an instance of SchemaDiff.
@@ -442,10 +443,10 @@ class Comparator
         }
 
         // Fix to handle default values in columnDefinition
-        if (!empty($properties2['columnDefinition'] ?? '')
-            && $properties2['type']->getName() == $properties2['type']->getName()
-            && $properties2['type']->getName() == \Doctrine\DBAL\Types\Type::INTEGER
-            && (1 === preg_match('/DEFAULT\s(\d+)$/', $properties2['columnDefinition'], $matches))
+        if (! empty($properties2['columnDefinition'] ?? '')
+            && $properties2['type']->getName() === $properties2['type']->getName()
+            && $properties2['type']->getName() === Types\Type::INTEGER
+            && preg_match('/DEFAULT\s(\d+)$/', $properties2['columnDefinition'], $matches)
         ) {
             $properties2['default'] = $matches[1][0];
         }

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -13,8 +13,8 @@ use function array_unique;
 use function assert;
 use function count;
 use function get_class;
-use function strtolower;
 use function preg_match;
+use function strtolower;
 
 /**
  * Compares two Schemas and return an instance of SchemaDiff.

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -442,15 +442,14 @@ class Comparator
         }
 
         // Fix to handle default values in columnDefinition
-        if (!empty($properties2['columnDefinition'] ?? '') &&
-            $properties2['type']->getName() == $properties2['type']->getName() &&
-            $properties2['type']->getName() == \Doctrine\DBAL\Types\Type::INTEGER &&
-            (1 === preg_match('/DEFAULT\s(\d+)$/', $properties2['columnDefinition'],
-                $matches, PREG_OFFSET_CAPTURE, 0))
+        if (!empty($properties2['columnDefinition'] ?? '')
+            && $properties2['type']->getName() == $properties2['type']->getName()
+            && $properties2['type']->getName() == \Doctrine\DBAL\Types\Type::INTEGER
+            && (1 === preg_match('/DEFAULT\s(\d+)$/', $properties2['columnDefinition'], $matches))
         ) {
             $properties2['default'] = $matches[1][0];
         }
-        
+
         // Null values need to be checked additionally as they tell whether to create or drop a default value.
         // null != 0, null != false, null != '' etc. This affects platform's table alteration SQL generation.
         if (($properties1['default'] === null) !== ($properties2['default'] === null)

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -441,6 +441,16 @@ class Comparator
             $changedProperties[] = 'comment';
         }
 
+        // Fix to handle default values in columnDefinition
+        if (!empty($properties2['columnDefinition'] ?? '') &&
+            $properties2['type']->getName() == $properties2['type']->getName() &&
+            $properties2['type']->getName() == \Doctrine\DBAL\Types\Type::INTEGER &&
+            (1 === preg_match('/DEFAULT\s(\d+)$/', $properties2['columnDefinition'],
+                $matches, PREG_OFFSET_CAPTURE, 0))
+        ) {
+            $properties2['default'] = $matches[1][0];
+        }
+        
         // Null values need to be checked additionally as they tell whether to create or drop a default value.
         // null != 0, null != false, null != '' etc. This affects platform's table alteration SQL generation.
         if (($properties1['default'] === null) !== ($properties2['default'] === null)


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | unknown

Fix to handle default values in columnDefinition

#### Summary

For example, you wanna set default value for filed that related to another table
```php
    /**
     * @var Employee $visa
     * @ORM\ManyToOne(targetEntity="Employee")
     * @ORM\JoinColumn(name="visa_id", referencedColumnName="id", nullable=false, columnDefinition="INT NOT NULL DEFAULT 434")
     */
    private $visa = null;
``` 
Without this fix, it's always trying to update schema, even when it's already valid.
```sql
ALTER TABLE contract CHANGE visa_id visa_id INT NOT NULL DEFAULT 434;
```
