### PR TITLE
Replaced func_get_args() with variadic arguments

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade to 3.0
 
+## BC BREAK: Changes in the QueryBuilder API.
+
+1. The `select()`, `addSelect()`, `groupBy()` and `addGroupBy()` methods no longer accept an array of arguments. Pass each expression as an individual argument or expand an array of expressions using the `...` operator.
+2. The `select()`, `addSelect()`, `groupBy()` and `addGroupBy()` methods no longer ignore the first argument if it's empty.
+3. The `addSelect()` method can be no longer called without arguments.
+
 ## BC BREAK: `QueryBuilder::insert()`, `update()` and `delete()` signatures changed
 
 These methods now require the `$table` parameter, and do not support aliases anymore.

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Query\Expression;
 
 use Doctrine\DBAL\Connection;
-use function func_get_arg;
-use function func_get_args;
-use function func_num_args;
 use function implode;
 use function sprintf;
 
@@ -41,7 +38,7 @@ class ExpressionBuilder
     }
 
     /**
-     * Creates a conjunction of the given boolean expressions.
+     * Creates a conjunction of the given expressions.
      *
      * Example:
      *
@@ -49,16 +46,15 @@ class ExpressionBuilder
      *     // (u.type = ?) AND (u.role = ?)
      *     $expr->andX('u.type = ?', 'u.role = ?'));
      *
-     * @param mixed $x Optional clause. Defaults = null, but requires
-     *                 at least one defined when converting to string.
+     * @param string|CompositeExpression ...$expressions Requires at least one defined when converting to string.
      */
-    public function andX($x = null) : CompositeExpression
+    public function andX(...$expressions) : CompositeExpression
     {
-        return new CompositeExpression(CompositeExpression::TYPE_AND, func_get_args());
+        return new CompositeExpression(CompositeExpression::TYPE_AND, $expressions);
     }
 
     /**
-     * Creates a disjunction of the given boolean expressions.
+     * Creates a disjunction of the given expressions.
      *
      * Example:
      *
@@ -66,12 +62,11 @@ class ExpressionBuilder
      *     // (u.type = ?) OR (u.role = ?)
      *     $qb->where($qb->expr()->orX('u.type = ?', 'u.role = ?'));
      *
-     * @param mixed $x Optional clause. Defaults = null, but requires
-     *                 at least one defined when converting to string.
+     * @param string|CompositeExpression ...$expressions Requires at least one defined when converting to string.
      */
-    public function orX($x = null) : CompositeExpression
+    public function orX(...$expressions) : CompositeExpression
     {
-        return new CompositeExpression(CompositeExpression::TYPE_OR, func_get_args());
+        return new CompositeExpression(CompositeExpression::TYPE_OR, $expressions);
     }
 
     /**
@@ -210,27 +205,27 @@ class ExpressionBuilder
     }
 
     /**
-     * Creates a LIKE() comparison expression with the given arguments.
+     * Creates a LIKE comparison expression.
      *
      * @param string $x Field in string format to be inspected by LIKE() comparison.
      * @param mixed  $y Argument to be used in LIKE() comparison.
      */
-    public function like(string $x, $y/*, ?string $escapeChar = null */) : string
+    public function like(string $x, $y, ?string $escapeChar = null) : string
     {
         return $this->comparison($x, 'LIKE', $y) .
-            (func_num_args() >= 3 ? sprintf(' ESCAPE %s', func_get_arg(2)) : '');
+            ($escapeChar !== null ? sprintf(' ESCAPE %s', $escapeChar) : '');
     }
 
     /**
-     * Creates a NOT LIKE() comparison expression with the given arguments.
+     * Creates a NOT LIKE comparison expression
      *
      * @param string $x Field in string format to be inspected by NOT LIKE() comparison.
      * @param mixed  $y Argument to be used in NOT LIKE() comparison.
      */
