### PR TITLE
Added builds against PHP nightly on Travis

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -21,7 +21,7 @@ before_commands:
 tools:
     external_code_coverage:
         timeout: 3600
-        runs: 30 # 25x Travis (jobs with COVERAGE=yes) + 3x AppVeyor (jobs with coverage=yes) + 2x ContinuousPHP
+        runs: 29 # 24x Travis (jobs with COVERAGE=yes) + 3x AppVeyor (jobs with coverage=yes) + 2x ContinuousPHP
 
 filter:
     excluded_paths:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -21,7 +21,7 @@ before_commands:
 tools:
     external_code_coverage:
         timeout: 3600
-        runs: 29 # 24x Travis (jobs with COVERAGE=yes) + 3x AppVeyor (jobs with coverage=yes) + 2x ContinuousPHP
+        runs: 26 # 21x Travis (jobs with COVERAGE=yes) + 3x AppVeyor (jobs with coverage=yes) + 2x ContinuousPHP
 
 filter:
     excluded_paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,11 @@ before_script:
   - if [[ "$DB" == "mysql" || "$DB" == "mysqli" || "$DB" == *"mariadb"* ]]; then mysql < tests/travis/create-mysql-schema.sql; fi;
 
 install:
-  - travis_retry composer -n install --prefer-dist
+  - |
+    if [[ $TRAVIS_PHP_VERSION = "nightly" ]]; then
+      export COMPOSER_FLAGS="--ignore-platform-reqs"
+    fi
+  - travis_retry composer -n install --prefer-dist $COMPOSER_FLAGS
 
 script:
   - |
@@ -302,6 +306,63 @@ jobs:
       before_script:
         - bash ./tests/travis/install-db2.sh
         - bash ./tests/travis/install-db2-ibm_db2.sh
+    - stage: Test
+      php: nightly
+      env: DB=mysql.docker MYSQL_VERSION=8.0
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mysql-8.0.sh
+    - stage: Test
+      php: nightly
+      env: DB=mysqli.docker MYSQL_VERSION=8.0
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mysql-8.0.sh
+    - stage: Test
+      php: nightly
+      env: DB=mariadb MARIADB_VERSION=10.3
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: nightly
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.3
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: nightly
+      env: DB=pgsql POSTGRESQL_VERSION=11.0
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-postgres-11.sh
+    - stage: Test
+      php: nightly
+      env: DB=sqlite
+    - stage: Test
+      php: nightly
+      env: DB=sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
+        - bash ./tests/travis/install-mssql-sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: nightly
+      env: DB=pdo_sqlsrv
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
+        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
 
     - stage: Test
       if: type = cron
@@ -313,3 +374,4 @@ jobs:
 
   allow_failures:
     - env: DEPENDENCIES=dev
+    - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,11 +145,6 @@ jobs:
         - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
       php: 7.3
-      env: DB=mariadb MARIADB_VERSION=10.0 COVERAGE=yes
-      addons:
-        mariadb: 10.0
-    - stage: Test
-      php: 7.3
       env: DB=mariadb MARIADB_VERSION=10.1 COVERAGE=yes
       addons:
         mariadb: 10.1
@@ -165,11 +160,6 @@ jobs:
         mariadb: 10.3
     - stage: Test
       php: 7.3
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.0 COVERAGE=yes
-      addons:
-        mariadb: 10.0
-    - stage: Test
-      php: 7.3
       env: DB=mariadb.mysqli MARIADB_VERSION=10.1 COVERAGE=yes
       addons:
         mariadb: 10.1
@@ -183,13 +173,6 @@ jobs:
       env: DB=mariadb.mysqli MARIADB_VERSION=10.3 COVERAGE=yes
       addons:
         mariadb: 10.3
-    - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=9.3 COVERAGE=yes
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.3"
     - stage: Test
       php: 7.3
       env: DB=pgsql POSTGRESQL_VERSION=9.4 COVERAGE=yes
@@ -218,7 +201,7 @@ jobs:
       services:
         - postgresql
       addons:
