### PR TITLE
Fixes for the recently introduced driver-level deprecations

### DIFF
--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Connection.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\DBAL\Driver\IBMDB2;
 
 final class Connection extends DB2Connection

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/Statement.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\DBAL\Driver\IBMDB2;
 
 final class Statement extends DB2Statement

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Connection.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\DBAL\Driver\Mysqli;
 
 final class Connection extends MysqliConnection

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Statement.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\DBAL\Driver\Mysqli;
 
 final class Statement extends MysqliStatement

--- a/lib/Doctrine/DBAL/Driver/OCI8/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Connection.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\DBAL\Driver\OCI8;
 
 final class Connection extends OCI8Connection

--- a/lib/Doctrine/DBAL/Driver/OCI8/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Statement.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\DBAL\Driver\OCI8;
 
 final class Statement extends OCI8Statement

--- a/lib/Doctrine/DBAL/Driver/PDO/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/Connection.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\DBAL\Driver\PDO;
 
 use Doctrine\DBAL\Driver\PDOConnection;

--- a/lib/Doctrine/DBAL/Driver/PDO/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/Statement.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\DBAL\Driver\PDO;
 
 use Doctrine\DBAL\Driver\PDOStatement;

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Connection.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\DBAL\Driver\SQLSrv;
 
 final class Connection extends SQLSrvConnection

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Statement.php
@@ -2,6 +2,6 @@
 
 namespace Doctrine\DBAL\Driver\SQLSrv;
 
-class Statement extends SQLSrvStatement
+final class Statement extends SQLSrvStatement
 {
 }

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Statement.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\DBAL\Driver\SQLSrv;
 
 class Statement extends SQLSrvStatement


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug, improvement
| BC Break     | no

1. Although the `declare(strict_types=1);` directives introduced in https://github.com/doctrine/dbal/pull/4100 are okay for `2.x` and don't have any real effect, after the code gets moved from the deprecated classes to the new ones in `3.0.x`, those files will no longer be able to hold the "strict types" contract because they don't yet enforce the scalar parameter types.
   
   Adding these directives will be only possible in `4.0.x` (https://github.com/doctrine/dbal/pull/3552, https://github.com/doctrine/dbal/pull/3568).
2. The `SQLSrv\Statement` class could have been marked `final` originally since it's already `final` in `master` (#3590). Only the PDO-related classes need some extra work to be marked `final`.