### PR TITLE
Deprecate some DBALException factory methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,7 @@
 ## `DBALException` factory method deprecations
 
 1. `DBALException::invalidPlatformType()` is deprecated as unused as of v2.7.0.
+2. `DBALException::invalidPdoInstance()` as passing a PDO instance via configuration is deprecated.
 
 ## `AbstractPlatform::fixSchemaElementName()` is deprecated.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.11
 
+## `DBALException` factory method deprecations
+
+1. `DBALException::invalidPlatformType()` is deprecated as unused as of v2.7.0.
+
 ## `AbstractPlatform::fixSchemaElementName()` is deprecated.
 
 The method is not used anywhere except for tests.

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -93,6 +93,8 @@ class DBALException extends Exception
     }
 
     /**
+     * @deprecated Passing a PDO instance in connection parameters is deprecated.
+     *
      * @return DBALException
      */
     public static function invalidPdoInstance()

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -38,6 +38,9 @@ class DBALException extends Exception
         return new self(sprintf("Operation '%s' is not supported by platform.", $method));
     }
 
+    /**
+     * @deprecated Use {@link invalidPlatformType()} instead.
+     */
     public static function invalidPlatformSpecified(): self
     {
         return new self(


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

1. `DBALException::invalidPlatformType()` is unused as of v2.7.0 (https://github.com/doctrine/dbal/commit/1119a3d8583b99d090569a85b272a13edd083c55).
2. The usage of user-provided PDO instance is deprecated as of v2.10.0 (#3554).