-        postgresql: "9.6"
+        postgresql: "10.0"
       before_script:
         - bash ./tests/travis/install-postgres-10.sh
     - stage: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 sudo: false
-dist: trusty
+dist: xenial
 
 cache:
     directories:
@@ -174,6 +174,8 @@ jobs:
     - stage: Test
       php: 7.4
       env: DB=mysql COVERAGE=yes
+      services:
+        - mysql
     - stage: Test
       php: 7.4
       env: DB=mysql.docker MYSQL_VERSION=5.7 COVERAGE=yes
@@ -191,6 +193,8 @@ jobs:
     - stage: Test
       php: 7.4
       env: DB=mysqli COVERAGE=yes
+      services:
+        - mysql
     - stage: Test
       php: 7.4
       env: DB=mysqli.docker MYSQL_VERSION=5.7 COVERAGE=yes
@@ -207,9 +211,11 @@ jobs:
         - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
       php: 7.4
-      env: DB=mariadb MARIADB_VERSION=10.1 COVERAGE=yes
-      addons:
-        mariadb: 10.1
+      env: DB=mariadb.docker MARIADB_VERSION=10.1 COVERAGE=yes
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mariadb.sh
     - stage: Test
       php: 7.4
       env: DB=mariadb MARIADB_VERSION=10.2 COVERAGE=yes
@@ -222,9 +228,11 @@ jobs:
         mariadb: 10.3
     - stage: Test
       php: 7.4
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.1 COVERAGE=yes
-      addons:
-        mariadb: 10.1
+      env: DB=mariadb.mysqli.docker MARIADB_VERSION=10.1 COVERAGE=yes
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mariadb.sh
     - stage: Test
       php: 7.4
       env: DB=mariadb.mysqli MARIADB_VERSION=10.2 COVERAGE=yes
@@ -238,32 +246,24 @@ jobs:
     - stage: Test
       php: 7.4
       env: DB=pgsql POSTGRESQL_VERSION=9.4 COVERAGE=yes
-      services:
-        - postgresql
       addons:
         postgresql: "9.4"
     - stage: Test
       php: 7.4
       env: DB=pgsql POSTGRESQL_VERSION=9.5 COVERAGE=yes
-      services:
-        - postgresql
       addons:
         postgresql: "9.5"
     - stage: Test
       php: 7.4
       env: DB=pgsql POSTGRESQL_VERSION=9.6 COVERAGE=yes
-      services:
-        - postgresql
       addons:
         postgresql: "9.6"
     - stage: Test
       php: 7.4
       env: DB=pgsql POSTGRESQL_VERSION=10.0 COVERAGE=yes
       sudo: required
-      services:
-        - postgresql
       addons:
-        postgresql: "10.0"
+        postgresql: "10"
       before_script:
         - bash ./tests/travis/install-postgres-10.sh
     - stage: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,13 +185,6 @@ jobs:
         mariadb: 10.3
     - stage: Test
       php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=9.2 COVERAGE=yes
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.2"
-    - stage: Test
-      php: 7.3
       env: DB=pgsql POSTGRESQL_VERSION=9.3 COVERAGE=yes
       services:
         - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - phpenv config-rm xdebug.ini || true
   - |
     if [ "x$COVERAGE" == "xyes" ]; then
-      pecl install pcov-1.0.0
+      pecl install pcov-1.0.6
     fi
 
 before_script:
@@ -39,15 +39,15 @@ jobs:
   include:
 
     - stage: Smoke Testing
-      php: 7.3
+      php: 7.4
       env: DB=sqlite COVERAGE=yes
     - stage: Smoke Testing
-      php: 7.3
+      php: 7.4
       env: PHPStan
       install: travis_retry composer install --prefer-dist
       script: vendor/bin/phpstan analyse
     - stage: Smoke Testing
-      php: 7.3
+      php: 7.4
       env: PHP_CodeSniffer
       install: travis_retry composer install --prefer-dist
       script: vendor/bin/phpcs
