### PR TITLE
Segregated support of unique index and unique constraint

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,16 @@
 # Upgrade to 3.0
 
+## BC BREAK: Doctrine\DBAL\Schema\Table constructor new parameter
+
+Deprecated parameter `$idGeneratorType` removed and added a new parameter `$uniqueConstraints`.
+Constructor changed from:
+
+`__construct($name, array $columns = [], array $indexes = [], array $fkConstraints = [], $idGeneratorType = 0, array $options = [])`
+
+To the new constructor:
+
+`__construct($name, array $columns = [], array $indexes = [], array $uniqueConstraints = [], array $fkConstraints = [], array $options = [])`
+
 ## BC BREAK: change in the behavior of `SchemaManager::dropDatabase()`
 
 When dropping a database, the DBAL no longer attempts to kill the client sessions that use the database.

--- a/src/Platforms/MySqlPlatform.php
+++ b/src/Platforms/MySqlPlatform.php
@@ -403,15 +403,15 @@ SQL
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
-            foreach ($options['uniqueConstraints'] as $index => $definition) {
-                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($index, $definition);
+            foreach ($options['uniqueConstraints'] as $constraintName => $definition) {
+                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($constraintName, $definition);
             }
         }
 
         // add all indexes
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
-            foreach ($options['indexes'] as $index => $definition) {
-                $queryFields .= ', ' . $this->getIndexDeclarationSQL($index, $definition);
+            foreach ($options['indexes'] as $indexName => $definition) {
+                $queryFields .= ', ' . $this->getIndexDeclarationSQL($indexName, $definition);
             }
         }
 
@@ -752,9 +752,7 @@ SQL
                 continue;
             }
 
