### PR TITLE
fixed unqualified table name of fk constraints when using schemas

### DIFF
--- a/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
+++ b/lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php
@@ -218,7 +218,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
         $position = strrpos($name, '.');
 
         if ($position !== false) {
-            $name = substr($name, $position);
+            $name = substr($name, $position + 1);
         }
 
         return strtolower($name);

--- a/tests/Doctrine/Tests/DBAL/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ForeignKeyConstraintTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Table;
 use PHPUnit\Framework\TestCase;
 
 class ForeignKeyConstraintTest extends TestCase
@@ -56,6 +57,32 @@ class ForeignKeyConstraintTest extends TestCase
             [['bloo', 'baz', 'foo'], true],
 
             [['FOO'], true],
+        ];
+    }
+
+    /**
+     * @param string|Table $foreignTableName
+     *
+     * @group DBAL-1062
+     * @dataProvider getUnqualifiedForeignTableNameData
+     */
+    public function testGetUnqualifiedForeignTableName($foreignTableName, string $expectedUnqualifiedTableName) : void
+    {
+        $foreignKey = new ForeignKeyConstraint(['foo', 'bar'], $foreignTableName, ['fk_foo', 'fk_bar']);
+
+        self::assertSame($expectedUnqualifiedTableName, $foreignKey->getUnqualifiedForeignTableName());
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public static function getUnqualifiedForeignTableNameData() : iterable
+    {
+        return [
+            ['schema.foreign_table', 'foreign_table'],
+            ['foreign_table', 'foreign_table'],
+            [new Table('schema.foreign_table'), 'foreign_table'],
+            [new Table('foreign_table'), 'foreign_table'],
         ];
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #3737

#### Summary
Return correct unqualified table name for foreign key contraints when referencing a table name including schema (see issue for details).

<!-- Provide a summary of your change. -->
