### PR TITLE
expectException() is not static

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Cache/ArrayStatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Cache/ArrayStatementTest.php
@@ -63,8 +63,8 @@ class ArrayStatementTest extends TestCase
     {
         $statement = $this->createTestArrayStatement();
 
-        self::expectException(InvalidArgumentException::class);
-        self::expectExceptionMessage('Caching layer does not support 2nd/3rd argument to setFetchMode().');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Caching layer does not support 2nd/3rd argument to setFetchMode().');
 
         $statement->setFetchMode(FetchMode::ASSOCIATIVE, 'arg1', 'arg2');
     }
@@ -114,8 +114,8 @@ class ArrayStatementTest extends TestCase
     {
         $statement = $this->createTestArrayStatement();
 
-        self::expectException(InvalidArgumentException::class);
-        self::expectExceptionMessage('Invalid fetch mode given for fetching result, 9999 given.');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid fetch mode given for fetching result, 9999 given.');
 
         $statement->fetch(9999);
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
@@ -40,8 +40,8 @@ class PDOStatementTest extends DbalFunctionalTestCase
             'name' => 'Bob',
         ]);
 
-        self::expectException(UnknownFetchMode::class);
-        self::expectExceptionMessage('Unknown fetch mode 12.');
+        $this->expectException(UnknownFetchMode::class);
+        $this->expectExceptionMessage('Unknown fetch mode 12.');
 
         $data = $this->connection->query('SELECT id, name FROM stmt_test ORDER BY id')
             ->fetchAll(PDO::FETCH_KEY_PAIR);

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -582,8 +582,8 @@ SQL;
         $connection    = DriverManager::getConnection($params);
         $schemaManager = $connection->getSchemaManager();
 
-        self::expectException(DatabaseRequired::class);
-        self::expectExceptionMessage('A database is required for the method: Doctrine\DBAL\Schema\AbstractSchemaManager::listTableColumns');
+        $this->expectException(DatabaseRequired::class);
+        $this->expectExceptionMessage('A database is required for the method: Doctrine\DBAL\Schema\AbstractSchemaManager::listTableColumns');
 
         $schemaManager->listTableColumns('users');
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
@@ -374,7 +374,7 @@ EOF
         // but the wrapper connection wraps everything in a DBAL exception
         $this->iniSet('error_reporting', '0');
 
-        self::expectException(DBALException::class);
+        $this->expectException(DBALException::class);
         $stmt->execute([null]);
     }
 
@@ -393,7 +393,7 @@ EOF
         $query    = $platform->getDummySelectSQL();
         $stmt     = $this->connection->query($query);
 
-        self::expectException(DBALException::class);
+        $this->expectException(DBALException::class);
         $stmt->fetchColumn($index);
     }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/ColumnTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ColumnTest.php
@@ -65,16 +65,16 @@ class ColumnTest extends TestCase
 
     public function testSettingUnknownOptionIsStillSupported() : void
     {
-        self::expectException(UnknownColumnOption::class);
-        self::expectExceptionMessage('The "unknown_option" column option is not supported.');
+        $this->expectException(UnknownColumnOption::class);
+        $this->expectExceptionMessage('The "unknown_option" column option is not supported.');
 
         new Column('foo', $this->createMock(Type::class), ['unknown_option' => 'bar']);
     }
 
     public function testOptionsShouldNotBeIgnored() : void
     {
-        self::expectException(UnknownColumnOption::class);
-        self::expectExceptionMessage('The "unknown_option" column option is not supported.');
+        $this->expectException(UnknownColumnOption::class);
+        $this->expectExceptionMessage('The "unknown_option" column option is not supported.');
 
         $col1 = new Column('bar', Type::getType(Types::INTEGER), ['unknown_option' => 'bar', 'notnull' => true]);
         self::assertTrue($col1->getNotnull());

--- a/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
@@ -44,8 +44,8 @@ class RunSqlCommandTest extends TestCase
 
     public function testMissingSqlArgument() : void
     {
-        self::expectException(RuntimeException::class);
-        self::expectExceptionMessage('Argument "sql" is required in order to execute this command correctly.');
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Argument "sql" is required in order to execute this command correctly.');
 
         $this->commandTester->execute([
             'command' => $this->command->getName(),
@@ -55,8 +55,8 @@ class RunSqlCommandTest extends TestCase
 
     public function testIncorrectDepthOption() : void
     {
-        self::expectException(LogicException::class);
-        self::expectExceptionMessage('Option "depth" must contains an integer value.');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Option "depth" must contains an integer value.');
 
         $this->commandTester->execute([
             'command' => $this->command->getName(),


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

All `expectException()` calls fixed.
As per https://github.com/doctrine/dbal/pull/3836#discussion_r370889027