### PR TITLE
Fix a condition that would not allow diffing of foreign keys for Sqlite

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -115,7 +115,7 @@ class SchemaDiff
             }
         }
 
-        if ($platform->supportsForeignKeyConstraints() && $saveMode === false) {
+        if ($platform->supportsCreateDropForeignKeyConstraints() && $saveMode === false) {
             foreach ($this->orphanedForeignKeys as $orphanedForeignKey) {
                 $sql[] = $platform->getDropForeignKeySQL($orphanedForeignKey, $orphanedForeignKey->getLocalTable());
             }

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -301,7 +301,7 @@ class ExceptionTest extends DbalFunctionalTestCase
         }
 
         // mode 0 is considered read-only on Windows
-        $mode = PHP_OS === 'Linux' ? 0444 : 0000;
+        $mode = PHP_OS === 'Windows' ? 0000 : 0444;
 
         $filename = sprintf('%s/%s', sys_get_temp_dir(), 'doctrine_failed_connection_' . $mode . '.db');
 

--- a/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaDiffTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Schema;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\SchemaDiff;
+use Doctrine\DBAL\Schema\Sequence;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SqliteSchemaDiffTest extends TestCase
+{
+    public function testSchemaDiffToSql() : void
+    {
+        $diff     = $this->createSchemaDiff();
+        $platform = $this->createPlatform(true);
+
+        $sql = $diff->toSql($platform);
+
+        $expected = ['create_table'];
+
+        self::assertEquals($expected, $sql);
+    }
+
+    public function testSchemaDiffToSaveSql() : void
+    {
+        $diff     = $this->createSchemaDiff();
+        $platform = $this->createPlatform(false);
+
+        $sql = $diff->toSaveSql($platform);
+
+        $expected = ['create_table'];
+
+        self::assertEquals($expected, $sql);
+    }
+
+    /**
+     * @return AbstractPlatform|MockObject
+     */
+    private function createPlatform(bool $unsafe)
+    {
+        $platform = $this->createMock(AbstractPlatform::class);
+
+        $platform->expects($this->exactly(1))
+                ->method('supportsSchemas')
+                ->will($this->returnValue(false));
+
+        $platform->expects($this->exactly(1))
+                ->method('supportsSequences')
+                ->will($this->returnValue(false));
+                
+        $platform->expects($this->exactly(0))
+                ->method('supportsForeignKeyConstraints')
+                ->will($this->returnValue(true));
+                
+        $platform->expects($this->any())
+            ->method('supportsCreateDropForeignKeyConstraints')
+            ->will($this->returnValue(false));
+        
+        $platform->expects($this->exactly(1))
+            ->method('getCreateTableSql')
+            ->with($this->isInstanceOf(Table::class))
+            ->will($this->returnValue(['create_table']));
+
+        $platform->expects($this->exactly(0))
+                 ->method('getCreateForeignKeySQL')
+                 ->with($this->isInstanceOf(ForeignKeyConstraint::class))
+                 ->will($this->throwException(
+                     new DBALException('Sqlite platform does not support alter foreign key, the table must be fully recreated using getAlterTableSQL.')
+                    ));
+
+        if ($unsafe) {
+            $platform->expects($this->exactly(0))
+                     ->method('getDropForeignKeySql')
+                     ->with(
+                         $this->isInstanceOf(ForeignKeyConstraint::class),
+                         $this->isInstanceOf(Table::class)
+                     )
+                     ->will($this->throwException(
+                            new DBALException('Sqlite platform does not support alter foreign key, the table must be fully recreated using getAlterTableSQL.')
+                        ));
+        }
+
+        return $platform;
+    }
+
+    public function createSchemaDiff() : SchemaDiff
+    {
+        $diff                              = new SchemaDiff();
+
+        $diff->newTables['foo_table']      = new Table('foo_table');
+        $diff->newTables['foo_table']->addColumn('foreign_id', 'integer');
+        $diff->newTables['foo_table']->addForeignKeyConstraint('foreign_table', ['foreign_id'], ['id']);
+
+        $fk = new ForeignKeyConstraint(['id'], 'foreign_table', ['id']);
+        $fk->setLocalTable(new Table('local_table'));
+        
+        $diff->orphanedForeignKeys[] = $fk;
+
+        return $diff;
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaDiffTest.php
@@ -6,9 +6,7 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\SchemaDiff;
-use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Schema\TableDiff;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -52,15 +50,15 @@ class SqliteSchemaDiffTest extends TestCase
         $platform->expects($this->exactly(1))
                 ->method('supportsSequences')
                 ->will($this->returnValue(false));
-                
+
         $platform->expects($this->exactly(0))
                 ->method('supportsForeignKeyConstraints')
                 ->will($this->returnValue(true));
-                
+
         $platform->expects($this->any())
             ->method('supportsCreateDropForeignKeyConstraints')
             ->will($this->returnValue(false));
-        
+
         $platform->expects($this->exactly(1))
             ->method('getCreateTableSql')
             ->with($this->isInstanceOf(Table::class))
@@ -71,7 +69,7 @@ class SqliteSchemaDiffTest extends TestCase
                  ->with($this->isInstanceOf(ForeignKeyConstraint::class))
                  ->will($this->throwException(
                      new DBALException('Sqlite platform does not support alter foreign key, the table must be fully recreated using getAlterTableSQL.')
-                    ));
+                 ));
 
         if ($unsafe) {
             $platform->expects($this->exactly(0))
@@ -81,8 +79,8 @@ class SqliteSchemaDiffTest extends TestCase
                          $this->isInstanceOf(Table::class)
                      )
                      ->will($this->throwException(
-                            new DBALException('Sqlite platform does not support alter foreign key, the table must be fully recreated using getAlterTableSQL.')
-                        ));
+                         new DBALException('Sqlite platform does not support alter foreign key, the table must be fully recreated using getAlterTableSQL.')
+                     ));
         }
 
         return $platform;
