### PR TITLE
Deprecate ExceptionConverterDriver

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.11
 
+## The `ExceptionConverterDriver` interface is deprecated
+
+All drivers will have to implement the exception conversion API.
+
 ## `DriverException::getErrorCode()` is deprecated
 
 The `DriverException::getErrorCode()` is deprecated as redundant and inconsistently supported by drivers. Use `::getCode()` or `::getSQLState()` instead.

--- a/lib/Doctrine/DBAL/Driver/AbstractDB2Driver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractDB2Driver.php
@@ -4,6 +4,8 @@ namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\DriverException as TheDriverException;
+use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
 
@@ -38,5 +40,15 @@ abstract class AbstractDB2Driver implements Driver
     public function getSchemaManager(Connection $conn)
     {
         return new DB2SchemaManager($conn);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return DriverException
+     */
+    public function convertException($message, TheDriverException $exception)
+    {
+        return new DriverException($message, $exception);
     }
 }

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
@@ -5,6 +5,8 @@ namespace Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\DriverException as TheDriverException;
+use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\SQLServer2005Platform;
 use Doctrine\DBAL\Platforms\SQLServer2008Platform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
@@ -91,5 +93,15 @@ abstract class AbstractSQLServerDriver implements Driver, VersionAwarePlatformDr
     public function getSchemaManager(Connection $conn)
     {
         return new SQLServerSchemaManager($conn);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return DriverException
+     */
+    public function convertException($message, TheDriverException $exception)
+    {
+        return new DriverException($message, $exception);
     }
 }

--- a/lib/Doctrine/DBAL/Driver/ExceptionConverterDriver.php
+++ b/lib/Doctrine/DBAL/Driver/ExceptionConverterDriver.php
@@ -2,11 +2,14 @@
 
 namespace Doctrine\DBAL\Driver;
 
+use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\DriverException as TheDriverException;
 use Doctrine\DBAL\Exception\DriverException;
 
 /**
  * Contract for a driver that is capable of converting DBAL driver exceptions into standardized DBAL driver exceptions.
+ *
+ * @deprecated All implementors of the {@link Driver} interface will have to implement this API.
  */
 interface ExceptionConverterDriver
 {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -100,6 +100,11 @@
         <exclude-pattern>lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php</exclude-pattern>
     </rule>
 
+    <!-- See https://github.com/slevomat/coding-standard/issues/770 -->
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <exclude-pattern>lib/Doctrine/DBAL/Driver/ExceptionConverterDriver.php</exclude-pattern>
+    </rule>
+
     <!-- See https://github.com/slevomat/coding-standard/issues/1038 -->
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
         <exclude-pattern>tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/StatementTest.php</exclude-pattern>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement, deprecation
| BC Break     | no

Having to branch based on the result of `instanceof` in `DBALException` creates extra complexity in exception handling for no real gain:
https://github.com/doctrine/dbal/blob/a7374a24d7d51500e2567499f53509666ee36247/lib/Doctrine/DBAL/DBALException.php#L171-L175

If the driver doesn't (yet) implement any handling of the underlying error details, it should just wrap the lower-level exception in a higher-level one like all implementors of the conversion API do by default.