### PR TITLE
Ensure the constructor arguments are passed to custom classes

### DIFF
--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -249,11 +249,7 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
-        if ($fetchArgument) {
-            return $this->stmt->fetchAll($fetchMode, $fetchArgument);
-        }
-
-        return $this->stmt->fetchAll($fetchMode);
+        return $this->stmt->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Statement;
@@ -28,7 +29,7 @@ class StatementTest extends DbalTestCase
     protected function setUp() : void
     {
         $this->pdoStatement = $this->getMockBuilder(PDOStatement::class)
-            ->onlyMethods(['execute', 'bindParam', 'bindValue'])
+            ->onlyMethods(['execute', 'bindParam', 'bindValue', 'fetchAll'])
             ->getMock();
 
         $driverConnection = $this->createMock(DriverConnection::class);
@@ -149,5 +150,16 @@ class StatementTest extends DbalTestCase
         $this->expectException(DBALException::class);
 
         $statement->execute();
+    }
+
+    public function testPDOCustomClassConstructorArgs() : void
+    {
+        $statement = new Statement('', $this->conn);
+
+        $this->pdoStatement->expects($this->once())
+            ->method('fetchAll')
+            ->with(self::equalTo(FetchMode::CUSTOM_OBJECT), self::equalTo('Example'), self::equalTo(['arg1']));
+
+        $statement->fetchAll(FetchMode::CUSTOM_OBJECT, 'Example', ['arg1']);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Currently using `FetchMode::CUSTOM_OBJECT` with constructor arguments doesn't work as the constructor arguments are silently dropped in the statement wrapper.
I had a look around and couldn't find any suggestion this is intentional, it's fixed in `master` as a by-product of  82f369f3ef99645991388cb979c6454bd9560ef2 so this PR proposes a fix for 2.*