### PR TITLE
Do not require hostname for non-persistent MySQL connection and require for persistent

### DIFF
--- a/src/Driver/Mysqli/HostRequired.php
+++ b/src/Driver/Mysqli/HostRequired.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli;
+
+/**
+ * @internal
+ */
+final class HostRequired extends MysqliException
+{
+    public static function forPersistentConnection() : self
+    {
+        return new self('The "host" parameter is required for a persistent connection');
+    }
+}

--- a/src/Driver/Mysqli/MysqliConnection.php
+++ b/src/Driver/Mysqli/MysqliConnection.php
@@ -49,11 +49,16 @@ class MysqliConnection implements PingableConnection, ServerInfoAwareConnection
     {
         $socket = $params['unix_socket'] ?? ini_get('mysqli.default_socket');
         $dbname = $params['dbname'] ?? null;
-        $host   = $params['host'];
         $port   = $params['port'] ?? null;
 
         if (! empty($params['persistent'])) {
-            $host = 'p:' . $host;
+            if (! isset($params['host'])) {
+                throw HostRequired::forPersistentConnection();
+            }
+
+            $host = 'p:' . $params['host'];
+        } else {
+            $host = $params['host'] ?? null;
         }
 
         $flags = $driverOptions[static::OPTION_FLAGS] ?? null;

--- a/tests/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Driver/Mysqli/MysqliConnectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Driver\Mysqli;
 
+use Doctrine\DBAL\Driver\Mysqli\HostRequired;
 use Doctrine\DBAL\Driver\Mysqli\MysqliConnection;
 use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
@@ -59,5 +60,11 @@ class MysqliConnectionTest extends FunctionalTestCase
         self::assertSame($handler, set_error_handler($default_handler), 'Restoring error handler failed.');
         restore_error_handler();
         restore_error_handler();
+    }
+
+    public function testHostnameIsRequiredForPersistentConnection() : void
+    {
+        $this->expectException(HostRequired::class);
+        new MysqliConnection(['persistent' => 'true'], '', '');
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #3942.

According to the [documentation](https://www.php.net/mysqli_real_connect), the hostname may be omitted and will default to "localhost". However, given the fact that the persistent connection flag is passed as part of the hostname, the hostname cannot be omitted for persistent connection.

The issue is not reproducible on 2.x because the "Undefined index" notice is suppressed by the error handler:
https://github.com/doctrine/dbal/blob/35beaca3bed81ad4983e58706ae38688de34a853/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php#L67-L70