### PR TITLE
Fix some whitelisted PHPStan errors

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -112,6 +112,7 @@ Table columns are no longer indexed by column name. Use the `name` attribute of 
 
 - Method `Doctrine\DBAL\Schema\AbstractSchemaManager::_getPortableViewDefinition()` no longer optionally returns false. It will always return a `Doctrine\DBAL\Schema\View` instance.
 - Method `Doctrine\DBAL\Schema\Comparator::diffTable()` now optionally returns null instead of false.
+- Property `Doctrine\DBAL\Schema\Table::$_primaryKeyName` is now optionally null instead of false.
 - Property `Doctrine\DBAL\Schema\TableDiff::$newName` is now optionally null instead of false.
 - Method `Doctrine\DBAL\Schema\AbstractSchemaManager::tablesExist()` no longer accepts a string. Use `Doctrine\DBAL\Schema\AbstractSchemaManager::tableExists()` instead.
 - Method `Doctrine\DBAL\Schema\OracleSchemaManager::createDatabase()` no longer accepts `null` for `$database` argument.

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3141,11 +3141,15 @@ abstract class AbstractPlatform
      */
     final public function escapeStringForLike(string $inputString, string $escapeChar) : string
     {
-        return preg_replace(
+        $sql = preg_replace(
             '~([' . preg_quote($this->getLikeWildcardCharacters() . $escapeChar, '~') . '])~u',
             addcslashes($escapeChar, '\\') . '$1',
             $inputString
         );
+
+        assert(is_string($sql));
+
+        return $sql;
     }
 
     protected function getLikeWildcardCharacters() : string

--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -41,8 +41,8 @@ class Table extends AbstractAsset
     /** @var Index[] */
     protected $_indexes = [];
 
-    /** @var string */
-    protected $_primaryKeyName = false;
+    /** @var string|null */
+    protected $_primaryKeyName;
 
     /** @var UniqueConstraint[] */
     protected $_uniqueConstraints = [];
@@ -163,8 +163,12 @@ class Table extends AbstractAsset
      */
     public function dropPrimaryKey() : void
     {
+        if ($this->_primaryKeyName === null) {
+            return;
+        }
+
         $this->dropIndex($this->_primaryKeyName);
-        $this->_primaryKeyName = false;
+        $this->_primaryKeyName = null;
     }
 
     /**
@@ -500,9 +504,11 @@ class Table extends AbstractAsset
      */
     public function getPrimaryKey() : ?Index
     {
-        return $this->hasPrimaryKey()
-            ? $this->getIndex($this->_primaryKeyName)
-            : null;
+        if ($this->_primaryKeyName !== null) {
+            return $this->getIndex($this->_primaryKeyName);
+        }
+
+        return null;
     }
 
     /**
@@ -528,7 +534,7 @@ class Table extends AbstractAsset
      */
     public function hasPrimaryKey() : bool
     {
-        return $this->_primaryKeyName && $this->hasIndex($this->_primaryKeyName);
+        return $this->_primaryKeyName !== null && $this->hasIndex($this->_primaryKeyName);
     }
 
     /**
@@ -684,7 +690,7 @@ class Table extends AbstractAsset
         }
 
         if ((isset($this->_indexes[$indexName]) && ! in_array($indexName, $replacedImplicitIndexes, true)) ||
-            ($this->_primaryKeyName !== false && $indexCandidate->isPrimary())
+            ($this->_primaryKeyName !== null && $indexCandidate->isPrimary())
         ) {
             throw IndexAlreadyExists::new($indexName, $this->_name);
         }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,7 +12,6 @@ parameters:
 
         # changing these would be a BC break, to be done in next major
         - '~^Method Doctrine\\DBAL\\Query\\QueryBuilder::execute\(\) should return Doctrine\\DBAL\\Driver\\Statement\|int but returns Doctrine\\DBAL\\Driver\\ResultStatement\.\z~'
-        - '~^Property Doctrine\\DBAL\\Schema\\Table::\$_primaryKeyName \(string\) does not accept (default value of type )?false\.\z~'
 
         # https://bugs.php.net/bug.php?id=78126
         - '~^Call to an undefined method PDO::sqliteCreateFunction\(\)\.\z~'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,7 +35,6 @@ parameters:
 
         # impossible inference for covariance
         - '~^Property Doctrine\\Tests\\DBAL\\Types\\\S+Test::\$type \(Doctrine\\DBAL\\Types\\\S+Type\) does not accept Doctrine\\DBAL\\Types\\Type\.\z~'
-        - '~^Property Doctrine\\Tests\\DBAL\\Tools\\Console\\RunSqlCommandTest::\$command \(Doctrine\\DBAL\\Tools\\Console\\Command\\RunSqlCommand\) does not accept Symfony\\Component\\Console\\Command\\Command\.\z~'
 
         # https://github.com/doctrine/dbal/pull/3582/files#r290847062
         -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,9 +19,6 @@ parameters:
         # https://github.com/phpstan/phpstan/issues/1847
         - '~^Parameter #2 \$registeredAliases of static method Doctrine\\DBAL\\Query\\QueryException::nonUniqueAlias\(\) expects array<string>, array<int, int|string> given\.\z~'
 
-        # PHPStan is too strict about preg_replace(): https://phpstan.org/r/993dc99f-0d43-4b51-868b-d01f982c1463
-        - '~^Method Doctrine\\DBAL\\Platforms\\AbstractPlatform::escapeStringForLike\(\) should return string but returns string\|null\.\z~'
-
         # legacy remnants from doctrine/common
         - '~^Class Doctrine\\Common\\(Collections\\Collection|Persistence\\Proxy) not found\.\z~'
         - '~^.+ on an unknown class Doctrine\\Common\\(Collections\\Collection|Persistence\\Proxy)\.\z~'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,46 +10,22 @@ parameters:
         # extension not available
         - '~^(Used )?(Function|Constant) sasql_\S+ not found\.\z~i'
 
-        # removing it would be BC break
-        - '~^Constructor of class Doctrine\\DBAL\\Schema\\Table has an unused parameter \$idGeneratorType\.\z~'
-
-        # declaring $tableName in AbstractSchemaManager::_getPortableTableIndexesList() non-optional will be a BC break
-        - '~^Parameter #2 \$table of class Doctrine\\DBAL\\Event\\SchemaIndexDefinitionEventArgs constructor expects string, string\|null given\.\z~'
-
         # changing these would be a BC break, to be done in next major
-        - "~^Casting to bool something that's already bool.~"
-        - "~^Casting to int something that's already int.~"
-        - '~^Method Doctrine\\DBAL\\Driver\\IBMDB2\\DB2Connection::exec\(\) should return int but returns bool\.\z~'
         - '~^Method Doctrine\\DBAL\\Query\\QueryBuilder::execute\(\) should return Doctrine\\DBAL\\Driver\\Statement\|int but returns Doctrine\\DBAL\\Driver\\ResultStatement\.\z~'
         - '~^Property Doctrine\\DBAL\\Schema\\Table::\$_primaryKeyName \(string\) does not accept (default value of type )?false\.\z~'
-        - '~^Property Doctrine\\DBAL\\Schema\\Schema::\$_schemaConfig \(Doctrine\\DBAL\\Schema\\SchemaConfig\) does not accept default value of type false\.\z~'
-        - '~^Method Doctrine\\DBAL\\Schema\\ForeignKeyConstraint::onEvent\(\) should return string\|null but returns false\.\z~'
-        - '~^Method Doctrine\\DBAL\\Schema\\(Oracle|PostgreSql|SQLServer)SchemaManager::_getPortableTableDefinition\(\) should return array but returns string\.\z~'
-        - '~^Method Doctrine\\DBAL\\Platforms\\(|SQLAnywhere|Sqlite)Platform::_getTransactionIsolationLevelSQL\(\) should return string but returns int\.\z~'
-        - '~^Method Doctrine\\DBAL\\Driver\\OCI8\\OCI8Connection::lastInsertId\(\) should return string but returns (int|false)\.\z~'
 
         # https://bugs.php.net/bug.php?id=78126
         - '~^Call to an undefined method PDO::sqliteCreateFunction\(\)\.\z~'
 
         # https://github.com/phpstan/phpstan/issues/1847
-        - '~^Parameter #2 \$registeredAliases of static method Doctrine\\DBAL\\Query\\QueryException::unknownAlias\(\) expects array<string>, array<int, int|string> given\.\z~'
         - '~^Parameter #2 \$registeredAliases of static method Doctrine\\DBAL\\Query\\QueryException::nonUniqueAlias\(\) expects array<string>, array<int, int|string> given\.\z~'
 
         # PHPStan is too strict about preg_replace(): https://phpstan.org/r/993dc99f-0d43-4b51-868b-d01f982c1463
         - '~^Method Doctrine\\DBAL\\Platforms\\AbstractPlatform::escapeStringForLike\(\) should return string but returns string\|null\.\z~'
 
-        # legacy variadic-like signature
-        - '~^Method Doctrine\\DBAL(\\.*)?Connection::query\(\) invoked with \d+ parameters?, 0 required\.\z~'
-
-        # some drivers actually do accept 2nd parameter...
-        - '~^Method Doctrine\\DBAL\\Platforms\\AbstractPlatform::getListTableForeignKeysSQL\(\) invoked with \d+ parameters, 1 required\.\z~'
-
         # legacy remnants from doctrine/common
         - '~^Class Doctrine\\Common\\(Collections\\Collection|Persistence\\Proxy) not found\.\z~'
         - '~^.+ on an unknown class Doctrine\\Common\\(Collections\\Collection|Persistence\\Proxy)\.\z~'
-
-        # inheritance variance inference issue
-        - '~^Method Doctrine\\DBAL\\Driver\\PDOConnection::\w+\(\) should return Doctrine\\DBAL\\Driver\\Statement but returns PDOStatement\.\z~'
 
         # may not exist when pdo_sqlsrv is not loaded but PDO is
         - '~^Access to undefined constant PDO::SQLSRV_ENCODING_BINARY\.\z~'
@@ -57,28 +33,9 @@ parameters:
         # weird class name, represented in stubs as OCI_(Lob|Collection)
         - '~unknown class OCI-(Lob|Collection)~'
 
-        # https://github.com/doctrine/dbal/issues/3237
-        - '~^Call to an undefined method Doctrine\\DBAL\\Driver\\PDOStatement::nextRowset\(\)~'
-
-        # https://github.com/phpstan/phpstan/pull/1886
-        -
-            message: '~^Strict comparison using === between string|false and null will always evaluate to false\.~'
-            path: %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/PDOStatement.php
-
         # impossible inference for covariance
         - '~^Property Doctrine\\Tests\\DBAL\\Types\\\S+Test::\$type \(Doctrine\\DBAL\\Types\\\S+Type\) does not accept Doctrine\\DBAL\\Types\\Type\.\z~'
         - '~^Property Doctrine\\Tests\\DBAL\\Tools\\Console\\RunSqlCommandTest::\$command \(Doctrine\\DBAL\\Tools\\Console\\Command\\RunSqlCommand\) does not accept Symfony\\Component\\Console\\Command\\Command\.\z~'
-
-        # https://github.com/phpstan/phpstan-phpunit/pull/28
-        -
-            message: '~Call to method expects\(\) on an unknown class \S+~'
-            path: %currentWorkingDirectory%/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
-        -
-            message: '~Call to method expects\(\) on an unknown class \S+~'
-            path: %currentWorkingDirectory%/tests/Doctrine/Tests/DBAL/ConnectionTest.php
-        -
-            message: '~Call to method expects\(\) on an unknown class \S+~'
-            path: %currentWorkingDirectory%/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
 
         # https://github.com/doctrine/dbal/pull/3582/files#r290847062
         -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -33,9 +33,6 @@ parameters:
         # weird class name, represented in stubs as OCI_(Lob|Collection)
         - '~unknown class OCI-(Lob|Collection)~'
 
-        # impossible inference for covariance
-        - '~^Property Doctrine\\Tests\\DBAL\\Types\\\S+Test::\$type \(Doctrine\\DBAL\\Types\\\S+Type\) does not accept Doctrine\\DBAL\\Types\\Type\.\z~'
-
         # https://github.com/doctrine/dbal/pull/3582/files#r290847062
         -
             message: '~Parameter #3 \$type of method Doctrine\\DBAL\\Driver\\Statement::bindValue\(\) expects int, string given\.~'

--- a/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
@@ -26,10 +26,10 @@ class RunSqlCommandTest extends TestCase
 
     protected function setUp() : void
     {
-        $application = new Application();
-        $application->add(new RunSqlCommand());
+        $this->command = new RunSqlCommand();
 
-        $this->command       = $application->find('dbal:run-sql');
+        (new Application())->add($this->command);
+
         $this->commandTester = new CommandTester($this->command);
 
         $this->connectionMock = $this->createMock(Connection::class);

--- a/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ArrayTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ArrayType;
 use Doctrine\DBAL\Types\ConversionException;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use function serialize;
@@ -23,7 +22,7 @@ class ArrayTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('array');
+        $this->type     = new ArrayType();
     }
 
     public function testArrayConvertsToDatabaseValue() : void

--- a/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\ConversionException;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -32,7 +31,7 @@ class BinaryTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('binary');
+        $this->type     = new BinaryType();
     }
 
     public function testReturnsBindingType() : void

--- a/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\BlobType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -24,7 +23,7 @@ class BlobTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('blob');
+        $this->type     = new BlobType();
     }
 
     public function testBlobNullConvertsToPHPValue() : void

--- a/tests/Doctrine/Tests/DBAL/Types/BooleanTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BooleanTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\BooleanType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -20,18 +19,28 @@ class BooleanTest extends DbalTestCase
 
     protected function setUp() : void
     {
-        $this->platform = $this->getMockForAbstractClass(AbstractPlatform::class);
-        $this->type     = Type::getType('boolean');
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->type     = new BooleanType();
     }
 
     public function testBooleanConvertsToDatabaseValue() : void
     {
-        self::assertIsInt($this->type->convertToDatabaseValue(1, $this->platform));
+        $this->platform->expects($this->once())
+            ->method('convertBooleansToDatabaseValue')
+            ->with(true)
+            ->willReturn(1);
+
+        self::assertSame(1, $this->type->convertToDatabaseValue(true, $this->platform));
     }
 
     public function testBooleanConvertsToPHPValue() : void
     {
-        self::assertIsBool($this->type->convertToPHPValue(0, $this->platform));
+        $this->platform->expects($this->once())
+            ->method('convertFromBoolean')
+            ->with(0)
+            ->willReturn(false);
+
+        self::assertFalse($this->type->convertToPHPValue(0, $this->platform));
     }
 
     public function testBooleanNullConvertsToPHPValue() : void

--- a/tests/Doctrine/Tests/DBAL/Types/DateImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateImmutableTypeTest.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateImmutableType;
-use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use function get_class;
@@ -25,8 +24,8 @@ class DateImmutableTypeTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->type     = Type::getType('date_immutable');
         $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->type     = new DateImmutableType();
     }
 
     public function testFactoryCreatesCorrectType() : void

--- a/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateIntervalTest.php
@@ -9,7 +9,6 @@ use DateTime;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateIntervalType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
@@ -28,9 +27,7 @@ final class DateIntervalTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('dateinterval');
-
-        self::assertInstanceOf(DateIntervalType::class, $this->type);
+        $this->type     = new DateIntervalType();
     }
 
     public function testDateIntervalConvertsToDatabaseValue() : void

--- a/tests/Doctrine/Tests/DBAL/Types/DateTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use DateTime;
 use Doctrine\DBAL\Types\ConversionException;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\DateType;
 use function date_default_timezone_set;
 
 class DateTest extends BaseDateTypeTestCase
@@ -16,7 +16,7 @@ class DateTest extends BaseDateTypeTestCase
      */
     protected function setUp() : void
     {
-        $this->type = Type::getType('date');
+        $this->type = new DateType();
 
         parent::setUp();
     }

--- a/tests/Doctrine/Tests/DBAL/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTimeImmutableTypeTest.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeImmutableType;
-use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use function get_class;
@@ -25,8 +24,8 @@ class DateTimeImmutableTypeTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->type     = Type::getType('datetime_immutable');
-        $this->platform = $this->getMockBuilder(AbstractPlatform::class)->getMock();
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->type     = new DateTimeImmutableType();
     }
 
     public function testFactoryCreatesCorrectType() : void
