### PR TITLE
Fix parsing column comments on SQLite

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -496,7 +496,7 @@ CREATE\sTABLE # Match "CREATE TABLE"
     private function parseColumnCommentFromSQL(string $column, string $sql) : ?string
     {
         $pattern = '{[\s(,](?:\W' . preg_quote($this->_platform->quoteSingleIdentifier($column)) . '\W|\W' . preg_quote($column)
-            . '\W)(?:\(.*?\)|[^,(])*?,?((?:(?!\n))(?:\s*--[^\n]*\n?)+)}i';
+            . '\W)(?:\([^)]*?\)|[^,(])*?,?((?:(?!\n))(?:\s*--[^\n]*\n?)+)}i';
 
         if (preg_match($pattern, $sql, $match) !== 1) {
             return null;

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -278,4 +278,19 @@ SQL;
         // with an empty table, non autoincrement rowid is always 1
         $this->assertEquals(1, $lastUsedIdAfterDelete);
     }
+
+    public function testOnlyOwnCommentIsParsed() : void
+    {
+        $table = new Table('own_column_comment');
+        $table->addColumn('col1', 'string', ['length' => 16]);
+        $table->addColumn('col2', 'string', ['length' => 16, 'comment' => 'Column #2']);
+        $table->addColumn('col3', 'string', ['length' => 16]);
+
+        $sm = $this->connection->getSchemaManager();
+        $sm->createTable($table);
+
+        $this->assertNull($sm->listTableDetails('own_column_comment')
+            ->getColumn('col1')
+            ->getComment());
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #3937

#### Summary

When a table DDL looks like the following:
```sql
CREATE TABLE column_comments (x VARCHAR(1), y VARCHAR(1) --Some comment
```
Then when parsing the comment for the `x` column, the existing `\(.*?\)` pattern instead of capturing `(1)`, captures `(1), y VARCHAR(1)`, so the `--Some comment` part is parsed as belonging to `x`.

The solution is to not allow the closing parentheses in the pattern to make sure that only the portion prior to the first closing parentheses is captured.

The existing non-greedy behavior of the pattern is not enough since even a non-greedy pattern aims to find a match while in our case there shouldn't be a match.