### PR TITLE
Make caching layer not rely on closeCursor()

### DIFF
--- a/docs/en/reference/caching.rst
+++ b/docs/en/reference/caching.rst
@@ -35,15 +35,13 @@ the default cache instance:
     new QueryCacheProfile(0, "some key", $cache);
 
 In order for the data to actually be cached its necessary to ensure that the entire
-result set is read (the easiest way to ensure this is to use ``fetchAll``) and the statement
-object is closed:
+result set is read (the easiest way to ensure this is to use one of the ``fetchAll*()`` methods):
 
 ::
 
     <?php
     $stmt = $conn->executeCacheQuery($query, $params, $types, new QueryCacheProfile(0, "some key"));
     $data = $stmt->fetchAllAssociative();
-    $stmt->closeCursor(); // at this point the result is cached
 
 .. warning::
 

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -135,7 +135,7 @@ class ResultCacheTest extends DbalFunctionalTestCase
         self::assertEquals($data, $dataIterator);
     }
 
-    public function testDontCloseNoCache(): void
+    public function testFetchAndFinishSavesCache(): void
     {
         $stmt = $this->connection->executeQuery('SELECT * FROM caching ORDER BY test_int ASC', [], [], new QueryCacheProfile(0, 'testcachekey'));
 
@@ -153,7 +153,7 @@ class ResultCacheTest extends DbalFunctionalTestCase
             $data[] = $row;
         }
 
-        self::assertCount(2, $this->sqlLogger->queries);
+        self::assertCount(1, $this->sqlLogger->queries);
     }
 
     public function testDontFinishNoCache(): void
@@ -161,7 +161,6 @@ class ResultCacheTest extends DbalFunctionalTestCase
         $stmt = $this->connection->executeQuery('SELECT * FROM caching ORDER BY test_int ASC', [], [], new QueryCacheProfile(0, 'testcachekey'));
 
         $stmt->fetch(FetchMode::ASSOCIATIVE);
-        $stmt->closeCursor();
 
         $stmt = $this->connection->executeQuery('SELECT * FROM caching ORDER BY test_int ASC', [], [], new QueryCacheProfile(0, 'testcachekey'));
 
@@ -170,12 +169,11 @@ class ResultCacheTest extends DbalFunctionalTestCase
         self::assertCount(2, $this->sqlLogger->queries);
     }
 
-    public function testFetchAllAndFinishSavesCache(): void
+    public function testFetchAllSavesCache(): void
     {
         $layerCache = new ArrayCache();
         $stmt       = $this->connection->executeQuery('SELECT * FROM caching WHERE test_int > 500', [], [], new QueryCacheProfile(0, 'testcachekey', $layerCache));
         $stmt->fetchAll();
-        $stmt->closeCursor();
 
         self::assertCount(1, $layerCache->fetch('testcachekey'));
     }
@@ -189,7 +187,6 @@ class ResultCacheTest extends DbalFunctionalTestCase
 
         $stmt = $this->connection->executeCacheQuery($query, [], [], $qcp);
         $stmt->fetchAll(FetchMode::COLUMN);
-        $stmt->closeCursor();
 
         $stmt = $this->connection->executeCacheQuery($query, [], [], $qcp);
 
@@ -251,8 +248,6 @@ class ResultCacheTest extends DbalFunctionalTestCase
             $data[] = is_array($row) ? array_change_key_case($row, CASE_LOWER) : $row;
         }
 
-        $stmt->closeCursor();
-
         return $data;
     }
 
@@ -266,8 +261,6 @@ class ResultCacheTest extends DbalFunctionalTestCase
         foreach ($stmt as $row) {
             $data[] = is_array($row) ? array_change_key_case($row, CASE_LOWER) : $row;
         }
-
-        $stmt->closeCursor();
 
         return $data;
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The current behavior, although it's documented in the form of a test, is counterintuitive:
https://github.com/doctrine/dbal/blob/c08d3bc8df1f2d048e2912c06110f6dc6faf688e/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php#L136

This test and the fact that all other tests call `$stmt->closeCursor()` imply that the statement result will be only cached if the statement cursor is closed.

The meaning of `closeCursor()` has nothing to deal with caching:
https://github.com/doctrine/dbal/blob/c08d3bc8df1f2d048e2912c06110f6dc6faf688e/lib/Doctrine/DBAL/Driver/ResultStatement.php#L13-L18

It should be used in certain environments when not the entire result set is fetched in order to prevent errors like this:

> SQLSTATE[HY000]: General error: 2014 Cannot execute queries while other unbuffered queries are active

In the case when the full result set is fetched, nothing should prevent the caching layer from caching the result. It happens at the end of `fetchAll()` or iterative `fetch()` operations.