### PR TITLE
Mark Connection::getParams() internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.11
 
+## `Connection::getParams()` has been marked internal
+
+Consumers of the Connection class should not rely on connection parameters stored in the connection object. If needed, they should be obtained from a different source, e.g. application configuration.
+
 ## Deprecated `Doctrine\DBAL\Driver::getDatabase()`
 
 - The usage of `Doctrine\DBAL\Driver::getDatabase()` is deprecated. Please use `Doctrine\DBAL\Connection::getDatabase()` instead.

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -225,6 +225,8 @@ class Connection implements DriverConnection
     /**
      * Gets the parameters used during instantiation.
      *
+     * @internal
+     *
      * @return mixed[]
      */
     public function getParams()
@@ -1199,7 +1201,7 @@ class Connection implements DriverConnection
             throw CacheException::noResultDriverConfigured();
         }
 
-        $connectionParams = $this->getParams();
+        $connectionParams = $this->params;
         unset($connectionParams['platform']);
 
         [$cacheKey, $realKey] = $qcp->generateCacheKeys($query, $params, $types, $connectionParams);

--- a/lib/Doctrine/DBAL/Id/TableGenerator.php
+++ b/lib/Doctrine/DBAL/Id/TableGenerator.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Id;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\LockMode;
 use Throwable;
@@ -69,12 +70,16 @@ class TableGenerator
      */
     public function __construct(Connection $conn, $generatorTableName = 'sequences')
     {
-        $params = $conn->getParams();
-        if ($params['driver'] === 'pdo_sqlite') {
+        if ($conn->getDriver() instanceof Driver\PDOSqlite\Driver) {
             throw new DBALException('Cannot use TableGenerator with SQLite.');
         }
 
-        $this->conn               = DriverManager::getConnection($params, $conn->getConfiguration(), $conn->getEventManager());
+        $this->conn = DriverManager::getConnection(
+            $conn->getParams(),
+            $conn->getConfiguration(),
+            $conn->getEventManager()
+        );
+
         $this->generatorTableName = $generatorTableName;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | -
| BC Break     | no

See #3593. I don't think I'll be able to get rid of all calls in one shot, especially given the low priority of the issue. Instead of deprecating the method, let's mark it internal (which it really is) and try to address each usage individually.

Some of them are much easier to get rid of in `3.0.x`. For instance, 

https://github.com/doctrine/dbal/blob/7b937a82afb39f45f67183ebf11e31669e620728/src/Portability/Connection.php#L38