### PR TITLE
PDO connection and statement classes made final

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 3.0
 
+## BC BREAK: Changes in PDO driver classes
+
+1. The `PDO\Connection` and `PDO\Statement` classes have been made final.
+2. The `PDOSqlsrv\Connection` and `PDOSqlsrv\Statement` classes have been made final and no longer extend the corresponding PDO classes.
+
 ## BC BREAK: Changes in driver-level exception handling
 
 1. The `convertException()` method has been removed from the `Driver` interface. The logic of exception conversion has been moved to the `ExceptionConverter` interface. The drivers now must implement the `getExceptionConverter()` method.

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -13,7 +13,7 @@ use PDOStatement;
 
 use function assert;
 
-class Connection implements ServerInfoAwareConnection
+final class Connection implements ServerInfoAwareConnection
 {
     /** @var PDO */
     private $connection;
@@ -57,6 +57,9 @@ class Connection implements ServerInfoAwareConnection
         return $this->connection->getAttribute(PDO::ATTR_SERVER_VERSION);
     }
 
+    /**
+     * @return Statement
+     */
     public function prepare(string $sql): StatementInterface
     {
         try {

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -14,7 +14,7 @@ use PDOStatement;
 use function array_slice;
 use function func_get_args;
 
-class Statement implements StatementInterface
+final class Statement implements StatementInterface
 {
     private const PARAM_TYPE_MAP = [
         ParameterType::NULL => PDO::PARAM_NULL,

--- a/src/Driver/PDOSqlsrv/Connection.php
+++ b/src/Driver/PDOSqlsrv/Connection.php
@@ -2,27 +2,66 @@
 
 namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
-use Doctrine\DBAL\Driver\PDO\Connection as BaseConnection;
-use Doctrine\DBAL\Driver\PDO\Statement as BaseStatement;
+use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use PDOStatement;
+use PDO;
 
 use function is_string;
 use function strpos;
 use function substr;
 
-/**
- * Sqlsrv Connection implementation.
- */
-class Connection extends BaseConnection
+final class Connection implements ServerInfoAwareConnection
 {
+    /** @var PDOConnection */
+    private $connection;
+
+    public function __construct(PDOConnection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function prepare(string $sql): StatementInterface
+    {
+        return new Statement(
+            $this->connection->prepare($sql)
+        );
+    }
+
+    public function query(string $sql): Result
+    {
+        return $this->connection->query($sql);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function quote($value, $type = ParameterType::STRING)
+    {
+        $val = $this->connection->quote($value, $type);
+
+        // Fix for a driver version terminating all values with null byte
+        if (is_string($val) && strpos($val, "\0") !== false) {
+            $val = substr($val, 0, -1);
+        }
+
+        return $val;
+    }
+
+    public function exec(string $statement): int
+    {
+        return $this->connection->exec($statement);
+    }
+
     /**
      * {@inheritDoc}
      */
     public function lastInsertId($name = null)
     {
         if ($name === null) {
-            return parent::lastInsertId($name);
+            return $this->connection->lastInsertId($name);
         }
 
         return $this->prepare('SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?')
@@ -33,20 +72,37 @@ class Connection extends BaseConnection
     /**
      * {@inheritDoc}
      */
-    public function quote($value, $type = ParameterType::STRING)
+    public function beginTransaction()
     {
-        $val = parent::quote($value, $type);
-
-        // Fix for a driver version terminating all values with null byte
-        if (is_string($val) && strpos($val, "\0") !== false) {
-            $val = substr($val, 0, -1);
-        }
-
-        return $val;
+        return $this->connection->beginTransaction();
     }
 
-    protected function createStatement(PDOStatement $stmt): BaseStatement
+    /**
+     * {@inheritDoc}
+     */
+    public function commit()
     {
-        return new Statement($stmt);
+        return $this->connection->commit();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function rollBack()
+    {
+        return $this->connection->rollBack();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getServerVersion()
+    {
+        return $this->connection->getServerVersion();
+    }
+
+    public function getWrappedConnection(): PDO
+    {
+        return $this->connection->getWrappedConnection();
     }
 }

--- a/src/Driver/PDOSqlsrv/Driver.php
+++ b/src/Driver/PDOSqlsrv/Driver.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
 use Doctrine\DBAL\Driver\Exception;
+use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
 use PDO;
 
 use function is_int;
@@ -37,10 +38,12 @@ class Driver extends AbstractSQLServerDriver
         }
 
         return new Connection(
-            $this->_constructPdoDsn($params, $dsnOptions),
-            $params['user'] ?? '',
-            $params['password'] ?? '',
-            $pdoOptions
+            new PDOConnection(
+                $this->_constructPdoDsn($params, $dsnOptions),
+                $params['user'] ?? '',
+                $params['password'] ?? '',
+                $pdoOptions
+            )
         );
     }
 

--- a/src/Driver/PDOSqlsrv/Statement.php
+++ b/src/Driver/PDOSqlsrv/Statement.php
@@ -2,17 +2,32 @@
 
 namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
-use Doctrine\DBAL\Driver\PDO\Statement as BaseStatement;
+use Doctrine\DBAL\Driver\PDO\Statement as PDOStatement;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
 use PDO;
 
 /**
  * PDO SQL Server Statement
  */
-class Statement extends BaseStatement
+final class Statement implements StatementInterface
 {
+    /** @var PDOStatement */
+    private $statement;
+
+    /**
+     * @internal The statement can be only instantiated by its driver connection.
+     */
+    public function __construct(PDOStatement $statement)
+    {
+        $this->statement = $statement;
+    }
+
     /**
      * {@inheritdoc}
+     *
+     * @param mixed $driverOptions
      */
     public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null, $driverOptions = null)
     {
@@ -23,7 +38,7 @@ class Statement extends BaseStatement
             $driverOptions = PDO::SQLSRV_ENCODING_BINARY;
         }
 
-        return parent::bindParam($column, $variable, $type, $length, $driverOptions);
+        return $this->statement->bindParam($column, $variable, $type, $length, $driverOptions);
     }
 
     /**
@@ -32,5 +47,13 @@ class Statement extends BaseStatement
     public function bindValue($param, $value, $type = ParameterType::STRING)
     {
         return $this->bindParam($param, $value, $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($params = null): Result
+    {
+        return $this->statement->execute($params);
     }
 }

--- a/tests/Functional/Driver/PDOSqlsrv/DriverTest.php
+++ b/tests/Functional/Driver/PDOSqlsrv/DriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Tests\Functional\Driver\PDOSqlsrv;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDO\Connection;
+use Doctrine\DBAL\Driver\PDOSqlsrv\Connection;
 use Doctrine\DBAL\Driver\PDOSqlsrv\Driver;
 use Doctrine\DBAL\Tests\Functional\Driver\AbstractDriverTest;
 use Doctrine\DBAL\Tests\TestUtil;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

`PDOSqlsrv\Connection` and `PDOSqlsrv\Statement` now wrap the corresponding `PDO` classes instead of extending them, and they all are now `final`.
