### PR TITLE
Only mark getMessage as mutation free

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractDriverException.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractDriverException.php
@@ -6,8 +6,6 @@ use Exception;
 
 /**
  * Abstract base implementation of the {@link DriverException} interface.
- *
- * @psalm-immutable
  */
 abstract class AbstractDriverException extends Exception implements DriverException
 {

--- a/lib/Doctrine/DBAL/Driver/DriverException.php
+++ b/lib/Doctrine/DBAL/Driver/DriverException.php
@@ -9,8 +9,6 @@ use Throwable;
  *
  * Driver exceptions provide the SQLSTATE of the driver
  * and the driver specific error code at the time the error occurred.
- *
- * @psalm-immutable
  */
 interface DriverException extends Throwable
 {
@@ -28,6 +26,8 @@ interface DriverException extends Throwable
      * Returns the driver error message.
      *
      * @return string
+     *
+     * @psalm-mutation-free
      */
     public function getMessage();
 

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliException.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliException.php
@@ -6,8 +6,6 @@ use Doctrine\DBAL\Driver\AbstractDriverException;
 
 /**
  * Exception thrown in case the mysqli driver errors.
- *
- * @psalm-immutable
  */
 class MysqliException extends AbstractDriverException
 {

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Exception.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Exception.php
@@ -4,9 +4,6 @@ namespace Doctrine\DBAL\Driver\OCI8;
 
 use Doctrine\DBAL\Driver\AbstractDriverException;
 
-/**
- * @psalm-immutable
- */
 class OCI8Exception extends AbstractDriverException
 {
     /**

--- a/lib/Doctrine/DBAL/Driver/PDOException.php
+++ b/lib/Doctrine/DBAL/Driver/PDOException.php
@@ -4,8 +4,6 @@ namespace Doctrine\DBAL\Driver;
 
 /**
  * Tiny wrapper for PDOException instances to implement the {@link DriverException} interface.
- *
- * @psalm-immutable
  */
 class PDOException extends \PDOException implements DriverException
 {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereException.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereException.php
@@ -12,8 +12,6 @@ use function sasql_stmt_error;
 
 /**
  * SAP Sybase SQL Anywhere driver exception.
- *
- * @psalm-immutable
  */
 class SQLAnywhereException extends AbstractDriverException
 {

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvException.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvException.php
@@ -7,9 +7,6 @@ use const SQLSRV_ERR_ERRORS;
 use function rtrim;
 use function sqlsrv_errors;
 
-/**
- * @psalm-immutable
- */
 class SQLSrvException extends AbstractDriverException
 {
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

We do not know if children classes do or do not mutate state.
This reverts commit 5a61341fea474990fe2c4fb5e27515c053ccf4a4.
This translates into many issues on master: having to mark much more exceptions as immutable, one of which actually isn't detected as such.

See https://github.com/doctrine/dbal/pull/3954#issuecomment-615350424
