### PR TITLE
Removed the OCI8Connection::getExecuteMode() method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -63,6 +63,7 @@ Table columns are no longer indexed by column name. Use the `name` attribute of 
 - Class `Doctrine\DBAL\Driver\Mysqli\Driver` was made final.
 - Class `Doctrine\DBAL\Driver\Mysqli\MysqliStatement` was made final.
 - Class `Doctrine\DBAL\Driver\OCI8\Driver` was made final.
+- Class `Doctrine\DBAL\Driver\OCI8\OCI8Connection` was made final.
 - Class `Doctrine\DBAL\Driver\OCI8\OCI8Statement` was made final.
 - Class `Doctrine\DBAL\Driver\PDOSqlsrv\Driver` was made final.
 - Class `Doctrine\DBAL\Driver\PDOSqlsrv\Statement` was made final.

--- a/lib/Doctrine/DBAL/Driver/OCI8/ExecutionMode.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/ExecutionMode.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\OCI8;
+
+/**
+ * Encapsulates the execution mode that is shared between the connection and its statements.
+ *
+ * @internal This class is not covered by the backward compatibility promise
+ */
+final class ExecutionMode
+{
+    /** @var bool */
+    private $isAutoCommitEnabled = true;
+
+    public function enableAutoCommit() : void
+    {
+        $this->isAutoCommitEnabled = true;
+    }
+
+    public function disableAutoCommit() : void
+    {
+        $this->isAutoCommitEnabled = false;
+    }
+
+    public function isAutoCommitEnabled() : bool
+    {
+        return $this->isAutoCommitEnabled;
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/ExecutionModeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/ExecutionModeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Driver\OCI8;
+
+use Doctrine\DBAL\Driver\OCI8\ExecutionMode;
+use PHPStan\Testing\TestCase;
+
+final class ExecutionModeTest extends TestCase
+{
+    /** @var ExecutionMode */
+    private $mode;
+
+    protected function setUp() : void
+    {
+        $this->mode = new ExecutionMode();
+    }
+
+    public function testDefaultAutoCommitStatus() : void
+    {
+        self::assertTrue($this->mode->isAutoCommitEnabled());
+    }
+
+    public function testChangeAutoCommitStatus() : void
+    {
+        $this->mode->disableAutoCommit();
+        self::assertFalse($this->mode->isAutoCommitEnabled());
+
+        $this->mode->enableAutoCommit();
+        self::assertTrue($this->mode->isAutoCommitEnabled());
+    }
+}


### PR DESCRIPTION
The existing relationship between the connection and its statement violate the ISP principle. Instead of having access only to the execution mode of the connection, statements have access to the entire connection API.

Having a method which is not defined in the driver connection interface makes it impossible to mark the method `final` (#3590).

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

#### Summary

<!-- Provide a summary of your change. -->
