### PR TITLE
Improve help of dbal:run-sql command

### DIFF
--- a/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
@@ -53,7 +53,10 @@ class RunSqlCommand extends Command
             new InputOption('force-fetch', null, InputOption::VALUE_NONE, 'Forces fetching the result.'),
         ])
         ->setHelp(<<<EOT
-Executes arbitrary SQL directly from the command line.
+The <info>%command.name%</info> command executes the given SQL query and
+outputs the results:
+
+<info>php %command.full_name% "SELECT * FROM users"</info>
 EOT
         );
     }


### PR DESCRIPTION
This makes it consistent with doctrine-bundle command

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Related issues | https://github.com/doctrine/DoctrineBundle/issues/1168

#### Summary

Since https://github.com/doctrine/DoctrineBundle/issues/1168, DBAL has now everything doctrine-bundle needs and we would like to use this command directly in future. This patch solves one small inconsistency with `doctrine:query:sql`. See https://github.com/doctrine/DoctrineBundle/blob/86d2469d6be06d55ad7b9e2f076f6942476f2e87/Command/Proxy/RunSqlDoctrineCommand.php#L24