### PR TITLE
Remove ExpressionBuilder::andX()/orX()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK: Removed `ExpressionBuilder` methods
+
+The `andX()` and `orX()` methods of the `ExpressionBuilder` class have been removed. Use `and()` and `or()` instead.
+
 ## BC BREAK: Removed `CompositeExpression` methods
 
 The `add()` and `addMultiple()` methods of the `CompositeExpression` class have been removed. Use `with()` instead, which returns a new instance.

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -61,26 +61,6 @@ class ExpressionBuilder
     }
 
     /**
-     * @deprecated Use `and()` instead.
-     *
-     * @param string|CompositeExpression ...$expressions Requires at least one defined when converting to string.
-     */
-    public function andX(...$expressions) : CompositeExpression
-    {
-        return new CompositeExpression(CompositeExpression::TYPE_AND, $expressions);
-    }
-
-    /**
-     * @deprecated Use `or()` instead.
-     *
-     * @param string|CompositeExpression ...$expressions Requires at least one defined when converting to string.
-     */
-    public function orX(...$expressions) : CompositeExpression
-    {
-        return new CompositeExpression(CompositeExpression::TYPE_OR, $expressions);
-    }
-
-    /**
      * Creates a comparison expression.
      *
      * @param string $x        The left expression.

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
@@ -41,22 +41,6 @@ class ExpressionBuilderTest extends DbalTestCase
     }
 
     /**
-     * @param string[]|CompositeExpression[] $parts
-     *
-     * @dataProvider provideDataForAnd
-     */
-    public function testAndX(array $parts, string $expected) : void
-    {
-        $composite = $this->expr->andX();
-
-        foreach ($parts as $part) {
-            $composite = $composite->with($part);
-        }
-
-        self::assertEquals($expected, (string) $composite);
-    }
-
-    /**
      * @return mixed[][]
      */
     public static function provideDataForAnd() : iterable
@@ -109,22 +93,6 @@ class ExpressionBuilderTest extends DbalTestCase
     public function testOr(array $parts, string $expected) : void
     {
         $composite = $this->expr->or(...$parts);
-
-        self::assertEquals($expected, (string) $composite);
-    }
-
-    /**
-     * @param string[]|CompositeExpression[] $parts
-     *
-     * @dataProvider provideDataForOr
-     */
-    public function testOrX(array $parts, string $expected) : void
-    {
-        $composite = $this->expr->orX();
-
-        foreach ($parts as $part) {
-            $composite = $composite->with($part);
-        }
 
         self::assertEquals($expected, (string) $composite);
     }


### PR DESCRIPTION
Continuing the work started in #3851, this time on `master`.