### PR TITLE
First parameter of ExpressionBuilder::and/or() mandatory

### DIFF
--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Query\Expression;
 
 use Doctrine\DBAL\Connection;
+use function array_merge;
 use function func_get_arg;
 use function func_get_args;
 use function func_num_args;
@@ -41,21 +42,23 @@ class ExpressionBuilder
     /**
      * Creates a conjunction of the given expressions.
      *
-     * @param string|CompositeExpression ...$expressions Requires at least one defined when converting to string.
+     * @param string|CompositeExpression $expression
+     * @param string|CompositeExpression ...$expressions
      */
-    public function and(...$expressions) : CompositeExpression
+    public function and($expression, ...$expressions) : CompositeExpression
     {
-        return new CompositeExpression(CompositeExpression::TYPE_AND, $expressions);
+        return new CompositeExpression(CompositeExpression::TYPE_AND, array_merge([$expression], $expressions));
     }
 
     /**
      * Creates a disjunction of the given expressions.
      *
-     * @param string|CompositeExpression ...$expressions Requires at least one defined when converting to string.
+     * @param string|CompositeExpression $expression
+     * @param string|CompositeExpression ...$expressions
      */
-    public function or(...$expressions) : CompositeExpression
+    public function or($expression, ...$expressions) : CompositeExpression
     {
-        return new CompositeExpression(CompositeExpression::TYPE_OR, $expressions);
+        return new CompositeExpression(CompositeExpression::TYPE_OR, array_merge([$expression], $expressions));
     }
 
     /**
@@ -68,7 +71,7 @@ class ExpressionBuilder
      */
     public function andX($x = null)
     {
-        return $this->and(...func_get_args());
+        return new CompositeExpression(CompositeExpression::TYPE_AND, func_get_args());
     }
 
     /**
@@ -81,7 +84,7 @@ class ExpressionBuilder
      */
     public function orX($x = null)
     {
-        return $this->or(...func_get_args());
+        return new CompositeExpression(CompositeExpression::TYPE_OR, func_get_args());
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
@@ -33,7 +33,19 @@ class ExpressionBuilderTest extends DbalTestCase
      */
     public function testAnd(array $parts, string $expected) : void
     {
-        $composite = $this->expr->and();
+        $composite = $this->expr->and(...$parts);
+
+        self::assertEquals($expected, (string) $composite);
+    }
+
+    /**
+     * @param string[]|CompositeExpression[] $parts
+     *
+     * @dataProvider provideDataForAnd
+     */
+    public function testAndX(array $parts, string $expected) : void
+    {
+        $composite = $this->expr->andX();
 
         foreach ($parts as $part) {
             $composite->add($part);
@@ -94,7 +106,19 @@ class ExpressionBuilderTest extends DbalTestCase
      */
     public function testOr(array $parts, string $expected) : void
     {
-        $composite = $this->expr->or();
+        $composite = $this->expr->or(...$parts);
+
+        self::assertEquals($expected, (string) $composite);
+    }
+
+    /**
+     * @param string[]|CompositeExpression[] $parts
+     *
+     * @dataProvider provideDataForOr
+     */
+    public function testOrX(array $parts, string $expected) : void
+    {
+        $composite = $this->expr->orX();
 
         foreach ($parts as $part) {
             $composite->add($part);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

Following #3851, we're now making the first parameter mandatory.