### PR TITLE
Change the branch alias of master from 3.0.x-dev to 4.0.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0.x-dev"
+            "dev-master": "4.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

As agreed internally, I created the `3.0.x` branchfrom `v2.10.1` (683438c86a5d7e9e8ab8ca6670986b53e267ba63). This warrants the change of the master branch alias to `4.0.x-dev`.