### PR TITLE
@link in convertException gives 404

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -24,8 +24,8 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
     /**
      * {@inheritdoc}
      *
-     * @link http://dev.mysql.com/doc/refman/5.7/en/error-messages-client.html
-     * @link http://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
+     * @link https://dev.mysql.com/doc/refman/8.0/en/client-error-reference.html
+     * @link https://dev.mysql.com/doc/refman/8.0/en/server-error-reference.html
      */
     public function convertException($message, DriverException $exception)
     {


### PR DESCRIPTION
The links in convertException give 404, I'm not 100% if I updated them correct, or if the e.g. should be updated to 8.0 already. 

https://dev.mysql.com/doc/refman/.0/en/server-error-reference.html
https://dev.mysql.com/doc/refman/8.0/en/client-error-reference.html

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

