### PR TITLE
Forward compatibility with PHPUnit 9.3

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -105,7 +105,7 @@ class OCI8StatementTest extends DbalTestCase
     public function testConvertNonTerminatedLiteral(string $sql, string $message): void
     {
         $this->expectException(OCI8Exception::class);
-        $this->expectExceptionMessageRegExp($message);
+        $this->expectExceptionMessageMatches($message);
         OCI8Statement::convertPositionalToNamedPlaceholders($sql);
     }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaTest.php
@@ -378,27 +378,19 @@ class SchemaTest extends TestCase
             ->method('acceptSchema')
             ->with($schema);
 
-        $visitor->expects($this->at(1))
+        $visitor->expects(self::exactly(2))
             ->method('acceptTable')
-            ->with($schema->getTable('baz'));
+            ->withConsecutive(
+                [$schema->getTable('baz')],
+                [$schema->getTable('bla.bloo')]
+            );
 
-        $visitor->expects($this->at(2))
-            ->method('acceptTable')
-            ->with($schema->getTable('bla.bloo'));
-
-        $visitor->expects($this->exactly(2))
-            ->method('acceptTable');
-
-        $visitor->expects($this->at(3))
+        $visitor->expects(self::exactly(2))
             ->method('acceptSequence')
-            ->with($schema->getSequence('moo'));
-
-        $visitor->expects($this->at(4))
-            ->method('acceptSequence')
-            ->with($schema->getSequence('war'));
-
-        $visitor->expects($this->exactly(2))
-            ->method('acceptSequence');
+            ->withConsecutive(
+                [$schema->getSequence('moo')],
+                [$schema->getSequence('war')]
+            );
 
         self::assertNull($schema->visit($visitor));
     }
@@ -436,9 +428,6 @@ class SchemaTest extends TestCase
             ->method('acceptNamespace')
             ->with('bla');
 
-        $visitor->expects($this->exactly(3))
-            ->method('acceptNamespace');
-
         $visitor->expects($this->at(4))
             ->method('acceptTable')
             ->with($schema->getTable('baz'));
@@ -447,9 +436,6 @@ class SchemaTest extends TestCase
             ->method('acceptTable')
             ->with($schema->getTable('bla.bloo'));
 
-        $visitor->expects($this->exactly(2))
-            ->method('acceptTable');
-
         $visitor->expects($this->at(6))
             ->method('acceptSequence')
             ->with($schema->getSequence('moo'));
@@ -457,9 +443,6 @@ class SchemaTest extends TestCase
         $visitor->expects($this->at(7))
             ->method('acceptSequence')
             ->with($schema->getSequence('war'));
-
-        $visitor->expects($this->exactly(2))
-            ->method('acceptSequence');
 
         self::assertNull($schema->visit($visitor));
     }

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/DropSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/DropSchemaSqlCollectorTest.php
@@ -28,16 +28,12 @@ class DropSchemaSqlCollectorTest extends TestCase
 
         $collector = new DropSchemaSqlCollector($platform);
 
-        $platform->expects($this->exactly(2))
-            ->method('getDropForeignKeySQL');
-
-        $platform->expects($this->at(0))
+        $platform->expects(self::exactly(2))
             ->method('getDropForeignKeySQL')
-            ->with($keyConstraintOne, $tableOne);
-
-        $platform->expects($this->at(1))
-            ->method('getDropForeignKeySQL')
-            ->with($keyConstraintTwo, $tableTwo);
+            ->withConsecutive(
+                [$keyConstraintOne, $tableOne],
+                [$keyConstraintTwo, $tableTwo]
+            );
 
         $collector->acceptForeignKey($tableOne, $keyConstraintOne);
         $collector->acceptForeignKey($tableTwo, $keyConstraintTwo);

--- a/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
@@ -31,10 +31,6 @@ class RunSqlCommandTest extends TestCase
         $this->commandTester = new CommandTester($this->command);
 
         $this->connectionMock = $this->createMock(Connection::class);
-        $this->connectionMock->method('fetchAllAssociative')
-            ->willReturn([[1]]);
-        $this->connectionMock->method('executeUpdate')
-            ->willReturn(42);
 
         $helperSet = ConsoleRunner::createHelperSet($this->connectionMock);
         $this->command->setHelperSet($helperSet);
@@ -97,21 +93,25 @@ class RunSqlCommandTest extends TestCase
     private function expectConnectionExecuteUpdate(): void
     {
         $this->connectionMock
-            ->expects($this->exactly(1))
-            ->method('executeUpdate');
+            ->expects($this->once())
+            ->method('executeUpdate')
+            ->willReturn(42);
+
         $this->connectionMock
-            ->expects($this->exactly(0))
+            ->expects($this->never())
             ->method('fetchAllAssociative');
     }
 
     private function expectConnectionFetchAllAssociative(): void
     {
         $this->connectionMock
-            ->expects($this->exactly(0))
-            ->method('executeUpdate');
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([[1]]);
+
         $this->connectionMock
-            ->expects($this->exactly(1))
-            ->method('fetchAllAssociative');
+            ->expects($this->never())
+            ->method('executeUpdate');
     }
 
     public function testStatementsWithFetchResultPrintsResult(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | [job #9388.31](https://travis-ci.org/github/doctrine/dbal/jobs/698103923)

#### Summary

Some of the forward compatibility issues detected by the build failed on `3.0.x` can be fixed in `2.11.x` and up-merged. Once https://github.com/doctrine/dbal/pull/4078 is merged, we can proceed with updating PHPUnit in `2.11.x` as well.