### PR TITLE
Deprecate the usage of the legacy platforms and drivers

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,23 @@
 # Upgrade to 2.11
 
+## Deprecated database platforms:
+
+1. PostgreSQL 9.3 and older
+2. MariaDB 10.0 and older
+3. SQL Server 2008 and older
+4. SQL Anywhere 12 and older
+5. Drizzle
+6. Azure SQL Database
+
+## Deprecated database drivers:
+
+1. PDO-based IBM DB2 driver
+2. Drizzle MySQL driver
+
+## Deprecated `Doctrine\DBAL\Sharding` package
+
+The sharding functionality in DBAL has been effectively unmaintained for a long time.
+
 ## Deprecated `Doctrine\DBAL\Version` class
 
 The usage of the `Doctrine\DBAL\Version` class is deprecated as internal implementation detail. Please refrain from checking the DBAL version at runtime.

--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -50,25 +50,25 @@ Oracle
 Microsoft SQL Server
 ^^^^^^^^^^^^^^^^^^^^
 
--  ``SQLServerPlatform`` for version 2000 and above.
--  ``SQLServer2005Platform`` for version 2005 and above.
--  ``SQLServer2008Platform`` for version 2008 and above.
+-  ``SQLServerPlatform`` for version 2000 and above (deprecated).
+-  ``SQLServer2005Platform`` for version 2005 and above (deprecated).
+-  ``SQLServer2008Platform`` for version 2008 and above (deprecated).
 -  ``SQLServer2012Platform`` for version 2012 and above.
 
 PostgreSQL
 ^^^^^^^^^^
 
--  ``PostgreSqlPlatform`` for all versions.
--  ``PostgreSQL91Platform`` for version 9.1 and above.
--  ``PostgreSQL92Platform`` for version 9.2 and above.
+-  ``PostgreSqlPlatform`` for version 9.0 and below (deprecated).
+-  ``PostgreSQL91Platform`` for version 9.1 and above (deprecated).
+-  ``PostgreSQL92Platform`` for version 9.2 and above (deprecated).
 -  ``PostgreSQL94Platform`` for version 9.4 and above.
 
 SAP Sybase SQL Anywhere
 ^^^^^^^^^^^^^^^^^^^^^^^
 
--  ``SQLAnywherePlatform`` for version 10 and above.
--  ``SQLAnywhere11Platform`` for version 11 and above.
--  ``SQLAnywhere12Platform`` for version 12 and above.
+-  ``SQLAnywherePlatform`` for version 10 and above (deprecated).
+-  ``SQLAnywhere11Platform`` for version 11 and above (deprecated).
+-  ``SQLAnywhere12Platform`` for version 12 and above (deprecated).
 -  ``SQLAnywhere16Platform`` for version 16 and above.
 
 SQLite
@@ -79,7 +79,7 @@ SQLite
 Drizzle
 ^^^^^^
 
--  ``DrizzlePlatform`` for all versions.
+-  ``DrizzlePlatform`` for all versions (deprecated).
 
 It is highly encouraged to use the platform class that matches your
 database vendor and version best. Otherwise it is not guaranteed
@@ -113,4 +113,3 @@ all the different database vendors, for example MySQL BIGINT and
 Oracle NUMBER should be handled as integer. Doctrine 2 offers a
 powerful way to abstract the database to php and back conversion,
 which is described in the next section.
-

--- a/lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Connection.php
@@ -5,6 +5,9 @@ namespace Doctrine\DBAL\Driver\DrizzlePDOMySql;
 use Doctrine\DBAL\Driver\PDOConnection;
 use Doctrine\DBAL\ParameterType;
 
