### PR TITLE
respect to platform restrictions when creating autoincrement identifier name

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -587,6 +587,22 @@ END;';
     }
 
     /**
+     * Adds suffix to identifier,
+     *
+     * if the new string exceeds max identifier length,
+     * keeps $suffix, cuts from $identifier as much as the part exceeding.
+     */
+    private function addSuffix(string $identifier, string $suffix) : string
+    {
+        $maxPossibleLengthWithoutSuffix = $this->getMaxIdentifierLength() - strlen($suffix);
+        if (strlen($identifier) > $maxPossibleLengthWithoutSuffix) {
+            $identifier = substr($identifier, 0, $maxPossibleLengthWithoutSuffix);
+        }
+
+        return $identifier . $suffix;
+    }
+
+    /**
      * Returns the autoincrement primary key identifier name for the given table identifier.
      *
      * Quotes the autoincrement primary key identifier name
@@ -598,7 +614,7 @@ END;';
      */
     private function getAutoincrementIdentifierName(Identifier $table)
     {
-        $identifierName = $table->getName() . '_AI_PK';
+        $identifierName = $this->addSuffix($table->getName(), '_AI_PK');
 
         return $table->isQuoted()
             ? $this->quoteSingleIdentifier($identifierName)
@@ -966,7 +982,7 @@ SQL
         $table = new Identifier($tableName);
 
         // No usage of column name to preserve BC compatibility with <2.5
-        $identitySequenceName = $table->getName() . '_SEQ';
+        $identitySequenceName = $this->addSuffix($table->getName(), '_SEQ');
 
         if ($table->isQuoted()) {
             $identitySequenceName = '"' . $identitySequenceName . '"';

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/PlatformRestrictionsTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/PlatformRestrictionsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Platform;
+
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalFunctionalTestCase;
+use function str_repeat;
+
+/**
+ * This class holds tests that make sure generated SQL statements respect to platform restrictions
+ * like maximum element name length
+ */
+class PlatformRestrictionsTest extends DbalFunctionalTestCase
+{
+    /**
+     * Tests element names that are at the boundary of the identifier length limit.
+     * Ensures generated auto-increment identifier name respects to platform restrictions.
+     */
+    public function testMaxIdentifierLengthLimitWithAutoIncrement() : void
+    {
+        $platform   = $this->connection->getDatabasePlatform();
+        $tableName  = str_repeat('x', $platform->getMaxIdentifierLength());
+        $columnName = str_repeat('y', $platform->getMaxIdentifierLength());
+        $table      = new Table($tableName);
+        $table->addColumn($columnName, 'integer', ['autoincrement' => true]);
+        $table->setPrimaryKey([$columnName]);
+        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $createdTable = $this->connection->getSchemaManager()->listTableDetails($tableName);
+
+        $this->assertTrue($createdTable->hasColumn($columnName));
+        $this->assertTrue($createdTable->hasPrimaryKey());
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

`OraclePlatform` does not respect to 30 character max element name restriction in `getAutoincrementIdentifierName` method. This situation leads to `ORA-00972: identifier is too long` error in Oracle databases like here https://github.com/owncloud/twofactor_totp/issues/140#issue-499219646. This PR aims to fix this bug.