### PR TITLE
Deprecate master/slave terminology and underlying feature

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 2.11
 
+## Deprecated `MasterSlaveConnection`
+
+The naming is offensive, the implementation very questionable. Use each
+endpoint connection explicitly.
+
 ## Deprecated `ArrayStatement` and `ResultCacheStatement` classes.
 
 The `ArrayStatement` and `ResultCacheStatement` classes are deprecated. In a future major release they will be renamed and marked internal as implementation details of the caching layer.

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -15,6 +15,10 @@ use function array_rand;
 use function assert;
 use function count;
 use function func_get_args;
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * Master-Slave Connection
@@ -52,6 +56,8 @@ use function func_get_args;
  *      $conn->connect('master');
  *
  * Instantiation through the DriverManager looks like:
+ *
+ * @deprecated use regular connections instead
  *
  * @example
  *
@@ -93,6 +99,11 @@ class MasterSlaveConnection extends Connection
      */
     public function __construct(array $params, Driver $driver, ?Configuration $config = null, ?EventManager $eventManager = null)
     {
+        @trigger_error(sprintf(
+            'Class "%s" is deprecated since doctrine/dbal 2.11 and will be removed in 3.0',
+            self::class
+        ), E_USER_DEPRECATED);
+
         if (! isset($params['slaves'], $params['master'])) {
             throw new InvalidArgumentException('master or slaves configuration missing');
         }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #4052

#### Summary

`MasterSlaveConnection` is left untouched, deprecated, copy/pasted/improved
Alternative to #4054

Targeting 2.11.x because of the deprecation.