### PR TITLE
Added ON UPDATE default field support for MySQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -476,7 +476,7 @@ SQL
             $field['default'] = null;
         }
 
-        if ($field['type'] instanceof Types\DateTimeType && substr(strtoupper($field['default']), -27) === "ON UPDATE CURRENT_TIMESTAMP") {
+        if ($field['type'] instanceof \Doctrine\DBAL\Types\DateTimeType && substr(strtoupper($field['default']), -27) === "ON UPDATE CURRENT_TIMESTAMP") {
             return ' DEFAULT ' . $field['default'];
         }
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\BlobType;
+use Doctrine\DBAL\Types\DateTimeType;
 use Doctrine\DBAL\Types\TextType;
 use InvalidArgumentException;
 use function array_diff_key;
@@ -24,6 +25,7 @@ use function is_string;
 use function sprintf;
 use function str_replace;
 use function strtoupper;
+use function substr;
 use function trim;
 
 /**
@@ -476,7 +478,7 @@ SQL
             $field['default'] = null;
         }
 
-        if ($field['type'] instanceof \Doctrine\DBAL\Types\DateTimeType && substr(strtoupper($field['default']), -27) === "ON UPDATE CURRENT_TIMESTAMP") {
+        if ($field['type'] instanceof DateTimeType && substr(strtoupper($field['default']), -27) === 'ON UPDATE CURRENT_TIMESTAMP') {
             return ' DEFAULT ' . $field['default'];
         }
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -476,6 +476,10 @@ SQL
             $field['default'] = null;
         }
 
+        if ($field['type'] instanceof Types\DateTimeType && substr(strtoupper($field['default']), -27) === "ON UPDATE CURRENT_TIMESTAMP") {
+            return ' DEFAULT ' . $field['default'];
+        }
+
         return parent::getDefaultValueDeclarationSQL($field);
     }
 

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -198,6 +198,10 @@ class MySqlSchemaManager extends AbstractSchemaManager
                 : null,
         ];
 
+        if (strpos($tableColumn['extra'], 'on update CURRENT_TIMESTAMP') !== false) {
+            $options['default'] .= strlen($options['default']) > 0 ? ' ' . strtoupper($tableColumn['extra']) : strtoupper($tableColumn['extra']);
+        }
+
         if ($scale !== null && $precision !== null) {
             $options['scale']     = (int) $scale;
             $options['precision'] = (int) $precision;

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -13,9 +13,11 @@ use function assert;
 use function explode;
 use function is_string;
 use function preg_match;
+use function strlen;
 use function strpos;
 use function strtok;
 use function strtolower;
+use function strtoupper;
 use function strtr;
 
 /**


### PR DESCRIPTION
See referenced issue #3966

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3966

#### Summary

When dumping schema the `ON UPDATE CURRENT_TIMESTAMP` default behaviour is not respected and not included in the generated SQL.

I added the needed MySQL platform and schema cases to render `ON UPDATE CURRENT_TIMESTAMP` in default value declarations.
