### PR TITLE
Error in listTableDetails of class PostgreSqlSchemaManager, when using uppercase letters in table name. 

### DIFF
--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -495,7 +495,8 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
 
         $platform = $this->_platform;
         assert($platform instanceof PostgreSQL94Platform);
-        $sql = $platform->getListTableMetadataSQL($tableName);
+        $tableIdentifier = new Identifier($tableName, true);
+        $sql = $platform->getListTableMetadataSQL($tableIdentifier->getQuotedName($platform));
 
         $tableOptions = $this->_conn->fetchAssoc($sql);
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -354,6 +354,25 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertNull($comparator->diffTable($offlineTable, $onlineTable));
     }
 
+
+    public function testListTableContainingUppercaseLetters() : void
+    {
+        $offlineTable = new Schema\Table('"public"."user_Users"');
+        $offlineTable->addColumn('id', 'integer');
+        $offlineTable->addColumn('username', 'string');
+        $offlineTable->addColumn('fk', 'integer');
+        $offlineTable->setPrimaryKey(['id']);
+        $offlineTable->addForeignKeyConstraint($offlineTable, ['fk'], ['id']);
+
+        $this->schemaManager->dropAndCreateTable($offlineTable);
+
+        $onlineTable = $this->schemaManager->listTableDetails('public.user_Users');
+
+        $comparator = new Schema\Comparator();
+
+        self::assertNull($comparator->diffTable($offlineTable, $onlineTable));
+    }
+
     public function testListTableDetailsWhenCurrentSchemaNameQuoted() : void
     {
         $this->connection->exec('CREATE SCHEMA "001_test"');


### PR DESCRIPTION
### Bug Report

|    Q        |   A
|------------ | ------
| BC Break    | ???
| Version     | 2.10.1

#### Summary

When I'm trying to retrive information about table which contains uppercase letters (for example user_Users) using method listTableDetails I've got this error:
```
Fatal error: Uncaught PDOException: SQLSTATE[42P01]: Undefined table: 7 BŁĄD: relacja "public.user_users" nie istnieje LINE 1: SELECT obj_description('public.user_Users'::regclass) AS tab... ^ in Doctrine\DBAL\Driver\AbstractPostgreSQLDriver.php on line 63

Doctrine\DBAL\Exception\TableNotFoundException: An exception occurred while executing 'SELECT obj_description('public.user_Users'::regclass) AS table_comment;': SQLSTATE[42P01]: Undefined table: 7 BŁĄD: relacja "public.user_users" nie istnieje LINE 1: SELECT obj_description('public.user_Users'::regclass) AS tab... ^ in \Doctrine\DBAL\Driver\AbstractPostgreSQLDriver.php on line 63

Trace:
1. Doctrine\DBAL\Schema\PostgreSqlSchemaManager->listTableDetails( ) | ...\UsersTable.php:134
2. Doctrine\DBAL\Connection->fetchAssoc( ) | ...\PostgreSqlSchemaManager.php:501
3. Doctrine\DBAL\Connection->executeQuery( ) | ...\Connection.php:553
```

In version v2.8.0 of doctrine/dbal everithing works fine. Problems ocurred after retriving information about table comment.

#### Current behaviour
Let assume that we've got table:
```sql
CREATE TABLE public."user_Users"
(
    "user_ID" integer NOT NULL,
    "user_Login" character varying(32) COLLATE pg_catalog."default" NOT NULL,
    "user_Name" character varying(100) COLLATE pg_catalog."default" NOT NULL,
    "user_Email" character varying(100) COLLATE pg_catalog."default" NOT NULL,
    "user_Password" character varying(100) COLLATE pg_catalog."default" NOT NULL,
    created_at timestamp(0) without time zone NOT NULL,
    updated_at timestamp(0) without time zone NOT NULL,
    CONSTRAINT "user_Users_pkey" PRIMARY KEY ("user_ID")
)
```

when i'm trying to get information about user_Users table in this way

```php
$conn->getSchemaManager()->listTableDetails("public.user_User");
```

then i've got this above error. When i quote table name:

```php
$conn->getSchemaManager()->listTableDetails('"public"."user_User"');
```
the details about table will looks like this. There is no information about columns, but there is table comment

```
Doctrine\DBAL\Schema\Table Object
(
    [_columns:protected] => Array  (  )
    [implicitIndexes:Doctrine\DBAL\Schema\Table:private] => Array  ( )
    [_indexes:protected] => Array  (  )
    [_primaryKeyName:protected] => 
    [_fkConstraints:protected] => Array   (   )
    [_options:protected] => Array  (
            [create_options] => Array ( )
            [comment] => Some comment
        )
    [_schemaConfig:protected] => 
    [_name:protected] => user_Users
    [_namespace:protected] => public
    [_quoted:protected] => 1
)
```
#### How to reproduce
Example code with error is here:

https://github.com/kotowszczak/dbal-pgsql-table-details-error




