### PR TITLE
CompositeExpression and()/or() factory methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,8 +6,9 @@ The usage of the `andX()` and `orX()` methods of the `ExpressionBuilder` class h
 
 ## Deprecated `CompositeExpression` methods
 
-The usage of the `add()` and `addMultiple()` methods of the `CompositeExpression` class has been deprecated. Use `with()` instead, which returns a new instance.
+- The usage of the `add()` and `addMultiple()` methods of the `CompositeExpression` class has been deprecated. Use `with()` instead, which returns a new instance.
 In the future, the `add*()` methods will be removed and the class will be effectively immutable.
+- The usage of the `CompositeExpression` constructor has been deprecated. Use the `and()` / `or()` factory methods.
 
 ## Deprecated calling `QueryBuilder` methods with an array argument
 

--- a/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
+++ b/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Query\Expression;
 
 use Countable;
+use function array_merge;
 use function count;
 use function implode;
 
@@ -36,6 +37,8 @@ class CompositeExpression implements Countable
     private $parts = [];
 
     /**
+     * @internal Use the and() / or() factory methods.
+     *
      * @param string          $type  Instance type of composite expression.
      * @param self[]|string[] $parts Composition of expressions to be joined on composite expression.
      */
@@ -44,6 +47,16 @@ class CompositeExpression implements Countable
         $this->type = $type;
 
         $this->addMultiple($parts);
+    }
+
+    public static function and($part, ...$parts) : self
+    {
+        return new self(self::TYPE_AND, array_merge([$part], $parts));
+    }
+
+    public static function or($part, ...$parts) : self
+    {
+        return new self(self::TYPE_OR, array_merge([$part], $parts));
     }
 
     /**

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -3,7 +3,6 @@
 namespace Doctrine\DBAL\Query\Expression;
 
 use Doctrine\DBAL\Connection;
-use function array_merge;
 use function func_get_arg;
 use function func_get_args;
 use function func_num_args;
@@ -47,7 +46,7 @@ class ExpressionBuilder
      */
     public function and($expression, ...$expressions) : CompositeExpression
     {
-        return new CompositeExpression(CompositeExpression::TYPE_AND, array_merge([$expression], $expressions));
+        return CompositeExpression::and($expression, ...$expressions);
     }
 
     /**
@@ -58,7 +57,7 @@ class ExpressionBuilder
      */
     public function or($expression, ...$expressions) : CompositeExpression
     {
-        return new CompositeExpression(CompositeExpression::TYPE_OR, array_merge([$expression], $expressions));
+        return CompositeExpression::or($expression, ...$expressions);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -799,7 +799,7 @@ class QueryBuilder
     public function where($predicates)
     {
         if (! (func_num_args() === 1 && $predicates instanceof CompositeExpression)) {
-            $predicates = new CompositeExpression(CompositeExpression::TYPE_AND, func_get_args());
+            $predicates = CompositeExpression::and(...func_get_args());
         }
 
         return $this->add('where', $predicates);
@@ -832,7 +832,7 @@ class QueryBuilder
             $where = $where->with(...$args);
         } else {
             array_unshift($args, $where);
-            $where = new CompositeExpression(CompositeExpression::TYPE_AND, $args);
+            $where = CompositeExpression::and(...$args);
         }
 
         return $this->add('where', $where, true);
@@ -865,7 +865,7 @@ class QueryBuilder
             $where = $where->with(...$args);
         } else {
             array_unshift($args, $where);
-            $where = new CompositeExpression(CompositeExpression::TYPE_OR, $args);
+            $where = CompositeExpression::or(...$args);
         }
 
         return $this->add('where', $where, true);
@@ -990,7 +990,7 @@ class QueryBuilder
     public function having($having)
     {
         if (! (func_num_args() === 1 && $having instanceof CompositeExpression)) {
-            $having = new CompositeExpression(CompositeExpression::TYPE_AND, func_get_args());
+            $having = CompositeExpression::and(...func_get_args());
         }
 
         return $this->add('having', $having);
@@ -1013,7 +1013,7 @@ class QueryBuilder
             $having = $having->with(...$args);
         } else {
             array_unshift($args, $having);
-            $having = new CompositeExpression(CompositeExpression::TYPE_AND, $args);
+            $having = CompositeExpression::and(...$args);
         }
 
         return $this->add('having', $having);
