### PR TITLE
Simplify test suite configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,24 +22,24 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <!-- "Real" test database -->
+        <!-- Test connection parameters -->
         <!-- Uncomment, otherwise SQLite runs
-        <var name="db_type" value="pdo_mysql"/>
+        <var name="db_driver" value="pdo_mysql"/>
         <var name="db_host" value="localhost" />
-        <var name="db_username" value="root" />
-        <var name="db_password" value="" />
-        <var name="db_name" value="doctrine_tests" />
         <var name="db_port" value="3306"/>
+        <var name="db_user" value="root" />
+        <var name="db_password" value="" />
+        <var name="db_dbname" value="doctrine_tests" />
         -->
         <!--<var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit">-->
 
-        <!-- Database for temporary connections (i.e. to drop/create the main database) -->
-        <var name="tmpdb_type" value="pdo_mysql"/>
+        <!-- Privileged user connection parameters. Used to create and drop the test database -->
+        <var name="tmpdb_driver" value="pdo_mysql"/>
         <var name="tmpdb_host" value="localhost" />
-        <var name="tmpdb_username" value="root" />
-        <var name="tmpdb_password" value="" />
-        <var name="tmpdb_name" value="doctrine_tests_tmp" />
         <var name="tmpdb_port" value="3306"/>
+        <var name="tmpdb_user" value="root" />
+        <var name="tmpdb_password" value="" />
+        <var name="tmpdb_dbname" value="doctrine_tests_tmp" />
     </php>
 
     <testsuites>

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/ConnectionTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\Mysqli\Driver;
 use Doctrine\DBAL\Driver\Mysqli\MysqliConnection;
 use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\Tests\DbalFunctionalTestCase;
+use Doctrine\Tests\TestUtil;
 use function extension_loaded;
 use const MYSQLI_OPT_CONNECT_TIMEOUT;
 
