### PR TITLE
Deprecated the concept of the fetch mode

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade to 2.11
 
+## Deprecated `FetchMode` and the corresponding methods
+
+1. The `FetchMode` class and the `setFetchMode()` method of the `Connection` and `Statement` interfaces are deprecated.
+2. The `Statement::fetch()` method is deprecated in favor of `fetchNumeric()`, `fetchAssociative()` and `fetchOne()`.
+3. The `Statement::fetchAll()` method is deprecated in favor of `fetchAllNumeric()` and `fetchAllAssociative()`. There is no currently replacement for `Statement::fetchAll(FETCH_MODE::COLUMN)`. In a future major version, `fetchColumn()` will be used as a replacement.
+4. The `Statement::fetchColumn()` method is deprecated in favor of `fetchOne()`.
+5. The `Connection::fetchArray()` and `fetchAssoc()` method are deprecated in favor of `fetchNumeric()` and `fetchAssociative()` respectively.
+6. The `StatementIterator` class and the usage of a `Statement` object as `Traversable` is deprecated in favor of `iterateNumeric()`, `iterateAssociative()` and `iterateColumn()`.
+7. Fetching data in mixed mode (`FetchMode::MIXED`) is deprecated.
+
 ## Deprecated `Connection::project()`
 
 The `Connection::project()` method is deprecated. Implement data transformation outside of DBAL.

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "nikic/php-parser": "^4.4",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^8.4.1",
+        "slevomat/coding-standard": "^6.3.6",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
         "vimeo/psalm": "^3.11"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bf4905b268231ccd58bdbe30d4ecf81",