@@ -46,7 +45,7 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeImmutableInstanceToDatabaseValue() : void
     {
-        $date = $this->getMockBuilder(DateTimeImmutable::class)->getMock();
+        $date = $this->createMock(DateTimeImmutable::class);
 
         $this->platform->expects($this->once())
             ->method('getDateTimeFormatString')

--- a/tests/Doctrine/Tests/DBAL/Types/DateTimeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTimeTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use DateTime;
 use Doctrine\DBAL\Types\ConversionException;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\DateTimeType;
 
 class DateTimeTest extends BaseDateTypeTestCase
 {
@@ -15,7 +15,7 @@ class DateTimeTest extends BaseDateTypeTestCase
      */
     protected function setUp() : void
     {
-        $this->type = Type::getType('datetime');
+        $this->type = new DateTimeType();
 
         parent::setUp();
     }

--- a/tests/Doctrine/Tests/DBAL/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTimeTzImmutableTypeTest.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeTzImmutableType;
-use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use function get_class;
@@ -25,8 +24,8 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->type     = Type::getType('datetimetz_immutable');
         $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->type     = new DateTimeTzImmutableType();
     }
 
     public function testFactoryCreatesCorrectType() : void

--- a/tests/Doctrine/Tests/DBAL/Types/DateTimeTzTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DateTimeTzTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use DateTime;
 use Doctrine\DBAL\Types\ConversionException;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\DateTimeTzType;
 
 class DateTimeTzTest extends BaseDateTypeTestCase
 {
@@ -15,7 +15,7 @@ class DateTimeTzTest extends BaseDateTypeTestCase
      */
     protected function setUp() : void
     {
-        $this->type = Type::getType('datetimetz');
+        $this->type = new DateTimeTzType();
 
         parent::setUp();
     }

--- a/tests/Doctrine/Tests/DBAL/Types/DecimalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/DecimalTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\DecimalType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -21,7 +20,7 @@ class DecimalTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('decimal');
+        $this->type     = new DecimalType();
     }
 
     public function testDecimalConvertsToPHPValue() : void

--- a/tests/Doctrine/Tests/DBAL/Types/FloatTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/FloatTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\FloatType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -21,7 +20,7 @@ class FloatTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('float');
+        $this->type     = new FloatType();
     }
 
     public function testFloatConvertsToPHPValue() : void

