### PR TITLE
Refactor portability statement into a functional composition

### DIFF
--- a/src/Portability/Converter.php
+++ b/src/Portability/Converter.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Portability;
+
+use function array_change_key_case;
+use function array_map;
+use function array_reduce;
+use function is_string;
+use function rtrim;
+
+final class Converter
+{
+    /** @var callable */
+    private $convertNumeric;
+
+    /** @var callable */
+    private $convertAssociative;
+
+    /** @var callable */
+    private $convertOne;
+
+    /** @var callable */
+    private $convertAllNumeric;
+
+    /** @var callable */
+    private $convertAllAssociative;
+
+    /** @var callable */
+    private $convertFirstColumn;
+
+    /**
+     * @param bool     $convertEmptyStringToNull Whether each empty string should be converted to NULL
+     * @param bool     $rightTrimString          Whether each string should right-trimmed
+     * @param int|null $case                     Convert the case of the column names
+     *                                           (one of {@link CASE_LOWER} and {@link CASE_UPPER})
+     */
+    public function __construct(bool $convertEmptyStringToNull, bool $rightTrimString, ?int $case)
+    {
+        $id = static function ($value) {
+            return $value;
+        };
+
+        $convertValue       = $this->createConvertValue($convertEmptyStringToNull, $rightTrimString);
+        $convertNumeric     = $this->createConvertRow($convertValue, null);
+        $convertAssociative = $this->createConvertRow($convertValue, $case);
+
+        $this->convertNumeric     = $this->createConvert($convertNumeric, $id);
+        $this->convertAssociative = $this->createConvert($convertAssociative, $id);
+        $this->convertOne         = $this->createConvert($convertValue, $id);
+
+        $this->convertAllNumeric     = $this->createConvertAll($convertNumeric, $id);
+        $this->convertAllAssociative = $this->createConvertAll($convertAssociative, $id);
+        $this->convertFirstColumn    = $this->createConvertAll($convertValue, $id);
+    }
+
+    /**
+     * @param array<int,mixed>|false $row
+     *
+     * @return array<int,mixed>|false
+     */
+    public function convertNumeric($row)
+    {
+        return ($this->convertNumeric)($row);
+    }
+
+    /**
+     * @param array<string,mixed>|false $row
+     *
+     * @return array<string,mixed>|false
+     */
+    public function convertAssociative($row)
+    {
+        return ($this->convertAssociative)($row);
+    }
+
+    /**
+     * @param mixed|false $value
+     *
+     * @return mixed|false
+     */
+    public function convertOne($value)
+    {
+        return ($this->convertOne)($value);
+    }
+
+    /**
+     * @param array<int,array<int,mixed>> $data
+     *
+     * @return array<int,array<int,mixed>>
+     */
+    public function convertAllNumeric(array $data) : array
+    {
+        return ($this->convertAllNumeric)($data);
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $data
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function convertAllAssociative(array $data) : array
+    {
+        return ($this->convertAllAssociative)($data);
+    }
+
+    /**
+     * @param array<int,mixed> $data
+     *
+     * @return array<int,mixed>
+     */
+    public function convertFirstColumn(array $data) : array
+    {
+        return ($this->convertFirstColumn)($data);
+    }
+
+    /**
+     * Creates a function that will convert each individual value retrieved from the database
+     *
+     * @param bool $convertEmptyStringToNull Whether each empty string should be converted to NULL
+     * @param bool $rightTrimString          Whether each string should right-trimmed
+     *
+     * @return callable|null The resulting function or NULL if no conversion is needed
+     */
+    private function createConvertValue(bool $convertEmptyStringToNull, bool $rightTrimString) : ?callable
+    {
+        $functions = [];
+
+        if ($convertEmptyStringToNull) {
+            $functions[] = static function ($value) {
+                if ($value === '') {
+                    return null;
+                }
+
+                return $value;
+            };
+        }
+
+        if ($rightTrimString) {
+            $functions[] = static function ($value) {
+                if (! is_string($value)) {
+                    return $value;
+                }
+
+                return rtrim($value);
+            };
+        }
+
+        return $this->compose(...$functions);
+    }
+
+    /**
+     * Creates a function that will convert each array-row retrieved from the database
+     *
+     * @param callable|null $function The function that will convert each value
+     * @param int|null      $case     Column name case
+     *
+     * @return callable|null The resulting function or NULL if no conversion is needed
+     */
+    private function createConvertRow(?callable $function, ?int $case) : ?callable
+    {
+        $functions = [];
+
+        if ($function !== null) {
+            $functions[] = $this->createMapper($function);
+        }
+
+        if ($case !== null) {
+            $functions[] = static function (array $row) use ($case) : array {
+                return array_change_key_case($row, $case);
+            };
+        }
+
+        return $this->compose(...$functions);
+    }
+
+    /**
+     * Creates a function that will be applied to the return value of Statement::fetch*()
+     * or an identity function if no conversion is needed
+     *
+     * @param callable|null $function The function that will convert each tow
+     * @param callable      $id       Identity function
+     */
+    private function createConvert(?callable $function, callable $id) : callable
+    {
+        if ($function === null) {
+            return $id;
+        }
+
+        return static function ($value) use ($function) {
+            if ($value === false) {
+                return false;
+            }
+
+            return $function($value);
+        };
+    }
+
+    /**
+     * Creates a function that will be applied to the return value of Statement::fetchAll*()
+     * or an identity function if no transformation is required
+     *
+     * @param callable|null $function The function that will transform each value
+     * @param callable      $id       Identity function
+     */
+    private function createConvertAll(?callable $function, callable $id) : callable
+    {
+        if ($function === null) {
+            return $id;
+        }
+
+        return $this->createMapper($function);
+    }
+
+    /**
+     * Creates a function that maps each value of the array using the given function
+     *
+     * @param callable $function The function that maps each value of the array
+     */
+    private function createMapper(callable $function) : callable
+    {
+        return static function (array $array) use ($function) : array {
+            return array_map($function, $array);
+        };
+    }
+
+    /**
+     * Creates a composition of the given set of functions
+     *
+     * @param callable ...$functions The functions to compose
+     *
+     * @return callable|null The composition or NULL if an empty set is provided
+     */
+    private function compose(callable ...$functions) : ?callable
+    {
+        return array_reduce($functions, static function (?callable $carry, callable $item) : callable {
+            if ($carry === null) {
+                return $item;
+            }
+
+            return static function ($value) use ($carry, $item) {
+                return $item($carry($value));
+            };
+        });
+    }
+}

--- a/tests/Portability/ConverterTest.php
+++ b/tests/Portability/ConverterTest.php
@@ -1,0 +1,512 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Portability;
+
+use Doctrine\DBAL\Portability\Converter;
+use PHPUnit\Framework\TestCase;
+use const CASE_LOWER;
+
+class ConverterTest extends TestCase
+{
+    /**
+     * @param array<int,mixed>|false $row
+     * @param array<int,mixed>|false $expected
+     *
+     * @dataProvider convertNumericProvider
+     */
+    public function testConvertNumeric($row, bool $convertEmptyStringToNull, bool $rightTrimString, $expected) : void
+    {
+        self::assertSame(
+            $expected,
+            $this->createConverter($convertEmptyStringToNull, $rightTrimString, null)
+                ->convertNumeric($row)
+        );
+    }
+
+    /**
+     * @return iterable<string,array<int,mixed>>
+     */
+    public static function convertNumericProvider() : iterable
+    {
+        $row = ['X ', ''];
+
+        yield 'None' => [
+            $row,
+            false,
+            false,
+            ['X ', ''],
+        ];
+
+        yield 'Trim' => [
+            $row,
+            false,
+            true,
+            ['X', ''],
+        ];
+
+        yield 'Empty to NULL' => [
+            $row,
+            true,
+            false,
+            ['X ', null],
+        ];
+
+        yield 'Empty to NULL and Trim' => [
+            $row,
+            true,
+            true,
+            ['X', null],
+        ];
+
+        yield 'False' => [false, true, true, false];
+    }
+
+    /**
+     * @param array<string,mixed>|false $row
+     * @param array<string,mixed>|false $expected
+     *
+     * @dataProvider convertAssociativeProvider
+     */
+    public function testConvertAssociative($row, bool $convertEmptyStringToNull, bool $rightTrimString, ?int $case, $expected) : void
+    {
+        self::assertSame(
+            $expected,
+            $this->createConverter($convertEmptyStringToNull, $rightTrimString, $case)
+                ->convertAssociative($row)
+        );
+    }
+
+    /**
+     * @return iterable<string,array<int,mixed>>
+     */
+    public static function convertAssociativeProvider() : iterable
+    {
+        $row = [
+            'FOO' => '',
+            'BAR' => 'X ',
+        ];
+
+        yield 'None' => [
+            $row,
+            false,
+            false,
+            null,
+            [
+                'FOO' => '',
+                'BAR' => 'X ',
+            ],
+        ];
+
+        yield 'Trim' => [
+            $row,
+            false,
+            true,
+            null,
+            [
+                'FOO' => '',
+                'BAR' => 'X',
+            ],
+        ];
+
+        yield 'Empty to NULL' => [
+            $row,
+            true,
+            false,
+            null,
+            [
+                'FOO' => null,
+                'BAR' => 'X ',
+            ],
+        ];
+
+        yield 'Empty to NULL and Trim' => [
+            $row,
+            true,
+            true,
+            null,
+            [
+                'FOO' => null,
+                'BAR' => 'X',
+            ],
+        ];
+
+        yield 'To lower' => [
+            $row,
+            false,
+            false,
+            CASE_LOWER,
+            [
+                'foo' => '',
+                'bar' => 'X ',
+            ],
+        ];
+
+        yield 'Trim and to lower' => [
+            $row,
+            false,
+            true,
+            CASE_LOWER,
+            [
+                'foo' => '',
+                'bar' => 'X',
+            ],
+        ];
+
+        yield 'Empty to NULL and to lower' => [
+            $row,
+            true,
+            false,
+            CASE_LOWER,
+            [
+                'foo' => null,
+                'bar' => 'X ',
+            ],
+        ];
+
+        yield 'Trim, empty to NULL and to lower' => [
+            $row,
+            true,
+            true,
+            CASE_LOWER,
+            [
+                'foo' => null,
+                'bar' => 'X',
+            ],
+        ];
+
+        yield 'False' => [false, true, true, null, false];
+    }
+
+    /**
+     * @param mixed|false $value
+     * @param mixed|false $expected
+     *
+     * @dataProvider convertOneProvider
+     */
+    public function testConvertOne($value, bool $convertEmptyStringToNull, bool $rightTrimString, $expected) : void
+    {
+        self::assertSame(
+            $expected,
+            $this->createConverter($convertEmptyStringToNull, $rightTrimString, null)
+                ->convertOne($value)
+        );
+    }
+
+    /**
+     * @return iterable<string,array<int,mixed>>
+     */
+    public static function convertOneProvider() : iterable
+    {
+        yield 'None, trailing space' => ['X ', false, false, 'X '];
+        yield 'None, empty string' => ['', false, false, ''];
+        yield 'Trim, trailing space' => ['X ', false, true, 'X'];
+        yield 'Trim, empty string' => ['', false, true, ''];
+        yield 'Empty to NULL, trailing space' => ['X ', true, false, 'X '];
+        yield 'Empty to NULL, empty string' => ['', true, false, null];
+        yield 'Empty to NULL and Trim, trailing space' => ['X ', true, true, 'X'];
+        yield 'Empty to NULL and Trim, empty string' => ['', true, true, null];
+
+        yield 'False' => [false, true, true, false];
+    }
+
+    /**
+     * @param array<int,array<int,mixed>> $data
+     * @param array<int,array<int,mixed>> $expected
+     *
+     * @dataProvider convertAllNumericProvider
+     */
+    public function testConvertAllNumeric(
+        array $data,
+        bool $convertEmptyStringToNull,
+        bool $rightTrimString,
+        array $expected
+    ) : void {
+        self::assertSame(
+            $expected,
+            $this->createConverter($convertEmptyStringToNull, $rightTrimString, null)
+                ->convertAllNumeric($data)
+        );
+    }
+
+    /**
+     * @return iterable<string,array<int,mixed>>
+     */
+    public static function convertAllNumericProvider() : iterable
+    {
+        $data = [
+            ['X ', ''],
+            ['', 'Y '],
+        ];
+
+        yield 'None' => [
+            $data,
+            false,
+            false,
+            [
+                ['X ', ''],
+                ['', 'Y '],
+            ],
+        ];
+
+        yield 'Trim' => [
+            $data,
+            false,
+            true,
+            [
+                ['X', ''],
+                ['', 'Y'],
+            ],
+        ];
+
+        yield 'Empty to NULL' => [
+            $data,
+            true,
+            false, [
+                ['X ', null],
+                [null, 'Y '],
+            ],
+        ];
+
+        yield 'Empty to NULL and Trim' => [
+            $data,
+            true,
+            true, [
+                ['X', null],
+                [null, 'Y'],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $row
+     * @param array<int,array<string,mixed>> $expected
+     *
+     * @dataProvider convertAllAssociativeProvider
+     */
+    public function testConvertAllAssociative(
+        array $row,
+        bool $convertEmptyStringToNull,
+        bool $rightTrimString,
+        ?int $case,
+        array $expected
+    ) : void {
+        self::assertSame(
+            $expected,
+            $this->createConverter($convertEmptyStringToNull, $rightTrimString, $case)
+                ->convertAllAssociative($row)
+        );
+    }
+
+    /**
+     * @return iterable<string,array<int,mixed>>
+     */
+    public static function convertAllAssociativeProvider() : iterable
+    {
+        $data = [
+            [
+                'FOO' => 'X ',
+                'BAR' => '',
+            ],
+            [
+                'FOO' => '',
+                'BAR' => 'Y ',
+            ],
+        ];
+
+        yield 'None' => [
+            $data,
+            false,
+            false,
+            null,
+            [
+                [
+                    'FOO' => 'X ',
+                    'BAR' => '',
+                ],
+                [
+                    'FOO' => '',
+                    'BAR' => 'Y ',
+                ],
+            ],
+        ];
+
+        yield 'Trim' => [
+            $data,
+            false,
+            true,
+            null,
+            [
+                [
+                    'FOO' => 'X',
+                    'BAR' => '',
+                ],
+                [
+                    'FOO' => '',
+                    'BAR' => 'Y',
+                ],
+            ],
+        ];
+
+        yield 'Empty to NULL' => [
+            $data,
+            true,
+            false,
+            null,
+            [
+                [
+                    'FOO' => 'X ',
+                    'BAR' => null,
+                ],
+                [
+                    'FOO' => null,
+                    'BAR' => 'Y ',
+                ],
+            ],
+        ];
+
+        yield 'Empty to NULL and Trim' => [
+            $data,
+            true,
+            true,
+            null,
+            [
+                [
+                    'FOO' => 'X',
+                    'BAR' => null,
+                ],
+                [
+                    'FOO' => null,
+                    'BAR' => 'Y',
+                ],
+            ],
+        ];
+
+        yield 'To lower' => [
+            $data,
+            false,
+            false,
+            CASE_LOWER,
+            [
+                [
+                    'foo' => 'X ',
+                    'bar' => '',
+                ],
+                [
+                    'foo' => '',
+                    'bar' => 'Y ',
+                ],
+            ],
+        ];
+
+        yield 'Trim and to lower' => [
+            $data,
+            false,
+            true,
+            CASE_LOWER,
+            [
+                [
+                    'foo' => 'X',
+                    'bar' => '',
+                ],
+                [
+                    'foo' => '',
+                    'bar' => 'Y',
+                ],
+            ],
+        ];
+
+        yield 'Empty to NULL and to lower' => [
+            $data,
+            true,
+            false,
+            CASE_LOWER,
+            [
+                [
+                    'foo' => 'X ',
+                    'bar' => null,
+                ],
+                [
+                    'foo' => null,
+                    'bar' => 'Y ',
+                ],
+            ],
+        ];
+
+        yield 'Trim, empty to NULL and to lower' => [
+            $data,
+            true,
+            true,
+            CASE_LOWER,
+            [
+                [
+                    'foo' => 'X',
+                    'bar' => null,
+                ],
+                [
+                    'foo' => null,
+                    'bar' => 'Y',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int,mixed> $column
+     * @param array<int,mixed> $expected
+     *
+     * @dataProvider convertFirstColumnProvider
+     */
+    public function testConvertFirstColumn(
+        array $column,
+        bool $convertEmptyStringToNull,
+        bool $rightTrimString,
+        array $expected
+    ) : void {
+        self::assertSame(
+            $expected,
+            $this->createConverter($convertEmptyStringToNull, $rightTrimString, null)
+                ->convertFirstColumn($column)
+        );
+    }
+
+    /**
+     * @return iterable<string,array<int,mixed>>
+     */
+    public static function convertFirstColumnProvider() : iterable
+    {
+        $column = ['X ', ''];
+
+        yield 'None' => [
+            $column,
+            false,
+            false,
+            ['X ', ''],
+        ];
+
+        yield 'Trim' => [
+            $column,
+            false,
+            true,
+            ['X', ''],
+        ];
+
+        yield 'Empty to NULL' => [
+            $column,
+            true,
+            false,
+            ['X ', null],
+        ];
+
+        yield 'Empty to NULL and Trim' => [
+            $column,
+            true,
+            true,
+            ['X', null],
+        ];
+    }
+
+    private function createConverter(bool $convertEmptyStringToNull, bool $rightTrimString, ?int $case) : Converter
+    {
+        return new Converter($convertEmptyStringToNull, $rightTrimString, $case);
+    }
+}

--- a/tests/Portability/StatementTest.php
+++ b/tests/Portability/StatementTest.php
@@ -5,15 +5,13 @@ namespace Doctrine\DBAL\Tests\Portability;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Portability\Connection;
+use Doctrine\DBAL\Portability\Converter;
 use Doctrine\DBAL\Portability\Statement;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class StatementTest extends TestCase
 {
-    /** @var Connection|MockObject */
-    protected $conn;
-
     /** @var Statement */
     protected $stmt;
 
@@ -23,8 +21,8 @@ class StatementTest extends TestCase
     protected function setUp() : void
     {
         $this->wrappedStmt = $this->createMock(DriverStatement::class);
-        $this->conn        = $this->createConnection();
-        $this->stmt        = $this->createStatement($this->wrappedStmt, $this->conn);
+        $converter         = new Converter(false, false, null);
+        $this->stmt        = new Statement($this->wrappedStmt, $converter);
     }
 
     /**
@@ -113,10 +111,5 @@ class StatementTest extends TestCase
         return $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-    }
-
-    protected function createStatement(DriverStatement $wrappedStatement, Connection $connection) : Statement
-    {
-        return new Statement($wrappedStatement, $connection);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The current implementation of the portability statement contains quite a lot of code repetition, especially introduced at #4019. The reason is that there's no clear separation of concerns of data fetching and data transformation which is aggravated by the number of possible configurations.

In order to make the code more extensible, the statement is split into a wrapper that fetches the data from the underlying statement and a converter that converts the data. Unlike the current design, the converter is created once per connection and is then reused for all fetches.

The other benefit that the separation of concerns gives is that the converter can be fully unit-tested w/o the need to mock the underlying statement or set up data fixtures.