### PR TITLE
Fixed the QueryBuilder::setMaxResults() signature to accept NULL

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -118,9 +118,9 @@ class QueryBuilder
     private $firstResult = null;
 
     /**
-     * The maximum number of results to retrieve.
+     * The maximum number of results to retrieve or NULL to retrieve all results.
      *
-     * @var int
+     * @var int|null
      */
     private $maxResults = null;
 
@@ -367,7 +367,6 @@ class QueryBuilder
 
     /**
      * Gets the position of the first result the query object was set to retrieve (the "offset").
-     * Returns NULL if {@link setFirstResult} was not applied to this QueryBuilder.
      *
      * @return int The position of the first result.
      */
@@ -379,7 +378,7 @@ class QueryBuilder
     /**
      * Sets the maximum number of results to retrieve (the "limit").
      *
-     * @param int $maxResults The maximum number of results to retrieve.
+     * @param int|null $maxResults The maximum number of results to retrieve or NULL to retrieve all results.
      *
      * @return $this This QueryBuilder instance.
      */
@@ -393,7 +392,7 @@ class QueryBuilder
 
     /**
      * Gets the maximum number of results the query object was set to retrieve (the "limit").
-     * Returns NULL if {@link setMaxResults} was not applied to this query builder.
+     * Returns NULL if all results will be returned.
      *
      * @return int The maximum number of results.
      */

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -569,13 +569,27 @@ class QueryBuilderTest extends DbalTestCase
         self::assertEquals($sql1, $qb->getSQL());
     }
 
-    public function testSetMaxResults() : void
+    /**
+     * @dataProvider maxResultsProvider
+     */
+    public function testSetMaxResults(?int $maxResults) : void
     {
         $qb = new QueryBuilder($this->conn);
-        $qb->setMaxResults(10);
+        $qb->setMaxResults($maxResults);
 
         self::assertEquals(QueryBuilder::STATE_DIRTY, $qb->getState());
-        self::assertEquals(10, $qb->getMaxResults());
+        self::assertEquals($maxResults, $qb->getMaxResults());
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public static function maxResultsProvider() : iterable
+    {
+        return [
+            'non-null' => [10],
+            'null' => [null],
+        ];
     }
 
     public function testSetFirstResult() : void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

This is a backport of #3840.