### PR TITLE
Switching Travis CI builds to Ubuntu Bionic Beaver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: php
-sudo: false
-dist: xenial
+dist: bionic
 
 cache:
-    directories:
-        - vendor
-        - $HOME/.composer/cache
+  directories:
+    - vendor
+    - $HOME/.composer/cache
 
 before_install:
   - phpenv config-rm xdebug.ini || true


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

According to the [documentation](https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure), `sudo: false` is no longed needed since Trusty.