### PR TITLE
Fix final class member names according to the coding standard

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -32,7 +32,7 @@ parameters:
             path: %currentWorkingDirectory%/tests/Functional/DataAccessTest.php
 
         # https://github.com/JetBrains/phpstorm-stubs/pull/766
-        - '~^Method Doctrine\\DBAL\\Driver\\Mysqli\\MysqliStatement::_fetch\(\) never returns null so it can be removed from the return typehint\.$~'
+        - '~^Method Doctrine\\DBAL\\Driver\\Mysqli\\MysqliStatement::fetch\(\) never returns null so it can be removed from the return typehint\.$~'
 
         # The ReflectionException in the case when the class does not exist is acceptable and does not need to be handled
         - '~^Parameter #1 \$argument of class ReflectionClass constructor expects class-string<T of object>\|T of object, string given\.$~'

--- a/src/Driver/Mysqli/MysqliStatement.php
+++ b/src/Driver/Mysqli/MysqliStatement.php
@@ -301,7 +301,7 @@ final class MysqliStatement implements Statement
     /**
      * @return mixed[]|false|null
      */
-    private function _fetch()
+    private function fetch()
     {
         $ret = $this->stmt->fetch();
 
@@ -328,7 +328,7 @@ final class MysqliStatement implements Statement
             return false;
         }
 
-        $values = $this->_fetch();
+        $values = $this->fetch();
 
         if ($values === null) {
             return false;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

See #3004. The classes are final as of #3808 and #3820. All protected class members made private and renamed to not contain a leading underscore. Additionally, the "dbh" and "sth" properties are renamed to "connection" and "statement" for consistency with the rest of the code.