### PR TITLE
Automatically Quote Identifiers with Spaces in Their Names

### DIFF
--- a/lib/Doctrine/DBAL/Schema/AbstractAsset.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractAsset.php
@@ -8,6 +8,7 @@ use function crc32;
 use function dechex;
 use function explode;
 use function implode;
+use function preg_match;
 use function str_replace;
 use function strpos;
 use function strtolower;
@@ -180,7 +181,7 @@ abstract class AbstractAsset
         $keywords = $platform->getReservedKeywordsList();
         $parts    = explode('.', $this->getName());
         foreach ($parts as $k => $v) {
-            $parts[$k] = $this->_quoted || $keywords->isKeyword($v) ? $platform->quoteIdentifier($v) : $v;
+            $parts[$k] = $this->_quoted || $keywords->isKeyword($v) || preg_match('/\W/', $v) ? $platform->quoteIdentifier($v) : $v;
         }
 
         return implode('.', $parts);

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -248,9 +248,9 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     /**
      * @return string[]
      */
-    protected function getQuotedColumnInPrimaryKeySQL() : array
+    protected function getQuotedColumnInPrimaryKeySQL(string $columnName) : array
     {
-        return ['CREATE TABLE `quoted` (`create` VARCHAR(255) NOT NULL, PRIMARY KEY(`create`)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB'];
+        return ['CREATE TABLE `quoted` (`' . $columnName . '` VARCHAR(255) NOT NULL, PRIMARY KEY(`' . $columnName . '`)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB'];
     }
 
     /**
@@ -272,13 +272,13 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     /**
      * @return string[]
      */
-    protected function getQuotedColumnInForeignKeySQL() : array
+    protected function getQuotedColumnInForeignKeySQL(string $columnName) : array
     {
         return [
-            'CREATE TABLE `quoted` (`create` VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, `bar` VARCHAR(255) NOT NULL) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB',
-            'ALTER TABLE `quoted` ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY (`create`, foo, `bar`) REFERENCES `foreign` (`create`, bar, `foo-bar`)',
-            'ALTER TABLE `quoted` ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY (`create`, foo, `bar`) REFERENCES foo (`create`, bar, `foo-bar`)',
-            'ALTER TABLE `quoted` ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY (`create`, foo, `bar`) REFERENCES `foo-bar` (`create`, bar, `foo-bar`)',
+            'CREATE TABLE `quoted` (`' . $columnName . '` VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, `bar` VARCHAR(255) NOT NULL) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB',
+            'ALTER TABLE `quoted` ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY (`' . $columnName . '`, foo, `bar`) REFERENCES `foreign` (`' . $columnName . '`, bar, `foo-bar`)',
+            'ALTER TABLE `quoted` ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY (`' . $columnName . '`, foo, `bar`) REFERENCES foo (`' . $columnName . '`, bar, `foo-bar`)',
+            'ALTER TABLE `quoted` ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY (`' . $columnName . '`, foo, `bar`) REFERENCES `foo-bar` (`' . $columnName . '`, bar, `foo-bar`)',
         ];
     }
 
