### PR TITLE
Mark result constructors internal

### DIFF
--- a/src/Driver/IBMDB2/Result.php
+++ b/src/Driver/IBMDB2/Result.php
@@ -21,6 +21,8 @@ final class Result implements ResultInterface
     private $statement;
 
     /**
+     * @internal The result can be only instantiated by its driver connection or statement.
+     *
      * @param resource $statement
      */
     public function __construct($statement)

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -43,6 +43,8 @@ final class Result implements ResultInterface
     private $boundValues = [];
 
     /**
+     * @internal The result can be only instantiated by its driver connection or statement.
+     *
      * @throws Exception
      */
     public function __construct(mysqli_stmt $statement)

--- a/src/Driver/OCI8/Result.php
+++ b/src/Driver/OCI8/Result.php
@@ -26,6 +26,8 @@ final class Result implements ResultInterface
     private $statement;
 
     /**
+     * @internal The result can be only instantiated by its driver connection or statement.
+     *
      * @param resource $statement
      */
     public function __construct($statement)

--- a/src/Driver/PDO/Result.php
+++ b/src/Driver/PDO/Result.php
@@ -17,6 +17,9 @@ final class Result implements ResultInterface
     /** @var PDOStatement */
     private $statement;
 
+    /**
+     * @internal The result can be only instantiated by its driver connection or statement.
+     */
     public function __construct(PDOStatement $statement)
     {
         $this->statement = $statement;

--- a/src/Driver/SQLSrv/Result.php
+++ b/src/Driver/SQLSrv/Result.php
@@ -21,6 +21,8 @@ final class Result implements ResultInterface
     private $statement;
 
     /**
+     * @internal The result can be only instantiated by its driver connection or statement.
+     *
      * @param resource $stmt
      */
     public function __construct($stmt)

--- a/src/Portability/Result.php
+++ b/src/Portability/Result.php
@@ -14,6 +14,9 @@ final class Result implements ResultInterface
     /** @var Converter */
     private $converter;
 
+    /**
+     * @internal The result can be only instantiated by the portability connection or statement.
+     */
     public function __construct(ResultInterface $result, Converter $converter)
     {
         $this->result    = $result;

--- a/src/Result.php
+++ b/src/Result.php
@@ -17,6 +17,9 @@ final class Result implements ResultInterface
     /** @var Connection */
     private $connection;
 
+    /**
+     * @internal The result can be only instantiated by {@link Connection} or {@link Statement}.
+     */
     public function __construct(DriverResult $result, Connection $connection)
     {
         $this->result     = $result;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Same as #4139 and #4119 but for the `Result` classes.