### PR TITLE
[IN PROGRESS] Removing calls to @@IDENTITY In \Doctrine\DBAL\Driver\SQLSrv\SQLSrvConnection::\Doctrine\DBAL\Driver\SQLSrv\SQLSrvConnection::lastInsertId

### DIFF
--- a/src/Driver/SQLSrv/SQLSrvConnection.php
+++ b/src/Driver/SQLSrv/SQLSrvConnection.php
@@ -88,6 +88,13 @@ final class SQLSrvConnection implements ServerInfoAwareConnection
             throw SQLSrvException::fromSqlSrvErrors();
         }
 
+        if (stripos($statement, 'INSERT INTO ') === 0) {
+            if ($lastInsertStmt = sqlsrv_query($this->conn, 'SELECT SCOPE_IDENTITY() AS LastInsertId;')) {
+                sqlsrv_fetch($lastInsertStmt);
+                $this->lastInsertId->setId(sqlsrv_get_field($lastInsertStmt, 0));
+            }
+        }
+
         return $rowsAffected;
     }
 

--- a/src/Driver/SQLSrv/SQLSrvConnection.php
+++ b/src/Driver/SQLSrv/SQLSrvConnection.php
@@ -91,16 +91,16 @@ final class SQLSrvConnection implements ServerInfoAwareConnection
         return $rowsAffected;
     }
 
-    public function lastInsertId(?string $name = null) : string
+    public function lastInsertId(?string $name = null): string
     {
         if ($name !== null) {
             $stmt = $this->prepare('SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?');
             $stmt->execute([$name]);
-        } else {
-            $stmt = $this->query('SELECT @@IDENTITY');
+
+            return $stmt->fetchColumn();
         }
 
-        return $stmt->fetchColumn();
+        return $this->lastInsertId->getId();
     }
 
     public function beginTransaction() : void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3516

#### Summary

3516 Concerns issues that arise from making calls to @@IDENTITY in \Doctrine\DBAL\Driver\SQLSrv\SQLSrvConnection::\Doctrine\DBAL\Driver\SQLSrv\SQLSrvConnection::lastInsertId 

the following change broke it: cadd79c
prior to this SCOPE_IDENTITY was used as following:

`SELECT SCOPE_IDENTITY() AS LastInsertId;`

now @@IDENTITY is used but there are well documented differences:
https://docs.microsoft.com/de-de/sql/t-sql/functions/identity-transact-sql?view=sql-server-2017

> @@IDENTITY and SCOPE_IDENTITY return the last identity value generated in any table in the current session. However, SCOPE_IDENTITY returns the value only within the current scope; @@IDENTITY is not limited to a specific scope.

One of the scenarios that expose this issue is when a trigger is used on a table. Therefor I have copied a test originally written by @sarven which tests whether the ID comes back correctly on a table with a trigger.

This test only verifies that triggers work only when they SET NOCOUNT ON which they should do (https://dba.stackexchange.com/questions/21148/should-i-add-set-nocount-on-to-all-my-triggers).

**This issue is in progress, we need to see the results from AppVeyor before this is merged in as @morozov believes this change was introduced originally to deal with failures in AppVeyor**