@@ -110,144 +110,12 @@ jobs:
         - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
-      php: 7.3
-      env: DB=mysql COVERAGE=yes
-    - stage: Test
-      php: 7.3
-      env: DB=mysql.docker MYSQL_VERSION=5.7 COVERAGE=yes
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
-    - stage: Test
-      php: 7.3
-      env: DB=mysql.docker MYSQL_VERSION=8.0 COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-mysql-8.0.sh
-    - stage: Test
-      php: 7.3
-      env: DB=mysqli COVERAGE=yes
-    - stage: Test
-      php: 7.3
-      env: DB=mysqli.docker MYSQL_VERSION=5.7 COVERAGE=yes
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-mysql-5.7.sh
-    - stage: Test
-      php: 7.3
-      env: DB=mysqli.docker MYSQL_VERSION=8.0 COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-mysql-8.0.sh
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb MARIADB_VERSION=10.1 COVERAGE=yes
-      addons:
-        mariadb: 10.1
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb MARIADB_VERSION=10.2 COVERAGE=yes
-      addons:
-        mariadb: 10.2
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb MARIADB_VERSION=10.3 COVERAGE=yes
-      addons:
-        mariadb: 10.3
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.1 COVERAGE=yes
-      addons:
-        mariadb: 10.1
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.2 COVERAGE=yes
-      addons:
-        mariadb: 10.2
-    - stage: Test
-      php: 7.3
-      env: DB=mariadb.mysqli MARIADB_VERSION=10.3 COVERAGE=yes
-      addons:
-        mariadb: 10.3
-    - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=9.4 COVERAGE=yes
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.4"
-    - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=9.5 COVERAGE=yes
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.5"
-    - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=9.6 COVERAGE=yes
-      services:
-        - postgresql
-      addons:
-        postgresql: "9.6"
-    - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=10.0 COVERAGE=yes
-      sudo: required
-      services:
-        - postgresql
-      addons:
-        postgresql: "10.0"
-      before_script:
-        - bash ./tests/travis/install-postgres-10.sh
-    - stage: Test
-      php: 7.3
-      env: DB=pgsql POSTGRESQL_VERSION=11.0 COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-postgres-11.sh
-    - stage: Test
-      php: 7.3
-      env: DB=sqlsrv COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-sqlsrv-dependencies.sh
-        - bash ./tests/travis/install-mssql-sqlsrv.sh
-        - bash ./tests/travis/install-mssql.sh
-    - stage: Test
-      php: 7.3
-      env: DB=pdo_sqlsrv COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-sqlsrv-dependencies.sh
-        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
-        - bash ./tests/travis/install-mssql.sh
-    - stage: Test
-      php: 7.3
-      env: DB=ibm_db2 COVERAGE=yes
-      sudo: required
-      services:
-        - docker
-      before_script:
-        - bash ./tests/travis/install-db2.sh
-        - bash ./tests/travis/install-db2-ibm_db2.sh
-    - stage: Test
-      php: 7.3
+      php: 7.2
       env: DB=sqlite DEPENDENCIES=low
       install:
         - travis_retry composer update --prefer-dist --prefer-lowest
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=mysql.docker MYSQL_VERSION=8.0
       sudo: required
       services:
@@ -255,7 +123,7 @@ jobs:
       before_script:
         - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=mysqli.docker MYSQL_VERSION=8.0
       sudo: required
       services:
@@ -263,17 +131,17 @@ jobs:
       before_script:
         - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=mariadb MARIADB_VERSION=10.3
       addons:
         mariadb: 10.3
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=mariadb.mysqli MARIADB_VERSION=10.3
       addons:
         mariadb: 10.3
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=pgsql POSTGRESQL_VERSION=11.0
       sudo: required
       services:
@@ -281,10 +149,10 @@ jobs:
       before_script:
         - bash ./tests/travis/install-postgres-11.sh
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=sqlite
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=sqlsrv
       sudo: required
       services:
@@ -294,7 +162,7 @@ jobs:
         - bash ./tests/travis/install-mssql-sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
-      php: 7.4
+      php: 7.3
       env: DB=pdo_sqlsrv
       sudo: required
       services:
@@ -303,6 +171,138 @@ jobs:
         - bash ./tests/travis/install-sqlsrv-dependencies.sh
         - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: 7.4
+      env: DB=mysql COVERAGE=yes
+    - stage: Test
+      php: 7.4
+      env: DB=mysql.docker MYSQL_VERSION=5.7 COVERAGE=yes
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-mysql-5.7.sh
+    - stage: Test
+      php: 7.4
+      env: DB=mysql.docker MYSQL_VERSION=8.0 COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mysql-8.0.sh
+    - stage: Test
+      php: 7.4
+      env: DB=mysqli COVERAGE=yes
+    - stage: Test
+      php: 7.4
+      env: DB=mysqli.docker MYSQL_VERSION=5.7 COVERAGE=yes
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-mysql-5.7.sh
+    - stage: Test
+      php: 7.4
+      env: DB=mysqli.docker MYSQL_VERSION=8.0 COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-mysql-8.0.sh
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb MARIADB_VERSION=10.1 COVERAGE=yes
+      addons:
+        mariadb: 10.1
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb MARIADB_VERSION=10.2 COVERAGE=yes
+      addons:
+        mariadb: 10.2
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb MARIADB_VERSION=10.3 COVERAGE=yes
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.1 COVERAGE=yes
+      addons:
+        mariadb: 10.1
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.2 COVERAGE=yes
+      addons:
+        mariadb: 10.2
+    - stage: Test
+      php: 7.4
+      env: DB=mariadb.mysqli MARIADB_VERSION=10.3 COVERAGE=yes
+      addons:
+        mariadb: 10.3
+    - stage: Test
+      php: 7.4
+      env: DB=pgsql POSTGRESQL_VERSION=9.4 COVERAGE=yes
+      services:
+        - postgresql
+      addons:
+        postgresql: "9.4"
+    - stage: Test
+      php: 7.4
+      env: DB=pgsql POSTGRESQL_VERSION=9.5 COVERAGE=yes
+      services:
+        - postgresql
+      addons:
+        postgresql: "9.5"
+    - stage: Test
+      php: 7.4
+      env: DB=pgsql POSTGRESQL_VERSION=9.6 COVERAGE=yes
+      services:
+        - postgresql
+      addons:
+        postgresql: "9.6"
+    - stage: Test
+      php: 7.4
+      env: DB=pgsql POSTGRESQL_VERSION=10.0 COVERAGE=yes
+      sudo: required
+      services:
+        - postgresql
+      addons:
+        postgresql: "10.0"
+      before_script:
+        - bash ./tests/travis/install-postgres-10.sh
+    - stage: Test
+      php: 7.4
+      env: DB=pgsql POSTGRESQL_VERSION=11.0 COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-postgres-11.sh
+    - stage: Test
+      php: 7.4
+      env: DB=sqlsrv COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
+        - bash ./tests/travis/install-mssql-sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: 7.4
+      env: DB=pdo_sqlsrv COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
+        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
+        - bash ./tests/travis/install-mssql.sh
+    - stage: Test
+      php: 7.4
+      env: DB=ibm_db2 COVERAGE=yes
+      sudo: required
+      services:
+        - docker
+      before_script:
+        - bash ./tests/travis/install-db2.sh
+        - bash ./tests/travis/install-db2-ibm_db2.sh
 
     - stage: Test
       if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -247,7 +247,7 @@ jobs:
       install:
         - travis_retry composer update --prefer-dist --prefer-lowest
     - stage: Test
-      php: 7.4snapshot
+      php: 7.4
       env: DB=mysql.docker MYSQL_VERSION=8.0
       sudo: required
       services:
@@ -255,7 +255,7 @@ jobs:
       before_script:
         - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
-      php: 7.4snapshot
+      php: 7.4
       env: DB=mysqli.docker MYSQL_VERSION=8.0
       sudo: required
       services:
