### PR TITLE
Remove superfluous Configuration instance

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -10,7 +10,6 @@ You can get a DBAL Connection through the
 .. code-block:: php
 
     <?php
-    $config = new \Doctrine\DBAL\Configuration();
     //..
     $connectionParams = array(
         'dbname' => 'mydb',
@@ -19,19 +18,18 @@ You can get a DBAL Connection through the
         'host' => 'localhost',
         'driver' => 'pdo_mysql',
     );
-    $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
+    $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams);
 
 Or, using the simpler URL form:
 
 .. code-block:: php
 
     <?php
-    $config = new \Doctrine\DBAL\Configuration();
     //..
     $connectionParams = array(
         'url' => 'mysql://user:secret@localhost/mydb',
     );
-    $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
+    $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams);
 
 The ``DriverManager`` returns an instance of
 ``Doctrine\DBAL\Connection`` which is a wrapper around the


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary
A configuration instance is not strictly required by [DriverManager::getConnection](https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/DriverManager.php#L139).

As an upside, it doesn't add an extra warning for people that use Psalm/PHPmd when starting off from the documentation example. As the Configuration class has an `@internal` block those tools threat it as the other meaning for `@internal`, as in class that is [internal to the library and not for public use](https://docs.phpdoc.org/references/phpdoc/tags/internal.html).