@@ -90,15 +88,15 @@ class SqliteSchemaDiffTest extends TestCase
 
     public function createSchemaDiff() : SchemaDiff
     {
-        $diff                              = new SchemaDiff();
+        $diff = new SchemaDiff();
 
-        $diff->newTables['foo_table']      = new Table('foo_table');
+        $diff->newTables['foo_table'] = new Table('foo_table');
         $diff->newTables['foo_table']->addColumn('foreign_id', 'integer');
         $diff->newTables['foo_table']->addForeignKeyConstraint('foreign_table', ['foreign_id'], ['id']);
 
         $fk = new ForeignKeyConstraint(['id'], 'foreign_table', ['id']);
         $fk->setLocalTable(new Table('local_table'));
-        
+
         $diff->orphanedForeignKeys[] = $fk;
 
         return $diff;

--- a/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SqliteSchemaDiffTest.php
@@ -12,34 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class SqliteSchemaDiffTest extends TestCase
 {
-    public function testSchemaDiffToSql() : void
-    {
-        $diff     = $this->createSchemaDiff();
-        $platform = $this->createPlatform(true);
-
-        $sql = $diff->toSql($platform);
-
-        $expected = ['create_table'];
-
-        self::assertEquals($expected, $sql);
-    }
-
-    public function testSchemaDiffToSaveSql() : void
-    {
-        $diff     = $this->createSchemaDiff();
-        $platform = $this->createPlatform(false);
-
-        $sql = $diff->toSaveSql($platform);
-
-        $expected = ['create_table'];
-
-        self::assertEquals($expected, $sql);
-    }
-
-    /**
-     * @return AbstractPlatform|MockObject
-     */
-    private function createPlatform(bool $unsafe)
+    private function getGenericPlatform() 
     {
         $platform = $this->createMock(AbstractPlatform::class);
 
@@ -55,35 +28,100 @@ class SqliteSchemaDiffTest extends TestCase
                 ->method('supportsForeignKeyConstraints')
                 ->will($this->returnValue(true));
 
-        $platform->expects($this->any())
-            ->method('supportsCreateDropForeignKeyConstraints')
-            ->will($this->returnValue(false));
-
         $platform->expects($this->exactly(1))
             ->method('getCreateTableSql')
             ->with($this->isInstanceOf(Table::class))
             ->will($this->returnValue(['create_table']));
 
+        return $platform;
+    }
+
+    private function getForeignKeyConstraintsOnlyPlatform(bool $unsafe = false)
+    {
+        $platform = $this->getGenericPlatform();
+
+        $platform->expects($this->any())
+                 ->method('supportsCreateDropForeignKeyConstraints')
+                 ->will($this->returnValue(false));
+
         $platform->expects($this->exactly(0))
                  ->method('getCreateForeignKeySQL')
                  ->with($this->isInstanceOf(ForeignKeyConstraint::class))
                  ->will($this->throwException(
-                     new DBALException('Sqlite platform does not support alter foreign key, the table must be fully recreated using getAlterTableSQL.')
+                     new DBALException('This platform does not support alter foreign key, the table must be fully recreated using getAlterTableSQL.')
                  ));
 
         if ($unsafe) {
             $platform->expects($this->exactly(0))
-                     ->method('getDropForeignKeySql')
-                     ->with(
-                         $this->isInstanceOf(ForeignKeyConstraint::class),
-                         $this->isInstanceOf(Table::class)
-                     )
-                     ->will($this->throwException(
-                         new DBALException('Sqlite platform does not support alter foreign key, the table must be fully recreated using getAlterTableSQL.')
-                     ));
+                        ->method('getDropForeignKeySql')
+                        ->with(
+                            $this->isInstanceOf(ForeignKeyConstraint::class),
+                            $this->isInstanceOf(Table::class)
+                        )
+                        ->will($this->throwException(
+                            new DBALException('This platform does not support alter foreign key, the table must be fully recreated using getAlterTableSQL.')
+                        ));
         }
 
         return $platform;
+    }
+
+    private function getCreateDropForeignKeyConstraintsPlatform(bool $unsafe = false)
+    {
+        $platform = $this->getGenericPlatform();
+
+        $platform->expects($this->any())
+                 ->method('supportsCreateDropForeignKeyConstraints')
+                 ->will($this->returnValue(true));
+
+        $platform->expects($this->exactly(1))
+                 ->method('getCreateForeignKeySQL')
+                 ->with($this->isInstanceOf(ForeignKeyConstraint::class))
+                 ->will($this->returnValue('create_foreign_key'));
+
+        if ($unsafe) {
+            $platform->expects($this->exactly(1))
+                     ->method('getDropForeignKeySql')
+                     ->with(
+                        $this->isInstanceOf(ForeignKeyConstraint::class),
+                        $this->isInstanceOf(Table::class)
+                     )
+                     ->will($this->returnValue('drop_orphan_fk'));
+        }
+
+        return $platform;
+    }
+
+    public function provider(): array 
+    {
+        $diff = $this->createSchemaDiff();
+
+        return [
+            'supportsForeignKeyConstraintsOnly' => [
+                ['create_table'],
+                $diff->toSql($this->getForeignKeyConstraintsOnlyPlatform(true)),
+            ],
+            'supportsForeignKeyConstraintsOnlySaveSql' => [
+                ['create_table'],
+                $diff->toSaveSql($this->getForeignKeyConstraintsOnlyPlatform()),
+            ],
+            'supportsCreateDropForeignKeyConstraints' => [
+                ['drop_orphan_fk', 'create_table', 'create_foreign_key'],
+                $diff->toSql($this->getCreateDropForeignKeyConstraintsPlatform(true)),
+            ],
+            'supportsCreateDropForeignKeyConstraintsSaveSql' => [
+                ['create_table', 'create_foreign_key'],
+                $diff->toSaveSql($this->getCreateDropForeignKeyConstraintsPlatform()),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function testSchemaDiff($expectedActions, $sql): void
+    {
+        self::assertEquals($expectedActions, $sql);
     }
 
     public function createSchemaDiff() : SchemaDiff


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #4010 

#### Summary

After the changes introduced by #1204, the SchemaDiff would throw an error when trying to diff an Sqlite-backed schema with foreign keys modifications.
