### PR TITLE
Invalid queries are generated

### DIFF
--- a/tests/Doctrine/Tests/BugScenarioTest.php
+++ b/tests/Doctrine/Tests/BugScenarioTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests;
+
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+
+final class BugScenarioTest extends DbalFunctionalTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $schemaManager = $this->connection->getSchemaManager();
+        $schema = $schemaManager->createSchema();
+
+        $originalTable = $schema->createTable('to_be_altered');
+        $column = $originalTable->addColumn('some_column_name', Types::TEXT);
+        $column->setNotnull(false);
+
+        $schemaManager->createTable($originalTable);
+    }
+
+    public function testInvalidQueryIsGenerated(): void
+    {
+        $schemaManager = $this->connection->getSchemaManager();
+        $schema = $schemaManager->createSchema();
+
+        $originalTable = $schema->getTable('to_be_altered');
+        $modifiedTable = clone $originalTable;
+
+        $column = $modifiedTable->getColumn('some_column_name');
+        $column->setType(Type::getType(Types::INTEGER));
+
+        $comparator = new Comparator();
+        $tableDiff = $comparator->diffTable($originalTable, $modifiedTable);
+
+        $schemaManager->alterTable($tableDiff);
+    }
+}

--- a/tests/Doctrine/Tests/BugScenarioTest.php
+++ b/tests/Doctrine/Tests/BugScenarioTest.php
@@ -10,24 +10,24 @@ use Doctrine\DBAL\Types\Types;
 
 final class BugScenarioTest extends DbalFunctionalTestCase
 {
-    public function setUp(): void
+    public function setUp() : void
     {
         parent::setUp();
 
         $schemaManager = $this->connection->getSchemaManager();
-        $schema = $schemaManager->createSchema();
+        $schema        = $schemaManager->createSchema();
 
         $originalTable = $schema->createTable('to_be_altered');
-        $column = $originalTable->addColumn('some_column_name', Types::TEXT);
+        $column        = $originalTable->addColumn('some_column_name', Types::TEXT);
         $column->setNotnull(false);
 
         $schemaManager->createTable($originalTable);
     }
 
-    public function testInvalidQueryIsGenerated(): void
+    public function testInvalidQueryIsGenerated() : void
     {
         $schemaManager = $this->connection->getSchemaManager();
-        $schema = $schemaManager->createSchema();
+        $schema        = $schemaManager->createSchema();
 
         $originalTable = $schema->getTable('to_be_altered');
         $modifiedTable = clone $originalTable;
@@ -36,7 +36,7 @@ final class BugScenarioTest extends DbalFunctionalTestCase
         $column->setType(Type::getType(Types::INTEGER));
 
         $comparator = new Comparator();
-        $tableDiff = $comparator->diffTable($originalTable, $modifiedTable);
+        $tableDiff  = $comparator->diffTable($originalTable, $modifiedTable);
 
         $schemaManager->alterTable($tableDiff);
     }

--- a/tests/Doctrine/Tests/DBAL/BugScenarioTest.php
+++ b/tests/Doctrine/Tests/DBAL/BugScenarioTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\DBAL;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Tests\DbalFunctionalTestCase;
 
 final class BugScenarioTest extends DbalFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/DBAL/BugScenarioTest.php
+++ b/tests/Doctrine/Tests/DBAL/BugScenarioTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\Tests;
+namespace Doctrine\Tests\DBAL;
 
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Types\Type;

--- a/tests/Doctrine/Tests/DBAL/BugScenarioTest.php
+++ b/tests/Doctrine/Tests/DBAL/BugScenarioTest.php
@@ -40,5 +40,7 @@ final class BugScenarioTest extends DbalFunctionalTestCase
         $tableDiff  = $comparator->diffTable($originalTable, $modifiedTable);
 
         $schemaManager->alterTable($tableDiff);
+
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes

#### Summary

When changing a column type the platform options are not considered, in version 2.9 for MySQL/MariaDB the `charset` key was not passed as platform option in a column object. Since 2.10 the `charset` key is passed and it is causing generation of invalid queries.

In this scenario the query generated to alter the table is:
```ALTER TABLE to_be_altered CHANGE some_column_name some_column_name INT CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci` ```

Obviously the charset should not be provided/processed for integer type columns.

I'd like to fix this, but I'm a little lost on where to do that. For example we could check the platform options when setting a type to the column and remove the irrelevant ones, but that would require specific logic for specific platform options in the column class.

Maybe introduce a `ColumnTypeModifier` class and have the logic in a separate place? Or am I missing something?