### PR TITLE
Update PHPStan to 0.12.31

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "doctrine/coding-standard": "^7.0",
         "jetbrains/phpstorm-stubs": "^2019.1",
         "nikic/php-parser": "^4.4",
-        "phpstan/phpstan": "^0.12.30",
+        "phpstan/phpstan": "^0.12.31",
         "phpunit/phpunit": "^8.5.5",
         "psalm/plugin-phpunit": "^0.10.0",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f636004536741040e603f9f76802dc11",
+    "content-hash": "dec9fb0cafafeca81a6e257452a8d7e2",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1349,16 +1349,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.30",
+            "version": "0.12.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "1f2c16d3fbb5eec6e55fbe2358e32570cefa20e5"
+                "reference": "776c8056b401e1b67f277b9e9fb334d1a274671d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1f2c16d3fbb5eec6e55fbe2358e32570cefa20e5",
-                "reference": "1f2c16d3fbb5eec6e55fbe2358e32570cefa20e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/776c8056b401e1b67f277b9e9fb334d1a274671d",
+                "reference": "776c8056b401e1b67f277b9e9fb334d1a274671d",
                 "shasum": ""
             },
             "require": {
@@ -1401,7 +1401,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-21T14:08:19+00:00"
+            "time": "2020-06-24T20:55:29+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -42,9 +42,6 @@ parameters:
         # weird class name, represented in stubs as OCI_(Lob|Collection)
         - '~unknown class OCI-(Lob|Collection)~'
 
-        # https://github.com/phpstan/phpstan-src/pull/255
-        - '~^Method Doctrine\\DBAL\\Driver\\Mysqli\\MysqliStatement::_fetch\(\) never returns null so it can be removed from the return typehint\.$~'
-
         # The ReflectionException in the case when the class does not exist is acceptable and does not need to be handled
         - '~^Parameter #1 \$argument of class ReflectionClass constructor expects class-string<T of object>\|T of object, string given\.$~'
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The update has fixes for https://github.com/phpstan/phpstan-src/pull/255 and https://github.com/phpstan/phpstan/issues/3527.

Besides the error suppression removed in this PR, it will allow removing one more in `2.11.x`:

https://github.com/doctrine/dbal/blob/50dd0ef98edff8c3f1787a161618a982f17b1a69/phpstan.neon.dist#L22-L25
