### PR TITLE
Test primarily against PHP 7.4 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - phpenv config-rm xdebug.ini || true
   - |
     if [ "x$COVERAGE" == "xyes" ]; then
-      pecl install pcov-1.0.0
+      pecl install pcov-1.0.6
     fi
 
 before_script:
@@ -40,15 +40,15 @@ jobs:
   include:
 
     - stage: Smoke Testing
-      php: 7.3
+      php: 7.4
       env: DB=sqlite COVERAGE=yes
     - stage: Smoke Testing
-      php: 7.3
+      php: 7.4
       env: PHPStan
       install: travis_retry composer install --prefer-dist
       script: vendor/bin/phpstan analyse
     - stage: Smoke Testing
-      php: 7.3
+      php: 7.4
       env: PHP_CodeSniffer
       install: travis_retry composer install --prefer-dist
       script: vendor/bin/phpcs
@@ -111,144 +111,12 @@ jobs:
         - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
-      php: 7.3
-      env: DB=mysql COVERAGE=yes
-    - stage: Test
-      php: 7.3
-      env: DB=mysql.docker MYSQL_VERSION=5.7 COVERAGE=yes
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
-    - stage: Test
-      php: 7.3
-      env: DB=mysql.docker MYSQL_VERSION=8.0 COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-mysql-8.0.sh
-    - stage: Test
-      php: 7.3
-      env: DB=mysqli COVERAGE=yes
-    - stage: Test
-      php: 7.3
-      env: DB=mysqli.docker MYSQL_VERSION=5.7 COVERAGE=yes
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
-    - stage: Test
-      php: 7.3
-      env: DB=mysqli.docker MYSQL_VERSION=8.0 COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-mysql-8.0.sh
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb MARIADB_VERSION=10.1 COVERAGE=yes
-      addons:
-        mariadb: 10.1
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb MARIADB_VERSION=10.2 COVERAGE=yes
-      addons:
-        mariadb: 10.2
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb MARIADB_VERSION=10.3 COVERAGE=yes
-      addons:
-        mariadb: 10.3
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.1 COVERAGE=yes
-      addons:
-        mariadb: 10.1
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.2 COVERAGE=yes
-      addons:
-        mariadb: 10.2
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.3 COVERAGE=yes
-      addons:
-        mariadb: 10.3
-    - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=9.4 COVERAGE=yes
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.4"
-    - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=9.5 COVERAGE=yes
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.5"
-    - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=9.6 COVERAGE=yes
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.6"
-    - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=10.0 COVERAGE=yes
-      sudo: required
-      services:
-        - postgresql
-      addons:
-        postgresql: "10.0"
-      before_script:
-        - bash ./tests/travis/install-postgres-10.sh
-    - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=11.0 COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-postgres-11.sh
-    - stage: Test
-      php: 7.3
-      env: DB=sqlsrv COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-sqlsrv-dependencies.sh
-        - bash ./tests/travis/install-mssql-sqlsrv.sh
-        - bash ./tests/travis/install-mssql.sh
-    - stage: Test
-      php: 7.3
-      env: DB=pdo_sqlsrv COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-sqlsrv-dependencies.sh
-        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
-        - bash ./tests/travis/install-mssql.sh
-    - stage: Test
-      php: 7.3
-      env: DB=ibm_db2 COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-db2.sh
-        - bash ./tests/travis/install-db2-ibm_db2.sh
-    - stage: Test
-      php: 7.3
+      php: 7.2
       env: DB=sqlite DEPENDENCIES=low
       install:
         - travis_retry composer update --prefer-dist --prefer-lowest
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=mysql.docker MYSQL_VERSION=8.0
       sudo: required
       services:
@@ -256,7 +124,7 @@ jobs:
       before_script:
         - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=mysqli.docker MYSQL_VERSION=8.0
       sudo: required
       services:
