### PR TITLE
Use the provided index name for primary keys

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -338,7 +338,7 @@ SQL
             $identifier = $table;
         }
 
-        $sql = 'ALTER TABLE ' . $identifier . ' ADD PRIMARY KEY';
+        $sql = 'ALTER TABLE ' . $identifier . ' ADD CONSTRAINT ' . $index->getQuotedName($this) . ' PRIMARY KEY';
 
         if ($index->hasFlag('nonclustered')) {
             $sql .= ' NONCLUSTERED';

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -498,13 +498,13 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     {
         $idx = new Index('idx', ['id'], false, true);
         $idx->addFlag('nonclustered');
-        self::assertEquals('ALTER TABLE tbl ADD PRIMARY KEY NONCLUSTERED (id)', $this->platform->getCreatePrimaryKeySQL($idx, 'tbl'));
+        self::assertEquals('ALTER TABLE tbl ADD CONSTRAINT idx PRIMARY KEY NONCLUSTERED (id)', $this->platform->getCreatePrimaryKeySQL($idx, 'tbl'));
     }
 
     public function testAlterAddPrimaryKey() : void
     {
         $idx = new Index('idx', ['id'], false, true);
-        self::assertEquals('ALTER TABLE tbl ADD PRIMARY KEY (id)', $this->platform->getCreateIndexSQL($idx, 'tbl'));
+        self::assertEquals('ALTER TABLE tbl ADD CONSTRAINT idx PRIMARY KEY (id)', $this->platform->getCreateIndexSQL($idx, 'tbl'));
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

If an index name is passed in setPrimaryKey(), it's not used by the SQL Server platform class and one generated by the database instead. This makes it impossible to specify the required key name when creating a full text column.