### PR TITLE
Fix JOIN with no condition bug

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1327,9 +1327,11 @@ class QueryBuilder
                 if (array_key_exists($join['joinAlias'], $knownAliases)) {
                     throw QueryException::nonUniqueAlias($join['joinAlias'], array_keys($knownAliases));
                 }
-                $sql                             .= ' ' . strtoupper($join['joinType'])
-                    . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias']
-                    . ' ON ' . ((string) $join['joinCondition']);
+                $sql .= ' ' . strtoupper($join['joinType'])
+                    . ' JOIN ' . $join['joinTable'] . ' ' . $join['joinAlias'];
+                if ($join['joinCondition'] !== null) {
+                    $sql .= ' ON ' . $join['joinCondition'];
+                }
                 $knownAliases[$join['joinAlias']] = true;
             }
 

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -92,9 +92,20 @@ class QueryBuilderTest extends DbalTestCase
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
-           ->Join('u', 'phones', 'p', $expr->eq('p.user_id', 'u.id'));
+           ->join('u', 'phones', 'p', $expr->eq('p.user_id', 'u.id'));
 
         self::assertEquals('SELECT u.*, p.* FROM users u INNER JOIN phones p ON p.user_id = u.id', (string) $qb);
+    }
+
+    public function testSelectWithJoinNoCondition() : void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('u.*', 'p.*')
+            ->from('users', 'u')
+            ->join('u', 'phones', 'p');
+
+        self::assertEquals('SELECT u.*, p.* FROM users u INNER JOIN phones p', (string) $qb);
     }
 
     public function testSelectWithInnerJoin() : void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | none

#### Summary

This fixes the bug raised in #3829 and #3830, where a JOIN with an empty condition would yield a syntax error in the resulting query: https://github.com/doctrine/dbal/pull/3830#discussion_r368217791