### PR TITLE
Fix documented return type

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -170,7 +170,7 @@ class Comparator
     /**
      * Returns the difference between the tables $table1 and $table2.
      *
-     * If there are no differences this method returns the boolean false.
+     * If there are no differences this method returns null.
      */
     public function diffTable(Table $table1, Table $table2) : ?TableDiff
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

`diffTable()` returns `null` if no differences, not `false`.