### PR TITLE
Use relative names in inline {@link} annotations where possible

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractDB2Driver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractDB2Driver.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for IBM DB2 based drivers.
+ * Abstract base implementation of the {@link Driver} interface for IBM DB2 based drivers.
  */
 abstract class AbstractDB2Driver implements Driver
 {

--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -18,7 +18,7 @@ use function stripos;
 use function version_compare;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for MySQL based drivers.
+ * Abstract base implementation of the {@link Driver} interface for MySQL based drivers.
  */
 abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, VersionAwarePlatformDriver
 {

--- a/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\OracleSchemaManager;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for Oracle based drivers.
+ * Abstract base implementation of the {@link Driver} interface for Oracle based drivers.
  */
 abstract class AbstractOracleDriver implements Driver, ExceptionConverterDriver
 {

--- a/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
@@ -19,7 +19,7 @@ use function strpos;
 use function version_compare;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for PostgreSQL based drivers.
+ * Abstract base implementation of the {@link Driver} interface for PostgreSQL based drivers.
  */
 abstract class AbstractPostgreSQLDriver implements Driver, ExceptionConverterDriver, VersionAwarePlatformDriver
 {

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
@@ -17,7 +17,7 @@ use function preg_match;
 use function version_compare;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for SAP Sybase SQL Anywhere based drivers.
+ * Abstract base implementation of the {@link Driver} interface for SAP Sybase SQL Anywhere based drivers.
  */
 abstract class AbstractSQLAnywhereDriver implements Driver, ExceptionConverterDriver, VersionAwarePlatformDriver
 {

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
@@ -16,7 +16,7 @@ use function preg_match;
 use function version_compare;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for Microsoft SQL Server based drivers.
+ * Abstract base implementation of the {@link Driver} interface for Microsoft SQL Server based drivers.
  */
 abstract class AbstractSQLServerDriver implements Driver, VersionAwarePlatformDriver
 {

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use function strpos;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for SQLite based drivers.
+ * Abstract base implementation of the {@link Driver} interface for SQLite based drivers.
  */
 abstract class AbstractSQLiteDriver implements Driver, ExceptionConverterDriver
 {

--- a/lib/Doctrine/DBAL/Driver/ExceptionConverterDriver.php
+++ b/lib/Doctrine/DBAL/Driver/ExceptionConverterDriver.php
@@ -11,7 +11,7 @@ interface ExceptionConverterDriver
      * Converts a given DBAL driver exception into a standardized DBAL driver exception.
      *
      * It evaluates the vendor specific error code and SQLSTATE and transforms
-     * it into a unified {@link Doctrine\DBAL\Exception\DriverException} subclass.
+     * it into a unified {@link DriverException} subclass.
      *
      * @param string          $message   The DBAL exception message to use.
      * @param DriverException $exception The DBAL driver exception to convert.

--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -29,7 +29,7 @@ interface ResultStatement extends Traversable
     /**
      * Sets the fetch mode to use while iterating this statement.
      *
-     * @param int   $fetchMode The fetch mode must be one of the {@link \Doctrine\DBAL\FetchMode} constants.
+     * @param int   $fetchMode The fetch mode must be one of the {@link FetchMode} constants.
      * @param mixed $arg2
      * @param mixed $arg3
      *
@@ -41,8 +41,8 @@ interface ResultStatement extends Traversable
      * Returns the next row of a result set.
      *
      * @param int|null $fetchMode         Controls how the next row will be returned to the caller.
-     *                                    The value must be one of the {@link \Doctrine\DBAL\FetchMode} constants,
-     *                                    defaulting to {@link \Doctrine\DBAL\FetchMode::MIXED}.
+     *                                    The value must be one of the {@link FetchMode} constants,
+     *                                    defaulting to {@link FetchMode::MIXED}.
      * @param int      $cursorOrientation For a ResultStatement object representing a scrollable cursor,
      *                                    this value determines which row will be returned to the caller.
      *                                    This value must be one of the \PDO::FETCH_ORI_* constants,
@@ -68,19 +68,19 @@ interface ResultStatement extends Traversable
      * Returns an array containing all of the result set rows.
      *
      * @param int|null     $fetchMode     Controls how the next row will be returned to the caller.
-     *                                    The value must be one of the {@link \Doctrine\DBAL\FetchMode} constants,
-     *                                    defaulting to {@link \Doctrine\DBAL\FetchMode::MIXED}.
+     *                                    The value must be one of the {@link FetchMode} constants,
+     *                                    defaulting to {@link FetchMode::MIXED}.
      * @param int|null     $fetchArgument This argument has a different meaning depending on the value of the $fetchMode parameter:
-     *                                    * {@link \Doctrine\DBAL\FetchMode::COLUMN}:
+     *                                    * {@link FetchMode::COLUMN}:
      *                                      Returns the indicated 0-indexed column.
-     *                                    * {@link \Doctrine\DBAL\FetchMode::CUSTOM_OBJECT}:
+     *                                    * {@link FetchMode::CUSTOM_OBJECT}:
      *                                      Returns instances of the specified class, mapping the columns of each row
      *                                      to named properties in the class.
-     *                                    * \PDO::FETCH_FUNC: Returns the results of calling the specified function, using each row's
+     *                                    * {@link PDO::FETCH_FUNC}: Returns the results of calling the specified function, using each row's
      *                                      columns as parameters in the call.
      * @param mixed[]|null $ctorArgs      Controls how the next row will be returned to the caller.
-     *                                    The value must be one of the {@link \Doctrine\DBAL\FetchMode} constants,
-     *                                    defaulting to {@link \Doctrine\DBAL\FetchMode::MIXED}.
+     *                                    The value must be one of the {@link FetchMode} constants,
+     *                                    defaulting to {@link FetchMode::MIXED}.
      *
      * @return mixed[]
      */

--- a/lib/Doctrine/DBAL/Driver/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/Statement.php
@@ -23,7 +23,7 @@ interface Statement extends ResultStatement
      *                          this will be a parameter name of the form :name. For a prepared statement
      *                          using question mark placeholders, this will be the 1-indexed position of the parameter.
      * @param mixed      $value The value to bind to the parameter.
-     * @param int        $type  Explicit data type for the parameter using the {@link \Doctrine\DBAL\ParameterType}
+     * @param int        $type  Explicit data type for the parameter using the {@link ParameterType}
      *                          constants.
      *
      * @return bool TRUE on success or FALSE on failure.
@@ -48,7 +48,7 @@ interface Statement extends ResultStatement
      *                             this will be a parameter name of the form :name. For a prepared statement using
      *                             question mark placeholders, this will be the 1-indexed position of the parameter.
      * @param mixed      $variable Name of the PHP variable to bind to the SQL statement parameter.
-     * @param int        $type     Explicit data type for the parameter using the {@link \Doctrine\DBAL\ParameterType}
+     * @param int        $type     Explicit data type for the parameter using the {@link ParameterType}
      *                             constants. To return an INOUT parameter from a stored procedure, use the bitwise
      *                             OR operator to set the PDO::PARAM_INPUT_OUTPUT bits for the data_type parameter.
      * @param int|null   $length   You must specify maxlength when using an OUT bind

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3232,8 +3232,7 @@ abstract class AbstractPlatform
      * Whether this platform can emulate schemas.
      *
      * Platforms that either support or emulate schemas don't automatically
-     * filter a schema for the namespaced elements in {@link
-     * AbstractManager#createSchema}.
+     * filter a schema for the namespaced elements in {@link AbstractManager::createSchema()}.
      *
      * @return bool
      */

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -642,9 +642,8 @@ SQL
      * Checks whether a given column diff is a logically unchanged binary type column.
      *
      * Used to determine whether a column alteration for a binary type column can be skipped.
-     * Doctrine's {@link \Doctrine\DBAL\Types\BinaryType} and {@link \Doctrine\DBAL\Types\BlobType}
-     * are mapped to the same database column type on this platform as this platform
-     * does not have a native VARBINARY/BINARY column type. Therefore the {@link \Doctrine\DBAL\Schema\Comparator}
+     * Doctrine's {@link BinaryType} and {@link BlobType} are mapped to the same database column type on this platform
+     * as this platform does not have a native VARBINARY/BINARY column type. Therefore the comparator
      * might detect differences for binary type columns which do not have to be propagated
      * to database as there actually is no difference at database level.
      *

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -265,7 +265,7 @@ class QueryBuilder
      *
      * @param string|int      $key   The parameter position or name.
      * @param mixed           $value The parameter value.
-     * @param string|int|null $type  One of the {@link \Doctrine\DBAL\ParameterType} constants.
+     * @param string|int|null $type  One of the {@link ParameterType} constants.
      *
      * @return $this This QueryBuilder instance.
      */

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -186,7 +186,7 @@ class SQLParserUtils
                     array_slice($types, 0, $needle),
                     $count ?
                         // array needles are at {@link \Doctrine\DBAL\ParameterType} constants
-                        // + {@link Doctrine\DBAL\Connection::ARRAY_PARAM_OFFSET}
+                        // + {@link \Doctrine\DBAL\Connection::ARRAY_PARAM_OFFSET}
                         array_fill(0, $count, $types[$needle] - Connection::ARRAY_PARAM_OFFSET) :
                         [],
                     array_slice($types, $needle + 1)

--- a/lib/Doctrine/DBAL/Sharding/ShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/ShardManager.php
@@ -62,7 +62,7 @@ interface ShardManager
      * Queries all shards in undefined order and return the results appended to
      * each other. Restore the previous distribution value after execution.
      *
-     * Using {@link \Doctrine\DBAL\Connection::fetchAll} to retrieve rows internally.
+     * Using {@link Connection::fetchAll()} to retrieve rows internally.
      *
      * @param string         $sql
      * @param mixed[]        $params

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -277,7 +277,7 @@ abstract class Type
      * Gets the (preferred) binding type for values of this type that
      * can be used when binding parameters to prepared statements.
      *
-     * This method should return one of the {@link \Doctrine\DBAL\ParameterType} constants.
+     * This method should return one of the {@link ParameterType} constants.
      *
      * @return int
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Some `{@link}` annotations like the following are highlighted as invalid by PhpStorm:

https://github.com/doctrine/dbal/blob/72b4e777543e19a67c9b94edb3f23d7b3e523be5/lib/Doctrine/DBAL/Driver/AbstractDB2Driver.php#L11

I assume that in namespaced code, class name reference in inline annotations should follow the same rules as in the rest of phpDoc.