### PR TITLE
Fix phpstan errors

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -49,7 +49,7 @@ final class ArrayStatement implements IteratorAggregate, ResultStatement
      */
     public function closeCursor() : void
     {
-        $this->data = null;
+        $this->data = [];
     }
 
     /**
@@ -65,10 +65,6 @@ final class ArrayStatement implements IteratorAggregate, ResultStatement
      */
     public function rowCount() : int
     {
-        if ($this->data === null) {
-            return 0;
-        }
-
         return count($this->data);
     }
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1264,6 +1264,8 @@ class Connection implements DriverConnection
     {
         $this->connect();
 
+        assert($this->_conn !== null);
+
         return $this->_conn;
     }
 

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -35,7 +35,7 @@ class Connection extends \Doctrine\DBAL\Connection
     /** @var int */
     private $portability = self::PORTABILITY_NONE;
 
-    /** @var int */
+    /** @var int|null */
     private $case;
 
     /**

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -26,7 +26,7 @@ final class Statement implements IteratorAggregate, DriverStatement
     /** @var DriverStatement|ResultStatement */
     private $stmt;
 
-    /** @var int */
+    /** @var int|null */
     private $case;
 
     /** @var int */
@@ -204,6 +204,7 @@ final class Statement implements IteratorAggregate, DriverStatement
         }
 
         if ($fixCase) {
+            assert($this->case !== null);
             $row = array_change_key_case($row, $this->case);
         }
 

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -393,9 +393,9 @@ class QueryBuilder
      * Gets the maximum number of results the query object was set to retrieve (the "limit").
      * Returns NULL if {@link setMaxResults} was not applied to this query builder.
      *
-     * @return int The maximum number of results.
+     * @return int|null The maximum number of results.
      */
-    public function getMaxResults() : int
+    public function getMaxResults() : ?int
     {
         return $this->maxResults;
     }

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -592,6 +592,8 @@ abstract class AbstractSchemaManager
      */
     protected function _getPortableDatabaseDefinition(array $database) : string
     {
+        assert(! empty($database));
+
         return array_shift($database);
     }
 
@@ -774,6 +776,8 @@ abstract class AbstractSchemaManager
      */
     protected function _getPortableTableDefinition(array $table) : string
     {
+        assert(! empty($table));
+
         return array_shift($table);
     }
 

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Types\Type;
 use const CASE_LOWER;
 use function array_change_key_case;
-use function array_shift;
 use function array_values;
 use function assert;
 use function explode;
@@ -51,14 +50,6 @@ class MySqlSchemaManager extends AbstractSchemaManager
     protected function _getPortableViewDefinition(array $view) : View
     {
         return new View($view['TABLE_NAME'], $view['VIEW_DEFINITION']);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _getPortableTableDefinition(array $table) : string
-    {
-        return array_shift($table);
     }
 
     /**

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -36,7 +36,7 @@ parameters:
         - '~^Parameter #2 \$registeredAliases of static method Doctrine\\DBAL\\Query\\QueryException::nonUniqueAlias\(\) expects array<string>, array<int, int|string> given\.\z~'
 
         # PHPStan is too strict about preg_replace(): https://phpstan.org/r/993dc99f-0d43-4b51-868b-d01f982c1463
-        - '~^Method Doctrine\\DBAL\\Platforms\\AbstractPlatform::escapeStringForLike\(\) should return string but returns string|null\.\z~'
+        - '~^Method Doctrine\\DBAL\\Platforms\\AbstractPlatform::escapeStringForLike\(\) should return string but returns string\|null\.\z~'
 
         # legacy variadic-like signature
         - '~^Method Doctrine\\DBAL(\\.*)?Connection::query\(\) invoked with \d+ parameters?, 0 required\.\z~'

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/DefaultValueTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/DefaultValueTest.php
@@ -41,8 +41,6 @@ class DefaultValueTest extends DbalFunctionalTestCase
     }
 
     /**
-     * @param mixed $expectedDefault
-     *
      * @dataProvider columnProvider
      */
     public function testEscapedDefaultValueCanBeIntrospected(string $name, ?string $expectedDefault) : void
@@ -58,8 +56,6 @@ class DefaultValueTest extends DbalFunctionalTestCase
     }
 
     /**
-     * @param mixed $expectedDefault
-     *
      * @dataProvider columnProvider
      */
     public function testEscapedDefaultValueCanBeInserted(string $name, ?string $expectedDefault) : void

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -177,7 +177,10 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($onlinePrimaryTable->hasColumn('"Id"'));
         self::assertSame('"Id"', $onlinePrimaryTable->getColumn('"Id"')->getQuotedName($platform));
         self::assertTrue($onlinePrimaryTable->hasPrimaryKey());
