### PR TITLE
Deprecate ServerInfoAwareConnection#requiresQueryForServerVersion() as an implementation detail

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.11
 
+##`ServerInfoAwareConnection::requiresQueryForServerVersion()` is deprecated.
+
+The `ServerInfoAwareConnection::requiresQueryForServerVersion()` method has been deprecated as an implementation detail which is the same for almost all supported drivers.
+
 ## Statement constructors are marked internal
 
 The driver and wrapper statement objects can be only created by the corresponding connection objects.

--- a/lib/Doctrine/DBAL/Driver/ServerInfoAwareConnection.php
+++ b/lib/Doctrine/DBAL/Driver/ServerInfoAwareConnection.php
@@ -17,6 +17,8 @@ interface ServerInfoAwareConnection
     /**
      * Checks whether a query is required to retrieve the database server version.
      *
+     * @deprecated
+     *
      * @return bool True if a query is required to retrieve the database server version, false otherwise.
      */
     public function requiresQueryForServerVersion();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

This deprecation is required to proceed with the removal of the classes deprecated in https://github.com/doctrine/dbal/pull/4100 in favor of the new ones marked `final`.

The actual removal was originally implemented in https://github.com/doctrine/dbal/pull/3807 and will be backported to `3.0.x`.