### PR TITLE
Add DBAL Connection Registry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "php": "^7.3",
         "doctrine/cache": "^1.0",
         "doctrine/event-manager": "^1.0",
-        "ocramius/package-versions": "^1.4"
+        "ocramius/package-versions": "^1.4",
+        "psr/container": "^1.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d06c0dac6585d3779056ae835b684c93",
+    "content-hash": "6d678fda37ae2cbf5e558ee3bc6cf0ab",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -203,6 +203,55 @@
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
             "time": "2019-11-15T16:17:10+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
         }
     ],
     "packages-dev": [
@@ -2435,8 +2484,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",

--- a/lib/Doctrine/DBAL/Registry/ConnectionRegistry.php
+++ b/lib/Doctrine/DBAL/Registry/ConnectionRegistry.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Registry;
+
+use Doctrine\DBAL\Connection;
+use InvalidArgumentException;
+
+interface ConnectionRegistry
+{
+    /**
+     * Gets the default connection name.
+     *
+     * @return string The default connection name.
+     */
+    public function getDefaultConnectionName() : string;
+
+    /**
+     * Gets the named connection.
+     *
+     * @param string $name The connection name (null for the default one).
+     *
+     * @throws InvalidArgumentException in case the connection for the given name does not exist.
+     */
+    public function getConnection(?string $name = null) : Connection;
+
+    /**
+     * Gets an array of all registered connections.
+     *
+     * @return array<string, Connection> An array of Connection instances.
+     */
+    public function getConnections() : array;
+
+    /**
+     * Gets all connection names.
+     *
+     * @return array<string> An array of connection names.
+     */
+    public function getConnectionNames() : array;
+}

--- a/lib/Doctrine/DBAL/Registry/Psr11ConnectionRegistry.php
+++ b/lib/Doctrine/DBAL/Registry/Psr11ConnectionRegistry.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Registry;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Registry\ConnectionRegistry;
+use InvalidArgumentException;
+use Psr\Container\ContainerInterface;
+use function sprintf;
+
+class Psr11ConnectionRegistry implements ConnectionRegistry
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    /** @var string */
+    private $defaultConnectionName;
+
+    /** @var string[] */
+    private $connectionNames;
+
+    /**
+     * @param string[] $connectionNames
+     */
+    public function __construct(ContainerInterface $container, string $defaultConnectionName, array $connectionNames)
+    {
+        $this->container             = $container;
+        $this->defaultConnectionName = $defaultConnectionName;
+        $this->connectionNames       = $connectionNames;
+    }
+
+    public function getDefaultConnectionName() : string
+    {
+        return $this->defaultConnectionName;
+    }
+
+    public function getConnection(?string $name = null) : Connection
+    {
+        $name = $name ?? $this->defaultConnectionName;
+
+        if (! $this->container->has($name)) {
+            throw new InvalidArgumentException(sprintf('Connection with name "%s" does not exist.', $name));
+        }
+
+        return $this->container->get($name);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getConnections() : array
+    {
+        $connections = [];
+
+        foreach ($this->connectionNames as $connectionName) {
+            $connections[$connectionName] = $this->container->get($connectionName);
+        }
+
+        return $connections;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getConnectionNames() : array
+    {
+        return $this->connectionNames;
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Registry/Psr11ConnectionRegistryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Registry/Psr11ConnectionRegistryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Registry;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Registry\ConnectionRegistry;
+use Doctrine\DBAL\Registry\Psr11ConnectionRegistry;
+use InvalidArgumentException;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use function array_keys;
+
+class Psr11ConnectionRegistryTest extends TestCase
+{
+    /** @var ConnectionRegistry */
+    private $registry;
+
+    /** @var array<string, Connection&Stub> */
+    private $connections;
+
+    protected function setUp() : void
+    {
+        /** @var Connection&Stub $fooConnection */
+        $fooConnection = $this->createStub(Connection::class);
+        /** @var Connection&Stub $barConnection */
+        $barConnection = $this->createStub(Connection::class);
+
+        $this->connections = [
+            'foo' => $fooConnection,
+            'bar' => $barConnection,
+        ];
+
+        /** @var ContainerInterface&Stub $container */
+        $container = $this->createStub(ContainerInterface::class);
+        $container->method('has')
+            ->willReturnCallback(function (string $name) : bool {
+                return isset($this->connections[$name]);
+            });
+
+        $container->method('get')
+            ->willReturnCallback(function (string $name) : Connection {
+                return $this->connections[$name];
+            });
+
+        $this->registry = new Psr11ConnectionRegistry($container, 'bar', array_keys($this->connections));
+    }
+
+    public function testGetDefaultConnection() : void
+    {
+        $this->assertSame($this->connections['bar'], $this->registry->getConnection());
+    }
+
+    public function testGetConnectionByName() : void
+    {
+        $this->assertSame($this->connections['foo'], $this->registry->getConnection('foo'));
+        $this->assertSame($this->connections['bar'], $this->registry->getConnection('bar'));
+    }
+
+    public function testGetNotExistentConnection() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Connection with name "something" does not exist.');
+        $this->registry->getConnection('something');
+    }
+
+    public function testGetDefaultConnectionName() : void
+    {
+        $this->assertSame('bar', $this->registry->getDefaultConnectionName());
+    }
+
+    public function getGetConnections() : void
+    {
+        $this->assertSame($this->connections, $this->registry->getConnections());
+    }
+
+    public function testGetConnectionNames() : void
+    {
+        $this->assertSame(array_keys($this->connections), $this->registry->getConnectionNames());
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | -

#### Summary

I am currently working on extracting the DBAL part out of `DoctrineBundle` and into https://github.com/doctrine/dbal-bundle. See https://github.com/doctrine/dbal-bundle/pull/1.

I discussed some details with @stof and @alcaeus on the last SymfonyHackday in Amsterdam.

The new dbal-bundle will need a `ConnectionRegistry` to retrieve registered dbal connections. Since the existing [ConnectionRegistry](https://github.com/doctrine/persistence/blob/master/lib/Doctrine/Persistence/ConnectionRegistry.php) in the persistence namespace is a bit generic (can return any object and is not specificly for DBAL connections) we propose to add this new registry interface (and a PSR-11 container implementation) here.

@stof maybe you can elaborate some more on how this could potentially also be used to simplify the DBAL commands?

