### PR TITLE
Bump PHP requirement to 7.3 as of DBAL 2.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,43 +34,6 @@ jobs:
       env: DB=sqlite
 
     - stage: Test
-      php: 7.2
-      env: DB=mysql.docker IMAGE=mysql:8.0
-    - stage: Test
-      php: 7.2
-      env: DB=mysqli.docker IMAGE=mysql:8.0
-    - stage: Test
-      php: 7.2
-      env: DB=mariadb.docker IMAGE=mariadb:10.3
-    - stage: Test
-      php: 7.2
-      env: DB=mariadb.mysqli.docker IMAGE=mariadb:10.3
-    - stage: Test
-      php: 7.2
-      env: DB=pgsql POSTGRESQL_VERSION=11.0
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-postgres-11.sh
-    - stage: Test
-      php: 7.2
-      env: DB=sqlite
-    - stage: Test
-      php: 7.2
-      env: DB=sqlsrv
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-sqlsrv-dependencies.sh
-        - bash ./tests/travis/install-mssql-sqlsrv.sh
-        - bash ./tests/travis/install-mssql.sh
-    - stage: Test
-      php: 7.2
-      env: DB=pdo_sqlsrv
-      sudo: required
-      before_script:
-        - bash ./tests/travis/install-sqlsrv-dependencies.sh
-        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
-        - bash ./tests/travis/install-mssql.sh
-    - stage: Test
       php: 7.3
       env: DB=mysql.docker IMAGE=mysql:5.7
     - stage: Test

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-pdo": "*",
         "doctrine/cache": "^1.0",
         "doctrine/event-manager": "^1.0"
@@ -54,7 +54,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.2.0"
+            "php": "7.3.0"
         }
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5c06fdb9d602a1498b1eba6aa45f1d4",
+    "content-hash": "84bb64fae33632b7c7f562447fda9b7d",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1364,20 +1364,6 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "funding": [
-                {
-                    "url": "https://github.com/ondrejmirtes",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/phpstan",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-22T16:51:47+00:00"
         },
         {
@@ -3007,8 +2993,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
@@ -3259,12 +3245,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-pdo": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2.0"
+        "php": "7.3.0"
     },
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Active support for PHP 7.2 by the PHP community [ended on November 30, 2019](https://www.php.net/supported-versions.php). Since the `2.11.x` release series of the DBAL will primary contain deprecations and the forward compatibility layer with the DBAL 3 that will not support PHP 7.3, there's no point in supporting it in `2.11.x` either.