-    public function notLike(string $x, $y/*, ?string $escapeChar = null */) : string
+    public function notLike(string $x, $y, ?string $escapeChar = null) : string
     {
         return $this->comparison($x, 'NOT LIKE', $y) .
-            (func_num_args() >= 3 ? sprintf(' ESCAPE %s', func_get_arg(2)) : '');
+            ($escapeChar !== null ? sprintf(' ESCAPE %s', $escapeChar) : '');
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -20,11 +20,8 @@ use function array_map;
 use function array_shift;
 use function array_values;
 use function assert;
-use function call_user_func_array;
 use function count;
-use function func_get_args;
 use function is_array;
-use function is_callable;
 use function preg_match;
 use function strtolower;
 
@@ -75,20 +72,14 @@ abstract class AbstractSchemaManager
      * $result = $sm->tryMethod('dropView', 'view_name');
      * </code>
      *
+     * @param mixed ...$arguments
+     *
      * @return mixed
      */
-    public function tryMethod()
+    public function tryMethod(string $method, ...$arguments)
     {
-        $args   = func_get_args();
-        $method = $args[0];
-        unset($args[0]);
-        $args = array_values($args);
-
-        $callback = [$this, $method];
-        assert(is_callable($callback));
-
         try {
-            return call_user_func_array($callback, $args);
+            return $this->$method(...$arguments);
         } catch (Throwable $e) {
             return false;
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -36,8 +36,8 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testRenameTable() : void
     {
-        $this->schemaManager->tryMethod('DropTable', 'list_tables_test');
-        $this->schemaManager->tryMethod('DropTable', 'list_tables_test_new_name');
+        $this->schemaManager->tryMethod('dropTable', 'list_tables_test');
+        $this->schemaManager->tryMethod('dropTable', 'list_tables_test_new_name');
 
         $this->createTestTable('list_tables_test');
         $this->schemaManager->renameTable('list_tables_test', 'list_tables_test_new_name');

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -125,8 +125,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectWithAndWhereConditions() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -138,8 +137,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectWithOrWhereConditions() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -151,8 +149,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectWithOrOrWhereConditions() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -164,8 +161,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectWithAndOrWhereConditions() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -179,8 +175,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectGroupBy() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -189,34 +184,9 @@ class QueryBuilderTest extends DbalTestCase
         self::assertEquals('SELECT u.*, p.* FROM users u GROUP BY u.id', (string) $qb);
     }
 
-    public function testSelectEmptyGroupBy() : void
-    {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
-
-        $qb->select('u.*', 'p.*')
-           ->groupBy([])
-           ->from('users', 'u');
-
-        self::assertEquals('SELECT u.*, p.* FROM users u', (string) $qb);
-    }
-
-    public function testSelectEmptyAddGroupBy() : void
-    {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
-
-        $qb->select('u.*', 'p.*')
-           ->addGroupBy([])
-           ->from('users', 'u');
-
-        self::assertEquals('SELECT u.*, p.* FROM users u', (string) $qb);
-    }
-
     public function testSelectAddGroupBy() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -228,8 +198,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectAddGroupBys() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -241,8 +210,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectHaving() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -254,8 +222,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectAndHaving() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -267,8 +234,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectHavingAndHaving() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -281,8 +247,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectHavingOrHaving() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -295,8 +260,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectOrHavingOrHaving() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -309,8 +273,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectHavingAndOrHaving() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -324,8 +287,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectOrderBy() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -336,8 +298,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectAddOrderBy() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -349,8 +310,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectAddAddOrderBy() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -371,8 +331,7 @@ class QueryBuilderTest extends DbalTestCase
 
     public function testSelectAddSelect() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*')
            ->addSelect('p.*')
@@ -381,19 +340,9 @@ class QueryBuilderTest extends DbalTestCase
         self::assertEquals('SELECT u.*, p.* FROM users u', (string) $qb);
     }
 
-    public function testEmptyAddSelect() : void
-    {
-        $qb  = new QueryBuilder($this->conn);
-        $qb2 = $qb->addSelect();
-
-        self::assertSame($qb, $qb2);
-        self::assertEquals(QueryBuilder::SELECT, $qb->getType());
-    }
-
     public function testSelectMultipleFrom() : void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*')
            ->addSelect('p.*')


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

Fixes #3825

In addition to the method signature changes, the following changes have been made:

1. The implementations of `where()`, `having()` and their `and*` and `or*` counterparts have been refactored to reduce code duplication.
2. The `QueryBuilder` tests that call `$qb->expr()` but don't use the return value have been cleaned up.