### PR TITLE
Mark non-interface OCI8 driver methods internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,7 @@
 
 The non-interface methods of driver-level classes have been marked internal:
 
+- `OCI8Connection::getExecuteMode()`
 - `OCI8Statement::convertPositionalToNamedPlaceholders()`
 
 ## Inconsistently and ambiguously named driver-level classes are deprecated

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade to 2.11
 
+## Non-interface driver methods have been marked internal
+
+The non-interface methods of driver-level classes have been marked internal:
+
+- `OCI8Statement::convertPositionalToNamedPlaceholders()`
+
 ## Inconsistently and ambiguously named driver-level classes are deprecated
 
 The following classes under the `Driver` namespace have been deprecated in favor of their consistently named counterparts:

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -176,6 +176,8 @@ class OCI8Connection implements ConnectionInterface, ServerInfoAwareConnection
     /**
      * Returns the current execution mode.
      *
+     * @internal
+     *
      * @return int
      */
     public function getExecuteMode()

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -133,6 +133,8 @@ class OCI8Statement implements IteratorAggregate, StatementInterface, Result
      * Question marks inside literal strings are therefore handled correctly by this method.
      * This comes at a cost, the whole sql statement has to be looped over.
      *
+     * @internal
+     *
      * @param string $statement The SQL statement to convert.
      *
      * @return mixed[] [0] => the statement value (string), [1] => the paramMap value (array).


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

See #4109.