### PR TITLE
Use proper check in acceptForeignKey()

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -55,7 +55,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
      */
     public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint)
     {
-        if (! $this->platform->supportsForeignKeyConstraints()) {
+        if (! $this->platform->supportsCreateDropForeignKeyConstraints()) {
             return;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/ForeignKeyTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/ForeignKeyTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Functional\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+class ForeignKeyTest extends DbalFunctionalTestCase
+{
+    public function testCreatingATableWithAForeignKey() : void
+    {
+        $schema = new Schema();
+
+        $referencedTable = $schema->createTable('referenced_table');
+        $referencedTable->addColumn('id', 'integer');
+        $referencedTable->setPrimaryKey(['id']);
+
+        $referencingTable = $schema->createTable('referencing_table');
+        $referencingTable->addColumn('referenced_id', 'integer');
+        $referencingTable->addForeignKeyConstraint(
+            $referencedTable,
+            ['referenced_id'],
+            ['id']
+        );
+
+        foreach ($schema->toSql($this->connection->getDatabasePlatform()) as $sql) {
+            $this->connection->exec($sql);
+        }
+
+        self::assertCount(
+            1,
+            $this->connection->getSchemaManager()->listTableForeignKeys('referencing_table')
+        );
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -29,7 +29,7 @@ class CreateSchemaSqlCollectorTest extends TestCase
                     'getCreateSchemaSQL',
                     'getCreateSequenceSQL',
                     'getCreateTableSQL',
-                    'supportsForeignKeyConstraints',
+                    'supportsCreateDropForeignKeyConstraints',
                     'supportsSchemas',
                 ]
             )
@@ -76,11 +76,11 @@ class CreateSchemaSqlCollectorTest extends TestCase
     public function testAcceptsForeignKey() : void
     {
         $this->platformMock->expects($this->at(0))
-            ->method('supportsForeignKeyConstraints')
+            ->method('supportsCreateDropForeignKeyConstraints')
             ->will($this->returnValue(false));
 
         $this->platformMock->expects($this->at(1))
-            ->method('supportsForeignKeyConstraints')
+            ->method('supportsCreateDropForeignKeyConstraints')
             ->will($this->returnValue(true));
 
         $table      = $this->createTableMock();
@@ -106,7 +106,7 @@ class CreateSchemaSqlCollectorTest extends TestCase
 
     public function testResetsQueries() : void
     {
-        foreach (['supportsSchemas', 'supportsForeignKeyConstraints'] as $method) {
+        foreach (['supportsSchemas', 'supportsCreateDropForeignKeyConstraints'] as $method) {
             $this->platformMock->expects($this->any())
                 ->method($method)
                 ->will($this->returnValue(true));


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | no
| Fixed issues | #3990 

#### Summary
Checking that the platform supports foreign key is not the right case
here, because we should check if we can create them by themselves, after
the table is created. It is not the case for Sqlite.

Closes #3990

# How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/doctrine-dbal
composer require doctrine/dbal "dev-check-for-alter-support as 2.10.2"
```
