### PR TITLE
Add parameter type hint

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Exception/UnknownFetchMode.php
+++ b/lib/Doctrine/DBAL/Driver/Exception/UnknownFetchMode.php
@@ -9,10 +9,7 @@ use function sprintf;
 
 final class UnknownFetchMode extends DBALException
 {
-    /**
-     * @param mixed $fetchMode
-     */
-    public static function new($fetchMode) : self
+    public static function new(int $fetchMode) : self
     {
         return new self(sprintf('Unknown fetch mode %d.', $fetchMode));
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

A factory method accepts `mixed` when only ever `int` will be passed (and fortunately, as it's given as sprintf `%d` parameter).