### PR TITLE
Refactor FK exception tests

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/ForeignKeyExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ForeignKeyExceptionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Functional;
+
+use Doctrine\DBAL\Driver\ExceptionConverterDriver;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+class ForeignKeyExceptionTest extends DbalFunctionalTestCase
+{
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        if (! $this->connection->getDriver() instanceof ExceptionConverterDriver) {
+            $this->markTestSkipped('Driver does not support special exception handling.');
+        }
+
+        $schemaManager = $this->connection->getSchemaManager();
+
+        $table = new Table('constraint_error_table');
+        $table->addColumn('id', 'integer', []);
+        $table->setPrimaryKey(['id']);
+
+        $owningTable = new Table('owning_table');
+        $owningTable->addColumn('id', 'integer', []);
+        $owningTable->addColumn('constraint_id', 'integer', []);
+        $owningTable->setPrimaryKey(['id']);
+        $owningTable->addForeignKeyConstraint($table, ['constraint_id'], ['id']);
+
+        $schemaManager->createTable($table);
+        $schemaManager->createTable($owningTable);
+    }
+
+    protected function tearDown() : void
+    {
+        parent::tearDown();
+
+        $schemaManager = $this->connection->getSchemaManager();
+
+        $schemaManager->dropTable('owning_table');
+        $schemaManager->dropTable('constraint_error_table');
+    }
+
+    public function testForeignKeyConstraintViolationExceptionOnInsert() : void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SqlitePlatform) {
+            $this->connection->exec('PRAGMA foreign_keys = ON');
+        } elseif (! $platform->supportsForeignKeyConstraints()) {
+            $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
+        }
+
+        $this->connection->insert('constraint_error_table', ['id' => 1]);
+        $this->connection->insert('owning_table', ['id' => 1, 'constraint_id' => 1]);
+
+        $this->expectException(Exception\ForeignKeyConstraintViolationException::class);
+
+        $this->connection->insert('owning_table', ['id' => 2, 'constraint_id' => 2]);
+    }
+
+    public function testForeignKeyConstraintViolationExceptionOnUpdate() : void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SqlitePlatform) {
+            $this->connection->exec('PRAGMA foreign_keys = ON');
+        } elseif (! $platform->supportsForeignKeyConstraints()) {
+            $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
+        }
+
+        $this->connection->insert('constraint_error_table', ['id' => 1]);
+        $this->connection->insert('owning_table', ['id' => 1, 'constraint_id' => 1]);
+
+        $this->expectException(Exception\ForeignKeyConstraintViolationException::class);
+
+        $this->connection->update('constraint_error_table', ['id' => 2], ['id' => 1]);
+    }
+
+    public function testForeignKeyConstraintViolationExceptionOnDelete() : void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SqlitePlatform) {
+            $this->connection->exec('PRAGMA foreign_keys = ON');
+        } elseif (! $platform->supportsForeignKeyConstraints()) {
+            $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
+        }
+
+        $this->connection->insert('constraint_error_table', ['id' => 1]);
+        $this->connection->insert('owning_table', ['id' => 1, 'constraint_id' => 1]);
+
+        $this->expectException(Exception\ForeignKeyConstraintViolationException::class);
+
+        $this->connection->delete('constraint_error_table', ['id' => 1]);
+    }
+
+    public function testForeignKeyConstraintViolationExceptionOnTruncate() : void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SqlitePlatform) {
+            $this->connection->exec('PRAGMA foreign_keys = ON');
+        } elseif (! $platform->supportsForeignKeyConstraints()) {
+            $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
+        }
+
+        $this->connection->insert('constraint_error_table', ['id' => 1]);
+        $this->connection->insert('owning_table', ['id' => 1, 'constraint_id' => 1]);
+
+        $this->expectException(Exception\ForeignKeyConstraintViolationException::class);
+
+        $this->connection->executeUpdate($platform->getTruncateTableSQL('constraint_error_table'));
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

<s>Several tests can be greatly simplified by delegating the tear-down tasks to `finally {}`, instead of catching and re-throwing exceptions.

This works fine with `expectException()`, too.</s>

Moved FK exception tests to their own class with proper `setUp()`/`tearDown()`.