### PR TITLE
Only pass the additional arguments if they are not null

### DIFF
--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -249,7 +249,15 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
-        return $this->stmt->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
+        if ($ctorArgs !== null) {
+            return $this->stmt->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
+        }
+
+        if ($fetchArgument !== null) {
+            return $this->stmt->fetchAll($fetchMode, $fetchArgument);
+        }
+
+        return $this->stmt->fetchAll($fetchMode);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3975

#### Summary

Following on from #3893 this PR ensures the additional arguments are only passed when they are non-null, as issues were reported in #3975
