### PR TITLE
Extend RetryableException from Throwable interface

### DIFF
--- a/lib/Doctrine/DBAL/Exception/RetryableException.php
+++ b/lib/Doctrine/DBAL/Exception/RetryableException.php
@@ -2,9 +2,13 @@
 
 namespace Doctrine\DBAL\Exception;
 
+use Throwable;
+
 /**
  * Marker interface for all exceptions where retrying the transaction makes sense.
+ *
+ * @psalm-immutable
  */
-interface RetryableException
+interface RetryableException extends Throwable
 {
 }


### PR DESCRIPTION
Let RetryableException extend from the Throwable interface to prevent errors in Psalm if catching RetryableException

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no, I don't think so
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

We have some code which catches the `RetryableException`. Now Psalm complains about that catch because the `RetryableException` does not implement the `Throwable` interface

> Class/interface Doctrine\DBAL\Exception\RetryableException cannot be caught (see https://psalm.dev/132)

This is my first PR here. I hope I have done everything right. Looking forward for feedback :blush: :wave: 