-            foreach ($diff->fromTable->getPrimaryKeyColumns() as $columnName) {
-                $column = $diff->fromTable->getColumn($columnName);
-
+            foreach ($diff->fromTable->getPrimaryKeyColumns() as $columnName => $column) {
                 // Check if an autoincrement column was dropped from the primary key.
                 if (! $column->getAutoincrement() || in_array($columnName, $changedIndex->getColumns(), true)) {
                     continue;

--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -331,8 +331,8 @@ SQL
         $columnListSql = $this->getColumnDeclarationListSQL($columns);
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
-            foreach ($options['uniqueConstraints'] as $indexName => $definition) {
-                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($indexName, $definition);
+            foreach ($options['uniqueConstraints'] as $constraintName => $definition) {
+                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($constraintName, $definition);
             }
         }
 
@@ -454,18 +454,6 @@ SQL
             $this->generateDefaultConstraintName($table, $column['name']) .
             $this->getDefaultValueDeclarationSQL($column) .
             ' FOR ' . $columnName->getQuotedName($this);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getUniqueConstraintDeclarationSQL($name, Index $index)
-    {
-        $constraint = parent::getUniqueConstraintDeclarationSQL($name, $index);
-
-        $constraint = $this->_appendUniqueConstraintDefinition($constraint, $index);
-
-        return $constraint;
     }
 
     /**

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -963,8 +963,8 @@ class SqlitePlatform extends AbstractPlatform
                 $table->getQuotedName($this),
                 $columns,
                 $this->getPrimaryIndexInAlteredTable($diff),
+                [],
                 $this->getForeignKeysInAlteredTable($diff),
-                0,
                 $table->getOptions()
             );
             $newTable->addOption('alter', true);

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -275,13 +275,14 @@ abstract class AbstractSchemaManager
     {
         $columns     = $this->listTableColumns($name);
         $foreignKeys = [];
+
         if ($this->_platform->supportsForeignKeyConstraints()) {
             $foreignKeys = $this->listTableForeignKeys($name);
         }
 
         $indexes = $this->listTableIndexes($name);
 
-        return new Table($name, $columns, $indexes, $foreignKeys);
+        return new Table($name, $columns, $indexes, [], $foreignKeys);
     }
 
     /**

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -11,7 +11,6 @@ use function array_map;
 use function array_search;
 use function array_shift;
 use function count;
-use function is_string;
 use function strtolower;
 
 class Index extends AbstractAsset implements Constraint
@@ -79,18 +78,10 @@ class Index extends AbstractAsset implements Constraint
     }
 
     /**
-     * @param string $column
-     *
-     * @return void
-     *
      * @throws InvalidArgumentException
      */
-    protected function _addColumn($column)
+    protected function _addColumn(string $column): void
     {
-        if (! is_string($column)) {
-            throw new InvalidArgumentException('Expecting a string as Index Column');
-        }
-
         $this->_columns[$column] = new Identifier($column);
     }
 

--- a/src/Schema/SchemaException.php
+++ b/src/Schema/SchemaException.php
@@ -22,7 +22,8 @@ class SchemaException extends DBALException
     public const SEQUENCE_ALREADY_EXISTS  = 80;
     public const INDEX_INVALID_NAME       = 90;
     public const FOREIGNKEY_DOESNT_EXIST  = 100;
-    public const NAMESPACE_ALREADY_EXISTS = 110;
+    public const CONSTRAINT_DOESNT_EXIST  = 110;
+    public const NAMESPACE_ALREADY_EXISTS = 120;
 
     /**
      * @param string $tableName
@@ -144,6 +145,20 @@ class SchemaException extends DBALException
     public static function sequenceDoesNotExist($name)
     {
         return new self("There exists no sequence with the name '" . $name . "'.", self::SEQUENCE_DOENST_EXIST);
+    }
+
+    /**
+     * @param string $constraintName
+     * @param string $table
+     *
+     * @return SchemaException
+     */
+    public static function uniqueConstraintDoesNotExist($constraintName, $table)
+    {
+        return new self(
+            sprintf('There exists no unique constraint with the name "%s" on table "%s".', $constraintName, $table),
+            self::CONSTRAINT_DOESNT_EXIST
+        );
     }
 
     /**

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -51,7 +51,6 @@ class Table extends AbstractAsset
     private $implicitIndexes = [];
 
     /**
-     * @param string                 $name
      * @param Column[]               $columns
      * @param Index[]                $indexes
      * @param UniqueConstraint[]     $uniqueConstraints
@@ -61,14 +60,14 @@ class Table extends AbstractAsset
      * @throws SchemaException
      */
     public function __construct(
-        $name,
+        string $name,
         array $columns = [],
         array $indexes = [],
         array $uniqueConstraints = [],
         array $fkConstraints = [],
         array $options = []
     ) {
-        if (strlen($name) === 0) {
+        if ($name === '') {
             throw InvalidTableName::new($name);
         }
 

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -8,8 +8,11 @@ use Doctrine\DBAL\Schema\Visitor\Visitor;
 use Doctrine\DBAL\Types\Type;
 
 use function array_filter;
+use function array_keys;
 use function array_merge;
 use function in_array;
+use function is_numeric;
+use function is_string;
 use function preg_match;
 use function strlen;
 use function strtolower;
@@ -25,13 +28,13 @@ class Table extends AbstractAsset
     protected $_columns = [];
 
     /** @var Index[] */
-    private $implicitIndexes = [];
-
-    /** @var Index[] */
     protected $_indexes = [];
 
-    /** @var string|false */
-    protected $_primaryKeyName = false;
+    /** @var string|null */
+    protected $_primaryKeyName = null;
+
+    /** @var UniqueConstraint[] */
+    protected $uniqueConstraints = [];
 
     /** @var ForeignKeyConstraint[] */
     protected $_fkConstraints = [];
@@ -44,12 +47,15 @@ class Table extends AbstractAsset
     /** @var SchemaConfig|null */
     protected $_schemaConfig = null;
 
+    /** @var Index[] */
+    private $implicitIndexes = [];
+
     /**
      * @param string                 $name
      * @param Column[]               $columns
      * @param Index[]                $indexes
+     * @param UniqueConstraint[]     $uniqueConstraints
      * @param ForeignKeyConstraint[] $fkConstraints
-     * @param int                    $idGeneratorType
      * @param mixed[]                $options
      *
      * @throws SchemaException
@@ -58,8 +64,8 @@ class Table extends AbstractAsset
         $name,
         array $columns = [],
         array $indexes = [],
+        array $uniqueConstraints = [],
         array $fkConstraints = [],
-        $idGeneratorType = 0,
         array $options = []
     ) {
         if (strlen($name) === 0) {
@@ -74,6 +80,10 @@ class Table extends AbstractAsset
 
         foreach ($indexes as $idx) {
             $this->_addIndex($idx);
+        }
+
+        foreach ($uniqueConstraints as $uniqueConstraint) {
+            $this->_addUniqueConstraint($uniqueConstraint);
         }
 
         foreach ($fkConstraints as $constraint) {
@@ -130,16 +140,15 @@ class Table extends AbstractAsset
     }
 
     /**
-     * @param string[]    $columnNames
-     * @param string|null $indexName
-     * @param string[]    $flags
-     * @param mixed[]     $options
+     * @param string[] $columnNames
+     * @param string[] $flags
+     * @param mixed[]  $options
      *
      * @return self
      *
      * @throws SchemaException
      */
-    public function addIndex(array $columnNames, $indexName = null, array $flags = [], array $options = [])
+    public function addIndex(array $columnNames, ?string $indexName = null, array $flags = [], array $options = [])
     {
         if ($indexName === null) {
             $indexName = $this->_generateIdentifierName(
@@ -153,6 +162,30 @@ class Table extends AbstractAsset
     }
 
     /**
+     * @param string[] $columnNames
+     * @param string[] $flags
+     * @param mixed[]  $options
+     *
+     * @return self
+     */
+    public function addUniqueConstraint(
+        array $columnNames,
+        ?string $indexName = null,
+        array $flags = [],
+        array $options = []
+    ): Table {
+        if ($indexName === null) {
+            $indexName = $this->_generateIdentifierName(
+                array_merge([$this->getName()], $columnNames),
+                'uniq',
+                $this->_getMaxIdentifierLength()
+            );
+        }
+
+        return $this->_addUniqueConstraint($this->_createUniqueConstraint($columnNames, $indexName, $flags, $options));
+    }
+
+    /**
      * Drops the primary key from this table.
      *
      * @return void
@@ -161,12 +194,12 @@ class Table extends AbstractAsset
      */
     public function dropPrimaryKey()
     {
-        if ($this->_primaryKeyName === false) {
+        if ($this->_primaryKeyName === null) {
             return;
         }
 
         $this->dropIndex($this->_primaryKeyName);
-        $this->_primaryKeyName = false;
+        $this->_primaryKeyName = null;
     }
 
     /**
@@ -181,6 +214,7 @@ class Table extends AbstractAsset
     public function dropIndex($name)
     {
         $name = $this->normalizeIdentifier($name);
+
         if (! $this->hasIndex($name)) {
             throw SchemaException::indexDoesNotExist($name, $this->_name);
         }
@@ -353,6 +387,7 @@ class Table extends AbstractAsset
     public function dropColumn($name)
     {
         $name = $this->normalizeIdentifier($name);
+
         unset($this->_columns[$name]);
 
         return $this;
@@ -409,9 +444,8 @@ class Table extends AbstractAsset
             $name,
             $options
         );
-        $this->_addForeignKeyConstraint($constraint);
 
-        return $this;
+        return $this->_addForeignKeyConstraint($constraint);
     }
 
     /**
@@ -467,7 +501,7 @@ class Table extends AbstractAsset
 
         if (
             (isset($this->_indexes[$indexName]) && ! in_array($indexName, $replacedImplicitIndexes, true)) ||
-            ($this->_primaryKeyName !== false && $indexCandidate->isPrimary())
+            ($this->_primaryKeyName !== null && $indexCandidate->isPrimary())
         ) {
             throw SchemaException::indexAlreadyExists($indexName, $this->_name);
         }
@@ -486,9 +520,39 @@ class Table extends AbstractAsset
     }
 
     /**
-     * @return void
-     *
-     * @throws SchemaException
+     * @return self
+     */
+    protected function _addUniqueConstraint(UniqueConstraint $constraint): Table
+    {
+        $mergedNames = array_merge([$this->getName()], $constraint->getColumns());
+        $name        = strlen($constraint->getName()) > 0
+            ? $constraint->getName()
+            : $this->_generateIdentifierName($mergedNames, 'fk', $this->_getMaxIdentifierLength());
+
+        $name = $this->normalizeIdentifier($name);
+
+        $this->uniqueConstraints[$name] = $constraint;
+
+        // If there is already an index that fulfills this requirements drop the request. In the case of __construct
+        // calling this method during hydration from schema-details all the explicitly added indexes lead to duplicates.
+        // This creates computation overhead in this case, however no duplicate indexes are ever added (column based).
+        $indexName = $this->_generateIdentifierName($mergedNames, 'idx', $this->_getMaxIdentifierLength());
+
+        $indexCandidate = $this->_createIndex($constraint->getColumns(), $indexName, true, false);
+
+        foreach ($this->_indexes as $existingIndex) {
+            if ($indexCandidate->isFullfilledBy($existingIndex)) {
+                return $this;
+            }
+        }
+
+        $this->implicitIndexes[$this->normalizeIdentifier($indexName)] = $indexCandidate;
+
+        return $this;
+    }
+
+    /**
+     * @return self
      */
     protected function _addForeignKeyConstraint(ForeignKeyConstraint $constraint)
     {
@@ -498,7 +562,7 @@ class Table extends AbstractAsset
             $name = $constraint->getName();
         } else {
             $name = $this->_generateIdentifierName(
-                array_merge((array) $this->getName(), $constraint->getLocalColumns()),
+                array_merge([$this->getName()], $constraint->getLocalColumns()),
                 'fk',
                 $this->_getMaxIdentifierLength()
             );
@@ -511,7 +575,8 @@ class Table extends AbstractAsset
         // Add an explicit index on the foreign key columns.
         // If there is already an index that fulfils this requirements drop the request.
         // In the case of __construct calling this method during hydration from schema-details
-        // all the explicitly added indexes lead to duplicates. This creates computation overhead in this case,
+        // all the explicitly added indexes lead to duplicates.
+        // This creates computation overhead in this case,
         // however no duplicate indexes are ever added (based on columns).
         $indexName      = $this->_generateIdentifierName(
             array_merge([$this->getName()], $constraint->getColumns()),
@@ -522,12 +587,14 @@ class Table extends AbstractAsset
 
         foreach ($this->_indexes as $existingIndex) {
             if ($indexCandidate->isFullfilledBy($existingIndex)) {
-                return;
+                return $this;
             }
         }
 
         $this->_addIndex($indexCandidate);
         $this->implicitIndexes[$this->normalizeIdentifier($indexName)] = $indexCandidate;
+
+        return $this;
     }
 
     /**
@@ -556,6 +623,7 @@ class Table extends AbstractAsset
     public function getForeignKey($name)
     {
         $name = $this->normalizeIdentifier($name);
+
         if (! $this->hasForeignKey($name)) {
             throw SchemaException::foreignKeyDoesNotExist($name, $this->_name);
         }
@@ -575,11 +643,54 @@ class Table extends AbstractAsset
     public function removeForeignKey($name)
     {
         $name = $this->normalizeIdentifier($name);
+
         if (! $this->hasForeignKey($name)) {
             throw SchemaException::foreignKeyDoesNotExist($name, $this->_name);
         }
 
         unset($this->_fkConstraints[$name]);
+    }
+
+    /**
+     * Returns whether this table has a unique constraint with the given name.
+     */
+    public function hasUniqueConstraint(string $name): bool
+    {
+        $name = $this->normalizeIdentifier($name);
+
+        return isset($this->uniqueConstraints[$name]);
+    }
+
+    /**
+     * Returns the unique constraint with the given name.
+     *
+     * @throws SchemaException If the unique constraint does not exist.
+     */
+    public function getUniqueConstraint(string $name): UniqueConstraint
+    {
+        $name = $this->normalizeIdentifier($name);
+
+        if (! $this->hasUniqueConstraint($name)) {
+            throw SchemaException::uniqueConstraintDoesNotExist($name, $this->_name);
+        }
+
+        return $this->uniqueConstraints[$name];
+    }
+
+    /**
+     * Removes the unique constraint with the given name.
+     *
+     * @throws SchemaException If the unique constraint does not exist.
+     */
+    public function removeUniqueConstraint(string $name): void
+    {
+        $name = $this->normalizeIdentifier($name);
+
+        if (! $this->hasForeignKey($name)) {
+            throw SchemaException::uniqueConstraintDoesNotExist($name, $this->_name);
+        }
+
+        unset($this->uniqueConstraints[$name]);
     }
 
     /**
@@ -589,26 +700,27 @@ class Table extends AbstractAsset
      */
     public function getColumns()
     {
-        $primaryKey        = $this->getPrimaryKey();
-        $primaryKeyColumns = [];
+        $primaryKeyColumns = $this->hasPrimaryKey() ? $this->getPrimaryKeyColumns() : [];
+        $foreignKeyColumns = $this->getForeignKeyColumns();
+        $remainderColumns  = $this->filterColumns(
+            array_merge(array_keys($primaryKeyColumns), array_keys($foreignKeyColumns)),
+            true
+        );
 
-        if ($primaryKey !== null) {
-            $primaryKeyColumns = $this->filterColumns($primaryKey->getColumns());
-        }
-
-        return array_merge($primaryKeyColumns, $this->getForeignKeyColumns(), $this->_columns);
+        return array_merge($primaryKeyColumns, $foreignKeyColumns, $remainderColumns);
     }
 
     /**
-     * Returns foreign key columns
+     * Returns the foreign key columns
      *
      * @return Column[]
      */
-    private function getForeignKeyColumns()
+    public function getForeignKeyColumns()
     {
         $foreignKeyColumns = [];
+
         foreach ($this->getForeignKeys() as $foreignKey) {
-            $foreignKeyColumns = array_merge($foreignKeyColumns, $foreignKey->getColumns());
+            $foreignKeyColumns = array_merge($foreignKeyColumns, $foreignKey->getLocalColumns());
         }
 
         return $this->filterColumns($foreignKeyColumns);
@@ -621,10 +733,10 @@ class Table extends AbstractAsset
      *
      * @return Column[]
      */
-    private function filterColumns(array $columnNames)
+    private function filterColumns(array $columnNames, bool $reverse = false): array
     {
-        return array_filter($this->_columns, static function ($columnName) use ($columnNames): bool {
-            return in_array($columnName, $columnNames, true);
+        return array_filter($this->_columns, static function ($columnName) use ($columnNames, $reverse): bool {
+            return in_array($columnName, $columnNames, true) !== $reverse;
         }, ARRAY_FILTER_USE_KEY);
     }
 
@@ -654,6 +766,7 @@ class Table extends AbstractAsset
     public function getColumn($name)
     {
         $name = $this->normalizeIdentifier($name);
+
         if (! $this->hasColumn($name)) {
             throw SchemaException::columnDoesNotExist($name, $this->_name);
         }
@@ -668,17 +781,15 @@ class Table extends AbstractAsset
      */
     public function getPrimaryKey()
     {
-        if ($this->_primaryKeyName !== false) {
-            return $this->getIndex($this->_primaryKeyName);
-        }
-
-        return null;
+        return $this->_primaryKeyName !== null
+            ? $this->getIndex($this->_primaryKeyName)
+            : null;
     }
 
     /**
      * Returns the primary key columns.
      *
-     * @return string[]
+     * @return Column[]
      *
      * @throws DBALException
      */
@@ -690,7 +801,7 @@ class Table extends AbstractAsset
             throw new DBALException('Table ' . $this->getName() . ' has no primary key.');
         }
 
-        return $primaryKey->getColumns();
+        return $this->filterColumns($primaryKey->getColumns());
     }
 
     /**
@@ -700,7 +811,7 @@ class Table extends AbstractAsset
      */
     public function hasPrimaryKey()
     {
-        return $this->_primaryKeyName !== false && $this->hasIndex($this->_primaryKeyName);
+        return $this->_primaryKeyName !== null && $this->hasIndex($this->_primaryKeyName);
     }
 
     /**
@@ -742,6 +853,16 @@ class Table extends AbstractAsset
     public function getIndexes()
     {
         return $this->_indexes;
+    }
+
+    /**
+     * Returns the unique constraints.
+     *
+     * @return UniqueConstraint[]
+     */
+    public function getUniqueConstraints(): array
+    {
+        return $this->uniqueConstraints;
     }
 
     /**
@@ -826,15 +947,43 @@ class Table extends AbstractAsset
     }
 
     /**
+     * @param string[] $columnNames
+     * @param string[] $flags
+     * @param mixed[]  $options
+     *
+     * @throws SchemaException
+     */
+    private function _createUniqueConstraint(
+        array $columnNames,
+        string $indexName,
+        array $flags = [],
+        array $options = []
+    ): UniqueConstraint {
+        if (preg_match('(([^a-zA-Z0-9_]+))', $this->normalizeIdentifier($indexName)) === 1) {
+            throw SchemaException::indexNameInvalid($indexName);
+        }
+
+        foreach ($columnNames as $columnName => $indexColOptions) {
+            if (is_numeric($columnName) && is_string($indexColOptions)) {
+                $columnName = $indexColOptions;
+            }
+
+            if (! $this->hasColumn($columnName)) {
+                throw SchemaException::columnDoesNotExist($columnName, $this->_name);
+            }
+        }
+
+        return new UniqueConstraint($indexName, $columnNames, $flags, $options);
+    }
+
+    /**
      * Normalizes a given identifier.
      *
      * Trims quotes and lowercases the given identifier.
      *
-     * @param string|null $identifier The identifier to normalize.
-     *
      * @return string The normalized identifier.
      */
-    private function normalizeIdentifier($identifier)
+    private function normalizeIdentifier(?string $identifier): string
     {
         if ($identifier === null) {
             return '';

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+use function array_keys;
+use function array_map;
+use function strtolower;
+
+/**
+ * Class for a unique constraint.
+ */
+class UniqueConstraint extends AbstractAsset implements Constraint
+{
+    /**
+     * Asset identifier instances of the column names the unique constraint is associated with.
+     * array($columnName => Identifier)
+     *
+     * @var Identifier[]
+     */
+    protected $columns = [];
+
+    /**
+     * Platform specific flags.
+     * array($flagName => true)
+     *
+     * @var true[]
+     */
+    protected $flags = [];
+
+    /**
+     * Platform specific options.
+     *
+     * @var mixed[]
+     */
+    private $options = [];
+
+    /**
+     * @param string[] $columns
+     * @param string[] $flags
+     * @param mixed[]  $options
+     */
+    public function __construct(string $name, array $columns, array $flags = [], array $options = [])
+    {
+        $this->_setName($name);
+
+        $this->options = $options;
+
+        foreach ($columns as $column) {
+            $this->addColumn($column);
+        }
+
+        foreach ($flags as $flag) {
+            $this->addFlag($flag);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumns()
+    {
+        return array_keys($this->columns);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getQuotedColumns(AbstractPlatform $platform)
+    {
+        $columns = [];
+
+        foreach ($this->columns as $column) {
+            $columns[] = $column->getQuotedName($platform);
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getUnquotedColumns(): array
+    {
+        return array_map([$this, 'trimQuotes'], $this->getColumns());
+    }
+
+    /**
+     * Returns platform specific flags for unique constraint.
+     *
+     * @return string[]
+     */
+    public function getFlags(): array
+    {
+        return array_keys($this->flags);
+    }
+
+    /**
+     * Adds flag for a unique constraint that translates to platform specific handling.
+     *
+     * @return $this
+     *
+     * @example $uniqueConstraint->addFlag('CLUSTERED')
+     */
+    public function addFlag(string $flag): UniqueConstraint
+    {
+        $this->flags[strtolower($flag)] = true;
+
+        return $this;
+    }
+
+    /**
+     * Does this unique constraint have a specific flag?
+     */
+    public function hasFlag(string $flag): bool
+    {
+        return isset($this->flags[strtolower($flag)]);
+    }
+
+    /**
+     * Removes a flag.
+     */
+    public function removeFlag(string $flag): void
+    {
+        unset($this->flags[strtolower($flag)]);
+    }
+
+    /**
+     * Does this unique constraint have a specific option?
+     */
+    public function hasOption(string $name): bool
+    {
+        return isset($this->options[strtolower($name)]);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOption(string $name)
+    {
+        return $this->options[strtolower($name)];
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * Adds a new column to the unique constraint.
+     */
+    protected function addColumn(string $column): void
+    {
+        $this->columns[$column] = new Identifier($column);
+    }
+}

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -28,7 +28,7 @@ use function touch;
 use function unlink;
 use function version_compare;
 
-use const PHP_OS;
+use const PHP_OS_FAMILY;
 
 class ExceptionTest extends FunctionalTestCase
 {
@@ -309,7 +309,7 @@ class ExceptionTest extends FunctionalTestCase
         }
 
         // mode 0 is considered read-only on Windows
-        $mode = PHP_OS === 'Linux' ? 0444 : 0000;
+        $mode = PHP_OS_FAMILY !== 'Windows' ? 0444 : 0000;
 
         $filename = sprintf('%s/%s', sys_get_temp_dir(), 'doctrine_failed_connection_' . $mode . '.db');
 
@@ -434,7 +434,7 @@ EOT
 
     private function isLinuxRoot(): bool
     {
-        return PHP_OS === 'Linux' && posix_getpwuid(posix_geteuid())['name'] === 'root';
+        return PHP_OS_FAMILY !== 'Windows' && posix_getpwuid(posix_geteuid())['name'] === 'root';
     }
 
     private function cleanupReadOnlyFile(string $filename): void

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -7,6 +7,8 @@ use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
+use function count;
+
 final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCase
 {
     protected function setUp(): void
@@ -57,7 +59,8 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
         self::assertTrue($validationTable->hasColumn('new_id'));
         self::assertTrue($validationTable->getColumn('new_id')->getAutoincrement());
         self::assertTrue($validationTable->hasPrimaryKey());
-        self::assertSame(['new_id'], $validationTable->getPrimaryKeyColumns());
+        self::assertEquals(1, count($validationTable->getPrimaryKeyColumns()));
+        self::assertArrayHasKey('new_id', $validationTable->getPrimaryKeyColumns());
     }
 
     private function getPlatform(): AbstractPlatform

--- a/tests/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySqlSchemaManagerTest.php
@@ -46,8 +46,8 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $primaryKey = $table->getPrimaryKeyColumns();
 
         self::assertCount(2, $primaryKey);
-        self::assertContains('bar_id', $primaryKey);
-        self::assertContains('foo_id', $primaryKey);
+        self::assertArrayHasKey('bar_id', $primaryKey);
+        self::assertArrayHasKey('foo_id', $primaryKey);
     }
 
     public function testDiffTableBug(): void

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -922,7 +922,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     protected function getTestTable(string $name, array $options = []): Table
     {
-        $table = new Table($name, [], [], [], false, $options);
+        $table = new Table($name, [], [], [], [], $options);
         $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
         $table->addColumn('id', 'integer', ['notnull' => true]);
         $table->setPrimaryKey(['id']);
@@ -934,7 +934,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     protected function getTestCompositeTable(string $name): Table
     {
-        $table = new Table($name, [], [], [], false, []);
+        $table = new Table($name, [], [], [], [], []);
         $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
         $table->addColumn('id', 'integer', ['notnull' => true]);
         $table->addColumn('other_id', 'integer', ['notnull' => true]);

--- a/tests/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1586,7 +1586,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
 
     protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL(): string
     {
-        return 'CONSTRAINT [select] UNIQUE (foo) WHERE foo IS NOT NULL';
+        return 'CONSTRAINT [select] UNIQUE (foo)';
     }
 
     protected function getQuotesReservedKeywordInIndexDeclarationSQL(): string

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -1274,6 +1274,7 @@ class ComparatorTest extends TestCase
                     'id_table1' => new Column('id_table1', Type::getType('integer')),
                 ],
                 [],
+                [],
                 [
                     new ForeignKeyConstraint(['id_table1'], 'table1', ['id'], 'fk_table2_table1'),
                 ]
@@ -1287,6 +1288,7 @@ class ComparatorTest extends TestCase
                     'id_table3' => new Column('id_table3', Type::getType('integer')),
                 ],
                 [],
+                [],
                 [
                     new ForeignKeyConstraint(['id_table3'], 'table3', ['id'], 'fk_table2_table3'),
                 ]
@@ -1299,6 +1301,7 @@ class ComparatorTest extends TestCase
             ),
         ]);
         $actual     = Comparator::compareSchemas($fromSchema, $toSchema);
+
         self::assertArrayHasKey('table2', $actual->changedTables);
         self::assertCount(1, $actual->orphanedForeignKeys);
         self::assertEquals('fk_table2_table1', $actual->orphanedForeignKeys[0]->getName());

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -27,7 +27,7 @@ class TableTest extends TestCase
 
     public function testGetName(): void
     {
-        $table =  new Table('foo', [], [], []);
+        $table =  new Table('foo', [], [], [], []);
         self::assertEquals('foo', $table->getName());
     }
 
@@ -167,7 +167,7 @@ class TableTest extends TestCase
     {
         $this->expectException(SchemaException::class);
 
-        $table = new Table('foo', [], [], []);
+        $table = new Table('foo', [], [], [], []);
         $table->getIndex('unknownIndex');
     }
 
@@ -181,7 +181,7 @@ class TableTest extends TestCase
             new Index('the_primary', ['foo'], true, true),
             new Index('other_primary', ['bar'], true, true),
         ];
-        $table   = new Table('foo', $columns, $indexes, []);
+        $table   = new Table('foo', $columns, $indexes, [], []);
     }
 
     public function testAddTwoIndexesWithSameNameThrowsException(): void
@@ -194,14 +194,14 @@ class TableTest extends TestCase
             new Index('an_idx', ['foo'], false, false),
             new Index('an_idx', ['bar'], false, false),
         ];
-        $table   = new Table('foo', $columns, $indexes, []);
+        $table   = new Table('foo', $columns, $indexes, [], []);
     }
 
     public function testConstraints(): void
     {
         $constraint = new ForeignKeyConstraint([], 'foo', []);
 
-        $tableA      = new Table('foo', [], [], [$constraint]);
+        $tableA      = new Table('foo', [], [], [], [$constraint]);
         $constraints = $tableA->getForeignKeys();
 
         self::assertCount(1, $constraints);
@@ -210,7 +210,7 @@ class TableTest extends TestCase
 
     public function testOptions(): void
     {
-        $table = new Table('foo', [], [], [], false, ['foo' => 'bar']);
+        $table = new Table('foo', [], [], [], [], ['foo' => 'bar']);
 
         self::assertTrue($table->hasOption('foo'));
         self::assertEquals('bar', $table->getOption('foo'));


### PR DESCRIPTION
Added missing commits: 

* https://github.com/doctrine/dbal/commit/400d73c8a1e4f53459a877c8652811ee22c0913b
* https://github.com/doctrine/dbal/commit/e91811cb3fe3101d7d8ac95c45f8bc1ba9bd913a
* https://github.com/doctrine/dbal/commit/a4ecf053186b11bc31fbff79ef36248500383908
* https://github.com/doctrine/dbal/commit/d7d1c397a35735383b34632d3a67bbc3a3371a45
* https://github.com/doctrine/dbal/commit/c71b3ae0425e5c039b047825dbf8351a773e6785
* https://github.com/doctrine/dbal/commit/2f9da39ec645b54d08c95649c99d7b87a32bdc72
* https://github.com/doctrine/dbal/commit/9aa4e79aab0477b4212b01d65de53193d9559e39

## BC BREAK: Doctrine\DBAL\Schema\Table constructor new parameter

Deprecated parameter `$idGeneratorType` removed and added a new parameter `$uniqueConstraints`.
Constructor changed from:

`__construct($tableName, array $columns = [], array $indexes = [], array $fkConstraints = [], $idGeneratorType = 0, array $options = [])`

To the new constructor:

`__construct($tableName, array $columns = [], array $indexes = [], array $uniqueConstraints = [], array $fkConstraints = [], array $options = [])`