@@ -263,17 +263,17 @@ jobs:
       before_script:
         - bash ./tests/travis/install-mysql-8.0.sh
     - stage: Test
-      php: 7.4snapshot
+      php: 7.4
       env: DB=mariadb MARIADB_VERSION=10.3
       addons:
         mariadb: 10.3
     - stage: Test
-      php: 7.4snapshot
+      php: 7.4
       env: DB=mariadb.mysqli MARIADB_VERSION=10.3
       addons:
         mariadb: 10.3
     - stage: Test
-      php: 7.4snapshot
+      php: 7.4
       env: DB=pgsql POSTGRESQL_VERSION=11.0
       sudo: required
       services:
@@ -281,10 +281,10 @@ jobs:
       before_script:
         - bash ./tests/travis/install-postgres-11.sh
     - stage: Test
-      php: 7.4snapshot
+      php: 7.4
       env: DB=sqlite
     - stage: Test
-      php: 7.4snapshot
+      php: 7.4
       env: DB=sqlsrv
       sudo: required
       services:
@@ -294,7 +294,7 @@ jobs:
         - bash ./tests/travis/install-mssql-sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
     - stage: Test
-      php: 7.4snapshot
+      php: 7.4
       env: DB=pdo_sqlsrv
       sudo: required
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: php
-sudo: false
-dist: xenial
+dist: bionic
 
 cache:
-    directories:
-        - vendor
-        - $HOME/.composer/cache
+  directories:
+    - vendor
+    - $HOME/.composer/cache
 
 before_install:
   - phpenv config-rm xdebug.ini || true

--- a/composer.lock
+++ b/composer.lock
@@ -2621,16 +2621,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.0",
+            "version": "3.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
                 "shasum": ""
             },
             "require": {
@@ -2663,12 +2663,12 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-12-19T23:57:18+00:00"
+            "time": "2019-12-04T04:46:47+00:00"
         },
         {
             "name": "symfony/console",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -79,4 +79,10 @@
         <exclude-pattern>lib/Doctrine/DBAL/Types/ObjectType.php</exclude-pattern>
         <exclude-pattern>tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php</exclude-pattern>
     </rule>
+
+    <!-- The SQLSRV_* functions are defined in the upper case by the sqlsrv extension and violate the standard
+         see https://docs.microsoft.com/en-us/sql/connect/php/constants-microsoft-drivers-for-php-for-sql-server -->
+    <rule ref="Squiz.PHP.LowercasePHPFunctions.UseStatementUppercase">
+        <exclude-pattern>lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -43,7 +43,7 @@ class ResultCacheTest extends DbalFunctionalTestCase
             $this->connection->insert('caching', $row);
         }
 
