### PR TITLE
Rework extension detection in tests

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Driver/IBMDB2/DB2ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/IBMDB2/DB2ConnectionTest.php
@@ -5,8 +5,10 @@ namespace Doctrine\Tests\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\IBMDB2\DB2Connection;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use function extension_loaded;
 
+/**
+ * @requires extension ibm_db2
+ */
 class DB2ConnectionTest extends DbalTestCase
 {
     /**
@@ -18,10 +20,6 @@ class DB2ConnectionTest extends DbalTestCase
 
     protected function setUp() : void
     {
-        if (! extension_loaded('ibm_db2')) {
-            $this->markTestSkipped('ibm_db2 is not installed.');
-        }
-
         parent::setUp();
 
         $this->connectionMock = $this->getMockBuilder(DB2Connection::class)

--- a/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
@@ -7,10 +7,12 @@ use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use function extension_loaded;
 use function restore_error_handler;
 use function set_error_handler;
 
+/**
+ * @requires extension mysqli
+ */
 class MysqliConnectionTest extends DbalFunctionalTestCase
 {
     /**
@@ -22,10 +24,6 @@ class MysqliConnectionTest extends DbalFunctionalTestCase
 
     protected function setUp() : void
     {
-        if (! extension_loaded('mysqli')) {
-            $this->markTestSkipped('mysqli is not installed.');
-        }
-
         parent::setUp();
 
         if (! $this->connection->getDatabasePlatform() instanceof MySqlPlatform) {

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8ConnectionTest.php
@@ -5,8 +5,10 @@ namespace Doctrine\Tests\DBAL\Driver\OCI8;
 use Doctrine\DBAL\Driver\OCI8\OCI8Connection;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use function extension_loaded;
 
+/**
+ * @requires extension oci8
+ */
 class OCI8ConnectionTest extends DbalTestCase
 {
     /**
@@ -18,10 +20,6 @@ class OCI8ConnectionTest extends DbalTestCase
 
     protected function setUp() : void
     {
-        if (! extension_loaded('oci8')) {
-            $this->markTestSkipped('oci8 is not installed.');
-        }
-
         parent::setUp();
 
         $this->connectionMock = $this->getMockBuilder(OCI8Connection::class)

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -7,19 +7,12 @@ use Doctrine\DBAL\Driver\OCI8\OCI8Exception;
 use Doctrine\DBAL\Driver\OCI8\OCI8Statement;
 use Doctrine\Tests\DbalTestCase;
 use ReflectionProperty;
-use function extension_loaded;
 
+/**
+ * @requires extension oci8
+ */
 class OCI8StatementTest extends DbalTestCase
 {
-    protected function setUp() : void
-    {
-        if (! extension_loaded('oci8')) {
-            $this->markTestSkipped('oci8 is not installed.');
-        }
-
-        parent::setUp();
-    }
-
     /**
      * This scenario shows that when the first parameter is not null
      * it properly sets $hasZeroIndex to 1 and calls bindValue starting at 1.

--- a/tests/Doctrine/Tests/DBAL/Driver/PDOExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDOExceptionTest.php
@@ -5,8 +5,10 @@ namespace Doctrine\Tests\DBAL\Driver;
 use Doctrine\DBAL\Driver\PDOException;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use function extension_loaded;
 
+/**
+ * @requires extension pdo
+ */
 class PDOExceptionTest extends DbalTestCase
 {
     public const ERROR_CODE = 666;
@@ -31,10 +33,6 @@ class PDOExceptionTest extends DbalTestCase
 
     protected function setUp() : void
     {
-        if (! extension_loaded('PDO')) {
-            $this->markTestSkipped('PDO is not installed.');
-        }
-
         parent::setUp();
 
         $this->wrappedException = new \PDOException(self::MESSAGE, self::SQLSTATE);

--- a/tests/Doctrine/Tests/DBAL/Driver/SQLAnywhere/SQLAnywhereConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/SQLAnywhere/SQLAnywhereConnectionTest.php
@@ -5,8 +5,10 @@ namespace Doctrine\Tests\DBAL\Driver\SQLAnywhere;
 use Doctrine\DBAL\Driver\SQLAnywhere\SQLAnywhereConnection;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use function extension_loaded;
 
+/**
+ * @requires extension sqlanywhere
+ */
 class SQLAnywhereConnectionTest extends DbalTestCase
 {
     /**
@@ -18,10 +20,6 @@ class SQLAnywhereConnectionTest extends DbalTestCase
 
     protected function setUp() : void
     {
-        if (! extension_loaded('sqlanywhere')) {
-            $this->markTestSkipped('sqlanywhere is not installed.');
-        }
-
         parent::setUp();
 
         $this->connectionMock = $this->getMockBuilder(SQLAnywhereConnection::class)

--- a/tests/Doctrine/Tests/DBAL/Driver/SQLSrv/SQLSrvConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/SQLSrv/SQLSrvConnectionTest.php
@@ -5,7 +5,6 @@ namespace Doctrine\Tests\DBAL\Driver\SQLSrv;
 use Doctrine\DBAL\Driver\SQLSrv\SQLSrvConnection;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use function extension_loaded;
 
 class SQLSrvConnectionTest extends DbalTestCase
 {
@@ -16,12 +15,11 @@ class SQLSrvConnectionTest extends DbalTestCase
      */
     private $connectionMock;
 
+    /**
+     * @requires extension sqlsrv
+     */
     protected function setUp() : void
     {
-        if (! extension_loaded('sqlsrv')) {
-            $this->markTestSkipped('sqlsrv is not installed.');
-        }
-
         parent::setUp();
 
         $this->connectionMock = $this->getMockBuilder(SQLSrvConnection::class)

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/DB2DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/DB2DriverTest.php
@@ -5,16 +5,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\IBMDB2;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
-use function extension_loaded;
 
+/**
+ * @requires extension ibm_db2
+ */
 class DB2DriverTest extends AbstractDriverTest
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('ibm_db2')) {
-            $this->markTestSkipped('ibm_db2 is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof DB2Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/DB2StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/DB2StatementTest.php
@@ -7,16 +7,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\IBMDB2\DB2Driver;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use PHPUnit\Framework\Error\Notice;
-use function extension_loaded;
 
+/**
+ * @requires extension ibm_db2
+ */
 class DB2StatementTest extends DbalFunctionalTestCase
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('ibm_db2')) {
-            $this->markTestSkipped('ibm_db2 is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof DB2Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/ConnectionTest.php
@@ -7,17 +7,15 @@ use Doctrine\DBAL\Driver\Mysqli\MysqliConnection;
 use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use Doctrine\Tests\TestUtil;
-use function extension_loaded;
 use const MYSQLI_OPT_CONNECT_TIMEOUT;
 
+/**
+ * @requires extension mysqli
+ */
 class ConnectionTest extends DbalFunctionalTestCase
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('mysqli')) {
-            $this->markTestSkipped('mysqli is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/DriverTest.php
@@ -5,16 +5,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\Mysqli;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Mysqli\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
-use function extension_loaded;
 
+/**
+ * @requires extension mysqli
+ */
 class DriverTest extends AbstractDriverTest
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('mysqli')) {
-            $this->markTestSkipped('mysqli is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/DriverTest.php
@@ -5,16 +5,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\OCI8;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\OCI8\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
-use function extension_loaded;
 
+/**
+ * @requires extension oci8
+ */
 class DriverTest extends AbstractDriverTest
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('oci8')) {
-            $this->markTestSkipped('oci8 is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/OCI8ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/OCI8ConnectionTest.php
@@ -6,8 +6,10 @@ use Doctrine\DBAL\Driver\OCI8\Driver;
 use Doctrine\DBAL\Driver\OCI8\OCI8Connection;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\Tests\DbalFunctionalTestCase;
-use function extension_loaded;
 
+/**
+ * @requires extension oci8
+ */
 class OCI8ConnectionTest extends DbalFunctionalTestCase
 {
     /** @var OCI8Connection */
@@ -15,10 +17,6 @@ class OCI8ConnectionTest extends DbalFunctionalTestCase
 
     protected function setUp() : void
     {
-        if (! extension_loaded('oci8')) {
-            $this->markTestSkipped('oci8 is not installed.');
-        }
-
         parent::setUp();
 
         if (! $this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/StatementTest.php
@@ -4,16 +4,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\OCI8;
 
 use Doctrine\DBAL\Driver\OCI8\Driver;
 use Doctrine\Tests\DbalFunctionalTestCase;
-use function extension_loaded;
 
+/**
+ * @requires extension oci8
+ */
 class StatementTest extends DbalFunctionalTestCase
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('oci8')) {
-            $this->markTestSkipped('oci8 is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOConnectionTest.php
@@ -9,10 +9,12 @@ use Doctrine\DBAL\Driver\PDOPgSql\Driver as PDOPgSQLDriver;
 use Doctrine\DBAL\Driver\PDOSqlsrv\Driver as PDOSQLSRVDriver;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use PDO;
-use function extension_loaded;
 use function get_class;
 use function sprintf;
 
+/**
+ * @requires extension pdo
+ */
 class PDOConnectionTest extends DbalFunctionalTestCase
 {
     /**
@@ -24,10 +26,6 @@ class PDOConnectionTest extends DbalFunctionalTestCase
 
     protected function setUp() : void
     {
-        if (! extension_loaded('PDO')) {
-            $this->markTestSkipped('PDO is not installed.');
-        }
-
         parent::setUp();
 
         $this->driverConnection = $this->connection->getWrappedConnection();

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOMySql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOMySql/DriverTest.php
@@ -5,16 +5,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDOMySql;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\PDOMySql\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
-use function extension_loaded;
 
+/**
+ * @requires extension pdo_mysql
+ */
 class DriverTest extends AbstractDriverTest
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('pdo_mysql')) {
-            $this->markTestSkipped('pdo_mysql is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOOracle/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOOracle/DriverTest.php
@@ -5,16 +5,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDOOracle;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\PDOOracle\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
-use function extension_loaded;
 
+/**
+ * @requires extension pdo_oci
+ */
 class DriverTest extends AbstractDriverTest
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('PDO_OCI')) {
-            $this->markTestSkipped('PDO_OCI is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
@@ -8,18 +8,16 @@ use Doctrine\DBAL\Driver\PDOPgSql\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 use Doctrine\Tests\TestUtil;
 use function array_key_exists;
-use function extension_loaded;
 use function microtime;
 use function sprintf;
 
+/**
+ * @requires extension pdo_pgsql
+ */
 class DriverTest extends AbstractDriverTest
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('pdo_pgsql')) {
-            $this->markTestSkipped('pdo_pgsql is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgsqlConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgsqlConnectionTest.php
@@ -6,16 +6,14 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\Tests\DbalFunctionalTestCase;
-use function extension_loaded;
 
+/**
+ * @requires extension pdo_pgsql
+ */
 class PDOPgsqlConnectionTest extends DbalFunctionalTestCase
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('pdo_pgsql')) {
-            $this->markTestSkipped('pdo_pgsql is not loaded.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
@@ -5,16 +5,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDOSqlite;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
-use function extension_loaded;
 
+/**
+ * @requires extension pdo_sqlite
+ */
 class DriverTest extends AbstractDriverTest
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('pdo_sqlite')) {
-            $this->markTestSkipped('pdo_sqlite is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
@@ -8,16 +8,14 @@ use Doctrine\DBAL\Driver\PDOSqlsrv\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 use Doctrine\Tests\TestUtil;
 use PDO;
-use function extension_loaded;
 
+/**
+ * @requires extension pdo_sqlsrv
+ */
 class DriverTest extends AbstractDriverTest
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('pdo_sqlsrv')) {
-            $this->markTestSkipped('pdo_sqlsrv is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/ConnectionTest.php
@@ -5,16 +5,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
 use Doctrine\DBAL\Driver\SQLAnywhere\Driver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\Tests\DbalFunctionalTestCase;
-use function extension_loaded;
 
+/**
+ * @requires extension sqlanywhere
+ */
 class ConnectionTest extends DbalFunctionalTestCase
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('sqlanywhere')) {
-            $this->markTestSkipped('sqlanywhere is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/DriverTest.php
@@ -6,16 +6,14 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\SQLAnywhere\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
-use function extension_loaded;
 
+/**
+ * @requires extension sqlanywhere
+ */
 class DriverTest extends AbstractDriverTest
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('sqlanywhere')) {
-            $this->markTestSkipped('sqlanywhere is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLAnywhere/StatementTest.php
@@ -5,16 +5,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\SQLAnywhere;
 use Doctrine\DBAL\Driver\SQLAnywhere\Driver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\Tests\DbalFunctionalTestCase;
-use function extension_loaded;
 
+/**
+ * @requires extension sqlanywhere
+ */
 class StatementTest extends DbalFunctionalTestCase
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('sqlanywhere')) {
-            $this->markTestSkipped('sqlanywhere is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/DriverTest.php
@@ -5,16 +5,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\SQLSrv;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\SQLSrv\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
-use function extension_loaded;
 
+/**
+ * @requires extension sqlsrv
+ */
 class DriverTest extends AbstractDriverTest
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('sqlsrv')) {
-            $this->markTestSkipped('sqlsrv is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/SQLSrv/StatementTest.php
@@ -5,16 +5,14 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\SQLSrv;
 use Doctrine\DBAL\Driver\SQLSrv\Driver;
 use Doctrine\DBAL\Driver\SQLSrv\SQLSrvException;
 use Doctrine\Tests\DbalFunctionalTestCase;
-use function extension_loaded;
 
+/**
+ * @requires extension sqlsrv
+ */
 class StatementTest extends DbalFunctionalTestCase
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('sqlsrv')) {
-            self::markTestSkipped('sqlsrv is not installed.');
-        }
-
         parent::setUp();
 
         if ($this->connection->getDriver() instanceof Driver) {

--- a/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PDOStatementTest.php
@@ -6,16 +6,14 @@ use Doctrine\DBAL\Driver\PDOConnection;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use PDO;
-use function extension_loaded;
 
+/**
+ * @requires extension pdo
+ */
 class PDOStatementTest extends DbalFunctionalTestCase
 {
     protected function setUp() : void
     {
-        if (! extension_loaded('pdo')) {
-            $this->markTestSkipped('PDO is not installed');
-        }
-
         parent::setUp();
 
         if (! $this->connection->getWrappedConnection() instanceof PDOConnection) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -9,11 +9,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
-use SQLite3;
-use function array_map;
 use function dirname;
-use function extension_loaded;
-use function version_compare;
 
 class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
@@ -157,34 +153,6 @@ EOS
 
         self::assertInstanceOf(BlobType::class, $table->getColumn('column_binary')->getType());
         self::assertFalse($table->getColumn('column_binary')->getFixed());
-    }
-
-    public function testNonDefaultPKOrder() : void
-    {
-        if (! extension_loaded('sqlite3')) {
-            $this->markTestSkipped('This test requires the SQLite3 extension.');
-        }
-
-        $version = SQLite3::version();
-        if (version_compare($version['versionString'], '3.7.16', '<')) {
-            $this->markTestSkipped('This version of sqlite doesn\'t return the order of the Primary Key.');
-        }
-
-        $this->connection->exec(<<<EOS
-CREATE TABLE non_default_pk_order (
-    id INTEGER,
-    other_id INTEGER,
-    PRIMARY KEY(other_id, id)
-)
-EOS
-        );
-
-        $tableIndexes = $this->schemaManager->listTableIndexes('non_default_pk_order');
-
-         self::assertCount(1, $tableIndexes);
-
-        self::assertArrayHasKey('primary', $tableIndexes, 'listTableIndexes() has to return a "primary" array key.');
-        self::assertEquals(['other_id', 'id'], array_map('strtolower', $tableIndexes['primary']->getColumns()));
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. Use `@requires extension` instead of `if (extension_loaded())` as a more declarative/idiomatic way.
2. Remove the test that requires `sqlite3` which is not supported.