### PR TITLE
Simplify Driver::connect() signature

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK changes the `Driver::connect()` signature
+
+The method no longer accepts the `$username`, `$password` and `$driverOptions` arguments. The corresponding values are expected to be passed as the "user", "password" and "driver_options" keys of the `$params` argument respectively.
+
 ## Removed `MasterSlaveConnection`
 
 This class was deprecated in favor of `PrimaryReadReplicaConnection`

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -83,11 +83,12 @@
     <!-- https://github.com/squizlabs/PHP_CodeSniffer/issues/2837 -->
     <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
         <!--
-            This file uses the return value db2_server_info(), which does not follow conventions
-            phpcs wrongly complains about it, and that has been reported here:
+            These files use the underlying driver APIs that don't comply with the coding standard
+            phpcs wrongly complains about them, and that has been reported here:
             https://github.com/squizlabs/PHP_CodeSniffer/issues/2950
         -->
         <exclude-pattern>src/Driver/IBMDB2/DB2Connection.php</exclude-pattern>
+        <exclude-pattern>src/Driver/Mysqli/MysqliConnection.php</exclude-pattern>
         <!-- See https://github.com/squizlabs/PHP_CodeSniffer/issues/2837 -->
         <exclude-pattern>src/SQLParserUtils.php</exclude-pattern>
         <exclude-pattern>src/Tools/Dumper.php</exclude-pattern>

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -352,12 +352,8 @@ class Connection implements DriverConnection
             return false;
         }
 
