### PR TITLE
[pg] fix getting table information if search_path contains escaped schema name

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -367,7 +367,7 @@ SQL
             [$schema, $table] = explode('.', $table);
             $schema           = $this->quoteStringLiteral($schema);
         } else {
-            $schema = "ANY(string_to_array((select replace(replace(setting,'\"\$user\"',user),' ','') from pg_catalog.pg_settings where name = 'search_path'),','))";
+            $schema = 'ANY(current_schemas(false))';
         }
 
         $table = new Identifier($table);

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -335,6 +335,18 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertFalse($comparator->diffTable($offlineTable, $onlineTable));
     }
 
+    public function testListTableDetailsWhenCurrentSchemaNameQuoted() : void
+    {
+        $this->connection->exec('CREATE SCHEMA "001_test"');
+        $this->connection->exec('SET search_path TO "001_test"');
+
+        try {
+            $this->testListQuotedTable();
+        } finally {
+            $this->connection->close();
+        }
+    }
+
     public function testListTablesExcludesViews() : void
     {
         $this->createTestTable('list_tables_excludes_views');


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

I got problem with doctrine migrations with postresql database: 
```There is no column with name 'version' on table 'migration_versions'.```

after research i found that error happiness if `search_path` contains escaped schema name (eg ``` set search_path = '123', public;```)

this patch fix my problem, also simplifies the code and use native processing of search_path from postgres (no need to handle "$user" anymore))