@@ -264,17 +132,17 @@ jobs:
       before_script:
         - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=mariadb MARIADB_VERSION=10.3
       addons:
         mariadb: 10.3
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=mariadb.mysqli MARIADB_VERSION=10.3
       addons:
         mariadb: 10.3
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=pgsql POSTGRESQL_VERSION=11.0
       sudo: required
       services:
@@ -282,10 +150,10 @@ jobs:
       before_script:
         - bash ./tests/travis/install-postgres-11.sh
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=sqlite
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=sqlsrv
       sudo: required
       services:
@@ -295,7 +163,7 @@ jobs:
         - bash ./tests/travis/install-mssql-sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=pdo_sqlsrv
       sudo: required
       services:
@@ -304,6 +172,138 @@ jobs:
         - bash ./tests/travis/install-sqlsrv-dependencies.sh
         - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: 7.4
+      env: DB=mysql COVERAGE=yes
+    - stage: Test
+      php: 7.4
+      env: DB=mysql.docker MYSQL_VERSION=5.7 COVERAGE=yes
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-mysql-5.7.sh
+    - stage: Test
+      php: 7.4
+      env: DB=mysql.docker MYSQL_VERSION=8.0 COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mysql-8.0.sh
+    - stage: Test
+      php: 7.4
+      env: DB=mysqli COVERAGE=yes
+    - stage: Test
+      php: 7.4
+      env: DB=mysqli.docker MYSQL_VERSION=5.7 COVERAGE=yes
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-mysql-5.7.sh
+    - stage: Test
+      php: 7.4
+      env: DB=mysqli.docker MYSQL_VERSION=8.0 COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mysql-8.0.sh
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb MARIADB_VERSION=10.1 COVERAGE=yes
+      addons:
+        mariadb: 10.1
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb MARIADB_VERSION=10.2 COVERAGE=yes
+      addons:
+        mariadb: 10.2
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb MARIADB_VERSION=10.3 COVERAGE=yes
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.1 COVERAGE=yes
+      addons:
+        mariadb: 10.1
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.2 COVERAGE=yes
+      addons:
+        mariadb: 10.2
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.3 COVERAGE=yes
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: 7.4
+      env: DB=pgsql POSTGRESQL_VERSION=9.4 COVERAGE=yes
+      services:
+        - postgresql
+      addons:
+        postgresql: "9.4"
+    - stage: Test
+      php: 7.4
+      env: DB=pgsql POSTGRESQL_VERSION=9.5 COVERAGE=yes
+      services:
+        - postgresql
+      addons:
+        postgresql: "9.5"
+    - stage: Test
+      php: 7.4
+      env: DB=pgsql POSTGRESQL_VERSION=9.6 COVERAGE=yes
+      services:
+        - postgresql
+      addons:
+        postgresql: "9.6"
+    - stage: Test
+      php: 7.4
+      env: DB=pgsql POSTGRESQL_VERSION=10.0 COVERAGE=yes
+      sudo: required
+      services:
+        - postgresql
+      addons:
+        postgresql: "10.0"
+      before_script:
+        - bash ./tests/travis/install-postgres-10.sh
+    - stage: Test
+      php: 7.4
+      env: DB=pgsql POSTGRESQL_VERSION=11.0 COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-postgres-11.sh
+    - stage: Test
+      php: 7.4
+      env: DB=sqlsrv COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
+        - bash ./tests/travis/install-mssql-sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: 7.4
+      env: DB=pdo_sqlsrv COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
+        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: 7.4
+      env: DB=ibm_db2 COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-db2.sh
+        - bash ./tests/travis/install-db2-ibm_db2.sh
 
     - stage: Test
       if: type = cron


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. Changed PHP 7.3 to 7.4 and 7.4 to 7.3 everywhere and reordered the blocks.
2. Updated PCOV to `1.0.6` for compatibility with PHP 7.4.
3. Moved the `DEPENDENCIES=low` section up from PHP 7.3 to 7.2 since otherwise the resolution of the lowest dependencies may be constrained by the non-lowest PHP version.
4. The build went through a series of intermittent apt-related hiccups but no changes were needed in the repo to address them.