### PR TITLE
Removed the hard-coded MySQL default port and the usage of ini-settings

### DIFF
--- a/src/Driver/Mysqli/MysqliConnection.php
+++ b/src/Driver/Mysqli/MysqliConnection.php
@@ -47,16 +47,10 @@ class MysqliConnection implements PingableConnection, ServerInfoAwareConnection
      */
     public function __construct(array $params, $username, $password, array $driverOptions = [])
     {
-        $port = $params['port'] ?? ini_get('mysqli.default_port');
-
-        // Fallback to default MySQL port if not given.
-        if (! $port) {
-            $port = 3306;
-        }
-
         $socket = $params['unix_socket'] ?? ini_get('mysqli.default_socket');
         $dbname = $params['dbname'] ?? null;
         $host   = $params['host'];
+        $port   = $params['port'] ?? null;
 
         if (! empty($params['persistent'])) {
             $host = 'p:' . $host;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

There's no need to use the hard-coded MySQL port `3306` in the DBALs codebase. There's also no need to manually pass the value obtainer from `ini_get('mysqli.default_port')` to the driver. The driver [doesn't require a port](https://github.com/php/php-src/blob/php-7.3.0/ext/mysqli/mysqli_nonapi.c#L124-L126) and is [aware of the default port](https://github.com/php/php-src/blob/php-7.3.0/ext/mysqli/mysqli.c#L512):
```php
<?php declare(strict_types=1);

$conn = mysqli_init();
$conn->real_connect('localhost', 'root');
var_dump($conn->query('SELECT VERSION()')->fetch_row());

/*array(1) {
  [0] =>
  string(6) "5.7.27"
}*/
```