--- a/tests/Doctrine/Tests/DBAL/Types/GuidTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/GuidTypeTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\GuidType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -21,7 +20,7 @@ class GuidTypeTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('guid');
+        $this->type     = new GuidType();
     }
 
     public function testConvertToPHPValue() : void

--- a/tests/Doctrine/Tests/DBAL/Types/IntegerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/IntegerTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\IntegerType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -21,7 +20,7 @@ class IntegerTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('integer');
+        $this->type     = new IntegerType();
     }
 
     public function testIntegerConvertsToPHPValue() : void

--- a/tests/Doctrine/Tests/DBAL/Types/JsonTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/JsonTest.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\JsonType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -29,7 +28,7 @@ class JsonTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('json');
+        $this->type     = new JsonType();
     }
 
     public function testReturnsBindingType() : void

--- a/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ObjectTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\ObjectType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
@@ -24,7 +23,7 @@ class ObjectTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('object');
+        $this->type     = new ObjectType();
     }
 
     public function testObjectConvertsToDatabaseValue() : void

--- a/tests/Doctrine/Tests/DBAL/Types/SmallIntTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/SmallIntTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\SmallIntType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -21,7 +20,7 @@ class SmallIntTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('smallint');
+        $this->type     = new SmallIntType();
     }
 
     public function testSmallIntConvertsToPHPValue() : void

