### PR TITLE
Fix docblock typos in DriverManager docs

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -88,20 +88,7 @@ final class DriverManager
      *
      * $params must contain at least one of the following.
      *
-     * Either 'driver' with one of the following values:
-     *
-     *     pdo_mysql
-     *     pdo_sqlite
-     *     pdo_pgsql
-     *     pdo_oci (unstable)
-     *     pdo_sqlsrv
-     *     pdo_sqlsrv
-     *     mysqli
-     *     sqlanywhere
-     *     sqlsrv
-     *     ibm_db2 (unstable)
-     *     drizzle_pdo_mysql
-     *
+     * Either 'driver' with one of the array keys of {@link $_driverMap},
      * OR 'driverClass' that contains the full class name (with namespace) of the
      * driver class to instantiate.
      *


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | documentation
| BC Break     | no
| Fixed issues | none

#### Summary

In the api docs the names of the drivers are incorrect. Also, could someone confirm that the `(unstable)` annotations are still correct?