-        $config                                = $this->connection->getConfiguration();
+        $config = $this->connection->getConfiguration();
         $config->setSQLLogger($this->sqlLogger = new DebugStack());
 
         $cache = new ArrayCache();

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/DrizzleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/DrizzleSchemaManagerTest.php
@@ -30,7 +30,7 @@ class DrizzleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testColumnCollation() : void
     {
-        $table                                  = new Table('test_collation');
+        $table = new Table('test_collation');
         $table->addOption('collate', $collation = 'utf8_unicode_ci');
         $table->addColumn('id', 'integer');
         $table->addColumn('text', 'text');

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -269,7 +269,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testColumnCollation() : void
     {
-        $table                                  = new Table('test_collation');
+        $table = new Table('test_collation');
         $table->addOption('collate', $collation = 'latin1_swedish_ci');
         $table->addOption('charset', 'latin1');
         $table->addColumn('id', 'integer');

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -170,7 +170,6 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
         );
 
         self::assertEquals(
-
             'SELECT ' .
             'u.id, ' .
             '(u.foo/2) foodiv, ' .

--- a/tests/travis/create-mysql-schema.sql
+++ b/tests/travis/create-mysql-schema.sql
@@ -1,3 +1,6 @@
+DROP USER IF EXISTS 'travis'@'%';
+CREATE USER 'travis'@'%';
+
 CREATE SCHEMA doctrine_tests;
 CREATE SCHEMA test_create_database;
 CREATE SCHEMA test_drop_database;

--- a/tests/travis/install-mariadb.sh
+++ b/tests/travis/install-mariadb.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -ex
+
+sudo docker run \
+    -d \
+    -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+    -e MYSQL_DATABASE=doctrine_tests \
+    -p 33306:3306 \
+    --name mariadb \
+    mariadb:${MARIADB_VERSION}
+
+sudo docker exec -i mariadb bash <<< 'until echo \\q | mysql doctrine_tests > /dev/null 2>&1 ; do sleep 1; done'

--- a/tests/travis/install-sqlsrv-dependencies.sh
+++ b/tests/travis/install-sqlsrv-dependencies.sh
@@ -5,6 +5,6 @@ set -ex
 echo Installing driver dependencies
 
 curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql.list
+curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql.list
 sudo apt-get update
 ACCEPT_EULA=Y sudo apt-get install -qy msodbcsql17 unixodbc unixodbc-dev libssl1.0.0

--- a/tests/travis/mariadb.docker.travis.xml
+++ b/tests/travis/mariadb.docker.travis.xml
@@ -10,18 +10,18 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="mysqli"/>
-        <var name="db_host" value="localhost" />
-        <var name="db_username" value="travis" />
+        <var name="db_type" value="pdo_mysql"/>
+        <var name="db_host" value="127.0.0.1" />
+        <var name="db_username" value="root" />
         <var name="db_password" value="" />
         <var name="db_name" value="doctrine_tests" />
-        <var name="db_port" value="3306"/>
+        <var name="db_port" value="33306"/>
 
-        <var name="tmpdb_type" value="mysqli"/>
-        <var name="tmpdb_host" value="localhost" />
-        <var name="tmpdb_username" value="travis" />
+        <var name="tmpdb_type" value="pdo_mysql"/>
+        <var name="tmpdb_host" value="127.0.0.1" />
+        <var name="tmpdb_username" value="root" />
         <var name="tmpdb_password" value="" />
-        <var name="tmpdb_port" value="3306"/>
+        <var name="tmpdb_port" value="33306"/>
     </php>
 
     <testsuites>

--- a/tests/travis/mariadb.mysqli.docker.travis.xml
+++ b/tests/travis/mariadb.mysqli.docker.travis.xml
@@ -11,17 +11,17 @@
         <ini name="error_reporting" value="-1" />
 
         <var name="db_type" value="mysqli"/>
-        <var name="db_host" value="localhost" />
-        <var name="db_username" value="travis" />
+        <var name="db_host" value="127.0.0.1" />
+        <var name="db_username" value="root" />
         <var name="db_password" value="" />
         <var name="db_name" value="doctrine_tests" />
-        <var name="db_port" value="3306"/>
+        <var name="db_port" value="33306"/>
 
         <var name="tmpdb_type" value="mysqli"/>
-        <var name="tmpdb_host" value="localhost" />
-        <var name="tmpdb_username" value="travis" />
+        <var name="tmpdb_host" value="127.0.0.1" />
+        <var name="tmpdb_username" value="root" />
         <var name="tmpdb_password" value="" />
-        <var name="tmpdb_port" value="3306"/>
+        <var name="tmpdb_port" value="33306"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. Backported #3754 in order to enable PHP_CodeSniffer on PHP 7.4.
2. Backported all CI updates between `3.0.x` and `master`:
   ```
   $ git log --stat 3.0.x..master -- .appveyor .scrutinizer.yml .travis.yml tests/{appveyor,continuousphp,travis}
   
   commit f37a88ed99a342080650b969a4dbebea21ca6ab8 (origin/master)
   Merge: 3e735a819 706660115
   Author: Sergei Morozov <morozov@tut.by>
   Date:   Wed Jan 1 20:14:58 2020 -0800
   
       Merge branch '2.10'
   
   commit 51d5c87a971f5f90a0c72b1d53dfb07bfda6f725
   Author: Sergei Morozov <morozov@tut.by>
   Date:   Thu Dec 19 16:42:33 2019 -0800
   
       Switching Travis CI builds to Ubuntu Bionic Beaver
       
       According to the [documentation](https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure), `sudo: false` is no longed needed since Trusty.
   
    .travis.yml | 9 ++++-----
    1 file changed, 4 insertions(+), 5 deletions(-)
   
   commit ff45edaefabbb802671405d9ad91dfa84944cefd
   Author: Sergei Morozov <morozov@tut.by>
   Date:   Mon Apr 22 18:48:35 2019 -0700
   
       Switching Travis CI builds to Ubuntu Xenial Xerus
   
    .travis.yml                                   | 32 +++++++++----------
    tests/travis/create-mysql-schema.sql          |  3 ++
    tests/travis/install-mariadb.sh               | 13 ++++++++
    tests/travis/install-sqlsrv-dependencies.sh   |  2 +-
    tests/travis/mariadb.docker.travis.xml        | 45 +++++++++++++++++++++++++++
    tests/travis/mariadb.mysqli.docker.travis.xml | 45 +++++++++++++++++++++++++++
    tests/travis/mariadb.mysqli.travis.xml        |  2 --
    7 files changed, 123 insertions(+), 19 deletions(-)
   
   commit 75cf1515ccfe00860cd3649926eea59d35cdc20d
   Author: Sergei Morozov <morozov@tut.by>
   Date:   Tue Dec 17 18:15:19 2019 -0800
   
       Test primarily against PHP 7.4 on Travis
   
    .travis.yml | 170 ++++++++++++++++++++++++++++++------------------------------
    1 file changed, 85 insertions(+), 85 deletions(-)
   
   commit 59728eb3501e888100b40daf9a67f4bf9188b400
   Author: Andrey Bolonin <andreybolonin@users.noreply.github.com>
   Date:   Mon Dec 16 09:34:01 2019 +0200
   
       Use PHP 7.4 instead of a snapshot on Travis
   
    .travis.yml | 16 ++++++++--------
    1 file changed, 8 insertions(+), 8 deletions(-)
   
   commit ed9eb002b0b8f8f725e31f1095aeb2997da0835b
   Merge: ab8889629 0a5790ba9
   Author: Sergei Morozov <morozov@tut.by>
   Date:   Mon Nov 25 13:09:51 2019 -0800
   
       Merge branch '2.10'
   
   commit 355d242f4cbc40f5d475c13a5bdbf85a44f35b89
   Author: Claudio Zizza <claudio@budgegeria.de>
   Date:   Thu Jun 13 23:11:19 2019 +0200
   
       Remove Postgres 9.3 and MariaDB 10.0 support
   
    .travis.yml | 19 +------------------
    1 file changed, 1 insertion(+), 18 deletions(-)
   
   commit f9b3e7908f548a96d4ec62a30c8cb9fed7f95c7f
   Author: Michael Moravec <me@majkl.me>
   Date:   Sat Aug 18 03:12:18 2018 +0200
   
       Enable PHPStan in tests
   
    tests/continuousphp/bootstrap.php | 2 ++
    1 file changed, 2 insertions(+)
   
   commit faefe46db39bb4c55f3c525443e1836a5413e70e
   Author: Michael Moravec <me@majkl.me>
   Date:   Fri Mar 16 18:30:16 2018 +0100
   
       Drop support for PostgreSQL <9.3
   
    .scrutinizer.yml | 2 +-
    .travis.yml      | 7 -------
    2 files changed, 1 insertion(+), 8 deletions(-)
   ```
3. Added a section for PHP `nightly` in the build matrix derived from `7.3` (as a non-primary build version, https://github.com/doctrine/dbal/pull/3347#issuecomment-439231396) with added `--ignore-platform-reqs` and `allow_failures`.
