### PR TITLE
Removing duplicate driver from get connection method documentation

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -98,7 +98,6 @@ final class DriverManager
      *     pdo_pgsql
      *     pdo_oci (unstable)
      *     pdo_sqlsrv
-     *     pdo_sqlsrv
      *     mysqli
      *     sqlanywhere
      *     sqlsrv


### PR DESCRIPTION
This is a very simple commit to remove a duplicate driver mentioned in the getConnection method of the DriverManager class. This is not a performance improvement or a bug fix, it's simply something I noticed duplicated in the PHPDocs of the method.