### PR TITLE
Proper classes for QueryBuilder SQL parts

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -14,13 +14,14 @@ use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use InvalidArgumentException;
 use function array_key_exists;
 use function array_keys;
+use function array_merge;
 use function array_unshift;
 use function func_get_args;
 use function func_num_args;
 use function implode;
 use function is_array;
 use function is_object;
-use function key;
+use function sprintf;
 use function strtoupper;
 use function substr;
 
@@ -529,7 +530,7 @@ class QueryBuilder
             return $this;
         }
 
-        $queryPartFrom = new QueryPartFrom();
+        $queryPartFrom        = new QueryPartFrom();
         $queryPartFrom->table = $update;
         $queryPartFrom->alias = $alias;
 
@@ -567,7 +568,7 @@ class QueryBuilder
             return $this;
         }
 
-        $queryPartFrom = new QueryPartFrom();
+        $queryPartFrom        = new QueryPartFrom();
         $queryPartFrom->table = $insert;
 
         $this->queryParts->from = [$queryPartFrom];
@@ -594,7 +595,7 @@ class QueryBuilder
      */
     public function from(string $from, ?string $alias = null)
     {
-        $queryPartFrom = new QueryPartFrom();
+        $queryPartFrom        = new QueryPartFrom();
         $queryPartFrom->table = $from;
         $queryPartFrom->alias = $alias;
 
@@ -1101,13 +1102,13 @@ class QueryBuilder
     /**
      * Resets SQL parts.
      *
-     * @todo Should we leave this function? We could just call getQueryParts()->resetXXX(), but this means that we
-     *       return our internal QueryParts object and allow the outside world to modify it directly.
-     *       Should we even keep this method, which is only used in tests?
-     *
      * @param array<int, string>|null $queryPartNames
      *
      * @return $this This QueryBuilder instance.
+     *
+     * @todo Should we leave this function? We could just call getQueryParts()->resetXXX(), but this means that we
+     *       return our internal QueryParts object and allow the outside world to modify it directly.
+     *       Should we even keep this method, which is only used in tests?
      */
     public function resetQueryParts(?array $queryPartNames = null) : self
     {
@@ -1125,13 +1126,13 @@ class QueryBuilder
     /**
      * Resets a single SQL part.
      *
-     * @todo Should we leave this function? We could just call getQueryParts()->resetXXX(), but this means that we
-     *       return our internal QueryParts object and allow the outside world to modify it directly.
-     *       Should we even keep this method, which is only used in tests?
-     *
      * @return $this This QueryBuilder instance.
      *
      * @throws InvalidArgumentException If the query part name is not known.
+     *
+     * @todo Should we leave this function? We could just call getQueryParts()->resetXXX(), but this means that we
+     *       return our internal QueryParts object and allow the outside world to modify it directly.
+     *       Should we even keep this method, which is only used in tests?
      */
     public function resetQueryPart(string $queryPartName) : self
     {
@@ -1401,7 +1402,7 @@ class QueryBuilder
                 if (array_key_exists($join->joinAlias, $knownAliases)) {
                     throw NonUniqueAlias::new($join->joinAlias, array_keys($knownAliases));
                 }
-                $sql                             .= ' ' . strtoupper($join->joinType)
+                $sql                           .= ' ' . strtoupper($join->joinType)
                     . ' JOIN ' . $join->joinTable . ' ' . $join->joinAlias
                     . ' ON ' . ((string) $join->joinCondition); // @todo (string) null would be a syntax error?
                 $knownAliases[$join->joinAlias] = true;

--- a/lib/Doctrine/DBAL/Query/QueryPartFrom.php
+++ b/lib/Doctrine/DBAL/Query/QueryPartFrom.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Query;
+
+class QueryPartFrom
+{
+    /**
+     * @var string|null
+     */
+    public $table;
+
+    /**
+     * @var string|null
+     */
+    public $alias;
+}

--- a/lib/Doctrine/DBAL/Query/QueryPartFrom.php
+++ b/lib/Doctrine/DBAL/Query/QueryPartFrom.php
@@ -6,13 +6,9 @@ namespace Doctrine\DBAL\Query;
 
 class QueryPartFrom
 {
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     public $table;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     public $alias;
 }

--- a/lib/Doctrine/DBAL/Query/QueryPartJoin.php
+++ b/lib/Doctrine/DBAL/Query/QueryPartJoin.php
@@ -6,23 +6,15 @@ namespace Doctrine\DBAL\Query;
 
 class QueryPartJoin
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $joinType;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $joinTable;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $joinAlias;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     public $joinCondition;
 }

--- a/lib/Doctrine/DBAL/Query/QueryPartJoin.php
+++ b/lib/Doctrine/DBAL/Query/QueryPartJoin.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Query;
+
+class QueryPartJoin
+{
+    /**
+     * @var string
+     */
+    public $joinType;
+
+    /**
+     * @var string
+     */
+    public $joinTable;
+
+    /**
+     * @var string
+     */
+    public $joinAlias;
+
+    /**
+     * @var string|null
+     */
+    public $joinCondition;
+}

--- a/lib/Doctrine/DBAL/Query/QueryParts.php
+++ b/lib/Doctrine/DBAL/Query/QueryParts.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Query;
+
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
+
+class QueryParts
+{
+    /**
+     * @var string[]
+     */
+    public $select = [];
+
+    /**
+     * @var bool
+     */
+    public $distinct = false;
+
+    /**
+     * @var QueryPartFrom[]
+     */
+    public $from = [];
+
+    /**
+     * Lists of joins indexed by from alias.
+     *
+     * @var array<string, QueryPartJoin[]>
+     */
+    public $join = [];
+
+    /**
+     * @var string[]
+     */
+    public $set = [];
+
+    /**
+     * @var CompositeExpression|null
+     */
+    public $where = null;
+
+    /**
+     * @var string[]
+     */
+    public $groupBy = [];
+
+    /**
+     * @var CompositeExpression|null
+     */
+    public $having = null;
+
+    /**
+     * @var string[]
+     */
+    public $orderBy = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    public $values = [];
+
+    public function reset() : void
+    {
+        $this->resetSelect();
+        $this->resetDistinct();
+        $this->resetFrom();
+        $this->resetJoin();
+        $this->resetSet();
+        $this->resetWhere();
+        $this->resetGroupBy();
+        $this->resetHaving();
+        $this->resetOrderBy();
+        $this->resetValues();
+    }
+
+    public function resetSelect() : void
+    {
+        $this->select = [];
+    }
+
+    public function resetDistinct() : void
+    {
+        $this->distinct = false;
+    }
+
+    public function resetFrom() : void
+    {
+        $this->from = [];
+    }
+
+    public function resetJoin() : void
+    {
+        $this->join = [];
+    }
+
+    public function resetSet() : void
+    {
+        $this->set = [];
+    }
+
+    public function resetWhere() : void
+    {
+        $this->where = null;
+    }
+
+    public function resetGroupBy() : void
+    {
+        $this->groupBy = [];
+    }
+
+    public function resetHaving() : void
+    {
+        $this->having = null;
+    }
+
+    public function resetOrderBy() : void
+    {
+        $this->orderBy = [];
+    }
+
+    public function resetValues() : void
+    {
+        $this->values = [];
+    }
+
+    /**
+     * Deep clone of all expression objects in the SQL parts.
+     */
+    public function __clone()
+    {
+        foreach ($this->from as $key => $from) {
+            $this->from[$key] = clone $from;
+        }
+
+        foreach ($this->join as $fromAlias => $joins) {
+            foreach ($joins as $key => $join) {
+                $this->join[$fromAlias][$key] = clone $join;
+            }
+        }
+
+        if ($this->where !== null) {
+            $this->where = clone $this->where;
+        }
+
+        if ($this->having !== null) {
+            $this->having = clone $this->having;
+        }
+
+        // @todo What about $values, should they be (deep-)cloned?
+        //       The previous implementation blindly cloned objects and 1-level deep arrays of objects, so this also
+        //       applied to the $sqlParts['values']; was this intentional? I'm not sure.
+    }
+}

--- a/lib/Doctrine/DBAL/Query/QueryParts.php
+++ b/lib/Doctrine/DBAL/Query/QueryParts.php
@@ -8,19 +8,13 @@ use Doctrine\DBAL\Query\Expression\CompositeExpression;
 
 class QueryParts
 {
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     public $select = [];
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $distinct = false;
 
-    /**
-     * @var QueryPartFrom[]
-     */
+    /** @var QueryPartFrom[] */
     public $from = [];
 
     /**
@@ -30,34 +24,22 @@ class QueryParts
      */
     public $join = [];
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     public $set = [];
 
-    /**
-     * @var CompositeExpression|null
-     */
+    /** @var CompositeExpression|null */
     public $where = null;
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     public $groupBy = [];
 
-    /**
-     * @var CompositeExpression|null
-     */
+    /** @var CompositeExpression|null */
     public $having = null;
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     public $orderBy = [];
 
-    /**
-     * @var array<string, mixed>
-     */
+    /** @var array<string, mixed> */
     public $values = [];
 
     public function reset() : void

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,9 +16,6 @@ parameters:
         # https://bugs.php.net/bug.php?id=78126
         - '~^Call to an undefined method PDO::sqliteCreateFunction\(\)\.\z~'
 
-        # https://github.com/phpstan/phpstan/issues/2857
-        - '~^Parameter #2 \$registeredAliases of static method Doctrine\\DBAL\\Query\\Exception\\NonUniqueAlias::new\(\) expects array<string>, array<int, int\|string> given\.\z~'
-
         # legacy remnants from doctrine/common
         - '~^Class Doctrine\\Common\\(Collections\\Collection|Persistence\\Proxy) not found\.\z~'
         - '~^.+ on an unknown class Doctrine\\Common\\(Collections\\Collection|Persistence\\Proxy)\.\z~'


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | none

#### Summary

As suggested by @morozov in https://github.com/doctrine/dbal/pull/3824#issuecomment-575706664:

> To get rid of the remaining PHPStan issue, we may replace the associative array representing a join in the Query Builder with an object similar to DependencyOrderNode used in #3762. This way, we will not only help static analyzers understand which properties and of what types a join has but also may help PHP manage memory more efficiently.

This PR introduces 3 classes, which replace the `$sqlParts` nested associative array:

- `QueryParts`
- `QueryPartFrom`
- `QueryPartJoin`

This is a first draft with both phpunit & phpstan happy.
A few pain points are to be discussed, though.