### PR TITLE
Merge release 2.10.1 into master

### DIFF
--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -14,7 +14,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    public const VERSION = '2.10.1';
+    public const VERSION = '2.10.2-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -14,7 +14,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    public const VERSION = '2.10.1-DEV';
+    public const VERSION = '2.10.1';
 
     /**
      * Compares a Doctrine version with the current one.


### PR DESCRIPTION
Release [2.10.1](https://github.com/doctrine/dbal/milestone/74)



2.10.1
======

- Total issues resolved: **3**
- Total pull requests resolved: **10**
- Total contributors: **11**

Documentation,Improvement
-------------------------

 - [3793: Remove superfluous Configuration instance](https://github.com/doctrine/dbal/pull/3793) thanks to @mhitza

Bug,Regression,Schema
---------------------

 - [3790: fixed unqualified table name of fk constraints when using schemas](https://github.com/doctrine/dbal/pull/3790) thanks to @stlrnz and @Alarich

CI,Improvement
--------------

 - [3784: Use PHP 7.4 instead of a snapshot on Travis](https://github.com/doctrine/dbal/pull/3784) thanks to @andreybolonin
 - [3778: &#91;GH-3777&#93; Don't remove composer lock travis on stable 2.10 branch](https://github.com/doctrine/dbal/pull/3778) thanks to @beberlei
 - [3753: Allow build failures for unstable dependencies](https://github.com/doctrine/dbal/pull/3753) thanks to @morozov

Bug,SQLite,Test Suite
---------------------

 - [3745: Remove temporary SQLite file on teardown](https://github.com/doctrine/dbal/pull/3745) thanks to @morozov

Deprecation,Documentation
-------------------------

 - [3739: Update deprecation messages to refer to DBAL](https://github.com/doctrine/dbal/pull/3739) thanks to @alcaeus

Bug,Prepared Statements,Regression,oci8
---------------------------------------

 - [3738: Fix breaks named parameters in Oracle](https://github.com/doctrine/dbal/pull/3738) thanks to @eisberg and @matesko

Bug,Deprecation,Documentation,Types
-----------------------------------

 - [3723: Fix annotations](https://github.com/doctrine/dbal/pull/3723) thanks to @enumag and @Pnoexz

CI,Improvement,pdo_oracle
-------------------------

 - [3720: Switched from PHPBrew-based configuration to the Docker-based](https://github.com/doctrine/dbal/pull/3720) thanks to @morozov


