### PR TITLE
Support named parameters in MySQLi connection->prepare()

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -235,7 +235,7 @@ class MysqliStatement implements IteratorAggregate, Statement
     /**
      * Converts an array of named parameters, e.g. ['id' => 1, 'foo' => 'bar'] to the corresponding array with
      * positional parameters referring to the prepared query, e.g. [1 => 1, 2 => 'bar', 3 => 'bar'] for a prepared query
-     * like "SELECT id FROM table WHERE foo = :foo and baz = :foo".
+     * such as "SELECT id FROM table WHERE foo = :foo and baz = :foo".
      *
      * @param array<int|string, mixed>|null $params
      *

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -61,7 +61,7 @@ class MysqliStatement implements IteratorAggregate, Statement
     protected $types;
 
     /** @var array<string, array<int, int>> maps parameter names to their placeholder number(s). */
-    protected $placeholderNamesToNumbers = [];
+    private $placeholderNamesToNumbers = [];
 
     /**
      * Contains ref values for bindValue().

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -241,7 +241,7 @@ class MysqliStatement implements IteratorAggregate, Statement
      *
      * @return mixed[]|null more specific: array<int, mixed>, I just don't know an elegant way to convince phpstan
      */
-    private function convertNamedToPositionalParamsIfNeeded(?array $params = null)
+    private function convertNamedToPositionalParamsIfNeeded(?array $params = null) : array
     {
         if ($params === null || count($params) === 0) {
             return $params;

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -14,6 +14,8 @@ use mysqli_stmt;
 use PDO;
 use function array_combine;
 use function array_fill;
+use function array_key_exists;
+use function array_keys;
 use function assert;
 use function count;
 use function feof;
@@ -22,8 +24,11 @@ use function get_resource_type;
 use function is_array;
 use function is_int;
 use function is_resource;
+use function is_string;
 use function sprintf;
 use function str_repeat;
+use function strlen;
+use function substr;
 
 class MysqliStatement implements IteratorAggregate, Statement
 {
@@ -55,9 +60,7 @@ class MysqliStatement implements IteratorAggregate, Statement
     /** @var string */
     protected $types;
 
-    /**
-     * @var array<string, array<int, int>> maps parameter names to their placeholder number(s).
-     */
+    /** @var array<string, array<int, int>> maps parameter names to their placeholder number(s). */
     protected $placeholderNamesToNumbers = [];
 
     /**
@@ -87,7 +90,7 @@ class MysqliStatement implements IteratorAggregate, Statement
         $this->_conn = $conn;
 
         $queryWithoutNamedParameters = $this->convertNamedToPositionalPlaceholders($prepareString);
-        $stmt = $conn->prepare($queryWithoutNamedParameters);
+        $stmt                        = $conn->prepare($queryWithoutNamedParameters);
 
         if ($stmt === false) {
             throw new MysqliException($this->_conn->error, $this->_conn->sqlstate, $this->_conn->errno);
@@ -108,14 +111,16 @@ class MysqliStatement implements IteratorAggregate, Statement
      * Converts named placeholders (":parameter") into positional ones ("?"), as MySQL does not support them.
      *
      * @param string $query The query string to create a prepared statement of.
+     *
      * @return string
      */
     private function convertNamedToPositionalPlaceholders($query)
     {
         $numberOfCharsQueryIsShortenedBy = 0;
-        $placeholderNumber = 0;
+        $placeholderNumber               = 0;
 
         foreach (SQLParserUtils::getPlaceholderPositions($query, false) as $placeholderPosition => $placeholderName) {
+            $placeholderName = (string) $placeholderName;
             if (array_key_exists($placeholderName, $this->placeholderNamesToNumbers) === false) {
                 $this->placeholderNamesToNumbers[$placeholderName] = [];
             }
@@ -123,9 +128,9 @@ class MysqliStatement implements IteratorAggregate, Statement
             $this->placeholderNamesToNumbers[$placeholderName][] = $placeholderNumber++;
 
             $placeholderPositionInShortenedQuery = $placeholderPosition - $numberOfCharsQueryIsShortenedBy;
-            $placeholderNameLength = strlen($placeholderName);
-            $query = substr($query, 0, $placeholderPositionInShortenedQuery) . '?' . substr($query, ($placeholderPositionInShortenedQuery + $placeholderNameLength + 1));
-            $numberOfCharsQueryIsShortenedBy += $placeholderNameLength;
+            $placeholderNameLength               = strlen($placeholderName);
+            $query                               = substr($query, 0, $placeholderPositionInShortenedQuery) . '?' . substr($query, ($placeholderPositionInShortenedQuery + $placeholderNameLength + 1));
+            $numberOfCharsQueryIsShortenedBy    += $placeholderNameLength;
         }
 
         return $query;
@@ -247,8 +252,9 @@ class MysqliStatement implements IteratorAggregate, Statement
      * positional parameters referring to the prepared query, e.g. [1 => 1, 2 => 'bar', 3 => 'bar'] for a prepared query
      * like "SELECT id FROM table WHERE foo = :foo and baz = :foo".
      *
-     * @param array $params
-     * @return array
+     * @param array<string, mixed> $params
+     *
+     * @return array<int, mixed>
      */
     private function convertNamedToPositionalParams(array $params)
     {

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -14,6 +14,8 @@ use mysqli_stmt;
 use PDO;
 use function array_combine;
 use function array_fill;
+use function array_key_exists;
+use function array_keys;
 use function assert;
 use function count;
 use function feof;
@@ -22,8 +24,11 @@ use function get_resource_type;
 use function is_array;
 use function is_int;
 use function is_resource;
+use function is_string;
 use function sprintf;
 use function str_repeat;
+use function strlen;
+use function substr;
 
 class MysqliStatement implements IteratorAggregate, Statement
 {
@@ -55,9 +60,7 @@ class MysqliStatement implements IteratorAggregate, Statement
     /** @var string */
     protected $types;
 
-    /**
-     * @var array<string, array<int, int>> maps parameter names to their placeholder number(s).
-     */
+    /** @var array<string, array<int, int>> maps parameter names to their placeholder number(s). */
     protected $placeholderNamesToNumbers = [];
 
     /**
@@ -87,7 +90,7 @@ class MysqliStatement implements IteratorAggregate, Statement
         $this->_conn = $conn;
 
         $queryWithoutNamedParameters = $this->convertNamedToPositionalPlaceholders($prepareString);
-        $stmt = $conn->prepare($queryWithoutNamedParameters);
+        $stmt                        = $conn->prepare($queryWithoutNamedParameters);
 
         if ($stmt === false) {
             throw new MysqliException($this->_conn->error, $this->_conn->sqlstate, $this->_conn->errno);
@@ -108,14 +111,17 @@ class MysqliStatement implements IteratorAggregate, Statement
      * Converts named placeholders (":parameter") into positional ones ("?"), as MySQL does not support them.
      *
      * @param string $query The query string to create a prepared statement of.
+     *
      * @return string
      */
     private function convertNamedToPositionalPlaceholders($query)
     {
         $numberOfCharsQueryIsShortenedBy = 0;
-        $placeholderNumber = 0;
+        $placeholderNumber               = 0;
 
-        foreach (SQLParserUtils::getPlaceholderPositions($query, false) as $placeholderPosition => $placeholderName) {
+        /** @var string[] $placeholderPositions */
+        $placeholderPositions = SQLParserUtils::getPlaceholderPositions($query, false);
+        foreach ($placeholderPositions as $placeholderPosition => $placeholderName) {
             if (array_key_exists($placeholderName, $this->placeholderNamesToNumbers) === false) {
                 $this->placeholderNamesToNumbers[$placeholderName] = [];
             }
@@ -123,9 +129,9 @@ class MysqliStatement implements IteratorAggregate, Statement
             $this->placeholderNamesToNumbers[$placeholderName][] = $placeholderNumber++;
 
             $placeholderPositionInShortenedQuery = $placeholderPosition - $numberOfCharsQueryIsShortenedBy;
-            $placeholderNameLength = strlen($placeholderName);
-            $query = substr($query, 0, $placeholderPositionInShortenedQuery) . '?' . substr($query, ($placeholderPositionInShortenedQuery + $placeholderNameLength + 1));
-            $numberOfCharsQueryIsShortenedBy += $placeholderNameLength;
+            $placeholderNameLength               = strlen($placeholderName);
+            $query                               = substr($query, 0, $placeholderPositionInShortenedQuery) . '?' . substr($query, ($placeholderPositionInShortenedQuery + $placeholderNameLength + 1));
+            $numberOfCharsQueryIsShortenedBy    += $placeholderNameLength;
         }
 
         return $query;
@@ -247,8 +253,9 @@ class MysqliStatement implements IteratorAggregate, Statement
      * positional parameters referring to the prepared query, e.g. [1 => 1, 2 => 'bar', 3 => 'bar'] for a prepared query
      * like "SELECT id FROM table WHERE foo = :foo and baz = :foo".
      *
-     * @param array $params
-     * @return array
+     * @param mixed[] $params
+     *
+     * @return mixed[]
      */
     private function convertNamedToPositionalParams(array $params)
     {

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -127,7 +127,7 @@ class MysqliStatement implements IteratorAggregate, Statement
 
             $placeholderPositionInShortenedQuery = $placeholderPosition - $numberOfCharsQueryIsShortenedBy;
             $placeholderNameLength               = strlen($placeholderName);
-            $query                               = substr($query, 0, $placeholderPositionInShortenedQuery) . '?' . 
+            $query                               = substr($query, 0, $placeholderPositionInShortenedQuery) . '?' .
                 substr($query, $placeholderPositionInShortenedQuery + $placeholderNameLength + 1);
             $numberOfCharsQueryIsShortenedBy    += $placeholderNameLength;
         }
@@ -241,7 +241,7 @@ class MysqliStatement implements IteratorAggregate, Statement
      *
      * @return mixed[]|null more specific: array<int, mixed>, I just don't know an elegant way to convince phpstan
      */
-    private function convertNamedToPositionalParamsIfNeeded(?array $params = null) : array
+    private function convertNamedToPositionalParamsIfNeeded(?array $params = null) : ?array
     {
         if ($params === null) {
             return $params;

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -14,8 +14,6 @@ use mysqli_stmt;
 use PDO;
 use function array_combine;
 use function array_fill;
-use function array_key_exists;
-use function array_keys;
 use function assert;
 use function count;
 use function feof;
@@ -24,11 +22,8 @@ use function get_resource_type;
 use function is_array;
 use function is_int;
 use function is_resource;
-use function is_string;
 use function sprintf;
 use function str_repeat;
-use function strlen;
-use function substr;
 
 class MysqliStatement implements IteratorAggregate, Statement
 {
@@ -60,7 +55,9 @@ class MysqliStatement implements IteratorAggregate, Statement
     /** @var string */
     protected $types;
 
-    /** @var array<string, array<int, int>> maps parameter names to their placeholder number(s). */
+    /**
+     * @var array<string, array<int, int>> maps parameter names to their placeholder number(s).
+     */
     protected $placeholderNamesToNumbers = [];
 
     /**
@@ -90,7 +87,7 @@ class MysqliStatement implements IteratorAggregate, Statement
         $this->_conn = $conn;
 
         $queryWithoutNamedParameters = $this->convertNamedToPositionalPlaceholders($prepareString);
-        $stmt                        = $conn->prepare($queryWithoutNamedParameters);
+        $stmt = $conn->prepare($queryWithoutNamedParameters);
 
         if ($stmt === false) {
             throw new MysqliException($this->_conn->error, $this->_conn->sqlstate, $this->_conn->errno);
@@ -111,17 +108,14 @@ class MysqliStatement implements IteratorAggregate, Statement
      * Converts named placeholders (":parameter") into positional ones ("?"), as MySQL does not support them.
      *
      * @param string $query The query string to create a prepared statement of.
-     *
      * @return string
      */
     private function convertNamedToPositionalPlaceholders($query)
     {
         $numberOfCharsQueryIsShortenedBy = 0;
-        $placeholderNumber               = 0;
+        $placeholderNumber = 0;
 
-        /** @var string[] $placeholderPositions */
-        $placeholderPositions = SQLParserUtils::getPlaceholderPositions($query, false);
-        foreach ($placeholderPositions as $placeholderPosition => $placeholderName) {
+        foreach (SQLParserUtils::getPlaceholderPositions($query, false) as $placeholderPosition => $placeholderName) {
             if (array_key_exists($placeholderName, $this->placeholderNamesToNumbers) === false) {
                 $this->placeholderNamesToNumbers[$placeholderName] = [];
             }
@@ -129,9 +123,9 @@ class MysqliStatement implements IteratorAggregate, Statement
             $this->placeholderNamesToNumbers[$placeholderName][] = $placeholderNumber++;
 
             $placeholderPositionInShortenedQuery = $placeholderPosition - $numberOfCharsQueryIsShortenedBy;
-            $placeholderNameLength               = strlen($placeholderName);
-            $query                               = substr($query, 0, $placeholderPositionInShortenedQuery) . '?' . substr($query, ($placeholderPositionInShortenedQuery + $placeholderNameLength + 1));
-            $numberOfCharsQueryIsShortenedBy    += $placeholderNameLength;
+            $placeholderNameLength = strlen($placeholderName);
+            $query = substr($query, 0, $placeholderPositionInShortenedQuery) . '?' . substr($query, ($placeholderPositionInShortenedQuery + $placeholderNameLength + 1));
+            $numberOfCharsQueryIsShortenedBy += $placeholderNameLength;
         }
 
         return $query;
@@ -253,9 +247,8 @@ class MysqliStatement implements IteratorAggregate, Statement
      * positional parameters referring to the prepared query, e.g. [1 => 1, 2 => 'bar', 3 => 'bar'] for a prepared query
      * like "SELECT id FROM table WHERE foo = :foo and baz = :foo".
      *
-     * @param mixed[] $params
-     *
-     * @return mixed[]
+     * @param array $params
+     * @return array
      */
     private function convertNamedToPositionalParams(array $params)
     {

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -243,7 +243,7 @@ class MysqliStatement implements IteratorAggregate, Statement
      */
     private function convertNamedToPositionalParamsIfNeeded(?array $params = null) : array
     {
-        if ($params === null || count($params) === 0) {
+        if ($params === null) {
             return $params;
         }
 

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -264,10 +264,8 @@ class MysqliStatement implements IteratorAggregate, Statement
 
     /**
      * @param mixed[] $array
-     *
-     * @return bool
      */
-    private function arrayHasOnlyIntegerKeys(array $array)
+    private function arrayHasOnlyIntegerKeys(array $array) : bool
     {
         return count(array_filter(array_keys($array), 'is_int')) === count($array);
     }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -517,7 +517,7 @@ class MysqliStatement implements IteratorAggregate, Statement
         return new StatementIterator($this);
     }
 
-    private function initializeColumnNamesIfNeeded()
+    private function initializeColumnNamesIfNeeded() : void
     {
         if ($this->_columnNames !== null) {
             return;

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -111,10 +111,8 @@ class MysqliStatement implements IteratorAggregate, Statement
      * Converts named placeholders (":parameter") into positional ones ("?"), as MySQL does not support them.
      *
      * @param string $query The query string to create a prepared statement of.
-     *
-     * @return string
      */
-    private function convertNamedToPositionalPlaceholders($query)
+    private function convertNamedToPositionalPlaceholders(string $query) : string
     {
         $numberOfCharsQueryIsShortenedBy = 0;
         $placeholderNumber               = 0;

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -252,7 +252,7 @@ class MysqliStatement implements IteratorAggregate, Statement
      * positional parameters referring to the prepared query, e.g. [1 => 1, 2 => 'bar', 3 => 'bar'] for a prepared query
      * like "SELECT id FROM table WHERE foo = :foo and baz = :foo".
      *
-     * @param array<string, mixed> $params
+     * @param array<mixed, mixed> $params
      *
      * @return array<int, mixed>
      */

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -127,7 +127,8 @@ class MysqliStatement implements IteratorAggregate, Statement
 
             $placeholderPositionInShortenedQuery = $placeholderPosition - $numberOfCharsQueryIsShortenedBy;
             $placeholderNameLength               = strlen($placeholderName);
-            $query                               = substr($query, 0, $placeholderPositionInShortenedQuery) . '?' . substr($query, ($placeholderPositionInShortenedQuery + $placeholderNameLength + 1));
+            $query                               = substr($query, 0, $placeholderPositionInShortenedQuery) . '?' . 
+                substr($query, $placeholderPositionInShortenedQuery + $placeholderNameLength + 1);
             $numberOfCharsQueryIsShortenedBy    += $placeholderNameLength;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/MysqliStatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/MysqliStatementTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Driver\Mysqli;
+
+use Doctrine\DBAL\Driver\Mysqli\Driver;
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalFunctionalTestCase;
+use Throwable;
+use const CASE_LOWER;
+use function array_change_key_case;
+use function extension_loaded;
+
+final class MysqliStatementTest extends DbalFunctionalTestCase
+{
+    /**
+     * @return iterable<string, array<string, mixed[], mixed[]>>
+     */
+    public static function prepareProvider() : iterable
+    {
+        return [
+            'single named parameter' => [
+                'SELECT * FROM mysqli_statement_test f WHERE f.foo = :foo',
+                ['foo' => 1],
+                [
+                    ['id' => 1, 'foo' => 1, 'bar' => 1],
+                    ['id' => 2, 'foo' => 1, 'bar' => 2],
+                    ['id' => 3, 'foo' => 1, 'bar' => 3],
+                    ['id' => 4, 'foo' => 1, 'bar' => 4],
+                ],
+            ],
+
+            'multiple parameters' => [
+                'SELECT * FROM mysqli_statement_test f WHERE f.foo = :foo AND f.bar = :bar',
+                [
+                    'foo' => 1,
+                    'bar' => 2,
+                ],
+                [
+                    ['id' => 2, 'foo' => 1, 'bar' => 2],
+                ],
+            ],
+
+            'same parameter at multiple positions' => [
+                'SELECT * FROM mysqli_statement_test f WHERE f.foo = :foo AND f.foo IN (:foo)',
+                ['foo' => 1],
+                [
+                    ['id' => 1, 'foo' => 1, 'bar' => 1],
+                    ['id' => 2, 'foo' => 1, 'bar' => 2],
+                    ['id' => 3, 'foo' => 1, 'bar' => 3],
+                    ['id' => 4, 'foo' => 1, 'bar' => 4],
+                ],
+            ],
+
+            'parameter with string value' => [
+                'SELECT * FROM mysqli_statement_test f WHERE f.foo = :foo',
+                ['foo' => '"\''],
+                [],
+            ],
+        ];
+    }
+
+    protected function setUp() : void
+    {
+        if (! extension_loaded('mysqli')) {
+            $this->markTestSkipped('mysqli is not installed.');
+        }
+
+        parent::setUp();
+
+        if (! ($this->connection->getDriver() instanceof Driver)) {
+            $this->markTestSkipped('MySQLi only test.');
+        }
+
+        if ($this->connection->getSchemaManager()->tablesExist('mysqli_statement_test')) {
+            return;
+        }
+
+        try {
+            $table = new Table('mysqli_statement_test');
+            $table->addColumn('id', 'integer');
+            $table->addColumn('foo', 'string');
+            $table->addColumn('bar', 'string');
+            $table->setPrimaryKey(['id']);
+
+            $sm = $this->connection->getSchemaManager();
+            $sm->createTable($table);
+
+            $this->connection->insert('mysqli_statement_test', [
+                'id'  => 1,
+                'foo' => 1,
+                'bar' => 1,
+            ]);
+            $this->connection->insert('mysqli_statement_test', [
+                'id'  => 2,
+                'foo' => 1,
+                'bar' => 2,
+            ]);
+            $this->connection->insert('mysqli_statement_test', [
+                'id'  => 3,
+                'foo' => 1,
+                'bar' => 3,
+            ]);
+            $this->connection->insert('mysqli_statement_test', [
+                'id'  => 4,
+                'foo' => 1,
+                'bar' => 4,
+            ]);
+            $this->connection->insert('mysqli_statement_test', [
+                'id'  => 5,
+                'foo' => 2,
+                'bar' => 1,
+            ]);
+            $this->connection->insert('mysqli_statement_test', [
+                'id'  => 6,
+                'foo' => 2,
+                'bar' => 2,
+            ]);
+        } catch (Throwable $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @param array<string, mixed>             $params
+     * @param array<int, array<string, mixed>> $expected
+     *
+     * @dataProvider prepareProvider
+     */
+    public function testPrepare(string $query, array $params, array $expected) : void
+    {
+        $stmt = $this->connection->prepare($query);
+        $stmt->execute($params);
+
+        $result = $stmt->fetchAll(FetchMode::ASSOCIATIVE);
+        foreach ($result as $k => $v) {
+            $result[$k] = array_change_key_case($v, CASE_LOWER);
+        }
+
+        self::assertEquals($result, $expected);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -17,7 +17,7 @@ use function array_change_key_case;
 class NamedParametersTest extends DbalFunctionalTestCase
 {
     /**
-     * @return iterable<int, array<string, array, array, array>>
+     * @return iterable<int, array<string, mixed[], mixed[], mixed[]>>
      */
     public static function executeQueryProvider() : iterable
     {
@@ -151,16 +151,14 @@ class NamedParametersTest extends DbalFunctionalTestCase
     }
 
     /**
-     * @return iterable<string, array<string, array, array>>
+     * @return iterable<string, array<string, mixed[], mixed[]>>
      */
     public static function prepareProvider() : iterable
     {
         return [
             'single named parameter' => [
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo',
-                [
-                    'foo' => 1,
-                ],
+                ['foo' => 1],
                 [
                     ['id' => 1, 'foo' => 1, 'bar' => 1],
                     ['id' => 2, 'foo' => 1, 'bar' => 2],
@@ -182,9 +180,7 @@ class NamedParametersTest extends DbalFunctionalTestCase
 
             'same parameter at multiple positions' => [
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.foo IN (:foo)',
-                [
-                    'foo' => 1,
-                ],
+                ['foo' => 1],
                 [
                     ['id' => 1, 'foo' => 1, 'bar' => 1],
                     ['id' => 2, 'foo' => 1, 'bar' => 2],
@@ -195,11 +191,8 @@ class NamedParametersTest extends DbalFunctionalTestCase
 
             'parameter with string value' => [
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo',
-                [
-                    'foo' => '"\'',
-                ],
-                [
-                ],
+                ['foo' => '"\''],
+                [],
             ],
         ];
     }
@@ -258,7 +251,6 @@ class NamedParametersTest extends DbalFunctionalTestCase
     }
 
     /**
-     * @param string                           $query
      * @param array<string, mixed>             $params
      * @param array<string, int>               $types
      * @param array<int, array<string, mixed>> $expected
@@ -278,7 +270,6 @@ class NamedParametersTest extends DbalFunctionalTestCase
     }
 
     /**
-     * @param string                           $query
      * @param array<string, mixed>             $params
      * @param array<int, array<string, mixed>> $expected
      *

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -17,7 +17,7 @@ use function array_change_key_case;
 class NamedParametersTest extends DbalFunctionalTestCase
 {
     /**
-     * @return iterable<int, array<string, mixed[], mixed[], mixed[]>>
+     * @return iterable<int, array<string, array, array, array>>
      */
     public static function executeQueryProvider() : iterable
     {
@@ -151,14 +151,16 @@ class NamedParametersTest extends DbalFunctionalTestCase
     }
 
     /**
-     * @return iterable<string, array<string, mixed[], mixed[]>>
+     * @return iterable<string, array<string, array, array>>
      */
     public static function prepareProvider() : iterable
     {
         return [
             'single named parameter' => [
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo',
-                ['foo' => 1],
+                [
+                    'foo' => 1,
+                ],
                 [
                     ['id' => 1, 'foo' => 1, 'bar' => 1],
                     ['id' => 2, 'foo' => 1, 'bar' => 2],
@@ -180,7 +182,9 @@ class NamedParametersTest extends DbalFunctionalTestCase
 
             'same parameter at multiple positions' => [
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.foo IN (:foo)',
-                ['foo' => 1],
+                [
+                    'foo' => 1,
+                ],
                 [
                     ['id' => 1, 'foo' => 1, 'bar' => 1],
                     ['id' => 2, 'foo' => 1, 'bar' => 2],
@@ -191,8 +195,11 @@ class NamedParametersTest extends DbalFunctionalTestCase
 
             'parameter with string value' => [
                 'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo',
-                ['foo' => '"\''],
-                [],
+                [
+                    'foo' => '"\'',
+                ],
+                [
+                ],
             ],
         ];
     }
@@ -251,6 +258,7 @@ class NamedParametersTest extends DbalFunctionalTestCase
     }
 
     /**
+     * @param string                           $query
      * @param array<string, mixed>             $params
      * @param array<string, int>               $types
      * @param array<int, array<string, mixed>> $expected
@@ -270,6 +278,7 @@ class NamedParametersTest extends DbalFunctionalTestCase
     }
 
     /**
+     * @param string                           $query
      * @param array<string, mixed>             $params
      * @param array<int, array<string, mixed>> $expected
      *

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -17,9 +17,9 @@ use function array_change_key_case;
 class NamedParametersTest extends DbalFunctionalTestCase
 {
     /**
-     * @return iterable<int, array<int, mixed>>
+     * @return iterable<int, array<string, array, array, array>>
      */
-    public static function ticketProvider() : iterable
+    public static function executeQueryProvider() : iterable
     {
         return [
             [
@@ -150,6 +150,60 @@ class NamedParametersTest extends DbalFunctionalTestCase
         ];
     }
 
+    /**
+     * @return iterable<string, array<string, array, array>>
+     */
+    public static function prepareProvider() : iterable
+    {
+        return [
+            'single named parameter' => [
+                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo',
+                [
+                    'foo' => 1,
+                ],
+                [
+                    ['id' => 1, 'foo' => 1, 'bar' => 1],
+                    ['id' => 2, 'foo' => 1, 'bar' => 2],
+                    ['id' => 3, 'foo' => 1, 'bar' => 3],
+                    ['id' => 4, 'foo' => 1, 'bar' => 4],
+                ],
+            ],
+
+            'multiple parameters' => [
+                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar = :bar',
+                [
+                    'foo' => 1,
+                    'bar' => 2,
+                ],
+                [
+                    ['id' => 2, 'foo' => 1, 'bar' => 2],
+                ],
+            ],
+
+            'same parameter at multiple positions' => [
+                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.foo IN (:foo)',
+                [
+                    'foo' => 1,
+                ],
+                [
+                    ['id' => 1, 'foo' => 1, 'bar' => 1],
+                    ['id' => 2, 'foo' => 1, 'bar' => 2],
+                    ['id' => 3, 'foo' => 1, 'bar' => 3],
+                    ['id' => 4, 'foo' => 1, 'bar' => 4],
+                ],
+            ],
+
+            'parameter with string value' => [
+                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo',
+                [
+                    'foo' => '"\'',
+                ],
+                [
+                ],
+            ],
+        ];
+    }
+
     protected function setUp() : void
     {
         parent::setUp();
@@ -204,15 +258,36 @@ class NamedParametersTest extends DbalFunctionalTestCase
     }
 
     /**
-     * @param mixed[] $params
-     * @param int[]   $types
-     * @param int[]   $expected
+     * @param string                           $query
+     * @param array<string, mixed>             $params
+     * @param array<string, int>               $types
+     * @param array<int, array<string, mixed>> $expected
      *
-     * @dataProvider ticketProvider
+     * @dataProvider executeQueryProvider
      */
-    public function testTicket(string $query, array $params, array $types, array $expected) : void
+    public function testExecuteQuery(string $query, array $params, array $types, array $expected) : void
     {
         $stmt   = $this->connection->executeQuery($query, $params, $types);
+        $result = $stmt->fetchAll(FetchMode::ASSOCIATIVE);
+
+        foreach ($result as $k => $v) {
+            $result[$k] = array_change_key_case($v, CASE_LOWER);
+        }
+
+        self::assertEquals($result, $expected);
+    }
+
+    /**
+     * @param string                           $query
+     * @param array<string, mixed>             $params
+     * @param array<int, array<string, mixed>> $expected
+     *
+     * @dataProvider prepareProvider
+     */
+    public function testPrepare(string $query, array $params, array $expected) : void
+    {
+        $stmt = $this->connection->prepare($query);
+        $stmt->execute($params);
         $result = $stmt->fetchAll(FetchMode::ASSOCIATIVE);
 
         foreach ($result as $k => $v) {

--- a/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/NamedParametersTest.php
@@ -17,9 +17,9 @@ use function array_change_key_case;
 class NamedParametersTest extends DbalFunctionalTestCase
 {
     /**
-     * @return iterable<int, array<string, array, array, array>>
+     * @return iterable<int, array<int, mixed>>
      */
-    public static function executeQueryProvider() : iterable
+    public static function ticketProvider() : iterable
     {
         return [
             [
@@ -150,60 +150,6 @@ class NamedParametersTest extends DbalFunctionalTestCase
         ];
     }
 
-    /**
-     * @return iterable<string, array<string, array, array>>
-     */
-    public static function prepareProvider() : iterable
-    {
-        return [
-            'single named parameter' => [
-                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo',
-                [
-                    'foo' => 1,
-                ],
-                [
-                    ['id' => 1, 'foo' => 1, 'bar' => 1],
-                    ['id' => 2, 'foo' => 1, 'bar' => 2],
-                    ['id' => 3, 'foo' => 1, 'bar' => 3],
-                    ['id' => 4, 'foo' => 1, 'bar' => 4],
-                ],
-            ],
-
-            'multiple parameters' => [
-                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.bar = :bar',
-                [
-                    'foo' => 1,
-                    'bar' => 2,
-                ],
-                [
-                    ['id' => 2, 'foo' => 1, 'bar' => 2],
-                ],
-            ],
-
-            'same parameter at multiple positions' => [
-                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo AND f.foo IN (:foo)',
-                [
-                    'foo' => 1,
-                ],
-                [
-                    ['id' => 1, 'foo' => 1, 'bar' => 1],
-                    ['id' => 2, 'foo' => 1, 'bar' => 2],
-                    ['id' => 3, 'foo' => 1, 'bar' => 3],
-                    ['id' => 4, 'foo' => 1, 'bar' => 4],
-                ],
-            ],
-
-            'parameter with string value' => [
-                'SELECT * FROM ddc1372_foobar f WHERE f.foo = :foo',
-                [
-                    'foo' => '"\'',
-                ],
-                [
-                ],
-            ],
-        ];
-    }
-
     protected function setUp() : void
     {
         parent::setUp();
@@ -258,36 +204,15 @@ class NamedParametersTest extends DbalFunctionalTestCase
     }
 
     /**
-     * @param string                           $query
-     * @param array<string, mixed>             $params
-     * @param array<string, int>               $types
-     * @param array<int, array<string, mixed>> $expected
+     * @param mixed[] $params
+     * @param int[]   $types
+     * @param int[]   $expected
      *
-     * @dataProvider executeQueryProvider
+     * @dataProvider ticketProvider
      */
-    public function testExecuteQuery(string $query, array $params, array $types, array $expected) : void
+    public function testTicket(string $query, array $params, array $types, array $expected) : void
     {
         $stmt   = $this->connection->executeQuery($query, $params, $types);
-        $result = $stmt->fetchAll(FetchMode::ASSOCIATIVE);
-
-        foreach ($result as $k => $v) {
-            $result[$k] = array_change_key_case($v, CASE_LOWER);
-        }
-
-        self::assertEquals($result, $expected);
-    }
-
-    /**
-     * @param string                           $query
-     * @param array<string, mixed>             $params
-     * @param array<int, array<string, mixed>> $expected
-     *
-     * @dataProvider prepareProvider
-     */
-    public function testPrepare(string $query, array $params, array $expected) : void
-    {
-        $stmt = $this->connection->prepare($query);
-        $stmt->execute($params);
         $result = $stmt->fetchAll(FetchMode::ASSOCIATIVE);
 
         foreach ($result as $k => $v) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues |

#### Summary

According to the [documentation](https://www.doctrine-project.org/projects/doctrine-dbal/en/2.10/reference/data-retrieval-and-manipulation.html#dynamic-parameters-and-prepared-statements), you can use named parameters in `$connection->prepare($query)`. This PR tests and adds support for that with MySQLi connections.