### PR TITLE
Update Slevomat Coding Standard to 6.3.10

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2512,16 +2512,16 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "6.3.3",
+            "version": "6.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "b905a82255749de847fd4de607c7a4c8163f058d"
+                "reference": "58fa5ea2c048357ae55185eb5e93ca2826fffde0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b905a82255749de847fd4de607c7a4c8163f058d",
-                "reference": "b905a82255749de847fd4de607c7a4c8163f058d",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/58fa5ea2c048357ae55185eb5e93ca2826fffde0",
+                "reference": "58fa5ea2c048357ae55185eb5e93ca2826fffde0",
                 "shasum": ""
             },
             "require": {
@@ -2565,7 +2565,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-04-28T07:15:08+00:00"
+            "time": "2020-06-22T11:33:09+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/tests/Doctrine/Tests/DBAL/Driver/StatementIteratorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/StatementIteratorTest.php
@@ -104,8 +104,10 @@ class StatementIteratorTest extends DbalTestCase
         yield [PortabilityStatement::class];
         yield [SQLAnywhereStatement::class];
 
-        if (extension_loaded('sqlsrv')) {
-            yield [SQLSrvStatement::class];
+        if (! extension_loaded('sqlsrv')) {
+            return;
         }
+
+        yield [SQLSrvStatement::class];
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The update fixes https://github.com/slevomat/coding-standard/issues/1038. In `2.11.x`, it will allow removing:

https://github.com/doctrine/dbal/blob/4b445ae71d9c0d4ab82641e79a3cd28d55186c1e/phpcs.xml.dist#L108-L111
