### PR TITLE
Remove unneeded and risky stubs parsing

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL\Driver\OCI8;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
-use const OCI_DEFAULT;
+use const OCI_NO_AUTO_COMMIT;
 
 /**
  * A Doctrine DBAL driver for the Oracle OCI8 PHP extensions.
@@ -22,7 +22,7 @@ class Driver extends AbstractOracleDriver
                 (string) $password,
                 $this->_constructDsn($params),
                 $params['charset'] ?? '',
-                $params['sessionMode'] ?? OCI_DEFAULT,
+                $params['sessionMode'] ?? OCI_NO_AUTO_COMMIT,
                 $params['persistent'] ?? false
             );
         } catch (OCI8Exception $e) {

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
 use UnexpectedValueException;
 use const OCI_COMMIT_ON_SUCCESS;
-use const OCI_DEFAULT;
 use const OCI_NO_AUTO_COMMIT;
 use function addcslashes;
 use function func_get_args;
@@ -51,7 +50,7 @@ class OCI8Connection implements Connection, ServerInfoAwareConnection
         $password,
         $db,
         $charset = '',
-        $sessionMode = OCI_DEFAULT,
+        $sessionMode = OCI_NO_AUTO_COMMIT,
         $persistent = false
     ) {
         $dbh = $persistent

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -72,3 +72,8 @@ parameters:
         -
             message: '~^Cannot cast array<string>\|bool\|string\|null to int\.$~'
             path: %currentWorkingDirectory%/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
+
+        # Requires a release of https://github.com/JetBrains/phpstorm-stubs/pull/732
+        -
+            message: '~^Access to undefined constant PDO::PGSQL_ATTR_DISABLE_PREPARES\.$~'
+            path: %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php

--- a/tests/phpstan-polyfill.php
+++ b/tests/phpstan-polyfill.php
@@ -2,12 +2,9 @@
 
 declare(strict_types=1);
 
-(static function () : void {
-    foreach (['ibm_db2', 'mysqli', 'oci8', 'sqlsrv', 'pgsql'] as $extension) {
-        if (extension_loaded($extension)) {
-            continue;
-        }
+// PHPStan does not read global constants from the stubs yet, remove this when it does
+if (defined('OCI_NO_AUTO_COMMIT')) {
+    return;
+}
 
-        require sprintf(__DIR__ . '/../vendor/jetbrains/phpstorm-stubs/%1$s/%1$s.php', $extension);
-    }
-})();
+define('OCI_NO_AUTO_COMMIT', 0);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

This fixes a crash I have when running phpstan on a machine that does not have mysqli enabled:

```
Note: Using configuration file /home/greg/dev/doctrine-dbal/phpstan.neon.dist.
PHP Fatal error:  Class mysqli_result must implement interface Traversable as part of either Iterator or IteratorAggregate in Unknown on line 0
Fatal error: Class mysqli_result must implement interface Traversable as part of either Iterator or IteratorAggregate in Unknown on line 0
```
