### PR TITLE
Dropped handling of one-based numeric arrays of parameters in Statement::execute()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK: Dropped handling of one-based numeric arrays of parameters in `Statement::execute()`
+
+The statement implementations no longer detect whether `$params` is a zero- or one-based array. A zero-based numeric array is expected.
+
 ## BC BREAK: `ServerInfoAwareConnection::requiresQueryForServerVersion()` is removed.
 
 The `ServerInfoAwareConnection::requiresQueryForServerVersion()` method has been removed as an implementation detail which is the same for almost all supported drivers.

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -351,10 +351,8 @@ class OCI8Statement implements IteratorAggregate, Statement
     public function execute(?array $params = null) : void
     {
         if ($params) {
-            $hasZeroIndex = array_key_exists(0, $params);
-
             foreach ($params as $key => $val) {
-                if ($hasZeroIndex && is_int($key)) {
+                if (is_int($key)) {
                     $param = $key + 1;
                 } else {
                     $param = $key;

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -204,10 +204,8 @@ final class SQLSrvStatement implements IteratorAggregate, Statement
     public function execute(?array $params = null) : void
     {
         if ($params) {
-            $hasZeroIndex = array_key_exists(0, $params);
-
             foreach ($params as $key => $val) {
-                if ($hasZeroIndex && is_int($key)) {
+                if (is_int($key)) {
                     $this->bindValue($key + 1, $val);
                 } else {
                     $this->bindValue($key, $val);

--- a/lib/Doctrine/DBAL/Driver/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/Statement.php
@@ -68,7 +68,7 @@ interface Statement extends ResultStatement
      * if any, of their associated parameter markers or pass an array of input-only
      * parameter values.
      *
-     * @param mixed[]|null $params An array of values with as many elements as there are
+     * @param mixed[]|null $params A numeric array of values with as many elements as there are
      *                             bound parameters in the SQL statement being executed.
      *
      * @throws DriverException

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -4,15 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\DBAL\Driver\OCI8;
 
-use Doctrine\DBAL\Driver\OCI8\OCI8Connection;
 use Doctrine\DBAL\Driver\OCI8\OCI8Exception;
 use Doctrine\DBAL\Driver\OCI8\OCI8Statement;
 use Doctrine\Tests\DbalTestCase;
-use PHPUnit\Framework\MockObject\MockObject;
-use ReflectionProperty;
-use const OCI_NO_AUTO_COMMIT;
 use function extension_loaded;
-use function fopen;
 
 class OCI8StatementTest extends DbalTestCase
 {
@@ -23,72 +18,6 @@ class OCI8StatementTest extends DbalTestCase
         }
 
         parent::setUp();
-    }
-
-    /**
-     * This scenario shows that when the first parameter is not null
-     * it properly sets $hasZeroIndex to 1 and calls bindValue starting at 1.
-     *
-     * This also verifies that the statement will check with the connection to
-     * see what the current execution mode is.
-     *
-     * The expected exception is due to oci_execute failing due to no valid connection.
-     *
-     * @param mixed[] $params
-     *
-     * @dataProvider executeDataProvider
-     */
-    public function testExecute(array $params) : void
-    {
-        /** @var OCI8Statement|MockObject $statement */
-        $statement = $this->getMockBuilder(OCI8Statement::class)
-            ->onlyMethods(['bindValue'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        foreach ($params as $index => $value) {
-            $statement->expects($this->at($index))
-                ->method('bindValue')
-                ->with(
-                    $this->equalTo($index + 1),
-                    $this->equalTo($value)
-                );
-        }
-
-        // can't pass to constructor since we don't have a real database handle,
-        // but execute must check the connection for the executeMode
-        $conn = $this->createMock(OCI8Connection::class);
-        $conn->expects($this->once())
-            ->method('getExecuteMode')
-            ->willReturn(OCI_NO_AUTO_COMMIT);
-
-        $connectionReflection = new ReflectionProperty($statement, '_conn');
-        $connectionReflection->setAccessible(true);
-        $connectionReflection->setValue($statement, $conn);
-
-        $handleReflection = new ReflectionProperty($statement, '_sth');
-        $handleReflection->setAccessible(true);
-        $handleReflection->setValue($statement, fopen('php://temp', 'r'));
-
-        $this->expectException(OCI8Exception::class);
-        $statement->execute($params);
-    }
-
-    /**
-     * @return array<int, array<int, mixed>>
-     */
-    public static function executeDataProvider() : iterable
-    {
-        return [
-            // $hasZeroIndex = isset($params[0]); == true
-            [
-                [0 => 'test', 1 => null, 2 => 'value'],
-            ],
-            // $hasZeroIndex = isset($params[0]); == false
-            [
-                [0 => null, 1 => 'test', 2 => 'value'],
-            ],
-        ];
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

The logic of handling one-based arrays existed in `OCI8Statement` (57a97eba01156c8ad02debae28620e72217b46bc) and `SQLSrvStatement` (#110) since their initial implementation without any explanation of why it was needed. Apart from that, the APIs with semantics implicitly defined by input are often more error-prone.

This behavior is not portable. Consider the following test:
```php
/**
 * @dataProvider paramsProvider
 */
public function testHasZeroKey(array $params) : void
{
    $sql  = $this->connection->getDatabasePlatform()->getDummySelectSQL('?, ?');
    $stmt = $this->connection->prepare($sql);
    $stmt->execute($params);

    self::assertEquals([1, 2], $stmt->fetch(FetchMode::NUMERIC));
}

public static function paramsProvider() : iterable
{
    return [
        'zero-based' => [
            [0 => 1, 1 => 2],
        ],
        'one-based' => [
            [1 => 1, 2 => 2],
        ],
        'arbitrary-keys' =>
        [
            [28 => 1, 71 => 2],
        ],
    ];
}
```
Currently, it produces the following results:
```
RUNNING TESTS WITH CONFIG ibm-db2.phpunit.xml
PHPUnit 8.4.1 by Sebastian Bergmann and contributors.

EEE (for some reason, the test doesn't work here)                   3 / 3 (100%)

RUNNING TESTS WITH CONFIG mysqli.phpunit.xml
PHPUnit 8.4.1 by Sebastian Bergmann and contributors.

...                                                                 3 / 3 (100%)

RUNNING TESTS WITH CONFIG oci8.phpunit.xml
PHPUnit 8.4.1 by Sebastian Bergmann and contributors.

..E                                                                 3 / 3 (100%)

RUNNING TESTS WITH CONFIG pdo-mysql.phpunit.xml
PHPUnit 8.4.1 by Sebastian Bergmann and contributors.

.EE                                                                 3 / 3 (100%)

RUNNING TESTS WITH CONFIG pdo-oci.phpunit.xml
PHPUnit 8.4.1 by Sebastian Bergmann and contributors.

.EE                                                                 3 / 3 (100%)

RUNNING TESTS WITH CONFIG pdo-pgsql.phpunit.xml
PHPUnit 8.4.1 by Sebastian Bergmann and contributors.

.EE                                                                 3 / 3 (100%)

RUNNING TESTS WITH CONFIG pdo-sqlite.phpunit.xml
PHPUnit 8.4.1 by Sebastian Bergmann and contributors.

.EE                                                                 3 / 3 (100%)

RUNNING TESTS WITH CONFIG pdo-sqlsrv.phpunit.xml
PHPUnit 8.4.1 by Sebastian Bergmann and contributors.

.EE                                                                 3 / 3 (100%)

RUNNING TESTS WITH CONFIG sqlsrv.phpunit.xml
PHPUnit 8.4.1 by Sebastian Bergmann and contributors.

..E                                                                 3 / 3 (100%)
```

As you can see, the 2nd test passes only on `sqlsrv`, `oci8` (where the logic being removed is explicitly implemented) and `mysqli` (which doesn't care about the keys at all because it binds parameters using a `foreach` loop).

Additionally, the test that covers the logic implemented in `OCI8Statement` currently fails on PHP 8 (#3802) and, if kept, would have to be reworked for #3808.

In the past, the test was the source of extra maintenance for no real reason: #3642, #3369, #2854, #3507, #3552.