### PR TITLE
Fix logging in functional tests in case of connection failure

### DIFF
--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -46,13 +46,14 @@ abstract class FunctionalTestCase extends TestCase
 
     protected function setUp() : void
     {
+        $this->sqlLoggerStack = new DebugStack();
+
         if (! isset(self::$sharedConnection)) {
             self::$sharedConnection = TestUtil::getConnection();
         }
 
         $this->connection = self::$sharedConnection;
 
-        $this->sqlLoggerStack = new DebugStack();
         $this->connection->getConfiguration()->setSQLLogger($this->sqlLoggerStack);
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | regression
| BC Break     | no

#### Summary

As of https://github.com/doctrine/dbal/pull/3932, if a functional test fails to establish a DB connection on setup (e.g. due to invalid configuration), it fails like this:
```
$ phpunit -c mysqli.phpunit.xml tests/Functional/ConnectionTest.php --stop-on-error
PHPUnit 9.1.1 by Sebastian Bergmann and contributors.

E

Time: 319 ms, Memory: 6.00 MB

There was 1 error:

1) Doctrine\DBAL\Tests\Functional\ConnectionTest::testGetWrappedConnection
Trying to get property 'queries' of non-object

/home/morozov/Projects/dbal/tests/FunctionalTestCase.php:72
```
The expected behavior is:
```
$ phpunit -c mysqli.phpunit.xml tests/Functional/ConnectionTest.php --stop-on-error
PHPUnit 9.1.1 by Sebastian Bergmann and contributors.

E

Time: 310 ms, Memory: 6.00 MB

There was 1 error:

1) Doctrine\DBAL\Tests\Functional\ConnectionTest::testGetWrappedConnection
Doctrine\DBAL\Exception\ConnectionException: An exception occurred in driver: php_network_getaddresses: getaddrinfo failed: Name or service not known
```
The reason is that we no longer check `if (isset($this->sqlLoggerStack->queries)` because `$sqlLoggerStack` is of type `DebugStack` and it's assumed that the `$queries` property is always set. Although, in the case of a connection failure, the logger is not initialized.

The solution is to initialize the logger before trying to connect.