### PR TITLE
Deprecated platform-specific portability mode constants

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 2.11
 
+## Deprecated `Portability\Connection::PORTABILITY_{PLATFORM}` constants`
+
+The platform-specific portability mode flags are meant to be used only by the portability layer internally to optimize
+the user-provided mode for the current database platform. 
+
 ## Deprecated `MasterSlaveConnection` use `PrimaryReadReplicaConnection`
 
 The `Doctrine\DBAL\Connections\MasterSlaveConnection` class is renamed to `Doctrine\DBAL\Connections\PrimaryReadReplicaConnection`.

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -23,6 +23,10 @@ class Connection extends \Doctrine\DBAL\Connection
     public const PORTABILITY_EMPTY_TO_NULL = 4;
     public const PORTABILITY_FIX_CASE      = 8;
 
+    /**#@+
+     *
+     * @deprecated Will be removed as internal implementation details.
+     */
     public const PORTABILITY_DB2          = 13;
     public const PORTABILITY_ORACLE       = 9;
     public const PORTABILITY_POSTGRESQL   = 13;
@@ -31,6 +35,7 @@ class Connection extends \Doctrine\DBAL\Connection
     public const PORTABILITY_DRIZZLE      = 13;
     public const PORTABILITY_SQLANYWHERE  = 13;
     public const PORTABILITY_SQLSRV       = 13;
+    /**#@-*/
 
     /** @var int */
     private $portability = self::PORTABILITY_NONE;
@@ -47,25 +52,10 @@ class Connection extends \Doctrine\DBAL\Connection
         if ($ret) {
             $params = $this->getParams();
             if (isset($params['portability'])) {
-                if ($this->getDatabasePlatform()->getName() === 'oracle') {
-                    $params['portability'] &= self::PORTABILITY_ORACLE;
-                } elseif ($this->getDatabasePlatform()->getName() === 'postgresql') {
-                    $params['portability'] &= self::PORTABILITY_POSTGRESQL;
-                } elseif ($this->getDatabasePlatform()->getName() === 'sqlite') {
-                    $params['portability'] &= self::PORTABILITY_SQLITE;
-                } elseif ($this->getDatabasePlatform()->getName() === 'drizzle') {
-                    $params['portability'] &= self::PORTABILITY_DRIZZLE;
-                } elseif ($this->getDatabasePlatform()->getName() === 'sqlanywhere') {
-                    $params['portability'] &= self::PORTABILITY_SQLANYWHERE;
-                } elseif ($this->getDatabasePlatform()->getName() === 'db2') {
-                    $params['portability'] &= self::PORTABILITY_DB2;
-                } elseif ($this->getDatabasePlatform()->getName() === 'mssql') {
-                    $params['portability'] &= self::PORTABILITY_SQLSRV;
-                } else {
-                    $params['portability'] &= self::PORTABILITY_OTHERVENDORS;
-                }
-
-                $this->portability = $params['portability'];
+                $this->portability = $params['portability'] = (new OptimizeFlags())(
+                    $this->getDatabasePlatform(),
+                    $params['portability']
+                );
             }
 
             if (isset($params['fetch_case']) && $this->portability & self::PORTABILITY_FIX_CASE) {

--- a/lib/Doctrine/DBAL/Portability/OptimizeFlags.php
+++ b/lib/Doctrine/DBAL/Portability/OptimizeFlags.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Portability;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\SQLAnywhere16Platform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+
+final class OptimizeFlags
+{
+    /**
+     * Platform-specific portability flags that need to be excluded from the user-provided mode
+     * since the platform already operates in this mode to avoid unnecessary conversion overhead.
+     *
+     * @var array<string,int>
+     */
+    private static $platforms = [
+        DB2Platform::class           => 0,
+        OraclePlatform::class        => Connection::PORTABILITY_EMPTY_TO_NULL,
+        PostgreSQL94Platform::class  => 0,
+        SQLAnywhere16Platform::class => 0,
+        SqlitePlatform::class        => 0,
+        SQLServer2012Platform::class => 0,
+    ];
+
+    public function __invoke(AbstractPlatform $platform, int $flags): int
+    {
+        foreach (self::$platforms as $class => $mask) {
+            if ($platform instanceof $class) {
+                $flags &= ~$mask;
+
+                break;
+            }
+        }
+
+        return $flags;
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Portability/OptimizeFlagsTest.php
+++ b/tests/Doctrine/Tests/DBAL/Portability/OptimizeFlagsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Portability;
+
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Portability\Connection;
+use Doctrine\DBAL\Portability\OptimizeFlags;
+use PHPUnit\Framework\TestCase;
+
+class OptimizeFlagsTest extends TestCase
+{
+    /** @var OptimizeFlags */
+    private $optimizeFlags;
+
+    protected function setUp(): void
+    {
+        $this->optimizeFlags = new OptimizeFlags();
+    }
+
+    public function testOracle(): void
+    {
+        $flags = ($this->optimizeFlags)(new OraclePlatform(), Connection::PORTABILITY_ALL);
+
+        self::assertSame(0, $flags & Connection::PORTABILITY_EMPTY_TO_NULL);
+    }
+
+    public function testAnotherPlatform(): void
+    {
+        $flags = ($this->optimizeFlags)(new SqlitePlatform(), Connection::PORTABILITY_ALL);
+
+        self::assertSame(Connection::PORTABILITY_ALL, $flags);
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

The way that the Portability Connection API is structured is quite cryptic:

1. Besides the user-facing portability mode constants (e.g. `PORTABILITY_EMPTY_TO_NULL`), it exposes the platform-specific `PORTABILITY_ORACLE` constants.
2. The meaning of the platform constants is "which of the user-provided bits need to be left intact because this behavior indeed may need to be ported from the current platform".
3. These constants are expressed in the form of absolute values which require interpretation.
4. Why most of the platforms include all flags but `PORTABILITY_OTHERVENDORS` doesn't include `PORTABILITY_RTRIM` is a mystery.

#### Proposal
1. Remove the platform mode constants from the public API as internal to the portability layer.
2. Instead of describing what _may_ need to be ported on a specific platform, describe what _does not_ need to be ported which is much easier to understand (e.g. Oracle cannot tell the difference between an empty string and `NULL`).
