### PR TITLE
Mark connection constructors internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -19,9 +19,11 @@ The method is not used anywhere except for tests.
 
 The `ServerInfoAwareConnection::requiresQueryForServerVersion()` method has been deprecated as an implementation detail which is the same for almost all supported drivers.
 
-## Statement constructors are marked internal
+## Connection and Statement constructors are marked internal
 
-The driver and wrapper statement objects can be only created by the corresponding connection objects.
+1. Driver connection objects can be only created by the corresponding drivers.
+2. Wrapper connection objects can be only created by the driver manager.
+3. The driver and wrapper connection objects can be only created by the corresponding connection objects.
 
 ## The `PingableConnection` interface is deprecated
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -25,6 +25,8 @@ The `ServerInfoAwareConnection::requiresQueryForServerVersion()` method has been
 2. Wrapper connection objects can be only created by the driver manager.
 3. The driver and wrapper connection objects can be only created by the corresponding connection objects.
 
+Additionally, the `SQLSrv\LastInsertId` class has been marked internal.
+
 ## The `PingableConnection` interface is deprecated
 
 The wrapper connection will automatically handle the lost connection if the driver supports reporting it.

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -168,6 +168,8 @@ class Connection implements DriverConnection
     /**
      * Initializes a new instance of the Connection class.
      *
+     * @internal The connection can be only instantiated by the driver manager.
+     *
      * @param mixed[]            $params       The connection parameters.
      * @param Driver             $driver       The driver to use.
      * @param Configuration|null $config       The configuration, optional.

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -20,6 +20,8 @@ class MasterSlaveConnection extends PrimaryReadReplicaConnection
     /**
      * Creates Primary Replica Connection.
      *
+     * @internal The connection can be only instantiated by the driver manager.
+     *
      * @param mixed[] $params
      *
      * @throws InvalidArgumentException

--- a/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
+++ b/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
@@ -90,6 +90,8 @@ class PrimaryReadReplicaConnection extends Connection
     /**
      * Creates Primary Replica Connection.
      *
+     * @internal The connection can be only instantiated by the driver manager.
+     *
      * @param mixed[] $params
      *
      * @throws InvalidArgumentException

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -40,6 +40,8 @@ class DB2Connection implements ConnectionInterface, ServerInfoAwareConnection
     private $conn = null;
 
     /**
+     * @internal The connection can be only instantiated by its driver.
+     *
      * @param mixed[] $params
      * @param string  $username
      * @param string  $password

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -46,6 +46,8 @@ class MysqliConnection implements ConnectionInterface, PingableConnection, Serve
     private $conn;
 
     /**
+     * @internal The connection can be only instantiated by its driver.
+     *
      * @param mixed[] $params
      * @param string  $username
      * @param string  $password

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -41,6 +41,8 @@ class OCI8Connection implements ConnectionInterface, ServerInfoAwareConnection
     /**
      * Creates a Connection to an Oracle Database using oci8 extension.
      *
+     * @internal The connection can be only instantiated by its driver.
+     *
      * @param string $username
      * @param string $password
      * @param string $db

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -22,6 +22,8 @@ use function func_get_args;
 class PDOConnection extends PDO implements ConnectionInterface, ServerInfoAwareConnection
 {
     /**
+     * @internal The connection can be only instantiated by its driver.
+     *
      * @param string       $dsn
      * @param string|null  $user
      * @param string|null  $password

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -17,6 +17,8 @@ use function substr;
 class Connection extends BaseConnection
 {
     /**
+     * @internal The connection can be only instantiated by its driver.
+     *
      * {@inheritdoc}
      */
     public function __construct($dsn, $user = null, $password = null, ?array $options = null)

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -36,6 +36,8 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
     /**
      * Connects to database with given connection string.
      *
+     * @internal The connection can be only instantiated by its driver.
+     *
      * @param string $dsn        The connection string.
      * @param bool   $persistent Whether or not to establish a persistent connection.
      *

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/LastInsertId.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/LastInsertId.php
@@ -4,6 +4,8 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 
 /**
  * Last Id Data Container.
+ *
+ * @internal
  */
 class LastInsertId
 {

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -39,6 +39,8 @@ class SQLSrvConnection implements ConnectionInterface, ServerInfoAwareConnection
     protected $lastInsertId;
 
     /**
+     * @internal The connection can be only instantiated by its driver.
+     *
      * @param string  $serverName
      * @param mixed[] $connectionOptions
      *

--- a/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardConnection.php
@@ -65,6 +65,8 @@ class PoolingShardConnection extends Connection
     /**
      * {@inheritDoc}
      *
+     * @internal The connection can be only instantiated by the driver manager.
+     *
      * @throws InvalidArgumentException
      */
     public function __construct(array $params, Driver $driver, ?Configuration $config = null, ?EventManager $eventManager = null)


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Similarly to #4119, mark connection constructors internal. Although there's no immediate need for that, it will help us avoid unnecessary BC breaks in the future (e.g. #4081). This corresponds to the approach taken by the underlying DB drivers that in most cases don't allow direct instantiation of any resources than the top-level one (e.g. `new PDO()`).
