### PR TITLE
Enable PHPStan strict rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
     "require-dev": {
         "doctrine/coding-standard": "^6.0",
         "jetbrains/phpstorm-stubs": "^2019.1",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^0.12.18",
+        "phpstan/phpstan-strict-rules": "^0.12.2",
         "phpunit/phpunit": "^9.0",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33232ba3c41c9de6f6bc60c784726991",
+    "content-hash": "194abb042dbd3732c1da46cf05ad7a07",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -876,7 +876,72 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-22T16:51:47+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-strict-rules",
+            "version": "0.12.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-strict-rules.git",
+                "reference": "a670a59aff7cf96f75d21b974860ada10e25b2ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/a670a59aff7cf96f75d21b974860ada10e25b2ee",
+                "reference": "a670a59aff7cf96f75d21b974860ada10e25b2ee",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1",
+                "phpstan/phpstan": "^0.12.6"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.0.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0",
+                "slevomat/coding-standard": "^4.5.2"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.12-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Extra strict and opinionated rules for PHPStan",
+            "time": "2020-01-20T13:08:52+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2444,5 +2509,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.3.0"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,7 @@ parameters:
         - %currentWorkingDirectory%/src
     autoload_files:
         - %currentWorkingDirectory%/tests/phpstan-polyfill.php
+    treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: false
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
@@ -72,3 +73,5 @@ parameters:
         -
             message: '~^Cannot cast array<string>\|bool\|string\|null to int\.$~'
             path: %currentWorkingDirectory%/src/Tools/Console/Command/RunSqlCommand.php
+includes:
+    - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -97,5 +97,11 @@ parameters:
                 - %currentWorkingDirectory%/src/Platforms/*Platform.php
                 - %currentWorkingDirectory%/src/Query/QueryBuilder.php
                 - %currentWorkingDirectory%/src/Schema/*SchemaManager.php
+
+        # FetchMode::CUSTOM_OBJECT requires variable property access
+        -
+            message: '~^Variable property access on object\.~'
+            paths:
+                - %currentWorkingDirectory%/src/Driver/*/*Statement.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -73,5 +73,10 @@ parameters:
         -
             message: '~^Cannot cast array<string>\|bool\|string\|null to int\.$~'
             path: %currentWorkingDirectory%/src/Tools/Console/Command/RunSqlCommand.php
+
+        # https://github.com/phpstan/phpstan/issues/3134
+        -
+            message: '~^Call to static method PHPUnit\\Framework\\Assert::assertSame\(\) with Doctrine\\DBAL\\Types\\Type and Doctrine\\DBAL\\Types\\Type will always evaluate to true\.$~'
+            path: %currentWorkingDirectory%/tests/Types/TypeRegistryTest.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -78,5 +78,15 @@ parameters:
         -
             message: '~^Call to static method PHPUnit\\Framework\\Assert::assertSame\(\) with Doctrine\\DBAL\\Types\\Type and Doctrine\\DBAL\\Types\\Type will always evaluate to true\.$~'
             path: %currentWorkingDirectory%/tests/Types/TypeRegistryTest.php
+
+        # https://github.com/phpstan/phpstan-strict-rules/issues/103
+        -
+            message: '~^Construct empty\(\) is not allowed. Use more strict comparison\.~'
+            paths:
+                - %currentWorkingDirectory%/src/Driver/*/*Connection.php
+                - %currentWorkingDirectory%/src/Driver/*/Driver.php
+                - %currentWorkingDirectory%/src/Driver/AbstractOracleDriver/EasyConnectString.php
+                - %currentWorkingDirectory%/src/Platforms/*Platform.php
+                - %currentWorkingDirectory%/src/Schema/*SchemaManager.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -88,5 +88,14 @@ parameters:
                 - %currentWorkingDirectory%/src/Driver/AbstractOracleDriver/EasyConnectString.php
                 - %currentWorkingDirectory%/src/Platforms/*Platform.php
                 - %currentWorkingDirectory%/src/Schema/*SchemaManager.php
+
+        # In some namespaces, we use array<string,mixed>, some elements of which are actually boolean
+        -
+            message: '~^Only booleans are allowed in .*, mixed given~'
+            paths:
+                - %currentWorkingDirectory%/src/Driver/*/Driver.php
+                - %currentWorkingDirectory%/src/Platforms/*Platform.php
+                - %currentWorkingDirectory%/src/Query/QueryBuilder.php
+                - %currentWorkingDirectory%/src/Schema/*SchemaManager.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -110,5 +110,11 @@ parameters:
             paths:
                 - %currentWorkingDirectory%/src/Schema/AbstractSchemaManager.php
                 - %currentWorkingDirectory%/src/Schema/Column.php
+
+        # https://github.com/phpstan/phpstan/issues/3146
+        -
+            message: '~^Only numeric types are allowed in -, int<1, max>\|false given on the left side\.~'
+            paths:
+                - %currentWorkingDirectory%/src/Platforms/SQLServer2012Platform.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -103,5 +103,12 @@ parameters:
             message: '~^Variable property access on object\.~'
             paths:
                 - %currentWorkingDirectory%/src/Driver/*/*Statement.php
+
+        # Some APIs use variable method calls internally
+        -
+            message: '~^Variable method call on .*~'
+            paths:
+                - %currentWorkingDirectory%/src/Schema/AbstractSchemaManager.php
+                - %currentWorkingDirectory%/src/Schema/Column.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/src/Cache/ArrayStatement.php
+++ b/src/Cache/ArrayStatement.php
@@ -32,7 +32,7 @@ class ArrayStatement implements IteratorAggregate, ResultStatement
     public function __construct(array $data)
     {
         $this->data = $data;
-        if (! count($data)) {
+        if (count($data) === 0) {
             return;
         }
 

--- a/src/Cache/ArrayStatement.php
+++ b/src/Cache/ArrayStatement.php
@@ -91,7 +91,7 @@ class ArrayStatement implements IteratorAggregate, ResultStatement
         }
 
         $row       = $this->data[$this->num++];
-        $fetchMode = $fetchMode ?: $this->defaultFetchMode;
+        $fetchMode = $fetchMode ?? $this->defaultFetchMode;
 
         if ($fetchMode === FetchMode::ASSOCIATIVE) {
             return $row;

--- a/src/Cache/ResultCacheStatement.php
+++ b/src/Cache/ResultCacheStatement.php
@@ -135,7 +135,7 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
         if ($row) {
             $this->data[] = $row;
 
-            $fetchMode = $fetchMode ?: $this->defaultFetchMode;
+            $fetchMode = $fetchMode ?? $this->defaultFetchMode;
 
             if ($fetchMode === FetchMode::ASSOCIATIVE) {
                 return $row;

--- a/src/Cache/ResultCacheStatement.php
+++ b/src/Cache/ResultCacheStatement.php
@@ -82,7 +82,7 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
         }
 
         $data = $this->resultCache->fetch($this->cacheKey);
-        if (! $data) {
+        if ($data === false) {
             $data = [];
         }
         $data[$this->realKey] = $this->data;
@@ -132,7 +132,7 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
 
         $row = $this->statement->fetch(FetchMode::ASSOCIATIVE);
 
-        if ($row) {
+        if ($row !== false) {
             $this->data[] = $row;
 
             $fetchMode = $fetchMode ?? $this->defaultFetchMode;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -72,14 +72,14 @@ class Configuration
      *
      * @deprecated Use Configuration::setSchemaAssetsFilter() instead
      *
-     * @param string $filterExpression
+     * @param string|null $filterExpression
      *
      * @return void
      */
     public function setFilterSchemaAssetsExpression($filterExpression)
     {
         $this->_attributes['filterSchemaAssetsExpression'] = $filterExpression;
-        if ($filterExpression) {
+        if ($filterExpression !== null) {
             $this->_attributes['filterSchemaAssetsExpressionCallable'] = $this->buildSchemaAssetsFilterFromExpression($filterExpression);
         } else {
             $this->_attributes['filterSchemaAssetsExpressionCallable'] = null;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -23,6 +23,7 @@ use Exception;
 use Throwable;
 use function array_key_exists;
 use function assert;
+use function count;
 use function implode;
 use function is_int;
 use function is_string;
@@ -420,7 +421,7 @@ class Connection implements DriverConnection
             try {
                 $this->connect();
             } catch (Throwable $originalException) {
-                if (empty($this->params['dbname'])) {
+                if (! isset($this->params['dbname'])) {
                     throw $originalException;
                 }
 
@@ -647,7 +648,7 @@ class Connection implements DriverConnection
      */
     public function delete($tableExpression, array $identifier, array $types = [])
     {
-        if (empty($identifier)) {
+        if (count($identifier) === 0) {
             throw InvalidArgumentException::fromEmptyCriteria();
         }
 
@@ -753,7 +754,7 @@ class Connection implements DriverConnection
      */
     public function insert($tableExpression, array $data, array $types = [])
     {
-        if (empty($data)) {
+        if (count($data) === 0) {
             return $this->executeUpdate('INSERT INTO ' . $tableExpression . ' () VALUES ()');
         }
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -197,11 +197,11 @@ class Connection implements DriverConnection
         }
 
         // Create default config and event manager if none given
-        if (! $config) {
+        if ($config === null) {
             $config = new Configuration();
         }
 
-        if (! $eventManager) {
+        if ($eventManager === null) {
             $eventManager = new EventManager();
         }
 
@@ -884,16 +884,16 @@ class Connection implements DriverConnection
         $connection = $this->getWrappedConnection();
 
         $logger = $this->_config->getSQLLogger();
-        if ($logger) {
+        if ($logger !== null) {
             $logger->startQuery($query, $params, $types);
         }
 
         try {
-            if ($params) {
+            if (count($params) > 0) {
                 [$query, $params, $types] = SQLParserUtils::expandListParameters($query, $params, $types);
 
                 $stmt = $connection->prepare($query);
-                if ($types) {
+                if (count($types) > 0) {
                     $this->_bindTypedValues($stmt, $params, $types);
                     $stmt->execute();
                 } else {
@@ -908,7 +908,7 @@ class Connection implements DriverConnection
 
         $stmt->setFetchMode($this->defaultFetchMode);
 
-        if ($logger) {
+        if ($logger !== null) {
             $logger->stopQuery();
         }
 
@@ -993,7 +993,7 @@ class Connection implements DriverConnection
         $connection = $this->getWrappedConnection();
 
         $logger = $this->_config->getSQLLogger();
-        if ($logger) {
+        if ($logger !== null) {
             $logger->startQuery($sql);
         }
 
@@ -1005,7 +1005,7 @@ class Connection implements DriverConnection
 
         $statement->setFetchMode($this->defaultFetchMode);
 
-        if ($logger) {
+        if ($logger !== null) {
             $logger->stopQuery();
         }
 
@@ -1029,17 +1029,17 @@ class Connection implements DriverConnection
         $connection = $this->getWrappedConnection();
 
         $logger = $this->_config->getSQLLogger();
-        if ($logger) {
+        if ($logger !== null) {
             $logger->startQuery($query, $params, $types);
         }
 
         try {
-            if ($params) {
+            if (count($params) > 0) {
                 [$query, $params, $types] = SQLParserUtils::expandListParameters($query, $params, $types);
 
                 $stmt = $connection->prepare($query);
 
-                if ($types) {
+                if (count($types) > 0) {
                     $this->_bindTypedValues($stmt, $params, $types);
                     $stmt->execute();
                 } else {
@@ -1053,7 +1053,7 @@ class Connection implements DriverConnection
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $query, $this->resolveParams($params, $types));
         }
 
-        if ($logger) {
+        if ($logger !== null) {
             $logger->stopQuery();
         }
 
@@ -1068,7 +1068,7 @@ class Connection implements DriverConnection
         $connection = $this->getWrappedConnection();
 
         $logger = $this->_config->getSQLLogger();
-        if ($logger) {
+        if ($logger !== null) {
             $logger->startQuery($statement);
         }
 
@@ -1078,7 +1078,7 @@ class Connection implements DriverConnection
             throw DBALException::driverExceptionDuringQuery($this->_driver, $ex, $statement);
         }
 
-        if ($logger) {
+        if ($logger !== null) {
             $logger->stopQuery();
         }
 
@@ -1217,21 +1217,21 @@ class Connection implements DriverConnection
         $logger = $this->_config->getSQLLogger();
 
         if ($this->transactionNestingLevel === 1) {
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->startQuery('"START TRANSACTION"');
             }
 
             $connection->beginTransaction();
 
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->stopQuery();
             }
         } elseif ($this->nestTransactionsWithSavepoints) {
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->startQuery('"SAVEPOINT"');
             }
             $this->createSavepoint($this->_getNestedTransactionSavePointName());
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->stopQuery();
             }
         }
@@ -1261,21 +1261,21 @@ class Connection implements DriverConnection
         $logger = $this->_config->getSQLLogger();
 
         if ($this->transactionNestingLevel === 1) {
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->startQuery('"COMMIT"');
             }
 
             $result = $connection->commit();
 
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->stopQuery();
             }
         } elseif ($this->nestTransactionsWithSavepoints) {
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->startQuery('"RELEASE SAVEPOINT"');
             }
             $this->releaseSavepoint($this->_getNestedTransactionSavePointName());
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->stopQuery();
             }
         }
@@ -1327,13 +1327,13 @@ class Connection implements DriverConnection
         $logger = $this->_config->getSQLLogger();
 
         if ($this->transactionNestingLevel === 1) {
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->startQuery('"ROLLBACK"');
             }
             $this->transactionNestingLevel = 0;
             $connection->rollBack();
             $this->isRollbackOnly = false;
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->stopQuery();
             }
 
@@ -1341,12 +1341,12 @@ class Connection implements DriverConnection
                 $this->beginTransaction();
             }
         } elseif ($this->nestTransactionsWithSavepoints) {
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->startQuery('"ROLLBACK TO SAVEPOINT"');
             }
             $this->rollbackSavepoint($this->_getNestedTransactionSavePointName());
             --$this->transactionNestingLevel;
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->stopQuery();
             }
         } else {

--- a/src/Connections/MasterSlaveConnection.php
+++ b/src/Connections/MasterSlaveConnection.php
@@ -128,7 +128,7 @@ class MasterSlaveConnection extends Connection
     public function connect($connectionName = null)
     {
         $requestedConnectionChange = ($connectionName !== null);
-        $connectionName            = $connectionName ?: 'slave';
+        $connectionName            = $connectionName ?? 'slave';
 
         if ($connectionName !== 'slave' && $connectionName !== 'master') {
             throw new InvalidArgumentException('Invalid option to connect(), only master or slave allowed.');

--- a/src/Connections/MasterSlaveConnection.php
+++ b/src/Connections/MasterSlaveConnection.php
@@ -351,7 +351,7 @@ class MasterSlaveConnection extends Connection
         assert($this->_conn instanceof DriverConnection);
 
         $logger = $this->getConfiguration()->getSQLLogger();
-        if ($logger) {
+        if ($logger !== null) {
             $logger->startQuery($sql);
         }
 
@@ -359,7 +359,7 @@ class MasterSlaveConnection extends Connection
 
         $statement->setFetchMode($this->defaultFetchMode);
 
-        if ($logger) {
+        if ($logger !== null) {
             $logger->stopQuery();
         }
 

--- a/src/DBALException.php
+++ b/src/DBALException.php
@@ -180,7 +180,7 @@ class DBALException extends Exception
      */
     private static function formatParameters(array $params)
     {
-        return '[' . implode(', ', array_map(static function ($param) {
+        return '[' . implode(', ', array_map(static function ($param) : string {
             if (is_resource($param)) {
                 return (string) $param;
             }

--- a/src/DBALException.php
+++ b/src/DBALException.php
@@ -11,6 +11,7 @@ use Exception;
 use Throwable;
 use function array_map;
 use function bin2hex;
+use function count;
 use function get_class;
 use function gettype;
 use function implode;
@@ -103,7 +104,7 @@ class DBALException extends Exception
      */
     public static function driverRequired($url = null)
     {
-        if ($url) {
+        if ($url !== null) {
             return new self(
                 sprintf(
                     "The options 'driver' or 'driverClass' are mandatory if a connection URL without scheme " .
@@ -138,7 +139,7 @@ class DBALException extends Exception
     public static function driverExceptionDuringQuery(Driver $driver, Throwable $driverEx, $sql, array $params = [])
     {
         $msg = "An exception occurred while executing '" . $sql . "'";
-        if ($params) {
+        if (count($params) > 0) {
             $msg .= ' with params ' . self::formatParameters($params);
         }
         $msg .= ":\n\n" . $driverEx->getMessage();

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -140,11 +140,11 @@ abstract class AbstractMySQLDriver implements ExceptionConverterDriver, VersionA
      */
     private function getOracleMysqlVersionNumber(string $versionString) : string
     {
-        if (! preg_match(
+        if (preg_match(
             '/^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?/',
             $versionString,
             $versionParts
-        )) {
+        ) === 0) {
             throw DBALException::invalidPlatformVersionSpecified(
                 $versionString,
                 '<major_version>.<minor_version>.<patch_version>'
@@ -171,11 +171,11 @@ abstract class AbstractMySQLDriver implements ExceptionConverterDriver, VersionA
      */
     private function getMariaDbMysqlVersionNumber(string $versionString) : string
     {
-        if (! preg_match(
+        if (preg_match(
             '/^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)/i',
             $versionString,
             $versionParts
-        )) {
+        ) === 0) {
             throw DBALException::invalidPlatformVersionSpecified(
                 $versionString,
                 '^(?:5\.5\.5-)?(mariadb-)?<major_version>.<minor_version>.<patch_version>'

--- a/src/Driver/AbstractOracleDriver/EasyConnectString.php
+++ b/src/Driver/AbstractOracleDriver/EasyConnectString.php
@@ -45,11 +45,11 @@ final class EasyConnectString
      */
     public static function fromConnectionParameters(array $params) : self
     {
-        if (! empty($params['connectstring'])) {
+        if (isset($params['connectstring'])) {
             return new self($params['connectstring']);
         }
 
-        if (empty($params['host'])) {
+        if (! isset($params['host'])) {
             return new self($params['dbname'] ?? '');
         }
 
@@ -58,7 +58,7 @@ final class EasyConnectString
         if (isset($params['servicename']) || isset($params['dbname'])) {
             $serviceKey = 'SID';
 
-            if (! empty($params['service'])) {
+            if (isset($params['service'])) {
                 $serviceKey = 'SERVICE_NAME';
             }
 
@@ -67,7 +67,7 @@ final class EasyConnectString
             $connectData[$serviceKey] = $serviceName;
         }
 
-        if (! empty($params['instancename'])) {
+        if (isset($params['instancename'])) {
             $connectData['INSTANCE_NAME'] = $params['instancename'];
         }
 

--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -80,7 +80,7 @@ abstract class AbstractPostgreSQLDriver implements ExceptionConverterDriver, Ver
      */
     public function createDatabasePlatformForVersion($version)
     {
-        if (! preg_match('/^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?/', $version, $versionParts)) {
+        if (preg_match('/^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?/', $version, $versionParts) === 0) {
             throw DBALException::invalidPlatformVersionSpecified(
                 $version,
                 '<major_version>.<minor_version>.<patch_version>'

--- a/src/Driver/AbstractSQLAnywhereDriver.php
+++ b/src/Driver/AbstractSQLAnywhereDriver.php
@@ -65,11 +65,11 @@ abstract class AbstractSQLAnywhereDriver implements ExceptionConverterDriver, Ve
      */
     public function createDatabasePlatformForVersion($version)
     {
-        if (! preg_match(
+        if (preg_match(
             '/^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+)(?:\.(?P<build>\d+))?)?)?/',
             $version,
             $versionParts
-        )) {
+        ) === 0) {
             throw DBALException::invalidPlatformVersionSpecified(
                 $version,
                 '<major_version>.<minor_version>.<patch_version>.<build_version>'

--- a/src/Driver/IBMDB2/DB2Connection.php
+++ b/src/Driver/IBMDB2/DB2Connection.php
@@ -81,7 +81,7 @@ class DB2Connection implements ServerInfoAwareConnection
     public function prepare(string $sql) : DriverStatement
     {
         $stmt = @db2_prepare($this->conn, $sql);
-        if (! $stmt) {
+        if ($stmt === false) {
             throw new DB2Exception(db2_stmt_errormsg());
         }
 

--- a/src/Driver/IBMDB2/DB2Statement.php
+++ b/src/Driver/IBMDB2/DB2Statement.php
@@ -160,7 +160,13 @@ class DB2Statement implements IteratorAggregate, Statement
      */
     public function columnCount()
     {
-        return db2_num_fields($this->stmt) ?: 0;
+        $count = db2_num_fields($this->stmt);
+
+        if ($count !== false) {
+            return $count;
+        }
+
+        return 0;
     }
 
     /**
@@ -261,7 +267,7 @@ class DB2Statement implements IteratorAggregate, Statement
             return false;
         }
 
-        $fetchMode = $fetchMode ?: $this->defaultFetchMode;
+        $fetchMode = $fetchMode ?? $this->defaultFetchMode;
         switch ($fetchMode) {
             case FetchMode::COLUMN:
                 return $this->fetchColumn();
@@ -346,7 +352,7 @@ class DB2Statement implements IteratorAggregate, Statement
      */
     public function rowCount() : int
     {
-        return @db2_num_rows($this->stmt) ? : 0;
+        return @db2_num_rows($this->stmt);
     }
 
     /**

--- a/src/Driver/IBMDB2/DB2Statement.php
+++ b/src/Driver/IBMDB2/DB2Statement.php
@@ -18,6 +18,7 @@ use const DB2_LONG;
 use const DB2_PARAM_FILE;
 use const DB2_PARAM_IN;
 use function array_change_key_case;
+use function assert;
 use function count;
 use function db2_bind_param;
 use function db2_execute;
@@ -34,6 +35,7 @@ use function error_get_last;
 use function fclose;
 use function fwrite;
 use function gettype;
+use function is_int;
 use function is_object;
 use function is_resource;
 use function is_string;
@@ -97,6 +99,8 @@ class DB2Statement implements IteratorAggregate, Statement
      */
     public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null)
     {
+        assert(is_int($column));
+
         switch ($type) {
             case ParameterType::INTEGER:
                 $this->bind($column, $variable, DB2_PARAM_IN, DB2_LONG);

--- a/src/Driver/Mysqli/MysqliConnection.php
+++ b/src/Driver/Mysqli/MysqliConnection.php
@@ -63,8 +63,10 @@ class MysqliConnection implements PingableConnection, ServerInfoAwareConnection
         $this->setSecureConnection($params);
         $this->setDriverOptions($driverOptions);
 
-        set_error_handler(static function () {
+        set_error_handler(static function () : bool {
+            return true;
         });
+
         try {
             if (! $this->conn->real_connect($host, $username, $password, $dbname, $port, $socket, $flags)) {
                 throw new MysqliException($this->conn->connect_error, $this->conn->sqlstate ?? 'HY000', $this->conn->connect_errno);

--- a/src/Driver/Mysqli/MysqliStatement.php
+++ b/src/Driver/Mysqli/MysqliStatement.php
@@ -314,7 +314,7 @@ class MysqliStatement implements IteratorAggregate, Statement
             return false;
         }
 
-        $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
+        $fetchMode = $fetchMode ?? $this->_defaultFetchMode;
 
         if ($fetchMode === FetchMode::COLUMN) {
             return $this->fetchColumn();
@@ -358,7 +358,7 @@ class MysqliStatement implements IteratorAggregate, Statement
      */
     public function fetchAll($fetchMode = null, ...$args)
     {
-        $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
+        $fetchMode = $fetchMode ?? $this->_defaultFetchMode;
 
         $rows = [];
 

--- a/src/Driver/OCI8/OCI8Connection.php
+++ b/src/Driver/OCI8/OCI8Connection.php
@@ -80,7 +80,7 @@ class OCI8Connection implements Connection, ServerInfoAwareConnection
             throw OCI8Exception::fromErrorInfo(oci_error($this->dbh));
         }
 
-        if (! preg_match('/\s+(\d+\.\d+\.\d+\.\d+\.\d+)\s+/', $version, $matches)) {
+        if (preg_match('/\s+(\d+\.\d+\.\d+\.\d+\.\d+)\s+/', $version, $matches) === 0) {
             throw new UnexpectedValueException(
                 sprintf(
                     'Unexpected database version string "%s". Cannot parse an appropriate version number from it. ' .

--- a/src/Driver/OCI8/OCI8Statement.php
+++ b/src/Driver/OCI8/OCI8Statement.php
@@ -291,7 +291,7 @@ class OCI8Statement implements IteratorAggregate, Statement
             $class = 'OCI-Lob';
             assert($lob instanceof $class);
 
-            $lob->writeTemporary($variable, OCI_TEMP_BLOB);
+            $lob->writetemporary($variable, OCI_TEMP_BLOB);
 
             $variable =& $lob;
         }

--- a/src/Driver/OCI8/OCI8Statement.php
+++ b/src/Driver/OCI8/OCI8Statement.php
@@ -191,7 +191,7 @@ class OCI8Statement implements IteratorAggregate, Statement
     ) {
         $token = self::findToken($statement, $tokenOffset, '/[?\'"]/');
 
-        if (! $token) {
+        if ($token === null) {
             return false;
         }
 
@@ -233,7 +233,7 @@ class OCI8Statement implements IteratorAggregate, Statement
             '/' . preg_quote($currentLiteralDelimiter, '/') . '/'
         );
 
-        if (! $token) {
+        if ($token === null) {
             return false;
         }
 
@@ -255,7 +255,7 @@ class OCI8Statement implements IteratorAggregate, Statement
      */
     private static function findToken($statement, &$offset, $regex)
     {
-        if (preg_match($regex, $statement, $matches, PREG_OFFSET_CAPTURE, $offset)) {
+        if (preg_match($regex, $statement, $matches, PREG_OFFSET_CAPTURE, $offset) === 1) {
             $offset = $matches[0][1];
 
             return $matches[0][0];
@@ -387,9 +387,8 @@ class OCI8Statement implements IteratorAggregate, Statement
      */
     public function execute($params = null)
     {
-        if ($params) {
+        if ($params !== null) {
             $hasZeroIndex = array_key_exists(0, $params);
-
             foreach ($params as $key => $val) {
                 if ($hasZeroIndex && is_int($key)) {
                     $this->bindValue($key + 1, $val);

--- a/src/Driver/OCI8/OCI8Statement.php
+++ b/src/Driver/OCI8/OCI8Statement.php
@@ -346,7 +346,13 @@ class OCI8Statement implements IteratorAggregate, Statement
      */
     public function columnCount()
     {
-        return oci_num_fields($this->_sth) ?: 0;
+        $count = oci_num_fields($this->_sth);
+
+        if ($count !== false) {
+            return $count;
+        }
+
+        return 0;
     }
 
     /**
@@ -432,7 +438,7 @@ class OCI8Statement implements IteratorAggregate, Statement
             return false;
         }
 
-        $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
+        $fetchMode = $fetchMode ?? $this->_defaultFetchMode;
 
         if ($fetchMode === FetchMode::COLUMN) {
             return $this->fetchColumn();
@@ -457,7 +463,7 @@ class OCI8Statement implements IteratorAggregate, Statement
      */
     public function fetchAll($fetchMode = null, ...$args)
     {
-        $fetchMode = $fetchMode ?: $this->_defaultFetchMode;
+        $fetchMode = $fetchMode ?? $this->_defaultFetchMode;
 
         $result = [];
 
@@ -531,6 +537,12 @@ class OCI8Statement implements IteratorAggregate, Statement
      */
     public function rowCount() : int
     {
-        return oci_num_rows($this->_sth) ?: 0;
+        $count = oci_num_rows($this->_sth);
+
+        if ($count !== false) {
+            return $count;
+        }
+
+        return 0;
     }
 }

--- a/src/Driver/PDOSqlsrv/Driver.php
+++ b/src/Driver/PDOSqlsrv/Driver.php
@@ -55,7 +55,7 @@ class Driver extends AbstractSQLServerDriver
             $dsn .= $params['host'];
         }
 
-        if (isset($params['port']) && ! empty($params['port'])) {
+        if (isset($params['port'])) {
             $dsn .= ',' . $params['port'];
         }
 

--- a/src/Driver/SQLAnywhere/Driver.php
+++ b/src/Driver/SQLAnywhere/Driver.php
@@ -51,22 +51,22 @@ class Driver extends AbstractSQLAnywhereDriver
     /**
      * Build the connection string for given connection parameters and driver options.
      *
-     * @param string  $host          Host address to connect to.
-     * @param int     $port          Port to use for the connection (default to SQL Anywhere standard port 2638).
-     * @param string  $server        Database server name on the host to connect to.
-     *                               SQL Anywhere allows multiple database server instances on the same host,
-     *                               therefore specifying the server instance name to use is mandatory.
-     * @param string  $dbname        Name of the database on the server instance to connect to.
-     * @param string  $username      User name to use for connection authentication.
-     * @param string  $password      Password to use for connection authentication.
-     * @param mixed[] $driverOptions Additional parameters to use for the connection.
+     * @param string|null $host          Host address to connect to.
+     * @param int|null    $port          Port to use for the connection (default to SQL Anywhere standard port 2638).
+     * @param string|null $server        Database server name on the host to connect to.
+     *                                   SQL Anywhere allows multiple database server instances on the same host,
+     *                                   therefore specifying the server instance name to use is mandatory.
+     * @param string|null $dbname        Name of the database on the server instance to connect to.
+     * @param string|null $username      User name to use for connection authentication.
+     * @param string|null $password      Password to use for connection authentication.
+     * @param mixed[]     $driverOptions Additional parameters to use for the connection.
      *
      * @return string
      */
     private function buildDsn($host, $port, $server, $dbname, $username = null, $password = null, array $driverOptions = [])
     {
-        $host = $host ?: 'localhost';
-        $port = $port ?: 2638;
+        $host = $host ?? 'localhost';
+        $port = $port ?? 2638;
 
         if (! empty($server)) {
             $server = ';ServerName=' . $server;

--- a/src/Driver/SQLAnywhere/Driver.php
+++ b/src/Driver/SQLAnywhere/Driver.php
@@ -79,7 +79,7 @@ class Driver extends AbstractSQLAnywhereDriver
             ';PWD=' . $password .
             ';' . implode(
                 ';',
-                array_map(static function ($key, $value) {
+                array_map(static function ($key, $value) : string {
                     return $key . '=' . $value;
                 }, array_keys($driverOptions), $driverOptions)
             );

--- a/src/Driver/SQLAnywhere/SQLAnywhereException.php
+++ b/src/Driver/SQLAnywhere/SQLAnywhereException.php
@@ -27,14 +27,14 @@ class SQLAnywhereException extends AbstractDriverException
      */
     public static function fromSQLAnywhereError($conn = null, $stmt = null)
     {
-        $state   = $conn ? sasql_sqlstate($conn) : sasql_sqlstate();
-        $code    = null;
+        $state   = $conn !== null ? sasql_sqlstate($conn) : sasql_sqlstate();
+        $code    = 0;
         $message = null;
 
         /**
          * Try retrieving the last error from statement resource if given
          */
-        if ($stmt) {
+        if ($stmt !== null) {
             $code    = sasql_stmt_errno($stmt);
             $message = sasql_stmt_error($stmt);
         }
@@ -47,7 +47,7 @@ class SQLAnywhereException extends AbstractDriverException
          * it from the connection resource even though it occurred during
          * a prepared statement.
          */
-        if ($conn && ! $code) {
+        if ($conn !== null && $code === 0) {
             $code    = sasql_errorcode($conn);
             $message = sasql_error($conn);
         }
@@ -57,7 +57,7 @@ class SQLAnywhereException extends AbstractDriverException
          * or the last error could not be retrieved from the given
          * connection / statement resource.
          */
-        if (! $conn || ! $code) {
+        if ($conn === null || $code === 0) {
             $code    = sasql_errorcode();
             $message = sasql_error();
         }

--- a/src/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/src/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -14,7 +14,6 @@ use const SASQL_BOTH;
 use function array_key_exists;
 use function count;
 use function gettype;
-use function is_array;
 use function is_int;
 use function is_object;
 use function is_resource;
@@ -171,7 +170,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
      */
     public function execute($params = null)
     {
-        if (is_array($params)) {
+        if ($params !== null) {
             $hasZeroIndex = array_key_exists(0, $params);
 
             foreach ($params as $key => $val) {

--- a/src/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/src/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -51,7 +51,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
     /** @var int Default fetch mode to use. */
     private $defaultFetchMode = FetchMode::MIXED;
 
-    /** @var resource The result set resource to fetch. */
+    /** @var resource|null The result set resource to fetch. */
     private $result;
 
     /** @var resource The prepared SQL statement to execute. */

--- a/src/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/src/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -203,7 +203,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
             return false;
         }
 
-        $fetchMode = $fetchMode ?: $this->defaultFetchMode;
+        $fetchMode = $fetchMode ?? $this->defaultFetchMode;
 
         switch ($fetchMode) {
             case FetchMode::COLUMN:

--- a/src/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/src/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -12,6 +12,7 @@ use ReflectionObject;
 use stdClass;
 use const SASQL_BOTH;
 use function array_key_exists;
+use function assert;
 use function count;
 use function gettype;
 use function is_int;
@@ -88,6 +89,8 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement
      */
     public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null)
     {
+        assert(is_int($column));
+
         switch ($type) {
             case ParameterType::INTEGER:
             case ParameterType::BOOLEAN:

--- a/src/Driver/SQLSrv/SQLSrvConnection.php
+++ b/src/Driver/SQLSrv/SQLSrvConnection.php
@@ -184,7 +184,7 @@ class SQLSrvConnection implements ServerInfoAwareConnection
     public function errorCode()
     {
         $errors = sqlsrv_errors(SQLSRV_ERR_ERRORS);
-        if ($errors) {
+        if ($errors !== null) {
             return $errors[0]['code'];
         }
 

--- a/src/Driver/SQLSrv/SQLSrvException.php
+++ b/src/Driver/SQLSrv/SQLSrvException.php
@@ -34,7 +34,7 @@ class SQLSrvException extends AbstractDriverException
             $errorCode = $error['code'];
         }
 
-        if (! $message) {
+        if ($message === '') {
             $message = 'SQL Server error occurred but no error message was retrieved from driver.';
         }
 

--- a/src/Driver/SQLSrv/SQLSrvStatement.php
+++ b/src/Driver/SQLSrv/SQLSrvStatement.php
@@ -209,7 +209,13 @@ class SQLSrvStatement implements IteratorAggregate, Statement
             return 0;
         }
 
-        return sqlsrv_num_fields($this->stmt) ?: 0;
+        $count = sqlsrv_num_fields($this->stmt);
+
+        if ($count !== false) {
+            return $count;
+        }
+
+        return 0;
     }
 
     /**
@@ -353,14 +359,14 @@ class SQLSrvStatement implements IteratorAggregate, Statement
             return false;
         }
 
-        $fetchMode = $fetchMode ?: $this->defaultFetchMode;
+        $fetchMode = $fetchMode ?? $this->defaultFetchMode;
 
         if ($fetchMode === FetchMode::COLUMN) {
             return $this->fetchColumn();
         }
 
         if (isset(self::$fetchMap[$fetchMode])) {
-            return sqlsrv_fetch_array($this->stmt, self::$fetchMap[$fetchMode]) ?: false;
+            return sqlsrv_fetch_array($this->stmt, self::$fetchMap[$fetchMode]) ?? false;
         }
 
         if (in_array($fetchMode, [FetchMode::STANDARD_OBJECT, FetchMode::CUSTOM_OBJECT], true)) {
@@ -372,7 +378,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
                 $ctorArgs  = $args[1] ?? [];
             }
 
-            return sqlsrv_fetch_object($this->stmt, $className, $ctorArgs) ?: false;
+            return sqlsrv_fetch_object($this->stmt, $className, $ctorArgs) ?? false;
         }
 
         throw new SQLSrvException('Fetch mode is not supported!');
@@ -430,6 +436,12 @@ class SQLSrvStatement implements IteratorAggregate, Statement
             return 0;
         }
 
-        return sqlsrv_rows_affected($this->stmt) ?: 0;
+        $count = sqlsrv_rows_affected($this->stmt);
+
+        if ($count !== false) {
+            return $count;
+        }
+
+        return 0;
     }
 }

--- a/src/Driver/SQLSrv/SQLSrvStatement.php
+++ b/src/Driver/SQLSrv/SQLSrvStatement.php
@@ -224,7 +224,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
     public function errorCode()
     {
         $errors = sqlsrv_errors(SQLSRV_ERR_ERRORS);
-        if ($errors) {
+        if ($errors !== null) {
             return $errors[0]['code'];
         }
 
@@ -244,9 +244,8 @@ class SQLSrvStatement implements IteratorAggregate, Statement
      */
     public function execute($params = null)
     {
-        if ($params) {
+        if ($params !== null) {
             $hasZeroIndex = array_key_exists(0, $params);
-
             foreach ($params as $key => $val) {
                 if ($hasZeroIndex && is_int($key)) {
                     $this->bindValue($key + 1, $val);
@@ -256,7 +255,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
             }
         }
 
-        if (! $this->stmt) {
+        if ($this->stmt === null) {
             $this->stmt = $this->prepare();
         }
 
@@ -264,7 +263,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
             throw SQLSrvException::fromSqlSrvErrors();
         }
 
-        if ($this->lastInsertId) {
+        if ($this->lastInsertId !== null) {
             sqlsrv_next_result($this->stmt);
             sqlsrv_fetch($this->stmt);
             $this->lastInsertId->setId(sqlsrv_get_field($this->stmt, 0));
@@ -313,7 +312,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement
 
         $stmt = sqlsrv_prepare($this->conn, $this->sql, $params);
 
-        if (! $stmt) {
+        if ($stmt === false) {
             throw SQLSrvException::fromSqlSrvErrors();
         }
 

--- a/src/Driver/Statement.php
+++ b/src/Driver/Statement.php
@@ -19,12 +19,12 @@ interface Statement extends ResultStatement
      * As mentioned above, the named parameters are not natively supported by the mysqli driver, use executeQuery(),
      * fetchAll(), fetchArray(), fetchColumn(), fetchAssoc() methods to have the named parameter emulated by doctrine.
      *
-     * @param mixed $param Parameter identifier. For a prepared statement using named placeholders,
-     *                     this will be a parameter name of the form :name. For a prepared statement
-     *                     using question mark placeholders, this will be the 1-indexed position of the parameter.
-     * @param mixed $value The value to bind to the parameter.
-     * @param int   $type  Explicit data type for the parameter using the {@link \Doctrine\DBAL\ParameterType}
-     *                     constants.
+     * @param string|int $param Parameter identifier. For a prepared statement using named placeholders,
+     *                          this will be a parameter name of the form :name. For a prepared statement
+     *                          using question mark placeholders, this will be the 1-indexed position of the parameter.
+     * @param mixed      $value The value to bind to the parameter.
+     * @param int        $type  Explicit data type for the parameter using the {@link \Doctrine\DBAL\ParameterType}
+     *                          constants.
      *
      * @return bool TRUE on success or FALSE on failure.
      */
@@ -44,14 +44,14 @@ interface Statement extends ResultStatement
      * of stored procedures that return data as output parameters, and some also as input/output
      * parameters that both send in data and are updated to receive it.
      *
-     * @param mixed    $column   Parameter identifier. For a prepared statement using named placeholders,
-     *                           this will be a parameter name of the form :name. For a prepared statement using
-     *                           question mark placeholders, this will be the 1-indexed position of the parameter.
-     * @param mixed    $variable Name of the PHP variable to bind to the SQL statement parameter.
-     * @param int      $type     Explicit data type for the parameter using the {@link \Doctrine\DBAL\ParameterType}
-     *                           constants.
-     * @param int|null $length   You must specify maxlength when using an OUT bind
-     *                           so that PHP allocates enough memory to hold the returned value.
+     * @param string|int $column   Parameter identifier. For a prepared statement using named placeholders,
+     *                             this will be a parameter name of the form :name. For a prepared statement using
+     *                             question mark placeholders, this will be the 1-indexed position of the parameter.
+     * @param mixed      $variable Name of the PHP variable to bind to the SQL statement parameter.
+     * @param int        $type     Explicit data type for the parameter using the {@link \Doctrine\DBAL\ParameterType}
+     *                             constants.
+     * @param int|null   $length   You must specify maxlength when using an OUT bind
+     *                             so that PHP allocates enough memory to hold the returned value.
      *
      * @return bool TRUE on success or FALSE on failure.
      */

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -195,7 +195,7 @@ final class DriverManager
             throw DBALException::unknownDriver($params['driver'], array_keys(self::$_driverMap));
         }
 
-        if (isset($params['driverClass']) && ! in_array(Driver::class, class_implements($params['driverClass'], true))) {
+        if (isset($params['driverClass']) && ! in_array(Driver::class, class_implements($params['driverClass']), true)) {
             throw DBALException::invalidDriverClass($params['driverClass']);
         }
     }

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -124,10 +124,10 @@ final class DriverManager
         ?EventManager $eventManager = null
     ) : Connection {
         // create default config and event manager, if not set
-        if (! $config) {
+        if ($config === null) {
             $config = new Configuration();
         }
-        if (! $eventManager) {
+        if ($eventManager === null) {
             $eventManager = new EventManager();
         }
 

--- a/src/Event/Listeners/MysqlSessionInit.php
+++ b/src/Event/Listeners/MysqlSessionInit.php
@@ -44,8 +44,13 @@ class MysqlSessionInit implements EventSubscriber
      */
     public function postConnect(ConnectionEventArgs $args)
     {
-        $collation = $this->collation ? ' COLLATE ' . $this->collation : '';
-        $args->getConnection()->executeUpdate('SET NAMES ' . $this->charset . $collation);
+        $statement = 'SET NAMES ' . $this->charset;
+
+        if ($this->collation !== false) {
+            $statement .= ' COLLATE ' . $this->collation;
+        }
+
+        $args->getConnection()->executeUpdate($statement);
     }
 
     /**

--- a/src/Event/Listeners/OracleSessionInit.php
+++ b/src/Event/Listeners/OracleSessionInit.php
@@ -45,7 +45,7 @@ class OracleSessionInit implements EventSubscriber
      */
     public function postConnect(ConnectionEventArgs $args)
     {
-        if (! count($this->_defaultSessionVars)) {
+        if (count($this->_defaultSessionVars) === 0) {
             return;
         }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1714,7 +1714,7 @@ abstract class AbstractPlatform
         }
         $query .= ')';
 
-        $sql[] = $query;
+        $sql = [$query];
 
         if (isset($options['foreignKeys'])) {
             foreach ((array) $options['foreignKeys'] as $definition) {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -335,8 +335,8 @@ abstract class AbstractPlatform
     }
 
     /**
-     * @param int  $length
-     * @param bool $fixed
+     * @param int|false $length
+     * @param bool      $fixed
      *
      * @return string
      *
@@ -350,8 +350,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL snippet used to declare a BINARY/VARBINARY column type.
      *
-     * @param int  $length The length of the column.
-     * @param bool $fixed  Whether the column length is fixed.
+     * @param int|false $length The length of the column.
+     * @param bool      $fixed  Whether the column length is fixed.
      *
      * @return string
      *

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -494,7 +494,7 @@ abstract class AbstractPlatform
 
         assert(is_array($this->doctrineTypeComments));
 
-        return in_array($doctrineType->getName(), $this->doctrineTypeComments);
+        return in_array($doctrineType->getName(), $this->doctrineTypeComments, true);
     }
 
     /**
@@ -1586,7 +1586,7 @@ abstract class AbstractPlatform
                 $columnData['length'] = 255;
             }
 
-            if (in_array($column->getName(), $options['primary'])) {
+            if (in_array($column->getName(), $options['primary'], true)) {
                 $columnData['primary'] = true;
             }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -140,7 +140,7 @@ abstract class AbstractPlatform
      */
     protected $doctrineTypeComments = null;
 
-    /** @var EventManager */
+    /** @var EventManager|null */
     protected $_eventManager;
 
     /**
@@ -167,7 +167,7 @@ abstract class AbstractPlatform
     /**
      * Gets the EventManager used by the Platform.
      *
-     * @return EventManager
+     * @return EventManager|null
      */
     public function getEventManager()
     {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -814,7 +814,7 @@ abstract class AbstractPlatform
             $expression .= $char . ' ';
         }
 
-        if ($mode || $char !== false) {
+        if ($mode !== TrimMode::UNSPECIFIED || $char !== false) {
             $expression .= 'FROM ';
         }
 
@@ -2247,19 +2247,18 @@ abstract class AbstractPlatform
         } else {
             $default = $this->getDefaultValueDeclarationSQL($field);
 
-            $charset = isset($field['charset']) && $field['charset'] ?
+            $charset = ! empty($field['charset']) ?
                 ' ' . $this->getColumnCharsetDeclarationSQL($field['charset']) : '';
 
-            $collation = isset($field['collation']) && $field['collation'] ?
+            $collation = ! empty($field['collation']) ?
                 ' ' . $this->getColumnCollationDeclarationSQL($field['collation']) : '';
 
-            $notnull = isset($field['notnull']) && $field['notnull'] ? ' NOT NULL' : '';
+            $notnull = ! empty($field['notnull']) ? ' NOT NULL' : '';
 
-            $unique = isset($field['unique']) && $field['unique'] ?
+            $unique = ! empty($field['unique']) ?
                 ' ' . $this->getUniqueFieldDeclarationSQL() : '';
 
-            $check = isset($field['check']) && $field['check'] ?
-                ' ' . $field['check'] : '';
+            $check = ! empty($field['check']) ? ' ' . $field['check'] : '';
 
             $typeDecl  = $field['type']->getSQLDeclaration($field, $this);
             $columnDef = $typeDecl . $charset . $default . $notnull . $unique . $check . $collation;
@@ -2557,7 +2556,7 @@ abstract class AbstractPlatform
     public function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey)
     {
         $sql = '';
-        if (strlen($foreignKey->getName())) {
+        if (strlen($foreignKey->getName()) > 0) {
             $sql .= 'CONSTRAINT ' . $foreignKey->getQuotedName($this) . ' ';
         }
         $sql .= 'FOREIGN KEY (';
@@ -3560,7 +3559,7 @@ abstract class AbstractPlatform
     final public function getReservedKeywordsList()
     {
         // Check for an existing instantiation of the keywords class.
-        if ($this->_keywords) {
+        if ($this->_keywords !== null) {
             return $this->_keywords;
         }
 

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -111,8 +111,8 @@ class DB2Platform extends AbstractPlatform
      */
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
-        return $fixed ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(254)')
-                : ($length ? 'VARCHAR(' . $length . ')' : 'VARCHAR(255)');
+        return $fixed ? ($length > 0 ? 'CHAR(' . $length . ')' : 'CHAR(254)')
+                : ($length > 0 ? 'VARCHAR(' . $length . ')' : 'VARCHAR(255)');
     }
 
     /**
@@ -664,7 +664,7 @@ class DB2Platform extends AbstractPlatform
 
         $alterClause = 'ALTER COLUMN ' . $columnDiff->column->getQuotedName($this);
 
-        if ($column['columnDefinition']) {
+        if ($column['columnDefinition'] !== null) {
             return [$alterClause . ' ' . $column['columnDefinition']];
         }
 
@@ -687,7 +687,7 @@ class DB2Platform extends AbstractPlatform
             if (isset($column['default'])) {
                 $defaultClause = $this->getDefaultValueDeclarationSQL($column);
 
-                if ($defaultClause) {
+                if ($defaultClause !== '') {
                     $clauses[] = $alterClause . ' SET' . $defaultClause;
                 }
             } else {
@@ -753,7 +753,7 @@ class DB2Platform extends AbstractPlatform
             return '';
         }
 
-        if (isset($field['version']) && $field['version']) {
+        if (! empty($field['version'])) {
             if ((string) $field['type'] !== 'DateTime') {
                 $field['default'] = '1';
             }

--- a/src/Platforms/Keywords/ReservedKeywordsValidator.php
+++ b/src/Platforms/Keywords/ReservedKeywordsValidator.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
+use function count;
 use function implode;
 use function str_replace;
 
@@ -67,7 +68,7 @@ class ReservedKeywordsValidator implements Visitor
      */
     private function addViolation($asset, $violatedPlatforms)
     {
-        if (! $violatedPlatforms) {
+        if (count($violatedPlatforms) === 0) {
             return;
         }
 

--- a/src/Platforms/MySqlPlatform.php
+++ b/src/Platforms/MySqlPlatform.php
@@ -233,7 +233,9 @@ class MySqlPlatform extends AbstractPlatform
      */
     protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
     {
-        return $fixed ? 'BINARY(' . ($length ?: 255) . ')' : 'VARBINARY(' . ($length ?: 255) . ')';
+        return $fixed
+            ? 'BINARY(' . ($length > 0 ? $length : 255) . ')'
+            : 'VARBINARY(' . ($length > 0 ? $length : 255) . ')';
     }
 
     /**

--- a/src/Platforms/MySqlPlatform.php
+++ b/src/Platforms/MySqlPlatform.php
@@ -765,7 +765,7 @@ SQL
                 $column = $diff->fromTable->getColumn($columnName);
 
                 // Check if an autoincrement column was dropped from the primary key.
-                if (! $column->getAutoincrement() || in_array($columnName, $changedIndex->getColumns())) {
+                if (! $column->getAutoincrement() || in_array($columnName, $changedIndex->getColumns(), true)) {
                     continue;
                 }
 

--- a/src/Platforms/MySqlPlatform.php
+++ b/src/Platforms/MySqlPlatform.php
@@ -150,7 +150,7 @@ class MySqlPlatform extends AbstractPlatform
      */
     public function getListTableIndexesSQL($table, $currentDatabase = null)
     {
-        if ($currentDatabase) {
+        if ($currentDatabase !== null) {
             $currentDatabase = $this->quoteStringLiteral($currentDatabase);
             $table           = $this->quoteStringLiteral($table);
 
@@ -224,8 +224,8 @@ class MySqlPlatform extends AbstractPlatform
      */
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
-        return $fixed ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(255)')
-                : ($length ? 'VARCHAR(' . $length . ')' : 'VARCHAR(255)');
+        return $fixed ? ($length > 0 ? 'CHAR(' . $length . ')' : 'CHAR(255)')
+                : ($length > 0 ? 'VARCHAR(' . $length . ')' : 'VARCHAR(255)');
     }
 
     /**
@@ -372,7 +372,7 @@ class MySqlPlatform extends AbstractPlatform
     {
         $table = $this->quoteStringLiteral($table);
 
-        if ($database) {
+        if ($database !== null) {
             $database = $this->quoteStringLiteral($database);
         } else {
             $database = 'DATABASE()';
@@ -394,7 +394,7 @@ FROM information_schema.TABLES
 WHERE TABLE_TYPE = 'BASE TABLE' AND TABLE_SCHEMA = %s AND TABLE_NAME = %s
 SQL
             ,
-            $database ? $this->quoteStringLiteral($database) : 'DATABASE()',
+            $database !== null ? $this->quoteStringLiteral($database) : 'DATABASE()',
             $this->quoteStringLiteral($table)
         );
     }

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -338,7 +338,7 @@ class OraclePlatform extends AbstractPlatform
      */
     protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
     {
-        return 'RAW(' . ($length ?: $this->getBinaryMaxLength()) . ')';
+        return 'RAW(' . ($length > 0 ? $length : $this->getBinaryMaxLength()) . ')';
     }
 
     /**

--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -662,7 +662,7 @@ SQL
 
         $fromColumn = $columnDiff->fromColumn instanceof Column ? $columnDiff->fromColumn : null;
 
-        if ($fromColumn) {
+        if ($fromColumn !== null) {
             $fromColumnType = $fromColumn->getType();
 
             if (! $fromColumnType instanceof BinaryType && ! $fromColumnType instanceof BlobType) {
@@ -1047,8 +1047,8 @@ SQL
      */
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
-        return $fixed ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(255)')
-            : ($length ? 'VARCHAR(' . $length . ')' : 'VARCHAR(255)');
+        return $fixed ? ($length > 0 ? 'CHAR(' . $length . ')' : 'CHAR(255)')
+            : ($length > 0 ? 'VARCHAR(' . $length . ')' : 'VARCHAR(255)');
     }
 
     /**
@@ -1277,7 +1277,7 @@ SQL
      */
     private function typeChangeBreaksDefaultValue(ColumnDiff $columnDiff) : bool
     {
-        if (! $columnDiff->fromColumn) {
+        if ($columnDiff->fromColumn === null) {
             return $columnDiff->hasChanged('type');
         }
 
@@ -1296,7 +1296,7 @@ SQL
 
     private function getOldColumnComment(ColumnDiff $columnDiff) : ?string
     {
-        return $columnDiff->fromColumn ? $this->getColumnComment($columnDiff->fromColumn) : null;
+        return $columnDiff->fromColumn !== null ? $this->getColumnComment($columnDiff->fromColumn) : null;
     }
 
     public function getListTableMetadataSQL(string $table, ?string $schema = null) : string

--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -905,7 +905,7 @@ SQL
 
         return $this->doConvertBooleans(
             $item,
-            static function ($boolean) {
+            static function ($boolean) : ?int {
                 return $boolean === null ? null : (int) $boolean;
             }
         );

--- a/src/Platforms/SQLAnywhere16Platform.php
+++ b/src/Platforms/SQLAnywhere16Platform.php
@@ -1132,7 +1132,7 @@ SQL
      */
     public function getTrimExpression($str, $pos = TrimMode::UNSPECIFIED, $char = false)
     {
-        if (! $char) {
+        if ($char === false) {
             switch ($pos) {
                 case TrimMode::LEADING:
                     return $this->getLtrimExpression($str);
@@ -1389,7 +1389,7 @@ SQL
             return $query;
         }
 
-        if (! preg_match('/^\s*(SELECT\s+(DISTINCT\s+)?)(.*)/i', $query, $matches)) {
+        if (preg_match('/^\s*(SELECT\s+(DISTINCT\s+)?)(.*)/i', $query, $matches) === 0) {
             return $query;
         }
 
@@ -1543,8 +1543,8 @@ SQL
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
         return $fixed
-            ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(' . $this->getVarcharDefaultLength() . ')')
-            : ($length ? 'VARCHAR(' . $length . ')' : 'VARCHAR(' . $this->getVarcharDefaultLength() . ')');
+            ? ($length > 0 ? 'CHAR(' . $length . ')' : 'CHAR(' . $this->getVarcharDefaultLength() . ')')
+            : ($length > 0 ? 'VARCHAR(' . $length . ')' : 'VARCHAR(' . $this->getVarcharDefaultLength() . ')');
     }
 
     /**

--- a/src/Platforms/SQLAnywhere16Platform.php
+++ b/src/Platforms/SQLAnywhere16Platform.php
@@ -1444,8 +1444,8 @@ SQL
     protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
     {
         return $fixed
-            ? 'BINARY(' . ($length ?: $this->getBinaryDefaultLength()) . ')'
-            : 'VARBINARY(' . ($length ?: $this->getBinaryDefaultLength()) . ')';
+            ? 'BINARY(' . ($length > 0 ? $length : $this->getBinaryDefaultLength()) . ')'
+            : 'VARBINARY(' . ($length > 0 ? $length : $this->getBinaryDefaultLength()) . ')';
     }
 
     /**

--- a/src/Platforms/SQLAnywhere16Platform.php
+++ b/src/Platforms/SQLAnywhere16Platform.php
@@ -373,7 +373,7 @@ class SQLAnywhere16Platform extends AbstractPlatform
      */
     public function getConcatExpression()
     {
-        return 'STRING(' . implode(', ', (array) func_get_args()) . ')';
+        return 'STRING(' . implode(', ', func_get_args()) . ')';
     }
 
     /**

--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -316,7 +316,7 @@ SQL
         // @todo does other code breaks because of this?
         // force primary keys to be not null
         foreach ($columns as &$column) {
-            if (isset($column['primary']) && $column['primary']) {
+            if (! empty($column['primary'])) {
                 $column['notnull'] = true;
             }
 
@@ -1123,7 +1123,7 @@ SQL
      */
     public function getTrimExpression($str, $pos = TrimMode::UNSPECIFIED, $char = false)
     {
-        if (! $char) {
+        if ($char === false) {
             switch ($pos) {
                 case TrimMode::LEADING:
                     $trimFn = 'LTRIM';
@@ -1261,7 +1261,9 @@ SQL
      */
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
-        return $fixed ? ($length ? 'NCHAR(' . $length . ')' : 'CHAR(255)') : ($length ? 'NVARCHAR(' . $length . ')' : 'NVARCHAR(255)');
+        return $fixed
+            ? ($length > 0 ? 'NCHAR(' . $length . ')' : 'CHAR(255)')
+            : ($length > 0 ? 'NVARCHAR(' . $length . ')' : 'NVARCHAR(255)');
     }
 
     /**
@@ -1352,9 +1354,9 @@ SQL
         }
 
         if ($orderByPos === false
-            || substr_count($query, '(', $orderByPos) - substr_count($query, ')', $orderByPos)
+            || substr_count($query, '(', $orderByPos) !== substr_count($query, ')', $orderByPos)
         ) {
-            if (preg_match('/^SELECT\s+DISTINCT/im', $query)) {
+            if (preg_match('/^SELECT\s+DISTINCT/im', $query) > 0) {
                 // SQL Server won't let us order by a non-selected column in a DISTINCT query,
                 // so we have to do this madness. This says, order by the first column in the
                 // result. SQL Server's docs say that a nonordered query's result order is non-
@@ -1399,10 +1401,10 @@ SQL
                     continue;
                 }
 
-                $item[$key] = $value ? 1 : 0;
+                $item[$key] = (int) (bool) $value;
             }
         } elseif (is_bool($item) || is_numeric($item)) {
-            $item = $item ? 1 : 0;
+            $item = (int) (bool) $item;
         }
 
         return $item;
@@ -1611,15 +1613,15 @@ SQL
         if (isset($field['columnDefinition'])) {
             $columnDef = $this->getCustomTypeDeclarationSQL($field);
         } else {
-            $collation = isset($field['collation']) && $field['collation'] ?
+            $collation = ! empty($field['collation']) ?
                 ' ' . $this->getColumnCollationDeclarationSQL($field['collation']) : '';
 
-            $notnull = isset($field['notnull']) && $field['notnull'] ? ' NOT NULL' : '';
+            $notnull = ! empty($field['notnull']) ? ' NOT NULL' : '';
 
-            $unique = isset($field['unique']) && $field['unique'] ?
+            $unique = ! empty($field['unique']) ?
                 ' ' . $this->getUniqueFieldDeclarationSQL() : '';
 
-            $check = isset($field['check']) && $field['check'] ?
+            $check = ! empty($field['check']) ?
                 ' ' . $field['check'] : '';
 
             $typeDecl  = $field['type']->getSQLDeclaration($field, $this);

--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -1269,7 +1269,9 @@ SQL
      */
     protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
     {
-        return $fixed ? 'BINARY(' . ($length ?: 255) . ')' : 'VARBINARY(' . ($length ?: 255) . ')';
+        return $fixed
+            ? 'BINARY(' . ($length > 0 ? $length : 255) . ')'
+            : 'VARBINARY(' . ($length > 0 ? $length : 255) . ')';
     }
 
     /**

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -394,8 +394,8 @@ class SqlitePlatform extends AbstractPlatform
      */
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
-        return $fixed ? ($length ? 'CHAR(' . $length . ')' : 'CHAR(255)')
-                : ($length ? 'VARCHAR(' . $length . ')' : 'TEXT');
+        return $fixed ? ($length > 0 ? 'CHAR(' . $length . ')' : 'CHAR(255)')
+            : ($length > 0 ? 'VARCHAR(' . $length . ')' : 'TEXT');
     }
 
     /**
@@ -1109,7 +1109,7 @@ class SqlitePlatform extends AbstractPlatform
 
         foreach ($diff->removedIndexes as $index) {
             $indexName = strtolower($index->getName());
-            if (! strlen($indexName) || ! isset($indexes[$indexName])) {
+            if (strlen($indexName) === 0 || ! isset($indexes[$indexName])) {
                 continue;
             }
 
@@ -1118,7 +1118,7 @@ class SqlitePlatform extends AbstractPlatform
 
         foreach (array_merge($diff->changedIndexes, $diff->addedIndexes, $diff->renamedIndexes) as $index) {
             $indexName = strtolower($index->getName());
-            if (strlen($indexName)) {
+            if (strlen($indexName) > 0) {
                 $indexes[$indexName] = $index;
             } else {
                 $indexes[] = $index;
@@ -1167,7 +1167,7 @@ class SqlitePlatform extends AbstractPlatform
             }
 
             $constraintName = strtolower($constraint->getName());
-            if (! strlen($constraintName) || ! isset($foreignKeys[$constraintName])) {
+            if (strlen($constraintName) === 0 || ! isset($foreignKeys[$constraintName])) {
                 continue;
             }
 
@@ -1176,7 +1176,7 @@ class SqlitePlatform extends AbstractPlatform
 
         foreach (array_merge($diff->changedForeignKeys, $diff->addedForeignKeys) as $constraint) {
             $constraintName = strtolower($constraint->getName());
-            if (strlen($constraintName)) {
+            if (strlen($constraintName) > 0) {
                 $foreignKeys[$constraintName] = $constraint;
             } else {
                 $foreignKeys[] = $constraint;

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -227,7 +227,7 @@ class SqlitePlatform extends AbstractPlatform
      *
      * @return string
      */
-    public function getTinyIntTypeDeclarationSql(array $field)
+    public function getTinyIntTypeDeclarationSQL(array $field)
     {
         //  SQLite autoincrement is implicit for INTEGER PKs, but not for TINYINT fields.
         if (! empty($field['autoincrement'])) {
@@ -255,7 +255,7 @@ class SqlitePlatform extends AbstractPlatform
      *
      * @return string
      */
-    public function getMediumIntTypeDeclarationSql(array $field)
+    public function getMediumIntTypeDeclarationSQL(array $field)
     {
         //  SQLite autoincrement is implicit for INTEGER PKs, but not for MEDIUMINT fields.
         if (! empty($field['autoincrement'])) {

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -3,7 +3,6 @@
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Constraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
@@ -958,8 +957,7 @@ class SqlitePlatform extends AbstractPlatform
     {
         // Suppress changes on integer type autoincrement columns.
         foreach ($diff->changedColumns as $oldColumnName => $columnDiff) {
-            if (! $columnDiff->fromColumn instanceof Column ||
-                ! $columnDiff->column instanceof Column ||
+            if ($columnDiff->fromColumn === null ||
                 ! $columnDiff->column->getAutoincrement() ||
                 ! $columnDiff->column->getType() instanceof Types\IntegerType
             ) {

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -325,8 +325,8 @@ class SqlitePlatform extends AbstractPlatform
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
-            foreach ($options['uniqueConstraints'] as $name => $definition) {
-                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($name, $definition);
+            foreach ($options['uniqueConstraints'] as $constraintName => $definition) {
+                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($constraintName, $definition);
             }
         }
 

--- a/src/Portability/Connection.php
+++ b/src/Portability/Connection.php
@@ -63,7 +63,7 @@ class Connection extends \Doctrine\DBAL\Connection
                 $this->portability = $params['portability'];
             }
 
-            if (isset($params['fetch_case']) && $this->portability & self::PORTABILITY_FIX_CASE) {
+            if (isset($params['fetch_case']) && ($this->portability & self::PORTABILITY_FIX_CASE) !== 0) {
                 if ($this->_conn instanceof PDOConnection) {
                     // make use of c-level support for case handling
                     $this->_conn->getWrappedConnection()->setAttribute(PDO::ATTR_CASE, $params['fetch_case']);

--- a/src/Portability/Statement.php
+++ b/src/Portability/Statement.php
@@ -135,10 +135,10 @@ class Statement implements IteratorAggregate, DriverStatement
 
         $row = $this->stmt->fetch($fetchMode, ...$args);
 
-        $iterateRow = $this->portability & (Connection::PORTABILITY_EMPTY_TO_NULL|Connection::PORTABILITY_RTRIM);
+        $iterateRow = ($this->portability & (Connection::PORTABILITY_EMPTY_TO_NULL|Connection::PORTABILITY_RTRIM)) !== 0;
         $fixCase    = $this->case !== null
             && ($fetchMode === FetchMode::ASSOCIATIVE || $fetchMode === FetchMode::MIXED)
-            && ($this->portability & Connection::PORTABILITY_FIX_CASE);
+            && ($this->portability & Connection::PORTABILITY_FIX_CASE) !== 0;
 
         $row = $this->fixRow($row, $iterateRow, $fixCase);
 
@@ -154,10 +154,10 @@ class Statement implements IteratorAggregate, DriverStatement
 
         $rows = $this->stmt->fetchAll($fetchMode, ...$args);
 
-        $iterateRow = $this->portability & (Connection::PORTABILITY_EMPTY_TO_NULL|Connection::PORTABILITY_RTRIM);
+        $iterateRow = ($this->portability & (Connection::PORTABILITY_EMPTY_TO_NULL|Connection::PORTABILITY_RTRIM)) !== 0;
         $fixCase    = $this->case !== null
             && ($fetchMode === FetchMode::ASSOCIATIVE || $fetchMode === FetchMode::MIXED)
-            && ($this->portability & Connection::PORTABILITY_FIX_CASE);
+            && ($this->portability & Connection::PORTABILITY_FIX_CASE) !== 0;
 
         if (! $iterateRow && ! $fixCase) {
             return $rows;
@@ -184,14 +184,14 @@ class Statement implements IteratorAggregate, DriverStatement
 
     /**
      * @param mixed $row
-     * @param int   $iterateRow
+     * @param bool  $iterateRow
      * @param bool  $fixCase
      *
      * @return mixed
      */
     protected function fixRow($row, $iterateRow, $fixCase)
     {
-        if (! $row) {
+        if ($row === false) {
             return $row;
         }
 
@@ -201,9 +201,9 @@ class Statement implements IteratorAggregate, DriverStatement
 
         if ($iterateRow) {
             foreach ($row as $k => $v) {
-                if (($this->portability & Connection::PORTABILITY_EMPTY_TO_NULL) && $v === '') {
+                if (($this->portability & Connection::PORTABILITY_EMPTY_TO_NULL) !== 0 && $v === '') {
                     $row[$k] = null;
-                } elseif (($this->portability & Connection::PORTABILITY_RTRIM) && is_string($v)) {
+                } elseif (($this->portability & Connection::PORTABILITY_RTRIM) !== 0 && is_string($v)) {
                     $row[$k] = rtrim($v);
                 }
             }
@@ -219,12 +219,10 @@ class Statement implements IteratorAggregate, DriverStatement
     {
         $value = $this->stmt->fetchColumn($columnIndex);
 
-        if ($this->portability & (Connection::PORTABILITY_EMPTY_TO_NULL|Connection::PORTABILITY_RTRIM)) {
-            if (($this->portability & Connection::PORTABILITY_EMPTY_TO_NULL) && $value === '') {
-                $value = null;
-            } elseif (($this->portability & Connection::PORTABILITY_RTRIM) && is_string($value)) {
-                $value = rtrim($value);
-            }
+        if (($this->portability & Connection::PORTABILITY_EMPTY_TO_NULL) !== 0 && $value === '') {
+            $value = null;
+        } elseif (($this->portability & Connection::PORTABILITY_RTRIM) !== 0 && is_string($value)) {
+            $value = rtrim($value);
         }
 
         return $value;

--- a/src/Portability/Statement.php
+++ b/src/Portability/Statement.php
@@ -131,7 +131,7 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function fetch($fetchMode = null, ...$args)
     {
-        $fetchMode = $fetchMode ?: $this->defaultFetchMode;
+        $fetchMode = $fetchMode ?? $this->defaultFetchMode;
 
         $row = $this->stmt->fetch($fetchMode, ...$args);
 
@@ -150,7 +150,7 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function fetchAll($fetchMode = null, ...$args)
     {
-        $fetchMode = $fetchMode ?: $this->defaultFetchMode;
+        $fetchMode = $fetchMode ?? $this->defaultFetchMode;
 
         $rows = $this->stmt->fetchAll($fetchMode, ...$args);
 

--- a/src/Query/Expression/CompositeExpression.php
+++ b/src/Query/Expression/CompositeExpression.php
@@ -96,7 +96,7 @@ class CompositeExpression implements Countable
      */
     public function add($part)
     {
-        if (empty($part)) {
+        if ($part === null) {
             return $this;
         }
 

--- a/src/Query/Expression/CompositeExpression.php
+++ b/src/Query/Expression/CompositeExpression.php
@@ -119,11 +119,7 @@ class CompositeExpression implements Countable
     {
         $that = clone $this;
 
-        $that->parts[] = $part;
-
-        foreach ($parts as $part) {
-            $that->parts[] = $part;
-        }
+        $that->parts = array_merge($that->parts, [$part], $parts);
 
         return $that;
     }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -548,7 +548,7 @@ class QueryBuilder
     {
         $this->type = self::DELETE;
 
-        if (! $delete) {
+        if ($delete === null) {
             return $this;
         }
 
@@ -578,7 +578,7 @@ class QueryBuilder
     {
         $this->type = self::UPDATE;
 
-        if (! $update) {
+        if ($update === null) {
             return $this;
         }
 
@@ -611,7 +611,7 @@ class QueryBuilder
     {
         $this->type = self::INSERT;
 
-        if (! $insert) {
+        if ($insert === null) {
             return $this;
         }
 
@@ -1053,7 +1053,7 @@ class QueryBuilder
      */
     public function orderBy($sort, $order = null)
     {
-        return $this->add('orderBy', $sort . ' ' . (! $order ? 'ASC' : $order), false);
+        return $this->add('orderBy', $sort . ' ' . ($order ?? 'ASC'), false);
     }
 
     /**
@@ -1066,7 +1066,7 @@ class QueryBuilder
      */
     public function addOrderBy($sort, $order = null)
     {
-        return $this->add('orderBy', $sort . ' ' . (! $order ? 'ASC' : $order), true);
+        return $this->add('orderBy', $sort . ' ' . ($order ?? 'ASC'), true);
     }
 
     /**

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use function array_key_exists;
 use function array_keys;
 use function array_unshift;
+use function count;
 use function func_get_args;
 use function func_num_args;
 use function implode;
@@ -468,7 +469,7 @@ class QueryBuilder
     {
         $this->type = self::SELECT;
 
-        if (empty($select)) {
+        if ($select === null) {
             return $this;
         }
 
@@ -518,7 +519,7 @@ class QueryBuilder
     {
         $this->type = self::SELECT;
 
-        if (empty($select)) {
+        if ($select === null) {
             return $this;
         }
 
@@ -890,7 +891,7 @@ class QueryBuilder
      */
     public function groupBy($groupBy/*, string ...$groupBys*/)
     {
-        if (empty($groupBy)) {
+        if (is_array($groupBy) && count($groupBy) === 0) {
             return $this;
         }
 
@@ -919,7 +920,7 @@ class QueryBuilder
      */
     public function addGroupBy($groupBy/*, string ...$groupBys*/)
     {
-        if (empty($groupBy)) {
+        if (is_array($groupBy) && count($groupBy) === 0) {
             return $this;
         }
 

--- a/src/SQLParserUtils.php
+++ b/src/SQLParserUtils.php
@@ -155,7 +155,7 @@ class SQLParserUtils
             $arrayPositions[$name] = false;
         }
 
-        if (( ! $arrayPositions && $isPositional)) {
+        if ($isPositional && count($arrayPositions) === 0) {
             return [$query, $params, $types];
         }
 
@@ -184,7 +184,7 @@ class SQLParserUtils
 
                 $types = array_merge(
                     array_slice($types, 0, $needle),
-                    $count ?
+                    $count > 0 ?
                         // array needles are at {@link \Doctrine\DBAL\ParameterType} constants
                         // + {@link Doctrine\DBAL\Connection::ARRAY_PARAM_OFFSET}
                         array_fill(0, $count, $types[$needle] - Connection::ARRAY_PARAM_OFFSET) :
@@ -192,7 +192,7 @@ class SQLParserUtils
                     array_slice($types, $needle + 1)
                 );
 
-                $expandStr = $count ? implode(', ', array_fill(0, $count, '?')) : 'NULL';
+                $expandStr = $count > 0 ? implode(', ', array_fill(0, $count, '?')) : 'NULL';
                 $query     = substr($query, 0, $needlePos) . $expandStr . substr($query, $needlePos + 1);
 
                 $paramOffset += ($count - 1); // Grows larger by number of parameters minus the replaced needle.

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -201,7 +201,7 @@ abstract class AbstractAsset
      */
     protected function _generateIdentifierName($columnNames, $prefix = '', $maxSize = 30)
     {
-        $hash = implode('', array_map(static function ($column) {
+        $hash = implode('', array_map(static function ($column) : string {
             return dechex(crc32($column));
         }, $columnNames));
 

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -114,7 +114,7 @@ abstract class AbstractAsset
     public function getFullQualifiedName($defaultNamespaceName)
     {
         $name = $this->getName();
-        if (! $this->_namespace) {
+        if ($this->_namespace === null) {
             $name = $defaultNamespaceName . '.' . $name;
         }
 
@@ -162,7 +162,7 @@ abstract class AbstractAsset
      */
     public function getName()
     {
-        if ($this->_namespace) {
+        if ($this->_namespace !== null) {
             return $this->_namespace . '.' . $this->_name;
         }
 

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -49,7 +49,7 @@ abstract class AbstractSchemaManager
     public function __construct(Connection $conn, ?AbstractPlatform $platform = null)
     {
         $this->_conn     = $conn;
-        $this->_platform = $platform ?: $this->_conn->getDatabasePlatform();
+        $this->_platform = $platform ?? $this->_conn->getDatabasePlatform();
     }
 
     /**

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -155,7 +155,7 @@ abstract class AbstractSchemaManager
      */
     public function listTableColumns($table, $database = null)
     {
-        if (! $database) {
+        if ($database === null) {
             $database = $this->_conn->getDatabase();
         }
 
@@ -226,7 +226,7 @@ abstract class AbstractSchemaManager
     protected function filterAssetNames($assetNames)
     {
         $filter = $this->_conn->getConfiguration()->getSchemaAssetsFilter();
-        if (! $filter) {
+        if ($filter === null) {
             return $assetNames;
         }
 
@@ -628,13 +628,7 @@ abstract class AbstractSchemaManager
     {
         $list = [];
         foreach ($databases as $value) {
-            $value = $this->_getPortableDatabaseDefinition($value);
-
-            if (! $value) {
-                continue;
-            }
-
-            $list[] = $value;
+            $list[] = $this->_getPortableDatabaseDefinition($value);
         }
 
         return $list;
@@ -806,7 +800,7 @@ abstract class AbstractSchemaManager
                 $column = $this->_getPortableTableColumnDefinition($tableColumn);
             }
 
-            if (! $column) {
+            if ($column === null) {
                 continue;
             }
 
@@ -886,7 +880,7 @@ abstract class AbstractSchemaManager
                 $index = new Index($data['name'], $data['columns'], $data['unique'], $data['primary'], $data['flags'], $data['options']);
             }
 
-            if (! $index) {
+            if ($index === null) {
                 continue;
             }
 
@@ -905,13 +899,7 @@ abstract class AbstractSchemaManager
     {
         $list = [];
         foreach ($tables as $value) {
-            $value = $this->_getPortableTableDefinition($value);
-
-            if (! $value) {
-                continue;
-            }
-
-            $list[] = $value;
+            $list[] = $this->_getPortableTableDefinition($value);
         }
 
         return $list;
@@ -936,13 +924,7 @@ abstract class AbstractSchemaManager
     {
         $list = [];
         foreach ($users as $value) {
-            $value = $this->_getPortableUserDefinition($value);
-
-            if (! $value) {
-                continue;
-            }
-
-            $list[] = $value;
+            $list[] = $this->_getPortableUserDefinition($value);
         }
 
         return $list;
@@ -969,7 +951,7 @@ abstract class AbstractSchemaManager
         foreach ($views as $value) {
             $view = $this->_getPortableViewDefinition($value);
 
-            if (! $view) {
+            if ($view === false) {
                 continue;
             }
 
@@ -1107,7 +1089,7 @@ abstract class AbstractSchemaManager
      */
     public function extractDoctrineTypeFromComment($comment, $currentType)
     {
-        if ($comment !== null && preg_match('(\(DC2Type:(((?!\)).)+)\))', $comment, $match)) {
+        if ($comment !== null && preg_match('(\(DC2Type:(((?!\)).)+)\))', $comment, $match) === 1) {
             return $match[1];
         }
 

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -18,7 +18,6 @@ use function assert;
 use function call_user_func_array;
 use function count;
 use function func_get_args;
-use function is_array;
 use function is_callable;
 use function preg_match;
 use function str_replace;
@@ -594,9 +593,6 @@ abstract class AbstractSchemaManager
     public function alterTable(TableDiff $tableDiff)
     {
         $queries = $this->_platform->getAlterTableSQL($tableDiff);
-        if (! is_array($queries) || ! count($queries)) {
-            return;
-        }
 
         foreach ($queries as $ddlQuery) {
             $this->_execSql($ddlQuery);

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -48,7 +48,7 @@ class ColumnDiff
      */
     public function getOldColumnName()
     {
-        $quote = $this->fromColumn && $this->fromColumn->isQuoted();
+        $quote = $this->fromColumn !== null && $this->fromColumn->isQuoted();
 
         return new Identifier($this->oldColumnName, $quote);
     }

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -40,7 +40,7 @@ class ColumnDiff
      */
     public function hasChanged($propertyName)
     {
-        return in_array($propertyName, $this->changedProperties);
+        return in_array($propertyName, $this->changedProperties, true);
     }
 
     /**

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -452,8 +452,8 @@ class Comparator
             $properties1['type'] instanceof Types\BinaryType
         ) {
             // check if value of length is set at all, default value assumed otherwise.
-            $length1 = $properties1['length'] ?: 255;
-            $length2 = $properties2['length'] ?: 255;
+            $length1 = $properties1['length'] ?? 255;
+            $length2 = $properties2['length'] ?? 255;
             if ($length1 !== $length2) {
                 $changedProperties[] = 'length';
             }
@@ -462,7 +462,7 @@ class Comparator
                 $changedProperties[] = 'fixed';
             }
         } elseif ($properties1['type'] instanceof Types\DecimalType) {
-            if (($properties1['precision'] ?: 10) !== ($properties2['precision'] ?: 10)) {
+            if (($properties1['precision'] ?? 10) !== ($properties2['precision'] ?? 10)) {
                 $changedProperties[] = 'precision';
             }
             if ($properties1['scale'] !== $properties2['scale']) {

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -293,7 +293,7 @@ class Comparator
             $changes++;
         }
 
-        return $changes ? $tableDifferences : false;
+        return $changes > 0 ? $tableDifferences : false;
     }
 
     /**

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -217,7 +217,7 @@ class Comparator
             // See if column has changed properties in table 2.
             $changedProperties = $this->diffColumn($column, $table2->getColumn($columnName));
 
-            if (empty($changedProperties)) {
+            if (count($changedProperties) === 0) {
                 continue;
             }
 

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -51,7 +51,7 @@ class DB2SchemaManager extends AbstractSchemaManager
         if ($tableColumn['default'] !== null && $tableColumn['default'] !== 'NULL') {
             $default = $tableColumn['default'];
 
-            if (preg_match('/^\'(.*)\'$/s', $default, $matches)) {
+            if (preg_match('/^\'(.*)\'$/s', $default, $matches) === 1) {
                 $default = str_replace("''", "'", $matches[1]);
             }
         }

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Types\Type;
 use const CASE_LOWER;
 use function array_change_key_case;
-use function is_resource;
 use function preg_match;
 use function str_replace;
 use function strpos;
@@ -201,11 +200,11 @@ class DB2SchemaManager extends AbstractSchemaManager
     protected function _getPortableViewDefinition($view)
     {
         $view = array_change_key_case($view, CASE_LOWER);
-        // sadly this still segfaults on PDO_IBM, see http://pecl.php.net/bugs/bug.php?id=17199
-        //$view['text'] = (is_resource($view['text']) ? stream_get_contents($view['text']) : $view['text']);
-        if (! is_resource($view['text'])) {
-            $pos = strpos($view['text'], ' AS ');
-            $sql = substr($view['text'], $pos+4);
+
+        $position = strpos($view['text'], ' AS ');
+
+        if ($position !== false) {
+            $sql = substr($view['text'], $position + 4);
         } else {
             $sql = '';
         }

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -5,7 +5,6 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use function array_keys;
 use function array_map;
-use function in_array;
 use function strrpos;
 use function strtolower;
 use function strtoupper;
@@ -360,7 +359,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
         if (isset($this->_options[$event])) {
             $onEvent = strtoupper($this->_options[$event]);
 
-            if (! in_array($onEvent, ['NO ACTION', 'RESTRICT'])) {
+            if ($onEvent !== 'NO ACTION' && $onEvent !== 'RESTRICT') {
                 return $onEvent;
             }
         }

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -164,7 +164,7 @@ class Index extends AbstractAsset implements Constraint
         $columnName   = $this->trimQuotes(strtolower($columnName));
         $indexColumns = array_map('strtolower', $this->getUnquotedColumns());
 
-        return array_search($columnName, $indexColumns) === $pos;
+        return array_search($columnName, $indexColumns, true) === $pos;
     }
 
     /**

--- a/src/Schema/MySqlSchemaManager.php
+++ b/src/Schema/MySqlSchemaManager.php
@@ -143,7 +143,11 @@ class MySqlSchemaManager extends AbstractSchemaManager
             case 'real':
             case 'numeric':
             case 'decimal':
-                if (preg_match('([A-Za-z]+\(([0-9]+)\,([0-9]+)\))', $tableColumn['type'], $match)) {
+                if (preg_match(
+                    '([A-Za-z]+\(([0-9]+),([0-9]+)\))',
+                    $tableColumn['type'],
+                    $match
+                ) === 1) {
                     $precision = $match[1];
                     $scale     = $match[2];
                     $length    = null;
@@ -237,7 +241,7 @@ class MySqlSchemaManager extends AbstractSchemaManager
             return null;
         }
 
-        if (preg_match('/^\'(.*)\'$/', $columnDefault, $matches)) {
+        if (preg_match('/^\'(.*)\'$/', $columnDefault, $matches) === 1) {
             return strtr($matches[1], self::MARIADB_ESCAPE_SEQUENCES);
         }
 

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -124,7 +124,7 @@ class OracleSchemaManager extends AbstractSchemaManager
 
         $dbType = strtolower($tableColumn['data_type']);
         if (strpos($dbType, 'timestamp(') === 0) {
-            if (strpos($dbType, 'with time zone')) {
+            if (strpos($dbType, 'with time zone') !== false) {
                 $dbType = 'timestamptz';
             } else {
                 $dbType = 'timestamp';
@@ -146,7 +146,7 @@ class OracleSchemaManager extends AbstractSchemaManager
 
         if ($tableColumn['data_default'] !== null) {
             // Default values returned from database are represented as literal expressions
-            if (preg_match('/^\'(.*)\'$/s', $tableColumn['data_default'], $matches)) {
+            if (preg_match('/^\'(.*)\'$/s', $tableColumn['data_default'], $matches) === 1) {
                 $tableColumn['data_default'] = str_replace("''", "'", $matches[1]);
             }
         }
@@ -345,7 +345,7 @@ class OracleSchemaManager extends AbstractSchemaManager
      */
     private function getQuotedIdentifierName($identifier)
     {
-        if (preg_match('/[a-z]/', $identifier)) {
+        if (preg_match('/[a-z]/', $identifier) === 1) {
             return $this->_platform->quoteIdentifier($identifier);
         }
 

--- a/src/Schema/PostgreSqlSchemaManager.php
+++ b/src/Schema/PostgreSqlSchemaManager.php
@@ -138,14 +138,26 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         $foreignColumns = [];
         $foreignTable   = null;
 
-        if (preg_match('(ON UPDATE ([a-zA-Z0-9]+( (NULL|ACTION|DEFAULT))?))', $tableForeignKey['condef'], $match)) {
+        if (preg_match(
+            '(ON UPDATE ([a-zA-Z0-9]+( (NULL|ACTION|DEFAULT))?))',
+            $tableForeignKey['condef'],
+            $match
+        ) === 1) {
             $onUpdate = $match[1];
         }
-        if (preg_match('(ON DELETE ([a-zA-Z0-9]+( (NULL|ACTION|DEFAULT))?))', $tableForeignKey['condef'], $match)) {
+        if (preg_match(
+            '(ON DELETE ([a-zA-Z0-9]+( (NULL|ACTION|DEFAULT))?))',
+            $tableForeignKey['condef'],
+            $match
+        ) === 1) {
             $onDelete = $match[1];
         }
 
-        if (preg_match('/FOREIGN KEY \((.+)\) REFERENCES (.+)\((.+)\)/', $tableForeignKey['condef'], $values)) {
+        if (preg_match(
+            '/FOREIGN KEY \((.+)\) REFERENCES (.+)\((.+)\)/',
+            $tableForeignKey['condef'],
+            $values
+        ) === 1) {
             // PostgreSQL returns identifiers that are keywords with quotes, we need them later, don't get
             // the idea to trim them here.
             $localColumns   = array_map('trim', explode(',', $values[1]));
@@ -323,15 +335,15 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         $matches = [];
 
         $autoincrement = false;
-        if (preg_match("/^nextval\('(.*)'(::.*)?\)$/", $tableColumn['default'], $matches)) {
+        if (preg_match("/^nextval\('(.*)'(::.*)?\)$/", $tableColumn['default'], $matches) === 1) {
             $tableColumn['sequence'] = $matches[1];
             $tableColumn['default']  = null;
             $autoincrement           = true;
         }
 
-        if (preg_match("/^['(](.*)[')]::/", $tableColumn['default'], $matches)) {
+        if (preg_match("/^['(](.*)[')]::/", $tableColumn['default'], $matches) === 1) {
             $tableColumn['default'] = $matches[1];
-        } elseif (preg_match('/^NULL::/', $tableColumn['default'])) {
+        } elseif (preg_match('/^NULL::/', $tableColumn['default']) === 1) {
             $tableColumn['default'] = null;
         }
 
@@ -353,7 +365,8 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         $jsonb     = null;
 
         $dbType = strtolower($tableColumn['type']);
-        if (strlen($tableColumn['domain_type']) && ! $this->_platform->hasDoctrineTypeMappingFor($tableColumn['type'])) {
+        if (strlen($tableColumn['domain_type']) > 0
+            && ! $this->_platform->hasDoctrineTypeMappingFor($tableColumn['type'])) {
             $dbType                       = strtolower($tableColumn['domain_type']);
             $tableColumn['complete_type'] = $tableColumn['domain_complete_type'];
         }
@@ -415,7 +428,11 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
             case 'numeric':
                 $tableColumn['default'] = $this->fixVersion94NegativeNumericDefaultValue($tableColumn['default']);
 
-                if (preg_match('([A-Za-z]+\(([0-9]+)\,([0-9]+)\))', $tableColumn['complete_type'], $match)) {
+                if (preg_match(
+                    '([A-Za-z]+\(([0-9]+)\,([0-9]+)\))',
+                    $tableColumn['complete_type'],
+                    $match
+                ) === 1) {
                     $precision = $match[1];
                     $scale     = $match[2];
                     $length    = null;
@@ -431,7 +448,11 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
                 break;
         }
 
-        if ($tableColumn['default'] && preg_match("('([^']+)'::)", $tableColumn['default'], $match)) {
+        if ($tableColumn['default'] !== null && preg_match(
+            "('([^']+)'::)",
+            $tableColumn['default'],
+            $match
+        ) === 1) {
             $tableColumn['default'] = $match[1];
         }
 

--- a/src/Schema/PostgreSqlSchemaManager.php
+++ b/src/Schema/PostgreSqlSchemaManager.php
@@ -94,7 +94,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         $paths = $this->getSchemaSearchPaths();
 
         $this->existingSchemaPaths = array_filter($paths, static function ($v) use ($names) {
-            return in_array($v, $names);
+            return in_array($v, $names, true);
         });
     }
 

--- a/src/Schema/PostgreSqlSchemaManager.php
+++ b/src/Schema/PostgreSqlSchemaManager.php
@@ -93,7 +93,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
         $names = $this->getSchemaNames();
         $paths = $this->getSchemaSearchPaths();
 
-        $this->existingSchemaPaths = array_filter($paths, static function ($v) use ($names) {
+        $this->existingSchemaPaths = array_filter($paths, static function ($v) use ($names) : bool {
             return in_array($v, $names, true);
         });
     }

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -134,7 +134,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
             return null;
         }
 
-        if (preg_match('/^\'(.*)\'$/s', $value, $matches)) {
+        if (preg_match('/^\'(.*)\'$/s', $value, $matches) === 1) {
             $value = str_replace("''", "'", $matches[1]);
         }
 

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -10,7 +10,6 @@ use PDOException;
 use Throwable;
 use function assert;
 use function count;
-use function in_array;
 use function is_string;
 use function preg_match;
 use function sprintf;
@@ -104,7 +103,6 @@ class SQLServerSchemaManager extends AbstractSchemaManager
         $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);
 
         $options = [
-            'length'        => $length === 0 || ! in_array($type, ['text', 'string']) ? null : $length,
             'unsigned'      => false,
             'fixed'         => (bool) $fixed,
             'default'       => $default,
@@ -114,6 +112,10 @@ class SQLServerSchemaManager extends AbstractSchemaManager
             'autoincrement' => (bool) $tableColumn['autoincrement'],
             'comment'       => $tableColumn['comment'] !== '' ? $tableColumn['comment'] : null,
         ];
+
+        if ($length !== 0 && ($type === 'text' || $type === 'string')) {
+            $options['length'] = $length;
+        }
 
         $column = new Column($tableColumn['name'], Type::getType($type), $options);
 

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -68,7 +68,7 @@ class Schema extends AbstractAsset
             $schemaConfig = new SchemaConfig();
         }
         $this->_schemaConfig = $schemaConfig;
-        $this->_setName($schemaConfig->getName() ?: 'public');
+        $this->_setName($schemaConfig->getName() ?? 'public');
 
         foreach ($namespaces as $namespace) {
             $this->createNamespace($namespace);

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -65,7 +65,11 @@ class Sequence extends AbstractAsset
      */
     public function setAllocationSize($allocationSize)
     {
-        $this->allocationSize = (int) $allocationSize ?: 1;
+        if ($allocationSize > 0) {
+            $this->allocationSize = (int) $allocationSize;
+        } else {
+            $this->allocationSize = 1;
+        }
 
         return $this;
     }
@@ -77,7 +81,11 @@ class Sequence extends AbstractAsset
      */
     public function setInitialValue($initialValue)
     {
-        $this->initialValue = (int) $initialValue ?: 1;
+        if ($initialValue > 0) {
+            $this->initialValue = (int) $initialValue;
+        } else {
+            $this->initialValue = 1;
+        }
 
         return $this;
     }

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -131,7 +131,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
                     )?#isx',
                 $createSql,
                 $match
-            )) {
+            ) > 0) {
                 $names      = array_reverse($match[1]);
                 $deferrable = array_reverse($match[2]);
                 $deferred   = array_reverse($match[3]);
@@ -334,7 +334,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
 
         if ($default !== null) {
             // SQLite returns the default value as a literal expression, so we need to parse it
-            if (preg_match('/^\'(.*)\'$/s', $default, $matches)) {
+            if (preg_match('/^\'(.*)\'$/s', $default, $matches) === 1) {
                 $default = str_replace("''", "'", $matches[1]);
             }
         }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -104,7 +104,11 @@ class Table extends AbstractAsset
      */
     public function setPrimaryKey(array $columnNames, $indexName = false)
     {
-        $this->_addIndex($this->_createIndex($columnNames, $indexName ?: 'primary', true, true));
+        if ($indexName === false) {
+            $indexName = 'primary';
+        }
+
+        $this->_addIndex($this->_createIndex($columnNames, $indexName, true, true));
 
         foreach ($columnNames as $columnName) {
             $column = $this->getColumn($columnName);
@@ -361,7 +365,9 @@ class Table extends AbstractAsset
      */
     public function addForeignKeyConstraint($foreignTable, array $localColumnNames, array $foreignColumnNames, array $options = [], $constraintName = null)
     {
-        $constraintName = $constraintName ?: $this->_generateIdentifierName(array_merge((array) $this->getName(), $localColumnNames), 'fk', $this->_getMaxIdentifierLength());
+        if ($constraintName === null) {
+            $constraintName = $this->_generateIdentifierName(array_merge((array) $this->getName(), $localColumnNames), 'fk', $this->_getMaxIdentifierLength());
+        }
 
         return $this->addNamedForeignKeyConstraint($constraintName, $foreignTable, $localColumnNames, $foreignColumnNames, $options);
     }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -27,7 +27,7 @@ class Table extends AbstractAsset
     /** @var Index[] */
     protected $_indexes = [];
 
-    /** @var string */
+    /** @var string|false */
     protected $_primaryKeyName = false;
 
     /** @var ForeignKeyConstraint[] */
@@ -142,6 +142,10 @@ class Table extends AbstractAsset
      */
     public function dropPrimaryKey()
     {
+        if ($this->_primaryKeyName === false) {
+            return;
+        }
+
         $this->dropIndex($this->_primaryKeyName);
         $this->_primaryKeyName = false;
     }
@@ -672,11 +676,11 @@ class Table extends AbstractAsset
      */
     public function getPrimaryKey()
     {
-        if (! $this->hasPrimaryKey()) {
-            return null;
+        if ($this->_primaryKeyName !== false) {
+            return $this->getIndex($this->_primaryKeyName);
         }
 
-        return $this->getIndex($this->_primaryKeyName);
+        return null;
     }
 
     /**

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -637,7 +637,7 @@ class Table extends AbstractAsset
      */
     private function filterColumns(array $columnNames)
     {
-        return array_filter($this->_columns, static function ($columnName) use ($columnNames) {
+        return array_filter($this->_columns, static function ($columnName) use ($columnNames) : bool {
             return in_array($columnName, $columnNames, true);
         }, ARRAY_FILTER_USE_KEY);
     }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -271,7 +271,7 @@ class Table extends AbstractAsset
      */
     private function _createIndex(array $columnNames, $indexName, $isUnique, $isPrimary, array $flags = [], array $options = [])
     {
-        if (preg_match('(([^a-zA-Z0-9_]+))', $this->normalizeIdentifier($indexName))) {
+        if (preg_match('(([^a-zA-Z0-9_]+))', $this->normalizeIdentifier($indexName)) === 1) {
             throw SchemaException::indexNameInvalid($indexName);
         }
 
@@ -511,7 +511,7 @@ class Table extends AbstractAsset
     {
         $constraint->setLocalTable($this);
 
-        if (strlen($constraint->getName())) {
+        if (strlen($constraint->getName()) > 0) {
             $name = $constraint->getName();
         } else {
             $name = $this->_generateIdentifierName(
@@ -714,7 +714,7 @@ class Table extends AbstractAsset
      */
     public function hasPrimaryKey()
     {
-        return $this->_primaryKeyName && $this->hasIndex($this->_primaryKeyName);
+        return $this->_primaryKeyName !== false && $this->hasIndex($this->_primaryKeyName);
     }
 
     /**

--- a/src/Schema/Visitor/Graphviz.php
+++ b/src/Schema/Visitor/Graphviz.php
@@ -84,7 +84,7 @@ class Graphviz extends AbstractVisitor
 
             $primaryKey = $table->getPrimaryKey();
 
-            if ($primaryKey !== null && in_array($column->getName(), $primaryKey->getColumns())) {
+            if ($primaryKey !== null && in_array($column->getName(), $primaryKey->getColumns(), true)) {
                 $label .= "\xe2\x9c\xb7";
             }
             $label .= '</TD></TR>';

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use IteratorAggregate;
 use Throwable;
-use function is_array;
 use function is_string;
 
 /**
@@ -139,19 +138,19 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function execute($params = null)
     {
-        if (is_array($params)) {
+        if ($params !== null) {
             $this->params = $params;
         }
 
         $logger = $this->conn->getConfiguration()->getSQLLogger();
-        if ($logger) {
+        if ($logger !== null) {
             $logger->startQuery($this->sql, $this->params, $this->types);
         }
 
         try {
             $stmt = $this->stmt->execute($params);
         } catch (Throwable $ex) {
-            if ($logger) {
+            if ($logger !== null) {
                 $logger->stopQuery();
             }
             throw DBALException::driverExceptionDuringQuery(
@@ -162,7 +161,7 @@ class Statement implements IteratorAggregate, DriverStatement
             );
         }
 
-        if ($logger) {
+        if ($logger !== null) {
             $logger->stopQuery();
         }
         $this->params = [];

--- a/src/Tools/Console/Command/ReservedWordsCommand.php
+++ b/src/Tools/Console/Command/ReservedWordsCommand.php
@@ -108,7 +108,7 @@ EOT
         $conn = $this->getHelper('db')->getConnection();
 
         $keywordLists = (array) $input->getOption('list');
-        if (! $keywordLists) {
+        if (count($keywordLists) === 0) {
             $keywordLists = array_keys($this->keywordListClasses);
         }
 

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use function assert;
+use function is_bool;
 use function is_numeric;
 use function is_string;
 use function stripos;
@@ -59,7 +60,10 @@ EOT
             throw new LogicException("Option 'depth' must contains an integer value");
         }
 
-        if (stripos($sql, 'select') === 0 || $input->getOption('force-fetch')) {
+        $forceFetch = $input->getOption('force-fetch');
+        assert(is_bool($forceFetch));
+
+        if (stripos($sql, 'select') === 0 || $forceFetch) {
             $resultSet = $conn->fetchAll($sql);
         } else {
             $resultSet = $conn->executeUpdate($sql);

--- a/src/Types/DateImmutableType.php
+++ b/src/Types/DateImmutableType.php
@@ -49,7 +49,7 @@ class DateImmutableType extends DateType
 
         $dateTime = DateTimeImmutable::createFromFormat('!' . $platform->getDateFormatString(), $value);
 
-        if (! $dateTime) {
+        if ($dateTime === false) {
             throw ConversionException::conversionFailedFormat(
                 $value,
                 $this->getName(),

--- a/src/Types/DateTimeImmutableType.php
+++ b/src/Types/DateTimeImmutableType.php
@@ -50,11 +50,11 @@ class DateTimeImmutableType extends DateTimeType
 
         $dateTime = DateTimeImmutable::createFromFormat($platform->getDateTimeFormatString(), $value);
 
-        if (! $dateTime) {
+        if ($dateTime === false) {
             $dateTime = date_create_immutable($value);
         }
 
-        if (! $dateTime) {
+        if ($dateTime === false) {
             throw ConversionException::conversionFailedFormat(
                 $value,
                 $this->getName(),

--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -55,11 +55,11 @@ class DateTimeType extends Type implements PhpDateTimeMappingType
 
         $val = DateTime::createFromFormat($platform->getDateTimeFormatString(), $value);
 
-        if (! $val) {
+        if ($val === false) {
             $val = date_create($value);
         }
 
-        if (! $val) {
+        if ($val === false) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateTimeFormatString());
         }
 

--- a/src/Types/DateTimeTzImmutableType.php
+++ b/src/Types/DateTimeTzImmutableType.php
@@ -49,7 +49,7 @@ class DateTimeTzImmutableType extends DateTimeTzType
 
         $dateTime = DateTimeImmutable::createFromFormat($platform->getDateTimeTzFormatString(), $value);
 
-        if (! $dateTime) {
+        if ($dateTime === false) {
             throw ConversionException::conversionFailedFormat(
                 $value,
                 $this->getName(),

--- a/src/Types/DateTimeTzType.php
+++ b/src/Types/DateTimeTzType.php
@@ -66,7 +66,7 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
         }
 
         $val = DateTime::createFromFormat($platform->getDateTimeTzFormatString(), $value);
-        if (! $val) {
+        if ($val === false) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateTimeTzFormatString());
         }
 

--- a/src/Types/DateType.php
+++ b/src/Types/DateType.php
@@ -53,7 +53,7 @@ class DateType extends Type
         }
 
         $val = DateTime::createFromFormat('!' . $platform->getDateFormatString(), $value);
-        if (! $val) {
+        if ($val === false) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateFormatString());
         }
 

--- a/src/Types/SimpleArrayType.php
+++ b/src/Types/SimpleArrayType.php
@@ -3,8 +3,10 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function count;
 use function explode;
 use function implode;
+use function is_array;
 use function is_resource;
 use function stream_get_contents;
 
@@ -28,7 +30,7 @@ class SimpleArrayType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        if (! $value) {
+        if (! is_array($value) || count($value) === 0) {
             return null;
         }
 

--- a/src/Types/TimeImmutableType.php
+++ b/src/Types/TimeImmutableType.php
@@ -49,7 +49,7 @@ class TimeImmutableType extends TimeType
 
         $dateTime = DateTimeImmutable::createFromFormat('!' . $platform->getTimeFormatString(), $value);
 
-        if (! $dateTime) {
+        if ($dateTime === false) {
             throw ConversionException::conversionFailedFormat(
                 $value,
                 $this->getName(),

--- a/src/Types/TimeType.php
+++ b/src/Types/TimeType.php
@@ -53,7 +53,7 @@ class TimeType extends Type
         }
 
         $val = DateTime::createFromFormat('!' . $platform->getTimeFormatString(), $value);
-        if (! $val) {
+        if ($val === false) {
             throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getTimeFormatString());
         }
 

--- a/src/Types/VarDateTimeImmutableType.php
+++ b/src/Types/VarDateTimeImmutableType.php
@@ -50,7 +50,7 @@ class VarDateTimeImmutableType extends VarDateTimeType
 
         $dateTime = date_create_immutable($value);
 
-        if (! $dateTime) {
+        if ($dateTime === false) {
             throw ConversionException::conversionFailed($value, $this->getName());
         }
 

--- a/src/Types/VarDateTimeType.php
+++ b/src/Types/VarDateTimeType.php
@@ -25,7 +25,7 @@ class VarDateTimeType extends DateTimeType
         }
 
         $val = date_create($value);
-        if (! $val) {
+        if ($val === false) {
             throw ConversionException::conversionFailed($value, $this->getName());
         }
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -56,9 +56,9 @@ class ConnectionTest extends TestCase
     {
         $driverMock = $this->createMock(Driver::class);
 
-        $driverMock->expects($this->any())
+        $driverMock->expects(self::any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->will(self::returnValue(
                 $this->createMock(DriverConnection::class)
             ));
 
@@ -146,13 +146,13 @@ class ConnectionTest extends TestCase
         $listenerMock = $this->getMockBuilder($this->getMockClass('ConnectDispatchEventListener'))
             ->addMethods(['postConnect'])
             ->getMock();
-        $listenerMock->expects($this->once())->method('postConnect');
+        $listenerMock->expects(self::once())->method('postConnect');
 
         $eventManager = new EventManager();
         $eventManager->addEventListener([Events::postConnect], $listenerMock);
 
         $driverMock = $this->createMock(Driver::class);
-        $driverMock->expects($this->at(0))
+        $driverMock->expects(self::at(0))
                    ->method('connect');
 
         $conn = new Connection([], $driverMock, new Configuration(), $eventManager);
@@ -165,13 +165,13 @@ class ConnectionTest extends TestCase
 
         /** @var AbstractPlatform|MockObject $driver */
         $platform = $this->createMock(AbstractPlatform::class);
-        $platform->expects($this->once())
+        $platform->expects(self::once())
             ->method('setEventManager')
             ->with($eventManager);
 
         /** @var Driver|MockObject $driver */
         $driver = $this->createMock(Driver::class);
-        $driver->expects($this->any())
+        $driver->expects(self::any())
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
@@ -247,9 +247,9 @@ class ConnectionTest extends TestCase
     public function testConnectStartsTransactionInNoAutoCommitMode() : void
     {
         $driverMock = $this->createMock(Driver::class);
-        $driverMock->expects($this->any())
+        $driverMock->expects(self::any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->will(self::returnValue(
                 $this->createMock(DriverConnection::class)
             ));
         $conn = new Connection([], $driverMock);
@@ -269,9 +269,9 @@ class ConnectionTest extends TestCase
     public function testCommitStartsTransactionInNoAutoCommitMode() : void
     {
         $driverMock = $this->createMock(Driver::class);
-        $driverMock->expects($this->any())
+        $driverMock->expects(self::any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->will(self::returnValue(
                 $this->createMock(DriverConnection::class)
             ));
         $conn = new Connection([], $driverMock);
@@ -289,13 +289,13 @@ class ConnectionTest extends TestCase
     public function testCommitReturn(bool $expectedResult) : void
     {
         $driverConnection = $this->createMock(DriverConnection::class);
-        $driverConnection->expects($this->once())
+        $driverConnection->expects(self::once())
             ->method('commit')->willReturn($expectedResult);
 
         $driverMock = $this->createMock(Driver::class);
-        $driverMock->expects($this->any())
+        $driverMock->expects(self::any())
             ->method('connect')
-            ->will($this->returnValue($driverConnection));
+            ->will(self::returnValue($driverConnection));
 
         $conn = new Connection([], $driverMock);
 
@@ -319,9 +319,9 @@ class ConnectionTest extends TestCase
     public function testRollBackStartsTransactionInNoAutoCommitMode() : void
     {
         $driverMock = $this->createMock(Driver::class);
-        $driverMock->expects($this->any())
+        $driverMock->expects(self::any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->will(self::returnValue(
                 $this->createMock(DriverConnection::class)
             ));
         $conn = new Connection([], $driverMock);
@@ -339,9 +339,9 @@ class ConnectionTest extends TestCase
     public function testSwitchingAutoCommitModeCommitsAllCurrentTransactions() : void
     {
         $driverMock = $this->createMock(Driver::class);
-        $driverMock->expects($this->any())
+        $driverMock->expects(self::any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->will(self::returnValue(
                 $this->createMock(DriverConnection::class)
             ));
         $conn = new Connection([], $driverMock);
@@ -364,7 +364,7 @@ class ConnectionTest extends TestCase
     {
         $conn = $this->getExecuteUpdateMockConnection();
 
-        $conn->expects($this->once())
+        $conn->expects(self::once())
             ->method('executeUpdate')
             ->with('INSERT INTO footable () VALUES ()');
 
@@ -378,7 +378,7 @@ class ConnectionTest extends TestCase
     {
         $conn = $this->getExecuteUpdateMockConnection();
 
-        $conn->expects($this->once())
+        $conn->expects(self::once())
             ->method('executeUpdate')
             ->with(
                 'UPDATE TestTable SET text = ?, is_edited = ? WHERE id = ? AND name = ?',
@@ -422,7 +422,7 @@ class ConnectionTest extends TestCase
     {
         $conn = $this->getExecuteUpdateMockConnection();
 
-        $conn->expects($this->once())
+        $conn->expects(self::once())
             ->method('executeUpdate')
             ->with(
                 'UPDATE TestTable SET text = ?, is_edited = ? WHERE id = ? AND is_edited = ?',
@@ -465,7 +465,7 @@ class ConnectionTest extends TestCase
     {
         $conn = $this->getExecuteUpdateMockConnection();
 
-        $conn->expects($this->once())
+        $conn->expects(self::once())
             ->method('executeUpdate')
             ->with(
                 'UPDATE TestTable SET text = ?, is_edited = ? WHERE id IS NULL AND name = ?',
@@ -507,7 +507,7 @@ class ConnectionTest extends TestCase
     {
         $conn = $this->getExecuteUpdateMockConnection();
 
-        $conn->expects($this->once())
+        $conn->expects(self::once())
             ->method('executeUpdate')
             ->with(
                 'DELETE FROM TestTable WHERE id IS NULL AND name = ?',
@@ -537,18 +537,18 @@ class ConnectionTest extends TestCase
 
         $driverMock = $this->createMock(Driver::class);
 
-        $driverMock->expects($this->any())
+        $driverMock->expects(self::any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->will(self::returnValue(
                 $this->createMock(DriverConnection::class)
             ));
 
         $driverStatementMock = $this->createMock(Statement::class);
 
-        $driverStatementMock->expects($this->once())
+        $driverStatementMock->expects(self::once())
             ->method('fetch')
             ->with(FetchMode::ASSOCIATIVE)
-            ->will($this->returnValue($result));
+            ->will(self::returnValue($result));
 
         /** @var Connection|MockObject $conn */
         $conn = $this->getMockBuilder(Connection::class)
@@ -556,10 +556,10 @@ class ConnectionTest extends TestCase
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
 
-        $conn->expects($this->once())
+        $conn->expects(self::once())
             ->method('executeQuery')
             ->with($statement, $params, $types)
-            ->will($this->returnValue($driverStatementMock));
+            ->will(self::returnValue($driverStatementMock));
 
         self::assertSame($result, $conn->fetchAssoc($statement, $params, $types));
     }
@@ -573,18 +573,18 @@ class ConnectionTest extends TestCase
 
         $driverMock = $this->createMock(Driver::class);
 
-        $driverMock->expects($this->any())
+        $driverMock->expects(self::any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->will(self::returnValue(
                 $this->createMock(DriverConnection::class)
             ));
 
         $driverStatementMock = $this->createMock(Statement::class);
 
-        $driverStatementMock->expects($this->once())
+        $driverStatementMock->expects(self::once())
             ->method('fetch')
             ->with(FetchMode::NUMERIC)
-            ->will($this->returnValue($result));
+            ->will(self::returnValue($result));
 
         /** @var Connection|MockObject $conn */
         $conn = $this->getMockBuilder(Connection::class)
@@ -592,10 +592,10 @@ class ConnectionTest extends TestCase
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
 
-        $conn->expects($this->once())
+        $conn->expects(self::once())
             ->method('executeQuery')
             ->with($statement, $params, $types)
-            ->will($this->returnValue($driverStatementMock));
+            ->will(self::returnValue($driverStatementMock));
 
         self::assertSame($result, $conn->fetchArray($statement, $params, $types));
     }
@@ -610,18 +610,18 @@ class ConnectionTest extends TestCase
 
         $driverMock = $this->createMock(Driver::class);
 
-        $driverMock->expects($this->any())
+        $driverMock->expects(self::any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->will(self::returnValue(
                 $this->createMock(DriverConnection::class)
             ));
 
         $driverStatementMock = $this->createMock(Statement::class);
 
-        $driverStatementMock->expects($this->once())
+        $driverStatementMock->expects(self::once())
             ->method('fetchColumn')
             ->with($column)
-            ->will($this->returnValue($result));
+            ->will(self::returnValue($result));
 
         /** @var Connection|MockObject $conn */
         $conn = $this->getMockBuilder(Connection::class)
@@ -629,10 +629,10 @@ class ConnectionTest extends TestCase
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
 
-        $conn->expects($this->once())
+        $conn->expects(self::once())
             ->method('executeQuery')
             ->with($statement, $params, $types)
-            ->will($this->returnValue($driverStatementMock));
+            ->will(self::returnValue($driverStatementMock));
 
         self::assertSame($result, $conn->fetchColumn($statement, $params, $column, $types));
     }
@@ -646,17 +646,17 @@ class ConnectionTest extends TestCase
 
         $driverMock = $this->createMock(Driver::class);
 
-        $driverMock->expects($this->any())
+        $driverMock->expects(self::any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->will(self::returnValue(
                 $this->createMock(DriverConnection::class)
             ));
 
         $driverStatementMock = $this->createMock(Statement::class);
 
-        $driverStatementMock->expects($this->once())
+        $driverStatementMock->expects(self::once())
             ->method('fetchAll')
-            ->will($this->returnValue($result));
+            ->will(self::returnValue($result));
 
         /** @var Connection|MockObject $conn */
         $conn = $this->getMockBuilder(Connection::class)
@@ -664,10 +664,10 @@ class ConnectionTest extends TestCase
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
 
-        $conn->expects($this->once())
+        $conn->expects(self::once())
             ->method('executeQuery')
             ->with($statement, $params, $types)
-            ->will($this->returnValue($driverStatementMock));
+            ->will(self::returnValue($driverStatementMock));
 
         self::assertSame($result, $conn->fetchAll($statement, $params, $types));
     }
@@ -686,7 +686,7 @@ class ConnectionTest extends TestCase
     {
         /** @var Driver|MockObject $driver */
         $driver = $this->createMock(Driver::class);
-        $driver->expects($this->once())
+        $driver->expects(self::once())
             ->method('connect');
 
         $platform = $this->createMock(AbstractPlatform::class);
@@ -712,22 +712,22 @@ class ConnectionTest extends TestCase
 
         $connection = new Connection([], $driverMock);
 
-        $driverMock->expects($this->once())
+        $driverMock->expects(self::once())
             ->method('connect')
-            ->will($this->returnValue($driverConnectionMock));
+            ->will(self::returnValue($driverConnectionMock));
 
-        $driverConnectionMock->expects($this->once())
+        $driverConnectionMock->expects(self::once())
             ->method('requiresQueryForServerVersion')
-            ->will($this->returnValue(false));
+            ->will(self::returnValue(false));
 
-        $driverConnectionMock->expects($this->once())
+        $driverConnectionMock->expects(self::once())
             ->method('getServerVersion')
-            ->will($this->returnValue('6.6.6'));
+            ->will(self::returnValue('6.6.6'));
 
-        $driverMock->expects($this->once())
+        $driverMock->expects(self::once())
             ->method('createDatabasePlatformForVersion')
             ->with('6.6.6')
-            ->will($this->returnValue($platformMock));
+            ->will(self::returnValue($platformMock));
 
         self::assertSame($platformMock, $connection->getDatabasePlatform());
     }
@@ -737,10 +737,10 @@ class ConnectionTest extends TestCase
         $resultCacheDriverMock = $this->createMock(Cache::class);
 
         $resultCacheDriverMock
-            ->expects($this->atLeastOnce())
+            ->expects(self::atLeastOnce())
             ->method('fetch')
             ->with('cacheKey')
-            ->will($this->returnValue(['realKey' => []]));
+            ->will(self::returnValue(['realKey' => []]));
 
         $query  = 'SELECT * FROM foo WHERE bar = ?';
         $params = [666];
@@ -750,16 +750,16 @@ class ConnectionTest extends TestCase
         $queryCacheProfileMock = $this->createMock(QueryCacheProfile::class);
 
         $queryCacheProfileMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getResultCacheDriver')
-            ->will($this->returnValue($resultCacheDriverMock));
+            ->will(self::returnValue($resultCacheDriverMock));
 
         // This is our main expectation
         $queryCacheProfileMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('generateCacheKeys')
             ->with($query, $params, $types, $this->params)
-            ->will($this->returnValue(['cacheKey', 'realKey']));
+            ->will(self::returnValue(['cacheKey', 'realKey']));
 
         /** @var Driver $driver */
         $driver = $this->createMock(Driver::class);
@@ -778,28 +778,28 @@ class ConnectionTest extends TestCase
         $resultCacheDriverMock = $this->createMock(Cache::class);
 
         $resultCacheDriverMock
-            ->expects($this->atLeastOnce())
+            ->expects(self::atLeastOnce())
             ->method('fetch')
             ->with('cacheKey')
-            ->will($this->returnValue(['realKey' => []]));
+            ->will(self::returnValue(['realKey' => []]));
 
         /** @var QueryCacheProfile|MockObject $queryCacheProfileMock */
         $queryCacheProfileMock = $this->createMock(QueryCacheProfile::class);
 
         $queryCacheProfileMock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getResultCacheDriver')
-            ->will($this->returnValue($resultCacheDriverMock));
+            ->will(self::returnValue($resultCacheDriverMock));
 
         $query = 'SELECT 1';
 
         $connectionParams = $this->params;
 
         $queryCacheProfileMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('generateCacheKeys')
             ->with($query, [], [], $connectionParams)
-            ->will($this->returnValue(['cacheKey', 'realKey']));
+            ->will(self::returnValue(['cacheKey', 'realKey']));
 
         $connectionParams['platform'] = $this->createMock(AbstractPlatform::class);
 
@@ -837,11 +837,11 @@ class ConnectionTest extends TestCase
         $originalException = new Exception('Original exception');
         $fallbackException = new Exception('Fallback exception');
 
-        $driverMock->expects($this->at(0))
+        $driverMock->expects(self::at(0))
             ->method('connect')
             ->willThrowException($originalException);
 
-        $driverMock->expects($this->at(1))
+        $driverMock->expects(self::at(1))
             ->method('connect')
             ->willThrowException($fallbackException);
 
@@ -868,15 +868,15 @@ class ConnectionTest extends TestCase
         $resultCacheDriver = $this->createMock(Cache::class);
 
         $queryCacheProfile
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getResultCacheDriver')
-            ->will($this->returnValue($resultCacheDriver));
+            ->will(self::returnValue($resultCacheDriver));
 
         $resultCacheDriver
-            ->expects($this->atLeastOnce())
+            ->expects(self::atLeastOnce())
             ->method('fetch')
             ->with('cacheKey')
-            ->will($this->returnValue(['realKey' => []]));
+            ->will(self::returnValue(['realKey' => []]));
 
         $query = 'SELECT 1';
 
@@ -889,10 +889,10 @@ class ConnectionTest extends TestCase
         unset($paramsWithoutPlatform['platform']);
 
         $queryCacheProfile
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('generateCacheKeys')
             ->with($query, [], [], $paramsWithoutPlatform)
-            ->will($this->returnValue(['cacheKey', 'realKey']));
+            ->will(self::returnValue(['cacheKey', 'realKey']));
 
         $connection = new Connection($params, $driver);
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -183,7 +183,7 @@ class ConnectionTest extends TestCase
      * @requires extension pdo_sqlite
      * @dataProvider getQueryMethods
      */
-    public function testDriverExceptionIsWrapped(string $method) : void
+    public function testDriverExceptionIsWrapped(callable $callback) : void
     {
         $this->expectException(DBALException::class);
         $this->expectExceptionMessage("An exception occurred while executing 'MUUHAAAAHAAAA':\n\nSQLSTATE[HY000]: General error: 1 near \"MUUHAAAAHAAAA\"");
@@ -193,20 +193,42 @@ class ConnectionTest extends TestCase
             'memory' => true,
         ]);
 
-        $connection->$method('MUUHAAAAHAAAA');
+        $callback($connection, 'MUUHAAAAHAAAA');
     }
 
     /**
-     * @return array<int, array<int, mixed>>
+     * @return iterable<string, array<int, callable>>
      */
     public static function getQueryMethods() : iterable
     {
-        return [
-            ['exec'],
-            ['query'],
-            ['executeQuery'],
-            ['executeUpdate'],
-            ['prepare'],
+        yield 'exec' => [
+            static function (Connection $connection, string $statement) : void {
+                $connection->exec($statement);
+            },
+        ];
+
+        yield 'query' => [
+            static function (Connection $connection, string $statement) : void {
+                $connection->query($statement);
+            },
+        ];
+
+        yield 'executeQuery' => [
+            static function (Connection $connection, string $statement) : void {
+                $connection->executeQuery($statement);
+            },
+        ];
+
+        yield 'executeUpdate' => [
+            static function (Connection $connection, string $statement) : void {
+                $connection->executeUpdate($statement);
+            },
+        ];
+
+        yield 'prepare' => [
+            static function (Connection $connection, string $statement) : void {
+                $connection->prepare($statement);
+            },
         ];
     }
 

--- a/tests/Driver/AbstractDriverTest.php
+++ b/tests/Driver/AbstractDriverTest.php
@@ -76,7 +76,7 @@ abstract class AbstractDriverTest extends TestCase
     public function testConvertsException($errorCode, ?string $sqlState, ?string $message, string $expectedClass) : void
     {
         if (! $this->driver instanceof ExceptionConverterDriver) {
-            $this->markTestSkipped('This test is only intended for exception converter drivers.');
+            self::markTestSkipped('This test is only intended for exception converter drivers.');
         }
 
         /** @var DriverExceptionInterface|MockObject $driverException */
@@ -102,7 +102,7 @@ abstract class AbstractDriverTest extends TestCase
     public function testCreatesDatabasePlatformForVersion() : void
     {
         if (! $this->driver instanceof VersionAwarePlatformDriver) {
-            $this->markTestSkipped('This test is only intended for version aware platform drivers.');
+            self::markTestSkipped('This test is only intended for version aware platform drivers.');
         }
 
         $data = $this->getDatabasePlatformsForVersions();
@@ -135,7 +135,7 @@ abstract class AbstractDriverTest extends TestCase
     public function testThrowsExceptionOnCreatingDatabasePlatformsForInvalidVersion() : void
     {
         if (! $this->driver instanceof VersionAwarePlatformDriver) {
-            $this->markTestSkipped('This test is only intended for version aware platform drivers.');
+            self::markTestSkipped('This test is only intended for version aware platform drivers.');
         }
 
         $this->expectException(DBALException::class);
@@ -152,9 +152,9 @@ abstract class AbstractDriverTest extends TestCase
 
         $connection = $this->getConnectionMock();
 
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->will(self::returnValue($params));
 
         self::assertSame($params['dbname'], $this->driver->getDatabase($connection));
     }

--- a/tests/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Driver/AbstractMySQLDriverTest.php
@@ -28,19 +28,19 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
 
         $statement = $this->createMock(ResultStatement::class);
 
-        $statement->expects($this->once())
+        $statement->expects(self::once())
             ->method('fetchColumn')
-            ->will($this->returnValue($database));
+            ->will(self::returnValue($database));
 
         $connection = $this->getConnectionMock();
 
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->will(self::returnValue($params));
 
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('query')
-            ->will($this->returnValue($statement));
+            ->will(self::returnValue($statement));
 
         self::assertSame($database, $this->driver->getDatabase($connection));
     }

--- a/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
+++ b/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
@@ -16,7 +16,7 @@ class EasyConnectStringTest extends TestCase
     {
         $string = EasyConnectString::fromConnectionParameters($params);
 
-        $this->assertSame($expected, (string) $string);
+        self::assertSame($expected, (string) $string);
     }
 
     /**

--- a/tests/Driver/AbstractOracleDriverTest.php
+++ b/tests/Driver/AbstractOracleDriverTest.php
@@ -22,9 +22,9 @@ class AbstractOracleDriverTest extends AbstractDriverTest
 
         $connection = $this->getConnectionMock();
 
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->will(self::returnValue($params));
 
         self::assertSame($params['user'], $this->driver->getDatabase($connection));
     }
@@ -41,9 +41,9 @@ class AbstractOracleDriverTest extends AbstractDriverTest
 
         $connection = $this->getConnectionMock();
 
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->will(self::returnValue($params));
 
         self::assertSame($params['user'], $this->driver->getDatabase($connection));
     }

--- a/tests/Driver/AbstractPostgreSQLDriverTest.php
+++ b/tests/Driver/AbstractPostgreSQLDriverTest.php
@@ -26,19 +26,19 @@ class AbstractPostgreSQLDriverTest extends AbstractDriverTest
 
         $statement = $this->createMock(ResultStatement::class);
 
-        $statement->expects($this->once())
+        $statement->expects(self::once())
             ->method('fetchColumn')
-            ->will($this->returnValue($database));
+            ->will(self::returnValue($database));
 
         $connection = $this->getConnectionMock();
 
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->will(self::returnValue($params));
 
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('query')
-            ->will($this->returnValue($statement));
+            ->will(self::returnValue($statement));
 
         self::assertSame($database, $this->driver->getDatabase($connection));
     }

--- a/tests/Driver/AbstractSQLiteDriverTest.php
+++ b/tests/Driver/AbstractSQLiteDriverTest.php
@@ -23,9 +23,9 @@ class AbstractSQLiteDriverTest extends AbstractDriverTest
 
         $connection = $this->getConnectionMock();
 
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->will(self::returnValue($params));
 
         self::assertSame($params['path'], $this->driver->getDatabase($connection));
     }

--- a/tests/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Driver/Mysqli/MysqliConnectionTest.php
@@ -23,7 +23,7 @@ class MysqliConnectionTest extends FunctionalTestCase
     protected function setUp() : void
     {
         if (! extension_loaded('mysqli')) {
-            $this->markTestSkipped('mysqli is not installed.');
+            self::markTestSkipped('mysqli is not installed.');
         }
 
         parent::setUp();

--- a/tests/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Driver/OCI8/OCI8StatementTest.php
@@ -40,23 +40,23 @@ class OCI8StatementTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $statement->expects($this->at(0))
+        $statement->expects(self::at(0))
             ->method('bindValue')
             ->with(
-                $this->equalTo(1),
-                $this->equalTo($params[0])
+                self::equalTo(1),
+                self::equalTo($params[0])
             );
-        $statement->expects($this->at(1))
+        $statement->expects(self::at(1))
             ->method('bindValue')
             ->with(
-                $this->equalTo(2),
-                $this->equalTo($params[1])
+                self::equalTo(2),
+                self::equalTo($params[1])
             );
-        $statement->expects($this->at(2))
+        $statement->expects(self::at(2))
             ->method('bindValue')
             ->with(
-                $this->equalTo(3),
-                $this->equalTo($params[2])
+                self::equalTo(3),
+                self::equalTo($params[2])
             );
 
         // the return value is irrelevant to the test
@@ -70,7 +70,7 @@ class OCI8StatementTest extends TestCase
             ->onlyMethods(['getExecuteMode'])
             ->disableOriginalConstructor()
             ->getMock();
-        $conn->expects($this->once())
+        $conn->expects(self::once())
             ->method('getExecuteMode');
 
         $reflProperty = new ReflectionProperty($statement, '_conn');

--- a/tests/Driver/StatementIteratorTest.php
+++ b/tests/Driver/StatementIteratorTest.php
@@ -25,9 +25,9 @@ class StatementIteratorTest extends TestCase
     {
         /** @var IteratorAggregate|MockObject $stmt */
         $stmt = $this->createPartialMock($class, ['fetch', 'fetchAll', 'fetchColumn']);
-        $stmt->expects($this->never())->method('fetch');
-        $stmt->expects($this->never())->method('fetchAll');
-        $stmt->expects($this->never())->method('fetchColumn');
+        $stmt->expects(self::never())->method('fetch');
+        $stmt->expects(self::never())->method('fetchAll');
+        $stmt->expects(self::never())->method('fetchColumn');
 
         $stmt->getIterator();
     }
@@ -61,7 +61,7 @@ class StatementIteratorTest extends TestCase
         $values = ['foo', '', 'bar', '0', 'baz', 0, 'qux', null, 'quz', false, 'impossible'];
         $calls  = 0;
 
-        $stmt->expects($this->exactly(10))
+        $stmt->expects(self::exactly(10))
             ->method('fetch')
             ->willReturnCallback(static function () use ($values, &$calls) {
                 $value = $values[$calls];
@@ -74,7 +74,7 @@ class StatementIteratorTest extends TestCase
     private function assertIterationCallsFetchOncePerStep(Traversable $iterator, int &$calls) : void
     {
         foreach ($iterator as $i => $_) {
-            $this->assertEquals($i + 1, $calls);
+            self::assertEquals($i + 1, $calls);
         }
     }
 

--- a/tests/Events/MysqlSessionInitTest.php
+++ b/tests/Events/MysqlSessionInitTest.php
@@ -13,9 +13,9 @@ class MysqlSessionInitTest extends TestCase
     public function testPostConnect() : void
     {
         $connectionMock = $this->createMock(Connection::class);
-        $connectionMock->expects($this->once())
+        $connectionMock->expects(self::once())
                        ->method('executeUpdate')
-                       ->with($this->equalTo('SET NAMES foo COLLATE bar'));
+                       ->with(self::equalTo('SET NAMES foo COLLATE bar'));
 
         $eventArgs = new ConnectionEventArgs($connectionMock);
 

--- a/tests/Events/OracleSessionInitTest.php
+++ b/tests/Events/OracleSessionInitTest.php
@@ -14,9 +14,9 @@ class OracleSessionInitTest extends TestCase
     public function testPostConnect() : void
     {
         $connectionMock = $this->createMock(Connection::class);
-        $connectionMock->expects($this->once())
+        $connectionMock->expects(self::once())
                        ->method('executeUpdate')
-                       ->with($this->isType('string'));
+                       ->with(self::isType('string'));
 
         $eventArgs = new ConnectionEventArgs($connectionMock);
 
@@ -33,9 +33,9 @@ class OracleSessionInitTest extends TestCase
         $connectionMock = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connectionMock->expects($this->once())
+        $connectionMock->expects(self::once())
             ->method('executeUpdate')
-            ->with($this->stringContains(sprintf('%s = %s', $name, $value)));
+            ->with(self::stringContains(sprintf('%s = %s', $name, $value)));
 
         $eventArgs = new ConnectionEventArgs($connectionMock);
 

--- a/tests/Events/SQLSessionInitTest.php
+++ b/tests/Events/SQLSessionInitTest.php
@@ -16,9 +16,9 @@ class SQLSessionInitTest extends TestCase
     public function testPostConnect() : void
     {
         $connectionMock = $this->createMock(Connection::class);
-        $connectionMock->expects($this->once())
+        $connectionMock->expects(self::once())
                        ->method('exec')
-                       ->with($this->equalTo("SET SEARCH_PATH TO foo, public, TIMEZONE TO 'Europe/Berlin'"));
+                       ->with(self::equalTo("SET SEARCH_PATH TO foo, public, TIMEZONE TO 'Europe/Berlin'"));
 
         $eventArgs = new ConnectionEventArgs($connectionMock);
 

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -25,7 +25,7 @@ class BlobTest extends FunctionalTestCase
         if ($this->connection->getDriver() instanceof PDOOracleDriver) {
             // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
             // see http://php.net/manual/en/pdo.lobs.php#example-1035
-            $this->markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');
+            self::markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');
         }
 
         $table = new Table('blob_table');
@@ -57,7 +57,7 @@ class BlobTest extends FunctionalTestCase
     {
         // https://github.com/doctrine/dbal/issues/3290
         if ($this->connection->getDriver() instanceof OCI8Driver) {
-            $this->markTestIncomplete('The oci8 driver does not support stream resources as parameters');
+            self::markTestIncomplete('The oci8 driver does not support stream resources as parameters');
         }
 
         $longBlob = str_repeat('x', 4 * 8192); // send 4 chunks
@@ -113,7 +113,7 @@ class BlobTest extends FunctionalTestCase
     {
         // https://github.com/doctrine/dbal/issues/3290
         if ($this->connection->getDriver() instanceof OCI8Driver) {
-            $this->markTestIncomplete('The oci8 driver does not support stream resources as parameters');
+            self::markTestIncomplete('The oci8 driver does not support stream resources as parameters');
         }
 
         $this->connection->insert('blob_table', [
@@ -140,7 +140,7 @@ class BlobTest extends FunctionalTestCase
     public function testBindParamProcessesStream() : void
     {
         if ($this->connection->getDriver() instanceof OCI8Driver) {
-            $this->markTestIncomplete('The oci8 driver does not support stream resources as parameters');
+            self::markTestIncomplete('The oci8 driver does not support stream resources as parameters');
         }
 
         $stmt = $this->connection->prepare("INSERT INTO blob_table(id, clobfield, blobfield) VALUES (1, 'ignored', ?)");

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -283,7 +283,7 @@ class ConnectionTest extends FunctionalTestCase
 
     public function testTransactionalReturnValue() : void
     {
-        $res = $this->connection->transactional(static function () {
+        $res = $this->connection->transactional(static function () : int {
             return 42;
         });
 

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -111,7 +111,7 @@ class ConnectionTest extends FunctionalTestCase
 
         $connection->beginTransaction();
         $connection->executeQuery('insert into test_nesting values (33)');
-        $connection->rollback();
+        $connection->rollBack();
 
         self::assertEquals(0, $connection->fetchColumn('select count(*) from test_nesting'));
     }

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -74,7 +74,7 @@ class ConnectionTest extends FunctionalTestCase
             self::assertTrue($this->connection->isRollbackOnly());
 
             $this->connection->commit(); // should throw exception
-            $this->fail('Transaction commit after failed nested transaction should fail.');
+            self::fail('Transaction commit after failed nested transaction should fail.');
         } catch (ConnectionException $e) {
             self::assertEquals(1, $this->connection->getTransactionNestingLevel());
             $this->connection->rollBack();
@@ -119,7 +119,7 @@ class ConnectionTest extends FunctionalTestCase
     public function testTransactionNestingBehaviorWithSavepoints() : void
     {
         if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
-            $this->markTestSkipped('This test requires the platform to support savepoints.');
+            self::markTestSkipped('This test requires the platform to support savepoints.');
         }
 
         $this->connection->setNestTransactionsWithSavepoints(true);
@@ -144,21 +144,20 @@ class ConnectionTest extends FunctionalTestCase
             self::assertFalse($this->connection->isRollbackOnly());
             try {
                 $this->connection->setNestTransactionsWithSavepoints(false);
-                $this->fail('Should not be able to disable savepoints in usage for nested transactions inside an open transaction.');
+                self::fail('Should not be able to disable savepoints in usage for nested transactions inside an open transaction.');
             } catch (ConnectionException $e) {
                 self::assertTrue($this->connection->getNestTransactionsWithSavepoints());
             }
             $this->connection->commit(); // should not throw exception
         } catch (ConnectionException $e) {
-            $this->fail('Transaction commit after failed nested transaction should not fail when using savepoints.');
-            $this->connection->rollBack();
+            self::fail('Transaction commit after failed nested transaction should not fail when using savepoints.');
         }
     }
 
     public function testTransactionNestingBehaviorCantBeChangedInActiveTransaction() : void
     {
         if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
-            $this->markTestSkipped('This test requires the platform to support savepoints.');
+            self::markTestSkipped('This test requires the platform to support savepoints.');
         }
 
         $this->connection->beginTransaction();
@@ -169,7 +168,7 @@ class ConnectionTest extends FunctionalTestCase
     public function testSetNestedTransactionsThroughSavepointsNotSupportedThrowsException() : void
     {
         if ($this->connection->getDatabasePlatform()->supportsSavepoints()) {
-            $this->markTestSkipped('This test requires the platform not to support savepoints.');
+            self::markTestSkipped('This test requires the platform not to support savepoints.');
         }
 
         $this->expectException(ConnectionException::class);
@@ -181,7 +180,7 @@ class ConnectionTest extends FunctionalTestCase
     public function testCreateSavepointsNotSupportedThrowsException() : void
     {
         if ($this->connection->getDatabasePlatform()->supportsSavepoints()) {
-            $this->markTestSkipped('This test requires the platform not to support savepoints.');
+            self::markTestSkipped('This test requires the platform not to support savepoints.');
         }
 
         $this->expectException(ConnectionException::class);
@@ -193,7 +192,7 @@ class ConnectionTest extends FunctionalTestCase
     public function testReleaseSavepointsNotSupportedThrowsException() : void
     {
         if ($this->connection->getDatabasePlatform()->supportsSavepoints()) {
-            $this->markTestSkipped('This test requires the platform not to support savepoints.');
+            self::markTestSkipped('This test requires the platform not to support savepoints.');
         }
 
         $this->expectException(ConnectionException::class);
@@ -205,7 +204,7 @@ class ConnectionTest extends FunctionalTestCase
     public function testRollbackSavepointsNotSupportedThrowsException() : void
     {
         if ($this->connection->getDatabasePlatform()->supportsSavepoints()) {
-            $this->markTestSkipped('This test requires the platform not to support savepoints.');
+            self::markTestSkipped('This test requires the platform not to support savepoints.');
         }
 
         $this->expectException(ConnectionException::class);
@@ -252,7 +251,7 @@ class ConnectionTest extends FunctionalTestCase
                 $conn->executeQuery($conn->getDatabasePlatform()->getDummySelectSQL());
                 throw new RuntimeException('Ooops!');
             });
-            $this->fail('Expected exception');
+            self::fail('Expected exception');
         } catch (RuntimeException $expected) {
             self::assertEquals(0, $this->connection->getTransactionNestingLevel());
         }
@@ -266,7 +265,7 @@ class ConnectionTest extends FunctionalTestCase
                 $conn->executeQuery($conn->getDatabasePlatform()->getDummySelectSQL());
                 throw new Error('Ooops!');
             });
-            $this->fail('Expected exception');
+            self::fail('Expected exception');
         } catch (Error $expected) {
             self::assertEquals(0, $this->connection->getTransactionNestingLevel());
         }
@@ -314,7 +313,7 @@ class ConnectionTest extends FunctionalTestCase
     public function testConnectWithoutExplicitDatabaseName() : void
     {
         if (in_array($this->connection->getDatabasePlatform()->getName(), ['oracle', 'db2'], true)) {
-            $this->markTestSkipped('Platform does not support connecting without database name.');
+            self::markTestSkipped('Platform does not support connecting without database name.');
         }
 
         $params = $this->connection->getParams();
@@ -337,7 +336,7 @@ class ConnectionTest extends FunctionalTestCase
     public function testDeterminesDatabasePlatformWhenConnectingToNonExistentDatabase() : void
     {
         if (in_array($this->connection->getDatabasePlatform()->getName(), ['oracle', 'db2'], true)) {
-            $this->markTestSkipped('Platform does not support connecting without database name.');
+            self::markTestSkipped('Platform does not support connecting without database name.');
         }
 
         $params = $this->connection->getParams();

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -20,13 +20,11 @@ use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
 use PDO;
 use const CASE_LOWER;
-use const PHP_EOL;
 use function array_change_key_case;
 use function array_filter;
 use function array_keys;
 use function count;
 use function date;
-use function implode;
 use function is_numeric;
 use function json_encode;
 use function property_exists;
@@ -701,14 +699,12 @@ class DataAccessTest extends FunctionalTestCase
             ]);
         }
 
-        $sql[] = 'SELECT ';
-        $sql[] = 'test_int, ';
-        $sql[] = 'test_string, ';
-        $sql[] = $platform->getBitOrComparisonExpression('test_int', 2) . ' AS bit_or, ';
-        $sql[] = $platform->getBitAndComparisonExpression('test_int', 2) . ' AS bit_and ';
-        $sql[] = 'FROM fetch_table';
+        $sql = 'SELECT test_int, test_string'
+            . ', ' . $platform->getBitOrComparisonExpression('test_int', 2) . ' AS bit_or'
+            . ', ' . $platform->getBitAndComparisonExpression('test_int', 2) . ' AS bit_and'
+            . ' FROM fetch_table';
 
-        $stmt = $this->connection->executeQuery(implode(PHP_EOL, $sql));
+        $stmt = $this->connection->executeQuery($sql);
         $data = $stmt->fetchAll(FetchMode::ASSOCIATIVE);
 
         self::assertCount(4, $data);

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -248,7 +248,7 @@ class DataAccessTest extends FunctionalTestCase
     {
         if ($this->connection->getDriver() instanceof MySQLiDriver ||
             $this->connection->getDriver() instanceof SQLSrvDriver) {
-            $this->markTestSkipped('mysqli and sqlsrv actually supports this');
+            self::markTestSkipped('mysqli and sqlsrv actually supports this');
         }
 
         $datetimeString = '2010-01-01 10:10:10';
@@ -319,7 +319,7 @@ class DataAccessTest extends FunctionalTestCase
     {
         if ($this->connection->getDriver() instanceof MySQLiDriver ||
             $this->connection->getDriver() instanceof SQLSrvDriver) {
-            $this->markTestSkipped('mysqli and sqlsrv actually supports this');
+            self::markTestSkipped('mysqli and sqlsrv actually supports this');
         }
 
         $datetimeString = '2010-01-01 10:10:10';
@@ -364,7 +364,7 @@ class DataAccessTest extends FunctionalTestCase
     {
         if ($this->connection->getDriver() instanceof MySQLiDriver ||
             $this->connection->getDriver() instanceof SQLSrvDriver) {
-            $this->markTestSkipped('mysqli and sqlsrv actually supports this');
+            self::markTestSkipped('mysqli and sqlsrv actually supports this');
         }
 
         $datetimeString = '2010-01-01 10:10:10';
@@ -411,7 +411,7 @@ class DataAccessTest extends FunctionalTestCase
     {
         if ($this->connection->getDriver() instanceof MySQLiDriver ||
             $this->connection->getDriver() instanceof SQLSrvDriver) {
-            $this->markTestSkipped('mysqli and sqlsrv actually supports this');
+            self::markTestSkipped('mysqli and sqlsrv actually supports this');
         }
 
         $datetimeString = '2010-01-01 10:10:10';
@@ -620,7 +620,7 @@ class DataAccessTest extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform();
 
         if (! $platform instanceof SqlitePlatform) {
-            $this->markTestSkipped('test is for sqlite only');
+            self::markTestSkipped('test is for sqlite only');
         }
 
         $table = new Table('fetch_table_date_math');
@@ -639,7 +639,7 @@ class DataAccessTest extends FunctionalTestCase
 
         $rowCount = $this->connection->fetchColumn($sql, [], 0);
 
-        $this->assertEquals(1, $rowCount);
+        self::assertEquals(1, $rowCount);
     }
 
     public function testLocateExpression() : void
@@ -942,11 +942,11 @@ class DataAccessTest extends FunctionalTestCase
         $driver = $this->connection->getDriver();
 
         if ($driver instanceof Oci8Driver) {
-            $this->markTestSkipped('Not supported by OCI8');
+            self::markTestSkipped('Not supported by OCI8');
         }
 
         if ($driver instanceof MySQLiDriver) {
-            $this->markTestSkipped('Mysqli driver dont support this feature.');
+            self::markTestSkipped('Mysqli driver dont support this feature.');
         }
 
         if (! $driver instanceof PDOOracleDriver) {

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -737,7 +737,7 @@ class DataAccessTest extends FunctionalTestCase
         $stmt->setFetchMode(FetchMode::NUMERIC);
 
         $row = array_keys($stmt->fetch());
-        self::assertCount(0, array_filter($row, static function ($v) {
+        self::assertCount(0, array_filter($row, static function ($v) : bool {
             return ! is_numeric($v);
         }), 'should be no non-numerical elements in the result.');
     }

--- a/tests/Functional/Driver/IBMDB2/DB2DriverTest.php
+++ b/tests/Functional/Driver/IBMDB2/DB2DriverTest.php
@@ -12,7 +12,7 @@ class DB2DriverTest extends AbstractDriverTest
     protected function setUp() : void
     {
         if (! extension_loaded('ibm_db2')) {
-            $this->markTestSkipped('ibm_db2 is not installed.');
+            self::markTestSkipped('ibm_db2 is not installed.');
         }
 
         parent::setUp();
@@ -21,7 +21,7 @@ class DB2DriverTest extends AbstractDriverTest
             return;
         }
 
-        $this->markTestSkipped('ibm_db2 only test.');
+        self::markTestSkipped('ibm_db2 only test.');
     }
 
     /**
@@ -29,7 +29,7 @@ class DB2DriverTest extends AbstractDriverTest
      */
     public function testConnectsWithoutDatabaseNameParameter() : void
     {
-        $this->markTestSkipped('IBM DB2 does not support connecting without database name.');
+        self::markTestSkipped('IBM DB2 does not support connecting without database name.');
     }
 
     /**
@@ -37,7 +37,7 @@ class DB2DriverTest extends AbstractDriverTest
      */
     public function testReturnsDatabaseNameWithoutDatabaseNameParameter() : void
     {
-        $this->markTestSkipped('IBM DB2 does not support connecting without database name.');
+        self::markTestSkipped('IBM DB2 does not support connecting without database name.');
     }
 
     /**

--- a/tests/Functional/Driver/IBMDB2/DB2StatementTest.php
+++ b/tests/Functional/Driver/IBMDB2/DB2StatementTest.php
@@ -13,7 +13,7 @@ class DB2StatementTest extends FunctionalTestCase
     protected function setUp() : void
     {
         if (! extension_loaded('ibm_db2')) {
-            $this->markTestSkipped('ibm_db2 is not installed.');
+            self::markTestSkipped('ibm_db2 is not installed.');
         }
 
         parent::setUp();
@@ -22,7 +22,7 @@ class DB2StatementTest extends FunctionalTestCase
             return;
         }
 
-        $this->markTestSkipped('ibm_db2 only test.');
+        self::markTestSkipped('ibm_db2 only test.');
     }
 
     public function testExecutionErrorsAreNotSuppressed() : void

--- a/tests/Functional/Driver/Mysqli/ConnectionTest.php
+++ b/tests/Functional/Driver/Mysqli/ConnectionTest.php
@@ -31,12 +31,10 @@ class ConnectionTest extends FunctionalTestCase
         parent::tearDown();
     }
 
-    public function testDriverOptions() : void
+    public function testSupportedDriverOptions() : void
     {
-        $driverOptions = [MYSQLI_OPT_CONNECT_TIMEOUT => 1];
-
-        $connection = $this->getConnection($driverOptions);
-        self::assertInstanceOf(MysqliConnection::class, $connection);
+        $this->expectNotToPerformAssertions();
+        $this->getConnection([MYSQLI_OPT_CONNECT_TIMEOUT => 1]);
     }
 
     public function testUnsupportedDriverOption() : void

--- a/tests/Functional/Driver/Mysqli/ConnectionTest.php
+++ b/tests/Functional/Driver/Mysqli/ConnectionTest.php
@@ -14,7 +14,7 @@ class ConnectionTest extends FunctionalTestCase
     protected function setUp() : void
     {
         if (! extension_loaded('mysqli')) {
-            $this->markTestSkipped('mysqli is not installed.');
+            self::markTestSkipped('mysqli is not installed.');
         }
 
         parent::setUp();
@@ -23,7 +23,7 @@ class ConnectionTest extends FunctionalTestCase
             return;
         }
 
-        $this->markTestSkipped('MySQLi only test.');
+        self::markTestSkipped('MySQLi only test.');
     }
 
     protected function tearDown() : void

--- a/tests/Functional/Driver/Mysqli/DriverTest.php
+++ b/tests/Functional/Driver/Mysqli/DriverTest.php
@@ -12,7 +12,7 @@ class DriverTest extends AbstractDriverTest
     protected function setUp() : void
     {
         if (! extension_loaded('mysqli')) {
-            $this->markTestSkipped('mysqli is not installed.');
+            self::markTestSkipped('mysqli is not installed.');
         }
 
         parent::setUp();
@@ -21,7 +21,7 @@ class DriverTest extends AbstractDriverTest
             return;
         }
 
-        $this->markTestSkipped('MySQLi only test.');
+        self::markTestSkipped('MySQLi only test.');
     }
 
     /**

--- a/tests/Functional/Driver/OCI8/DriverTest.php
+++ b/tests/Functional/Driver/OCI8/DriverTest.php
@@ -12,7 +12,7 @@ class DriverTest extends AbstractDriverTest
     protected function setUp() : void
     {
         if (! extension_loaded('oci8')) {
-            $this->markTestSkipped('oci8 is not installed.');
+            self::markTestSkipped('oci8 is not installed.');
         }
 
         parent::setUp();
@@ -21,7 +21,7 @@ class DriverTest extends AbstractDriverTest
             return;
         }
 
-        $this->markTestSkipped('oci8 only test.');
+        self::markTestSkipped('oci8 only test.');
     }
 
     /**
@@ -29,7 +29,7 @@ class DriverTest extends AbstractDriverTest
      */
     public function testConnectsWithoutDatabaseNameParameter() : void
     {
-        $this->markTestSkipped('Oracle does not support connecting without database name.');
+        self::markTestSkipped('Oracle does not support connecting without database name.');
     }
 
     /**
@@ -37,7 +37,7 @@ class DriverTest extends AbstractDriverTest
      */
     public function testReturnsDatabaseNameWithoutDatabaseNameParameter() : void
     {
-        $this->markTestSkipped('Oracle does not support connecting without database name.');
+        self::markTestSkipped('Oracle does not support connecting without database name.');
     }
 
     /**

--- a/tests/Functional/Driver/OCI8/OCI8ConnectionTest.php
+++ b/tests/Functional/Driver/OCI8/OCI8ConnectionTest.php
@@ -16,13 +16,13 @@ class OCI8ConnectionTest extends FunctionalTestCase
     protected function setUp() : void
     {
         if (! extension_loaded('oci8')) {
-            $this->markTestSkipped('oci8 is not installed.');
+            self::markTestSkipped('oci8 is not installed.');
         }
 
         parent::setUp();
 
         if (! $this->connection->getDriver() instanceof Driver) {
-            $this->markTestSkipped('oci8 only test.');
+            self::markTestSkipped('oci8 only test.');
         }
 
         $this->driverConnection = $this->connection->getWrappedConnection();

--- a/tests/Functional/Driver/OCI8/StatementTest.php
+++ b/tests/Functional/Driver/OCI8/StatementTest.php
@@ -11,7 +11,7 @@ class StatementTest extends FunctionalTestCase
     protected function setUp() : void
     {
         if (! extension_loaded('oci8')) {
-            $this->markTestSkipped('oci8 is not installed.');
+            self::markTestSkipped('oci8 is not installed.');
         }
 
         parent::setUp();
@@ -20,7 +20,7 @@ class StatementTest extends FunctionalTestCase
             return;
         }
 
-        $this->markTestSkipped('oci8 only test.');
+        self::markTestSkipped('oci8 only test.');
     }
 
     /**

--- a/tests/Functional/Driver/PDOConnectionTest.php
+++ b/tests/Functional/Driver/PDOConnectionTest.php
@@ -34,7 +34,7 @@ class PDOConnectionTest extends FunctionalTestCase
             return;
         }
 
-        $this->markTestSkipped('PDO connection only test.');
+        self::markTestSkipped('PDO connection only test.');
     }
 
     protected function tearDown() : void
@@ -71,7 +71,7 @@ class PDOConnectionTest extends FunctionalTestCase
         $driver = $this->connection->getDriver();
 
         if ($driver instanceof PDOSQLSRVDriver) {
-            $this->markTestSkipped('pdo_sqlsrv does not allow setting PDO::ATTR_EMULATE_PREPARES at connection level.');
+            self::markTestSkipped('pdo_sqlsrv does not allow setting PDO::ATTR_EMULATE_PREPARES at connection level.');
         }
 
         // Some PDO adapters do not check the query server-side

--- a/tests/Functional/Driver/PDOMySql/DriverTest.php
+++ b/tests/Functional/Driver/PDOMySql/DriverTest.php
@@ -12,7 +12,7 @@ class DriverTest extends AbstractDriverTest
     protected function setUp() : void
     {
         if (! extension_loaded('pdo_mysql')) {
-            $this->markTestSkipped('pdo_mysql is not installed.');
+            self::markTestSkipped('pdo_mysql is not installed.');
         }
 
         parent::setUp();
@@ -21,7 +21,7 @@ class DriverTest extends AbstractDriverTest
             return;
         }
 
-        $this->markTestSkipped('pdo_mysql only test.');
+        self::markTestSkipped('pdo_mysql only test.');
     }
 
     /**

--- a/tests/Functional/Driver/PDOOracle/DriverTest.php
+++ b/tests/Functional/Driver/PDOOracle/DriverTest.php
@@ -12,7 +12,7 @@ class DriverTest extends AbstractDriverTest
     protected function setUp() : void
     {
         if (! extension_loaded('PDO_OCI')) {
-            $this->markTestSkipped('PDO_OCI is not installed.');
+            self::markTestSkipped('PDO_OCI is not installed.');
         }
 
         parent::setUp();
@@ -21,7 +21,7 @@ class DriverTest extends AbstractDriverTest
             return;
         }
 
-        $this->markTestSkipped('PDO_OCI only test.');
+        self::markTestSkipped('PDO_OCI only test.');
     }
 
     /**
@@ -29,7 +29,7 @@ class DriverTest extends AbstractDriverTest
      */
     public function testConnectsWithoutDatabaseNameParameter() : void
     {
-        $this->markTestSkipped('Oracle does not support connecting without database name.');
+        self::markTestSkipped('Oracle does not support connecting without database name.');
     }
 
     /**
@@ -37,7 +37,7 @@ class DriverTest extends AbstractDriverTest
      */
     public function testReturnsDatabaseNameWithoutDatabaseNameParameter() : void
     {
-        $this->markTestSkipped('Oracle does not support connecting without database name.');
+        self::markTestSkipped('Oracle does not support connecting without database name.');
     }
 
     /**

--- a/tests/Functional/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Functional/Driver/PDOPgSql/DriverTest.php
@@ -17,7 +17,7 @@ class DriverTest extends AbstractDriverTest
     protected function setUp() : void
     {
         if (! extension_loaded('pdo_pgsql')) {
-            $this->markTestSkipped('pdo_pgsql is not installed.');
+            self::markTestSkipped('pdo_pgsql is not installed.');
         }
 
         parent::setUp();
@@ -26,7 +26,7 @@ class DriverTest extends AbstractDriverTest
             return;
         }
 
-        $this->markTestSkipped('pdo_pgsql only test.');
+        self::markTestSkipped('pdo_pgsql only test.');
     }
 
     /**
@@ -98,7 +98,7 @@ class DriverTest extends AbstractDriverTest
             }
         }
 
-        $this->fail(sprintf('Query result does not contain a record where column "query" equals "%s".', $sql));
+        self::fail(sprintf('Query result does not contain a record where column "query" equals "%s".', $sql));
     }
 
     /**

--- a/tests/Functional/Driver/PDOPgsqlConnectionTest.php
+++ b/tests/Functional/Driver/PDOPgsqlConnectionTest.php
@@ -13,7 +13,7 @@ class PDOPgsqlConnectionTest extends FunctionalTestCase
     protected function setUp() : void
     {
         if (! extension_loaded('pdo_pgsql')) {
-            $this->markTestSkipped('pdo_pgsql is not loaded.');
+            self::markTestSkipped('pdo_pgsql is not loaded.');
         }
 
         parent::setUp();
@@ -22,7 +22,7 @@ class PDOPgsqlConnectionTest extends FunctionalTestCase
             return;
         }
 
-        $this->markTestSkipped('PDOPgsql only test.');
+        self::markTestSkipped('PDOPgsql only test.');
     }
 
     /**

--- a/tests/Functional/Driver/PDOSqlite/DriverTest.php
+++ b/tests/Functional/Driver/PDOSqlite/DriverTest.php
@@ -12,7 +12,7 @@ class DriverTest extends AbstractDriverTest
     protected function setUp() : void
     {
         if (! extension_loaded('pdo_sqlite')) {
-            $this->markTestSkipped('pdo_sqlite is not installed.');
+            self::markTestSkipped('pdo_sqlite is not installed.');
         }
 
         parent::setUp();
@@ -21,7 +21,7 @@ class DriverTest extends AbstractDriverTest
             return;
         }
 
-        $this->markTestSkipped('pdo_sqlite only test.');
+        self::markTestSkipped('pdo_sqlite only test.');
     }
 
     /**

--- a/tests/Functional/Driver/PDOSqlsrv/DriverTest.php
+++ b/tests/Functional/Driver/PDOSqlsrv/DriverTest.php
@@ -16,7 +16,7 @@ class DriverTest extends AbstractDriverTest
     protected function setUp() : void
     {
         if (! extension_loaded('pdo_sqlsrv')) {
-            $this->markTestSkipped('pdo_sqlsrv is not installed.');
+            self::markTestSkipped('pdo_sqlsrv is not installed.');
         }
 
         parent::setUp();
@@ -25,7 +25,7 @@ class DriverTest extends AbstractDriverTest
             return;
         }
 
-        $this->markTestSkipped('pdo_sqlsrv only test.');
+        self::markTestSkipped('pdo_sqlsrv only test.');
     }
 
     /**

--- a/tests/Functional/Driver/SQLAnywhere/ConnectionTest.php
+++ b/tests/Functional/Driver/SQLAnywhere/ConnectionTest.php
@@ -12,7 +12,7 @@ class ConnectionTest extends FunctionalTestCase
     protected function setUp() : void
     {
         if (! extension_loaded('sqlanywhere')) {
-            $this->markTestSkipped('sqlanywhere is not installed.');
+            self::markTestSkipped('sqlanywhere is not installed.');
         }
 
         parent::setUp();
@@ -21,7 +21,7 @@ class ConnectionTest extends FunctionalTestCase
             return;
         }
 
-        $this->markTestSkipped('sqlanywhere only test.');
+        self::markTestSkipped('sqlanywhere only test.');
     }
 
     public function testNonPersistentConnection() : void

--- a/tests/Functional/Driver/SQLAnywhere/DriverTest.php
+++ b/tests/Functional/Driver/SQLAnywhere/DriverTest.php
@@ -13,7 +13,7 @@ class DriverTest extends AbstractDriverTest
     protected function setUp() : void
     {
         if (! extension_loaded('sqlanywhere')) {
-            $this->markTestSkipped('sqlanywhere is not installed.');
+            self::markTestSkipped('sqlanywhere is not installed.');
         }
 
         parent::setUp();
@@ -22,7 +22,7 @@ class DriverTest extends AbstractDriverTest
             return;
         }
 
-        $this->markTestSkipped('sqlanywhere only test.');
+        self::markTestSkipped('sqlanywhere only test.');
     }
 
     public function testReturnsDatabaseNameWithoutDatabaseNameParameter() : void

--- a/tests/Functional/Driver/SQLAnywhere/StatementTest.php
+++ b/tests/Functional/Driver/SQLAnywhere/StatementTest.php
@@ -12,7 +12,7 @@ class StatementTest extends FunctionalTestCase
     protected function setUp() : void
     {
         if (! extension_loaded('sqlanywhere')) {
-            $this->markTestSkipped('sqlanywhere is not installed.');
+            self::markTestSkipped('sqlanywhere is not installed.');
         }
 
         parent::setUp();
@@ -21,7 +21,7 @@ class StatementTest extends FunctionalTestCase
             return;
         }
 
-        $this->markTestSkipped('sqlanywhere only test.');
+        self::markTestSkipped('sqlanywhere only test.');
     }
 
     public function testNonPersistentStatement() : void

--- a/tests/Functional/Driver/SQLSrv/DriverTest.php
+++ b/tests/Functional/Driver/SQLSrv/DriverTest.php
@@ -12,7 +12,7 @@ class DriverTest extends AbstractDriverTest
     protected function setUp() : void
     {
         if (! extension_loaded('sqlsrv')) {
-            $this->markTestSkipped('sqlsrv is not installed.');
+            self::markTestSkipped('sqlsrv is not installed.');
         }
 
         parent::setUp();
@@ -21,7 +21,7 @@ class DriverTest extends AbstractDriverTest
             return;
         }
 
-        $this->markTestSkipped('sqlsrv only test.');
+        self::markTestSkipped('sqlsrv only test.');
     }
 
     /**

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -37,7 +37,7 @@ class ExceptionTest extends FunctionalTestCase
             return;
         }
 
-        $this->markTestSkipped('Driver does not support special exception handling.');
+        self::markTestSkipped('Driver does not support special exception handling.');
     }
 
     public function testPrimaryConstraintViolationException() : void
@@ -296,7 +296,7 @@ class ExceptionTest extends FunctionalTestCase
     public function testConnectionExceptionSqLite() : void
     {
         if (! ($this->connection->getDatabasePlatform() instanceof SqlitePlatform)) {
-            $this->markTestSkipped('Only fails this way on sqlite');
+            self::markTestSkipped('Only fails this way on sqlite');
         }
 
         // mode 0 is considered read-only on Windows
@@ -353,11 +353,11 @@ EOT
         $platform = $this->connection->getDatabasePlatform();
 
         if ($platform instanceof SqlitePlatform) {
-            $this->markTestSkipped('Only skipped if platform is not sqlite');
+            self::markTestSkipped('Only skipped if platform is not sqlite');
         }
 
         if ($platform instanceof PostgreSQL94Platform && isset($params['password'])) {
-            $this->markTestSkipped('Does not work on Travis');
+            self::markTestSkipped('Does not work on Travis');
         }
 
         if ($platform instanceof MySqlPlatform && isset($params['user'])) {
@@ -365,7 +365,7 @@ EOT
             assert($wrappedConnection instanceof ServerInfoAwareConnection);
 
             if (version_compare($wrappedConnection->getServerVersion(), '8', '>=')) {
-                $this->markTestIncomplete('PHP currently does not completely support MySQL 8');
+                self::markTestIncomplete('PHP currently does not completely support MySQL 8');
             }
         }
 

--- a/tests/Functional/LikeWildcardsEscapingTest.php
+++ b/tests/Functional/LikeWildcardsEscapingTest.php
@@ -23,6 +23,6 @@ final class LikeWildcardsEscapingTest extends FunctionalTestCase
             )
         );
         $stmt->execute();
-        $this->assertTrue((bool) $stmt->fetchColumn());
+        self::assertTrue((bool) $stmt->fetchColumn());
     }
 }

--- a/tests/Functional/LoggingTest.php
+++ b/tests/Functional/LoggingTest.php
@@ -12,10 +12,10 @@ class LoggingTest extends FunctionalTestCase
         $sql = $this->connection->getDatabasePlatform()->getDummySelectSQL();
 
         $logMock = $this->createMock(SQLLogger::class);
-        $logMock->expects($this->at(0))
+        $logMock->expects(self::at(0))
                 ->method('startQuery')
-                ->with($this->equalTo($sql), $this->equalTo([]), $this->equalTo([]));
-        $logMock->expects($this->at(1))
+                ->with(self::equalTo($sql), self::equalTo([]), self::equalTo([]));
+        $logMock->expects(self::at(1))
                 ->method('stopQuery');
         $this->connection->getConfiguration()->setSQLLogger($logMock);
         $this->connection->executeQuery($sql, []);
@@ -28,10 +28,10 @@ class LoggingTest extends FunctionalTestCase
         $sql = $this->connection->getDatabasePlatform()->getDummySelectSQL();
 
         $logMock = $this->createMock(SQLLogger::class);
-        $logMock->expects($this->at(0))
+        $logMock->expects(self::at(0))
                 ->method('startQuery')
-                ->with($this->equalTo($sql), $this->equalTo([]), $this->equalTo([]));
-        $logMock->expects($this->at(1))
+                ->with(self::equalTo($sql), self::equalTo([]), self::equalTo([]));
+        $logMock->expects(self::at(1))
                 ->method('stopQuery');
         $this->connection->getConfiguration()->setSQLLogger($logMock);
         $this->connection->executeUpdate($sql, []);
@@ -42,10 +42,10 @@ class LoggingTest extends FunctionalTestCase
         $sql = $this->connection->getDatabasePlatform()->getDummySelectSQL();
 
         $logMock = $this->createMock(SQLLogger::class);
-        $logMock->expects($this->once())
+        $logMock->expects(self::once())
                 ->method('startQuery')
-                ->with($this->equalTo($sql), $this->equalTo([]));
-        $logMock->expects($this->at(1))
+                ->with(self::equalTo($sql), self::equalTo([]));
+        $logMock->expects(self::at(1))
                 ->method('stopQuery');
         $this->connection->getConfiguration()->setSQLLogger($logMock);
 

--- a/tests/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Functional/MasterSlaveConnectionTest.php
@@ -28,7 +28,7 @@ class MasterSlaveConnectionTest extends FunctionalTestCase
 
         // This is a MySQL specific test, skip other vendors.
         if ($platformName !== 'mysql') {
-            $this->markTestSkipped(sprintf('Test does not work on %s.', $platformName));
+            self::markTestSkipped(sprintf('Test does not work on %s.', $platformName));
         }
 
         try {

--- a/tests/Functional/NamedParametersTest.php
+++ b/tests/Functional/NamedParametersTest.php
@@ -199,7 +199,7 @@ class NamedParametersTest extends FunctionalTestCase
                 'bar' => 2,
             ]);
         } catch (Throwable $e) {
-            $this->fail($e->getMessage());
+            self::fail($e->getMessage());
         }
     }
 

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -3,9 +3,9 @@
 namespace Doctrine\DBAL\Tests\Functional\Platform;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
-use function in_array;
 
 final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCase
 {
@@ -16,7 +16,7 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
     {
         parent::setUp();
 
-        if (in_array($this->getPlatform()->getName(), ['mysql'])) {
+        if ($this->getPlatform() instanceof MySqlPlatform) {
             return;
         }
 

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -20,7 +20,7 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
             return;
         }
 
-        $this->markTestSkipped('Restricted to MySQL.');
+        self::markTestSkipped('Restricted to MySQL.');
     }
 
     /**
@@ -57,10 +57,10 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
         $validationSchema = $schemaManager->createSchema();
         $validationTable  = $validationSchema->getTable($table->getName());
 
-        $this->assertTrue($validationTable->hasColumn('new_id'));
-        $this->assertTrue($validationTable->getColumn('new_id')->getAutoincrement());
-        $this->assertTrue($validationTable->hasPrimaryKey());
-        $this->assertSame(['new_id'], $validationTable->getPrimaryKeyColumns());
+        self::assertTrue($validationTable->hasColumn('new_id'));
+        self::assertTrue($validationTable->getColumn('new_id')->getAutoincrement());
+        self::assertTrue($validationTable->hasPrimaryKey());
+        self::assertSame(['new_id'], $validationTable->getPrimaryKeyColumns());
     }
 
     private function getPlatform() : AbstractPlatform

--- a/tests/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySqlSchemaManagerTest.php
@@ -178,7 +178,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testDoesNotPropagateDefaultValuesForUnsupportedColumnTypes() : void
     {
         if ($this->schemaManager->getDatabasePlatform() instanceof MariaDb1027Platform) {
-            $this->markTestSkipped(
+            self::markTestSkipped(
                 'MariaDb102Platform supports default values for BLOB and TEXT columns and will propagate values'
             );
         }
@@ -489,7 +489,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testColumnDefaultValuesCurrentTimeAndDate() : void
     {
         if (! $this->schemaManager->getDatabasePlatform() instanceof MariaDb1027Platform) {
-            $this->markTestSkipped('Only relevant for MariaDb102Platform.');
+            self::markTestSkipped('Only relevant for MariaDb102Platform.');
         }
 
         $platform = $this->schemaManager->getDatabasePlatform();

--- a/tests/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -224,7 +224,7 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testListForeignKeys() : void
     {
         if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped('Does not support foreign key constraints.');
+            self::markTestSkipped('Does not support foreign key constraints.');
         }
 
         $fkOptions   = ['SET NULL', 'SET DEFAULT', 'NO ACTION','CASCADE', 'RESTRICT'];

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -171,26 +171,24 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             );
         }
 
-        $sequence = new Sequence('list_sequences_test_seq', 20, 10);
-        $this->schemaManager->createSequence($sequence);
+        $this->schemaManager->createSequence(
+            new Sequence('list_sequences_test_seq', 20, 10)
+        );
 
         $sequences = $this->schemaManager->listSequences();
 
         self::assertIsArray($sequences, 'listSequences() should return an array.');
 
-        $foundSequence = null;
         foreach ($sequences as $sequence) {
-            self::assertInstanceOf(Sequence::class, $sequence, 'Array elements of listSequences() should be Sequence instances.');
-            if (strtolower($sequence->getName()) !== 'list_sequences_test_seq') {
-                continue;
-            }
+            if (strtolower($sequence->getName()) === 'list_sequences_test_seq') {
+                self::assertSame(20, $sequence->getAllocationSize());
+                self::assertSame(10, $sequence->getInitialValue());
 
-            $foundSequence = $sequence;
+                return;
+            }
         }
 
-        self::assertNotNull($foundSequence, "Sequence with name 'list_sequences_test_seq' was not found.");
-        self::assertSame(20, $foundSequence->getAllocationSize(), 'Allocation Size is expected to be 20.');
-        self::assertSame(10, $foundSequence->getInitialValue(), 'Initial Value is expected to be 10.');
+        self::fail('Sequence was not found.');
     }
 
     public function testListDatabases() : void

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -281,11 +281,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         self::assertArrayHasKey('id', $columns);
         self::assertEquals(0, array_search('id', $columnsKeys));
-        self::assertEquals('id', strtolower($columns['id']->getname()));
-        self::assertInstanceOf(IntegerType::class, $columns['id']->gettype());
-        self::assertEquals(false, $columns['id']->getunsigned());
-        self::assertEquals(true, $columns['id']->getnotnull());
-        self::assertEquals(null, $columns['id']->getdefault());
+        self::assertEquals('id', strtolower($columns['id']->getName()));
+        self::assertInstanceOf(IntegerType::class, $columns['id']->getType());
+        self::assertEquals(false, $columns['id']->getUnsigned());
+        self::assertEquals(true, $columns['id']->getNotnull());
+        self::assertEquals(null, $columns['id']->getDefault());
         self::assertIsArray($columns['id']->getPlatformOptions());
 
         self::assertArrayHasKey('test', $columns);

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -220,7 +220,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $namespaces = $this->schemaManager->listNamespaceNames();
         $namespaces = array_map('strtolower', $namespaces);
 
-        if (! in_array('test_create_schema', $namespaces)) {
+        if (! in_array('test_create_schema', $namespaces, true)) {
             $this->connection->executeUpdate($this->schemaManager->getDatabasePlatform()->getCreateSchemaSQL('test_create_schema'));
 
             $namespaces = $this->schemaManager->listNamespaceNames();

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -280,7 +280,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $columnsKeys = array_keys($columns);
 
         self::assertArrayHasKey('id', $columns);
-        self::assertEquals(0, array_search('id', $columnsKeys));
+        self::assertEquals(0, array_search('id', $columnsKeys, true));
         self::assertEquals('id', strtolower($columns['id']->getName()));
         self::assertInstanceOf(IntegerType::class, $columns['id']->getType());
         self::assertEquals(false, $columns['id']->getUnsigned());
@@ -289,7 +289,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertIsArray($columns['id']->getPlatformOptions());
 
         self::assertArrayHasKey('test', $columns);
-        self::assertEquals(1, array_search('test', $columnsKeys));
+        self::assertEquals(1, array_search('test', $columnsKeys, true));
         self::assertEquals('test', strtolower($columns['test']->getname()));
         self::assertInstanceOf(StringType::class, $columns['test']->gettype());
         self::assertEquals(255, $columns['test']->getlength());
@@ -299,7 +299,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertIsArray($columns['test']->getPlatformOptions());
 
         self::assertEquals('foo', strtolower($columns['foo']->getname()));
-        self::assertEquals(2, array_search('foo', $columnsKeys));
+        self::assertEquals(2, array_search('foo', $columnsKeys, true));
         self::assertInstanceOf(TextType::class, $columns['foo']->gettype());
         self::assertEquals(false, $columns['foo']->getunsigned());
         self::assertEquals(false, $columns['foo']->getfixed());
@@ -308,7 +308,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertIsArray($columns['foo']->getPlatformOptions());
 
         self::assertEquals('bar', strtolower($columns['bar']->getname()));
-        self::assertEquals(3, array_search('bar', $columnsKeys));
+        self::assertEquals(3, array_search('bar', $columnsKeys, true));
         self::assertInstanceOf(DecimalType::class, $columns['bar']->gettype());
         self::assertEquals(null, $columns['bar']->getlength());
         self::assertEquals(10, $columns['bar']->getprecision());
@@ -320,21 +320,21 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertIsArray($columns['bar']->getPlatformOptions());
 
         self::assertEquals('baz1', strtolower($columns['baz1']->getname()));
-        self::assertEquals(4, array_search('baz1', $columnsKeys));
+        self::assertEquals(4, array_search('baz1', $columnsKeys, true));
         self::assertInstanceOf(DateTimeType::class, $columns['baz1']->gettype());
         self::assertEquals(true, $columns['baz1']->getnotnull());
         self::assertEquals(null, $columns['baz1']->getdefault());
         self::assertIsArray($columns['baz1']->getPlatformOptions());
 
         self::assertEquals('baz2', strtolower($columns['baz2']->getname()));
-        self::assertEquals(5, array_search('baz2', $columnsKeys));
+        self::assertEquals(5, array_search('baz2', $columnsKeys, true));
         self::assertContains($columns['baz2']->gettype()->getName(), ['time', 'date', 'datetime']);
         self::assertEquals(true, $columns['baz2']->getnotnull());
         self::assertEquals(null, $columns['baz2']->getdefault());
         self::assertIsArray($columns['baz2']->getPlatformOptions());
 
         self::assertEquals('baz3', strtolower($columns['baz3']->getname()));
-        self::assertEquals(6, array_search('baz3', $columnsKeys));
+        self::assertEquals(6, array_search('baz3', $columnsKeys, true));
         self::assertContains($columns['baz3']->gettype()->getName(), ['time', 'date', 'datetime']);
         self::assertEquals(true, $columns['baz3']->getnotnull());
         self::assertEquals(null, $columns['baz3']->getdefault());

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -68,7 +68,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $dbms = $this->getPlatformName();
 
         if ($this->connection->getDatabasePlatform()->getName() !== $dbms) {
-            $this->markTestSkipped(static::class . ' requires the use of ' . $dbms);
+            self::markTestSkipped(static::class . ' requires the use of ' . $dbms);
         }
 
         $this->schemaManager = $this->connection->getSchemaManager();
@@ -95,7 +95,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testDropsDatabaseWithActiveConnections() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsCreateDropDatabase()) {
-            $this->markTestSkipped('Cannot drop Database client side with this Driver.');
+            self::markTestSkipped('Cannot drop Database client side with this Driver.');
         }
 
         $this->schemaManager->dropAndCreateDatabase('test_drop_database');
@@ -134,7 +134,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform();
 
         if (! $platform->supportsSequences()) {
-            $this->markTestSkipped(
+            self::markTestSkipped(
                 sprintf('The "%s" platform does not support sequences.', $platform->getName())
             );
         }
@@ -166,7 +166,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform();
 
         if (! $platform->supportsSequences()) {
-            $this->markTestSkipped(
+            self::markTestSkipped(
                 sprintf('The "%s" platform does not support sequences.', $platform->getName())
             );
         }
@@ -196,7 +196,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testListDatabases() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsCreateDropDatabase()) {
-            $this->markTestSkipped('Cannot drop Database client side with this Driver.');
+            self::markTestSkipped('Cannot drop Database client side with this Driver.');
         }
 
         $this->schemaManager->dropAndCreateDatabase('test_create_database');
@@ -213,7 +213,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testListNamespaceNames() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsSchemas()) {
-            $this->markTestSkipped('Platform does not support schemas.');
+            self::markTestSkipped('Platform does not support schemas.');
         }
 
         // Currently dropping schemas is not supported, so we have to workaround here.
@@ -372,7 +372,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             ->getMock();
 
         $listenerMock
-            ->expects($this->exactly(7))
+            ->expects(self::exactly(7))
             ->method('onSchemaColumnDefinition');
 
         $oldEventManager = $this->schemaManager->getDatabasePlatform()->getEventManager();
@@ -399,7 +399,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             ->addMethods(['onSchemaIndexDefinition'])
             ->getMock();
         $listenerMock
-            ->expects($this->exactly(3))
+            ->expects(self::exactly(3))
             ->method('onSchemaIndexDefinition');
 
         $oldEventManager = $this->schemaManager->getDatabasePlatform()->getEventManager();
@@ -417,7 +417,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testDiffListTableColumns() : void
     {
         if ($this->schemaManager->getDatabasePlatform()->getName() === 'oracle') {
-            $this->markTestSkipped('Does not work with Oracle, since it cannot detect DateTime, Date and Time differenecs (at the moment).');
+            self::markTestSkipped('Does not work with Oracle, since it cannot detect DateTime, Date and Time differenecs (at the moment).');
         }
 
         $offlineTable = $this->createListTableColumns();
@@ -477,7 +477,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testCreateTableWithForeignKeys() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped('Platform does not support foreign keys.');
+            self::markTestSkipped('Platform does not support foreign keys.');
         }
 
         $tableB = $this->getTestTable('test_foreign');
@@ -505,7 +505,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testListForeignKeys() : void
     {
         if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped('Does not support foreign key constraints.');
+            self::markTestSkipped('Does not support foreign key constraints.');
         }
 
         $this->createTestTable('test_create_fk1');
@@ -539,7 +539,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     protected function getCreateExampleViewSql() : void
     {
-        $this->markTestSkipped('No Create Example View SQL was defined for this SchemaManager');
+        self::markTestSkipped('No Create Example View SQL was defined for this SchemaManager');
     }
 
     public function testCreateSchema() : void
@@ -553,7 +553,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testAlterTableScenario() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsAlterTable()) {
-            $this->markTestSkipped('Alter Table is not supported by this platform.');
+            self::markTestSkipped('Alter Table is not supported by this platform.');
         }
 
         $alterTable = $this->createTestTable('alter_table');
@@ -642,7 +642,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testTableInNamespace() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsSchemas()) {
-            $this->markTestSkipped('Schema definition is not supported by this platform.');
+            self::markTestSkipped('Schema definition is not supported by this platform.');
         }
 
         //create schema
@@ -666,7 +666,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testCreateAndListViews() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsViews()) {
-            $this->markTestSkipped('Views is not supported by this platform.');
+            self::markTestSkipped('Views is not supported by this platform.');
         }
 
         $this->createTestTable('view_test_table');
@@ -684,7 +684,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testAutoincrementDetection() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsIdentityColumns()) {
-            $this->markTestSkipped('This test is only supported on platforms that have autoincrement');
+            self::markTestSkipped('This test is only supported on platforms that have autoincrement');
         }
 
         $table = new Table('test_autoincrement');
@@ -705,7 +705,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testAutoincrementDetectionMulticolumns() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsIdentityColumns()) {
-            $this->markTestSkipped('This test is only supported on platforms that have autoincrement');
+            self::markTestSkipped('This test is only supported on platforms that have autoincrement');
         }
 
         $table = new Table('test_not_autoincrement');
@@ -727,7 +727,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testUpdateSchemaWithForeignKeyRenaming() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped('This test is only supported on platforms that have foreign keys.');
+            self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
         }
 
         $table = new Table('test_fk_base');
@@ -772,7 +772,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testRenameIndexUsedInForeignKeyConstraint() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped('This test is only supported on platforms that have foreign keys.');
+            self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
         }
 
         $primaryTable = new Table('test_rename_index_primary');
@@ -815,7 +815,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         if (! $this->connection->getDatabasePlatform()->supportsInlineColumnComments() &&
              ! $this->connection->getDatabasePlatform()->supportsCommentOnStatement() &&
             $this->connection->getDatabasePlatform()->getName() !== 'mssql') {
-            $this->markTestSkipped('Database does not support column comments.');
+            self::markTestSkipped('Database does not support column comments.');
         }
 
         $table = new Table('column_comment_test');
@@ -859,7 +859,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         if (! $this->connection->getDatabasePlatform()->supportsInlineColumnComments() &&
              ! $this->connection->getDatabasePlatform()->supportsCommentOnStatement() &&
             $this->connection->getDatabasePlatform()->getName() !== 'mssql') {
-            $this->markTestSkipped('Database does not support column comments.');
+            self::markTestSkipped('Database does not support column comments.');
         }
 
         $table = new Table('column_comment_test2');
@@ -887,7 +887,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         if (! $this->connection->getDatabasePlatform()->supportsInlineColumnComments() &&
             ! $this->connection->getDatabasePlatform()->supportsCommentOnStatement() &&
             $this->connection->getDatabasePlatform()->getName() !== 'mssql') {
-            $this->markTestSkipped('Database does not support column comments.');
+            self::markTestSkipped('Database does not support column comments.');
         }
 
         $table = new Table('column_dateinterval_comment');
@@ -1024,7 +1024,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testListForeignKeysComposite() : void
     {
         if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped('Does not support foreign key constraints.');
+            self::markTestSkipped('Does not support foreign key constraints.');
         }
 
         $this->schemaManager->createTable($this->getTestTable('test_create_fk3'));
@@ -1126,7 +1126,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testListTableDetailsWithFullQualifiedTableName() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsSchemas()) {
-            $this->markTestSkipped('Test only works on platforms that support schemas.');
+            self::markTestSkipped('Test only works on platforms that support schemas.');
         }
 
         $defaultSchemaName = $this->schemaManager->getDatabasePlatform()->getDefaultSchemaName();
@@ -1168,7 +1168,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         if (! $this->connection->getDatabasePlatform()->supportsInlineColumnComments() &&
             ! $this->connection->getDatabasePlatform()->supportsCommentOnStatement() &&
             $this->connection->getDatabasePlatform()->getName() !== 'mssql') {
-            $this->markTestSkipped('Database does not support column comments.');
+            self::markTestSkipped('Database does not support column comments.');
         }
 
         $table = new Table('my_table');
@@ -1184,7 +1184,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testCommentNotDuplicated() : void
     {
         if (! $this->connection->getDatabasePlatform()->supportsInlineColumnComments()) {
-            $this->markTestSkipped('Database does not support column comments.');
+            self::markTestSkipped('Database does not support column comments.');
         }
 
         $options          = [
@@ -1216,7 +1216,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         if (! $this->connection->getDatabasePlatform()->supportsInlineColumnComments() &&
             ! $this->connection->getDatabasePlatform()->supportsCommentOnStatement() &&
             $this->connection->getDatabasePlatform()->getName() !== 'mssql') {
-            $this->markTestSkipped('Database does not support column comments.');
+            self::markTestSkipped('Database does not support column comments.');
         }
 
         $offlineTable = new Table('alter_column_comment_test');
@@ -1281,7 +1281,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testDoesNotListIndexesImplicitlyCreatedByForeignKeys() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped('This test is only supported on platforms that have foreign keys.');
+            self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
         }
 
         $primaryTable = new Table('test_list_index_impl_primary');
@@ -1435,7 +1435,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testComparatorShouldNotAddCommentToJsonTypeSinceItIsTheDefaultNow() : void
     {
         if (! $this->schemaManager->getDatabasePlatform()->hasNativeJsonType()) {
-            $this->markTestSkipped('This test is only supported on platforms that have native JSON type.');
+            self::markTestSkipped('This test is only supported on platforms that have native JSON type.');
         }
 
         $this->connection->executeQuery('CREATE TABLE json_test (parameters JSON NOT NULL)');
@@ -1571,7 +1571,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $query->execute();
         $lastUsedIdAfterDelete = (int) $query->fetchColumn();
 
-        $this->assertGreaterThan($lastUsedIdBeforeDelete, $lastUsedIdAfterDelete);
+        self::assertGreaterThan($lastUsedIdBeforeDelete, $lastUsedIdAfterDelete);
     }
 
     public function testGenerateAnIndexWithPartialColumnLength() : void

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -162,12 +162,12 @@ EOS
     public function testNonDefaultPKOrder() : void
     {
         if (! extension_loaded('sqlite3')) {
-            $this->markTestSkipped('This test requires the SQLite3 extension.');
+            self::markTestSkipped('This test requires the SQLite3 extension.');
         }
 
         $version = SQLite3::version();
         if (version_compare($version['versionString'], '3.7.16', '<')) {
-            $this->markTestSkipped('This version of sqlite doesn\'t return the order of the Primary Key.');
+            self::markTestSkipped('This version of sqlite doesn\'t return the order of the Primary Key.');
         }
         $this->connection->exec(<<<EOS
 CREATE TABLE non_default_pk_order (
@@ -276,6 +276,6 @@ SQL;
         $lastUsedIdAfterDelete = (int) $query->fetchColumn();
 
         // with an empty table, non autoincrement rowid is always 1
-        $this->assertEquals(1, $lastUsedIdAfterDelete);
+        self::assertEquals(1, $lastUsedIdAfterDelete);
     }
 }

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -118,7 +118,7 @@ sneNxmNb/POO1pRXc7vnF2nc13Rq0cFWiyXkuHmzxuOtzUYfC7fEmK/3mx4QZd5u4E7XJWz6+dey
 Za4tXHUiPyB8Vm781oaT+3fN6Y/eUFDfPkcNWetNxb+tlxEZsPqPdZMOzS4rxwJ8CDC+ABj1+Tu0
 d+N0hqezcjblboJ3Bj8ARJilHX4FAAA=
 EOF
-        );
+        , true);
 
         $this->connection->insert('stmt_long_blob', ['contents' => $contents], [ParameterType::LARGE_OBJECT]);
 

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -303,7 +303,7 @@ EOF
                 false,
             ],
             'fetch-all' => [
-                static function (Statement $stmt) {
+                static function (Statement $stmt) : array {
                     return $stmt->fetchAll();
                 },
                 [],

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -27,7 +27,7 @@ class StatementTest extends FunctionalTestCase
     public function testStatementIsReusableAfterClosingCursor() : void
     {
         if ($this->connection->getDriver() instanceof PDOOracleDriver) {
-            $this->markTestIncomplete('See https://bugs.php.net/bug.php?id=77181');
+            self::markTestIncomplete('See https://bugs.php.net/bug.php?id=77181');
         }
 
         $this->connection->insert('stmt_test', ['id' => 1]);
@@ -52,7 +52,7 @@ class StatementTest extends FunctionalTestCase
     public function testReuseStatementWithLongerResults() : void
     {
         if ($this->connection->getDriver() instanceof PDOOracleDriver) {
-            $this->markTestIncomplete('PDO_OCI doesn\'t support fetching blobs via PDOStatement::fetchAll()');
+            self::markTestIncomplete('PDO_OCI doesn\'t support fetching blobs via PDOStatement::fetchAll()');
         }
 
         $sm    = $this->connection->getSchemaManager();
@@ -91,7 +91,7 @@ class StatementTest extends FunctionalTestCase
         if ($this->connection->getDriver() instanceof PDOOracleDriver) {
             // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
             // see http://php.net/manual/en/pdo.lobs.php#example-1035
-            $this->markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');
+            self::markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');
         }
 
         // make sure memory limit is large enough to not cause false positives,
@@ -154,7 +154,7 @@ EOF
     public function testReuseStatementAfterClosingCursor() : void
     {
         if ($this->connection->getDriver() instanceof PDOOracleDriver) {
-            $this->markTestIncomplete('See https://bugs.php.net/bug.php?id=77181');
+            self::markTestIncomplete('See https://bugs.php.net/bug.php?id=77181');
         }
 
         $this->connection->insert('stmt_test', ['id' => 1]);

--- a/tests/Functional/TableGeneratorTest.php
+++ b/tests/Functional/TableGeneratorTest.php
@@ -22,7 +22,7 @@ class TableGeneratorTest extends FunctionalTestCase
 
         $platform = $this->connection->getDatabasePlatform();
         if ($platform->getName() === 'sqlite') {
-            $this->markTestSkipped('TableGenerator does not work with SQLite');
+            self::markTestSkipped('TableGenerator does not work with SQLite');
         }
 
         try {

--- a/tests/Functional/TemporaryTableTest.php
+++ b/tests/Functional/TemporaryTableTest.php
@@ -38,7 +38,7 @@ class TemporaryTableTest extends FunctionalTestCase
     {
         if ($this->connection->getDatabasePlatform()->getName() === 'sqlanywhere' ||
             $this->connection->getDatabasePlatform()->getName() === 'oracle') {
-            $this->markTestSkipped('Test does not work on Oracle and SQL Anywhere.');
+            self::markTestSkipped('Test does not work on Oracle and SQL Anywhere.');
         }
 
         $platform          = $this->connection->getDatabasePlatform();
@@ -73,7 +73,7 @@ class TemporaryTableTest extends FunctionalTestCase
     {
         if ($this->connection->getDatabasePlatform()->getName() === 'sqlanywhere' ||
             $this->connection->getDatabasePlatform()->getName() === 'oracle') {
-            $this->markTestSkipped('Test does not work on Oracle and SQL Anywhere.');
+            self::markTestSkipped('Test does not work on Oracle and SQL Anywhere.');
         }
 
         $platform          = $this->connection->getDatabasePlatform();

--- a/tests/Functional/Ticket/DBAL168Test.php
+++ b/tests/Functional/Ticket/DBAL168Test.php
@@ -13,7 +13,7 @@ class DBAL168Test extends FunctionalTestCase
     public function testDomainsTable() : void
     {
         if ($this->connection->getDatabasePlatform()->getName() !== 'postgresql') {
-            $this->markTestSkipped('PostgreSQL only test');
+            self::markTestSkipped('PostgreSQL only test');
         }
 
         $table = new Table('domains');

--- a/tests/Functional/Ticket/DBAL202Test.php
+++ b/tests/Functional/Ticket/DBAL202Test.php
@@ -15,7 +15,7 @@ class DBAL202Test extends FunctionalTestCase
         parent::setUp();
 
         if ($this->connection->getDatabasePlatform()->getName() !== 'oracle') {
-            $this->markTestSkipped('OCI8 only test');
+            self::markTestSkipped('OCI8 only test');
         }
 
         if ($this->connection->getSchemaManager()->tablesExist('DBAL202')) {

--- a/tests/Functional/Ticket/DBAL461Test.php
+++ b/tests/Functional/Ticket/DBAL461Test.php
@@ -36,6 +36,6 @@ class DBAL461Test extends TestCase
             'comment' => null,
         ]);
 
-        $this->assertInstanceOf(DecimalType::class, $column->getType());
+        self::assertInstanceOf(DecimalType::class, $column->getType());
     }
 }

--- a/tests/Functional/Ticket/DBAL510Test.php
+++ b/tests/Functional/Ticket/DBAL510Test.php
@@ -19,7 +19,7 @@ class DBAL510Test extends FunctionalTestCase
             return;
         }
 
-        $this->markTestSkipped('PostgreSQL Only test');
+        self::markTestSkipped('PostgreSQL Only test');
     }
 
     public function testSearchPathSchemaChanges() : void

--- a/tests/Functional/Ticket/DBAL630Test.php
+++ b/tests/Functional/Ticket/DBAL630Test.php
@@ -4,9 +4,9 @@ namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use PDO;
-use function in_array;
 
 /**
  * @group DBAL-630
@@ -20,9 +20,7 @@ class DBAL630Test extends FunctionalTestCase
     {
         parent::setUp();
 
-        $platform = $this->connection->getDatabasePlatform()->getName();
-
-        if (! in_array($platform, ['postgresql'])) {
+        if (! $this->connection->getDatabasePlatform() instanceof PostgreSQL94Platform) {
             self::markTestSkipped('Currently restricted to PostgreSQL');
         }
 

--- a/tests/Functional/Ticket/DBAL630Test.php
+++ b/tests/Functional/Ticket/DBAL630Test.php
@@ -23,7 +23,7 @@ class DBAL630Test extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform()->getName();
 
         if (! in_array($platform, ['postgresql'])) {
-            $this->markTestSkipped('Currently restricted to PostgreSQL');
+            self::markTestSkipped('Currently restricted to PostgreSQL');
         }
 
         try {

--- a/tests/Functional/Ticket/DBAL752Test.php
+++ b/tests/Functional/Ticket/DBAL752Test.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
-use function in_array;
 
 /**
  * @group DBAL-752
@@ -14,9 +14,7 @@ class DBAL752Test extends FunctionalTestCase
     {
         parent::setUp();
 
-        $platform = $this->connection->getDatabasePlatform()->getName();
-
-        if (in_array($platform, ['sqlite'])) {
+        if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
             return;
         }
 

--- a/tests/Functional/Ticket/DBAL752Test.php
+++ b/tests/Functional/Ticket/DBAL752Test.php
@@ -20,7 +20,7 @@ class DBAL752Test extends FunctionalTestCase
             return;
         }
 
-        $this->markTestSkipped('Related to SQLite only');
+        self::markTestSkipped('Related to SQLite only');
     }
 
     public function testUnsignedIntegerDetection() : void

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -30,10 +30,10 @@ class TransactionTest extends FunctionalTestCase
     {
         $this->connection->query('SET SESSION wait_timeout=1');
 
-        $this->assertTrue($this->connection->beginTransaction());
+        self::assertTrue($this->connection->beginTransaction());
 
         sleep(2); // during the sleep mysql will close the connection
 
-        $this->assertFalse(@$this->connection->commit()); // we will ignore `MySQL server has gone away` warnings
+        self::assertFalse(@$this->connection->commit()); // we will ignore `MySQL server has gone away` warnings
     }
 }

--- a/tests/Functional/TypeConversionTest.php
+++ b/tests/Functional/TypeConversionTest.php
@@ -122,7 +122,7 @@ class TypeConversionTest extends FunctionalTestCase
         if ($type === 'text' && $this->connection->getDriver() instanceof PDOOracleDriver) {
             // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
             // see http://php.net/manual/en/pdo.lobs.php#example-1035
-            $this->markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');
+            self::markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');
         }
 
         $dbValue = $this->processValue($type, $originalValue);

--- a/tests/Functional/Types/BinaryTest.php
+++ b/tests/Functional/Types/BinaryTest.php
@@ -21,7 +21,7 @@ class BinaryTest extends FunctionalTestCase
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof PDOOracleDriver) {
-            $this->markTestSkipped('PDO_OCI doesn\'t support binding binary values');
+            self::markTestSkipped('PDO_OCI doesn\'t support binding binary values');
         }
 
         $table = new Table('binary_table');
@@ -53,8 +53,8 @@ class BinaryTest extends FunctionalTestCase
         $this->insert($id1, $value1);
         $this->insert($id2, $value2);
 
-        $this->assertSame($value1, $this->select($id1));
-        $this->assertSame($value2, $this->select($id2));
+        self::assertSame($value1, $this->select($id1));
+        self::assertSame($value2, $this->select($id2));
     }
 
     private function insert(string $id, string $value) : void

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -169,7 +169,7 @@ class WriteTest extends FunctionalTestCase
         }
 
         $sequences = $this->connection->getSchemaManager()->listSequences();
-        self::assertCount(1, array_filter($sequences, static function ($sequence) {
+        self::assertCount(1, array_filter($sequences, static function ($sequence) : bool {
             return strtolower($sequence->getName()) === 'write_table_id_seq';
         }));
 

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -146,7 +146,7 @@ class WriteTest extends FunctionalTestCase
     public function testLastInsertId() : void
     {
         if (! $this->connection->getDatabasePlatform()->prefersIdentityColumns()) {
-            $this->markTestSkipped('Test only works on platforms with identity columns.');
+            self::markTestSkipped('Test only works on platforms with identity columns.');
         }
 
         self::assertEquals(1, $this->connection->insert('write_table', ['test_int' => 2, 'test_string' => 'bar']));
@@ -159,7 +159,7 @@ class WriteTest extends FunctionalTestCase
     public function testLastInsertIdSequence() : void
     {
         if (! $this->connection->getDatabasePlatform()->supportsSequences()) {
-            $this->markTestSkipped('Test only works on platforms with sequences.');
+            self::markTestSkipped('Test only works on platforms with sequences.');
         }
 
         $sequence = new Sequence('write_table_id_seq');
@@ -185,7 +185,7 @@ class WriteTest extends FunctionalTestCase
     public function testLastInsertIdNoSequenceGiven() : void
     {
         if (! $this->connection->getDatabasePlatform()->supportsSequences() || $this->connection->getDatabasePlatform()->supportsIdentityColumns()) {
-            $this->markTestSkipped("Test only works consistently on platforms that support sequences and don't support identity columns.");
+            self::markTestSkipped("Test only works consistently on platforms that support sequences and don't support identity columns.");
         }
 
         self::assertFalse($this->lastInsertId());
@@ -260,7 +260,7 @@ class WriteTest extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform();
 
         if (! ($platform->supportsIdentityColumns() || $platform->usesSequenceEmulatedIdentityColumns())) {
-            $this->markTestSkipped(
+            self::markTestSkipped(
                 'Test only works on platforms with identity columns or sequence emulated identity columns.'
             );
         }
@@ -350,7 +350,7 @@ class WriteTest extends FunctionalTestCase
             return $this->connection->lastInsertId($name);
         } catch (DriverException $e) {
             if ($e->getCode() === 'IM001') {
-                $this->markTestSkipped($e->getMessage());
+                self::markTestSkipped($e->getMessage());
             }
 
             throw $e;

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -72,7 +72,7 @@ abstract class FunctionalTestCase extends TestCase
             $queries = '';
             $i       = count($this->sqlLoggerStack->queries);
             foreach (array_reverse($this->sqlLoggerStack->queries) as $query) {
-                $params   = array_map(static function ($p) {
+                $params   = array_map(static function ($p) : string {
                     if (is_object($p)) {
                         return get_class($p);
                     }

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -68,7 +68,7 @@ abstract class FunctionalTestCase extends TestCase
             throw $t;
         }
 
-        if (isset($this->sqlLoggerStack->queries) && count($this->sqlLoggerStack->queries)) {
+        if (count($this->sqlLoggerStack->queries) > 0) {
             $queries = '';
             $i       = count($this->sqlLoggerStack->queries);
             foreach (array_reverse($this->sqlLoggerStack->queries) as $query) {

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -82,7 +82,7 @@ abstract class FunctionalTestCase extends TestCase
                     }
 
                     return var_export($p, true);
-                }, $query['params'] ?: []);
+                }, $query['params'] ?? []);
                 $queries .= $i . ". SQL: '" . $query['sql'] . "' Params: " . implode(', ', $params) . PHP_EOL;
                 $i--;
             }

--- a/tests/Logging/LoggerChainTest.php
+++ b/tests/Logging/LoggerChainTest.php
@@ -47,7 +47,7 @@ class LoggerChainTest extends TestCase
     private function createLogger(string $method, ...$args) : SQLLogger
     {
         $logger = $this->createMock(SQLLogger::class);
-        $logger->expects($this->once())
+        $logger->expects(self::once())
             ->method($method)
             ->with(...$args);
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -39,7 +39,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testQuoteIdentifier() : void
     {
         if ($this->platform->getName() === 'mssql') {
-            $this->markTestSkipped('Not working this way on mssql.');
+            self::markTestSkipped('Not working this way on mssql.');
         }
 
         $c = $this->platform->getIdentifierQuoteCharacter();
@@ -54,7 +54,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testQuoteSingleIdentifier() : void
     {
         if ($this->platform->getName() === 'mssql') {
-            $this->markTestSkipped('Not working this way on mssql.');
+            self::markTestSkipped('Not working this way on mssql.');
         }
 
         $c = $this->platform->getIdentifierQuoteCharacter();
@@ -379,10 +379,10 @@ abstract class AbstractPlatformTestCase extends TestCase
             ->addMethods(['onSchemaCreateTable', 'onSchemaCreateTableColumn'])
             ->getMock();
         $listenerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('onSchemaCreateTable');
         $listenerMock
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('onSchemaCreateTableColumn');
 
         $eventManager = new EventManager();
@@ -403,7 +403,7 @@ abstract class AbstractPlatformTestCase extends TestCase
             ->addMethods(['onSchemaDropTable'])
             ->getMock();
         $listenerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('onSchemaDropTable');
 
         $eventManager = new EventManager();
@@ -428,19 +428,19 @@ abstract class AbstractPlatformTestCase extends TestCase
             ->addMethods($events)
             ->getMock();
         $listenerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('onSchemaAlterTable');
         $listenerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('onSchemaAlterTableAddColumn');
         $listenerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('onSchemaAlterTableRemoveColumn');
         $listenerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('onSchemaAlterTableChangeColumn');
         $listenerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('onSchemaAlterTableRenameColumn');
 
         $eventManager = new EventManager();
@@ -533,7 +533,7 @@ abstract class AbstractPlatformTestCase extends TestCase
      */
     public function getCreateTableColumnCommentsSQL() : array
     {
-        $this->markTestSkipped('Platform does not support Column comments.');
+        self::markTestSkipped('Platform does not support Column comments.');
     }
 
     /**
@@ -541,7 +541,7 @@ abstract class AbstractPlatformTestCase extends TestCase
      */
     public function getAlterTableColumnCommentsSQL() : array
     {
-        $this->markTestSkipped('Platform does not support Column comments.');
+        self::markTestSkipped('Platform does not support Column comments.');
     }
 
     /**
@@ -549,7 +549,7 @@ abstract class AbstractPlatformTestCase extends TestCase
      */
     public function getCreateTableColumnTypeCommentsSQL() : array
     {
-        $this->markTestSkipped('Platform does not support Column comments.');
+        self::markTestSkipped('Platform does not support Column comments.');
     }
 
     public function testGetDefaultValueDeclarationSQL() : void
@@ -1119,7 +1119,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testQuotesDropForeignKeySQL() : void
     {
         if (! $this->platform->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped(
+            self::markTestSkipped(
                 sprintf('%s does not support foreign key constraints.', get_class($this->platform))
             );
         }
@@ -1226,7 +1226,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testGeneratesInlineColumnCommentSQL(?string $comment, string $expectedSql) : void
     {
         if (! $this->platform->supportsInlineColumnComments()) {
-            $this->markTestSkipped(sprintf('%s does not support inline column comments.', get_class($this->platform)));
+            self::markTestSkipped(sprintf('%s does not support inline column comments.', get_class($this->platform)));
         }
 
         self::assertSame($expectedSql, $this->platform->getInlineColumnCommentSQL($comment));
@@ -1291,7 +1291,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testThrowsExceptionOnGeneratingInlineColumnCommentSQLIfUnsupported() : void
     {
         if ($this->platform->supportsInlineColumnComments()) {
-            $this->markTestSkipped(sprintf('%s supports inline column comments.', get_class($this->platform)));
+            self::markTestSkipped(sprintf('%s supports inline column comments.', get_class($this->platform)));
         }
 
         $this->expectException(DBALException::class);

--- a/tests/Platforms/AbstractPostgreSQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractPostgreSQLPlatformTestCase.php
@@ -896,8 +896,8 @@ abstract class AbstractPostgreSQLPlatformTestCase extends AbstractPlatformTestCa
 
         $tableDiff = $comparator->diffTable($table1, $table2);
 
-        $this->assertInstanceOf('Doctrine\DBAL\Schema\TableDiff', $tableDiff);
-        $this->assertSame(
+        self::assertInstanceOf('Doctrine\DBAL\Schema\TableDiff', $tableDiff);
+        self::assertSame(
             [
                 'ALTER TABLE "foo" ALTER "bar" TYPE TIMESTAMP(0) WITHOUT TIME ZONE',
                 'ALTER TABLE "foo" ALTER "bar" DROP DEFAULT',

--- a/tests/Platforms/AbstractPostgreSQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractPostgreSQLPlatformTestCase.php
@@ -199,8 +199,8 @@ abstract class AbstractPostgreSQLPlatformTestCase extends AbstractPlatformTestCa
     {
         $table  = new Table('autoinc_table_notnull');
         $column = $table->addColumn('id', $type);
-        $column->setAutoIncrement(true);
-        $column->setNotNull(false);
+        $column->setAutoincrement(true);
+        $column->setNotnull(false);
 
         $sql = $this->platform->getCreateTableSQL($table);
 
@@ -215,8 +215,8 @@ abstract class AbstractPostgreSQLPlatformTestCase extends AbstractPlatformTestCa
     {
         $table  = new Table('autoinc_table_notnull_enabled');
         $column = $table->addColumn('id', $type);
-        $column->setAutoIncrement(true);
-        $column->setNotNull(true);
+        $column->setAutoincrement(true);
+        $column->setNotnull(true);
 
         $sql = $this->platform->getCreateTableSQL($table);
 

--- a/tests/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1082,7 +1082,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
      */
     protected function getQuotedAlterTableChangeColumnLengthSQL() : array
     {
-        $this->markTestIncomplete('Not implemented yet');
+        self::markTestIncomplete('Not implemented yet');
     }
 
     /**

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -502,7 +502,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
      */
     protected function getQuotedAlterTableChangeColumnLengthSQL() : array
     {
-        $this->markTestIncomplete('Not implemented yet');
+        self::markTestIncomplete('Not implemented yet');
     }
 
     /**

--- a/tests/Platforms/MariaDb1027PlatformTest.php
+++ b/tests/Platforms/MariaDb1027PlatformTest.php
@@ -45,6 +45,6 @@ class MariaDb1027PlatformTest extends AbstractMySQLPlatformTestCase
      */
     public function testDoesNotPropagateDefaultValuesForUnsupportedColumnTypes() : void
     {
-        $this->markTestSkipped('MariaDB102Platform support propagation of default values for BLOB and TEXT columns');
+        self::markTestSkipped('MariaDB102Platform support propagation of default values for BLOB and TEXT columns');
     }
 }

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -632,7 +632,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
      */
     protected function getQuotedAlterTableChangeColumnLengthSQL() : array
     {
-        $this->markTestIncomplete('Not implemented yet');
+        self::markTestIncomplete('Not implemented yet');
     }
 
     /**

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -87,7 +87,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
-     * @return mixed[]
+     * {@inheritDoc}
      */
     public function getGenerateTableWithMultiColumnUniqueIndexSql() : array
     {
@@ -405,7 +405,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
-     * @return mixed[]
+     * {@inheritDoc}
      */
     protected function getQuotedColumnInPrimaryKeySQL() : array
     {
@@ -413,7 +413,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
-     * @return mixed[]
+     * {@inheritDoc}
      */
     protected function getQuotedColumnInIndexSQL() : array
     {
@@ -424,7 +424,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
-     * @return mixed[]
+     * {@inheritDoc}
      */
     protected function getQuotedNameInIndexSQL() : array
     {
@@ -435,7 +435,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     }
 
     /**
-     * @return mixed[]
+     * {@inheritDoc}
      */
     protected function getQuotedColumnInForeignKeySQL() : array
     {

--- a/tests/Platforms/SQLAnywhere16PlatformTest.php
+++ b/tests/Platforms/SQLAnywhere16PlatformTest.php
@@ -447,7 +447,7 @@ class SQLAnywhere16PlatformTest extends AbstractPlatformTestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $this->platform->getForeignKeyMatchCLauseSQL(3);
+        $this->platform->getForeignKeyMatchClauseSQL(3);
     }
 
     public function testCannotGenerateForeignKeyConstraintSQLWithEmptyLocalColumns() : void

--- a/tests/Platforms/SQLAnywhere16PlatformTest.php
+++ b/tests/Platforms/SQLAnywhere16PlatformTest.php
@@ -1025,7 +1025,7 @@ class SQLAnywhere16PlatformTest extends AbstractPlatformTestCase
      */
     protected function getQuotedAlterTableChangeColumnLengthSQL() : array
     {
-        $this->markTestIncomplete('Not implemented yet');
+        self::markTestIncomplete('Not implemented yet');
     }
 
     /**

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -595,7 +595,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
      */
     public function testAlterTableRenameIndexInSchema() : void
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test currently produces broken SQL due to SQLLitePlatform::getAlterTable being broken ' .
             'when used with schemas.'
         );
@@ -606,7 +606,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
      */
     public function testQuotesAlterTableRenameIndexInSchema() : void
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test currently produces broken SQL due to SQLLitePlatform::getAlterTable being broken ' .
             'when used with schemas.'
         );

--- a/tests/Portability/StatementTest.php
+++ b/tests/Portability/StatementTest.php
@@ -43,10 +43,10 @@ class StatementTest extends TestCase
         $type     = ParameterType::STRING;
         $length   = 666;
 
-        $this->wrappedStmt->expects($this->once())
+        $this->wrappedStmt->expects(self::once())
             ->method('bindParam')
             ->with($column, $variable, $type, $length)
-            ->will($this->returnValue(true));
+            ->will(self::returnValue(true));
 
         self::assertTrue($this->stmt->bindParam($column, $variable, $type, $length));
     }
@@ -57,19 +57,19 @@ class StatementTest extends TestCase
         $value = 'myvalue';
         $type  = ParameterType::STRING;
 
-        $this->wrappedStmt->expects($this->once())
+        $this->wrappedStmt->expects(self::once())
             ->method('bindValue')
             ->with($param, $value, $type)
-            ->will($this->returnValue(true));
+            ->will(self::returnValue(true));
 
         self::assertTrue($this->stmt->bindValue($param, $value, $type));
     }
 
     public function testCloseCursor() : void
     {
-        $this->wrappedStmt->expects($this->once())
+        $this->wrappedStmt->expects(self::once())
             ->method('closeCursor')
-            ->will($this->returnValue(true));
+            ->will(self::returnValue(true));
 
         self::assertTrue($this->stmt->closeCursor());
     }
@@ -78,9 +78,9 @@ class StatementTest extends TestCase
     {
         $columnCount = 666;
 
-        $this->wrappedStmt->expects($this->once())
+        $this->wrappedStmt->expects(self::once())
             ->method('columnCount')
-            ->will($this->returnValue($columnCount));
+            ->will(self::returnValue($columnCount));
 
         self::assertSame($columnCount, $this->stmt->columnCount());
     }
@@ -89,9 +89,9 @@ class StatementTest extends TestCase
     {
         $errorCode = '666';
 
-        $this->wrappedStmt->expects($this->once())
+        $this->wrappedStmt->expects(self::once())
             ->method('errorCode')
-            ->will($this->returnValue($errorCode));
+            ->will(self::returnValue($errorCode));
 
         self::assertSame($errorCode, $this->stmt->errorCode());
     }
@@ -100,9 +100,9 @@ class StatementTest extends TestCase
     {
         $errorInfo = ['666', 'Evil error.'];
 
-        $this->wrappedStmt->expects($this->once())
+        $this->wrappedStmt->expects(self::once())
             ->method('errorInfo')
-            ->will($this->returnValue($errorInfo));
+            ->will(self::returnValue($errorInfo));
 
         self::assertSame($errorInfo, $this->stmt->errorInfo());
     }
@@ -114,10 +114,10 @@ class StatementTest extends TestCase
             'bar',
         ];
 
-        $this->wrappedStmt->expects($this->once())
+        $this->wrappedStmt->expects(self::once())
             ->method('execute')
             ->with($params)
-            ->will($this->returnValue(true));
+            ->will(self::returnValue(true));
 
         self::assertTrue($this->stmt->execute($params));
     }
@@ -128,10 +128,10 @@ class StatementTest extends TestCase
         $arg1      = 'MyClass';
         $arg2      = [1, 2];
 
-        $this->wrappedStmt->expects($this->once())
+        $this->wrappedStmt->expects(self::once())
             ->method('setFetchMode')
             ->with($fetchMode, $arg1, $arg2)
-            ->will($this->returnValue(true));
+            ->will(self::returnValue(true));
 
         $re = new ReflectionProperty($this->stmt, 'defaultFetchMode');
         $re->setAccessible(true);
@@ -143,7 +143,7 @@ class StatementTest extends TestCase
 
     public function testGetIterator() : void
     {
-        $this->wrappedStmt->expects($this->exactly(3))
+        $this->wrappedStmt->expects(self::exactly(3))
             ->method('fetch')
             ->willReturnOnConsecutiveCalls('foo', 'bar', false);
 
@@ -154,9 +154,9 @@ class StatementTest extends TestCase
     {
         $rowCount = 666;
 
-        $this->wrappedStmt->expects($this->once())
+        $this->wrappedStmt->expects(self::once())
             ->method('rowCount')
-            ->will($this->returnValue($rowCount));
+            ->will(self::returnValue($rowCount));
 
         self::assertSame($rowCount, $this->stmt->rowCount());
     }

--- a/tests/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Query/Expression/ExpressionBuilderTest.php
@@ -179,7 +179,7 @@ class ExpressionBuilderTest extends TestCase
     {
         $part = $this->expr->comparison($leftExpr, $operator, $rightExpr);
 
-        self::assertEquals($expected, (string) $part);
+        self::assertEquals($expected, $part);
     }
 
     /**

--- a/tests/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Query/Expression/ExpressionBuilderTest.php
@@ -21,9 +21,9 @@ class ExpressionBuilderTest extends TestCase
 
         $this->expr = new ExpressionBuilder($conn);
 
-        $conn->expects($this->any())
+        $conn->expects(self::any())
              ->method('getExpressionBuilder')
-             ->will($this->returnValue($this->expr));
+             ->will(self::returnValue($this->expr));
     }
 
     /**

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -23,9 +23,9 @@ class QueryBuilderTest extends TestCase
 
         $expressionBuilder = new ExpressionBuilder($this->conn);
 
-        $this->conn->expects($this->any())
+        $this->conn->expects(self::any())
                    ->method('getExpressionBuilder')
-                   ->will($this->returnValue($expressionBuilder));
+                   ->will(self::returnValue($expressionBuilder));
     }
 
     /**

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -23,7 +23,7 @@ class ColumnTest extends TestCase
         self::assertEquals(5, $column->getPrecision());
         self::assertEquals(2, $column->getScale());
         self::assertTrue($column->getUnsigned());
-        self::assertFalse($column->getNotNull());
+        self::assertFalse($column->getNotnull());
         self::assertTrue($column->getFixed());
         self::assertEquals('baz', $column->getDefault());
 

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -1178,33 +1178,33 @@ class ComparatorTest extends TestCase
             ->onlyMethods(['getNamespaces', 'hasNamespace'])
             ->getMock();
 
-        $fromSchema->expects($this->once())
+        $fromSchema->expects(self::once())
             ->method('getNamespaces')
-            ->will($this->returnValue(['foo', 'bar']));
+            ->will(self::returnValue(['foo', 'bar']));
 
-        $fromSchema->expects($this->at(0))
+        $fromSchema->expects(self::at(0))
             ->method('hasNamespace')
             ->with('bar')
-            ->will($this->returnValue(true));
+            ->will(self::returnValue(true));
 
-        $fromSchema->expects($this->at(1))
+        $fromSchema->expects(self::at(1))
             ->method('hasNamespace')
             ->with('baz')
-            ->will($this->returnValue(false));
+            ->will(self::returnValue(false));
 
-        $toSchema->expects($this->once())
+        $toSchema->expects(self::once())
             ->method('getNamespaces')
-            ->will($this->returnValue(['bar', 'baz']));
+            ->will(self::returnValue(['bar', 'baz']));
 
-        $toSchema->expects($this->at(1))
+        $toSchema->expects(self::at(1))
             ->method('hasNamespace')
             ->with('foo')
-            ->will($this->returnValue(false));
+            ->will(self::returnValue(false));
 
-        $toSchema->expects($this->at(2))
+        $toSchema->expects(self::at(2))
             ->method('hasNamespace')
             ->with('bar')
-            ->will($this->returnValue(true));
+            ->will(self::returnValue(true));
 
         $expected                    = new SchemaDiff();
         $expected->fromSchema        = $fromSchema;

--- a/tests/Schema/DB2SchemaManagerTest.php
+++ b/tests/Schema/DB2SchemaManagerTest.php
@@ -93,7 +93,7 @@ final class DB2SchemaManagerTest extends TestCase
     {
         $accepted = ['T_FOO', 'T_BAR'];
         $this->conn->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) use ($accepted) {
-            return in_array($assetName, $accepted);
+            return in_array($assetName, $accepted, true);
         });
         $this->conn->expects(self::any())->method('quote');
         $this->conn->expects(self::once())->method('fetchAll')->will(self::returnValue([

--- a/tests/Schema/DB2SchemaManagerTest.php
+++ b/tests/Schema/DB2SchemaManagerTest.php
@@ -92,7 +92,7 @@ final class DB2SchemaManagerTest extends TestCase
     public function testListTableNamesFiltersAssetNamesCorrectlyWithCallable() : void
     {
         $accepted = ['T_FOO', 'T_BAR'];
-        $this->conn->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) use ($accepted) {
+        $this->conn->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) use ($accepted) : bool {
             return in_array($assetName, $accepted, true);
         });
         $this->conn->expects(self::any())->method('quote');

--- a/tests/Schema/DB2SchemaManagerTest.php
+++ b/tests/Schema/DB2SchemaManagerTest.php
@@ -44,7 +44,7 @@ final class DB2SchemaManagerTest extends TestCase
     public function testListTableNamesFiltersAssetNamesCorrectly() : void
     {
         $this->conn->getConfiguration()->setFilterSchemaAssetsExpression('/^(?!T_)/');
-        $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue([
+        $this->conn->expects(self::once())->method('fetchAll')->will(self::returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
@@ -67,7 +67,7 @@ final class DB2SchemaManagerTest extends TestCase
     {
         $filterExpression = '/^(?!T_)/';
         $this->conn->getConfiguration()->setFilterSchemaAssetsExpression($filterExpression);
-        $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue([
+        $this->conn->expects(self::once())->method('fetchAll')->will(self::returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
@@ -86,7 +86,7 @@ final class DB2SchemaManagerTest extends TestCase
         self::assertIsCallable($callable);
 
         // BC check: Test that regexp expression is still preserved & accessible.
-        $this->assertEquals($filterExpression, $this->conn->getConfiguration()->getFilterSchemaAssetsExpression());
+        self::assertEquals($filterExpression, $this->conn->getConfiguration()->getFilterSchemaAssetsExpression());
     }
 
     public function testListTableNamesFiltersAssetNamesCorrectlyWithCallable() : void
@@ -95,8 +95,8 @@ final class DB2SchemaManagerTest extends TestCase
         $this->conn->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) use ($accepted) {
             return in_array($assetName, $accepted);
         });
-        $this->conn->expects($this->any())->method('quote');
-        $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue([
+        $this->conn->expects(self::any())->method('quote');
+        $this->conn->expects(self::once())->method('fetchAll')->will(self::returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
@@ -111,7 +111,7 @@ final class DB2SchemaManagerTest extends TestCase
             $this->manager->listTableNames()
         );
 
-        $this->assertNull($this->conn->getConfiguration()->getFilterSchemaAssetsExpression());
+        self::assertNull($this->conn->getConfiguration()->getFilterSchemaAssetsExpression());
     }
 
     public function testSettingNullExpressionWillResetCallable() : void
@@ -120,8 +120,8 @@ final class DB2SchemaManagerTest extends TestCase
         $this->conn->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) use ($accepted) {
             return in_array($assetName, $accepted);
         });
-        $this->conn->expects($this->any())->method('quote');
-        $this->conn->expects($this->atLeastOnce())->method('fetchAll')->will($this->returnValue([
+        $this->conn->expects(self::any())->method('quote');
+        $this->conn->expects($this->atLeastOnce())->method('fetchAll')->will(self::returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
@@ -148,7 +148,7 @@ final class DB2SchemaManagerTest extends TestCase
             $this->manager->listTableNames()
         );
 
-        $this->assertNull($this->conn->getConfiguration()->getSchemaAssetsFilter());
+        self::assertNull($this->conn->getConfiguration()->getSchemaAssetsFilter());
     }
 
     public function testSettingNullAsCallableClearsExpression() : void
@@ -156,7 +156,7 @@ final class DB2SchemaManagerTest extends TestCase
         $filterExpression = '/^(?!T_)/';
         $this->conn->getConfiguration()->setFilterSchemaAssetsExpression($filterExpression);
 
-        $this->conn->expects($this->exactly(2))->method('fetchAll')->will($this->returnValue([
+        $this->conn->expects(self::exactly(2))->method('fetchAll')->will(self::returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],

--- a/tests/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Schema/ForeignKeyConstraintTest.php
@@ -22,9 +22,9 @@ class ForeignKeyConstraintTest extends TestCase
         $index = $this->getMockBuilder(Index::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $index->expects($this->once())
+        $index->expects(self::once())
             ->method('getColumns')
-            ->will($this->returnValue($indexColumns));
+            ->will(self::returnValue($indexColumns));
 
         self::assertSame($expectedResult, $foreignKey->intersectsIndexColumns($index));
     }

--- a/tests/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Schema/MySqlSchemaManagerTest.php
@@ -35,7 +35,7 @@ class MySqlSchemaManagerTest extends TestCase
 
     public function testCompositeForeignKeys() : void
     {
-        $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue($this->getFKDefinition()));
+        $this->conn->expects(self::once())->method('fetchAll')->will(self::returnValue($this->getFKDefinition()));
         $fkeys = $this->manager->listTableForeignKeys('dummy');
         self::assertCount(1, $fkeys, 'Table has to have one foreign key.');
 

--- a/tests/Schema/SchemaDiffTest.php
+++ b/tests/Schema/SchemaDiffTest.php
@@ -44,60 +44,60 @@ class SchemaDiffTest extends TestCase
     {
         /** @var AbstractPlatform|MockObject $platform */
         $platform = $this->createMock(AbstractPlatform::class);
-        $platform->expects($this->exactly(1))
+        $platform->expects(self::exactly(1))
             ->method('getCreateSchemaSQL')
             ->with('foo_ns')
-            ->will($this->returnValue('create_schema'));
+            ->will(self::returnValue('create_schema'));
         if ($unsafe) {
-            $platform->expects($this->exactly(1))
+            $platform->expects(self::exactly(1))
                  ->method('getDropSequenceSql')
-                 ->with($this->isInstanceOf(Sequence::class))
-                 ->will($this->returnValue('drop_seq'));
+                 ->with(self::isInstanceOf(Sequence::class))
+                 ->will(self::returnValue('drop_seq'));
         }
-        $platform->expects($this->exactly(1))
+        $platform->expects(self::exactly(1))
                  ->method('getAlterSequenceSql')
-                 ->with($this->isInstanceOf(Sequence::class))
-                 ->will($this->returnValue('alter_seq'));
-        $platform->expects($this->exactly(1))
+                 ->with(self::isInstanceOf(Sequence::class))
+                 ->will(self::returnValue('alter_seq'));
+        $platform->expects(self::exactly(1))
                  ->method('getCreateSequenceSql')
-                 ->with($this->isInstanceOf(Sequence::class))
-                 ->will($this->returnValue('create_seq'));
+                 ->with(self::isInstanceOf(Sequence::class))
+                 ->will(self::returnValue('create_seq'));
         if ($unsafe) {
-            $platform->expects($this->exactly(1))
+            $platform->expects(self::exactly(1))
                      ->method('getDropTableSql')
-                     ->with($this->isInstanceOf(Table::class))
-                     ->will($this->returnValue('drop_table'));
+                     ->with(self::isInstanceOf(Table::class))
+                     ->will(self::returnValue('drop_table'));
         }
-        $platform->expects($this->exactly(1))
+        $platform->expects(self::exactly(1))
                  ->method('getCreateTableSql')
-                 ->with($this->isInstanceOf(Table::class))
-                 ->will($this->returnValue(['create_table']));
-        $platform->expects($this->exactly(1))
+                 ->with(self::isInstanceOf(Table::class))
+                 ->will(self::returnValue(['create_table']));
+        $platform->expects(self::exactly(1))
                  ->method('getCreateForeignKeySQL')
-                 ->with($this->isInstanceOf(ForeignKeyConstraint::class))
-                 ->will($this->returnValue('create_foreign_key'));
-        $platform->expects($this->exactly(1))
+                 ->with(self::isInstanceOf(ForeignKeyConstraint::class))
+                 ->will(self::returnValue('create_foreign_key'));
+        $platform->expects(self::exactly(1))
                  ->method('getAlterTableSql')
-                 ->with($this->isInstanceOf(TableDiff::class))
-                 ->will($this->returnValue(['alter_table']));
+                 ->with(self::isInstanceOf(TableDiff::class))
+                 ->will(self::returnValue(['alter_table']));
         if ($unsafe) {
-            $platform->expects($this->exactly(1))
+            $platform->expects(self::exactly(1))
                      ->method('getDropForeignKeySql')
                      ->with(
-                         $this->isInstanceOf(ForeignKeyConstraint::class),
-                         $this->isInstanceOf(Table::class)
+                         self::isInstanceOf(ForeignKeyConstraint::class),
+                         self::isInstanceOf(Table::class)
                      )
-                     ->will($this->returnValue('drop_orphan_fk'));
+                     ->will(self::returnValue('drop_orphan_fk'));
         }
-        $platform->expects($this->exactly(1))
+        $platform->expects(self::exactly(1))
                 ->method('supportsSchemas')
-                ->will($this->returnValue(true));
-        $platform->expects($this->exactly(1))
+                ->will(self::returnValue(true));
+        $platform->expects(self::exactly(1))
                 ->method('supportsSequences')
-                ->will($this->returnValue(true));
-        $platform->expects($this->exactly(2))
+                ->will(self::returnValue(true));
+        $platform->expects(self::exactly(2))
                 ->method('supportsForeignKeyConstraints')
-                ->will($this->returnValue(true));
+                ->will(self::returnValue(true));
 
         return $platform;
     }

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -373,30 +373,30 @@ class SchemaTest extends TestCase
         $schema->createSequence('moo');
         $schema->createSequence('war');
 
-        $visitor->expects($this->once())
+        $visitor->expects(self::once())
             ->method('acceptSchema')
             ->with($schema);
 
-        $visitor->expects($this->at(1))
+        $visitor->expects(self::at(1))
             ->method('acceptTable')
             ->with($schema->getTable('baz'));
 
-        $visitor->expects($this->at(2))
+        $visitor->expects(self::at(2))
             ->method('acceptTable')
             ->with($schema->getTable('bla.bloo'));
 
-        $visitor->expects($this->exactly(2))
+        $visitor->expects(self::exactly(2))
             ->method('acceptTable');
 
-        $visitor->expects($this->at(3))
+        $visitor->expects(self::at(3))
             ->method('acceptSequence')
             ->with($schema->getSequence('moo'));
 
-        $visitor->expects($this->at(4))
+        $visitor->expects(self::at(4))
             ->method('acceptSequence')
             ->with($schema->getSequence('war'));
 
-        $visitor->expects($this->exactly(2))
+        $visitor->expects(self::exactly(2))
             ->method('acceptSequence');
 
         self::assertNull($schema->visit($visitor));
@@ -419,45 +419,45 @@ class SchemaTest extends TestCase
         $schema->createSequence('moo');
         $schema->createSequence('war');
 
-        $visitor->expects($this->once())
+        $visitor->expects(self::once())
             ->method('acceptSchema')
             ->with($schema);
 
-        $visitor->expects($this->at(1))
+        $visitor->expects(self::at(1))
             ->method('acceptNamespace')
             ->with('foo');
 
-        $visitor->expects($this->at(2))
+        $visitor->expects(self::at(2))
             ->method('acceptNamespace')
             ->with('bar');
 
-        $visitor->expects($this->at(3))
+        $visitor->expects(self::at(3))
             ->method('acceptNamespace')
             ->with('bla');
 
-        $visitor->expects($this->exactly(3))
+        $visitor->expects(self::exactly(3))
             ->method('acceptNamespace');
 
-        $visitor->expects($this->at(4))
+        $visitor->expects(self::at(4))
             ->method('acceptTable')
             ->with($schema->getTable('baz'));
 
-        $visitor->expects($this->at(5))
+        $visitor->expects(self::at(5))
             ->method('acceptTable')
             ->with($schema->getTable('bla.bloo'));
 
-        $visitor->expects($this->exactly(2))
+        $visitor->expects(self::exactly(2))
             ->method('acceptTable');
 
-        $visitor->expects($this->at(6))
+        $visitor->expects(self::at(6))
             ->method('acceptSequence')
             ->with($schema->getSequence('moo'));
 
-        $visitor->expects($this->at(7))
+        $visitor->expects(self::at(7))
             ->method('acceptSequence')
             ->with($schema->getSequence('war'));
 
-        $visitor->expects($this->exactly(2))
+        $visitor->expects(self::exactly(2))
             ->method('acceptSequence');
 
         self::assertNull($schema->visit($visitor));

--- a/tests/Schema/TableDiffTest.php
+++ b/tests/Schema/TableDiffTest.php
@@ -41,10 +41,10 @@ class TableDiffTest extends TestCase
         $tableDiff            = new TableDiff('foo');
         $tableDiff->fromTable = $tableMock;
 
-        $tableMock->expects($this->once())
+        $tableMock->expects(self::once())
             ->method('getQuotedName')
             ->with($this->platform)
-            ->will($this->returnValue('foo'));
+            ->will(self::returnValue('foo'));
 
         self::assertEquals(new Identifier('foo'), $tableDiff->getName($this->platform));
     }

--- a/tests/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -50,13 +50,13 @@ class CreateSchemaSqlCollectorTest extends TestCase
 
     public function testAcceptsNamespace() : void
     {
-        $this->platformMock->expects($this->at(0))
+        $this->platformMock->expects(self::at(0))
             ->method('supportsSchemas')
-            ->will($this->returnValue(false));
+            ->will(self::returnValue(false));
 
-        $this->platformMock->expects($this->at(1))
+        $this->platformMock->expects(self::at(1))
             ->method('supportsSchemas')
-            ->will($this->returnValue(true));
+            ->will(self::returnValue(true));
 
         $this->visitor->acceptNamespace('foo');
 
@@ -78,13 +78,13 @@ class CreateSchemaSqlCollectorTest extends TestCase
 
     public function testAcceptsForeignKey() : void
     {
-        $this->platformMock->expects($this->at(0))
+        $this->platformMock->expects(self::at(0))
             ->method('supportsForeignKeyConstraints')
-            ->will($this->returnValue(false));
+            ->will(self::returnValue(false));
 
-        $this->platformMock->expects($this->at(1))
+        $this->platformMock->expects(self::at(1))
             ->method('supportsForeignKeyConstraints')
-            ->will($this->returnValue(true));
+            ->will(self::returnValue(true));
 
         $table      = $this->createTableMock();
         $foreignKey = $this->createForeignKeyConstraintMock();
@@ -110,9 +110,9 @@ class CreateSchemaSqlCollectorTest extends TestCase
     public function testResetsQueries() : void
     {
         foreach (['supportsSchemas', 'supportsForeignKeyConstraints'] as $method) {
-            $this->platformMock->expects($this->any())
+            $this->platformMock->expects(self::any())
                 ->method($method)
-                ->will($this->returnValue(true));
+                ->will(self::returnValue(true));
         }
 
         $table      = $this->createTableMock();

--- a/tests/Schema/Visitor/DropSchemaSqlCollectorTest.php
+++ b/tests/Schema/Visitor/DropSchemaSqlCollectorTest.php
@@ -28,14 +28,14 @@ class DropSchemaSqlCollectorTest extends TestCase
 
         $collector = new DropSchemaSqlCollector($platform);
 
-        $platform->expects($this->exactly(2))
+        $platform->expects(self::exactly(2))
             ->method('getDropForeignKeySQL');
 
-        $platform->expects($this->at(0))
+        $platform->expects(self::at(0))
             ->method('getDropForeignKeySQL')
             ->with($keyConstraintOne, $tableOne);
 
-        $platform->expects($this->at(1))
+        $platform->expects(self::at(1))
             ->method('getDropForeignKeySQL')
             ->with($keyConstraintTwo, $tableTwo);
 
@@ -49,17 +49,17 @@ class DropSchemaSqlCollectorTest extends TestCase
     {
         $constraint = $this->createMock(ForeignKeyConstraint::class);
 
-        $constraint->expects($this->any())
+        $constraint->expects(self::any())
             ->method('getName')
-            ->will($this->returnValue($name));
+            ->will(self::returnValue($name));
 
-        $constraint->expects($this->any())
+        $constraint->expects(self::any())
             ->method('getForeignColumns')
-            ->will($this->returnValue([]));
+            ->will(self::returnValue([]));
 
-        $constraint->expects($this->any())
+        $constraint->expects(self::any())
             ->method('getColumns')
-            ->will($this->returnValue([]));
+            ->will(self::returnValue([]));
 
         return $constraint;
     }

--- a/tests/Schema/Visitor/SchemaSqlCollectorTest.php
+++ b/tests/Schema/Visitor/SchemaSqlCollectorTest.php
@@ -13,15 +13,15 @@ class SchemaSqlCollectorTest extends TestCase
         $platformMock = $this->getMockBuilder(MySqlPlatform::class)
             ->onlyMethods(['getCreateTableSql', 'getCreateSequenceSql', 'getCreateForeignKeySql'])
             ->getMock();
-        $platformMock->expects($this->exactly(2))
+        $platformMock->expects(self::exactly(2))
                      ->method('getCreateTableSql')
-                     ->will($this->returnValue(['foo']));
-        $platformMock->expects($this->exactly(1))
+                     ->will(self::returnValue(['foo']));
+        $platformMock->expects(self::exactly(1))
                      ->method('getCreateSequenceSql')
-                     ->will($this->returnValue('bar'));
-        $platformMock->expects($this->exactly(1))
+                     ->will(self::returnValue('bar'));
+        $platformMock->expects(self::exactly(1))
                      ->method('getCreateForeignKeySql')
-                     ->will($this->returnValue('baz'));
+                     ->will(self::returnValue('baz'));
 
         $schema = $this->createFixtureSchema();
 
@@ -35,15 +35,15 @@ class SchemaSqlCollectorTest extends TestCase
         $platformMock = $this->getMockBuilder(MySqlPlatform::class)
             ->onlyMethods(['getDropTableSql', 'getDropSequenceSql', 'getDropForeignKeySql'])
             ->getMock();
-        $platformMock->expects($this->exactly(2))
+        $platformMock->expects(self::exactly(2))
                      ->method('getDropTableSql')
-                     ->will($this->returnValue('tbl'));
-        $platformMock->expects($this->exactly(1))
+                     ->will(self::returnValue('tbl'));
+        $platformMock->expects(self::exactly(1))
                      ->method('getDropSequenceSql')
-                     ->will($this->returnValue('seq'));
-        $platformMock->expects($this->exactly(1))
+                     ->will(self::returnValue('seq'));
+        $platformMock->expects(self::exactly(1))
                      ->method('getDropForeignKeySql')
-                     ->will($this->returnValue('fk'));
+                     ->will(self::returnValue('fk'));
 
         $schema = $this->createFixtureSchema();
 

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -40,18 +40,18 @@ class StatementTest extends TestCase
         $this->conn = $this->getMockBuilder(Connection::class)
             ->setConstructorArgs([[], $driver])
             ->getMock();
-        $this->conn->expects($this->atLeastOnce())
+        $this->conn->expects(self::atLeastOnce())
                 ->method('getWrappedConnection')
-                ->will($this->returnValue($driverConnection));
+                ->will(self::returnValue($driverConnection));
 
         $this->configuration = $this->createMock(Configuration::class);
-        $this->conn->expects($this->any())
+        $this->conn->expects(self::any())
                 ->method('getConfiguration')
-                ->will($this->returnValue($this->configuration));
+                ->will(self::returnValue($this->configuration));
 
-        $this->conn->expects($this->any())
+        $this->conn->expects(self::any())
             ->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->will(self::returnValue($driver));
     }
 
     public function testExecuteCallsLoggerStartQueryWithParametersWhenValuesBound() : void
@@ -64,13 +64,13 @@ class StatementTest extends TestCase
         $sql    = '';
 
         $logger = $this->createMock(SQLLogger::class);
-        $logger->expects($this->once())
+        $logger->expects(self::once())
                 ->method('startQuery')
-                ->with($this->equalTo($sql), $this->equalTo($values), $this->equalTo($types));
+                ->with(self::equalTo($sql), self::equalTo($values), self::equalTo($types));
 
-        $this->configuration->expects($this->once())
+        $this->configuration->expects(self::once())
                 ->method('getSQLLogger')
-                ->will($this->returnValue($logger));
+                ->will(self::returnValue($logger));
 
         $statement = new Statement($sql, $this->conn);
         $statement->bindValue($name, $var, $type);
@@ -86,13 +86,13 @@ class StatementTest extends TestCase
         $sql    = '';
 
         $logger = $this->createMock(SQLLogger::class);
-        $logger->expects($this->once())
+        $logger->expects(self::once())
                 ->method('startQuery')
-                ->with($this->equalTo($sql), $this->equalTo($values), $this->equalTo($types));
+                ->with(self::equalTo($sql), self::equalTo($values), self::equalTo($types));
 
-        $this->configuration->expects($this->once())
+        $this->configuration->expects(self::once())
                 ->method('getSQLLogger')
-                ->will($this->returnValue($logger));
+                ->will(self::returnValue($logger));
 
         $statement = new Statement($sql, $this->conn);
         $statement->execute($values);
@@ -124,24 +124,24 @@ class StatementTest extends TestCase
     {
         $logger = $this->createMock(SQLLogger::class);
 
-        $this->configuration->expects($this->once())
+        $this->configuration->expects(self::once())
             ->method('getSQLLogger')
-            ->will($this->returnValue($logger));
+            ->will(self::returnValue($logger));
 
         // Needed to satisfy construction of DBALException
-        $this->conn->expects($this->any())
+        $this->conn->expects(self::any())
             ->method('resolveParams')
-            ->will($this->returnValue([]));
+            ->will(self::returnValue([]));
 
-        $logger->expects($this->once())
+        $logger->expects(self::once())
             ->method('startQuery');
 
-        $logger->expects($this->once())
+        $logger->expects(self::once())
             ->method('stopQuery');
 
-        $this->driverStatement->expects($this->once())
+        $this->driverStatement->expects(self::once())
             ->method('execute')
-            ->will($this->throwException(new Exception('Mock test exception')));
+            ->will(self::throwException(new Exception('Mock test exception')));
 
         $statement = new Statement('', $this->conn);
 
@@ -154,7 +154,7 @@ class StatementTest extends TestCase
     {
         $statement = new Statement('', $this->conn);
 
-        $this->driverStatement->expects($this->once())
+        $this->driverStatement->expects(self::once())
             ->method('fetchAll')
             ->with(self::equalTo(FetchMode::CUSTOM_OBJECT), self::equalTo('Example'), self::equalTo(['arg1']));
 

--- a/tests/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Tools/Console/RunSqlCommandTest.php
@@ -46,7 +46,7 @@ class RunSqlCommandTest extends TestCase
                 'command' => $this->command->getName(),
                 'sql' => null,
             ]);
-            $this->fail('Expected a runtime exception when omitting sql argument');
+            self::fail('Expected a runtime exception when omitting sql argument');
         } catch (RuntimeException $e) {
             self::assertStringContainsString("Argument 'SQL", $e->getMessage());
         }
@@ -60,7 +60,7 @@ class RunSqlCommandTest extends TestCase
                 'sql' => 'SELECT 1',
                 '--depth' => 'string',
             ]);
-            $this->fail('Expected a logic exception when executing with a stringy depth');
+            self::fail('Expected a logic exception when executing with a stringy depth');
         } catch (LogicException $e) {
             self::assertStringContainsString("Option 'depth'", $e->getMessage());
         }
@@ -74,7 +74,7 @@ class RunSqlCommandTest extends TestCase
             'command' => $this->command->getName(),
             'sql' => 'SELECT 1',
         ]);
-        $this->assertSame(0, $exitCode);
+        self::assertSame(0, $exitCode);
 
         self::assertRegExp('@int.*1.*@', $this->commandTester->getDisplay());
         self::assertRegExp('@array.*1.*@', $this->commandTester->getDisplay());
@@ -96,20 +96,20 @@ class RunSqlCommandTest extends TestCase
     private function expectConnectionExecuteUpdate() : void
     {
         $this->connectionMock
-            ->expects($this->exactly(1))
+            ->expects(self::exactly(1))
             ->method('executeUpdate');
         $this->connectionMock
-            ->expects($this->exactly(0))
+            ->expects(self::exactly(0))
             ->method('fetchAll');
     }
 
     private function expectConnectionFetchAll() : void
     {
         $this->connectionMock
-            ->expects($this->exactly(0))
+            ->expects(self::exactly(0))
             ->method('executeUpdate');
         $this->connectionMock
-            ->expects($this->exactly(1))
+            ->expects(self::exactly(1))
             ->method('fetchAll');
     }
 

--- a/tests/Types/BinaryTest.php
+++ b/tests/Types/BinaryTest.php
@@ -43,7 +43,7 @@ class BinaryTest extends TestCase
 
     public function testReturnsSQLDeclaration() : void
     {
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getBinaryTypeDeclarationSQL')
             ->willReturn('TEST_BINARY');
 

--- a/tests/Types/DateImmutableTypeTest.php
+++ b/tests/Types/DateImmutableTypeTest.php
@@ -46,10 +46,10 @@ class DateImmutableTypeTest extends TestCase
     {
         $date = $this->createMock(DateTimeImmutable::class);
 
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getDateFormatString')
             ->willReturn('Y-m-d');
-        $date->expects($this->once())
+        $date->expects(self::once())
             ->method('format')
             ->with('Y-m-d')
             ->willReturn('2016-01-01');
@@ -86,7 +86,7 @@ class DateImmutableTypeTest extends TestCase
 
     public function testConvertsDateStringToPHPValue() : void
     {
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getDateFormatString')
             ->willReturn('Y-m-d');
 
@@ -98,7 +98,7 @@ class DateImmutableTypeTest extends TestCase
 
     public function testResetTimeFractionsWhenConvertingToPHPValue() : void
     {
-        $this->platform->expects($this->any())
+        $this->platform->expects(self::any())
             ->method('getDateFormatString')
             ->willReturn('Y-m-d');
 

--- a/tests/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Types/DateTimeImmutableTypeTest.php
@@ -46,10 +46,10 @@ class DateTimeImmutableTypeTest extends TestCase
     {
         $date = $this->getMockBuilder(DateTimeImmutable::class)->getMock();
 
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getDateTimeFormatString')
             ->willReturn('Y-m-d H:i:s');
-        $date->expects($this->once())
+        $date->expects(self::once())
             ->method('format')
             ->with('Y-m-d H:i:s')
             ->willReturn('2016-01-01 15:58:59');
@@ -86,7 +86,7 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeStringToPHPValue() : void
     {
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getDateTimeFormatString')
             ->willReturn('Y-m-d H:i:s');
 
@@ -101,7 +101,7 @@ class DateTimeImmutableTypeTest extends TestCase
      */
     public function testConvertsDateTimeStringWithMicrosecondsToPHPValue() : void
     {
-        $this->platform->expects($this->any())
+        $this->platform->expects(self::any())
             ->method('getDateTimeFormatString')
             ->willReturn('Y-m-d H:i:s');
 
@@ -112,7 +112,7 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testThrowsExceptionDuringConversionToPHPValueWithInvalidDateTimeString() : void
     {
-        $this->platform->expects($this->atLeastOnce())
+        $this->platform->expects(self::atLeastOnce())
             ->method('getDateTimeFormatString')
             ->willReturn('Y-m-d H:i:s');
 

--- a/tests/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Types/DateTimeTzImmutableTypeTest.php
@@ -46,10 +46,10 @@ class DateTimeTzImmutableTypeTest extends TestCase
     {
         $date = $this->createMock(DateTimeImmutable::class);
 
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getDateTimeTzFormatString')
             ->willReturn('Y-m-d H:i:s T');
-        $date->expects($this->once())
+        $date->expects(self::once())
             ->method('format')
             ->with('Y-m-d H:i:s T')
             ->willReturn('2016-01-01 15:58:59 UTC');
@@ -86,7 +86,7 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeWithTimezoneStringToPHPValue() : void
     {
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getDateTimeTzFormatString')
             ->willReturn('Y-m-d H:i:s T');
 
@@ -98,7 +98,7 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
     public function testThrowsExceptionDuringConversionToPHPValueWithInvalidDateTimeWithTimezoneString() : void
     {
-        $this->platform->expects($this->atLeastOnce())
+        $this->platform->expects(self::atLeastOnce())
             ->method('getDateTimeTzFormatString')
             ->willReturn('Y-m-d H:i:s T');
 

--- a/tests/Types/GuidTypeTest.php
+++ b/tests/Types/GuidTypeTest.php
@@ -37,9 +37,9 @@ class GuidTypeTest extends TestCase
     {
         self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
 
-        $this->platform->expects($this->any())
+        $this->platform->expects(self::any())
              ->method('hasNativeGuidType')
-             ->will($this->returnValue(true));
+             ->will(self::returnValue(true));
 
         self::assertFalse($this->type->requiresSQLCommentHint($this->platform));
     }

--- a/tests/Types/JsonArrayTest.php
+++ b/tests/Types/JsonArrayTest.php
@@ -42,7 +42,7 @@ class JsonArrayTest extends TestCase
 
     public function testReturnsSQLDeclaration() : void
     {
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getJsonTypeDeclarationSQL')
             ->willReturn('TEST_JSON');
 

--- a/tests/Types/JsonTest.php
+++ b/tests/Types/JsonTest.php
@@ -43,7 +43,7 @@ class JsonTest extends TestCase
 
     public function testReturnsSQLDeclaration() : void
     {
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getJsonTypeDeclarationSQL')
             ->willReturn('TEST_JSON');
 

--- a/tests/Types/StringTest.php
+++ b/tests/Types/StringTest.php
@@ -24,7 +24,7 @@ class StringTest extends TestCase
 
     public function testReturnsSqlDeclarationFromPlatformVarchar() : void
     {
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getVarcharTypeDeclarationSQL')
             ->willReturn('TEST_VARCHAR');
 
@@ -33,7 +33,7 @@ class StringTest extends TestCase
 
     public function testReturnsDefaultLengthFromPlatformVarchar() : void
     {
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getVarcharDefaultLength')
             ->willReturn(255);
 

--- a/tests/Types/StringTest.php
+++ b/tests/Types/StringTest.php
@@ -28,7 +28,7 @@ class StringTest extends TestCase
             ->method('getVarcharTypeDeclarationSQL')
             ->willReturn('TEST_VARCHAR');
 
-        self::assertEquals('TEST_VARCHAR', $this->type->getSqlDeclaration([], $this->platform));
+        self::assertEquals('TEST_VARCHAR', $this->type->getSQLDeclaration([], $this->platform));
     }
 
     public function testReturnsDefaultLengthFromPlatformVarchar() : void

--- a/tests/Types/TimeImmutableTypeTest.php
+++ b/tests/Types/TimeImmutableTypeTest.php
@@ -46,10 +46,10 @@ class TimeImmutableTypeTest extends TestCase
     {
         $date = $this->getMockBuilder(DateTimeImmutable::class)->getMock();
 
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getTimeFormatString')
             ->willReturn('H:i:s');
-        $date->expects($this->once())
+        $date->expects(self::once())
             ->method('format')
             ->with('H:i:s')
             ->willReturn('15:58:59');
@@ -86,7 +86,7 @@ class TimeImmutableTypeTest extends TestCase
 
     public function testConvertsTimeStringToPHPValue() : void
     {
-        $this->platform->expects($this->once())
+        $this->platform->expects(self::once())
             ->method('getTimeFormatString')
             ->willReturn('H:i:s');
 
@@ -98,7 +98,7 @@ class TimeImmutableTypeTest extends TestCase
 
     public function testResetDateFractionsWhenConvertingToPHPValue() : void
     {
-        $this->platform->expects($this->any())
+        $this->platform->expects(self::any())
             ->method('getTimeFormatString')
             ->willReturn('H:i:s');
 

--- a/tests/Types/VarDateTimeImmutableTypeTest.php
+++ b/tests/Types/VarDateTimeImmutableTypeTest.php
@@ -44,7 +44,7 @@ class VarDateTimeImmutableTypeTest extends TestCase
     {
         $date = $this->getMockBuilder(DateTimeImmutable::class)->getMock();
 
-        $date->expects($this->once())
+        $date->expects(self::once())
             ->method('format')
             ->with('Y-m-d H:i:s')
             ->willReturn('2016-01-01 15:58:59');


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

The initial work was done on top of `master` and then backported to `3.0.x` to get the tests improved as well. This is an important addition on top of the existing code quality checks since it helps to find potential bugs and prevents the new code of questionable quality from being introduced.

Additionally, in `master` the test suite will be cleaned up since a lot of assertions are no longer needed thanks to the improved type system (https://github.com/doctrine/dbal/pull/3348).

**Fixed issues:**

The analysis identified a couple of potential issues and deviations from the best practices:
1. The _constraint_ `$name` variable declared in the `foreach` loop overrides the _table_ `$name` method argument that is used down the line. Most likely, a table with such constraints will have an invalid name: https://github.com/doctrine/dbal/blob/8be6d1632696641c06c992b3a41bc973d1ac4583/src/Platforms/SqlitePlatform.php#L329-L331
2. This is unlikely a bug but usually, a loose comparison of the `strpos()` return value looks suspicious: https://github.com/doctrine/dbal/blob/8be6d1632696641c06c992b3a41bc973d1ac4583/src/Schema/OracleSchemaManager.php#L127
3. Also unlikely a bug but depending on the fetch mode, an empty value stored in the cache may be ignored: https://github.com/doctrine/dbal/blob/936e7e3350dd15a2d3de147821dfe5249169ed8b/src/Cache/ResultCacheStatement.php#L84-L85
4. An empty-ish comment like `"0"` set on a table in Oracle may be ignored: https://github.com/doctrine/dbal/blob/8be6d1632696641c06c992b3a41bc973d1ac4583/src/Platforms/OraclePlatform.php#L788-L790
5. This code is barely readable. The only situation when this expression evaluates to `TRUE` is when the counts are not equal which should have been coded explicitly: https://github.com/doctrine/dbal/blob/8be6d1632696641c06c992b3a41bc973d1ac4583/src/Platforms/SQLServer2012Platform.php#L1353

**Technically, BC-breaks:**
1. A zero value of the `$fetchMode` argument in the `Statement` methods is no longer ignored. Not that anyone should have used it but in order to use the default mode, it should be omitted or expressed as `NULL`.
2. The empty values of the "connectstring", "host", "service" and "instancename" parameters of the `oci8` and `pdo_oci` drivers are no longer ignored if passed explicitly.
3. The empty value of the "port" parameter of the `pdo_sqlsrv` driver is no longer ignored if passed explicitly.
4. The following `QueryBuilder` methods still accept null as an optional parameter but will no longer ignore another explicitly passed empty value: `::select()`, `::addSelect()`, `::insert()`, `::update()`, `::delete()`.
5. `Statement::execute()`, `QueryBuilder::groupBy()` and `::addGroupBy()` will no longer an explicitly passed non-array empty value.
6. `AbstractPlatform::getTrimExpression()` will no longer ignore an empty value of `$mode` (use `TrimMode::UNSPECIFIED` or omit); and an empty value of `$char` (use `false` or omit).

 Other empty values in various configurations are not ignored if passed explicitly

**Future improvements identified**

The errors suppressed in the PHPStan configuration identify the by-design issues that need to be fixed in the future:

1. Internal data structures are represented as untyped associative arrays instead of objects (e.g. connection configuration, table/column definitions). A similar improvement was recently implemented in https://github.com/doctrine/dbal/pull/3836.
2. The `AbstractSchemaManager::tryMethod()` implements dynamic method calls and needs to be redesigned and internalized to DBAL.

**Additional, not strictly relevant issues fixed:**
1. The comma in the regular expression pattern doesn't need to be escaped: https://github.com/doctrine/dbal/blob/936e7e3350dd15a2d3de147821dfe5249169ed8b/src/Schema/MySqlSchemaManager.php#L146

**TODO:**
- [x] Rebase on top of https://github.com/doctrine/dbal/pull/3933.
- [x] Rebase on top of https://github.com/doctrine/dbal/pull/3934.
- [x] Document the no longer ignored empty values.
- [ ] When merging up to `master`, revisit the list of whitelisted errors. Some of them will be no longer relevant.