@@ -1036,7 +1036,7 @@ class QueryBuilder
             $having = $having->with(...$args);
         } else {
             array_unshift($args, $having);
-            $having = new CompositeExpression(CompositeExpression::TYPE_OR, $args);
+            $having = CompositeExpression::or(...$args);
         }
 
         return $this->add('having', $having);

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
@@ -12,7 +12,7 @@ class CompositeExpressionTest extends DbalTestCase
 {
     public function testCount() : void
     {
-        $expr = new CompositeExpression(CompositeExpression::TYPE_OR, ['u.group_id = 1']);
+        $expr = CompositeExpression::or('u.group_id = 1');
 
         self::assertCount(1, $expr);
 
@@ -23,7 +23,7 @@ class CompositeExpressionTest extends DbalTestCase
 
     public function testAdd() : void
     {
-        $expr = new CompositeExpression(CompositeExpression::TYPE_OR, ['u.group_id = 1']);
+        $expr = CompositeExpression::or('u.group_id = 1');
 
         self::assertCount(1, $expr);
 
@@ -31,7 +31,7 @@ class CompositeExpressionTest extends DbalTestCase
 
         self::assertCount(1, $expr);
 
-        $expr->add(new CompositeExpression(CompositeExpression::TYPE_OR, ['u.user_id = 1']));
+        $expr->add(CompositeExpression::or('u.user_id = 1'));
 
         self::assertCount(2, $expr);
 
@@ -46,16 +46,16 @@ class CompositeExpressionTest extends DbalTestCase
 
     public function testWith() : void
     {
-        $expr = new CompositeExpression(CompositeExpression::TYPE_OR, ['u.group_id = 1']);
+        $expr = CompositeExpression::or('u.group_id = 1');
 
         self::assertCount(1, $expr);
 
         // test immutability
-        $expr->with(new CompositeExpression(CompositeExpression::TYPE_OR, ['u.user_id = 1']));
+        $expr->with(CompositeExpression::or('u.user_id = 1'));
 
         self::assertCount(1, $expr);
 
-        $expr = $expr->with(new CompositeExpression(CompositeExpression::TYPE_OR, ['u.user_id = 1']));
+        $expr = $expr->with(CompositeExpression::or('u.user_id = 1'));
 
         self::assertCount(2, $expr);
 
@@ -106,9 +106,9 @@ class CompositeExpressionTest extends DbalTestCase
                 CompositeExpression::TYPE_AND,
                 [
                     'u.user = 1',
-                    new CompositeExpression(
-                        CompositeExpression::TYPE_OR,
-                        ['u.group_id = 1', 'u.group_id = 2']
+                    CompositeExpression::or(
+                        'u.group_id = 1',
+                        'u.group_id = 2'
                     ),
                 ],
                 '(u.user = 1) AND ((u.group_id = 1) OR (u.group_id = 2))',
@@ -117,9 +117,9 @@ class CompositeExpressionTest extends DbalTestCase
                 CompositeExpression::TYPE_OR,
                 [
                     'u.group_id = 1',
-                    new CompositeExpression(
-                        CompositeExpression::TYPE_AND,
-                        ['u.user = 1', 'u.group_id = 2']
+                    CompositeExpression::and(
+                        'u.user = 1',
+                        'u.group_id = 2'
                     ),
                 ],
                 '(u.group_id = 1) OR ((u.user = 1) AND (u.group_id = 2))',

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
@@ -79,9 +79,9 @@ class ExpressionBuilderTest extends DbalTestCase
             [
                 [
                     'u.user = 1',
-                    new CompositeExpression(
-                        CompositeExpression::TYPE_OR,
-                        ['u.group_id = 1', 'u.group_id = 2']
+                    CompositeExpression::or(
+                        'u.group_id = 1',
+                        'u.group_id = 2'
                     ),
                 ],
                 '(u.user = 1) AND ((u.group_id = 1) OR (u.group_id = 2))',
@@ -89,9 +89,9 @@ class ExpressionBuilderTest extends DbalTestCase
             [
                 [
                     'u.group_id = 1',
-                    new CompositeExpression(
-                        CompositeExpression::TYPE_AND,
-                        ['u.user = 1', 'u.group_id = 2']
+                    CompositeExpression::and(
+                        'u.user = 1',
+                        'u.group_id = 2'
                     ),
                 ],
                 '(u.group_id = 1) AND ((u.user = 1) AND (u.group_id = 2))',
@@ -152,9 +152,9 @@ class ExpressionBuilderTest extends DbalTestCase
             [
                 [
                     'u.user = 1',
-                    new CompositeExpression(
-                        CompositeExpression::TYPE_OR,
-                        ['u.group_id = 1', 'u.group_id = 2']
+                    CompositeExpression::or(
+                        'u.group_id = 1',
+                        'u.group_id = 2'
                     ),
                 ],
                 '(u.user = 1) OR ((u.group_id = 1) OR (u.group_id = 2))',
@@ -162,9 +162,9 @@ class ExpressionBuilderTest extends DbalTestCase
             [
                 [
                     'u.group_id = 1',
-                    new CompositeExpression(
-                        CompositeExpression::TYPE_AND,
-                        ['u.user = 1', 'u.group_id = 2']
+                    CompositeExpression::and(
+                        'u.user = 1',
+                        'u.group_id = 2'
                     ),
                 ],
                 '(u.group_id = 1) OR ((u.user = 1) AND (u.group_id = 2))',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

To properly implement #3845 (forbidding empty `CompositeExpression`), we want to only allow creating expressions through `and()` / `or()` factory methods, that force at least one parameter.

Before doing so in `master`, I'm adding the factory methods to `2.11` and deprecating the constructor.