-        $driverOptions = $this->params['driverOptions'] ?? [];
-        $user          = $this->params['user'] ?? null;
-        $password      = $this->params['password'] ?? null;
-
         try {
-            $this->_conn = $this->_driver->connect($this->params, $user, $password, $driverOptions);
+            $this->_conn = $this->_driver->connect($this->params);
         } catch (DriverException $e) {
             throw DBALException::driverException($this->_driver, $e);
         }

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -225,15 +225,10 @@ class PrimaryReadReplicaConnection extends Connection
     {
         $params = $this->getParams();
 
-        $driverOptions = $params['driverOptions'] ?? [];
-
         $connectionParams = $this->chooseConnectionConfiguration($connectionName, $params);
 
-        $user     = $connectionParams['user'] ?? null;
-        $password = $connectionParams['password'] ?? null;
-
         try {
-            return $this->_driver->connect($connectionParams, $user, $password, $driverOptions);
+            return $this->_driver->connect($connectionParams);
         } catch (DriverException $e) {
             throw DBALException::driverException($this->_driver, $e);
         }

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL;
 
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -15,18 +16,13 @@ interface Driver
     /**
      * Attempts to create a connection with the database.
      *
-     * The usage of NULL to indicate empty username or password is deprecated. Use an empty string instead.
+     * @param mixed[] $params All connection parameters.
      *
-     * @param mixed[]     $params        All connection parameters passed by the user.
-     * @param string|null $username      The username to use when connecting.
-     * @param string|null $password      The password to use when connecting.
-     * @param mixed[]     $driverOptions The driver options to use when connecting.
-     *
-     * @return \Doctrine\DBAL\Driver\Connection The database connection.
+     * @return DriverConnection The database connection.
      *
      * @throws DriverException
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = []);
+    public function connect(array $params);
 
     /**
      * Gets the DatabasePlatform instance that provides all the metadata about

--- a/src/Driver/IBMDB2/DB2Connection.php
+++ b/src/Driver/IBMDB2/DB2Connection.php
@@ -33,21 +33,21 @@ class DB2Connection implements ServerInfoAwareConnection
     private $conn = null;
 
     /**
-     * @param mixed[] $params
-     * @param string  $username
-     * @param string  $password
-     * @param mixed[] $driverOptions
+     * @param array<string,mixed> $driverOptions
      *
      * @throws DB2Exception
      */
-    public function __construct(array $params, $username, $password, $driverOptions = [])
-    {
-        $isPersistent = (isset($params['persistent']) && $params['persistent'] === true);
-
-        if ($isPersistent) {
-            $conn = db2_pconnect($params['dbname'], $username, $password, $driverOptions);
+    public function __construct(
+        string $database,
+        bool $persistent,
+        string $username,
+        string $password,
+        array $driverOptions = []
+    ) {
+        if ($persistent) {
+            $conn = db2_pconnect($database, $username, $password, $driverOptions);
         } else {
-            $conn = db2_connect($params['dbname'], $username, $password, $driverOptions);
+            $conn = db2_connect($database, $username, $password, $driverOptions);
         }
 
         if ($conn === false) {

--- a/src/Driver/IBMDB2/DB2Driver.php
+++ b/src/Driver/IBMDB2/DB2Driver.php
@@ -12,17 +12,14 @@ class DB2Driver extends AbstractDB2Driver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params)
     {
-        $params['user']     = $username;
-        $params['password'] = $password;
-        $params['dbname']   = DataSourceName::fromConnectionParameters($params)->toString();
-
         return new DB2Connection(
-            $params,
-            (string) $username,
-            (string) $password,
-            $driverOptions
+            DataSourceName::fromConnectionParameters($params)->toString(),
+            isset($params['persistent']) && $params['persistent'] === true,
+            $params['user'] ?? '',
+            $params['password'] ?? '',
+            $params['driver_options'] ?? []
         );
     }
 

--- a/src/Driver/Mysqli/Driver.php
+++ b/src/Driver/Mysqli/Driver.php
@@ -3,15 +3,115 @@
 namespace Doctrine\DBAL\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Doctrine\DBAL\Driver\Mysqli\Initializer\Charset;
+use Doctrine\DBAL\Driver\Mysqli\Initializer\Options;
+use Doctrine\DBAL\Driver\Mysqli\Initializer\Secure;
+
+use function count;
 
 class Driver extends AbstractMySQLDriver
 {
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params)
     {
-        return new MysqliConnection($params, (string) $username, (string) $password, $driverOptions);
+        if (! empty($params['persistent'])) {
+            if (! isset($params['host'])) {
+                throw HostRequired::forPersistentConnection();
+            }
+
+            $host = 'p:' . $params['host'];
+        } else {
+            $host = $params['host'] ?? null;
+        }
+
+        $flags = null;
+
+        $preInitializers = $postInitializers = [];
+
+        if (isset($params['driver_options'])) {
+            $driverOptions = $params['driver_options'];
+
+            if (isset($driverOptions[MysqliConnection::OPTION_FLAGS])) {
+                $flags = $driverOptions[MysqliConnection::OPTION_FLAGS];
+                unset($driverOptions[MysqliConnection::OPTION_FLAGS]);
+            }
+
+            $preInitializers = $this->withOptions($preInitializers, $driverOptions);
+        }
+
+        $preInitializers  = $this->withSecure($preInitializers, $params);
+        $postInitializers = $this->withCharset($postInitializers, $params);
+
+        return new MysqliConnection(
+            $host,
+            $params['user'] ?? null,
+            $params['password'] ?? null,
+            $params['dbname'] ?? null,
+            $params['port'] ?? null,
+            $params['unix_socket'] ?? null,
+            $flags,
+            $preInitializers,
+            $postInitializers
+        );
+    }
+
+    /**
+     * @param list<Initializer> $initializers
+     * @param array<int,mixed>  $options
+     *
+     * @return list<Initializer>
+     */
+    private function withOptions(array $initializers, array $options): array
+    {
+        if (count($options) !== 0) {
+            $initializers[] = new Options($options);
+        }
+
+        return $initializers;
+    }
+
+    /**
+     * @param list<Initializer>   $initializers
+     * @param array<string,mixed> $params
+     *
+     * @return list<Initializer>
+     */
+    private function withSecure(array $initializers, array $params): array
+    {
+        if (
+            isset($params['ssl_key']) ||
+            isset($params['ssl_cert']) ||
+            isset($params['ssl_ca']) ||
+            isset($params['ssl_capath']) ||
+            isset($params['ssl_cipher'])
+        ) {
+            $initializers[] = new Secure(
+                $params['ssl_key']    ?? null,
+                $params['ssl_cert']   ?? null,
+                $params['ssl_ca']     ?? null,
+                $params['ssl_capath'] ?? null,
+                $params['ssl_cipher'] ?? null
+            );
+        }
+
+        return $initializers;
+    }
+
+    /**
+     * @param list<Initializer>   $initializers
+     * @param array<string,mixed> $params
+     *
+     * @return list<Initializer>
+     */
+    private function withCharset(array $initializers, array $params): array
+    {
+        if (isset($params['charset'])) {
+            $initializers[] = new Charset($params['charset']);
+        }
+
+        return $initializers;
     }
 
     /**

--- a/src/Driver/Mysqli/Exception/InvalidCharset.php
+++ b/src/Driver/Mysqli/Exception/InvalidCharset.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Exception;
+
+use Doctrine\DBAL\Driver\Mysqli\MysqliException;
+use mysqli;
+
+use function sprintf;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class InvalidCharset extends MysqliException
+{
+    public static function fromCharset(mysqli $connection, string $charset): self
+    {
+        return new self(
+            sprintf('Failed to set charset "%s": %s', $charset, $connection->error),
+            $connection->sqlstate,
+            $connection->errno
+        );
+    }
+}

--- a/src/Driver/Mysqli/Exception/InvalidOption.php
+++ b/src/Driver/Mysqli/Exception/InvalidOption.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Exception;
+
+use Doctrine\DBAL\Driver\Mysqli\MysqliException;
+
+use function sprintf;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class InvalidOption extends MysqliException
+{
+    /**
+     * @param mixed $value
+     */
+    public static function fromOption(int $option, $value): self
+    {
+        return new self(
+            sprintf('Failed to set option %d with value "%s"', $option, $value)
+        );
+    }
+}

--- a/src/Driver/Mysqli/Initializer.php
+++ b/src/Driver/Mysqli/Initializer.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli;
+
+use mysqli;
+
+interface Initializer
+{
+    /**
+     * @throws MysqliException
+     */
+    public function initialize(mysqli $connection): void;
+}

--- a/src/Driver/Mysqli/Initializer/Charset.php
+++ b/src/Driver/Mysqli/Initializer/Charset.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Initializer;
+
+use Doctrine\DBAL\Driver\Mysqli\Exception\InvalidCharset;
+use Doctrine\DBAL\Driver\Mysqli\Initializer;
+use mysqli;
+
+final class Charset implements Initializer
+{
+    /** @var string */
+    private $charset;
+
+    public function __construct(string $charset)
+    {
+        $this->charset = $charset;
+    }
+
+    public function initialize(mysqli $connection): void
+    {
+        if ($connection->set_charset($this->charset)) {
+            return;
+        }
+
+        throw InvalidCharset::fromCharset($connection, $this->charset);
+    }
+}

--- a/src/Driver/Mysqli/Initializer/Options.php
+++ b/src/Driver/Mysqli/Initializer/Options.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Initializer;
+
+use Doctrine\DBAL\Driver\Mysqli\Exception\InvalidOption;
+use Doctrine\DBAL\Driver\Mysqli\Initializer;
+use mysqli;
+
+use function mysqli_options;
+
+final class Options implements Initializer
+{
+    /** @var array<int,mixed> */
+    private $options;
+
+    /**
+     * @param array<int,mixed> $options
+     */
+    public function __construct(array $options)
+    {
+        $this->options = $options;
+    }
+
+    public function initialize(mysqli $connection): void
+    {
+        foreach ($this->options as $option => $value) {
+            if (! mysqli_options($connection, $option, $value)) {
+                throw InvalidOption::fromOption($option, $value);
+            }
+        }
+    }
+}

--- a/src/Driver/Mysqli/Initializer/Secure.php
+++ b/src/Driver/Mysqli/Initializer/Secure.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Initializer;
+
+use Doctrine\DBAL\Driver\Mysqli\Initializer;
+use mysqli;
+
+final class Secure implements Initializer
+{
+    /** @var string|null */
+    private $key;
+
+    /** @var string|null */
+    private $cert;
+
+    /** @var string|null */
+    private $ca;
+
+    /** @var string|null */
+    private $capath;
+
+    /** @var string|null */
+    private $cipher;
+
+    public function __construct(?string $key, ?string $cert, ?string $ca, ?string $capath, ?string $cipher)
+    {
+        $this->key    = $key;
+        $this->cert   = $cert;
+        $this->ca     = $ca;
+        $this->capath = $capath;
+        $this->cipher = $cipher;
+    }
+
+    public function initialize(mysqli $connection): void
+    {
+        $connection->ssl_set($this->key, $this->cert, $this->ca, $this->capath, $this->cipher);
+    }
+}

--- a/src/Driver/OCI8/Driver.php
+++ b/src/Driver/OCI8/Driver.php
@@ -14,11 +14,11 @@ class Driver extends AbstractOracleDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params)
     {
         return new OCI8Connection(
-            (string) $username,
-            (string) $password,
+            $params['user'] ?? '',
+            $params['password'] ?? '',
             $this->_constructDsn($params),
             $params['charset'] ?? '',
             $params['sessionMode'] ?? OCI_NO_AUTO_COMMIT,

--- a/src/Driver/PDOMySql/Driver.php
+++ b/src/Driver/PDOMySql/Driver.php
@@ -14,16 +14,18 @@ class Driver extends AbstractMySQLDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params)
     {
+        $driverOptions = $params['driver_options'] ?? [];
+
         if (! empty($params['persistent'])) {
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
         return new PDOConnection(
             $this->constructPdoDsn($params),
-            $username,
-            $password,
+            $params['user'] ?? '',
+            $params['password'] ?? '',
             $driverOptions
         );
     }

--- a/src/Driver/PDOOracle/Driver.php
+++ b/src/Driver/PDOOracle/Driver.php
@@ -19,16 +19,18 @@ class Driver extends AbstractOracleDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params)
     {
+        $driverOptions = $params['driver_options'] ?? [];
+
         if (! empty($params['persistent'])) {
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
         return new PDOConnection(
             $this->constructPdoDsn($params),
-            $username,
-            $password,
+            $params['user'] ?? '',
+            $params['password'] ?? '',
             $driverOptions
         );
     }

--- a/src/Driver/PDOPgSql/Driver.php
+++ b/src/Driver/PDOPgSql/Driver.php
@@ -16,17 +16,19 @@ class Driver extends AbstractPostgreSQLDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params)
     {
+        $driverOptions = $params['driver_options'] ?? [];
+
         if (! empty($params['persistent'])) {
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
         $connection = new PDOConnection(
             $this->_constructPdoDsn($params),
-            $username,
-            $password,
-            $driverOptions
+            $params['user'] ?? '',
+            $params['password'] ?? '',
+            $driverOptions,
         );
 
         if (

--- a/src/Driver/PDOSqlite/Driver.php
+++ b/src/Driver/PDOSqlite/Driver.php
@@ -23,8 +23,10 @@ class Driver extends AbstractSQLiteDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params)
     {
+        $driverOptions = $params['driver_options'] ?? [];
+
         if (isset($driverOptions['userDefinedFunctions'])) {
             $this->_userDefinedFunctions = array_merge(
                 $this->_userDefinedFunctions,
@@ -35,8 +37,8 @@ class Driver extends AbstractSQLiteDriver
 
         $connection = new PDOConnection(
             $this->_constructPdoDsn($params),
-            $username,
-            $password,
+            $params['user'] ?? '',
+            $params['password'] ?? '',
             $driverOptions
         );
 

--- a/src/Driver/PDOSqlsrv/Driver.php
+++ b/src/Driver/PDOSqlsrv/Driver.php
@@ -16,15 +16,17 @@ class Driver extends AbstractSQLServerDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params)
     {
         $pdoOptions = $dsnOptions = [];
 
-        foreach ($driverOptions as $option => $value) {
-            if (is_int($option)) {
-                $pdoOptions[$option] = $value;
-            } else {
-                $dsnOptions[$option] = $value;
+        if (isset($params['driver_options'])) {
+            foreach ($params['driver_options'] as $option => $value) {
+                if (is_int($option)) {
+                    $pdoOptions[$option] = $value;
+                } else {
+                    $dsnOptions[$option] = $value;
+                }
             }
         }
 
@@ -34,8 +36,8 @@ class Driver extends AbstractSQLServerDriver
 
         return new Connection(
             $this->_constructPdoDsn($params, $dsnOptions),
-            $username,
-            $password,
+            $params['user'] ?? '',
+            $params['password'] ?? '',
             $pdoOptions
         );
     }

--- a/src/Driver/SQLSrv/Driver.php
+++ b/src/Driver/SQLSrv/Driver.php
@@ -12,7 +12,7 @@ class Driver extends AbstractSQLServerDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params)
     {
         if (! isset($params['host'])) {
             throw new SQLSrvException("Missing 'host' in configuration for sqlsrv driver.");
@@ -23,6 +23,8 @@ class Driver extends AbstractSQLServerDriver
             $serverName .= ', ' . $params['port'];
         }
 
+        $driverOptions = $params['driver_options'] ?? [];
+
         if (isset($params['dbname'])) {
             $driverOptions['Database'] = $params['dbname'];
         }
@@ -31,12 +33,12 @@ class Driver extends AbstractSQLServerDriver
             $driverOptions['CharacterSet'] = $params['charset'];
         }
 
-        if ($username !== null) {
-            $driverOptions['UID'] = $username;
+        if (isset($params['user'])) {
+            $driverOptions['UID'] = $params['user'];
         }
 
-        if ($password !== null) {
-            $driverOptions['PWD'] = $password;
+        if (isset($params['password'])) {
+            $driverOptions['PWD'] = $params['password'];
         }
 
         if (! isset($driverOptions['ReturnDatesAsStrings'])) {

--- a/tests/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Driver/Mysqli/MysqliConnectionTest.php
@@ -4,14 +4,11 @@ namespace Doctrine\DBAL\Tests\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\Mysqli\HostRequired;
 use Doctrine\DBAL\Driver\Mysqli\MysqliConnection;
-use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
 use function extension_loaded;
-use function restore_error_handler;
-use function set_error_handler;
 
 class MysqliConnectionTest extends FunctionalTestCase
 {
@@ -42,26 +39,6 @@ class MysqliConnectionTest extends FunctionalTestCase
     public function testDoesNotRequireQueryForServerVersion(): void
     {
         self::assertFalse($this->connectionMock->requiresQueryForServerVersion());
-    }
-
-    public function testRestoresErrorHandlerOnException(): void
-    {
-        $handler = static function (): bool {
-            self::fail('Never expected this to be called');
-        };
-
-        $defaultHandler = set_error_handler($handler);
-
-        try {
-            new MysqliConnection(['host' => '255.255.255.255'], 'user', 'pass');
-            self::fail('An exception was supposed to be raised');
-        } catch (MysqliException $e) {
-            self::assertSame('Network is unreachable', $e->getMessage());
-        }
-
-        self::assertSame($handler, set_error_handler($defaultHandler), 'Restoring error handler failed.');
-        restore_error_handler();
-        restore_error_handler();
     }
 
     public function testHostnameIsRequiredForPersistentConnection(): void

--- a/tests/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Driver/Mysqli/MysqliConnectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Driver\Mysqli;
 
+use Doctrine\DBAL\Driver\Mysqli\Driver;
 use Doctrine\DBAL\Driver\Mysqli\HostRequired;
 use Doctrine\DBAL\Driver\Mysqli\MysqliConnection;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
@@ -44,6 +45,6 @@ class MysqliConnectionTest extends FunctionalTestCase
     public function testHostnameIsRequiredForPersistentConnection(): void
     {
         $this->expectException(HostRequired::class);
-        new MysqliConnection(['persistent' => 'true'], '', '');
+        (new Driver())->connect(['persistent' => 'true']);
     }
 }

--- a/tests/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Driver/PDOPgSql/DriverTest.php
@@ -3,12 +3,14 @@
 namespace Doctrine\DBAL\Tests\Driver\PDOPgSql;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\PDOPgSql\Driver;
 use Doctrine\DBAL\Tests\Driver\AbstractPostgreSQLDriverTest;
 use Doctrine\DBAL\Tests\TestUtil;
 use PDO;
 use PDOException;
+
+use function array_merge;
 
 class DriverTest extends AbstractPostgreSQLDriverTest
 {
@@ -92,15 +94,13 @@ class DriverTest extends AbstractPostgreSQLDriverTest
     /**
      * @param array<int,mixed> $driverOptions
      */
-    private function connect(array $driverOptions): PDOConnection
+    private function connect(array $driverOptions): Connection
     {
-        $params = TestUtil::getConnectionParams();
-
         return $this->createDriver()->connect(
-            $params,
-            $params['user'] ?? '',
-            $params['password'] ?? '',
-            $driverOptions
+            array_merge(
+                TestUtil::getConnectionParams(),
+                ['driver_options' => $driverOptions]
+            )
         );
     }
 }

--- a/tests/Functional/Driver/AbstractDriverTest.php
+++ b/tests/Functional/Driver/AbstractDriverTest.php
@@ -31,10 +31,7 @@ abstract class AbstractDriverTest extends FunctionalTestCase
         $params = $this->connection->getParams();
         unset($params['dbname']);
 
-        $user     = $params['user'] ?? null;
-        $password = $params['password'] ?? null;
-
-        $connection = $this->driver->connect($params, $user, $password);
+        $connection = $this->driver->connect($params);
 
         self::assertInstanceOf(DriverConnection::class, $connection);
     }

--- a/tests/Functional/Driver/Mysqli/ConnectionTest.php
+++ b/tests/Functional/Driver/Mysqli/ConnectionTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 
+use function array_merge;
 use function extension_loaded;
 
 use const MYSQLI_OPT_CONNECT_TIMEOUT;
@@ -73,11 +74,11 @@ class ConnectionTest extends FunctionalTestCase
     {
         $params = TestUtil::getConnectionParams();
 
-        return new MysqliConnection(
-            $params,
-            $params['user'] ?? '',
-            $params['password'] ?? '',
-            $driverOptions
+        return (new Driver())->connect(
+            array_merge(
+                $params,
+                ['driver_options' => $driverOptions]
+            )
         );
     }
 }

--- a/tests/Functional/Driver/Mysqli/ConnectionTest.php
+++ b/tests/Functional/Driver/Mysqli/ConnectionTest.php
@@ -47,6 +47,19 @@ class ConnectionTest extends FunctionalTestCase
         $this->getConnection([12345 => 'world']);
     }
 
+    public function testInvalidCharset(): void
+    {
+        $params = TestUtil::getConnectionParams();
+
+        $this->expectException(MysqliException::class);
+        (new Driver())->connect(
+            array_merge(
+                $params,
+                ['charset' => 'invalid']
+            )
+        );
+    }
+
     public function testPing(): void
     {
         $conn = $this->getConnection([]);

--- a/tests/Functional/Driver/Mysqli/ConnectionTest.php
+++ b/tests/Functional/Driver/Mysqli/ConnectionTest.php
@@ -44,7 +44,7 @@ class ConnectionTest extends FunctionalTestCase
     {
         $this->expectException(MysqliException::class);
 
-        $this->getConnection(['hello' => 'world']); // use local infile
+        $this->getConnection([12345 => 'world']);
     }
 
     public function testPing(): void

--- a/tests/Functional/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Functional/Driver/PDOPgSql/DriverTest.php
@@ -78,10 +78,7 @@ class DriverTest extends AbstractDriverTest
         $parameters                     = $this->connection->getParams();
         $parameters['application_name'] = 'doctrine';
 
-        $user     = $parameters['user'] ?? null;
-        $password = $parameters['password'] ?? null;
-
-        $connection = $this->driver->connect($parameters, $user, $password);
+        $connection = $this->driver->connect($parameters);
 
         $hash    = microtime(true); // required to identify the record in the results uniquely
         $sql     = sprintf('SELECT * FROM pg_stat_activity WHERE %d = %d', $hash, $hash);

--- a/tests/Functional/Driver/PDOSqlsrv/DriverTest.php
+++ b/tests/Functional/Driver/PDOSqlsrv/DriverTest.php
@@ -10,8 +10,8 @@ use Doctrine\DBAL\Tests\Functional\Driver\AbstractDriverTest;
 use Doctrine\DBAL\Tests\TestUtil;
 use PDO;
 
+use function array_merge;
 use function assert;
-
 use function extension_loaded;
 
 class DriverTest extends AbstractDriverTest
@@ -46,13 +46,11 @@ class DriverTest extends AbstractDriverTest
      */
     protected function getConnection(array $driverOptions): Connection
     {
-        $params = TestUtil::getConnectionParams();
-
         return $this->connection->getDriver()->connect(
-            $params,
-            $params['user'] ?? '',
-            $params['password'] ?? '',
-            $driverOptions
+            array_merge(
+                TestUtil::getConnectionParams(),
+                ['driver_options' => $driverOptions]
+            )
         );
     }
 

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -117,10 +117,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             $params['dbname'] = 'test_drop_database';
         }
 
-        $user     = $params['user'] ?? null;
-        $password = $params['password'] ?? null;
-
-        $connection = $this->connection->getDriver()->connect($params, $user, $password);
+        $connection = $this->connection->getDriver()->connect($params);
 
         self::assertInstanceOf(Connection::class, $connection);
 

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -50,10 +50,7 @@ class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $params           = $this->connection->getParams();
         $params['dbname'] = 'test_drop_database';
 
-        $user     = $params['user'] ?? null;
-        $password = $params['password'] ?? null;
-
-        $connection = $this->connection->getDriver()->connect($params, $user, $password);
+        $connection = $this->connection->getDriver()->connect($params);
 
         self::assertInstanceOf(Connection::class, $connection);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

API design considerations:

1. `Driver::connect()` is an adapter between the DBAL `Connection::connect()` and the `Driver\Connection::__construct()` APIs. It should do all conversion of the parameters and not leak `array $params` into the connection.
2. `Driver\Connection::__construct()` is a tiny wrapper over the underlying driver's "connect" function. Its API should be as close to the "connect" function as possible but not too close to have to leak the underlying connection resource back to the driver like it happens in some PDO drivers:
   1. https://github.com/doctrine/dbal/blob/ae8c7208f64fa4647709df0232ea8514a4299169/src/Driver/PDOPgSql/Driver.php#L38
   2. https://github.com/doctrine/dbal/blob/ae8c7208f64fa4647709df0232ea8514a4299169/src/Driver/PDOSqlite/Driver.php#L43-L47
   In order to avoid the leakage but not to have too many parameters in MySQLi connection constructor either, a concept of connection initializers has been introduced. It can be thought of as an implementation of the Builder or Functional Options pattern.

**Additional changes**:
1. The custom error handler in MySQLi connection has been removed in favor of an error suppression operator. The error handler would yield the same results but required maintenance and a dedicated unit test that doesn't pass on Windows. Additionally, it masked improper usage of `$connection->sqlstate` in case of a connection failure (should help fixing #3947).
2. `$supportedDriverOptions` have been removed from the MySQLi connection. Whether the option is supported will be determined by the call to `mysqli_options()`. The previous approach led to improper error handling around `mysqli_options()` because an error was impossible to reproduce.

Although the code implementing secure MySQLi connection has been modified, it's not tested as it never was. It should be possible to set up a build job using [cyprien/mysql-tls](https://hub.docker.com/r/cyprien/mysql-tls/) on Travis later.

Fixes #4069