### PR TITLE
Allow to configure the Comparator

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -20,13 +20,13 @@ use function strtolower;
  */
 class Comparator
 {
-    public const DETECT_COLUMN_RENAMINGS = 0b0001;
-    public const DETECT_INDEX_RENAMINGS  = 0b0010;
+    public const SKIP_COLUMN_RENAMING_DETECTION = 0b0001;
+    public const SKIP_INDEX_RENAMING_DETECTION  = 0b0010;
 
     /** @var int */
     private $flags;
 
-    public function __construct(int $flags = self::DETECT_COLUMN_RENAMINGS | self::DETECT_INDEX_RENAMINGS)
+    public function __construct(int $flags = 0)
     {
         $this->flags = $flags;
     }
@@ -238,9 +238,7 @@ class Comparator
             $changes++;
         }
 
-        if ($this->flags & self::DETECT_COLUMN_RENAMINGS) {
-            $this->detectColumnRenamings($tableDifferences);
-        }
+        $this->detectColumnRenamings($tableDifferences);
 
         $table1Indexes = $table1->getIndexes();
         $table2Indexes = $table2->getIndexes();
@@ -277,9 +275,7 @@ class Comparator
             $changes++;
         }
 
-        if ($this->flags & self::DETECT_INDEX_RENAMINGS) {
-            $this->detectIndexRenamings($tableDifferences);
-        }
+        $this->detectIndexRenamings($tableDifferences);
 
         $fromFkeys = $table1->getForeignKeys();
         $toFkeys   = $table2->getForeignKeys();
@@ -319,6 +315,10 @@ class Comparator
      */
     private function detectColumnRenamings(TableDiff $tableDifferences)
     {
+        if ($this->flags & self::SKIP_COLUMN_RENAMING_DETECTION) {
+            return;
+        }
+
         $renameCandidates = [];
         foreach ($tableDifferences->addedColumns as $addedColumnName => $addedColumn) {
             foreach ($tableDifferences->removedColumns as $removedColumn) {
@@ -359,6 +359,10 @@ class Comparator
      */
     private function detectIndexRenamings(TableDiff $tableDifferences)
     {
+        if ($this->flags & self::SKIP_INDEX_RENAMING_DETECTION) {
+            return;
+        }
+
         $renameCandidates = [];
 
         // Gather possible rename candidates by comparing each added and removed index based on semantics.

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -20,6 +20,17 @@ use function strtolower;
  */
 class Comparator
 {
+    public const DETECT_COLUMN_RENAMINGS = 0b0001;
+    public const DETECT_INDEX_RENAMINGS  = 0b0010;
+
+    /** @var int */
+    private $flags;
+
+    public function __construct(int $flags = self::DETECT_COLUMN_RENAMINGS | self::DETECT_INDEX_RENAMINGS)
+    {
+        $this->flags = $flags;
+    }
+
     /**
      * @return SchemaDiff
      */
@@ -227,7 +238,9 @@ class Comparator
             $changes++;
         }
 
-        $this->detectColumnRenamings($tableDifferences);
+        if ($this->flags & self::DETECT_COLUMN_RENAMINGS) {
+            $this->detectColumnRenamings($tableDifferences);
+        }
 
         $table1Indexes = $table1->getIndexes();
         $table2Indexes = $table2->getIndexes();
@@ -264,7 +277,9 @@ class Comparator
             $changes++;
         }
 
-        $this->detectIndexRenamings($tableDifferences);
+        if ($this->flags & self::DETECT_INDEX_RENAMINGS) {
+            $this->detectIndexRenamings($tableDifferences);
+        }
 
         $fromFkeys = $table1->getForeignKeys();
         $toFkeys   = $table2->getForeignKeys();

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -417,9 +417,9 @@ class Schema extends AbstractAsset
     /**
      * @return string[]
      */
-    public function getMigrateToSql(Schema $toSchema, AbstractPlatform $platform)
+    public function getMigrateToSql(Schema $toSchema, AbstractPlatform $platform, ?Comparator $comparator = null)
     {
-        $comparator = new Comparator();
+        $comparator = $comparator ?? new Comparator();
         $schemaDiff = $comparator->compare($this, $toSchema);
 
         return $schemaDiff->toSql($platform);
@@ -428,9 +428,9 @@ class Schema extends AbstractAsset
     /**
      * @return string[]
      */
-    public function getMigrateFromSql(Schema $fromSchema, AbstractPlatform $platform)
+    public function getMigrateFromSql(Schema $fromSchema, AbstractPlatform $platform, ?Comparator $comparator = null)
     {
-        $comparator = new Comparator();
+        $comparator = $comparator ?? new Comparator();
         $schemaDiff = $comparator->compare($fromSchema, $this);
 
         return $schemaDiff->toSql($platform);

--- a/src/Schema/Synchronizer/SingleDatabaseSynchronizer.php
+++ b/src/Schema/Synchronizer/SingleDatabaseSynchronizer.php
@@ -17,10 +17,14 @@ class SingleDatabaseSynchronizer extends AbstractSchemaSynchronizer
     /** @var AbstractPlatform */
     private $platform;
 
-    public function __construct(Connection $conn)
+    /** @var Comparator */
+    private $comparator;
+
+    public function __construct(Connection $conn, ?Comparator $comparator = null)
     {
         parent::__construct($conn);
-        $this->platform = $conn->getDatabasePlatform();
+        $this->platform   = $conn->getDatabasePlatform();
+        $this->comparator = $comparator ?? new Comparator();
     }
 
     /**
@@ -36,11 +40,10 @@ class SingleDatabaseSynchronizer extends AbstractSchemaSynchronizer
      */
     public function getUpdateSchema(Schema $toSchema, $noDrops = false)
     {
-        $comparator = new Comparator();
-        $sm         = $this->conn->getSchemaManager();
+        $sm = $this->conn->getSchemaManager();
 
         $fromSchema = $sm->createSchema();
-        $schemaDiff = $comparator->compare($fromSchema, $toSchema);
+        $schemaDiff = $this->comparator->compare($fromSchema, $toSchema);
 
         if ($noDrops) {
             return $schemaDiff->toSaveSql($this->platform);

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -737,7 +737,7 @@ class ComparatorTest extends TestCase
         $tableB = new Table('foo');
         $tableB->addColumn('bar', 'integer');
 
-        $c         = new Comparator(Comparator::DETECT_INDEX_RENAMINGS);
+        $c         = new Comparator(Comparator::SKIP_COLUMN_RENAMING_DETECTION);
         $tableDiff = $c->diffTable($tableA, $tableB);
 
         self::assertCount(1, $tableDiff->addedColumns);
@@ -811,7 +811,7 @@ class ComparatorTest extends TestCase
 
         $table2->addIndex(['foo'], 'idx_bar');
 
-        $comparator = new Comparator(Comparator::DETECT_COLUMN_RENAMINGS);
+        $comparator = new Comparator(Comparator::SKIP_INDEX_RENAMING_DETECTION);
         $tableDiff  = $comparator->diffTable($table1, $table2);
 
         self::assertCount(1, $tableDiff->addedIndexes);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #3661

#### Summary

As described in the related issue, we need to be able to stop DBAL from trying to detect column renamings.
