### PR TITLE
Allow using on PHP 7.3 with Composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
+        "composer/package-versions-deprecated": "^1.8",
         "doctrine/cache": "^1.0",
-        "doctrine/event-manager": "^1.0",
-        "ocramius/package-versions": "^1.4"
+        "doctrine/event-manager": "^1.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^8.0",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

In order to support Composer 2, `ocramius/package-versions` requires PHP 7.4.
This effectively means that using it in "require" forces ppl on PHP 7.3 to use Composer 1.

@seldaek created the `composer/package-versions-deprecated` to unlock this situation.