+/**
+ * @deprecated
+ */
 class Connection extends PDOConnection
 {
     /**

--- a/lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Driver.php
@@ -7,6 +7,8 @@ use Doctrine\DBAL\Schema\DrizzleSchemaManager;
 
 /**
  * Drizzle driver using PDO MySql.
+ *
+ * @deprecated
  */
 class Driver extends \Doctrine\DBAL\Driver\PDOMySql\Driver
 {

--- a/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
@@ -7,6 +7,8 @@ use Doctrine\DBAL\Driver\PDOConnection;
 
 /**
  * Driver for the PDO IBM extension.
+ *
+ * @deprecated Use the driver based on the ibm_db2 extension instead.
  */
 class Driver extends AbstractDB2Driver
 {

--- a/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php
@@ -23,6 +23,8 @@ use function trim;
 
 /**
  * Drizzle platform
+ *
+ * @deprecated
  */
 class DrizzlePlatform extends AbstractPlatform
 {

--- a/lib/Doctrine/DBAL/Platforms/PostgreSQL91Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSQL91Platform.php
@@ -6,6 +6,8 @@ use function explode;
 
 /**
  * Provides the behavior, features and SQL dialect of the PostgreSQL 9.1 database platform.
+ *
+ * @deprecated Use PostgreSQL 9.4 or newer
  */
 class PostgreSQL91Platform extends PostgreSqlPlatform
 {

--- a/lib/Doctrine/DBAL/Platforms/PostgreSQL92Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSQL92Platform.php
@@ -7,6 +7,8 @@ use function sprintf;
 
 /**
  * Provides the behavior, features and SQL dialect of the PostgreSQL 9.2 database platform.
+ *
+ * @deprecated Use PostgreSQL 9.4 or newer
  */
 class PostgreSQL92Platform extends PostgreSQL91Platform
 {

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -35,6 +35,8 @@ use function trim;
 /**
  * PostgreSqlPlatform.
  *
+ * @deprecated Use PostgreSQL 9.4 or newer
+ *
  * @todo   Rename: PostgreSQLPlatform
  */
 class PostgreSqlPlatform extends AbstractPlatform

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywhere11Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywhere11Platform.php
@@ -5,6 +5,8 @@ namespace Doctrine\DBAL\Platforms;
 /**
  * The SQLAnywhere11Platform provides the behavior, features and SQL dialect of the
  * SAP Sybase SQL Anywhere 11 database platform.
+ *
+ * @deprecated Use SQLAnywhere 16 or newer
  */
 class SQLAnywhere11Platform extends SQLAnywherePlatform
 {

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywhere12Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywhere12Platform.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Schema\Sequence;
 /**
  * The SQLAnywhere12Platform provides the behavior, features and SQL dialect of the
  * SAP Sybase SQL Anywhere 12 database platform.
+ *
+ * @deprecated Use SQLAnywhere 16 or newer
  */
 class SQLAnywhere12Platform extends SQLAnywhere11Platform
 {

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -33,6 +33,8 @@ use function substr;
 /**
  * The SQLAnywherePlatform provides the behavior, features and SQL dialect of the
  * SAP Sybase SQL Anywhere 10 database platform.
+ *
+ * @deprecated Use SQLAnywhere 16 or newer
  */
 class SQLAnywherePlatform extends AbstractPlatform
 {

--- a/lib/Doctrine/DBAL/Platforms/SQLAzurePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAzurePlatform.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Schema\Table;
  * On top of SQL Server 2008 the following functionality is added:
  *
  * - Create tables with the FEDERATED ON syntax.
+ *
+ * @deprecated
  */
 class SQLAzurePlatform extends SQLServer2008Platform
 {

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2005Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2005Platform.php
@@ -15,6 +15,8 @@ namespace Doctrine\DBAL\Platforms;
  *   NVARCHAR(max) replace the old TEXT, NTEXT and IMAGE types. See
  *   {@link http://www.sql-server-helper.com/faq/sql-server-2005-varchar-max-p01.aspx}
  *   for more information.
+ *
+ * @deprecated Use SQL Server 2012 or newer
  */
 class SQLServer2005Platform extends SQLServerPlatform
 {

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Platforms;
  *
  * Differences to SQL Server 2005 and before are that a new DATETIME2 type was
  * introduced that has a higher precision.
+ *
+ * @deprecated Use SQL Server 2012 or newer
  */
 class SQLServer2008Platform extends SQLServer2005Platform
 {

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -38,6 +38,8 @@ use function substr_count;
 /**
  * The SQLServerPlatform provides the behavior, features and SQL dialect of the
  * Microsoft SQL Server database platform.
+ *
+ * @deprecated Use SQL Server 2012 or newer
  */
 class SQLServerPlatform extends AbstractPlatform
 {

--- a/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
@@ -32,6 +32,8 @@ use function is_string;
  *
  * Instantiation through the DriverManager looks like:
  *
+ * @deprecated
+ *
  * @example
  *
  * $conn = DriverManager::getConnection(array(

--- a/lib/Doctrine/DBAL/Sharding/PoolingShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardManager.php
@@ -7,6 +7,8 @@ use RuntimeException;
 
 /**
  * Shard Manager for the Connection Pooling Shard Strategy
+ *
+ * @deprecated
  */
 class PoolingShardManager implements ShardManager
 {

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizer.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureFederationsSynchronizer.php
@@ -20,6 +20,8 @@ use function array_merge;
  * by partitioning the passed schema into subschemas for the federation and the
  * global database and then applying the operations step by step using the
  * {@see \Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer}.
+ *
+ * @deprecated
  */
 class SQLAzureFederationsSynchronizer extends AbstractSchemaSynchronizer
 {

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
@@ -11,6 +11,8 @@ use function sprintf;
 
 /**
  * Sharding using the SQL Azure Federations support.
+ *
+ * @deprecated
  */
 class SQLAzureShardManager implements ShardManager
 {

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/Schema/MultiTenantVisitor.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/Schema/MultiTenantVisitor.php
@@ -30,6 +30,8 @@ use function in_array;
  *   (otherwise they will affect the same-id rows from other tenants as well).
  *   SQLAzure throws errors when you try to create IDENTIY columns on federated
  *   tables.
+ *
+ * @deprecated
  */
 class MultiTenantVisitor implements Visitor
 {

--- a/lib/Doctrine/DBAL/Sharding/ShardChoser/MultiTenantShardChoser.php
+++ b/lib/Doctrine/DBAL/Sharding/ShardChoser/MultiTenantShardChoser.php
@@ -7,6 +7,8 @@ use Doctrine\DBAL\Sharding\PoolingShardConnection;
 /**
  * The MultiTenant Shard choser assumes that the distribution value directly
  * maps to the shard id.
+ *
+ * @deprecated
  */
 class MultiTenantShardChoser implements ShardChoser
 {

--- a/lib/Doctrine/DBAL/Sharding/ShardChoser/ShardChoser.php
+++ b/lib/Doctrine/DBAL/Sharding/ShardChoser/ShardChoser.php
@@ -7,6 +7,8 @@ use Doctrine\DBAL\Sharding\PoolingShardConnection;
 /**
  * Given a distribution value this shard-choser strategy will pick the shard to
  * connect to for retrieving rows with the distribution value.
+ *
+ * @deprecated
  */
 interface ShardChoser
 {

--- a/lib/Doctrine/DBAL/Sharding/ShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/ShardManager.php
@@ -17,6 +17,8 @@ namespace Doctrine\DBAL\Sharding;
  * executed against the last shard that was selected. If a query is created for
  * a shard Y but then a shard X is selected when its actually executed you
  * will hit the wrong shard.
+ *
+ * @deprecated
  */
 interface ShardManager
 {

--- a/lib/Doctrine/DBAL/Sharding/ShardingException.php
+++ b/lib/Doctrine/DBAL/Sharding/ShardingException.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\DBALException;
 
 /**
  * Sharding related Exceptions
+ *
+ * @deprecated
  */
 class ShardingException extends DBALException
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Fixes #3855. The actual removal in DBAL 3.0 is being backported in #3906.