### PR TITLE
Deprecate DriverException::getErrorCode()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.11
 
+## `DriverException::getErrorCode()` is deprecated
+
+The `DriverException::getErrorCode()` is deprecated as redundant and inconsistently supported by drivers. Use `::getCode()` or `::getSQLState()` instead.
+
 ## Non-interface driver methods have been marked internal
 
 The non-interface methods of driver-level classes have been marked internal:

--- a/lib/Doctrine/DBAL/Driver/Exception.php
+++ b/lib/Doctrine/DBAL/Driver/Exception.php
@@ -14,6 +14,8 @@ interface Exception extends Throwable
     /**
      * Returns the driver specific error code if available.
      *
+     * @deprecated Use {@link getCode()} or {@link getSQLState()} instead
+     *
      * Returns null if no driver specific error code is available
      * for the error raised by the driver.
      *


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

This deprecation is very nice to have to proceed with the removal of the classes deprecated in https://github.com/doctrine/dbal/pull/4100. Specifically, the `PDOException` class that bluntly mixes the SQLSTATE and the exception code:

https://github.com/doctrine/dbal/blob/a7374a24d7d51500e2567499f53509666ee36247/tests/Doctrine/Tests/DBAL/Driver/PDO/ExceptionTest.php#L49-L52

The actual removal was originally implemented in https://github.com/doctrine/dbal/pull/3505 and will be backported to `3.0.x`.