### PR TITLE
Allow running `dbal:run-sql` using arbitrary connection

### DIFF
--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -30,6 +30,7 @@ class RunSqlCommand extends Command
         ->setDescription('Executes arbitrary SQL directly from the command line.')
         ->setDefinition([
             new InputArgument('sql', InputArgument::REQUIRED, 'The SQL statement to execute.'),
+            new InputOption('connection', null, InputOption::VALUE_REQUIRED, 'The database connection on which to execute the SQL statement', 'db'),
             new InputOption('depth', null, InputOption::VALUE_REQUIRED, 'Dumping depth of result set.', 7),
             new InputOption('force-fetch', null, InputOption::VALUE_NONE, 'Forces fetching the result.'),
         ])
@@ -44,7 +45,9 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $conn = $this->getHelper('db')->getConnection();
+        $connection = $this->getOption('connection');
+        
+        $conn = $this->getHelper($connection)->getConnection();
 
         $sql = $input->getArgument('sql');
 

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tools\Console\Command;
 
+use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\DBAL\Tools\Dumper;
 use LogicException;
 use RuntimeException;
@@ -47,7 +48,22 @@ EOT
     {
         $connection = $input->getOption('connection');
 
-        $conn = $this->getHelper($connection)->getConnection();
+        if (!is_string($connection)) {
+            throw new LogicException("Option 'connection' must contain a string value");
+        }
+
+
+        $connHelper = $this->getHelper($connection);
+
+        if (!$connHelper instanceof ConnectionHelper) {
+            throw new LogicException(sprintf(
+                "Helper '%s' must be a valid '%s' object.",
+                $connection,
+                ConnectionHelper::class
+            ));
+        }
+
+        $conn = $connHelper->getConnection();
 
         $sql = $input->getArgument('sql');
 

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -15,6 +15,7 @@ use function assert;
 use function is_bool;
 use function is_numeric;
 use function is_string;
+use function sprintf;
 use function stripos;
 
 /**
@@ -48,14 +49,13 @@ EOT
     {
         $connection = $input->getOption('connection');
 
-        if (!is_string($connection)) {
+        if (! is_string($connection)) {
             throw new LogicException("Option 'connection' must contain a string value");
         }
 
-
         $connHelper = $this->getHelper($connection);
 
-        if (!$connHelper instanceof ConnectionHelper) {
+        if (! $connHelper instanceof ConnectionHelper) {
             throw new LogicException(sprintf(
                 "Helper '%s' must be a valid '%s' object.",
                 $connection,

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -45,8 +45,8 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $connection = $this->getOption('connection');
-        
+        $connection = $input->getOption('connection');
+
         $conn = $this->getHelper($connection)->getConnection();
 
         $sql = $input->getArgument('sql');


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no

#### Summary

This slight modification allows running the `dbal:run-sql` command using an arbitrary database connection, which is specially useful in CLI applications that use multiple database connections. Backwards compatibility is maintained by using the default 'db' value for the input option.

The command now includes a `--connection` option, which defaults to 'db'. If specified, a ConnectionHelper is searched for that matches the provided connection name.
