### PR TITLE
Restore the PortWithoutHost exception parent class

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver/Exception/PortWithoutHost.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver/Exception/PortWithoutHost.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception;
 
-use Doctrine\DBAL\Driver\AbstractException;
+use Doctrine\DBAL\Driver\AbstractDriverException;
 
 /**
  * @internal
  *
  * @psalm-immutable
  */
-final class PortWithoutHost extends AbstractException
+final class PortWithoutHost extends AbstractDriverException
 {
     public static function new(): self
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | https://github.com/doctrine/dbal/pull/4100#discussion_r447095084