@@ -802,25 +802,25 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL(string $constraintName) : string
     {
-        return 'CONSTRAINT `select` UNIQUE (foo)';
+        return 'CONSTRAINT `' . $constraintName . '` UNIQUE (foo)';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInIndexDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL(string $indexName) : string
     {
-        return 'INDEX `select` (foo)';
+        return 'INDEX `' . $indexName . '` (foo)';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInTruncateTableSQL() : string
+    protected function getQuotesReservedKeywordInTruncateTableSQL(string $tableName) : string
     {
-        return 'TRUNCATE `select`';
+        return 'TRUNCATE `' . $tableName . '`';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -383,9 +383,9 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     /**
      * {@inheritDoc}
      */
-    protected function getQuotedColumnInPrimaryKeySQL() : array
+    protected function getQuotedColumnInPrimaryKeySQL(string $columnName) : array
     {
-        return ['CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, PRIMARY KEY("create"))'];
+        return ['CREATE TABLE "quoted" ("' . $columnName . '" VARCHAR(255) NOT NULL, PRIMARY KEY("' . $columnName . '"))'];
     }
 
     /**
@@ -413,13 +413,13 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     /**
      * {@inheritDoc}
      */
-    protected function getQuotedColumnInForeignKeySQL() : array
+    protected function getQuotedColumnInForeignKeySQL(string $columnName) : array
     {
         return [
-            'CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL)',
-            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES "foreign" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
-            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES foo ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
-            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") REFERENCES "foo-bar" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
+            'CREATE TABLE "quoted" ("' . $columnName . '" VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL)',
+            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES "foreign" ("' . $columnName . '", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
+            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES foo ("' . $columnName . '", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
+            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES "foo-bar" ("' . $columnName . '", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
         ];
     }
 
@@ -910,25 +910,25 @@ abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCa
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL(string $constraintName) : string
     {
-        return 'CONSTRAINT "select" UNIQUE (foo)';
+        return 'CONSTRAINT "' . $constraintName . '" UNIQUE (foo)';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInIndexDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL(string $indexName) : string
     {
-        return 'INDEX "select" (foo)';
+        return 'INDEX "' . $indexName . '" (foo)';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInTruncateTableSQL() : string
+    protected function getQuotesReservedKeywordInTruncateTableSQL(string $tableName) : string
     {
-        return 'TRUNCATE "select"';
+        return 'TRUNCATE "' . $tableName . '"';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -549,9 +549,9 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     /**
      * {@inheritDoc}
      */
-    protected function getQuotedColumnInPrimaryKeySQL() : array
+    protected function getQuotedColumnInPrimaryKeySQL(string $columnName) : array
     {
-        return ['CREATE TABLE [quoted] ([create] NVARCHAR(255) NOT NULL, PRIMARY KEY ([create]))'];
+        return ['CREATE TABLE [quoted] ([' . $columnName . '] NVARCHAR(255) NOT NULL, PRIMARY KEY ([' . $columnName . ']))'];
     }
 
     /**
@@ -579,13 +579,13 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     /**
      * {@inheritDoc}
      */
-    protected function getQuotedColumnInForeignKeySQL() : array
+    protected function getQuotedColumnInForeignKeySQL(string $columnName) : array
     {
         return [
-            'CREATE TABLE [quoted] ([create] NVARCHAR(255) NOT NULL, foo NVARCHAR(255) NOT NULL, [bar] NVARCHAR(255) NOT NULL)',
-            'ALTER TABLE [quoted] ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ([create], foo, [bar]) REFERENCES [foreign] ([create], bar, [foo-bar])',
-            'ALTER TABLE [quoted] ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ([create], foo, [bar]) REFERENCES foo ([create], bar, [foo-bar])',
-            'ALTER TABLE [quoted] ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ([create], foo, [bar]) REFERENCES [foo-bar] ([create], bar, [foo-bar])',
+            'CREATE TABLE [quoted] ([' . $columnName . '] NVARCHAR(255) NOT NULL, foo NVARCHAR(255) NOT NULL, [bar] NVARCHAR(255) NOT NULL)',
+            'ALTER TABLE [quoted] ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ([' . $columnName . '], foo, [bar]) REFERENCES [foreign] ([' . $columnName . '], bar, [foo-bar])',
+            'ALTER TABLE [quoted] ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ([' . $columnName . '], foo, [bar]) REFERENCES foo ([' . $columnName . '], bar, [foo-bar])',
+            'ALTER TABLE [quoted] ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ([' . $columnName . '], foo, [bar]) REFERENCES [foo-bar] ([' . $columnName . '], bar, [foo-bar])',
         ];
     }
 
@@ -1414,25 +1414,25 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL(string $constraintName) : string
     {
-        return 'CONSTRAINT [select] UNIQUE (foo) WHERE foo IS NOT NULL';
+        return 'CONSTRAINT [' . $constraintName . '] UNIQUE (foo) WHERE foo IS NOT NULL';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInIndexDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL(string $indexName) : string
     {
-        return 'INDEX [select] (foo)';
+        return 'INDEX [' . $indexName . '] (foo)';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInTruncateTableSQL() : string
+    protected function getQuotesReservedKeywordInTruncateTableSQL(string $tableName) : string
     {
-        return 'TRUNCATE TABLE [select]';
+        return 'TRUNCATE TABLE [' . $tableName . ']';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -76,13 +76,13 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritDoc}
      */
-    protected function getQuotedColumnInForeignKeySQL() : array
+    protected function getQuotedColumnInForeignKeySQL(string $columnName) : array
     {
         return [
-            'CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL)',
-            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES "foreign" ("create", bar, "foo-bar")',
-            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES foo ("create", bar, "foo-bar")',
-            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") REFERENCES "foo-bar" ("create", bar, "foo-bar")',
+            'CREATE TABLE "quoted" ("' . $columnName . '" VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL)',
+            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES "foreign" ("' . $columnName . '", bar, "foo-bar")',
+            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES foo ("' . $columnName . '", bar, "foo-bar")',
+            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES "foo-bar" ("' . $columnName . '", bar, "foo-bar")',
         ];
     }
 
@@ -111,9 +111,9 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritDoc}
      */
-    protected function getQuotedColumnInPrimaryKeySQL() : array
+    protected function getQuotedColumnInPrimaryKeySQL(string $columnName) : array
     {
-        return ['CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, PRIMARY KEY("create"))'];
+        return ['CREATE TABLE "quoted" ("' . $columnName . '" VARCHAR(255) NOT NULL, PRIMARY KEY("' . $columnName . '"))'];
     }
 
     protected function getBitAndComparisonExpressionSql(string $value1, string $value2) : string
@@ -664,15 +664,15 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL(string $constraintName) : string
     {
-        return 'CONSTRAINT "select" UNIQUE (foo)';
+        return 'CONSTRAINT "' . $constraintName . '" UNIQUE (foo)';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInIndexDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL(string $indexName) : string
     {
         return ''; // not supported by this platform
     }
@@ -680,9 +680,9 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInTruncateTableSQL() : string
+    protected function getQuotesReservedKeywordInTruncateTableSQL(string $tableName) : string
     {
-        return 'TRUNCATE "select" IMMEDIATE';
+        return 'TRUNCATE "' . $tableName . '" IMMEDIATE';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -407,9 +407,9 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     /**
      * @return mixed[]
      */
-    protected function getQuotedColumnInPrimaryKeySQL() : array
+    protected function getQuotedColumnInPrimaryKeySQL(string $columnName) : array
     {
-        return ['CREATE TABLE "quoted" ("create" VARCHAR2(255) NOT NULL, PRIMARY KEY("create"))'];
+        return ['CREATE TABLE "quoted" ("' . $columnName . '" VARCHAR2(255) NOT NULL, PRIMARY KEY("' . $columnName . '"))'];
     }
 
     /**
@@ -437,13 +437,13 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     /**
      * @return mixed[]
      */
-    protected function getQuotedColumnInForeignKeySQL() : array
+    protected function getQuotedColumnInForeignKeySQL(string $columnName) : array
     {
         return [
-            'CREATE TABLE "quoted" ("create" VARCHAR2(255) NOT NULL, foo VARCHAR2(255) NOT NULL, "bar" VARCHAR2(255) NOT NULL)',
-            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES foreign ("create", bar, "foo-bar")',
-            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES foo ("create", bar, "foo-bar")',
-            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") REFERENCES "foo-bar" ("create", bar, "foo-bar")',
+            'CREATE TABLE "quoted" ("' . $columnName . '" VARCHAR2(255) NOT NULL, foo VARCHAR2(255) NOT NULL, "bar" VARCHAR2(255) NOT NULL)',
+            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES foreign ("' . $columnName . '", bar, "foo-bar")',
+            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES foo ("' . $columnName . '", bar, "foo-bar")',
+            'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES "foo-bar" ("' . $columnName . '", bar, "foo-bar")',
         ];
     }
 
@@ -884,25 +884,25 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL(string $constraintName) : string
     {
-        return 'CONSTRAINT "select" UNIQUE (foo)';
+        return 'CONSTRAINT "' . $constraintName . '" UNIQUE (foo)';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInIndexDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL(string $indexName) : string
     {
-        return 'INDEX "select" (foo)';
+        return 'INDEX "' . $indexName . '" (foo)';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInTruncateTableSQL() : string
+    protected function getQuotesReservedKeywordInTruncateTableSQL(string $tableName) : string
     {
-        return 'TRUNCATE TABLE "select"';
+        return 'TRUNCATE TABLE "' . $tableName . '"';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -77,9 +77,9 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritDoc}
      */
-    protected function getQuotedColumnInForeignKeySQL() : array
+    protected function getQuotedColumnInForeignKeySQL(string $columnName) : array
     {
-        return ['CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL, CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES "foreign" ("create", bar, "foo-bar"), CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES foo ("create", bar, "foo-bar"), CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") REFERENCES "foo-bar" ("create", bar, "foo-bar"))'];
+        return ['CREATE TABLE "quoted" ("' . $columnName . '" VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL, CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES "foreign" ("' . $columnName . '", bar, "foo-bar"), CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES foo ("' . $columnName . '", bar, "foo-bar"), CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES "foo-bar" ("' . $columnName . '", bar, "foo-bar"))'];
     }
 
     /**
@@ -107,9 +107,9 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritDoc}
      */
-    protected function getQuotedColumnInPrimaryKeySQL() : array
+    protected function getQuotedColumnInPrimaryKeySQL(string $columnName) : array
     {
-        return ['CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, PRIMARY KEY ("create"))'];
+        return ['CREATE TABLE "quoted" ("' . $columnName . '" VARCHAR(255) NOT NULL, PRIMARY KEY ("' . $columnName . '"))'];
     }
 
     /**
@@ -985,15 +985,15 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL(string $constraintName) : string
     {
-        return 'CONSTRAINT "select" UNIQUE (foo)';
+        return 'CONSTRAINT "' . $constraintName . '" UNIQUE (foo)';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInIndexDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL(string $indexName) : string
     {
         return ''; // not supported by this platform
     }
@@ -1001,9 +1001,9 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInTruncateTableSQL() : string
+    protected function getQuotesReservedKeywordInTruncateTableSQL(string $tableName) : string
     {
-        return 'TRUNCATE TABLE "select"';
+        return 'TRUNCATE TABLE "' . $tableName . '"';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -450,9 +450,9 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritDoc}
      */
-    protected function getQuotedColumnInPrimaryKeySQL() : array
+    protected function getQuotedColumnInPrimaryKeySQL(string $columnName) : array
     {
-        return ['CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, PRIMARY KEY("create"))'];
+        return ['CREATE TABLE "quoted" ("' . $columnName . '" VARCHAR(255) NOT NULL, PRIMARY KEY("' . $columnName . '"))'];
     }
 
     /**
@@ -480,14 +480,14 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritDoc}
      */
-    protected function getQuotedColumnInForeignKeySQL() : array
+    protected function getQuotedColumnInForeignKeySQL(string $columnName) : array
     {
         return [
             'CREATE TABLE "quoted" (' .
-            '"create" VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL, ' .
-            'CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES "foreign" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE, ' .
-            'CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar") REFERENCES foo ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE, ' .
-            'CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") REFERENCES "foo-bar" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE)',
+            '"' . $columnName . '" VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL, ' .
+            'CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES "foreign" ("' . $columnName . '", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE, ' .
+            'CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES foo ("' . $columnName . '", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE, ' .
+            'CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("' . $columnName . '", foo, "bar") REFERENCES "foo-bar" ("' . $columnName . '", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE)',
         ];
     }
 
@@ -692,25 +692,25 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL(string $constraintName) : string
     {
-        return 'CONSTRAINT "select" UNIQUE (foo)';
+        return 'CONSTRAINT "' . $constraintName . '" UNIQUE (foo)';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInIndexDeclarationSQL() : string
+    protected function getQuotesReservedKeywordInIndexDeclarationSQL(string $indexName) : string
     {
-        return 'INDEX "select" (foo)';
+        return 'INDEX "' . $indexName . '" (foo)';
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getQuotesReservedKeywordInTruncateTableSQL() : string
+    protected function getQuotesReservedKeywordInTruncateTableSQL(string $tableName) : string
     {
-        return 'DELETE FROM "select"';
+        return 'DELETE FROM "' . $tableName . '"';
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2979 

#### Summary
Automatically quote identifiers with spaces in their names.

I know that automatically quoting identifiers is frowned upon, for the reasons described in #146, but `AbstractAsset::getquotedName` already makes an exceptions for keywords, since not quoting those would break the generated SQL anyhow.  In the same way, spaces in column names and other identifiers break the generated SQL, so I think this is justified.