### PR TITLE
Support ForeignKeyConstraintViolationException in SQLite

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
@@ -39,6 +39,10 @@ abstract class AbstractSQLiteDriver implements Driver, ExceptionConverterDriver
             return new Exception\UniqueConstraintViolationException($message, $exception);
         }
 
+        if (strpos($exception->getMessage(), 'FOREIGN KEY constraint failed') !== false) {
+            return new Exception\ForeignKeyConstraintViolationException($message, $exception);
+        }
+
         if (strpos($exception->getMessage(), 'may not be NULL') !== false ||
             strpos($exception->getMessage(), 'NOT NULL constraint failed') !== false
         ) {

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLiteDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLiteDriverTest.php
@@ -65,7 +65,7 @@ class AbstractSQLiteDriverTest extends AbstractDriverTest
                 [0, null, 'are not unique'],
             ],
             self::EXCEPTION_FOREIGN_KEY_CONSTRAINT_VIOLATION => [
-                [0, null, 'FOREIGN KEY constraint failed']
+                [0, null, 'FOREIGN KEY constraint failed'],
             ],
             self::EXCEPTION_LOCK_WAIT_TIMEOUT => [
                 [0, null, 'database is locked'],

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLiteDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLiteDriverTest.php
@@ -64,6 +64,9 @@ class AbstractSQLiteDriverTest extends AbstractDriverTest
                 [0, null, 'is not unique'],
                 [0, null, 'are not unique'],
             ],
+            self::EXCEPTION_FOREIGN_KEY_CONSTRAINT_VIOLATION => [
+                [0, null, 'FOREIGN KEY constraint failed']
+            ],
             self::EXCEPTION_LOCK_WAIT_TIMEOUT => [
                 [0, null, 'database is locked'],
             ],

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDOSqlite;
 
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver;
-use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 use function extension_loaded;
 
@@ -46,32 +45,5 @@ class DriverTest extends AbstractDriverTest
     protected static function getDatabaseNameForConnectionWithoutDatabaseNameParameter() : ?string
     {
         return '';
-    }
-
-    public function testForeignKeyConstraintViolationException() : void
-    {
-        $this->connection->exec('PRAGMA foreign_keys = ON');
-
-        $this->connection->exec('
-            CREATE TABLE parent (
-                id INTEGER PRIMARY KEY
-            )
-        ');
-
-        $this->connection->exec('
-            CREATE TABLE child ( 
-                id INTEGER PRIMARY KEY, 
-                parent_id INTEGER,
-                FOREIGN KEY (parent_id) REFERENCES parent(id)
-            );
-        ');
-
-        $this->connection->exec('INSERT INTO parent (id) VALUES (1)');
-        $this->connection->exec('INSERT INTO child (id, parent_id) VALUES (1, 1)');
-        $this->connection->exec('INSERT INTO child (id, parent_id) VALUES (2, 1)');
-
-        $this->expectException(ForeignKeyConstraintViolationException::class);
-
-        $this->connection->exec('INSERT INTO child (id, parent_id) VALUES (3, 2)');
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDOSqlite;
 
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 use function extension_loaded;
 
@@ -45,5 +46,32 @@ class DriverTest extends AbstractDriverTest
     protected static function getDatabaseNameForConnectionWithoutDatabaseNameParameter() : ?string
     {
         return '';
+    }
+
+    public function testForeignKeyConstraintViolationException() : void
+    {
+        $this->connection->exec('PRAGMA foreign_keys = ON');
+
+        $this->connection->exec('
+            CREATE TABLE parent (
+                id INTEGER PRIMARY KEY
+            )
+        ');
+
+        $this->connection->exec('
+            CREATE TABLE child ( 
+                id INTEGER PRIMARY KEY, 
+                parent_id INTEGER,
+                FOREIGN KEY (parent_id) REFERENCES parent(id)
+            );
+        ');
+
+        $this->connection->exec('INSERT INTO parent (id) VALUES (1)');
+        $this->connection->exec('INSERT INTO child (id, parent_id) VALUES (1, 1)');
+        $this->connection->exec('INSERT INTO child (id, parent_id) VALUES (2, 1)');
+
+        $this->expectException(ForeignKeyConstraintViolationException::class);
+
+        $this->connection->exec('INSERT INTO child (id, parent_id) VALUES (3, 2)');
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -78,7 +78,11 @@ class ExceptionTest extends DbalFunctionalTestCase
 
     public function testForeignKeyConstraintViolationExceptionOnInsert() : void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SqlitePlatform) {
+            $this->connection->exec('PRAGMA foreign_keys = ON');
+        } elseif (! $platform->supportsForeignKeyConstraints()) {
             $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
         }
 
@@ -112,7 +116,11 @@ class ExceptionTest extends DbalFunctionalTestCase
 
     public function testForeignKeyConstraintViolationExceptionOnUpdate() : void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SqlitePlatform) {
+            $this->connection->exec('PRAGMA foreign_keys = ON');
+        } elseif (! $platform->supportsForeignKeyConstraints()) {
             $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
         }
 
@@ -146,7 +154,11 @@ class ExceptionTest extends DbalFunctionalTestCase
 
     public function testForeignKeyConstraintViolationExceptionOnDelete() : void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SqlitePlatform) {
+            $this->connection->exec('PRAGMA foreign_keys = ON');
+        } elseif (! $platform->supportsForeignKeyConstraints()) {
             $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
         }
 
@@ -182,7 +194,9 @@ class ExceptionTest extends DbalFunctionalTestCase
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        if (! $platform->supportsForeignKeyConstraints()) {
+        if ($platform instanceof SqlitePlatform) {
+            $this->connection->exec('PRAGMA foreign_keys = ON');
+        } elseif (! $platform->supportsForeignKeyConstraints()) {
             $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

SQLite [supports foreign keys](https://www.sqlite.org/foreignkeys.html), but `ForeignKeyConstraintViolationException` is not handled by the DBAL.