### PR TITLE
Removed deprecation leftovers

### DIFF
--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -267,8 +267,6 @@ class OracleSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritdoc}
-     *
-     * @deprecated
      */
     protected function _getPortableDatabaseDefinition(array $database) : string
     {
@@ -279,8 +277,6 @@ class OracleSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritdoc}
-     *
-     * Calling this method without an argument or by passing NULL is deprecated.
      */
     public function createDatabase(string $database) : void
     {

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -238,8 +238,6 @@ class SqliteSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritdoc}
-     *
-     * @deprecated
      */
     protected function _getPortableTableColumnList(string $table, string $database, array $tableColumns) : array
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3508

1. `SqliteSchemaManager#_getPortableTableColumnList()` was mistakenly marked `@deprecated` instead of `#_getPortableTableIndexDefinition()` in #3565.
2. `OracleSchemaManager#_getPortableDatabaseDefinition()` was mistakenly marked `@deprecated` instead of `#_getPortableFunctionDefinition()` in #3565.
3. The deprecation message in the `OracleSchemaManager#createDatabase()` description is irrelevant as of #3565.

