### PR TITLE
Remove useless rules

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -98,11 +98,6 @@
         <exclude-pattern>lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php</exclude-pattern>
     </rule>
 
-    <!-- sqlsrv functions are documented in upper case but reflected in lower case -->
-    <rule ref="Squiz.PHP.LowercasePHPFunctions.CallUppercase">
-        <exclude-pattern>lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php</exclude-pattern>
-    </rule>
-
     <!-- see https://github.com/doctrine/dbal/issues/3377 -->
     <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedNotEqualOperator">
         <exclude-pattern>lib/Doctrine/DBAL/Schema/Comparator.php</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -61,11 +61,6 @@
         <exclude-pattern>tests/Doctrine/Tests/DBAL/Tools/TestAsset/*</exclude-pattern>
     </rule>
 
-    <!-- https://github.com/slevomat/coding-standard/issues/868 -->
-    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses.UselessParentheses">
-        <exclude-pattern>tests/continuousphp/bootstrap.php</exclude-pattern>
-    </rule>
-
     <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/2099 -->
     <rule ref="Squiz.Commenting.FunctionComment.InvalidNoReturn">
         <exclude-pattern>lib/Doctrine/DBAL/Platforms/AbstractPlatform.php</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -37,10 +37,6 @@
         </properties>
     </rule>
 
-    <rule ref="Squiz.NamingConventions.ValidVariableName.PublicHasUnderscore">
-        <exclude-pattern>*/lib/*</exclude-pattern>
-    </rule>
-
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
         <exclude-pattern>*/lib/*</exclude-pattern>
     </rule>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

This removes ignore rule that no longer seem useful. I left 2 rules that don't have an effect on my machine though. First, this one:

https://github.com/doctrine/dbal/blob/4c03ed81471c62f178581eb325339a3c34f3b71a/phpcs.xml.dist#L120-L124

It's about not adding strict types, that we don't have on this branch, but that we have in other branches. Removing it would make up merges needlessly difficult and seems pointless since it's going to appear again.

Then we have this one:

https://github.com/doctrine/dbal/blob/4c03ed81471c62f178581eb325339a3c34f3b71a/phpcs.xml.dist#L126-L130

It does nothing on my machine but I suspect it might be because I don't have an extension that provides sqlsrv functions, and it looks like being a built-in function has a special effect:

https://github.com/squizlabs/PHP_CodeSniffer/blob/e9ebf5253a3e6dd3cc4b584ce54b1f4c34fcb1f3/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php#L70-L75


