### PR TITLE
Deprecate inconsistently and ambiguously named driver-level classes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,37 @@
 # Upgrade to 2.11
 
+## Inconsistently and ambiguously named driver-level classes are deprecated
+
+The following classes under the `Driver` namespace have been deprecated in favor of their consistently named counterparts:
+
+- `DriverException` → `Exception`
+- `AbstractDriverException` → `AbstractException`
+- `IBMDB2\DB2Driver` → `IBMDB2\Driver`
+- `IBMDB2\DB2Connection` → `IBMDB2\Connection`
+- `IBMDB2\DB2Statement` → `IBMDB2\Statement`
+- `Mysqli\MysqliConnection` → `Mysqli\Connection`
+- `Mysqli\MysqliStatement` → `Mysqli\Statement`
+- `OCI8\OCI8Connection` → `OCI8\Connection`
+- `OCI8\OCI8Statement` → `OCI8\Statement`
+- `SQLSrv\SQLSrvConnection` → `SQLSrv\Connection`
+- `SQLSrv\SQLSrvStatement` → `SQLSrv\Statement`
+- `PDOConnection` → `PDO\Connection`
+- `PDOStatement` → `PDO\Statement`
+
+All driver-specific exception classes have been deprecated:
+
+- `IBMDB2\DB2Exception`
+- `Mysqli\MysqliException`
+- `OCI8\OCI8Exception`
+- `PDOException`
+- `SQLSrv\SQLSrvException`
+
+A driver-level exception should be only identified as a subtype of `Driver\Exception`.
+Internal driver-level exception implementations may use `Driver\AbstractException` as the base class.
+Driver-specific exception handling has to be implemented either in the driver or based on the type of the `Driver` implementation.
+
+The `Driver\AbstractException` class has been marked internal.
+
 ## `Connection::getParams()` has been marked internal
 
 Consumers of the Connection class should not rely on connection parameters stored in the connection object. If needed, they should be obtained from a different source, e.g. application configuration.

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL\Cache;
 
 use ArrayIterator;
 use Doctrine\Common\Cache\Cache;
-use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\ResultStatement;
@@ -297,7 +297,7 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement, Result
     /**
      * @return array<string,mixed>|false
      *
-     * @throws DriverException
+     * @throws Exception
      */
     private function doFetch()
     {

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL;
 
-use Doctrine\DBAL\Driver\DriverException as DriverExceptionInterface;
+use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -168,7 +168,7 @@ class DBALException extends Exception
             return $driverEx;
         }
 
