### PR TITLE
Added the missing argument type to Connection::executeQuery($types)

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -788,8 +788,12 @@ class Connection implements DriverConnection
      *
      * @throws DBALException
      */
-    public function executeQuery(string $query, array $params = [], $types = [], ?QueryCacheProfile $qcp = null) : ResultStatement
-    {
+    public function executeQuery(
+        string $query,
+        array $params = [],
+        array $types = [],
+        ?QueryCacheProfile $qcp = null
+    ) : ResultStatement {
         if ($qcp !== null) {
             return $this->executeCacheQuery($query, $params, $types, $qcp);
         }

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -95,8 +95,12 @@ class Connection extends \Doctrine\DBAL\Connection
     /**
      * {@inheritdoc}
      */
-    public function executeQuery(string $query, array $params = [], $types = [], ?QueryCacheProfile $qcp = null) : ResultStatement
-    {
+    public function executeQuery(
+        string $query,
+        array $params = [],
+        array $types = [],
+        ?QueryCacheProfile $qcp = null
+    ) : ResultStatement {
         $stmt = new Statement(parent::executeQuery($query, $params, $types, $qcp), $this);
         $stmt->setFetchMode($this->defaultFetchMode);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

The argument type was not automatically added due to https://github.com/slevomat/coding-standard/issues/856. Once the issue in the coding standard is addressed, we will revisit the rest of the type declarations.