### PR TITLE
Ignore all violations of the LowercasePHPFunctions sniff in SQLSrvStatement

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -111,7 +111,7 @@
 
     <!-- The SQLSRV_* functions are defined in the upper case by the sqlsrv extension and violate the standard
          see https://docs.microsoft.com/en-us/sql/connect/php/constants-microsoft-drivers-for-php-for-sql-server -->
-    <rule ref="Squiz.PHP.LowercasePHPFunctions.UseStatementUppercase">
+    <rule ref="Squiz.PHP.LowercasePHPFunctions">
         <exclude-pattern>lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php</exclude-pattern>
     </rule>
 </ruleset>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

```
$ phpcs lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php

FILE: lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
------------------------------------------------------------------------------------------------
 291 | ERROR | [x] Calls to PHP native functions must be lowercase; expected
     |       |     "sqlsrv_phptype_stream" but found "SQLSRV_PHPTYPE_STREAM"
     |       |     (Squiz.PHP.LowercasePHPFunctions.CallUppercase)
 292 | ERROR | [x] Calls to PHP native functions must be lowercase; expected
     |       |     "sqlsrv_sqltype_varbinary" but found "SQLSRV_SQLTYPE_VARBINARY"
     |       |     (Squiz.PHP.LowercasePHPFunctions.CallUppercase)
 300 | ERROR | [x] Calls to PHP native functions must be lowercase; expected
     |       |     "sqlsrv_phptype_string" but found "SQLSRV_PHPTYPE_STRING"
     |       |     (Squiz.PHP.LowercasePHPFunctions.CallUppercase)
------------------------------------------------------------------------------------------------
```
See https://github.com/squizlabs/PHP_CodeSniffer/issues/2970.