-        if ($driver instanceof ExceptionConverterDriver && $driverEx instanceof DriverExceptionInterface) {
+        if ($driver instanceof ExceptionConverterDriver && $driverEx instanceof DeprecatedDriverException) {
             return $driver->convertException($msg, $driverEx);
         }
 

--- a/lib/Doctrine/DBAL/Driver/AbstractDriverException.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractDriverException.php
@@ -2,55 +2,11 @@
 
 namespace Doctrine\DBAL\Driver;
 
-use Exception;
-
 /**
- * Abstract base implementation of the {@link DriverException} interface.
+ * @deprecated
  *
  * @psalm-immutable
  */
-abstract class AbstractDriverException extends Exception implements DriverException
+class AbstractDriverException extends AbstractException
 {
-    /**
-     * The driver specific error code.
-     *
-     * @var int|string|null
-     */
-    private $errorCode;
-
-    /**
-     * The SQLSTATE of the driver.
-     *
-     * @var string|null
-     */
-    private $sqlState;
-
-    /**
-     * @param string          $message   The driver error message.
-     * @param string|null     $sqlState  The SQLSTATE the driver is in at the time the error occurred, if any.
-     * @param int|string|null $errorCode The driver specific error code if any.
-     */
-    public function __construct($message, $sqlState = null, $errorCode = null)
-    {
-        parent::__construct($message);
-
-        $this->errorCode = $errorCode;
-        $this->sqlState  = $sqlState;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getErrorCode()
-    {
-        return $this->errorCode;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLState()
-    {
-        return $this->sqlState;
-    }
 }

--- a/lib/Doctrine/DBAL/Driver/AbstractException.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractException.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver;
+
+use Exception as BaseException;
+
+/**
+ * Base implementation of the {@link Exception} interface.
+ *
+ * @internal
+ *
+ * @psalm-immutable
+ */
+abstract class AbstractException extends BaseException implements DriverException
+{
+    /**
+     * The driver specific error code.
+     *
+     * @var int|string|null
+     */
+    private $errorCode;
+
+    /**
+     * The SQLSTATE of the driver.
+     *
+     * @var string|null
+     */
+    private $sqlState;
+
+    /**
+     * @param string          $message   The driver error message.
+     * @param string|null     $sqlState  The SQLSTATE the driver is in at the time the error occurred, if any.
+     * @param int|string|null $errorCode The driver specific error code if any.
+     */
+    public function __construct($message, $sqlState = null, $errorCode = null)
+    {
+        parent::__construct($message);
+
+        $this->errorCode = $errorCode;
+        $this->sqlState  = $sqlState;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorCode()
+    {
+        return $this->errorCode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLState()
+    {
+        return $this->sqlState;
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -5,7 +5,19 @@ namespace Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
+use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
+use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
+use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
+use Doctrine\DBAL\Exception\SyntaxErrorException;
+use Doctrine\DBAL\Exception\TableExistsException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
@@ -19,7 +31,7 @@ use function stripos;
 use function version_compare;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for MySQL based drivers.
+ * Abstract base implementation of the {@link Driver} interface for MySQL based drivers.
  */
 abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, VersionAwarePlatformDriver
 {
@@ -29,44 +41,44 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
      * @link https://dev.mysql.com/doc/refman/8.0/en/client-error-reference.html
      * @link https://dev.mysql.com/doc/refman/8.0/en/server-error-reference.html
      */
-    public function convertException($message, DriverException $exception)
+    public function convertException($message, DeprecatedDriverException $exception)
     {
         switch ($exception->getErrorCode()) {
             case '1213':
-                return new Exception\DeadlockException($message, $exception);
+                return new DeadlockException($message, $exception);
 
             case '1205':
-                return new Exception\LockWaitTimeoutException($message, $exception);
+                return new LockWaitTimeoutException($message, $exception);
 
             case '1050':
-                return new Exception\TableExistsException($message, $exception);
+                return new TableExistsException($message, $exception);
 
             case '1051':
             case '1146':
-                return new Exception\TableNotFoundException($message, $exception);
+                return new TableNotFoundException($message, $exception);
 
             case '1216':
             case '1217':
             case '1451':
             case '1452':
             case '1701':
-                return new Exception\ForeignKeyConstraintViolationException($message, $exception);
+                return new ForeignKeyConstraintViolationException($message, $exception);
 
             case '1062':
             case '1557':
             case '1569':
             case '1586':
-                return new Exception\UniqueConstraintViolationException($message, $exception);
+                return new UniqueConstraintViolationException($message, $exception);
 
             case '1054':
             case '1166':
             case '1611':
-                return new Exception\InvalidFieldNameException($message, $exception);
+                return new InvalidFieldNameException($message, $exception);
 
             case '1052':
             case '1060':
             case '1110':
-                return new Exception\NonUniqueFieldNameException($message, $exception);
+                return new NonUniqueFieldNameException($message, $exception);
 
             case '1064':
             case '1149':
@@ -80,7 +92,7 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
             case '1541':
             case '1554':
             case '1626':
-                return new Exception\SyntaxErrorException($message, $exception);
+                return new SyntaxErrorException($message, $exception);
 
             case '1044':
             case '1045':
@@ -94,7 +106,7 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
             case '1429':
             case '2002':
             case '2005':
-                return new Exception\ConnectionException($message, $exception);
+                return new ConnectionException($message, $exception);
 
             case '1048':
             case '1121':
@@ -104,10 +116,10 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
             case '1263':
             case '1364':
             case '1566':
-                return new Exception\NotNullConstraintViolationException($message, $exception);
+                return new NotNullConstraintViolationException($message, $exception);
         }
 
-        return new Exception\DriverException($message, $exception);
+        return new DriverException($message, $exception);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
@@ -5,56 +5,66 @@ namespace Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\AbstractOracleDriver\EasyConnectString;
-use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
+use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
+use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
+use Doctrine\DBAL\Exception\SyntaxErrorException;
+use Doctrine\DBAL\Exception\TableExistsException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\OracleSchemaManager;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for Oracle based drivers.
+ * Abstract base implementation of the {@link Driver} interface for Oracle based drivers.
  */
 abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
 {
     /**
      * {@inheritdoc}
      */
-    public function convertException($message, DriverException $exception)
+    public function convertException($message, DeprecatedDriverException $exception)
     {
         switch ($exception->getErrorCode()) {
             case '1':
             case '2299':
             case '38911':
-                return new Exception\UniqueConstraintViolationException($message, $exception);
+                return new UniqueConstraintViolationException($message, $exception);
 
             case '904':
-                return new Exception\InvalidFieldNameException($message, $exception);
+                return new InvalidFieldNameException($message, $exception);
 
             case '918':
             case '960':
-                return new Exception\NonUniqueFieldNameException($message, $exception);
+                return new NonUniqueFieldNameException($message, $exception);
 
             case '923':
-                return new Exception\SyntaxErrorException($message, $exception);
+                return new SyntaxErrorException($message, $exception);
 
             case '942':
-                return new Exception\TableNotFoundException($message, $exception);
+                return new TableNotFoundException($message, $exception);
 
             case '955':
-                return new Exception\TableExistsException($message, $exception);
+                return new TableExistsException($message, $exception);
 
             case '1017':
             case '12545':
-                return new Exception\ConnectionException($message, $exception);
+                return new ConnectionException($message, $exception);
 
             case '1400':
-                return new Exception\NotNullConstraintViolationException($message, $exception);
+                return new NotNullConstraintViolationException($message, $exception);
 
             case '2266':
             case '2291':
             case '2292':
-                return new Exception\ForeignKeyConstraintViolationException($message, $exception);
+                return new ForeignKeyConstraintViolationException($message, $exception);
         }
 
-        return new Exception\DriverException($message, $exception);
+        return new DriverException($message, $exception);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
@@ -5,7 +5,18 @@ namespace Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
+use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
+use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
+use Doctrine\DBAL\Exception\SyntaxErrorException;
+use Doctrine\DBAL\Exception\TableExistsException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL91Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL92Platform;
@@ -20,7 +31,7 @@ use function strpos;
 use function version_compare;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for PostgreSQL based drivers.
+ * Abstract base implementation of the {@link Driver} interface for PostgreSQL based drivers.
  */
 abstract class AbstractPostgreSQLDriver implements Driver, ExceptionConverterDriver, VersionAwarePlatformDriver
 {
@@ -29,58 +40,58 @@ abstract class AbstractPostgreSQLDriver implements Driver, ExceptionConverterDri
      *
      * @link http://www.postgresql.org/docs/9.3/static/errcodes-appendix.html
      */
-    public function convertException($message, DriverException $exception)
+    public function convertException($message, DeprecatedDriverException $exception)
     {
         switch ($exception->getSQLState()) {
             case '40001':
             case '40P01':
-                return new Exception\DeadlockException($message, $exception);
+                return new DeadlockException($message, $exception);
 
             case '0A000':
                 // Foreign key constraint violations during a TRUNCATE operation
                 // are considered "feature not supported" in PostgreSQL.
                 if (strpos($exception->getMessage(), 'truncate') !== false) {
-                    return new Exception\ForeignKeyConstraintViolationException($message, $exception);
+                    return new ForeignKeyConstraintViolationException($message, $exception);
                 }
 
                 break;
 
             case '23502':
-                return new Exception\NotNullConstraintViolationException($message, $exception);
+                return new NotNullConstraintViolationException($message, $exception);
 
             case '23503':
-                return new Exception\ForeignKeyConstraintViolationException($message, $exception);
+                return new ForeignKeyConstraintViolationException($message, $exception);
 
             case '23505':
-                return new Exception\UniqueConstraintViolationException($message, $exception);
+                return new UniqueConstraintViolationException($message, $exception);
 
             case '42601':
-                return new Exception\SyntaxErrorException($message, $exception);
+                return new SyntaxErrorException($message, $exception);
 
             case '42702':
-                return new Exception\NonUniqueFieldNameException($message, $exception);
+                return new NonUniqueFieldNameException($message, $exception);
 
             case '42703':
-                return new Exception\InvalidFieldNameException($message, $exception);
+                return new InvalidFieldNameException($message, $exception);
 
             case '42P01':
-                return new Exception\TableNotFoundException($message, $exception);
+                return new TableNotFoundException($message, $exception);
 
             case '42P07':
-                return new Exception\TableExistsException($message, $exception);
+                return new TableExistsException($message, $exception);
 
             case '7':
                 // In some case (mainly connection errors) the PDO exception does not provide a SQLSTATE via its code.
                 // The exception code is always set to 7 here.
                 // We have to match against the SQLSTATE in the error message in these cases.
                 if (strpos($exception->getMessage(), 'SQLSTATE[08006]') !== false) {
-                    return new Exception\ConnectionException($message, $exception);
+                    return new ConnectionException($message, $exception);
                 }
 
                 break;
         }
 
-        return new Exception\DriverException($message, $exception);
+        return new DriverException($message, $exception);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
@@ -5,7 +5,19 @@ namespace Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
+use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
+use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
+use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
+use Doctrine\DBAL\Exception\SyntaxErrorException;
+use Doctrine\DBAL\Exception\TableExistsException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Platforms\SQLAnywhere11Platform;
 use Doctrine\DBAL\Platforms\SQLAnywhere12Platform;
 use Doctrine\DBAL\Platforms\SQLAnywhere16Platform;
@@ -18,7 +30,7 @@ use function preg_match;
 use function version_compare;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for SAP Sybase SQL Anywhere based drivers.
+ * Abstract base implementation of the {@link Driver} interface for SAP Sybase SQL Anywhere based drivers.
  */
 abstract class AbstractSQLAnywhereDriver implements Driver, ExceptionConverterDriver, VersionAwarePlatformDriver
 {
@@ -27,54 +39,54 @@ abstract class AbstractSQLAnywhereDriver implements Driver, ExceptionConverterDr
      *
      * @link http://dcx.sybase.com/index.html#sa160/en/saerrors/sqlerror.html
      */
-    public function convertException($message, DriverException $exception)
+    public function convertException($message, DeprecatedDriverException $exception)
     {
         switch ($exception->getErrorCode()) {
             case '-306':
             case '-307':
             case '-684':
-                return new Exception\DeadlockException($message, $exception);
+                return new DeadlockException($message, $exception);
 
             case '-210':
             case '-1175':
             case '-1281':
-                return new Exception\LockWaitTimeoutException($message, $exception);
+                return new LockWaitTimeoutException($message, $exception);
 
             case '-100':
             case '-103':
             case '-832':
-                return new Exception\ConnectionException($message, $exception);
+                return new ConnectionException($message, $exception);
 
             case '-143':
-                return new Exception\InvalidFieldNameException($message, $exception);
+                return new InvalidFieldNameException($message, $exception);
 
             case '-193':
             case '-196':
-                return new Exception\UniqueConstraintViolationException($message, $exception);
+                return new UniqueConstraintViolationException($message, $exception);
 
             case '-194':
             case '-198':
-                return new Exception\ForeignKeyConstraintViolationException($message, $exception);
+                return new ForeignKeyConstraintViolationException($message, $exception);
 
             case '-144':
-                return new Exception\NonUniqueFieldNameException($message, $exception);
+                return new NonUniqueFieldNameException($message, $exception);
 
             case '-184':
             case '-195':
-                return new Exception\NotNullConstraintViolationException($message, $exception);
+                return new NotNullConstraintViolationException($message, $exception);
 
             case '-131':
-                return new Exception\SyntaxErrorException($message, $exception);
+                return new SyntaxErrorException($message, $exception);
 
             case '-110':
-                return new Exception\TableExistsException($message, $exception);
+                return new TableExistsException($message, $exception);
 
             case '-141':
             case '-1041':
-                return new Exception\TableNotFoundException($message, $exception);
+                return new TableNotFoundException($message, $exception);
         }
 
-        return new Exception\DriverException($message, $exception);
+        return new DriverException($message, $exception);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver/Exception/PortWithoutHost.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver/Exception/PortWithoutHost.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\DBAL\Driver\AbstractSQLServerDriver;
+namespace Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception;
 
-use Doctrine\DBAL\Driver\AbstractDriverException;
+use Doctrine\DBAL\Driver\AbstractException;
 
 /**
  * @internal
  *
  * @psalm-immutable
  */
-final class PortWithoutHost extends AbstractDriverException
+final class PortWithoutHost extends AbstractException
 {
     public static function new(): self
     {

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
@@ -4,7 +4,19 @@ namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
+use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
+use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
+use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
+use Doctrine\DBAL\Exception\ReadOnlyException;
+use Doctrine\DBAL\Exception\SyntaxErrorException;
+use Doctrine\DBAL\Exception\TableExistsException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\SqliteSchemaManager;
 
@@ -20,10 +32,10 @@ abstract class AbstractSQLiteDriver implements Driver, ExceptionConverterDriver
      *
      * @link http://www.sqlite.org/c3ref/c_abort.html
      */
-    public function convertException($message, DriverException $exception)
+    public function convertException($message, DeprecatedDriverException $exception)
     {
         if (strpos($exception->getMessage(), 'database is locked') !== false) {
-            return new Exception\LockWaitTimeoutException($message, $exception);
+            return new LockWaitTimeoutException($message, $exception);
         }
 
         if (
@@ -32,49 +44,49 @@ abstract class AbstractSQLiteDriver implements Driver, ExceptionConverterDriver
             strpos($exception->getMessage(), 'are not unique') !== false ||
             strpos($exception->getMessage(), 'UNIQUE constraint failed') !== false
         ) {
-            return new Exception\UniqueConstraintViolationException($message, $exception);
+            return new UniqueConstraintViolationException($message, $exception);
         }
 
         if (
             strpos($exception->getMessage(), 'may not be NULL') !== false ||
             strpos($exception->getMessage(), 'NOT NULL constraint failed') !== false
         ) {
-            return new Exception\NotNullConstraintViolationException($message, $exception);
+            return new NotNullConstraintViolationException($message, $exception);
         }
 
         if (strpos($exception->getMessage(), 'no such table:') !== false) {
-            return new Exception\TableNotFoundException($message, $exception);
+            return new TableNotFoundException($message, $exception);
         }
 
         if (strpos($exception->getMessage(), 'already exists') !== false) {
-            return new Exception\TableExistsException($message, $exception);
+            return new TableExistsException($message, $exception);
         }
 
         if (strpos($exception->getMessage(), 'has no column named') !== false) {
-            return new Exception\InvalidFieldNameException($message, $exception);
+            return new InvalidFieldNameException($message, $exception);
         }
 
         if (strpos($exception->getMessage(), 'ambiguous column name') !== false) {
-            return new Exception\NonUniqueFieldNameException($message, $exception);
+            return new NonUniqueFieldNameException($message, $exception);
         }
 
         if (strpos($exception->getMessage(), 'syntax error') !== false) {
-            return new Exception\SyntaxErrorException($message, $exception);
+            return new SyntaxErrorException($message, $exception);
         }
 
         if (strpos($exception->getMessage(), 'attempt to write a readonly database') !== false) {
-            return new Exception\ReadOnlyException($message, $exception);
+            return new ReadOnlyException($message, $exception);
         }
 
         if (strpos($exception->getMessage(), 'unable to open database file') !== false) {
-            return new Exception\ConnectionException($message, $exception);
+            return new ConnectionException($message, $exception);
         }
 
         if (strpos($exception->getMessage(), 'FOREIGN KEY constraint failed') !== false) {
-            return new Exception\ForeignKeyConstraintViolationException($message, $exception);
+            return new ForeignKeyConstraintViolationException($message, $exception);
         }
 
-        return new Exception\DriverException($message, $exception);
+        return new DriverException($message, $exception);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/DriverException.php
+++ b/lib/Doctrine/DBAL/Driver/DriverException.php
@@ -2,34 +2,11 @@
 
 namespace Doctrine\DBAL\Driver;
 
-use Throwable;
-
 /**
- * Contract for a driver exception.
- *
- * Driver exceptions provide the SQLSTATE of the driver
- * and the driver specific error code at the time the error occurred.
+ * @deprecated Use {@link Exception} instead
  *
  * @psalm-immutable
  */
-interface DriverException extends Throwable
+interface DriverException extends Exception
 {
-    /**
-     * Returns the driver specific error code if available.
-     *
-     * Returns null if no driver specific error code is available
-     * for the error raised by the driver.
-     *
-     * @return int|string|null
-     */
-    public function getErrorCode();
-
-    /**
-     * Returns the SQLSTATE the driver was in at the time the error occurred.
-     *
-     * Returns null if the driver does not provide a SQLSTATE for the error occurred.
-     *
-     * @return string|null
-     */
-    public function getSQLState();
 }

--- a/lib/Doctrine/DBAL/Driver/Exception.php
+++ b/lib/Doctrine/DBAL/Driver/Exception.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver;
+
+use Throwable;
+
+/**
+ * @psalm-immutable
+ */
+interface Exception extends Throwable
+{
+    /**
+     * Returns the driver specific error code if available.
+     *
+     * Returns null if no driver specific error code is available
+     * for the error raised by the driver.
+     *
+     * @return int|string|null
+     */
+    public function getErrorCode();
+
+    /**
+     * Returns the SQLSTATE the driver was in at the time the error occurred.
+     *
+     * Returns null if the driver does not provide a SQLSTATE for the error occurred.
+     *
+     * @return string|null
+     */
+    public function getSQLState();
+}

--- a/lib/Doctrine/DBAL/Driver/ExceptionConverterDriver.php
+++ b/lib/Doctrine/DBAL/Driver/ExceptionConverterDriver.php
@@ -2,6 +2,9 @@
 
 namespace Doctrine\DBAL\Driver;
 
+use Doctrine\DBAL\Driver\DriverException as TheDriverException;
+use Doctrine\DBAL\Exception\DriverException;
+
 /**
  * Contract for a driver that is capable of converting DBAL driver exceptions into standardized DBAL driver exceptions.
  */
@@ -11,12 +14,12 @@ interface ExceptionConverterDriver
      * Converts a given DBAL driver exception into a standardized DBAL driver exception.
      *
      * It evaluates the vendor specific error code and SQLSTATE and transforms
-     * it into a unified {@link Doctrine\DBAL\Exception\DriverException} subclass.
+     * it into a unified {@link DriverException} subclass.
      *
-     * @param string          $message   The DBAL exception message to use.
-     * @param DriverException $exception The DBAL driver exception to convert.
+     * @param string             $message   The DBAL exception message to use.
+     * @param TheDriverException $exception The DBAL driver exception to convert.
      *
-     * @return \Doctrine\DBAL\Exception\DriverException An instance of one of the DriverException subclasses.
+     * @return DriverException An instance of one of the DriverException subclasses.
      */
-    public function convertException($message, DriverException $exception);
+    public function convertException($message, TheDriverException $exception);
 }

--- a/lib/Doctrine/DBAL/Driver/FetchUtils.php
+++ b/lib/Doctrine/DBAL/Driver/FetchUtils.php
@@ -12,7 +12,7 @@ final class FetchUtils
     /**
      * @return mixed|false
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public static function fetchOne(Result $result)
     {
@@ -28,7 +28,7 @@ final class FetchUtils
     /**
      * @return array<int,array<int,mixed>>
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public static function fetchAllNumeric(Result $result): array
     {
@@ -44,7 +44,7 @@ final class FetchUtils
     /**
      * @return array<int,array<string,mixed>>
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public static function fetchAllAssociative(Result $result): array
     {
@@ -60,7 +60,7 @@ final class FetchUtils
     /**
      * @return array<int,mixed>
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public static function fetchFirstColumn(Result $result): array
     {

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Connection.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\IBMDB2;
+
+final class Connection extends DB2Connection
+{
+}

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Driver\IBMDB2;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionError;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionFailed;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\PrepareFailed;
@@ -31,7 +31,10 @@ use function is_bool;
 use const DB2_AUTOCOMMIT_OFF;
 use const DB2_AUTOCOMMIT_ON;
 
-class DB2Connection implements Connection, ServerInfoAwareConnection
+/**
+ * @deprecated Use {@link Connection} instead
+ */
+class DB2Connection implements ConnectionInterface, ServerInfoAwareConnection
 {
     /** @var resource */
     private $conn = null;
@@ -91,7 +94,7 @@ class DB2Connection implements Connection, ServerInfoAwareConnection
             throw PrepareFailed::new(error_get_last()['message']);
         }
 
-        return new DB2Statement($stmt);
+        return new Statement($stmt);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Driver.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Driver.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\Driver\AbstractDB2Driver;
 
 /**
  * IBM DB2 Driver.
+ *
+ * @deprecated Use {@link Driver} instead
  */
 class DB2Driver extends AbstractDB2Driver
 {
@@ -18,7 +20,7 @@ class DB2Driver extends AbstractDB2Driver
         $params['password'] = $password;
         $params['dbname']   = DataSourceName::fromConnectionParameters($params)->toString();
 
-        return new DB2Connection(
+        return new Connection(
             $params,
             (string) $username,
             (string) $password,

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Exception.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Exception.php
@@ -5,6 +5,8 @@ namespace Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\AbstractDriverException;
 
 /**
+ * @deprecated Use {@link Exception} instead
+ *
  * @psalm-immutable
  */
 class DB2Exception extends AbstractDriverException

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -3,6 +3,9 @@
 namespace Doctrine\DBAL\Driver\IBMDB2;
 
 use Doctrine\DBAL\Driver\FetchUtils;
+use Doctrine\DBAL\Driver\IBMDB2\Exception\CannotCopyStreamToStream;
+use Doctrine\DBAL\Driver\IBMDB2\Exception\CannotCreateTemporaryFile;
+use Doctrine\DBAL\Driver\IBMDB2\Exception\CannotWriteToTemporaryFile;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\StatementError;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
@@ -522,7 +525,7 @@ class DB2Statement implements IteratorAggregate, StatementInterface, Result
         $handle = @tmpfile();
 
         if ($handle === false) {
-            throw new DB2Exception('Could not create temporary file: ' . error_get_last()['message']);
+            throw CannotCreateTemporaryFile::new(error_get_last()['message']);
         }
 
         return $handle;
@@ -537,7 +540,7 @@ class DB2Statement implements IteratorAggregate, StatementInterface, Result
     private function copyStreamToStream($source, $target): void
     {
         if (@stream_copy_to_stream($source, $target) === false) {
-            throw new DB2Exception('Could not copy source stream to temporary file: ' . error_get_last()['message']);
+            throw CannotCopyStreamToStream::new(error_get_last()['message']);
         }
     }
 
@@ -549,7 +552,7 @@ class DB2Statement implements IteratorAggregate, StatementInterface, Result
     private function writeStringToStream(string $string, $target): void
     {
         if (@fwrite($target, $string) === false) {
-            throw new DB2Exception('Could not write string to temporary file: ' . error_get_last()['message']);
+            throw CannotWriteToTemporaryFile::new(error_get_last()['message']);
         }
     }
 }

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\StatementError;
 use Doctrine\DBAL\Driver\Result;
-use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\Driver\StatementIterator;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
@@ -53,7 +53,10 @@ use const DB2_LONG;
 use const DB2_PARAM_FILE;
 use const DB2_PARAM_IN;
 
-class DB2Statement implements IteratorAggregate, Statement, Result
+/**
+ * @deprecated Use {@link Statement} instead
+ */
+class DB2Statement implements IteratorAggregate, StatementInterface, Result
 {
     /** @var resource */
     private $stmt;

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Driver.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\IBMDB2;
+
+final class Driver extends DB2Driver
+{
+}

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/CannotCopyStreamToStream.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/CannotCopyStreamToStream.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\IBMDB2\Exception;
+
+use Doctrine\DBAL\Driver\IBMDB2\DB2Exception;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class CannotCopyStreamToStream extends DB2Exception
+{
+    public static function new(string $message): self
+    {
+        return new self('Could not copy source stream to temporary file: ' . $message);
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/CannotCreateTemporaryFile.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/CannotCreateTemporaryFile.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\IBMDB2\Exception;
+
+use Doctrine\DBAL\Driver\IBMDB2\DB2Exception;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class CannotCreateTemporaryFile extends DB2Exception
+{
+    public static function new(string $message): self
+    {
+        return new self('Could not create temporary file: ' . $message);
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/CannotWriteToTemporaryFile.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/CannotWriteToTemporaryFile.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\IBMDB2\Exception;
+
+use Doctrine\DBAL\Driver\IBMDB2\DB2Exception;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class CannotWriteToTemporaryFile extends DB2Exception
+{
+    public static function new(string $message): self
+    {
+        return new self('Could not write string to temporary file: ' . $message);
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/ConnectionError.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/ConnectionError.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\IBMDB2\Exception;
 
-use Doctrine\DBAL\Driver\IBMDB2\DB2Exception;
+use Doctrine\DBAL\Driver\AbstractException;
 
 use function db2_conn_error;
 use function db2_conn_errormsg;
 
 /**
+ * @internal
+ *
  * @psalm-immutable
  */
-final class ConnectionError extends DB2Exception
+final class ConnectionError extends AbstractException
 {
     /**
      * @param resource $connection

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/ConnectionFailed.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/ConnectionFailed.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\IBMDB2\Exception;
 
-use Doctrine\DBAL\Driver\IBMDB2\DB2Exception;
+use Doctrine\DBAL\Driver\AbstractException;
 
 use function db2_conn_error;
 use function db2_conn_errormsg;
 
 /**
+ * @internal
+ *
  * @psalm-immutable
  */
-final class ConnectionFailed extends DB2Exception
+final class ConnectionFailed extends AbstractException
 {
     public static function new(): self
     {

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/PrepareFailed.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/PrepareFailed.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\IBMDB2\Exception;
 
-use Doctrine\DBAL\Driver\IBMDB2\DB2Exception;
+use Doctrine\DBAL\Driver\AbstractException;
 
 /**
+ * @internal
+ *
  * @psalm-immutable
  */
-final class PrepareFailed extends DB2Exception
+final class PrepareFailed extends AbstractException
 {
     public static function new(string $message): self
     {

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/StatementError.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Exception/StatementError.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\IBMDB2\Exception;
 
-use Doctrine\DBAL\Driver\IBMDB2\DB2Exception;
+use Doctrine\DBAL\Driver\AbstractException;
 
 use function db2_stmt_error;
 use function db2_stmt_errormsg;
 
 /**
+ * @internal
+ *
  * @psalm-immutable
  */
-final class StatementError extends DB2Exception
+final class StatementError extends AbstractException
 {
     /**
      * @param resource $statement

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Statement.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\IBMDB2;
+
+final class Statement extends DB2Statement
+{
+}

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Connection.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli;
+
+final class Connection extends MysqliConnection
+{
+}

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
@@ -13,7 +13,7 @@ class Driver extends AbstractMySQLDriver
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         try {
-            return new MysqliConnection($params, (string) $username, (string) $password, $driverOptions);
+            return new Connection($params, (string) $username, (string) $password, $driverOptions);
         } catch (MysqliException $e) {
             throw DBALException::driverException($this, $e);
         }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionError.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionError.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Exception;
+
+use Doctrine\DBAL\Driver\Mysqli\MysqliException;
+use mysqli;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class ConnectionError extends MysqliException
+{
+    public static function new(mysqli $connection): self
+    {
+        return new self($connection->error, $connection->sqlstate, $connection->errno);
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionFailed.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionFailed.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Exception;
+
+use Doctrine\DBAL\Driver\Mysqli\MysqliException;
+use mysqli;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class ConnectionFailed extends MysqliException
+{
+    public static function new(mysqli $connection): self
+    {
+        return new self($connection->connect_error, 'HY000', $connection->connect_errno);
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Exception/FailedReadingStreamOffset.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Exception/FailedReadingStreamOffset.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Exception;
+
+use Doctrine\DBAL\Driver\Mysqli\MysqliException;
+
+use function sprintf;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class FailedReadingStreamOffset extends MysqliException
+{
+    public static function new(int $offset): self
+    {
+        return new self(sprintf('Failed reading the stream resource for parameter offset %d.', $offset));
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Exception/InvalidOption.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Exception/InvalidOption.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Exception;
+
+use Doctrine\DBAL\Driver\Mysqli\MysqliException;
+
+use function sprintf;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class InvalidOption extends MysqliException
+{
+    /**
+     * @param mixed $option
+     * @param mixed $value
+     */
+    public static function fromOption($option, $value): self
+    {
+        return new self(
+            sprintf('Failed to set option %d with value "%s"', $option, $value)
+        );
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Exception/StatementError.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Exception/StatementError.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Exception;
+
+use Doctrine\DBAL\Driver\Mysqli\MysqliException;
+use mysqli_stmt;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class StatementError extends MysqliException
+{
+    public static function new(mysqli_stmt $statement): self
+    {
+        return new self($statement->error, $statement->sqlstate, $statement->errno);
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Exception/UnknownType.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Exception/UnknownType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Exception;
+
+use Doctrine\DBAL\Driver\Mysqli\MysqliException;
+
+use function sprintf;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class UnknownType extends MysqliException
+{
+    /**
+     * @param mixed $type
+     */
+    public static function new($type): self
+    {
+        return new self(sprintf('Unknown type, %d given.', $type));
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Driver\Mysqli;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\PingableConnection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
@@ -29,7 +29,10 @@ use const MYSQLI_READ_DEFAULT_FILE;
 use const MYSQLI_READ_DEFAULT_GROUP;
 use const MYSQLI_SERVER_PUBLIC_KEY;
 
-class MysqliConnection implements Connection, PingableConnection, ServerInfoAwareConnection
+/**
+ * @deprecated Use {@link Connection} instead
+ */
+class MysqliConnection implements ConnectionInterface, PingableConnection, ServerInfoAwareConnection
 {
     /**
      * Name of the option to set connection flags
@@ -130,7 +133,7 @@ class MysqliConnection implements Connection, PingableConnection, ServerInfoAwar
      */
     public function prepare($prepareString)
     {
-        return new MysqliStatement($this->conn, $prepareString);
+        return new Statement($this->conn, $prepareString);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliException.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliException.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL\Driver\Mysqli;
 use Doctrine\DBAL\Driver\AbstractDriverException;
 
 /**
- * Exception thrown in case the mysqli driver errors.
+ * @deprecated Use {@link Exception} instead
  *
  * @psalm-immutable
  */

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\Result;
-use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\Driver\StatementIterator;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\FetchMode;
@@ -27,7 +27,10 @@ use function is_resource;
 use function sprintf;
 use function str_repeat;
 
-class MysqliStatement implements IteratorAggregate, Statement, Result
+/**
+ * @deprecated Use {@link Statement} instead
+ */
+class MysqliStatement implements IteratorAggregate, StatementInterface, Result
 {
     /** @var string[] */
     protected static $_paramTypeMap = [

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -3,6 +3,10 @@
 namespace Doctrine\DBAL\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\FetchUtils;
+use Doctrine\DBAL\Driver\Mysqli\Exception\ConnectionError;
+use Doctrine\DBAL\Driver\Mysqli\Exception\FailedReadingStreamOffset;
+use Doctrine\DBAL\Driver\Mysqli\Exception\StatementError;
+use Doctrine\DBAL\Driver\Mysqli\Exception\UnknownType;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\Driver\StatementIterator;
@@ -89,7 +93,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
         $stmt = $conn->prepare($prepareString);
 
         if ($stmt === false) {
-            throw new MysqliException($this->_conn->error, $this->_conn->sqlstate, $this->_conn->errno);
+            throw ConnectionError::new($this->_conn);
         }
 
         $this->_stmt = $stmt;
@@ -111,7 +115,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
         assert(is_int($column));
 
         if (! isset(self::$_paramTypeMap[$type])) {
-            throw new MysqliException(sprintf("Unknown type: '%s'", $type));
+            throw UnknownType::new($type);
         }
 
         $this->_bindedValues[$column] =& $variable;
@@ -128,7 +132,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
         assert(is_int($param));
 
         if (! isset(self::$_paramTypeMap[$type])) {
-            throw new MysqliException(sprintf("Unknown type: '%s'", $type));
+            throw UnknownType::new($type);
         }
 
         $this->_values[$param]       = $value;
@@ -146,7 +150,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
         if ($this->_bindedValues !== null) {
             if ($params !== null) {
                 if (! $this->bindUntypedValues($params)) {
-                    throw new MysqliException($this->_stmt->error, $this->_stmt->errno);
+                    throw StatementError::new($this->_stmt);
                 }
             } else {
                 $this->bindTypedParameters();
@@ -154,7 +158,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
         }
 
         if (! $this->_stmt->execute()) {
-            throw new MysqliException($this->_stmt->error, $this->_stmt->sqlstate, $this->_stmt->errno);
+            throw StatementError::new($this->_stmt);
         }
 
         if ($this->_columnNames === null) {
@@ -201,7 +205,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
             }
 
             if (! $this->_stmt->bind_result(...$refs)) {
-                throw new MysqliException($this->_stmt->error, $this->_stmt->sqlstate, $this->_stmt->errno);
+                throw StatementError::new($this->_stmt);
             }
         }
 
@@ -243,7 +247,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
         }
 
         if (! $this->_stmt->bind_param($types, ...$values)) {
-            throw new MysqliException($this->_stmt->error, $this->_stmt->sqlstate, $this->_stmt->errno);
+            throw StatementError::new($this->_stmt);
         }
 
         $this->sendLongData($streams);
@@ -263,11 +267,11 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
                 $chunk = fread($stream, 8192);
 
                 if ($chunk === false) {
-                    throw new MysqliException("Failed reading the stream resource for parameter offset ${paramNr}.");
+                    throw FailedReadingStreamOffset::new($paramNr);
                 }
 
                 if (! $this->_stmt->send_long_data($paramNr - 1, $chunk)) {
-                    throw new MysqliException($this->_stmt->error, $this->_stmt->sqlstate, $this->_stmt->errno);
+                    throw StatementError::new($this->_stmt);
                 }
             }
         }
@@ -337,7 +341,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
         }
 
         if ($values === false) {
-            throw new MysqliException($this->_stmt->error, $this->_stmt->sqlstate, $this->_stmt->errno);
+            throw StatementError::new($this->_stmt);
         }
 
         if ($fetchMode === FetchMode::NUMERIC) {
@@ -423,7 +427,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
         }
 
         if ($values === false) {
-            throw new MysqliException($this->_stmt->error, $this->_stmt->sqlstate, $this->_stmt->errno);
+            throw StatementError::new($this->_stmt);
         }
 
         return $values;

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Statement.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli;
+
+final class Statement extends MysqliStatement
+{
+}

--- a/lib/Doctrine/DBAL/Driver/OCI8/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Connection.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\OCI8;
+
+final class Connection extends OCI8Connection
+{
+}

--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -18,7 +18,7 @@ class Driver extends AbstractOracleDriver
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         try {
-            return new OCI8Connection(
+            return new Connection(
                 (string) $username,
                 (string) $password,
                 $this->_constructDsn($params),

--- a/lib/Doctrine/DBAL/Driver/OCI8/Exception/NonTerminatedStringLiteral.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Exception/NonTerminatedStringLiteral.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\OCI8\Exception;
+
+use Doctrine\DBAL\Driver\OCI8\OCI8Exception;
+
+use function sprintf;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class NonTerminatedStringLiteral extends OCI8Exception
+{
+    public static function new(int $offset): self
+    {
+        return new self(
+            sprintf(
+                'The statement contains non-terminated string literal starting at offset %d.',
+                $offset
+            )
+        );
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/OCI8/Exception/SequenceDoesNotExist.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Exception/SequenceDoesNotExist.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\OCI8\Exception;
+
+use Doctrine\DBAL\Driver\OCI8\OCI8Exception;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class SequenceDoesNotExist extends OCI8Exception
+{
+    public static function new(): self
+    {
+        return new self('lastInsertId failed: Query was executed but no result was returned.');
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/OCI8/Exception/UnknownParameterIndex.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Exception/UnknownParameterIndex.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\OCI8\Exception;
+
+use Doctrine\DBAL\Driver\OCI8\OCI8Exception;
+
+use function sprintf;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class UnknownParameterIndex extends OCI8Exception
+{
+    public static function new(int $index): self
+    {
+        return new self(
+            sprintf('Could not find variable mapping with index %d, in the SQL statement', $index)
+        );
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Driver\OCI8;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
 use UnexpectedValueException;
@@ -26,8 +26,10 @@ use const OCI_NO_AUTO_COMMIT;
 
 /**
  * OCI8 implementation of the Connection interface.
+ *
+ * @deprecated Use {@link Connection} instead
  */
-class OCI8Connection implements Connection, ServerInfoAwareConnection
+class OCI8Connection implements ConnectionInterface, ServerInfoAwareConnection
 {
     /** @var resource */
     protected $dbh;
@@ -106,7 +108,7 @@ class OCI8Connection implements Connection, ServerInfoAwareConnection
      */
     public function prepare($prepareString)
     {
-        return new OCI8Statement($this->dbh, $prepareString, $this);
+        return new Statement($this->dbh, $prepareString, $this);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Driver\OCI8;
 
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
+use Doctrine\DBAL\Driver\OCI8\Exception\SequenceDoesNotExist;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
 use UnexpectedValueException;
@@ -166,7 +167,7 @@ class OCI8Connection implements ConnectionInterface, ServerInfoAwareConnection
         $result = $stmt->fetchColumn();
 
         if ($result === false) {
-            throw new OCI8Exception('lastInsertId failed: Query was executed but no result was returned.');
+            throw SequenceDoesNotExist::new();
         }
 
         return (int) $result;

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Exception.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Exception.php
@@ -5,6 +5,8 @@ namespace Doctrine\DBAL\Driver\OCI8;
 use Doctrine\DBAL\Driver\AbstractDriverException;
 
 /**
+ * @deprecated Use {@link Exception} instead
+ *
  * @psalm-immutable
  */
 class OCI8Exception extends AbstractDriverException

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL\Driver\OCI8;
 
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\Result;
-use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\Driver\StatementIterator;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
@@ -50,8 +50,10 @@ use const SQLT_CHR;
 
 /**
  * The OCI8 implementation of the Statement interface.
+ *
+ * @deprecated Use {@link Statement} instead
  */
-class OCI8Statement implements IteratorAggregate, Statement, Result
+class OCI8Statement implements IteratorAggregate, StatementInterface, Result
 {
     /** @var resource */
     protected $_dbh;

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -3,6 +3,8 @@
 namespace Doctrine\DBAL\Driver\OCI8;
 
 use Doctrine\DBAL\Driver\FetchUtils;
+use Doctrine\DBAL\Driver\OCI8\Exception\NonTerminatedStringLiteral;
+use Doctrine\DBAL\Driver\OCI8\Exception\UnknownParameterIndex;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\Driver\StatementIterator;
@@ -31,7 +33,6 @@ use function oci_num_rows;
 use function oci_parse;
 use function preg_match;
 use function preg_quote;
-use function sprintf;
 use function substr;
 
 use const OCI_ASSOC;
@@ -163,10 +164,7 @@ class OCI8Statement implements IteratorAggregate, StatementInterface, Result
         } while ($result);
 
         if ($currentLiteralDelimiter) {
-            throw new OCI8Exception(sprintf(
-                'The statement contains non-terminated string literal starting at offset %d',
-                $tokenOffset - 1
-            ));
+            throw NonTerminatedStringLiteral::new($tokenOffset - 1);
         }
 
         $fragments[] = substr($statement, $fragmentOffset);
@@ -286,7 +284,7 @@ class OCI8Statement implements IteratorAggregate, StatementInterface, Result
     {
         if (is_int($param)) {
             if (! isset($this->_paramMap[$param])) {
-                throw new OCI8Exception(sprintf('Could not find variable mapping with index %d, in the SQL statement', $param));
+                throw UnknownParameterIndex::new($param);
             }
 
             $param = $this->_paramMap[$param];

--- a/lib/Doctrine/DBAL/Driver/OCI8/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Statement.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\OCI8;
+
+final class Statement extends OCI8Statement
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDO/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/Connection.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\PDO;
+
+use Doctrine\DBAL\Driver\PDOConnection;
+
+class Connection extends PDOConnection
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDO/Exception.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/Exception.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\PDO;
+
+use Doctrine\DBAL\Driver\PDOException;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class Exception extends PDOException
+{
+    public static function new(\PDOException $exception): self
+    {
+        return new self($exception);
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/PDO/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/Statement.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\PDO;
+
+use Doctrine\DBAL\Driver\PDOStatement;
+
+class Statement extends PDOStatement
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -2,8 +2,13 @@
 
 namespace Doctrine\DBAL\Driver;
 
+use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
+use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\DBAL\Driver\PDO\Statement;
 use Doctrine\DBAL\ParameterType;
 use PDO;
+use PDOException;
+use PDOStatement;
 
 use function assert;
 use function func_get_args;
@@ -11,8 +16,10 @@ use function func_get_args;
 /**
  * PDO implementation of the Connection interface.
  * Used by all PDO-based drivers.
+ *
+ * @deprecated Use {@link Connection} instead
  */
-class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
+class PDOConnection extends PDO implements ConnectionInterface, ServerInfoAwareConnection
 {
     /**
      * @param string       $dsn
@@ -26,10 +33,10 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
     {
         try {
             parent::__construct($dsn, (string) $user, (string) $password, (array) $options);
-            $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, [PDOStatement::class, []]);
+            $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, [Statement::class, []]);
             $this->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 
@@ -43,8 +50,8 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
             assert($result !== false);
 
             return $result;
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 
@@ -60,24 +67,24 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
      * @param string          $prepareString
      * @param array<int, int> $driverOptions
      *
-     * @return \PDOStatement
+     * @return PDOStatement
      */
     public function prepare($prepareString, $driverOptions = [])
     {
         try {
             $statement = parent::prepare($prepareString, $driverOptions);
-            assert($statement instanceof \PDOStatement);
+            assert($statement instanceof PDOStatement);
 
             return $statement;
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 
     /**
      * {@inheritdoc}
      *
-     * @return \PDOStatement
+     * @return PDOStatement
      */
     public function query()
     {
@@ -85,11 +92,11 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
 
         try {
             $stmt = parent::query(...$args);
-            assert($stmt instanceof \PDOStatement);
+            assert($stmt instanceof PDOStatement);
 
             return $stmt;
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 
@@ -112,8 +119,8 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
             }
 
             return parent::lastInsertId($name);
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 

--- a/lib/Doctrine/DBAL/Driver/PDOException.php
+++ b/lib/Doctrine/DBAL/Driver/PDOException.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Driver;
 
 /**
- * Tiny wrapper for PDOException instances to implement the {@link DriverException} interface.
+ * @deprecated Use {@link Exception} instead
  *
  * @psalm-immutable
  */

--- a/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Driver\PDOIbm;
 
 use Doctrine\DBAL\Driver\AbstractDB2Driver;
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Connection;
 
 /**
  * Driver for the PDO IBM extension.
@@ -17,7 +17,7 @@ class Driver extends AbstractDB2Driver
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
-        return new PDOConnection(
+        return new Connection(
             $this->_constructPdoDsn($params),
             $username,
             $password,

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL\Driver\PDOMySql;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Connection;
 use PDOException;
 
 /**
@@ -18,7 +18,7 @@ class Driver extends AbstractMySQLDriver
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         try {
-            $conn = new PDOConnection(
+            $conn = new Connection(
                 $this->constructPdoDsn($params),
                 $username,
                 $password,

--- a/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL\Driver\PDOOracle;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Connection;
 use PDOException;
 
 /**
@@ -23,7 +23,7 @@ class Driver extends AbstractOracleDriver
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         try {
-            return new PDOConnection(
+            return new Connection(
                 $this->constructPdoDsn($params),
                 $username,
                 $password,

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL\Driver\PDOPgSql;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Connection;
 use PDO;
 use PDOException;
 
@@ -21,7 +21,7 @@ class Driver extends AbstractPostgreSQLDriver
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         try {
-            $pdo = new PDOConnection(
+            $pdo = new Connection(
                 $this->_constructPdoDsn($params),
                 $username,
                 $password,

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL\Driver\PDOSqlite;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use PDOException;
 
@@ -36,7 +36,7 @@ class Driver extends AbstractSQLiteDriver
         }
 
         try {
-            $pdo = new PDOConnection(
+            $pdo = new Connection(
                 $this->_constructPdoDsn($params),
                 $username,
                 $password,

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Connection as BaseStatement;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\ParameterType;
 use PDO;
@@ -14,7 +14,7 @@ use function substr;
 /**
  * Sqlsrv Connection implementation.
  */
-class Connection extends PDOConnection
+class Connection extends BaseStatement
 {
     /**
      * {@inheritdoc}

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
-use Doctrine\DBAL\Driver\AbstractSQLServerDriver\PortWithoutHost;
+use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
 
 use function is_int;
 use function sprintf;

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Statement.php
@@ -2,14 +2,14 @@
 
 namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
-use Doctrine\DBAL\Driver\PDOStatement;
+use Doctrine\DBAL\Driver\PDO\Statement as BaseStatement;
 use Doctrine\DBAL\ParameterType;
 use PDO;
 
 /**
  * PDO SQL Server Statement
  */
-class Statement extends PDOStatement
+class Statement extends BaseStatement
 {
     /**
      * {@inheritdoc}

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -2,9 +2,12 @@
 
 namespace Doctrine\DBAL\Driver;
 
+use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use PDO;
+use PDOException;
 
 use function array_slice;
 use function assert;
@@ -18,8 +21,10 @@ use const E_USER_DEPRECATED;
 /**
  * The PDO implementation of the Statement interface.
  * Used by all PDO-based drivers.
+ *
+ * @deprecated Use {@link Statement} instead
  */
-class PDOStatement extends \PDOStatement implements Statement, Result
+class PDOStatement extends \PDOStatement implements StatementInterface, Result
 {
     private const PARAM_TYPE_MAP = [
         ParameterType::NULL         => PDO::PARAM_NULL,
@@ -69,8 +74,8 @@ class PDOStatement extends \PDOStatement implements Statement, Result
             }
 
             return parent::setFetchMode($fetchMode, $arg2, $arg3);
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 
@@ -83,8 +88,8 @@ class PDOStatement extends \PDOStatement implements Statement, Result
 
         try {
             return parent::bindValue($param, $value, $type);
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 
@@ -103,8 +108,8 @@ class PDOStatement extends \PDOStatement implements Statement, Result
 
         try {
             return parent::bindParam($column, $variable, $type, ...array_slice(func_get_args(), 3));
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 
@@ -117,7 +122,7 @@ class PDOStatement extends \PDOStatement implements Statement, Result
     {
         try {
             return parent::closeCursor();
-        } catch (\PDOException $exception) {
+        } catch (PDOException $exception) {
             // Exceptions not allowed by the interface.
             // In case driver implementations do not adhere to the interface, silence exceptions here.
             return true;
@@ -131,8 +136,8 @@ class PDOStatement extends \PDOStatement implements Statement, Result
     {
         try {
             return parent::execute($params);
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 
@@ -151,8 +156,8 @@ class PDOStatement extends \PDOStatement implements Statement, Result
 
         try {
             return parent::fetch(...$args);
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 
@@ -184,8 +189,8 @@ class PDOStatement extends \PDOStatement implements Statement, Result
             assert(is_array($data));
 
             return $data;
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 
@@ -198,8 +203,8 @@ class PDOStatement extends \PDOStatement implements Statement, Result
     {
         try {
             return parent::fetchColumn($columnIndex);
-        } catch (\PDOException $exception) {
-            throw new PDOException($exception);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
         }
     }
 

--- a/lib/Doctrine/DBAL/Driver/Result.php
+++ b/lib/Doctrine/DBAL/Driver/Result.php
@@ -14,7 +14,7 @@ interface Result
      *
      * @return array<int,mixed>|false
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public function fetchNumeric();
 
@@ -23,7 +23,7 @@ interface Result
      *
      * @return array<string,mixed>|false
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public function fetchAssociative();
 
@@ -32,7 +32,7 @@ interface Result
      *
      * @return mixed|false
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public function fetchOne();
 
@@ -41,7 +41,7 @@ interface Result
      *
      * @return array<int,array<int,mixed>>
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public function fetchAllNumeric(): array;
 
@@ -50,7 +50,7 @@ interface Result
      *
      * @return array<int,array<string,mixed>>
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public function fetchAllAssociative(): array;
 
@@ -59,7 +59,7 @@ interface Result
      *
      * @return array<int,mixed>
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public function fetchFirstColumn(): array;
 

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Driver\SQLAnywhere;
 
-use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement;
@@ -350,7 +350,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement, Result
     /**
      * {@inheritdoc}
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public function fetchOne()
     {
@@ -360,7 +360,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement, Result
     /**
      * @return array<int,array<int,mixed>>
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public function fetchAllNumeric(): array
     {
@@ -370,7 +370,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement, Result
     /**
      * @return array<int,array<string,mixed>>
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public function fetchAllAssociative(): array
     {
@@ -380,7 +380,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement, Result
     /**
      * @return array<int,mixed>
      *
-     * @throws DriverException
+     * @throws Exception
      */
     public function fetchFirstColumn(): array
     {

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Connection.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\SQLSrv;
+
+final class Connection extends SQLSrvConnection
+{
+}

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Driver\SQLSrv;
 
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
-use Doctrine\DBAL\Driver\AbstractSQLServerDriver\PortWithoutHost;
+use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
 
 /**
  * Driver for ext/sqlsrv.
@@ -47,7 +47,7 @@ class Driver extends AbstractSQLServerDriver
             $driverOptions['ReturnDatesAsStrings'] = 1;
         }
 
-        return new SQLSrvConnection($serverName, $driverOptions);
+        return new Connection($serverName, $driverOptions);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Exception/Error.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Exception/Error.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\SQLSrv\Exception;
+
+use Doctrine\DBAL\Driver\SQLSrv\SQLSrvException;
+
+use function rtrim;
+use function sqlsrv_errors;
+
+use const SQLSRV_ERR_ERRORS;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class Error extends SQLSrvException
+{
+    public static function new(): self
+    {
+        $message   = '';
+        $sqlState  = null;
+        $errorCode = null;
+
+        foreach ((array) sqlsrv_errors(SQLSRV_ERR_ERRORS) as $error) {
+            $message .= 'SQLSTATE [' . $error['SQLSTATE'] . ', ' . $error['code'] . ']: ' . $error['message'] . "\n";
+
+            if ($sqlState === null) {
+                $sqlState = $error['SQLSTATE'];
+            }
+
+            if ($errorCode !== null) {
+                continue;
+            }
+
+            $errorCode = $error['code'];
+        }
+
+        if (! $message) {
+            $message = 'SQL Server error occurred but no error message was retrieved from driver.';
+        }
+
+        return new self(rtrim($message), $sqlState, $errorCode);
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -2,9 +2,10 @@
 
 namespace Doctrine\DBAL\Driver\SQLSrv;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
 use Doctrine\DBAL\ParameterType;
 
 use function func_get_args;
@@ -26,8 +27,10 @@ use const SQLSRV_ERR_ERRORS;
 
 /**
  * SQL Server implementation for the Connection interface.
+ *
+ * @deprecated Use {@link Connection} instead
  */
-class SQLSrvConnection implements Connection, ServerInfoAwareConnection
+class SQLSrvConnection implements ConnectionInterface, ServerInfoAwareConnection
 {
     /** @var resource */
     protected $conn;
@@ -44,13 +47,13 @@ class SQLSrvConnection implements Connection, ServerInfoAwareConnection
     public function __construct($serverName, $connectionOptions)
     {
         if (! sqlsrv_configure('WarningsReturnAsErrors', 0)) {
-            throw SQLSrvException::fromSqlSrvErrors();
+            throw Error::new();
         }
 
         $conn = sqlsrv_connect($serverName, $connectionOptions);
 
         if ($conn === false) {
-            throw SQLSrvException::fromSqlSrvErrors();
+            throw Error::new();
         }
 
         $this->conn         = $conn;
@@ -80,7 +83,7 @@ class SQLSrvConnection implements Connection, ServerInfoAwareConnection
      */
     public function prepare($sql)
     {
-        return new SQLSrvStatement($this->conn, $sql, $this->lastInsertId);
+        return new Statement($this->conn, $sql, $this->lastInsertId);
     }
 
     /**
@@ -120,13 +123,13 @@ class SQLSrvConnection implements Connection, ServerInfoAwareConnection
         $stmt = sqlsrv_query($this->conn, $statement);
 
         if ($stmt === false) {
-            throw SQLSrvException::fromSqlSrvErrors();
+            throw Error::new();
         }
 
         $rowsAffected = sqlsrv_rows_affected($stmt);
 
         if ($rowsAffected === false) {
-            throw SQLSrvException::fromSqlSrvErrors();
+            throw Error::new();
         }
 
         return $rowsAffected;
@@ -157,7 +160,7 @@ class SQLSrvConnection implements Connection, ServerInfoAwareConnection
     public function beginTransaction()
     {
         if (! sqlsrv_begin_transaction($this->conn)) {
-            throw SQLSrvException::fromSqlSrvErrors();
+            throw Error::new();
         }
 
         return true;
@@ -169,7 +172,7 @@ class SQLSrvConnection implements Connection, ServerInfoAwareConnection
     public function commit()
     {
         if (! sqlsrv_commit($this->conn)) {
-            throw SQLSrvException::fromSqlSrvErrors();
+            throw Error::new();
         }
 
         return true;
@@ -181,7 +184,7 @@ class SQLSrvConnection implements Connection, ServerInfoAwareConnection
     public function rollBack()
     {
         if (! sqlsrv_rollback($this->conn)) {
-            throw SQLSrvException::fromSqlSrvErrors();
+            throw Error::new();
         }
 
         return true;

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvException.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvException.php
@@ -3,13 +3,11 @@
 namespace Doctrine\DBAL\Driver\SQLSrv;
 
 use Doctrine\DBAL\Driver\AbstractDriverException;
-
-use function rtrim;
-use function sqlsrv_errors;
-
-use const SQLSRV_ERR_ERRORS;
+use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
 
 /**
+ * @deprecated Use {@link Exception} instead
+ *
  * @psalm-immutable
  */
 class SQLSrvException extends AbstractDriverException
@@ -21,28 +19,6 @@ class SQLSrvException extends AbstractDriverException
      */
     public static function fromSqlSrvErrors()
     {
-        $message   = '';
-        $sqlState  = null;
-        $errorCode = null;
-
-        foreach ((array) sqlsrv_errors(SQLSRV_ERR_ERRORS) as $error) {
-            $message .= 'SQLSTATE [' . $error['SQLSTATE'] . ', ' . $error['code'] . ']: ' . $error['message'] . "\n";
-
-            if ($sqlState === null) {
-                $sqlState = $error['SQLSTATE'];
-            }
-
-            if ($errorCode !== null) {
-                continue;
-            }
-
-            $errorCode = $error['code'];
-        }
-
-        if (! $message) {
-            $message = 'SQL Server error occurred but no error message was retrieved from driver.';
-        }
-
-        return new self(rtrim($message), $sqlState, $errorCode);
+        return Error::new();
     }
 }

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -4,7 +4,8 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\Result;
-use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\Driver\StatementIterator;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
@@ -41,8 +42,10 @@ use const SQLSRV_PARAM_IN;
 
 /**
  * SQL Server Statement.
+ *
+ * @deprecated Use {@link Statement} instead
  */
-class SQLSrvStatement implements IteratorAggregate, Statement, Result
+class SQLSrvStatement implements IteratorAggregate, StatementInterface, Result
 {
     /**
      * The SQLSRV Resource.
@@ -255,7 +258,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement, Result
         }
 
         if (! sqlsrv_execute($this->stmt)) {
-            throw SQLSrvException::fromSqlSrvErrors();
+            throw Error::new();
         }
 
         if ($this->lastInsertId) {
@@ -308,7 +311,7 @@ class SQLSrvStatement implements IteratorAggregate, Statement, Result
         $stmt = sqlsrv_prepare($this->conn, $this->sql, $params);
 
         if (! $stmt) {
-            throw SQLSrvException::fromSqlSrvErrors();
+            throw Error::new();
         }
 
         return $stmt;

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Statement.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\SQLSrv;
+
+class Statement extends SQLSrvStatement
+{
+}

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL;
 
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver as DrizzlePDOMySQLDriver;
-use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
+use Doctrine\DBAL\Driver\IBMDB2\Driver as IBMDB2Driver;
 use Doctrine\DBAL\Driver\Mysqli\Driver as MySQLiDriver;
 use Doctrine\DBAL\Driver\OCI8\Driver as OCI8Driver;
 use Doctrine\DBAL\Driver\PDOMySql\Driver as PDOMySQLDriver;
@@ -50,7 +50,7 @@ final class DriverManager
         'pdo_pgsql'          => PDOPgSQLDriver::class,
         'pdo_oci'            => PDOOCIDriver::class,
         'oci8'               => OCI8Driver::class,
-        'ibm_db2'            => DB2Driver::class,
+        'ibm_db2'            => IBMDB2Driver::class,
         'pdo_sqlsrv'         => PDOSQLSrvDriver::class,
         'mysqli'             => MySQLiDriver::class,
         'drizzle_pdo_mysql'  => DrizzlePDOMySQLDriver::class,

--- a/lib/Doctrine/DBAL/Exception/DriverException.php
+++ b/lib/Doctrine/DBAL/Exception/DriverException.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Exception;
 
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
 use Exception;
 
 /**
@@ -15,15 +16,15 @@ class DriverException extends DBALException
     /**
      * The previous DBAL driver exception.
      *
-     * @var \Doctrine\DBAL\Driver\DriverException
+     * @var DeprecatedDriverException
      */
     private $driverException;
 
     /**
-     * @param string                                $message         The exception message.
-     * @param \Doctrine\DBAL\Driver\DriverException $driverException The DBAL driver exception to chain.
+     * @param string                    $message         The exception message.
+     * @param DeprecatedDriverException $driverException The DBAL driver exception to chain.
      */
-    public function __construct($message, \Doctrine\DBAL\Driver\DriverException $driverException)
+    public function __construct($message, DeprecatedDriverException $driverException)
     {
         $exception = null;
 

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -4,7 +4,8 @@ namespace Doctrine\DBAL\Portability;
 
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\ColumnCase;
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Connection as BaseConnection;
+use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
 use PDO;
 
 use function func_get_args;
@@ -15,7 +16,7 @@ use const CASE_UPPER;
 /**
  * Portability wrapper for a Connection.
  */
-class Connection extends \Doctrine\DBAL\Connection
+class Connection extends BaseConnection
 {
     public const PORTABILITY_ALL           = 255;
     public const PORTABILITY_NONE          = 0;

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Types\Type;
 use Throwable;
@@ -37,7 +37,7 @@ class OracleSchemaManager extends AbstractSchemaManager
             $exception = $exception->getPrevious();
             assert($exception instanceof Throwable);
 
-            if (! $exception instanceof DriverException) {
+            if (! $exception instanceof Exception) {
                 throw $exception;
             }
 

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\Type;
 use PDOException;
@@ -35,7 +35,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
             $exception = $exception->getPrevious();
             assert($exception instanceof Throwable);
 
-            if (! $exception instanceof DriverException) {
+            if (! $exception instanceof Exception) {
                 throw $exception;
             }
 

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL;
 
 use Doctrine\DBAL\Abstraction\Result;
-use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
@@ -296,7 +296,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
             }
 
             return $this->stmt->fetch(FetchMode::NUMERIC);
-        } catch (DriverException $e) {
+        } catch (Exception $e) {
             throw DBALException::driverException($this->conn->getDriver(), $e);
         }
     }
@@ -314,7 +314,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
             }
 
             return $this->stmt->fetch(FetchMode::ASSOCIATIVE);
-        } catch (DriverException $e) {
+        } catch (Exception $e) {
             throw DBALException::driverException($this->conn->getDriver(), $e);
         }
     }
@@ -332,7 +332,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
             }
 
             return $this->stmt->fetch(FetchMode::COLUMN);
-        } catch (DriverException $e) {
+        } catch (Exception $e) {
             throw DBALException::driverException($this->conn->getDriver(), $e);
         }
     }
@@ -350,7 +350,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
             }
 
             return $this->stmt->fetchAll(FetchMode::NUMERIC);
-        } catch (DriverException $e) {
+        } catch (Exception $e) {
             throw DBALException::driverException($this->conn->getDriver(), $e);
         }
     }
@@ -368,7 +368,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
             }
 
             return $this->stmt->fetchAll(FetchMode::ASSOCIATIVE);
-        } catch (DriverException $e) {
+        } catch (Exception $e) {
             throw DBALException::driverException($this->conn->getDriver(), $e);
         }
     }
@@ -386,7 +386,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
             }
 
             return $this->stmt->fetchAll(FetchMode::COLUMN);
-        } catch (DriverException $e) {
+        } catch (Exception $e) {
             throw DBALException::driverException($this->conn->getDriver(), $e);
         }
     }
@@ -410,7 +410,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
                     yield $row;
                 }
             }
-        } catch (DriverException $e) {
+        } catch (Exception $e) {
             throw DBALException::driverException($this->conn->getDriver(), $e);
         }
     }
@@ -434,7 +434,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
                     yield $row;
                 }
             }
-        } catch (DriverException $e) {
+        } catch (Exception $e) {
             throw DBALException::driverException($this->conn->getDriver(), $e);
         }
     }
@@ -458,7 +458,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
                     yield $value;
                 }
             }
-        } catch (DriverException $e) {
+        } catch (Exception $e) {
             throw DBALException::driverException($this->conn->getDriver(), $e);
         }
     }

--- a/lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\DBAL\Tools\Console\Command;
 
-use Doctrine\DBAL\Driver\PDOConnection;
-use Doctrine\DBAL\Driver\PDOStatement;
+use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Statement as PDOStatement;
 use InvalidArgumentException;
 use PDOException;
 use RuntimeException;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -87,6 +87,7 @@
             https://github.com/squizlabs/PHP_CodeSniffer/issues/2950
         -->
         <exclude-pattern>lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionFailed.php</exclude-pattern>
         <!-- See https://github.com/squizlabs/PHP_CodeSniffer/issues/2837 -->
         <exclude-pattern>lib/Doctrine/DBAL/SQLParserUtils.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/DBAL/Tools/Dumper.php</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -101,7 +101,7 @@
 
     <!-- See https://github.com/slevomat/coding-standard/issues/1038 -->
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
-        <exclude-pattern>tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/DB2StatementTest.php</exclude-pattern>
+        <exclude-pattern>tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/StatementTest.php</exclude-pattern>
     </rule>
 
     <!-- see https://github.com/doctrine/dbal/issues/3377 -->

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLServerDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLServerDriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\AbstractSQLServerDriver\PortWithoutHost;
+use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2005Platform;
 use Doctrine\DBAL\Platforms\SQLServer2008Platform;

--- a/tests/Doctrine/Tests/DBAL/Driver/IBMDB2/DB2DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/IBMDB2/DB2DriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Driver\IBMDB2;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
+use Doctrine\DBAL\Driver\IBMDB2\Driver;
 use Doctrine\Tests\DBAL\Driver\AbstractDB2DriverTest;
 
 class DB2DriverTest extends AbstractDB2DriverTest
@@ -15,6 +15,6 @@ class DB2DriverTest extends AbstractDB2DriverTest
 
     protected function createDriver(): DriverInterface
     {
-        return new DB2Driver();
+        return new Driver();
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Driver/PDO/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDO/ExceptionTest.php
@@ -1,14 +1,15 @@
 <?php
 
-namespace Doctrine\Tests\DBAL\Driver;
+namespace Doctrine\Tests\DBAL\Driver\PDO;
 
-use Doctrine\DBAL\Driver\PDOException;
+use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\Tests\DbalTestCase;
+use PDOException;
 use PHPUnit\Framework\MockObject\MockObject;
 
 use function extension_loaded;
 
-class PDOExceptionTest extends DbalTestCase
+class ExceptionTest extends DbalTestCase
 {
     public const ERROR_CODE = 666;
 
@@ -19,14 +20,14 @@ class PDOExceptionTest extends DbalTestCase
     /**
      * The PDO exception wrapper under test.
      *
-     * @var PDOException
+     * @var Exception
      */
     private $exception;
 
     /**
      * The wrapped PDO exception mock.
      *
-     * @var \PDOException|MockObject
+     * @var PDOException|MockObject
      */
     private $wrappedException;
 
@@ -38,11 +39,11 @@ class PDOExceptionTest extends DbalTestCase
 
         parent::setUp();
 
-        $this->wrappedException = new \PDOException(self::MESSAGE, self::SQLSTATE);
+        $this->wrappedException = new PDOException(self::MESSAGE, self::SQLSTATE);
 
         $this->wrappedException->errorInfo = [self::SQLSTATE, self::ERROR_CODE];
 
-        $this->exception = new PDOException($this->wrappedException);
+        $this->exception = new Exception($this->wrappedException);
     }
 
     public function testReturnsCode(): void

--- a/tests/Doctrine/Tests/DBAL/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDOPgSql/DriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Driver\PDOPgSql;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDOPgSql\Driver;
 use Doctrine\Tests\DBAL\Driver\AbstractPostgreSQLDriverTest;
 use Doctrine\Tests\TestUtil;
@@ -89,7 +89,7 @@ class DriverTest extends AbstractPostgreSQLDriverTest
     /**
      * @param array<int,mixed> $driverOptions
      */
-    private function connect(array $driverOptions): PDOConnection
+    private function connect(array $driverOptions): Connection
     {
         $params = TestUtil::getConnectionParams();
 

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -5,10 +5,10 @@ namespace Doctrine\Tests\DBAL\Functional;
 use DateTime;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
+use Doctrine\DBAL\Driver\IBMDB2\Driver as IBMDB2Driver;
 use Doctrine\DBAL\Driver\Mysqli\Driver as MySQLiDriver;
 use Doctrine\DBAL\Driver\OCI8\Driver as Oci8Driver;
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
 use Doctrine\DBAL\Driver\PDOOracle\Driver as PDOOracleDriver;
 use Doctrine\DBAL\Driver\SQLSrv\Driver as SQLSrvDriver;
 use Doctrine\DBAL\FetchMode;
@@ -258,7 +258,7 @@ class DataAccessTest extends DbalFunctionalTestCase
         }
 
         if (
-            $this->connection->getDriver() instanceof DB2Driver
+            $this->connection->getDriver() instanceof IBMDB2Driver
         ) {
             $this->markTestSkipped(
                 'ibm_ibm2 may or may not report the error depending on the PHP version and the connection state'

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/ConnectionTest.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Driver\IBMDB2;
 
-use Doctrine\DBAL\Driver\IBMDB2\DB2Connection;
-use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
+use Doctrine\DBAL\Driver\IBMDB2\Connection;
+use Doctrine\DBAL\Driver\IBMDB2\Driver;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionFailed;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\PrepareFailed;
 use Doctrine\Tests\DbalFunctionalTestCase;
@@ -11,6 +11,7 @@ use ReflectionProperty;
 
 use function db2_close;
 use function extension_loaded;
+use function get_parent_class;
 
 class ConnectionTest extends DbalFunctionalTestCase
 {
@@ -22,7 +23,7 @@ class ConnectionTest extends DbalFunctionalTestCase
 
         parent::setUp();
 
-        if ($this->connection->getDriver() instanceof DB2Driver) {
+        if ($this->connection->getDriver() instanceof Driver) {
             return;
         }
 
@@ -37,14 +38,14 @@ class ConnectionTest extends DbalFunctionalTestCase
     public function testConnectionFailure(): void
     {
         $this->expectException(ConnectionFailed::class);
-        new DB2Connection(['dbname' => 'garbage'], '', '');
+        new Connection(['dbname' => 'garbage'], '', '');
     }
 
     public function testPrepareFailure(): void
     {
         $driverConnection = $this->connection->getWrappedConnection();
 
-        $re = new ReflectionProperty($driverConnection, 'conn');
+        $re = new ReflectionProperty(get_parent_class($driverConnection), 'conn');
         $re->setAccessible(true);
         $conn = $re->getValue($driverConnection);
         db2_close($conn);

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/DriverTest.php
@@ -2,13 +2,13 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Driver\IBMDB2;
 
-use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
+use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\IBMDB2\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 
 use function extension_loaded;
 
-class DB2DriverTest extends AbstractDriverTest
+class DriverTest extends AbstractDriverTest
 {
     protected function setUp(): void
     {
@@ -18,7 +18,7 @@ class DB2DriverTest extends AbstractDriverTest
 
         parent::setUp();
 
-        if ($this->connection->getDriver() instanceof DB2Driver) {
+        if ($this->connection->getDriver() instanceof Driver) {
             return;
         }
 
@@ -35,8 +35,8 @@ class DB2DriverTest extends AbstractDriverTest
         $this->markTestSkipped('IBM DB2 does not support connecting without database name.');
     }
 
-    protected function createDriver(): Driver
+    protected function createDriver(): DriverInterface
     {
-        return new DB2Driver();
+        return new Driver();
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/StatementTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\DBAL\Functional\Driver\IBMDB2;
 
-use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
+use Doctrine\DBAL\Driver\IBMDB2\Driver;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\StatementError;
 use Doctrine\Tests\DbalFunctionalTestCase;
 
@@ -14,7 +14,7 @@ use const E_ALL;
 use const E_NOTICE;
 use const E_WARNING;
 
-class DB2StatementTest extends DbalFunctionalTestCase
+class StatementTest extends DbalFunctionalTestCase
 {
     protected function setUp(): void
     {
@@ -24,7 +24,7 @@ class DB2StatementTest extends DbalFunctionalTestCase
 
         parent::setUp();
 
-        if ($this->connection->getDriver() instanceof DB2Driver) {
+        if ($this->connection->getDriver() instanceof Driver) {
             return;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/ConnectionTest.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Driver\Mysqli;
 
+use Doctrine\DBAL\Driver\Mysqli\Connection;
 use Doctrine\DBAL\Driver\Mysqli\Driver;
-use Doctrine\DBAL\Driver\Mysqli\MysqliConnection;
 use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use Doctrine\Tests\TestUtil;
@@ -39,7 +39,7 @@ class ConnectionTest extends DbalFunctionalTestCase
         $driverOptions = [MYSQLI_OPT_CONNECT_TIMEOUT => 1];
 
         $connection = $this->getConnection($driverOptions);
-        self::assertInstanceOf(MysqliConnection::class, $connection);
+        self::assertInstanceOf(Connection::class, $connection);
     }
 
     public function testUnsupportedDriverOption(): void
@@ -58,11 +58,11 @@ class ConnectionTest extends DbalFunctionalTestCase
     /**
      * @param mixed[] $driverOptions
      */
-    private function getConnection(array $driverOptions): MysqliConnection
+    private function getConnection(array $driverOptions): Connection
     {
         $params = TestUtil::getConnectionParams();
 
-        return new MysqliConnection(
+        return new Connection(
             $params,
             $params['user'] ?? '',
             $params['password'] ?? '',

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/ConnectionTest.php
@@ -2,16 +2,16 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Driver\OCI8;
 
+use Doctrine\DBAL\Driver\OCI8\Connection;
 use Doctrine\DBAL\Driver\OCI8\Driver;
-use Doctrine\DBAL\Driver\OCI8\OCI8Connection;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\Tests\DbalFunctionalTestCase;
 
 use function extension_loaded;
 
-class OCI8ConnectionTest extends DbalFunctionalTestCase
+class ConnectionTest extends DbalFunctionalTestCase
 {
-    /** @var OCI8Connection */
+    /** @var Connection */
     protected $driverConnection;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDO/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDO/ConnectionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Doctrine\Tests\DBAL\Functional\Driver;
+namespace Doctrine\Tests\DBAL\Functional\Driver\PDO;
 
-use Doctrine\DBAL\Driver\PDOConnection;
-use Doctrine\DBAL\Driver\PDOException;
+use Doctrine\DBAL\Driver\PDO\Connection;
+use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\DBAL\Driver\PDOOracle\Driver as PDOOracleDriver;
 use Doctrine\DBAL\Driver\PDOPgSql\Driver as PDOPgSQLDriver;
 use Doctrine\DBAL\Driver\PDOSqlsrv\Driver as PDOSQLSRVDriver;
@@ -14,12 +14,12 @@ use function extension_loaded;
 use function get_class;
 use function sprintf;
 
-class PDOConnectionTest extends DbalFunctionalTestCase
+class ConnectionTest extends DbalFunctionalTestCase
 {
     /**
      * The PDO driver connection under test.
      *
-     * @var PDOConnection
+     * @var Connection
      */
     protected $driverConnection;
 
@@ -33,7 +33,7 @@ class PDOConnectionTest extends DbalFunctionalTestCase
 
         $this->driverConnection = $this->connection->getWrappedConnection();
 
-        if ($this->driverConnection instanceof PDOConnection) {
+        if ($this->driverConnection instanceof Connection) {
             return;
         }
 
@@ -54,9 +54,9 @@ class PDOConnectionTest extends DbalFunctionalTestCase
 
     public function testThrowsWrappedExceptionOnConstruct(): void
     {
-        $this->expectException(PDOException::class);
+        $this->expectException(Exception::class);
 
-        new PDOConnection('foo');
+        new Connection('foo');
     }
 
     /**
@@ -64,7 +64,7 @@ class PDOConnectionTest extends DbalFunctionalTestCase
      */
     public function testThrowsWrappedExceptionOnExec(): void
     {
-        $this->expectException(PDOException::class);
+        $this->expectException(Exception::class);
 
         $this->driverConnection->exec('foo');
     }
@@ -94,14 +94,14 @@ class PDOConnectionTest extends DbalFunctionalTestCase
         // so that PDO actually communicates with the database server to check the query.
         $this->driverConnection->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 
-        $this->expectException(PDOException::class);
+        $this->expectException(Exception::class);
 
         $this->driverConnection->prepare('foo');
     }
 
     public function testThrowsWrappedExceptionOnQuery(): void
     {
-        $this->expectException(PDOException::class);
+        $this->expectException(Exception::class);
 
         $this->driverConnection->query('foo');
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/ConnectionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Tests\DBAL\Functional\Driver;
+namespace Doctrine\Tests\DBAL\Functional\Driver\PDOPgSql;
 
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\FetchMode;
@@ -9,7 +9,7 @@ use Doctrine\Tests\DbalFunctionalTestCase;
 
 use function extension_loaded;
 
-class PDOPgsqlConnectionTest extends DbalFunctionalTestCase
+class ConnectionTest extends DbalFunctionalTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional\Driver\PDOSqlsrv;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDOSqlsrv\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 use Doctrine\Tests\TestUtil;
@@ -41,7 +41,7 @@ class DriverTest extends AbstractDriverTest
     /**
      * @param int[]|string[] $driverOptions
      */
-    private function getConnection(array $driverOptions): PDOConnection
+    private function getConnection(array $driverOptions): Connection
     {
         $params = TestUtil::getConnectionParams();
 

--- a/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Functional;
 
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use PDO;
@@ -19,7 +19,7 @@ class PDOStatementTest extends DbalFunctionalTestCase
 
         parent::setUp();
 
-        if (! $this->connection->getWrappedConnection() instanceof PDOConnection) {
+        if (! $this->connection->getWrappedConnection() instanceof Connection) {
             $this->markTestSkipped('PDO-only test');
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional\Ticket;
 
 use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Driver\PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use PDO;
@@ -173,10 +173,10 @@ class DBAL630Test extends DbalFunctionalTestCase
         ];
     }
 
-    private function getWrappedConnection(): PDOConnection
+    private function getWrappedConnection(): Connection
     {
         $connection = $this->connection->getWrappedConnection();
-        self::assertInstanceOf(PDOConnection::class, $connection);
+        self::assertInstanceOf(Connection::class, $connection);
 
         return $connection;
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Types/BinaryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\DBAL\Functional\Types;
 
-use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
+use Doctrine\DBAL\Driver\IBMDB2\Driver;
 use Doctrine\DBAL\Driver\PDOOracle\Driver as PDOOracleDriver;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
@@ -46,7 +46,7 @@ class BinaryTest extends DbalFunctionalTestCase
         $value2 = random_bytes(64);
 
         /** @see https://bugs.php.net/bug.php?id=76322 */
-        if ($this->connection->getDriver() instanceof DB2Driver) {
+        if ($this->connection->getDriver() instanceof Driver) {
             $value1 = str_replace("\x00", "\xFF", $value1);
             $value2 = str_replace("\x00", "\xFF", $value2);
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use DateTime;
-use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
@@ -347,13 +347,13 @@ class WriteTest extends DbalFunctionalTestCase
      *
      * @return string|false
      *
-     * @throws DriverException
+     * @throws Exception
      */
     private function lastInsertId(?string $name = null)
     {
         try {
             return $this->connection->lastInsertId($name);
-        } catch (DriverException $e) {
+        } catch (Exception $e) {
             if ($e->getCode() === 'IM001') {
                 $this->markTestSkipped($e->getMessage());
             }

--- a/tests/Doctrine/Tests/DBAL/UtilTest.php
+++ b/tests/Doctrine/Tests/DBAL/UtilTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Tests\DBAL;
 
-use Doctrine\DBAL\Driver\OCI8\OCI8Statement;
+use Doctrine\DBAL\Driver\OCI8\Statement;
 use Doctrine\Tests\DbalTestCase;
 
 class UtilTest extends DbalTestCase
@@ -73,7 +73,7 @@ class UtilTest extends DbalTestCase
      */
     public function testConvertPositionalToNamedParameters(string $inputSQL, string $expectedOutputSQL, array $expectedOutputParamsMap): void
     {
-        [$statement, $params] = OCI8Statement::convertPositionalToNamedPlaceholders($inputSQL);
+        [$statement, $params] = Statement::convertPositionalToNamedPlaceholders($inputSQL);
 
         self::assertEquals($expectedOutputSQL, $statement);
         self::assertEquals($expectedOutputParamsMap, $params);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. `Driver` and driver-level `Connection` and `Statement` classes have been renamed for consistency.
2. The `PDO`-related classes have been additionally moved under the `PDO` namespace.
3. The `Driver\DriverException` class has been renamed to `Driver\Exception`. On the one hand, the class name duplicated the name of its namespace; on the other, there's another `DriverException` class in the codebase.
4. The `Driver\AbstractDriverException` class has been renamed to `Driver\AbstractException` and marked internal.
5. Abstract driver-level exception classes have been deprecated in favor of the `Driver\Exception` interface and named exception classes.