+    "content-hash": "ae54b78f0088f88dbcfa8e179be7c43b",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -2416,16 +2416,16 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "6.3.3",
+            "version": "6.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "b905a82255749de847fd4de607c7a4c8163f058d"
+                "reference": "7876032a4f55acf2de2cf3cd538feaf98a8a0fee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b905a82255749de847fd4de607c7a4c8163f058d",
-                "reference": "b905a82255749de847fd4de607c7a4c8163f058d",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/7876032a4f55acf2de2cf3cd538feaf98a8a0fee",
+                "reference": "7876032a4f55acf2de2cf3cd538feaf98a8a0fee",
                 "shasum": ""
             },
             "require": {
@@ -2469,7 +2469,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-04-28T07:15:08+00:00"
+            "time": "2020-05-22T15:11:14+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -2920,8 +2920,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "arne@blankerts.de"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",

--- a/lib/Doctrine/DBAL/Driver/FetchUtils.php
+++ b/lib/Doctrine/DBAL/Driver/FetchUtils.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver;
+
+use Doctrine\DBAL\ForwardCompatibility\Driver\ResultStatement;
+
+/**
+ * @internal
+ */
+final class FetchUtils
+{
+    /**
+     * @return mixed|false
+     *
+     * @throws DriverException
+     */
+    public static function fetchOne(ResultStatement $stmt)
+    {
+        $row = $stmt->fetchNumeric();
+
+        if ($row === false) {
+            return false;
+        }
+
+        return $row[0];
+    }
+
+    /**
+     * @return array<int,array<int,mixed>>
+     *
+     * @throws DriverException
+     */
+    public static function fetchAllNumeric(ResultStatement $stmt) : array
+    {
+        $rows = [];
+
+        while (($row = $stmt->fetchNumeric()) !== false) {
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     *
+     * @throws DriverException
+     */
+    public static function fetchAllAssociative(ResultStatement $stmt) : array
+    {
+        $rows = [];
+
+        while (($row = $stmt->fetchAssociative()) !== false) {
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -232,6 +232,8 @@ class DB2Statement implements IteratorAggregate, Statement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use one of the fetch- or iterate-related methods.
      */
     public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
@@ -244,6 +246,8 @@ class DB2Statement implements IteratorAggregate, Statement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */
     public function getIterator()
     {
@@ -252,6 +256,8 @@ class DB2Statement implements IteratorAggregate, Statement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use fetchNumeric(), fetchAssociative() or fetchOne() instead.
      */
     public function fetch($fetchMode = null, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
@@ -303,6 +309,8 @@ class DB2Statement implements IteratorAggregate, Statement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use fetchAllNumeric(), fetchAllAssociative() or fetchColumn() instead.
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
@@ -334,6 +342,8 @@ class DB2Statement implements IteratorAggregate, Statement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use fetchOne() instead.
      */
     public function fetchColumn($columnIndex = 0)
     {

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
 use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\ForwardCompatibility\Driver\ResultStatement as ForwardCompatibleResultStatement;
 use Doctrine\DBAL\ParameterType;
 use PDO;
 use function strpos;
@@ -33,6 +34,10 @@ class Connection extends PDOConnection
 
         $stmt = $this->prepare('SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?');
         $stmt->execute([$name]);
+
+        if ($stmt instanceof ForwardCompatibleResultStatement) {
+            return $stmt->fetchOne();
+        }
 
         return $stmt->fetchColumn();
     }

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\ForwardCompatibility\Driver\ResultStatement as ForwardCompatibleResultStatement;
 use Doctrine\DBAL\ParameterType;
 use PDO;
 use function array_slice;
@@ -17,7 +18,7 @@ use const E_USER_DEPRECATED;
  * The PDO implementation of the Statement interface.
  * Used by all PDO-based drivers.
  */
-class PDOStatement extends \PDOStatement implements Statement
+class PDOStatement extends \PDOStatement implements Statement, ForwardCompatibleResultStatement
 {
     private const PARAM_TYPE_MAP = [
         ParameterType::NULL         => PDO::PARAM_NULL,
@@ -46,6 +47,8 @@ class PDOStatement extends \PDOStatement implements Statement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use one of the fetch- or iterate-related methods.
      */
     public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
@@ -132,6 +135,8 @@ class PDOStatement extends \PDOStatement implements Statement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use fetchNumeric(), fetchAssociative() or fetchOne() instead.
      */
     public function fetch($fetchMode = null, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
@@ -150,6 +155,8 @@ class PDOStatement extends \PDOStatement implements Statement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use fetchAllNumeric(), fetchAllAssociative() or fetchColumn() instead.
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
@@ -181,6 +188,8 @@ class PDOStatement extends \PDOStatement implements Statement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use fetchOne() instead.
      */
     public function fetchColumn($columnIndex = 0)
     {
@@ -189,6 +198,46 @@ class PDOStatement extends \PDOStatement implements Statement
         } catch (\PDOException $exception) {
             throw new PDOException($exception);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchNumeric()
+    {
+        return $this->fetch(PDO::FETCH_NUM);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAssociative()
+    {
+        return $this->fetch(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchOne()
+    {
+        return $this->fetch(PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAllNumeric() : array
+    {
+        return $this->fetchAll(PDO::FETCH_NUM);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAllAssociative() : array
+    {
+        return $this->fetchAll(PDO::FETCH_ASSOC);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -29,6 +29,8 @@ interface ResultStatement extends Traversable
     /**
      * Sets the fetch mode to use while iterating this statement.
      *
+     * @deprecated Use one of the fetch- or iterate-related methods.
+     *
      * @param int   $fetchMode The fetch mode must be one of the {@link \Doctrine\DBAL\FetchMode} constants.
      * @param mixed $arg2
      * @param mixed $arg3
@@ -39,6 +41,8 @@ interface ResultStatement extends Traversable
 
     /**
      * Returns the next row of a result set.
+     *
+     * @deprecated Use fetchNumeric(), fetchAssociative() or fetchOne() instead.
      *
      * @param int|null $fetchMode         Controls how the next row will be returned to the caller.
      *                                    The value must be one of the {@link \Doctrine\DBAL\FetchMode} constants,
@@ -67,6 +71,8 @@ interface ResultStatement extends Traversable
     /**
      * Returns an array containing all of the result set rows.
      *
+     * @deprecated Use fetchAllNumeric(), fetchAllAssociative() or fetchColumn() instead.
+     *
      * @param int|null     $fetchMode     Controls how the next row will be returned to the caller.
      *                                    The value must be one of the {@link \Doctrine\DBAL\FetchMode} constants,
      *                                    defaulting to {@link \Doctrine\DBAL\FetchMode::MIXED}.
@@ -88,6 +94,8 @@ interface ResultStatement extends Traversable
 
     /**
      * Returns a single column from the next row of a result set or FALSE if there are no more rows.
+     *
+     * @deprecated Use fetchOne() instead.
      *
      * @param int $columnIndex 0-indexed number of the column you wish to retrieve from the row.
      *                         If no value is supplied, fetches the first column.

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Driver\SQLAnywhere;
 
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\ForwardCompatibility\Driver\ResultStatement as ForwardCompatibleResultStatement;
 use Doctrine\DBAL\ParameterType;
 use function assert;
 use function func_get_args;
@@ -125,7 +126,13 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
      */
     public function getServerVersion()
     {
-        $version = $this->query("SELECT PROPERTY('ProductVersion')")->fetchColumn();
+        $stmt = $this->query("SELECT PROPERTY('ProductVersion')");
+
+        if ($stmt instanceof ForwardCompatibleResultStatement) {
+            $version = $stmt->fetchOne();
+        } else {
+            $version = $stmt->fetchColumn();
+        }
 
         assert(is_string($version));
 
@@ -141,7 +148,13 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
             return sasql_insert_id($this->connection);
         }
 
-        return $this->query('SELECT ' . $name . '.CURRVAL')->fetchColumn();
+        $stmt = $this->query('SELECT ' . $name . '.CURRVAL');
+
+        if ($stmt instanceof ForwardCompatibleResultStatement) {
+            return $stmt->fetchOne();
+        }
+
+        return $stmt->fetchColumn();
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\ForwardCompatibility\Driver\ResultStatement as ForwardCompatibleResultStatement;
 use Doctrine\DBAL\ParameterType;
 use function func_get_args;
 use function is_float;
@@ -139,6 +140,10 @@ class SQLSrvConnection implements Connection, ServerInfoAwareConnection
             $stmt->execute([$name]);
         } else {
             $stmt = $this->query('SELECT @@IDENTITY');
+        }
+
+        if ($stmt instanceof ForwardCompatibleResultStatement) {
+            return $stmt->fetchOne();
         }
 
         return $stmt->fetchColumn();

--- a/lib/Doctrine/DBAL/Driver/StatementIterator.php
+++ b/lib/Doctrine/DBAL/Driver/StatementIterator.php
@@ -4,6 +4,9 @@ namespace Doctrine\DBAL\Driver;
 
 use IteratorAggregate;
 
+/**
+ * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn().
+ */
 class StatementIterator implements IteratorAggregate
 {
     /** @var ResultStatement */

--- a/lib/Doctrine/DBAL/FetchMode.php
+++ b/lib/Doctrine/DBAL/FetchMode.php
@@ -6,6 +6,8 @@ use PDO;
 
 /**
  * Contains statement fetch modes.
+ *
+ * @deprecated Use one of the fetch- or iterate-related methods on the Statement.
  */
 final class FetchMode
 {

--- a/lib/Doctrine/DBAL/ForwardCompatibility/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/ForwardCompatibility/Driver/ResultStatement.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\ForwardCompatibility\Driver;
+
+use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Driver\ResultStatement as BaseResultStatement;
+
+/**
+ * Forward compatibility extension for the ResultStatement interface.
+ */
+interface ResultStatement extends BaseResultStatement
+{
+    /**
+     * Returns the next row of a result set as a numeric array or FALSE if there are no more rows.
+     *
+     * @return array<int,mixed>|false
+     *
+     * @throws DriverException
+     */
+    public function fetchNumeric();
+
+    /**
+     * Returns the next row of a result set as an associative array or FALSE if there are no more rows.
+     *
+     * @return array<string,mixed>|false
+     *
+     * @throws DriverException
+     */
+    public function fetchAssociative();
+
+    /**
+     * Returns the first value of the next row of a result set or FALSE if there are no more rows.
+     *
+     * @return mixed|false
+     *
+     * @throws DriverException
+     */
+    public function fetchOne();
+
+    /**
+     * Returns an array containing all of the result set rows represented as numeric arrays.
+     *
+     * @return array<int,array<int,mixed>>
+     *
+     * @throws DriverException
+     */
+    public function fetchAllNumeric() : array;
+
+    /**
+     * Returns an array containing all of the result set rows represented as associative arrays.
+     *
+     * @return array<int,array<string,mixed>>
+     *
+     * @throws DriverException
+     */
+    public function fetchAllAssociative() : array;
+}

--- a/lib/Doctrine/DBAL/ForwardCompatibility/ResultStatement.php
+++ b/lib/Doctrine/DBAL/ForwardCompatibility/ResultStatement.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\ForwardCompatibility;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\ForwardCompatibility\Driver\ResultStatement as BaseResultStatement;
+use Traversable;
+
+/**
+ * Forward compatibility extension for the DBAL ResultStatement interface.
+ */
+interface ResultStatement extends BaseResultStatement
+{
+    /**
+     * Returns an iterator over the result set rows represented as numeric arrays.
+     *
+     * @return Traversable<int,array<int,mixed>>
+     *
+     * @throws DBALException
+     */
+    public function iterateNumeric() : Traversable;
+
+    /**
+     * Returns an iterator over the result set rows represented as associative arrays.
+     *
+     * @return Traversable<int,array<string,mixed>>
+     *
+     * @throws DBALException
+     */
+    public function iterateAssociative() : Traversable;
+
+    /**
+     * Returns an iterator over the values of the first column of the result set.
+     *
+     * @return Traversable<int,mixed>
+     *
+     * @throws DBALException
+     */
+    public function iterateColumn() : Traversable;
+}

--- a/lib/Doctrine/DBAL/Id/TableGenerator.php
+++ b/lib/Doctrine/DBAL/Id/TableGenerator.php
@@ -5,7 +5,6 @@ namespace Doctrine\DBAL\Id;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\DriverManager;
-use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\LockMode;
 use Throwable;
 use function array_change_key_case;
@@ -105,8 +104,7 @@ class TableGenerator
             $sql      = 'SELECT sequence_value, sequence_increment_by'
                 . ' FROM ' . $platform->appendLockHint($this->generatorTableName, LockMode::PESSIMISTIC_WRITE)
                 . ' WHERE sequence_name = ? ' . $platform->getWriteLockSQL();
-            $stmt     = $this->conn->executeQuery($sql, [$sequenceName]);
-            $row      = $stmt->fetch(FetchMode::ASSOCIATIVE);
+            $row      = $this->conn->fetchAssociative($sql, [$sequenceName]);
 
             if ($row !== false) {
                 $row = array_change_key_case($row, CASE_LOWER);

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -101,7 +101,7 @@ abstract class AbstractSchemaManager
     {
         $sql = $this->_platform->getListDatabasesSQL();
 
-        $databases = $this->_conn->fetchAll($sql);
+        $databases = $this->_conn->fetchAllAssociative($sql);
 
         return $this->_getPortableDatabasesList($databases);
     }
@@ -115,7 +115,7 @@ abstract class AbstractSchemaManager
     {
         $sql = $this->_platform->getListNamespacesSQL();
 
-        $namespaces = $this->_conn->fetchAll($sql);
+        $namespaces = $this->_conn->fetchAllAssociative($sql);
 
         return $this->getPortableNamespacesList($namespaces);
     }
@@ -135,7 +135,7 @@ abstract class AbstractSchemaManager
 
         $sql = $this->_platform->getListSequencesSQL($database);
 
-        $sequences = $this->_conn->fetchAll($sql);
+        $sequences = $this->_conn->fetchAllAssociative($sql);
 
         return $this->filterAssetNames($this->_getPortableSequencesList($sequences));
     }
@@ -163,7 +163,7 @@ abstract class AbstractSchemaManager
 
         $sql = $this->_platform->getListTableColumnsSQL($table, $database);
 
-        $tableColumns = $this->_conn->fetchAll($sql);
+        $tableColumns = $this->_conn->fetchAllAssociative($sql);
 
         return $this->_getPortableTableColumnList($table, $database, $tableColumns);
     }
@@ -181,7 +181,7 @@ abstract class AbstractSchemaManager
     {
         $sql = $this->_platform->getListTableIndexesSQL($table, $this->_conn->getDatabase());
 
-        $tableIndexes = $this->_conn->fetchAll($sql);
+        $tableIndexes = $this->_conn->fetchAllAssociative($sql);
 
         return $this->_getPortableTableIndexesList($tableIndexes, $table);
     }
@@ -211,7 +211,7 @@ abstract class AbstractSchemaManager
     {
         $sql = $this->_platform->getListTablesSQL();
 
-        $tables     = $this->_conn->fetchAll($sql);
+        $tables     = $this->_conn->fetchAllAssociative($sql);
         $tableNames = $this->_getPortableTablesList($tables);
 
         return $this->filterAssetNames($tableNames);
@@ -289,7 +289,7 @@ abstract class AbstractSchemaManager
     {
         $database = $this->_conn->getDatabase();
         $sql      = $this->_platform->getListViewsSQL($database);
-        $views    = $this->_conn->fetchAll($sql);
+        $views    = $this->_conn->fetchAllAssociative($sql);
 
         return $this->_getPortableViewsList($views);
     }
@@ -309,7 +309,7 @@ abstract class AbstractSchemaManager
         }
 
         $sql              = $this->_platform->getListTableForeignKeysSQL($table, $database);
-        $tableForeignKeys = $this->_conn->fetchAll($sql);
+        $tableForeignKeys = $this->_conn->fetchAllAssociative($sql);
 
         return $this->_getPortableTableForeignKeysList($tableForeignKeys);
     }

--- a/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
@@ -30,7 +30,7 @@ class DB2SchemaManager extends AbstractSchemaManager
         $sql  = $this->_platform->getListTablesSQL();
         $sql .= ' AND CREATOR = UPPER(' . $this->_conn->quote($this->_conn->getUsername()) . ')';
 
-        $tables = $this->_conn->fetchAll($sql);
+        $tables = $this->_conn->fetchAllAssociative($sql);
 
         return $this->filterAssetNames($this->_getPortableTablesList($tables));
     }
@@ -228,7 +228,7 @@ class DB2SchemaManager extends AbstractSchemaManager
         assert($platform instanceof DB2Platform);
         $sql = $platform->getListTableCommentsSQL($tableName);
 
-        $tableOptions = $this->_conn->fetchAssoc($sql);
+        $tableOptions = $this->_conn->fetchAssociative($sql);
 
         if ($tableOptions !== false) {
             $table->addOption('comment', $tableOptions['REMARKS']);

--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -326,7 +326,7 @@ class MySqlSchemaManager extends AbstractSchemaManager
         assert($platform instanceof MySqlPlatform);
         $sql = $platform->getListTableMetadataSQL($tableName);
 
-        $tableOptions = $this->_conn->fetchAssoc($sql);
+        $tableOptions = $this->_conn->fetchAssociative($sql);
 
         if ($tableOptions === false) {
             return $table;

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -380,7 +380,7 @@ WHERE
     AND p.addr(+) = s.paddr
 SQL;
 
-        $activeUserSessions = $this->_conn->fetchAll($sql, [strtoupper($user)]);
+        $activeUserSessions = $this->_conn->fetchAllAssociative($sql, [strtoupper($user)]);
 
         foreach ($activeUserSessions as $activeUserSession) {
             $activeUserSession = array_change_key_case($activeUserSession, CASE_LOWER);
@@ -406,7 +406,7 @@ SQL;
         assert($platform instanceof OraclePlatform);
         $sql = $platform->getListTableCommentsSQL($tableName);
 
-        $tableOptions = $this->_conn->fetchAssoc($sql);
+        $tableOptions = $this->_conn->fetchAssociative($sql);
 
         if ($tableOptions !== false) {
             $table->addOption('comment', $tableOptions['COMMENTS']);

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -221,8 +221,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
                 implode(' ,', $colNumbers)
             );
 
-            $stmt         = $this->_conn->executeQuery($columnNameSql);
-            $indexColumns = $stmt->fetchAll();
+            $indexColumns = $this->_conn->fetchAllAssociative($columnNameSql);
 
             // required for getting the order of the columns right.
             foreach ($colNumbers as $colNum) {

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -248,7 +248,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
         $sql = $this->_platform->getListTableIndexesSQL($table, $this->_conn->getDatabase());
 
         try {
-            $tableIndexes = $this->_conn->fetchAll($sql);
+            $tableIndexes = $this->_conn->fetchAllAssociative($sql);
         } catch (PDOException $e) {
             if ($e->getCode() === 'IMSSP') {
                 return [];
@@ -274,7 +274,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
         if (count($tableDiff->removedColumns) > 0) {
             foreach ($tableDiff->removedColumns as $col) {
                 $columnConstraintSql = $this->getColumnConstraintSQL($tableDiff->name, $col->getName());
-                foreach ($this->_conn->fetchAll($columnConstraintSql) as $constraint) {
+                foreach ($this->_conn->fetchAllAssociative($columnConstraintSql) as $constraint) {
                     $this->_conn->exec(
                         sprintf(
                             'ALTER TABLE %s DROP CONSTRAINT %s',
@@ -340,7 +340,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
         assert($platform instanceof SQLServerPlatform);
         $sql = $platform->getListTableMetadataSQL($tableName);
 
-        $tableOptions = $this->_conn->fetchAssoc($sql);
+        $tableOptions = $this->_conn->fetchAssociative($sql);
 
         if ($tableOptions !== false) {
             $table->addOption('comment', $tableOptions['table_comment']);

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -4,7 +4,6 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\DriverManager;
-use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
@@ -115,7 +114,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         }
 
         $sql              = $this->_platform->getListTableForeignKeysSQL($table, $database);
-        $tableForeignKeys = $this->_conn->fetchAll($sql);
+        $tableForeignKeys = $this->_conn->fetchAllAssociative($sql);
 
         if (! empty($tableForeignKeys)) {
             $createSql = $this->getCreateTableSQL($table);
@@ -169,11 +168,10 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $indexBuffer = [];
 
         // fetch primary
-        $stmt       = $this->_conn->executeQuery(sprintf(
+        $indexArray = $this->_conn->fetchAllAssociative(sprintf(
             'PRAGMA TABLE_INFO (%s)',
             $this->_conn->quote($tableName)
         ));
-        $indexArray = $stmt->fetchAll(FetchMode::ASSOCIATIVE);
 
         usort($indexArray, static function ($a, $b) {
             if ($a['pk'] === $b['pk']) {
@@ -208,11 +206,10 @@ class SqliteSchemaManager extends AbstractSchemaManager
             $idx['primary']    = false;
             $idx['non_unique'] = ! $tableIndex['unique'];
 
-                $stmt       = $this->_conn->executeQuery(sprintf(
-                    'PRAGMA INDEX_INFO (%s)',
-                    $this->_conn->quote($keyName)
-                ));
-                $indexArray = $stmt->fetchAll(FetchMode::ASSOCIATIVE);
+            $indexArray = $this->_conn->fetchAllAssociative(sprintf(
+                'PRAGMA INDEX_INFO (%s)',
+                $this->_conn->quote($keyName)
+            ));
 
             foreach ($indexArray as $indexColumnRow) {
                 $idx['column_name'] = $indexColumnRow['name'];

--- a/lib/Doctrine/DBAL/Sharding/PoolingShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardManager.php
@@ -87,7 +87,7 @@ class PoolingShardManager implements ShardManager
 
         foreach ($shards as $shard) {
             $this->conn->connect($shard['id']);
-            foreach ($this->conn->fetchAll($sql, $params, $types) as $row) {
+            foreach ($this->conn->fetchAllAssociative($sql, $params, $types) as $row) {
                 $result[] = $row;
             }
         }

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
@@ -159,7 +159,7 @@ class SQLAzureShardManager implements ShardManager
                       INNER JOIN sys.federations f ON f.federation_id = d.federation_id
                       WHERE f.name = ' . $this->conn->quote($this->federationName);
 
-        return $this->conn->fetchAll($sql);
+        return $this->conn->fetchAllAssociative($sql);
     }
 
      /**
@@ -177,7 +177,7 @@ class SQLAzureShardManager implements ShardManager
 
         foreach ($shards as $shard) {
             $this->selectShard($shard['rangeLow']);
-            foreach ($this->conn->fetchAll($sql, $params, $types) as $row) {
+            foreach ($this->conn->fetchAllAssociative($sql, $params, $types) as $row) {
                 $result[] = $row;
             }
         }

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -2,12 +2,15 @@
 
 namespace Doctrine\DBAL;
 
+use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
+use Doctrine\DBAL\ForwardCompatibility\ResultStatement as ForwardCompatibleResultStatement;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use IteratorAggregate;
 use PDO;
 use Throwable;
+use Traversable;
 use function is_array;
 use function is_string;
 
@@ -15,7 +18,7 @@ use function is_string;
  * A thin wrapper around a Doctrine\DBAL\Driver\Statement that adds support
  * for logging, DBAL mapping types, etc.
  */
-class Statement implements IteratorAggregate, DriverStatement
+class Statement implements IteratorAggregate, DriverStatement, ForwardCompatibleResultStatement
 {
     /**
      * The SQL statement.
@@ -219,6 +222,8 @@ class Statement implements IteratorAggregate, DriverStatement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use one of the fetch- or iterate-related methods.
      */
     public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
@@ -236,6 +241,8 @@ class Statement implements IteratorAggregate, DriverStatement
     /**
      * Required by interface IteratorAggregate.
      *
+     * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
+     *
      * {@inheritdoc}
      */
     public function getIterator()
@@ -245,6 +252,8 @@ class Statement implements IteratorAggregate, DriverStatement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use fetchNumeric(), fetchAssociative() or fetchOne() instead.
      */
     public function fetch($fetchMode = null, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
@@ -253,6 +262,8 @@ class Statement implements IteratorAggregate, DriverStatement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use fetchAllNumeric(), fetchAllAssociative() or fetchColumn() instead.
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
@@ -261,10 +272,174 @@ class Statement implements IteratorAggregate, DriverStatement
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use fetchOne() instead.
      */
     public function fetchColumn($columnIndex = 0)
     {
         return $this->stmt->fetchColumn($columnIndex);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws DBALException
+     */
+    public function fetchNumeric()
+    {
+        try {
+            if ($this->stmt instanceof ForwardCompatibleResultStatement) {
+                return $this->stmt->fetchNumeric();
+            }
+
+            return $this->stmt->fetch(FetchMode::NUMERIC);
+        } catch (DriverException $e) {
+            throw DBALException::driverException($this->conn->getDriver(), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws DBALException
+     */
+    public function fetchAssociative()
+    {
+        try {
+            if ($this->stmt instanceof ForwardCompatibleResultStatement) {
+                return $this->stmt->fetchAssociative();
+            }
+
+            return $this->stmt->fetch(FetchMode::ASSOCIATIVE);
+        } catch (DriverException $e) {
+            throw DBALException::driverException($this->conn->getDriver(), $e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws DBALException
+     */
+    public function fetchOne()
+    {
+        try {
+            if ($this->stmt instanceof ForwardCompatibleResultStatement) {
+                return $this->stmt->fetchOne();
+            }
+
+            return $this->stmt->fetch(FetchMode::COLUMN);
+        } catch (DriverException $e) {
+            throw DBALException::driverException($this->conn->getDriver(), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws DBALException
+     */
+    public function fetchAllNumeric() : array
+    {
+        try {
+            if ($this->stmt instanceof ForwardCompatibleResultStatement) {
+                return $this->stmt->fetchAllNumeric();
+            }
+
+            return $this->stmt->fetchAll(FetchMode::NUMERIC);
+        } catch (DriverException $e) {
+            throw DBALException::driverException($this->conn->getDriver(), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws DBALException
+     */
+    public function fetchAllAssociative() : array
+    {
+        try {
+            if ($this->stmt instanceof ForwardCompatibleResultStatement) {
+                return $this->stmt->fetchAllAssociative();
+            }
+
+            return $this->stmt->fetchAll(FetchMode::ASSOCIATIVE);
+        } catch (DriverException $e) {
+            throw DBALException::driverException($this->conn->getDriver(), $e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Traversable<int,array<int,mixed>>
+     *
+     * @throws DBALException
+     */
+    public function iterateNumeric() : Traversable
+    {
+        try {
+            if ($this->stmt instanceof ForwardCompatibleResultStatement) {
+                while (($row = $this->stmt->fetchNumeric()) !== false) {
+                    yield $row;
+                }
+            } else {
+                while (($row = $this->stmt->fetch(FetchMode::NUMERIC)) !== false) {
+                    yield $row;
+                }
+            }
+        } catch (DriverException $e) {
+            throw DBALException::driverException($this->conn->getDriver(), $e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Traversable<int,array<string,mixed>>
+     *
+     * @throws DBALException
+     */
+    public function iterateAssociative() : Traversable
+    {
+        try {
+            if ($this->stmt instanceof ForwardCompatibleResultStatement) {
+                while (($row = $this->stmt->fetchAssociative()) !== false) {
+                    yield $row;
+                }
+            } else {
+                while (($row = $this->stmt->fetch(FetchMode::ASSOCIATIVE)) !== false) {
+                    yield $row;
+                }
+            }
+        } catch (DriverException $e) {
+            throw DBALException::driverException($this->conn->getDriver(), $e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Traversable<int,mixed>
+     *
+     * @throws DBALException
+     */
+    public function iterateColumn() : Traversable
+    {
+        try {
+            if ($this->stmt instanceof ForwardCompatibleResultStatement) {
+                while (($value = $this->stmt->fetchOne()) !== false) {
+                    yield $value;
+                }
+            } else {
+                while (($value = $this->stmt->fetch(FetchMode::COLUMN)) !== false) {
+                    yield $value;
+                }
+            }
+        } catch (DriverException $e) {
+            throw DBALException::driverException($this->conn->getDriver(), $e);
+        }
     }
 
     /**

--- a/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
@@ -83,7 +83,7 @@ EOT
         }
 
         if (stripos($sql, 'select') === 0 || $input->getOption('force-fetch')) {
-            $resultSet = $conn->fetchAll($sql);
+            $resultSet = $conn->fetchAllAssociative($sql);
         } else {
             $resultSet = $conn->executeUpdate($sql);
         }

--- a/tests/Doctrine/Tests/DBAL/Driver/StatementIteratorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/StatementIteratorTest.php
@@ -97,8 +97,10 @@ class StatementIteratorTest extends DbalTestCase
         yield [PortabilityStatement::class];
         yield [SQLAnywhereStatement::class];
 
-        if (extension_loaded('sqlsrv')) {
-            yield [SQLSrvStatement::class];
+        if (! extension_loaded('sqlsrv')) {
+            return;
         }
+
+        yield [SQLSrvStatement::class];
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/Connection.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/Connection.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Connection\BackwardCompatibility;
+
+use Doctrine\DBAL\Cache\QueryCacheProfile;
+use Doctrine\DBAL\Connection as BaseConnection;
+use function func_get_args;
+
+/**
+ * Wraps statements in a non-forward-compatible wrapper.
+ */
+class Connection extends BaseConnection
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function executeQuery($query, array $params = [], $types = [], ?QueryCacheProfile $qcp = null)
+    {
+        return new Statement(parent::executeQuery($query, $params, $types, $qcp));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepare($statement)
+    {
+        return new Statement(parent::prepare($statement));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function query()
+    {
+        return new Statement(parent::query(...func_get_args()));
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/FetchTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/FetchTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Connection\BackwardCompatibility;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\Tests\DBAL\Functional\Connection\FetchTest as BaseFetchTest;
+use function array_merge;
+
+class FetchTest extends BaseFetchTest
+{
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $this->connection = DriverManager::getConnection(
+            array_merge($this->connection->getParams(), [
+                'wrapperClass' => Connection::class,
+            ]),
+            $this->connection->getConfiguration(),
+            $this->connection->getEventManager()
+        );
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/Statement.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/Statement.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Connection\BackwardCompatibility;
+
+use Doctrine\DBAL\Driver\ResultStatement;
+use Doctrine\DBAL\Driver\Statement as DriverStatement;
+use Doctrine\DBAL\Driver\StatementIterator;
+use Doctrine\DBAL\ParameterType;
+use IteratorAggregate;
+use PDO;
+use function assert;
+
+/**
+ * A wrapper that does not implement the forward-compatible statement interface.
+ */
+class Statement implements IteratorAggregate, DriverStatement
+{
+    /** @var DriverStatement|ResultStatement */
+    private $stmt;
+
+    /**
+     * @param DriverStatement|ResultStatement $stmt
+     */
+    public function __construct($stmt)
+    {
+        $this->stmt = $stmt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null)
+    {
+        assert($this->stmt instanceof DriverStatement);
+
+        return $this->stmt->bindParam($column, $variable, $type, $length);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindValue($param, $value, $type = ParameterType::STRING)
+    {
+        assert($this->stmt instanceof DriverStatement);
+
+        return $this->stmt->bindValue($param, $value, $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function closeCursor()
+    {
+        return $this->stmt->closeCursor();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function columnCount()
+    {
+        return $this->stmt->columnCount();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated The error information is available via exceptions.
+     */
+    public function errorCode()
+    {
+        assert($this->stmt instanceof DriverStatement);
+
+        return $this->stmt->errorCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated The error information is available via exceptions.
+     */
+    public function errorInfo()
+    {
+        assert($this->stmt instanceof DriverStatement);
+
+        return $this->stmt->errorInfo();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($params = null)
+    {
+        assert($this->stmt instanceof DriverStatement);
+
+        return $this->stmt->execute($params);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated Use one of the fetch- or iterate-related methods.
+     */
+    public function setFetchMode($fetchMode, $arg1 = null, $arg2 = null)
+    {
+        return $this->stmt->setFetchMode($fetchMode, $arg1, $arg2);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
+     */
+    public function getIterator()
+    {
+        return new StatementIterator($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated Use fetchNumeric(), fetchAssociative() or fetchOne() instead.
+     */
+    public function fetch($fetchMode = null, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
+    {
+        return $this->stmt->fetch($fetchMode);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated Use fetchAllNumeric(), fetchAllAssociative() or fetchColumn() instead.
+     */
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
+    {
+        return $this->stmt->fetchAll($fetchMode, $fetchArgument);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated Use fetchOne() instead.
+     */
+    public function fetchColumn($columnIndex = 0)
+    {
+        return $this->stmt->fetchColumn($columnIndex);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rowCount()
+    {
+        assert($this->stmt instanceof DriverStatement);
+
+        return $this->stmt->rowCount();
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Connection/FetchTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Connection/FetchTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Connection;
+
+use Doctrine\Tests\DbalFunctionalTestCase;
+use Doctrine\Tests\TestUtil;
+use function iterator_to_array;
+
+class FetchTest extends DbalFunctionalTestCase
+{
+    /** @var string */
+    private $query;
+
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $this->query = TestUtil::generateResultSetQuery([
+            [
+                'a' => 'foo',
+                'b' => 1,
+            ],
+            [
+                'a' => 'bar',
+                'b' => 2,
+            ],
+            [
+                'a' => 'baz',
+                'b' => 3,
+            ],
+        ], $this->connection->getDatabasePlatform());
+    }
+
+    public function testFetchNumeric() : void
+    {
+        self::assertEquals(['foo', 1], $this->connection->fetchNumeric($this->query));
+    }
+
+    public function testFetchOne() : void
+    {
+        self::assertEquals('foo', $this->connection->fetchOne($this->query));
+    }
+
+    public function testFetchAssociative() : void
+    {
+        self::assertEquals([
+            'a' => 'foo',
+            'b' => 1,
+        ], $this->connection->fetchAssociative($this->query));
+    }
+
+    public function testFetchAllNumeric() : void
+    {
+        self::assertEquals([
+            ['foo', 1],
+            ['bar', 2],
+            ['baz', 3],
+        ], $this->connection->fetchAllNumeric($this->query));
+    }
+
+    public function testFetchAllAssociative() : void
+    {
+        self::assertEquals([
+            [
+                'a' => 'foo',
+                'b' => 1,
+            ],
+            [
+                'a' => 'bar',
+                'b' => 2,
+            ],
+            [
+                'a' => 'baz',
+                'b' => 3,
+            ],
+        ], $this->connection->fetchAllAssociative($this->query));
+    }
+
+    public function testIterateNumeric() : void
+    {
+        self::assertEquals([
+            ['foo', 1],
+            ['bar', 2],
+            ['baz', 3],
+        ], iterator_to_array($this->connection->iterateNumeric($this->query)));
+    }
+
+    public function testIterateAssociative() : void
+    {
+        self::assertEquals([
+            [
+                'a' => 'foo',
+                'b' => 1,
+            ],
+            [
+                'a' => 'bar',
+                'b' => 2,
+            ],
+            [
+                'a' => 'baz',
+                'b' => 3,
+            ],
+        ], iterator_to_array($this->connection->iterateAssociative($this->query)));
+    }
+
+    public function testIterateColumn() : void
+    {
+        self::assertEquals([
+            'foo',
+            'bar',
+            'baz',
+        ], iterator_to_array($this->connection->iterateColumn($this->query)));
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
@@ -30,7 +30,7 @@ final class DB2SchemaManagerTest extends TestCase
         $platform      = $this->createMock(DB2Platform::class);
         $this->conn    = $this
             ->getMockBuilder(Connection::class)
-            ->onlyMethods(['fetchAll', 'quote'])
+            ->onlyMethods(['fetchAllAssociative', 'quote'])
             ->setConstructorArgs([['platform' => $platform], $driverMock, new Configuration(), $eventManager])
             ->getMock();
         $this->manager = new DB2SchemaManager($this->conn);
@@ -44,7 +44,7 @@ final class DB2SchemaManagerTest extends TestCase
     public function testListTableNamesFiltersAssetNamesCorrectly() : void
     {
         $this->conn->getConfiguration()->setFilterSchemaAssetsExpression('/^(?!T_)/');
-        $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue([
+        $this->conn->expects($this->once())->method('fetchAllAssociative')->will($this->returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
@@ -67,7 +67,7 @@ final class DB2SchemaManagerTest extends TestCase
     {
         $filterExpression = '/^(?!T_)/';
         $this->conn->getConfiguration()->setFilterSchemaAssetsExpression($filterExpression);
-        $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue([
+        $this->conn->expects($this->once())->method('fetchAllAssociative')->will($this->returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
@@ -96,7 +96,7 @@ final class DB2SchemaManagerTest extends TestCase
             return in_array($assetName, $accepted);
         });
         $this->conn->expects($this->any())->method('quote');
-        $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue([
+        $this->conn->expects($this->once())->method('fetchAllAssociative')->will($this->returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
@@ -121,7 +121,7 @@ final class DB2SchemaManagerTest extends TestCase
             return in_array($assetName, $accepted);
         });
         $this->conn->expects($this->any())->method('quote');
-        $this->conn->expects($this->atLeastOnce())->method('fetchAll')->will($this->returnValue([
+        $this->conn->expects($this->atLeastOnce())->method('fetchAllAssociative')->will($this->returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
@@ -156,7 +156,7 @@ final class DB2SchemaManagerTest extends TestCase
         $filterExpression = '/^(?!T_)/';
         $this->conn->getConfiguration()->setFilterSchemaAssetsExpression($filterExpression);
 
-        $this->conn->expects($this->exactly(2))->method('fetchAll')->will($this->returnValue([
+        $this->conn->expects($this->exactly(2))->method('fetchAllAssociative')->will($this->returnValue([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],

--- a/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
@@ -23,11 +23,15 @@ class MySqlSchemaManagerTest extends TestCase
 
     protected function setUp() : void
     {
-        $eventManager  = new EventManager();
-        $driverMock    = $this->createMock(Driver::class);
-        $platform      = $this->createMock(MySqlPlatform::class);
+        $eventManager = new EventManager();
+        $driverMock   = $this->createMock(Driver::class);
+
+        $platform = $this->createMock(MySqlPlatform::class);
+        $platform->method('getListTableForeignKeysSQL')
+            ->willReturn('');
+
         $this->conn    = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['fetchAll'])
+            ->onlyMethods(['fetchAllAssociative'])
             ->setConstructorArgs([['platform' => $platform], $driverMock, new Configuration(), $eventManager])
             ->getMock();
         $this->manager = new MySqlSchemaManager($this->conn);
@@ -35,7 +39,7 @@ class MySqlSchemaManagerTest extends TestCase
 
     public function testCompositeForeignKeys() : void
     {
-        $this->conn->expects($this->once())->method('fetchAll')->will($this->returnValue($this->getFKDefinition()));
+        $this->conn->expects($this->once())->method('fetchAllAssociative')->will($this->returnValue($this->getFKDefinition()));
         $fkeys = $this->manager->listTableForeignKeys('dummy');
         self::assertCount(1, $fkeys, 'Table has to have one foreign key.');
 

--- a/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
@@ -16,7 +16,7 @@ class PoolingShardManagerTest extends TestCase
     private function createConnectionMock() : PoolingShardConnection
     {
         return $this->getMockBuilder(PoolingShardConnection::class)
-            ->onlyMethods(['connect', 'getParams', 'fetchAll'])
+            ->onlyMethods(['connect', 'getParams', 'fetchAllAssociative'])
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -101,12 +101,12 @@ class PoolingShardManagerTest extends TestCase
         ));
         $conn->expects($this->at(2))->method('connect')->with($this->equalTo(1));
         $conn->expects($this->at(3))
-             ->method('fetchAll')
+             ->method('fetchAllAssociative')
              ->with($this->equalTo($sql), $this->equalTo($params), $this->equalTo($types))
              ->will($this->returnValue([ ['id' => 1] ]));
         $conn->expects($this->at(4))->method('connect')->with($this->equalTo(2));
         $conn->expects($this->at(5))
-             ->method('fetchAll')
+             ->method('fetchAllAssociative')
              ->with($this->equalTo($sql), $this->equalTo($params), $this->equalTo($types))
              ->will($this->returnValue([ ['id' => 2] ]));
 
@@ -131,12 +131,12 @@ class PoolingShardManagerTest extends TestCase
         ));
         $conn->expects($this->at(2))->method('connect')->with($this->equalTo(1));
         $conn->expects($this->at(3))
-            ->method('fetchAll')
+            ->method('fetchAllAssociative')
             ->with($this->equalTo($sql), $this->equalTo($params), $this->equalTo($types))
             ->will($this->returnValue([ ['id' => 1] ]));
         $conn->expects($this->at(4))->method('connect')->with($this->equalTo(2));
         $conn->expects($this->at(5))
-            ->method('fetchAll')
+            ->method('fetchAllAssociative')
             ->with($this->equalTo($sql), $this->equalTo($params), $this->equalTo($types))
             ->will($this->returnValue([ ['id' => 2] ]));
 

--- a/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
@@ -30,7 +30,7 @@ class RunSqlCommandTest extends TestCase
         $this->commandTester = new CommandTester($this->command);
 
         $this->connectionMock = $this->createMock(Connection::class);
-        $this->connectionMock->method('fetchAll')
+        $this->connectionMock->method('fetchAllAssociative')
             ->willReturn([[1]]);
         $this->connectionMock->method('executeUpdate')
             ->willReturn(42);
@@ -68,7 +68,7 @@ class RunSqlCommandTest extends TestCase
 
     public function testSelectStatementsPrintsResult() : void
     {
-        $this->expectConnectionFetchAll();
+        $this->expectConnectionFetchAllAssociative();
 
         $exitCode = $this->commandTester->execute([
             'command' => $this->command->getName(),
@@ -100,22 +100,22 @@ class RunSqlCommandTest extends TestCase
             ->method('executeUpdate');
         $this->connectionMock
             ->expects($this->exactly(0))
-            ->method('fetchAll');
+            ->method('fetchAllAssociative');
     }
 
-    private function expectConnectionFetchAll() : void
+    private function expectConnectionFetchAllAssociative() : void
     {
         $this->connectionMock
             ->expects($this->exactly(0))
             ->method('executeUpdate');
         $this->connectionMock
             ->expects($this->exactly(1))
-            ->method('fetchAll');
+            ->method('fetchAllAssociative');
     }
 
     public function testStatementsWithFetchResultPrintsResult() : void
     {
-        $this->expectConnectionFetchAll();
+        $this->expectConnectionFetchAllAssociative();
 
         $this->commandTester->execute([
             'command' => $this->command->getName(),

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -4,9 +4,15 @@ namespace Doctrine\Tests;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use PHPUnit\Framework\Assert;
+use function array_keys;
+use function array_map;
+use function array_values;
 use function explode;
 use function extension_loaded;
+use function implode;
+use function is_string;
 use function unlink;
 
 /**
@@ -206,5 +212,25 @@ class TestUtil
     public static function getTempConnection() : Connection
     {
         return DriverManager::getConnection(self::getParamsForTemporaryConnection());
+    }
+
+    /**
+     * Generates a query that will return the given rows without the need to create a temporary table.
+     *
+     * @param array<int,array<string,mixed>> $rows
+     */
+    public static function generateResultSetQuery(array $rows, AbstractPlatform $platform) : string
+    {
+        return implode(' UNION ALL ', array_map(static function (array $row) use ($platform) : string {
+            return $platform->getDummySelectSQL(
+                implode(', ', array_map(static function (string $column, $value) use ($platform) : string {
+                    if (is_string($value)) {
+                        $value = $platform->quoteStringLiteral($value);
+                    }
+
+                    return $value . ' ' . $platform->quoteIdentifier($column);
+                }, array_keys($row), array_values($row)))
+            );
+        }, $rows));
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature, deprecation
| BC Break     | no

**Proposed changes:**
1. The `FetchMode` class, the `UnknownFetchMode` exception and the `setFetchMode()` methods are deprecated as well as the entire concept of the fetch mode.
2. The `fetch()` method is deprecated in favor of `fetchNumeric()`, `fetchAssociative()` and `fetchOne()` (like [`fetchOne()` in ZF1](https://framework.zend.com/manual/1.12/en/zend.db.adapter.html#zend.db.adapter.select.fetchone)).
3. The `fetchAll()` method is deprecated in favor of `fetchAllNumeric()` and `fetchAllAssociative()`. There's no currently replacement for `fetchAll(FETCH_MODE::COLUMN)`. In a future major version, `fetchColumn()` will be used as a replacement (like [`fetchCol()` in ZF1](https://framework.zend.com/manual/1.12/en/zend.db.adapter.html#zend.db.adapter.select.fetchcol)).
4. `Connection::fetchAssoc()` and `::fetchArray()` are deprecated in favor of `::fetchAssociative()` and `::fetchNumeric()` respectively for consistency.
5. In order to make the Driver and the DBAL APIs distinct, two forward-compatible result statement interfaces are introduced. The one at the DBAL level extends the one at the Driver level (therefore, it can gain new DBAL-level features w/o having to implement them at the driver level).
6. Iteration over statements is deprecated. Only DBAL-level statements may be iterated via `iterateNumeric()`, `iterateAssociative()` or `iterateColumn()`.
7. The `StatementIterator` class is deprecated.
8. Fetching in the “mixed”/“both” mode is deprecated.

See https://github.com/doctrine/dbal/pull/4007.

**TODO:**
- [x] ~~See if the deprecated methods can be partially reimplemented using the new ones (the new ones don't support mixed fetch mode).~~ Too much work for throwaway code.
- [x] Add tests for the newly added APIs.
- [x] Add tests to ensure that forward-incompatible implementations still work.
- [x] Update slevomat/coding-standard in order to avoid false detection of the code like the following (cannot find the corresponding fixed issue):
   ```php
   if ($condition) {
       yield from [];
   } else {
       yield from [];
   }
   ```

The existing tests are changed to the necessary minimum (only the expected method invocations) and do not represent intentional breaking changes.