### PR TITLE
Deprecate Driver::getDatabase()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 2.11
 
+## Deprecated `Doctrine\DBAL\Driver::getDatabase()`
+
+- The usage of `Doctrine\DBAL\Driver::getDatabase()` is deprecated. Please use `Doctrine\DBAL\Connection::getDatabase()` instead.
+- The behavior of the SQLite connection returning the database file path as the database is deprecated and shouldn't be relied upon.
+
 ## Deprecated `Portability\Connection::PORTABILITY_{PLATFORM}` constants`
 
 The platform-specific portability mode flags are meant to be used only by the portability layer internally to optimize

--- a/lib/Doctrine/DBAL/Driver.php
+++ b/lib/Doctrine/DBAL/Driver.php
@@ -53,6 +53,8 @@ interface Driver
     /**
      * Gets the name of the database connected to for this driver.
      *
+     * @deprecated Use Connection::getDatabase() instead.
+     *
      * @return string The name of the database.
      */
     public function getDatabase(Connection $conn);

--- a/lib/Doctrine/DBAL/Driver/AbstractDB2Driver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractDB2Driver.php
@@ -14,6 +14,8 @@ abstract class AbstractDB2Driver implements Driver
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use Connection::getDatabase() instead.
      */
     public function getDatabase(Connection $conn)
     {

--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -197,6 +197,8 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use Connection::getDatabase() instead.
      */
     public function getDatabase(Connection $conn)
     {

--- a/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
@@ -59,6 +59,8 @@ abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use Connection::getDatabase() instead.
      */
     public function getDatabase(Connection $conn)
     {

--- a/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
@@ -115,6 +115,8 @@ abstract class AbstractPostgreSQLDriver implements Driver, ExceptionConverterDri
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use Connection::getDatabase() instead.
      */
     public function getDatabase(Connection $conn)
     {

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
@@ -117,6 +117,8 @@ abstract class AbstractSQLAnywhereDriver implements Driver, ExceptionConverterDr
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use Connection::getDatabase() instead.
      */
     public function getDatabase(Connection $conn)
     {

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
@@ -58,6 +58,8 @@ abstract class AbstractSQLServerDriver implements Driver, VersionAwarePlatformDr
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use Connection::getDatabase() instead.
      */
     public function getDatabase(Connection $conn)
     {

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
@@ -79,6 +79,8 @@ abstract class AbstractSQLiteDriver implements Driver, ExceptionConverterDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use Connection::getDatabase() instead.
      */
     public function getDatabase(Connection $conn)
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

The actual removal was already done in #3606 but it wasn't accompanied by deprecation.