### PR TITLE
Clean up unused variables

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1093,8 +1093,6 @@ class Connection implements DriverConnection
             throw CommitFailedRollbackOnly::new();
         }
 
-        $result = true;
-
         $connection = $this->getWrappedConnection();
 
         $logger = $this->_config->getSQLLogger();

--- a/tests/Doctrine/Tests/DBAL/Cache/QueryCacheProfileTest.php
+++ b/tests/Doctrine/Tests/DBAL/Cache/QueryCacheProfileTest.php
@@ -99,7 +99,7 @@ class QueryCacheProfileTest extends DbalTestCase
     {
         $this->queryCacheProfile = $this->queryCacheProfile->setCacheKey(null);
 
-        [$cacheKey, $queryString] = $this->queryCacheProfile->generateCacheKeys(
+        [, $queryString] = $this->queryCacheProfile->generateCacheKeys(
             $this->query,
             $this->params,
             $this->types,

--- a/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
@@ -31,10 +31,10 @@ class MysqliConnectionTest extends DbalFunctionalTestCase
 
     public function testRestoresErrorHandlerOnException() : void
     {
-        $handler         = static function () : bool {
+        $handler = static function () : bool {
             self::fail('Never expected this to be called');
         };
-        $default_handler = set_error_handler($handler);
+        set_error_handler($handler);
 
         try {
             new MysqliConnection(['host' => '255.255.255.255'], 'user', 'pass');

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -213,10 +213,10 @@ class ResultCacheTest extends DbalFunctionalTestCase
     public function testEmptyResultCache() : void
     {
         $stmt = $this->connection->executeQuery('SELECT * FROM caching WHERE test_int > 500', [], [], new QueryCacheProfile(10, 'emptycachekey'));
-        $data = $this->hydrateStmt($stmt);
+        $this->hydrateStmt($stmt);
 
         $stmt = $this->connection->executeQuery('SELECT * FROM caching WHERE test_int > 500', [], [], new QueryCacheProfile(10, 'emptycachekey'));
-        $data = $this->hydrateStmt($stmt);
+        $this->hydrateStmt($stmt);
 
         self::assertCount(1, $this->sqlLogger->queries, 'just one dbal hit');
     }
@@ -224,11 +224,11 @@ class ResultCacheTest extends DbalFunctionalTestCase
     public function testChangeCacheImpl() : void
     {
         $stmt = $this->connection->executeQuery('SELECT * FROM caching WHERE test_int > 500', [], [], new QueryCacheProfile(10, 'emptycachekey'));
-        $data = $this->hydrateStmt($stmt);
+        $this->hydrateStmt($stmt);
 
         $secondCache = new ArrayCache();
         $stmt        = $this->connection->executeQuery('SELECT * FROM caching WHERE test_int > 500', [], [], new QueryCacheProfile(10, 'emptycachekey', $secondCache));
-        $data        = $this->hydrateStmt($stmt);
+        $this->hydrateStmt($stmt);
 
         self::assertCount(2, $this->sqlLogger->queries, 'two hits');
         self::assertCount(1, $secondCache->fetch('emptycachekey'));

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -98,7 +98,7 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testAlterTableAutoIncrementAdd() : void
     {
         $tableFrom = new Table('autoinc_table_add');
-        $column    = $tableFrom->addColumn('id', 'integer');
+        $tableFrom->addColumn('id', 'integer');
         $this->schemaManager->createTable($tableFrom);
         $tableFrom = $this->schemaManager->listTableDetails('autoinc_table_add');
         self::assertFalse($tableFrom->getColumn('id')->getAutoincrement());
@@ -137,7 +137,7 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($tableFrom->getColumn('id')->getAutoincrement());
 
         $tableTo = new Table('autoinc_table_drop');
-        $column  = $tableTo->addColumn('id', 'integer');
+        $tableTo->addColumn('id', 'integer');
 
         $c    = new Comparator();
         $diff = $c->diffTable($tableFrom, $tableTo);
@@ -219,10 +219,10 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testFilterSchemaExpression() : void
     {
         $testTable = new Table('dbal204_test_prefix');
-        $column    = $testTable->addColumn('id', 'integer');
+        $testTable->addColumn('id', 'integer');
         $this->schemaManager->createTable($testTable);
         $testTable = new Table('dbal204_without_prefix');
-        $column    = $testTable->addColumn('id', 'integer');
+        $testTable->addColumn('id', 'integer');
         $this->schemaManager->createTable($testTable);
 
         $this->connection->getConfiguration()->setSchemaAssetsFilter(static function (string $name) : bool {

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -165,7 +165,7 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
         $table = new Table('test');
 
         $this->expectException(DBALException::class);
-        $sql = $this->platform->getCreateTableSQL($table);
+        $this->platform->getCreateTableSQL($table);
     }
 
     public function testGeneratesTableCreationSql() : void

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -863,8 +863,8 @@ class ComparatorTest extends TestCase
      */
     public function testChangedSequence() : void
     {
-        $schema   = new Schema();
-        $sequence = $schema->createSequence('baz');
+        $schema = new Schema();
+        $schema->createSequence('baz');
 
         $schemaNew = clone $schema;
         $schemaNew->getSequence('baz')->setAllocationSize(20);

--- a/tests/Doctrine/Tests/DBAL/Schema/MySqlInheritCharsetTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/MySqlInheritCharsetTest.php
@@ -37,9 +37,7 @@ class MySqlInheritCharsetTest extends TestCase
 
     public function testTableOptions() : void
     {
-        $eventManager = new EventManager();
-        $driverMock   = $this->createMock(Driver::class);
-        $platform     = new MySqlPlatform();
+        $platform = new MySqlPlatform();
 
         // default, no overrides
         $table = new Table('foobar', [new Column('aa', Type::getType('integer'))]);

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
@@ -63,7 +63,7 @@ class SchemaTest extends TestCase
         $table     = new Table($tableName);
         $tables    = [$table, $table];
 
-        $schema = new Schema($tables);
+        new Schema($tables);
     }
 
     public function testRenameTable() : void
@@ -172,7 +172,7 @@ class SchemaTest extends TestCase
 
         $sequence = new Sequence('a_seq', 1, 1);
 
-        $schema = new Schema([], [$sequence, $sequence]);
+        new Schema([], [$sequence, $sequence]);
     }
 
     public function testConfigMaxIdentifierLength() : void

--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -111,7 +111,7 @@ class TableTest extends DbalTestCase
         $columns   = [];
         $columns[] = new Column('foo', $type);
         $columns[] = new Column('foo', $type);
-        $table     = new Table('foo', $columns, [], []);
+        new Table('foo', $columns, [], []);
     }
 
     public function testCreateIndex() : void
@@ -184,7 +184,7 @@ class TableTest extends DbalTestCase
             new Index('the_primary', ['foo'], true, true),
             new Index('other_primary', ['bar'], true, true),
         ];
-        $table   = new Table('foo', $columns, $indexes, []);
+        new Table('foo', $columns, $indexes, []);
     }
 
     public function testAddTwoIndexesWithSameNameThrowsException() : void
@@ -197,7 +197,7 @@ class TableTest extends DbalTestCase
             new Index('an_idx', ['foo'], false, false),
             new Index('an_idx', ['bar'], false, false),
         ];
-        $table   = new Table('foo', $columns, $indexes, []);
+        new Table('foo', $columns, $indexes, []);
     }
 
     public function testConstraints() : void

--- a/tests/Doctrine/Tests/DBAL/Types/Exception/SerializationFailedTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/Exception/SerializationFailedTest.php
@@ -14,8 +14,8 @@ class SerializationFailedTest extends TestCase
 {
     public function testNew() : void
     {
-        $value   = NAN;
-        $encoded = json_encode($value);
+        $value = NAN;
+        json_encode($value);
 
         $exception = SerializationFailed::new($value, 'json', json_last_error_msg());
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

Clean up unused variables, as reported by PHPStorm.

@morozov, how is this not spotted by phpstan?
