### PR TITLE
Use proper check in acceptForeignKey()

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -55,7 +55,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
      */
     public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint)
     {
-        if (! $this->platform->supportsForeignKeyConstraints()) {
+        if (! $this->platform->supportsCreateDropForeignKeyConstraints()) {
             return;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -294,4 +294,26 @@ SQL;
             ->getColumn('col1')
             ->getComment());
     }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testCreatingATableWithAForeignKey() : void
+    {
+        $schema = new Schema\Schema();
+
+        $referencedTable = $schema->createTable('referenced');
+        $referencedTable->addColumn('id', 'integer');
+
+        $referencingTable = $schema->createTable('referencing');
+        $referencingTable->addColumn('id', 'integer');
+        $referencingTable->addColumn('referenced_id', 'integer');
+        $referencingTable->addForeignKeyConstraint(
+            $referencedTable,
+            ['referenced_id'],
+            ['id']
+        );
+
+        $schema->toSql($this->connection->getDatabasePlatform());
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -29,7 +29,7 @@ class CreateSchemaSqlCollectorTest extends TestCase
                     'getCreateSchemaSQL',
                     'getCreateSequenceSQL',
                     'getCreateTableSQL',
-                    'supportsForeignKeyConstraints',
+                    'supportsCreateDropForeignKeyConstraints',
                     'supportsSchemas',
                 ]
             )
@@ -76,11 +76,11 @@ class CreateSchemaSqlCollectorTest extends TestCase
     public function testAcceptsForeignKey() : void
     {
         $this->platformMock->expects($this->at(0))
-            ->method('supportsForeignKeyConstraints')
+            ->method('supportsCreateDropForeignKeyConstraints')
             ->will($this->returnValue(false));
 
         $this->platformMock->expects($this->at(1))
-            ->method('supportsForeignKeyConstraints')
+            ->method('supportsCreateDropForeignKeyConstraints')
             ->will($this->returnValue(true));
 
         $table      = $this->createTableMock();
@@ -106,7 +106,7 @@ class CreateSchemaSqlCollectorTest extends TestCase
 
     public function testResetsQueries() : void
     {
-        foreach (['supportsSchemas', 'supportsForeignKeyConstraints'] as $method) {
+        foreach (['supportsSchemas', 'supportsCreateDropForeignKeyConstraints'] as $method) {
             $this->platformMock->expects($this->any())
                 ->method($method)
                 ->will($this->returnValue(true));


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | no
| Fixed issues | #3990 

#### Summary
Checking that the platform supports foreign key is not the right case
here, because we should check if we can create them by themselves, after
the table is created. It is not the case for Sqlite.

Closes #3990

# How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/doctrine-dbal
composer require doctrine/dbal "dev-check-for-alter-support as 2.10.2"
```
