### PR TITLE
Fix error "Undefined index: COMMENTS"

### DIFF
--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -367,7 +367,10 @@ SQL;
         $sql = $platform->getListTableCommentsSQL($tableName);
 
         $tableOptions = $this->_conn->fetchAssoc($sql);
-        $table->addOption('comment', $tableOptions['COMMENTS']);
+        
+        $tableOptions = array_change_key_case($tableOptions, CASE_LOWER);
+
+        $table->addOption('comment', $tableOptions['comments']);
 
         return $table;
     }

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -368,9 +368,10 @@ SQL;
 
         $tableOptions = $this->_conn->fetchAssoc($sql);
         
-        $tableOptions = array_change_key_case($tableOptions, CASE_LOWER);
-
-        $table->addOption('comment', $tableOptions['comments']);
+        if ($tableOptions !== false) {
+            $tableOptionsLowerKeys = array_change_key_case($tableOptions, CASE_LOWER);
+            $table->addOption('comment', $tableOptionsLowerKeys['comments']);
+        }
 
         return $table;
     }

--- a/tests/Doctrine/Tests/DBAL/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/OracleSchemaManagerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Table;
+use PHPUnit\Framework\TestCase;
+
+class OracleSchemaManagerTest extends TestCase
+{
+    public function testListTableDetails() : void
+    {
+        $table = new Table('test');
+
+        self::assertFalse($table->hasOption('comment'));
+
+        $tableOptions = ['COMMENTS' => 'a comment'];
+        $tableOptionsLowerKeys = array_change_key_case($tableOptions, CASE_LOWER);
+        $table->addOption('comment', $tableOptionsLowerKeys['comments']);
+
+        self::assertTrue($table->hasOption('comment'));
+        self::assertEquals('a comment', $table->getComment());
+    }
+}


### PR DESCRIPTION
Inside "listTableDetails" function you are trying to access the "COMMENTS" index, but the correct way would be "comments". To be 100% sure, we always convert the keys to lower case.

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3877 