--- a/tests/Doctrine/Tests/DBAL/Types/StringTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/StringTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\StringType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -21,7 +20,7 @@ class StringTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = Type::getType('string');
+        $this->type     = new StringType();
     }
 
     public function testReturnsSQLDeclaration() : void

--- a/tests/Doctrine/Tests/DBAL/Types/TimeImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/TimeImmutableTypeTest.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\TimeImmutableType;
-use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use function get_class;
@@ -25,8 +24,8 @@ class TimeImmutableTypeTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->type     = Type::getType('time_immutable');
-        $this->platform = $this->getMockBuilder(AbstractPlatform::class)->getMock();
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->type     = new TimeImmutableType();
     }
 
     public function testFactoryCreatesCorrectType() : void
@@ -46,7 +45,7 @@ class TimeImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeImmutableInstanceToDatabaseValue() : void
     {
-        $date = $this->getMockBuilder(DateTimeImmutable::class)->getMock();
+        $date = $this->createMock(DateTimeImmutable::class);
 
         $this->platform->expects($this->once())
             ->method('getTimeFormatString')

--- a/tests/Doctrine/Tests/DBAL/Types/TimeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/TimeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Types\ConversionException;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TimeType;
 
 class TimeTest extends BaseDateTypeTestCase
 {
@@ -14,7 +14,7 @@ class TimeTest extends BaseDateTypeTestCase
      */
     protected function setUp() : void
     {
-        $this->type = Type::getType('time');
+        $this->type = new TimeType();
 
         parent::setUp();
     }

--- a/tests/Doctrine/Tests/DBAL/Types/VarDateTimeImmutableTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/VarDateTimeImmutableTypeTest.php
@@ -9,7 +9,6 @@ use DateTimeImmutable;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\VarDateTimeImmutableType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -24,12 +23,8 @@ class VarDateTimeImmutableTypeTest extends TestCase
 
     protected function setUp() : void
     {
-        if (! Type::hasType('vardatetime_immutable')) {
-            Type::addType('vardatetime_immutable', VarDateTimeImmutableType::class);
-        }
-
-        $this->type     = Type::getType('vardatetime_immutable');
-        $this->platform = $this->getMockForAbstractClass(AbstractPlatform::class);
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->type     = new VarDateTimeImmutableType();
     }
 
     public function testReturnsName() : void
@@ -44,7 +39,11 @@ class VarDateTimeImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeImmutableInstanceToDatabaseValue() : void
     {
-        $date = $this->getMockBuilder(DateTimeImmutable::class)->getMock();
+        $this->platform->expects($this->any())
+            ->method('getDateTimeFormatString')
+            ->will($this->returnValue('Y-m-d H:i:s'));
+
+        $date = $this->createMock(DateTimeImmutable::class);
 
         $date->expects($this->once())
             ->method('format')

--- a/tests/Doctrine/Tests/DBAL/Types/VarDateTimeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/VarDateTimeTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\DBAL\Types;
 use DateTime;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\VarDateTimeType;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -27,10 +26,7 @@ class VarDateTimeTest extends DbalTestCase
             ->method('getDateTimeFormatString')
             ->will($this->returnValue('U'));
 
-        if (! Type::hasType('vardatetime')) {
-            Type::addType('vardatetime', VarDateTimeType::class);
-        }
-        $this->type = Type::getType('vardatetime');
+        $this->type = new VarDateTimeType();
     }
 
     public function testDateTimeConvertsToDatabaseValue() : void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | #3603, partially

1. Some errors are no longer relevant due to the code changes and issues fixed in PHPStan.
2. The `RunSqlCommandTest` is reworked to comply with its type constraints.
3. `Type` tests were reworked to test their respective classes w/o using the type registry (less coupling). Additionally, the platform mocks were reworked to mock the expected behavior explicitly instead of relying on the default platform logic (less coupling).
4. The absence of the primary key is indicated by `Table::$_primaryKey = null` instead of `false` (the actual BC break).
5. Removed the `preg_replace()` error from the whitelist and added an assertion. Unless it's known under which circumstances a NULL may be returned (as pointed out in https://github.com/phpstan/phpstan/issues/1901), we cannot test it. Hence, it's an assertion, not a condition with an exception.