@@ -57,14 +58,12 @@ class ConnectionTest extends DbalFunctionalTestCase
      */
     private function getConnection(array $driverOptions) : MysqliConnection
     {
+        $params = TestUtil::getConnectionParams();
+
         return new MysqliConnection(
-            [
-                'host' => $GLOBALS['db_host'],
-                'dbname' => $GLOBALS['db_name'],
-                'port' => $GLOBALS['db_port'],
-            ],
-            $GLOBALS['db_username'],
-            $GLOBALS['db_password'],
+            $params,
+            $params['user'] ?? '',
+            $params['password'] ?? '',
             $driverOptions
         );
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\PDOSqlsrv\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
+use Doctrine\Tests\TestUtil;
 use PDO;
 use function extension_loaded;
 
@@ -41,13 +42,12 @@ class DriverTest extends AbstractDriverTest
      */
     protected function getConnection(array $driverOptions) : Connection
     {
+        $params = TestUtil::getConnectionParams();
+
         return $this->connection->getDriver()->connect(
-            [
-                'host' => $GLOBALS['db_host'],
-                'port' => $GLOBALS['db_port'],
-            ],
-            $GLOBALS['db_username'],
-            $GLOBALS['db_password'],
+            $params,
+            $params['user'] ?? '',
+            $params['password'] ?? '',
             $driverOptions
         );
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -22,12 +22,12 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
             return;
         }
 
-        if (! isset($GLOBALS['db_username'])) {
+        if (! isset($GLOBALS['db_user'])) {
             self::markTestSkipped('Username must be explicitly specified in connection parameters for this test');
         }
 
-        TestUtil::getTempConnection()
-            ->exec('GRANT ALL PRIVILEGES TO ' . $GLOBALS['db_username']);
+        TestUtil::getPrivilegedConnection()
+            ->exec('GRANT ALL PRIVILEGES TO ' . $GLOBALS['db_user']);
 
         self::$privilegesGranted = true;
     }
@@ -104,8 +104,8 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testListDatabases() : void
     {
-        // We need the temp connection that has privileges to create a database.
-        $sm = TestUtil::getTempConnection()->getSchemaManager();
+        // We need a privileged connection to create the database.
+        $sm = TestUtil::getPrivilegedConnection()->getSchemaManager();
 
         $sm->dropAndCreateDatabase('c##test_create_database');
 
@@ -233,7 +233,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $otherTable = new Table($table->getName());
         $otherTable->addColumn('id', Types::STRING);
-        TestUtil::getTempConnection()->getSchemaManager()->dropAndCreateTable($otherTable);
+        TestUtil::getPrivilegedConnection()->getSchemaManager()->dropAndCreateTable($otherTable);
 
         $columns = $this->schemaManager->listTableColumns($table->getName(), $this->connection->getUsername());
         self::assertCount(7, $columns);

--- a/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/AbstractTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/AbstractTestCase.php
@@ -19,14 +19,14 @@ abstract class AbstractTestCase extends TestCase
 
     protected function setUp() : void
     {
-        if (! isset($GLOBALS['db_type']) || strpos($GLOBALS['db_type'], 'sqlsrv') === false) {
+        if (! isset($GLOBALS['db_driver']) || strpos($GLOBALS['db_driver'], 'sqlsrv') === false) {
             $this->markTestSkipped('No driver or sqlserver driver specified.');
         }
 
         $params     = [
-            'driver' => $GLOBALS['db_type'],
-            'dbname' => $GLOBALS['db_name'],
-            'user' => $GLOBALS['db_username'],
+            'driver' => $GLOBALS['db_driver'],
+            'dbname' => $GLOBALS['db_dbname'],
+            'user' => $GLOBALS['db_user'],
             'password' => $GLOBALS['db_password'],
             'host' => $GLOBALS['db_host'],
             'sharding' => [

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -18,23 +18,21 @@ class TestUtil
     private static $initialized = false;
 
     /**
-     * Gets a <b>real</b> database connection using the following parameters
+     * Creates a new <b>test</b> database connection using the following parameters
      * of the $GLOBALS array:
      *
-     * 'db_type' : The name of the Doctrine DBAL database driver to use.
-     * 'db_username' : The username to use for connecting.
-     * 'db_password' : The password to use for connecting.
-     * 'db_host' : The hostname of the database to connect to.
-     * 'db_server' : The server name of the database to connect to
-     *               (optional, some vendors allow multiple server instances with different names on the same host).
-     * 'db_name' : The name of the database to connect to.
-     * 'db_port' : The port of the database to connect to.
+     * 'db_driver':   The name of the Doctrine DBAL database driver to use.
+     * 'db_user':     The username to use for connecting.
+     * 'db_password': The password to use for connecting.
+     * 'db_host':     The hostname of the database to connect to.
+     * 'db_server':   The server name of the database to connect to
+     *                (optional, some vendors allow multiple server instances with different names on the same host).
+     * 'db_dbname':   The name of the database to connect to.
+     * 'db_port':     The port of the database to connect to.
      *
      * Usually these variables of the $GLOBALS array are filled by PHPUnit based
      * on an XML configuration file. If no such parameters exist, an SQLite
      * in-memory database is used.
-     *
-     * IMPORTANT: Each invocation of this method returns a NEW database connection.
      *
      * @return Connection The database connection instance.
      */
@@ -58,7 +56,7 @@ class TestUtil
     public static function getConnectionParams() : array
     {
         if (self::hasRequiredConnectionParams()) {
-            return self::getParamsForMainConnection();
+            return self::getTestConnectionParameters();
         }
 
         return self::getFallbackConnectionParams();
@@ -66,50 +64,36 @@ class TestUtil
 
     private static function hasRequiredConnectionParams() : bool
     {
-        return isset(
-            $GLOBALS['db_type'],
-            $GLOBALS['db_username'],
-            $GLOBALS['db_password'],
-            $GLOBALS['db_host'],
-            $GLOBALS['db_name'],
-            $GLOBALS['db_port']
-        )
-        && isset(
-            $GLOBALS['tmpdb_type'],
-            $GLOBALS['tmpdb_username'],
-            $GLOBALS['tmpdb_password'],
-            $GLOBALS['tmpdb_host'],
-            $GLOBALS['tmpdb_port']
-        );
+        return isset($GLOBALS['db_driver']);
     }
 
     private static function initializeDatabase() : void
     {
-        $realDbParams = self::getParamsForMainConnection();
-        $tmpDbParams  = self::getParamsForTemporaryConnection();
+        $testConnParams = self::getTestConnectionParameters();
+        $privConnParams = self::getPrivilegedConnectionParameters();
 
-        $realConn = DriverManager::getConnection($realDbParams);
+        $testConn = DriverManager::getConnection($testConnParams);
 
-        // Connect to tmpdb in order to drop and create the real test db.
-        $tmpConn = DriverManager::getConnection($tmpDbParams);
+        // Connect as a privileged user to create and drop the test database.
+        $privConn = DriverManager::getConnection($privConnParams);
 
-        $platform = $tmpConn->getDatabasePlatform();
+        $platform = $privConn->getDatabasePlatform();
 
         if ($platform->supportsCreateDropDatabase()) {
-            $dbname = $realConn->getDatabase();
-            $realConn->close();
+            $dbname = $testConn->getDatabase();
+            $testConn->close();
 
-            $tmpConn->getSchemaManager()->dropAndCreateDatabase($dbname);
+            $privConn->getSchemaManager()->dropAndCreateDatabase($dbname);
 
-            $tmpConn->close();
+            $privConn->close();
         } else {
-            $sm = $realConn->getSchemaManager();
+            $sm = $testConn->getSchemaManager();
 
             $schema = $sm->createSchema();
-            $stmts  = $schema->toDropSql($realConn->getDatabasePlatform());
+            $stmts  = $schema->toDropSql($testConn->getDatabasePlatform());
 
             foreach ($stmts as $stmt) {
-                $realConn->exec($stmt);
+                $testConn->exec($stmt);
             }
         }
     }
@@ -152,59 +136,57 @@ class TestUtil
     /**
      * @return mixed[]
      */
-    private static function getParamsForTemporaryConnection() : array
+    private static function getPrivilegedConnectionParameters() : array
     {
-        $connectionParams = [
-            'driver' => $GLOBALS['tmpdb_type'],
-            'user' => $GLOBALS['tmpdb_username'],
-            'password' => $GLOBALS['tmpdb_password'],
-            'host' => $GLOBALS['tmpdb_host'],
-            'dbname' => null,
-            'port' => $GLOBALS['tmpdb_port'],
-        ];
-
-        if (isset($GLOBALS['tmpdb_name'])) {
-            $connectionParams['dbname'] = $GLOBALS['tmpdb_name'];
+        if (isset($GLOBALS['tmpdb_driver'])) {
+            return self::mapConnectionParameters($GLOBALS, 'tmpdb_');
         }
 
-        if (isset($GLOBALS['tmpdb_server'])) {
-            $connectionParams['server'] = $GLOBALS['tmpdb_server'];
-        }
+        $parameters = self::mapConnectionParameters($GLOBALS, 'db_');
+        unset($parameters['dbname']);
 
-        if (isset($GLOBALS['tmpdb_unix_socket'])) {
-            $connectionParams['unix_socket'] = $GLOBALS['tmpdb_unix_socket'];
-        }
-
-        return $connectionParams;
+        return $parameters;
     }
 
     /**
      * @return mixed[]
      */
-    private static function getParamsForMainConnection() : array
+    private static function getTestConnectionParameters() : array
     {
-        $connectionParams = [
-            'driver' => $GLOBALS['db_type'],
-            'user' => $GLOBALS['db_username'],
-            'password' => $GLOBALS['db_password'],
-            'host' => $GLOBALS['db_host'],
-            'dbname' => $GLOBALS['db_name'],
-            'port' => $GLOBALS['db_port'],
-        ];
-
-        if (isset($GLOBALS['db_server'])) {
-            $connectionParams['server'] = $GLOBALS['db_server'];
-        }
-
-        if (isset($GLOBALS['db_unix_socket'])) {
-            $connectionParams['unix_socket'] = $GLOBALS['db_unix_socket'];
-        }
-
-        return $connectionParams;
+        return self::mapConnectionParameters($GLOBALS, 'db_');
     }
 
-    public static function getTempConnection() : Connection
+    /**
+     * @param array<string,mixed> $configuration
+     *
+     * @return array<string,mixed>
+     */
+    private static function mapConnectionParameters(array $configuration, string $prefix) : array
     {
-        return DriverManager::getConnection(self::getParamsForTemporaryConnection());
+        $parameters = [];
+
+        foreach ([
+            'driver',
+            'user',
+            'password',
+            'host',
+            'dbname',
+            'port',
+            'server',
+            'unix_socket',
+        ] as $parameter) {
+            if (! isset($configuration[$prefix . $parameter])) {
+                continue;
+            }
+
+            $parameters[$parameter] = $configuration[$prefix . $parameter];
+        }
+
+        return $parameters;
+    }
+
+    public static function getPrivilegedConnection() : Connection
+    {
+        return DriverManager::getConnection(self::getPrivilegedConnectionParameters());
     }
 }

--- a/tests/appveyor/mssql.sql2008r2sp2.sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2008r2sp2.sqlsrv.appveyor.xml
@@ -11,18 +11,11 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="sqlsrv"/>
+        <var name="db_driver" value="sqlsrv"/>
         <var name="db_host" value="(local)\SQL2008R2SP2" />
-        <var name="db_username" value="sa" />
+        <var name="db_user" value="sa" />
         <var name="db_password" value="Password12!" />
-        <var name="db_name" value="doctrine_tests" />
-        <var name="db_port" value="1433" />
-
-        <var name="tmpdb_type" value="sqlsrv"/>
-        <var name="tmpdb_host" value="(local)\SQL2008R2SP2" />
-        <var name="tmpdb_username" value="sa" />
-        <var name="tmpdb_password" value="Password12!" />
-        <var name="tmpdb_port" value="1433" />
+        <var name="db_dbname" value="doctrine_tests" />
     </php>
 
     <testsuites>

--- a/tests/appveyor/mssql.sql2012sp1.sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2012sp1.sqlsrv.appveyor.xml
@@ -11,18 +11,11 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="sqlsrv"/>
+        <var name="db_driver" value="sqlsrv"/>
         <var name="db_host" value="(local)\SQL2012SP1" />
-        <var name="db_username" value="sa" />
+        <var name="db_user" value="sa" />
         <var name="db_password" value="Password12!" />
-        <var name="db_name" value="doctrine_tests" />
-        <var name="db_port" value="1433" />
-
-        <var name="tmpdb_type" value="sqlsrv"/>
-        <var name="tmpdb_host" value="(local)\SQL2012SP1" />
-        <var name="tmpdb_username" value="sa" />
-        <var name="tmpdb_password" value="Password12!" />
-        <var name="tmpdb_port" value="1433" />
+        <var name="db_dbname" value="doctrine_tests" />
     </php>
 
     <testsuites>

--- a/tests/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
@@ -11,18 +11,11 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="pdo_sqlsrv"/>
+        <var name="db_driver" value="pdo_sqlsrv"/>
         <var name="db_host" value="(local)\SQL2017" />
-        <var name="db_username" value="sa" />
+        <var name="db_user" value="sa" />
         <var name="db_password" value="Password12!" />
-        <var name="db_name" value="doctrine_tests" />
-        <var name="db_port" value="1433"/>
-
-        <var name="tmpdb_type" value="pdo_sqlsrv"/>
-        <var name="tmpdb_host" value="(local)\SQL2017" />
-        <var name="tmpdb_username" value="sa" />
-        <var name="tmpdb_password" value="Password12!" />
-        <var name="tmpdb_port" value="1433"/>
+        <var name="db_dbname" value="doctrine_tests" />
     </php>
 
     <testsuites>

--- a/tests/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
@@ -11,18 +11,11 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="sqlsrv"/>
+        <var name="db_driver" value="sqlsrv"/>
         <var name="db_host" value="(local)\SQL2017" />
-        <var name="db_username" value="sa" />
+        <var name="db_user" value="sa" />
         <var name="db_password" value="Password12!" />
-        <var name="db_name" value="doctrine_tests" />
-        <var name="db_port" value="1433" />
-
-        <var name="tmpdb_type" value="sqlsrv"/>
-        <var name="tmpdb_host" value="(local)\SQL2017" />
-        <var name="tmpdb_username" value="sa" />
-        <var name="tmpdb_password" value="Password12!" />
-        <var name="tmpdb_port" value="1433" />
+        <var name="db_dbname" value="doctrine_tests" />
     </php>
 
     <testsuites>

--- a/tests/continuousphp/oci8.phpunit.continuousphp.xml
+++ b/tests/continuousphp/oci8.phpunit.continuousphp.xml
@@ -11,20 +11,18 @@
   <php>
     <ini name="error_reporting" value="-1" />
 
-    <var name="db_type" value="oci8"/>
+    <var name="db_driver" value="oci8"/>
     <var name="db_host" value="oracle-xe-11" />
-    <var name="db_username" value="C##doctrine" />
+    <var name="db_user" value="C##doctrine" />
     <var name="db_password" value="ORACLE" />
-    <var name="db_name" value="XE" />
-    <var name="db_port" value="1521"/>
+    <var name="db_dbname" value="XE" />
     <var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit"/>
 
-    <var name="tmpdb_type" value="oci8"/>
+    <var name="tmpdb_driver" value="oci8"/>
     <var name="tmpdb_host" value="oracle-xe-11" />
-    <var name="tmpdb_username" value="ORACLE" />
+    <var name="tmpdb_user" value="ORACLE" />
     <var name="tmpdb_password" value="ORACLE" />
-    <var name="tmpdb_name" value="XE" />
-    <var name="tmpdb_port" value="1521"/>
+    <var name="tmpdb_dbname" value="XE" />
   </php>
 
   <testsuites>

--- a/tests/continuousphp/pdo-oci.phpunit.xml
+++ b/tests/continuousphp/pdo-oci.phpunit.xml
@@ -9,20 +9,18 @@
          bootstrap="bootstrap.php"
 >
   <php>
-    <var name="db_type" value="pdo_oci"/>
+    <var name="db_driver" value="pdo_oci"/>
     <var name="db_host" value="oracle-xe-11" />
-    <var name="db_username" value="C##doctrine" />
+    <var name="db_user" value="C##doctrine" />
     <var name="db_password" value="ORACLE" />
-    <var name="db_name" value="XE" />
-    <var name="db_port" value="1521"/>
+    <var name="db_dbname" value="XE" />
     <var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit"/>
 
-    <var name="tmpdb_type" value="pdo_oci"/>
+    <var name="tmpdb_driver" value="pdo_oci"/>
     <var name="tmpdb_host" value="oracle-xe-11" />
-    <var name="tmpdb_username" value="ORACLE" />
+    <var name="tmpdb_user" value="ORACLE" />
     <var name="tmpdb_password" value="ORACLE" />
-    <var name="tmpdb_name" value="XE" />
-    <var name="tmpdb_port" value="1521"/>
+    <var name="tmpdb_dbname" value="XE" />
   </php>
 
   <testsuites>

--- a/tests/travis/ibm_db2.travis.xml
+++ b/tests/travis/ibm_db2.travis.xml
@@ -10,19 +10,11 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="ibm_db2"/>
+        <var name="db_driver" value="ibm_db2"/>
         <var name="db_host" value="127.0.0.1"/>
-        <var name="db_username" value="db2inst1"/>
+        <var name="db_user" value="db2inst1"/>
         <var name="db_password" value="Doctrine2018"/>
-        <var name="db_name" value="HOSTNAME=127.0.0.1;UID=db2inst1;PWD=Doctrine2018;DATABASE=doctrine"/>
-        <var name="db_port" value="50000"/>
-
-        <var name="tmpdb_type" value="ibm_db2"/>
-        <var name="tmpdb_host" value="127.0.0.1"/>
-        <var name="tmpdb_username" value="db2inst1"/>
-        <var name="tmpdb_password" value="Doctrine2018"/>
-        <var name="tmpdb_name" value="HOSTNAME=127.0.0.1;UID=db2inst1;PWD=Doctrine2018;DATABASE=doctrine"/>
-        <var name="tmpdb_port" value="50000"/>
+        <var name="db_dbname" value="HOSTNAME=127.0.0.1;UID=db2inst1;PWD=Doctrine2018;DATABASE=doctrine"/>
     </php>
 
     <testsuites>

--- a/tests/travis/mariadb.docker.travis.xml
+++ b/tests/travis/mariadb.docker.travis.xml
@@ -10,18 +10,11 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="pdo_mysql"/>
+        <var name="db_driver" value="pdo_mysql"/>
         <var name="db_host" value="127.0.0.1" />
-        <var name="db_username" value="root" />
-        <var name="db_password" value="" />
-        <var name="db_name" value="doctrine_tests" />
         <var name="db_port" value="33306"/>
-
-        <var name="tmpdb_type" value="pdo_mysql"/>
-        <var name="tmpdb_host" value="127.0.0.1" />
-        <var name="tmpdb_username" value="root" />
-        <var name="tmpdb_password" value="" />
-        <var name="tmpdb_port" value="33306"/>
+        <var name="db_user" value="root" />
+        <var name="db_dbname" value="doctrine_tests" />
     </php>
 
     <testsuites>

--- a/tests/travis/mariadb.mysqli.docker.travis.xml
+++ b/tests/travis/mariadb.mysqli.docker.travis.xml
@@ -10,18 +10,11 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="mysqli"/>
+        <var name="db_driver" value="mysqli"/>
         <var name="db_host" value="127.0.0.1" />
-        <var name="db_username" value="root" />
-        <var name="db_password" value="" />
-        <var name="db_name" value="doctrine_tests" />
         <var name="db_port" value="33306"/>
-
-        <var name="tmpdb_type" value="mysqli"/>
-        <var name="tmpdb_host" value="127.0.0.1" />
-        <var name="tmpdb_username" value="root" />
-        <var name="tmpdb_password" value="" />
-        <var name="tmpdb_port" value="33306"/>
+        <var name="db_user" value="root" />
+        <var name="db_dbname" value="doctrine_tests" />
     </php>
 
     <testsuites>

--- a/tests/travis/mysql.docker.travis.xml
+++ b/tests/travis/mysql.docker.travis.xml
@@ -10,18 +10,11 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="pdo_mysql"/>
+        <var name="db_driver" value="pdo_mysql"/>
         <var name="db_host" value="127.0.0.1" />
-        <var name="db_username" value="root" />
-        <var name="db_password" value="" />
-        <var name="db_name" value="doctrine_tests" />
         <var name="db_port" value="33306"/>
-
-        <var name="tmpdb_type" value="pdo_mysql"/>
-        <var name="tmpdb_host" value="127.0.0.1" />
-        <var name="tmpdb_username" value="root" />
-        <var name="tmpdb_password" value="" />
-        <var name="tmpdb_port" value="33306"/>
+        <var name="db_user" value="root" />
+        <var name="db_dbname" value="doctrine_tests" />
     </php>
 
     <testsuites>

--- a/tests/travis/mysqli.docker.travis.xml
+++ b/tests/travis/mysqli.docker.travis.xml
@@ -10,18 +10,11 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="mysqli"/>
+        <var name="db_driver" value="mysqli"/>
         <var name="db_host" value="127.0.0.1" />
-        <var name="db_username" value="root" />
-        <var name="db_password" value="" />
-        <var name="db_name" value="doctrine_tests" />
         <var name="db_port" value="33306"/>
-
-        <var name="tmpdb_type" value="mysqli"/>
-        <var name="tmpdb_host" value="127.0.0.1" />
-        <var name="tmpdb_username" value="root" />
-        <var name="tmpdb_password" value="" />
-        <var name="tmpdb_port" value="33306"/>
+        <var name="db_user" value="root" />
+        <var name="db_dbname" value="doctrine_tests" />
     </php>
 
     <testsuites>

--- a/tests/travis/pdo_sqlsrv.travis.xml
+++ b/tests/travis/pdo_sqlsrv.travis.xml
@@ -10,18 +10,11 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="pdo_sqlsrv"/>
+        <var name="db_driver" value="pdo_sqlsrv"/>
         <var name="db_host" value="127.0.0.1" />
-        <var name="db_username" value="sa" />
+        <var name="db_user" value="sa" />
         <var name="db_password" value="Doctrine2018" />
-        <var name="db_name" value="doctrine" />
-        <var name="db_port" value="1433"/>
-
-        <var name="tmpdb_type" value="pdo_sqlsrv"/>
-        <var name="tmpdb_host" value="127.0.0.1" />
-        <var name="tmpdb_username" value="sa" />
-        <var name="tmpdb_password" value="Doctrine2018" />
-        <var name="tmpdb_port" value="1433"/>
+        <var name="db_dbname" value="doctrine" />
     </php>
 
     <testsuites>

--- a/tests/travis/pgsql.travis.xml
+++ b/tests/travis/pgsql.travis.xml
@@ -10,18 +10,10 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="pdo_pgsql"/>
+        <var name="db_driver" value="pdo_pgsql"/>
         <var name="db_host" value="localhost" />
-        <var name="db_username" value="postgres" />
-        <var name="db_password" value="" />
-        <var name="db_name" value="doctrine_tests" />
-        <var name="db_port" value="5432"/>
-
-        <var name="tmpdb_type" value="pdo_pgsql"/>
-        <var name="tmpdb_host" value="localhost" />
-        <var name="tmpdb_username" value="postgres" />
-        <var name="tmpdb_password" value="" />
-        <var name="tmpdb_port" value="5432"/>
+        <var name="db_user" value="postgres" />
+        <var name="db_dbname" value="doctrine_tests" />
     </php>
 
     <testsuites>

--- a/tests/travis/sqlsrv.travis.xml
+++ b/tests/travis/sqlsrv.travis.xml
@@ -10,18 +10,11 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_type" value="sqlsrv"/>
+        <var name="db_driver" value="sqlsrv"/>
         <var name="db_host" value="127.0.0.1" />
-        <var name="db_username" value="sa" />
+        <var name="db_user" value="sa" />
         <var name="db_password" value="Doctrine2018" />
-        <var name="db_name" value="doctrine" />
-        <var name="db_port" value="1433"/>
-
-        <var name="tmpdb_type" value="sqlsrv"/>
-        <var name="tmpdb_host" value="127.0.0.1" />
-        <var name="tmpdb_username" value="sa" />
-        <var name="tmpdb_password" value="Doctrine2018" />
-        <var name="tmpdb_port" value="1433"/>
+        <var name="db_dbname" value="doctrine" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. None of the supported drivers require all the connection parameters required by the test suite configuration. Most of them have default values for most of the parameters (e.g. `mysqli` can connect even w/o any parameters). Having to specify them all in a local development environment is unnecessarily tedious.
2. All so-called temporary connections look identical to the primary ones with the exception that the temporary one doesn't usually have a database name specified (creating a database is the primary purpose of the temporary connection). Instead of requiring the parameters to be specified explicitly, in the absence of the parameters, the test suite can fall back to the primary connection parameters and ignore the database.
3. There's no exact match between the test suite configuration parameter names and the connection parameters. E.g. the the `driver` is configured as `db_type`, `dbname` is configured as `db_name`. It would be nice to have a direct correspondence.

BTW, `tmp_host`, `tmp_port`, etc. also look redundant.

## Change summary
1. `(tmp)db_type` → `(tmp)db_driver`
2. `(tmp)db_username` → `(tmp)db_user`. This isn't nice but it corresponds to the connection parameter name.
3. `(tmp)db_name` → `(tmp)db_dbname`. This isn't nice either, but this is because we're not configuring a database (`db_`), we're configuring a test database _connection_. We may get rid of the `db_` prefix in parameter names or replace it with something else (e.g. `test_`).
4. Connection parameters are reordered logically: `driver`, `host`, `port`, `user`, `password`.