### PR TITLE
Removed Connection::project()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -103,6 +103,7 @@ Table columns are no longer indexed by column name. Use the `name` attribute of 
 
 - The following methods have been removed as leaking internal implementation details: `::getHost()`, `::getPort()`, `::getUsername()`, `::getPassword()`.
 - The `::getDatabase()` method can now return null which means that no database is currently selected.
+- The `::project()` method has been removed. Use `::executeQuery()` and fetch the data from the statement using one of the `Statement::fetch*()` methods instead.
 
 ## BC BREAK: Changes in `Doctrine\DBAL\Driver\SQLSrv\LastInsertId`
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -869,32 +869,6 @@ class Connection implements DriverConnection
     }
 
     /**
-     * Executes an, optionally parametrized, SQL query and returns the result,
-     * applying a given projection/transformation function on each row of the result.
-     *
-     * @param string                                 $query    The SQL query to execute.
-     * @param array<int, mixed>|array<string, mixed> $params   The parameters, if any.
-     * @param Closure                                $function The transformation function that is applied on each row.
-     *                                                          The function receives a single parameter, an array, that
-     *                                                          represents a row of the result set.
-     *
-     * @return array<int, mixed> The projected result of the query.
-     */
-    public function project(string $query, array $params, Closure $function) : array
-    {
-        $result = [];
-        $stmt   = $this->executeQuery($query, $params);
-
-        while ($row = $stmt->fetch()) {
-            $result[] = $function($row);
-        }
-
-        $stmt->closeCursor();
-
-        return $result;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function query(string $sql) : ResultStatement


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

As originally discussed in https://github.com/doctrine/dbal/pull/3703#issuecomment-554185811, the method has more limitations and caveats than provides real use:

1. It fetches all data in memory which is often inefficient (see #2718).
2. It fetches rows in memory one by one instead of using `fetchAll()`.
4. It doesn't allow to specify the statement fetch mode since it's instantiated internally.
5. It can be easily replaced with:
   ```php
   foreach ($conn->executeQuery($query, $params, $types) as $value) {
      yield $function($value);
   }
   ```
