### PR TITLE
Make the $database argument of OracleSchemaManager::createDatabase() mandatory

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC BREAK: Changes in `OracleSchemaManager::createDatabase()`
+
+The `$database` argument is no longer nullable or optional.
+
 ## BC BREAK: `Doctrine\DBAL\Types\Type::__toString()` removed
 
 Relying on string representation was discouraged and has been removed.

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -279,17 +279,9 @@ class OracleSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritdoc}
-     *
-     * @param string|null $database
-     *
-     * Calling this method without an argument or by passing NULL is deprecated.
      */
-    public function createDatabase($database = null)
+    public function createDatabase($database)
     {
-        if ($database === null) {
-            $database = $this->_conn->getDatabase();
-        }
-
         $params   = $this->_conn->getParams();
         $username = $database;
         $password = $params['password'];


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
