### PR TITLE
Specify the platform configuration in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,9 @@
     },
     "bin": ["bin/doctrine-dbal"],
     "config": {
+        "platform": {
+            "php": "7.2.0"
+        },
         "sort-packages": true
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "120172ae44052999ec9a50b1121414cc",
+    "content-hash": "5917f568d73e1f502700514d88d00b8c",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -3129,8 +3129,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2",
-        "ext-pdo": "*"
+        "php": "^7.2"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.2.0"
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | [build #643647287](https://travis-ci.org/doctrine/dbal/builds/643647287)

Having the target platform specified in Composer configuration will help make sure we won't lock the dependencies to a version incompatible with the oldest supported PHP version (see the linked build) without the need to use the oldest supported PHP in the development environment.