### PR TITLE
Moved rowCount() from Statement to ResultStatement

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK `Statement::rowCount()` is moved.
+
+`Statement::rowCount()` has been moved to the `ResultStatement` interface where it belongs by definition.
+
 ## Removed `FetchMode` and the corresponding methods
 
 1. The `FetchMode` class and the `setFetchMode()` method of the `Connection` and `Statement` interfaces are removed.

--- a/src/Cache/ArrayStatement.php
+++ b/src/Cache/ArrayStatement.php
@@ -50,6 +50,15 @@ class ArrayStatement implements ResultStatement
         return $this->columnCount;
     }
 
+    public function rowCount() : int
+    {
+        if ($this->data === null) {
+            return 0;
+        }
+
+        return count($this->data);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Cache/ResultCacheStatement.php
+++ b/src/Cache/ResultCacheStatement.php
@@ -94,6 +94,11 @@ class ResultCacheStatement implements ResultStatement
         return $this->statement->columnCount();
     }
 
+    public function rowCount() : int
+    {
+        return $this->statement->rowCount();
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Driver/ResultStatement.php
+++ b/src/Driver/ResultStatement.php
@@ -26,6 +26,17 @@ interface ResultStatement
     public function columnCount();
 
     /**
+     * Returns the number of rows affected by the last DELETE, INSERT, or UPDATE statement
+     * executed by the corresponding object.
+     *
+     * If the last SQL statement executed by the associated Statement object was a SELECT statement,
+     * some databases may return the number of rows returned by that statement. However,
+     * this behaviour is not guaranteed for all databases and should not be
+     * relied on for portable applications.
+     */
+    public function rowCount() : int;
+
+    /**
      * Returns the next row of a result set as a numeric array or FALSE if there are no more rows.
      *
      * @return array<int,mixed>|false

--- a/src/Driver/Statement.php
+++ b/src/Driver/Statement.php
@@ -72,17 +72,4 @@ interface Statement extends ResultStatement
      * @return bool TRUE on success or FALSE on failure.
      */
     public function execute($params = null);
-
-    /**
-     * Returns the number of rows affected by the last DELETE, INSERT, or UPDATE statement
-     * executed by the corresponding object.
-     *
-     * If the last SQL statement executed by the associated Statement object was a SELECT statement,
-     * some databases may return the number of rows returned by that statement. However,
-     * this behaviour is not guaranteed for all databases and should not be
-     * relied on for portable applications.
-     *
-     * @return int The number of rows.
-     */
-    public function rowCount() : int;
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

This is a backport of #3483 needed to continue the rework of the `Statement` and `ResultStatement` interfaces.