-        self::assertSame(['"Id"'], $onlinePrimaryTable->getPrimaryKey()->getQuotedColumns($platform));
+
+        $onlinePrimaryTablePrimaryKey = $onlinePrimaryTable->getPrimaryKey();
+        self::assertNotNull($onlinePrimaryTablePrimaryKey);
+        self::assertSame(['"Id"'], $onlinePrimaryTablePrimaryKey->getQuotedColumns($platform));
 
         self::assertTrue($onlinePrimaryTable->hasColumn('select'));
         self::assertSame('"select"', $onlinePrimaryTable->getColumn('select')->getQuotedName($platform));
@@ -211,7 +214,10 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($onlineForeignTable->hasColumn('id'));
         self::assertSame('ID', $onlineForeignTable->getColumn('id')->getQuotedName($platform));
         self::assertTrue($onlineForeignTable->hasPrimaryKey());
-        self::assertSame(['ID'], $onlineForeignTable->getPrimaryKey()->getQuotedColumns($platform));
+
+        $onlineForeignTablePrimaryKey = $onlineForeignTable->getPrimaryKey();
+        self::assertNotNull($onlineForeignTablePrimaryKey);
+        self::assertSame(['ID'], $onlineForeignTablePrimaryKey->getQuotedColumns($platform));
 
         self::assertTrue($onlineForeignTable->hasColumn('"Fk"'));
         self::assertSame('"Fk"', $onlineForeignTable->getColumn('"Fk"')->getQuotedName($platform));

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -178,11 +178,15 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $nestedSchemaTable = $this->schemaManager->listTableDetails('nested.schematable');
         self::assertTrue($nestedSchemaTable->hasColumn('id'));
-        self::assertEquals(['id'], $nestedSchemaTable->getPrimaryKey()->getColumns());
+
+        $primaryKey = $nestedSchemaTable->getPrimaryKey();
+        self::assertNotNull($primaryKey);
+        self::assertEquals(['id'], $primaryKey->getColumns());
 
         $relatedFks = $nestedSchemaTable->getForeignKeys();
         self::assertCount(1, $relatedFks);
         $relatedFk = array_pop($relatedFks);
+        self::assertNotNull($relatedFk);
         self::assertEquals('nested.schemarelated', $relatedFk->getForeignTableName());
     }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -271,7 +271,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
 
     public function getGenerateForeignKeySql() : string
     {
-        return null;
+        $this->fail('Foreign key constraints are not yet supported for SQLite.');
     }
 
     public function testModifyLimitQuery() : void

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -254,6 +254,7 @@ class ComparatorTest extends TestCase
         $c         = new Comparator();
         $tableDiff = $c->diffTable($tableA, $tableB);
 
+        self::assertNotNull($tableDiff);
         self::assertCount(1, $tableDiff->renamedColumns, 'we should have one rename datefield1 => new_datefield1.');
         self::assertArrayHasKey('datefield1', $tableDiff->renamedColumns, "'datefield1' should be set to be renamed to new_datefield1");
         self::assertCount(1, $tableDiff->addedColumns, "'new_datefield2' should be added");
@@ -723,6 +724,7 @@ class ComparatorTest extends TestCase
         $c         = new Comparator();
         $tableDiff = $c->diffTable($tableA, $tableB);
 
+        self::assertNotNull($tableDiff);
         self::assertCount(0, $tableDiff->addedColumns);
         self::assertCount(0, $tableDiff->removedColumns);
         self::assertArrayHasKey('foo', $tableDiff->renamedColumns);
@@ -748,6 +750,7 @@ class ComparatorTest extends TestCase
         $c         = new Comparator();
         $tableDiff = $c->diffTable($tableA, $tableB);
 
+        self::assertNotNull($tableDiff);
         self::assertCount(1, $tableDiff->addedColumns, "'baz' should be added, not created through renaming!");
         self::assertArrayHasKey('baz', $tableDiff->addedColumns, "'baz' should be added, not created through renaming!");
         self::assertCount(2, $tableDiff->removedColumns, "'foo' and 'bar' should both be dropped, an ambiguity exists which one could be renamed to 'baz'.");
@@ -773,6 +776,7 @@ class ComparatorTest extends TestCase
         $comparator = new Comparator();
         $tableDiff  = $comparator->diffTable($table1, $table2);
 
+        self::assertNotNull($tableDiff);
         self::assertCount(0, $tableDiff->addedIndexes);
         self::assertCount(0, $tableDiff->removedIndexes);
         self::assertArrayHasKey('idx_foo', $tableDiff->renamedIndexes);
@@ -801,6 +805,7 @@ class ComparatorTest extends TestCase
         $comparator = new Comparator();
         $tableDiff  = $comparator->diffTable($table1, $table2);
 
+        self::assertNotNull($tableDiff);
         self::assertCount(1, $tableDiff->addedIndexes);
         self::assertArrayHasKey('idx_baz', $tableDiff->addedIndexes);
         self::assertCount(2, $tableDiff->removedIndexes);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

A method declared with a `string` return type attempts to return `null`. This is not caught by tests as this method is never called because `SqlitePlatform` does not support exceptions.

This now throws a `LogicException` instead, as this is not expected to be executed.

#### Update

Following the discussion below, this now fixes many more phpstan errors.