### PR TITLE
Driver::connect() should throw only driver-level exceptions

### DIFF
--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -5,8 +5,10 @@ namespace Doctrine\DBAL\Connections;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
@@ -230,7 +232,11 @@ class PrimaryReadReplicaConnection extends Connection
         $user     = $connectionParams['user'] ?? null;
         $password = $connectionParams['password'] ?? null;
 
-        return $this->_driver->connect($connectionParams, $user, $password, $driverOptions);
+        try {
+            return $this->_driver->connect($connectionParams, $user, $password, $driverOptions);
+        } catch (DriverException $e) {
+            throw DBALException::driverException($this->_driver, $e);
+        }
     }
 
     /**

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL;
 
+use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 
@@ -22,6 +23,8 @@ interface Driver
      * @param mixed[]     $driverOptions The driver options to use when connecting.
      *
      * @return \Doctrine\DBAL\Driver\Connection The database connection.
+     *
+     * @throws DriverException
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = []);
 

--- a/src/Driver/Mysqli/Driver.php
+++ b/src/Driver/Mysqli/Driver.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\DBAL\Driver\Mysqli;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 
 class Driver extends AbstractMySQLDriver
@@ -12,11 +11,7 @@ class Driver extends AbstractMySQLDriver
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
-        try {
-            return new MysqliConnection($params, (string) $username, (string) $password, $driverOptions);
-        } catch (MysqliException $e) {
-            throw DBALException::driverException($this, $e);
-        }
+        return new MysqliConnection($params, (string) $username, (string) $password, $driverOptions);
     }
 
     /**

--- a/src/Driver/OCI8/Driver.php
+++ b/src/Driver/OCI8/Driver.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\DBAL\Driver\OCI8;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
 
 use const OCI_NO_AUTO_COMMIT;
@@ -17,18 +16,14 @@ class Driver extends AbstractOracleDriver
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
-        try {
-            return new OCI8Connection(
-                (string) $username,
-                (string) $password,
-                $this->_constructDsn($params),
-                $params['charset'] ?? '',
-                $params['sessionMode'] ?? OCI_NO_AUTO_COMMIT,
-                $params['persistent'] ?? false
-            );
-        } catch (OCI8Exception $e) {
-            throw DBALException::driverException($this, $e);
-        }
+        return new OCI8Connection(
+            (string) $username,
+            (string) $password,
+            $this->_constructDsn($params),
+            $params['charset'] ?? '',
+            $params['sessionMode'] ?? OCI_NO_AUTO_COMMIT,
+            $params['persistent'] ?? false
+        );
     }
 
     /**

--- a/src/Driver/PDOMySql/Driver.php
+++ b/src/Driver/PDOMySql/Driver.php
@@ -2,11 +2,9 @@
 
 namespace Doctrine\DBAL\Driver\PDOMySql;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Driver\PDOConnection;
 use PDO;
-use PDOException;
 
 /**
  * PDO MySql driver.
@@ -22,18 +20,12 @@ class Driver extends AbstractMySQLDriver
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
-        try {
-            $conn = new PDOConnection(
-                $this->constructPdoDsn($params),
-                $username,
-                $password,
-                $driverOptions
-            );
-        } catch (PDOException $e) {
-            throw DBALException::driverException($this, $e);
-        }
-
-        return $conn;
+        return new PDOConnection(
+            $this->constructPdoDsn($params),
+            $username,
+            $password,
+            $driverOptions
+        );
     }
 
     /**

--- a/src/Driver/PDOOracle/Driver.php
+++ b/src/Driver/PDOOracle/Driver.php
@@ -2,11 +2,9 @@
 
 namespace Doctrine\DBAL\Driver\PDOOracle;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
 use Doctrine\DBAL\Driver\PDOConnection;
 use PDO;
-use PDOException;
 
 /**
  * PDO Oracle driver.
@@ -27,16 +25,12 @@ class Driver extends AbstractOracleDriver
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
-        try {
-            return new PDOConnection(
-                $this->constructPdoDsn($params),
-                $username,
-                $password,
-                $driverOptions
-            );
-        } catch (PDOException $e) {
-            throw DBALException::driverException($this, $e);
-        }
+        return new PDOConnection(
+            $this->constructPdoDsn($params),
+            $username,
+            $password,
+            $driverOptions
+        );
     }
 
     /**

--- a/src/Driver/PDOSqlite/Driver.php
+++ b/src/Driver/PDOSqlite/Driver.php
@@ -2,11 +2,9 @@
 
 namespace Doctrine\DBAL\Driver\PDOSqlite;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use Doctrine\DBAL\Driver\PDOConnection;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use PDOException;
 
 use function array_merge;
 
@@ -35,16 +33,12 @@ class Driver extends AbstractSQLiteDriver
             unset($driverOptions['userDefinedFunctions']);
         }
 
-        try {
-            $connection = new PDOConnection(
-                $this->_constructPdoDsn($params),
-                $username,
-                $password,
-                $driverOptions
-            );
-        } catch (PDOException $ex) {
-            throw DBALException::driverException($this, $ex);
-        }
+        $connection = new PDOConnection(
+            $this->_constructPdoDsn($params),
+            $username,
+            $password,
+            $driverOptions
+        );
 
         $pdo = $connection->getWrappedConnection();
 

--- a/src/Driver/SQLAnywhere/Driver.php
+++ b/src/Driver/SQLAnywhere/Driver.php
@@ -21,22 +21,18 @@ class Driver extends AbstractSQLAnywhereDriver
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
-        try {
-            return new SQLAnywhereConnection(
-                $this->buildDsn(
-                    $params['host'] ?? null,
-                    $params['port'] ?? null,
-                    $params['server'] ?? null,
-                    $params['dbname'] ?? null,
-                    $username,
-                    $password,
-                    $driverOptions
-                ),
-                $params['persistent'] ?? false
-            );
-        } catch (SQLAnywhereException $e) {
-            throw DBALException::driverException($this, $e);
-        }
+        return new SQLAnywhereConnection(
+            $this->buildDsn(
+                $params['host'] ?? null,
+                $params['port'] ?? null,
+                $params['server'] ?? null,
+                $params['dbname'] ?? null,
+                $username,
+                $password,
+                $driverOptions
+            ),
+            $params['persistent'] ?? false
+        );
     }
 
     /**

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -20,7 +20,6 @@ use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
-use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -788,8 +787,8 @@ class ConnectionTest extends TestCase
         $driverMock = $this->createMock(VersionAwarePlatformDriver::class);
 
         $connection        = new Connection(['dbname' => 'foo'], $driverMock);
-        $originalException = new Exception('Original exception');
-        $fallbackException = new Exception('Fallback exception');
+        $originalException = new DBALException('Original exception');
+        $fallbackException = new DBALException('Fallback exception');
 
         $driverMock->expects(self::at(0))
             ->method('connect')


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

#### Summary

Currently, most of the `Driver::connect()` throw a `DBALException` on failure but some throw a `DriverException` exception. The lower level abstraction (drivers) should not be aware of the higher-level abstraction (DBAL). This way, instead of being implemented in one place, the higher-level logic gets inconsistently duplicated in multiple places.

#### Additional changes

1. `Driver::connect()` is documented as `@throws DriverException`.
2. `Connection::connect()` is documented as `@throws DBALException`.
3. `Connection::getDatabasePlatformVersion()` will not expect `Connection::connect()` to throw anything else than a `DBALException`.

#### Testing

The code being changed is covered by existing tests (e.g. `ExceptionTest::testConnectionException()`). It doesn't look reasonable to add the unit tests that would cover the specific thrown exception types. Ideally, this should be tested statically (e.g. PhpStorm supports that but I'm not sure if other tools that can run on CI do).