### PR TITLE
Added specific handling of string type query parameters

### DIFF
--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -28,6 +28,7 @@ use function sqlsrv_prepare;
 use function sqlsrv_rows_affected;
 use function SQLSRV_SQLTYPE_VARBINARY;
 use function stripos;
+use function strlen;
 use const SQLSRV_ENC_BINARY;
 use const SQLSRV_ERR_ERRORS;
 use const SQLSRV_FETCH_ASSOC;
@@ -298,6 +299,15 @@ class SQLSrvStatement implements IteratorAggregate, Statement
                         &$variable,
                         SQLSRV_PARAM_IN,
                         SQLSRV_PHPTYPE_STRING(SQLSRV_ENC_BINARY),
+                    ];
+                    break;
+
+                case ParameterType::STRING:
+                    $params[$column - 1] = [
+                        &$variable,
+                        SQLSRV_PARAM_IN,
+                        null,
+                        SQLSRV_SQLTYPE_NVARCHAR(strlen($variable) > 0 ? strlen($variable) : 1),
                     ];
                     break;
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

This change introduces specific handling of strings, which will assist the SQL server query optimizer in choosing the best possible execution plan.

The current behaviour causes all string parameters to be sent to the SQL server as NVARCHAR(4000).
This causes an unfortunate situation for the query optimizer, that will create a sub-optimal execution plan from the assumption that the parameters are big data strings.

In production we saw multiple instances of a factor 10 or more changes in query time, with the proposed change.
