### PR TITLE
Deprecate classes in Driver\PDO* namespaces

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,17 @@
 # Upgrade to 2.11
 
+## PDO-related classes outside of the PDO namespace are deprecated
+
+The following outside of the PDO namespace have been deprecated in favor of their counterparts in the PDO namespace:
+
+- `PDOMySql\Driver` → `PDO\MySQL\Driver`
+- `PDOOracle\Driver` → `PDO\OCI\Driver`
+- `PDOPgSql\Driver` → `PDO\PgSQL\Driver`
+- `PDOSqlite\Driver` → `PDO\SQLite\Driver`
+- `PDOSqlsrv\Driver` → `PDO\SQLSrv\Driver`
+- `PDOSqlsrv\Connection` → `PDO\SQLSrv\Connection`
+- `PDOSqlsrv\Statement` → `PDO\SQLSrv\Statement`
+
 ## Deprecations in driver-level exception handling
 
 1. The `ExceptionConverterDriver` interface and the usage of the `convertException()` method on the `Driver` objects are deprecated.

--- a/lib/Doctrine/DBAL/Driver/PDO/MySQL/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/MySQL/Driver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PDO\MySQL;
+
+use Doctrine\DBAL\Driver\PDOMySql;
+
+final class Driver extends PDOMySql\Driver
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDO/OCI/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/OCI/Driver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PDO\OCI;
+
+use Doctrine\DBAL\Driver\PDOOracle;
+
+final class Driver extends PDOOracle\Driver
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDO/PgSQL/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/PgSQL/Driver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PDO\PgSQL;
+
+use Doctrine\DBAL\Driver\PDOPgSql;
+
+final class Driver extends PDOPgSql\Driver
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDO/SQLSrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/SQLSrv/Connection.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PDO\SQLSrv;
+
+use Doctrine\DBAL\Driver\PDOSqlsrv;
+
+final class Connection extends PDOSqlsrv\Connection
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDO/SQLSrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/SQLSrv/Driver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PDO\SQLSrv;
+
+use Doctrine\DBAL\Driver\PDOSqlsrv;
+
+final class Driver extends PDOSqlsrv\Driver
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDO/SQLSrv/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/SQLSrv/Statement.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PDO\SQLSrv;
+
+use Doctrine\DBAL\Driver\PDOSqlsrv;
+
+final class Statement extends PDOSqlsrv\Statement
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDO/SQLite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDO/SQLite/Driver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PDO\SQLite;
+
+use Doctrine\DBAL\Driver\PDOSqlite;
+
+final class Driver extends PDOSqlite\Driver
+{
+}

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -4,11 +4,13 @@ namespace Doctrine\DBAL\Driver\PDOMySql;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
-use Doctrine\DBAL\Driver\PDO\Connection;
+use Doctrine\DBAL\Driver\PDO;
 use PDOException;
 
 /**
  * PDO MySql driver.
+ *
+ * @deprecated Use {@link PDO\MySQL\Driver} instead.
  */
 class Driver extends AbstractMySQLDriver
 {
@@ -18,7 +20,7 @@ class Driver extends AbstractMySQLDriver
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         try {
-            $conn = new Connection(
+            $conn = new PDO\Connection(
                 $this->constructPdoDsn($params),
                 $username,
                 $password,

--- a/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL\Driver\PDOOracle;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
-use Doctrine\DBAL\Driver\PDO\Connection;
+use Doctrine\DBAL\Driver\PDO;
 use PDOException;
 
 /**
@@ -14,6 +14,8 @@ use PDOException;
  * stuff. PDO Oracle is not maintained by Oracle or anyone in the PHP community,
  * which leads us to the recommendation to use the "oci8" driver to connect
  * to Oracle instead.
+ *
+ * @deprecated Use {@link PDO\OCI\Driver} instead.
  */
 class Driver extends AbstractOracleDriver
 {
@@ -23,7 +25,7 @@ class Driver extends AbstractOracleDriver
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         try {
-            return new Connection(
+            return new PDO\Connection(
                 $this->constructPdoDsn($params),
                 $username,
                 $password,

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -4,14 +4,15 @@ namespace Doctrine\DBAL\Driver\PDOPgSql;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
-use Doctrine\DBAL\Driver\PDO\Connection;
-use PDO;
+use Doctrine\DBAL\Driver\PDO;
 use PDOException;
 
 use function defined;
 
 /**
  * Driver that connects through pdo_pgsql.
+ *
+ * @deprecated Use {@link PDO\PgSQL\Driver} instead.
  */
 class Driver extends AbstractPostgreSQLDriver
 {
@@ -21,7 +22,7 @@ class Driver extends AbstractPostgreSQLDriver
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         try {
-            $pdo = new Connection(
+            $pdo = new PDO\Connection(
                 $this->_constructPdoDsn($params),
                 $username,
                 $password,
@@ -30,11 +31,11 @@ class Driver extends AbstractPostgreSQLDriver
 
             if (
                 defined('PDO::PGSQL_ATTR_DISABLE_PREPARES')
-                && (! isset($driverOptions[PDO::PGSQL_ATTR_DISABLE_PREPARES])
-                    || $driverOptions[PDO::PGSQL_ATTR_DISABLE_PREPARES] === true
+                && (! isset($driverOptions[\PDO::PGSQL_ATTR_DISABLE_PREPARES])
+                    || $driverOptions[\PDO::PGSQL_ATTR_DISABLE_PREPARES] === true
                 )
             ) {
-                $pdo->setAttribute(PDO::PGSQL_ATTR_DISABLE_PREPARES, true);
+                $pdo->setAttribute(\PDO::PGSQL_ATTR_DISABLE_PREPARES, true);
             }
 
             /* defining client_encoding via SET NAMES to avoid inconsistent DSN support

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -4,7 +4,7 @@ namespace Doctrine\DBAL\Driver\PDOSqlite;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
-use Doctrine\DBAL\Driver\PDO\Connection;
+use Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use PDOException;
 
@@ -12,6 +12,8 @@ use function array_merge;
 
 /**
  * The PDO Sqlite driver.
+ *
+ * @deprecated Use {@link PDO\SQLite\Driver} instead.
  */
 class Driver extends AbstractSQLiteDriver
 {
@@ -36,7 +38,7 @@ class Driver extends AbstractSQLiteDriver
         }
 
         try {
-            $pdo = new Connection(
+            $pdo = new PDO\Connection(
                 $this->_constructPdoDsn($params),
                 $username,
                 $password,

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -2,10 +2,9 @@
 
 namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
-use Doctrine\DBAL\Driver\PDO\Connection as BaseConnection;
+use Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\ParameterType;
-use PDO;
 
 use function is_string;
 use function strpos;
@@ -13,8 +12,10 @@ use function substr;
 
 /**
  * Sqlsrv Connection implementation.
+ *
+ * @deprecated Use {@link PDO\SQLSrv\Connection} instead.
  */
-class Connection extends BaseConnection
+class Connection extends PDO\Connection
 {
     /**
      * @internal The connection can be only instantiated by its driver.
@@ -24,7 +25,7 @@ class Connection extends BaseConnection
     public function __construct($dsn, $user = null, $password = null, ?array $options = null)
     {
         parent::__construct($dsn, $user, $password, $options);
-        $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, [Statement::class, []]);
+        $this->setAttribute(\PDO::ATTR_STATEMENT_CLASS, [PDO\SQLSrv\Statement::class, []]);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
@@ -4,12 +4,15 @@ namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
+use Doctrine\DBAL\Driver\PDO;
 
 use function is_int;
 use function sprintf;
 
 /**
  * The PDO-based Sqlsrv driver.
+ *
+ * @deprecated Use {@link PDO\SQLSrv\Driver} instead.
  */
 class Driver extends AbstractSQLServerDriver
 {
@@ -28,7 +31,7 @@ class Driver extends AbstractSQLServerDriver
             }
         }
 
-        return new Connection(
+        return new PDO\SQLSrv\Connection(
             $this->_constructPdoDsn($params, $dsnOptions),
             $username,
             $password,

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Statement.php
@@ -2,14 +2,15 @@
 
 namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
-use Doctrine\DBAL\Driver\PDO\Statement as BaseStatement;
+use Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\ParameterType;
-use PDO;
 
 /**
  * PDO SQL Server Statement
+ *
+ * @deprecated Use {@link PDO\SQLSrv\Statement} instead.
  */
-class Statement extends BaseStatement
+class Statement extends PDO\Statement
 {
     /**
      * {@inheritdoc}
@@ -20,7 +21,7 @@ class Statement extends BaseStatement
             ($type === ParameterType::LARGE_OBJECT || $type === ParameterType::BINARY)
             && $driverOptions === null
         ) {
-            $driverOptions = PDO::SQLSRV_ENCODING_BINARY;
+            $driverOptions = \PDO::SQLSRV_ENCODING_BINARY;
         }
 
         return parent::bindParam($column, $variable, $type, $length, $driverOptions);

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -3,18 +3,13 @@
 namespace Doctrine\DBAL;
 
 use Doctrine\Common\EventManager;
-use Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver as DrizzlePDOMySQLDriver;
-use Doctrine\DBAL\Driver\IBMDB2\Driver as IBMDB2Driver;
-use Doctrine\DBAL\Driver\Mysqli\Driver as MySQLiDriver;
-use Doctrine\DBAL\Driver\OCI8\Driver as OCI8Driver;
-use Doctrine\DBAL\Driver\PDOMySql\Driver as PDOMySQLDriver;
-use Doctrine\DBAL\Driver\PDOOracle\Driver as PDOOCIDriver;
-use Doctrine\DBAL\Driver\PDOPgSql\Driver as PDOPgSQLDriver;
-use Doctrine\DBAL\Driver\PDOSqlite\Driver as PDOSQLiteDriver;
-use Doctrine\DBAL\Driver\PDOSqlsrv\Driver as PDOSQLSrvDriver;
-use Doctrine\DBAL\Driver\SQLAnywhere\Driver as SQLAnywhereDriver;
-use Doctrine\DBAL\Driver\SQLSrv\Driver as SQLSrvDriver;
-use PDO;
+use Doctrine\DBAL\Driver\DrizzlePDOMySql;
+use Doctrine\DBAL\Driver\IBMDB2;
+use Doctrine\DBAL\Driver\Mysqli;
+use Doctrine\DBAL\Driver\OCI8;
+use Doctrine\DBAL\Driver\PDO;
+use Doctrine\DBAL\Driver\SQLAnywhere;
+use Doctrine\DBAL\Driver\SQLSrv;
 
 use function array_keys;
 use function array_map;
@@ -45,17 +40,17 @@ final class DriverManager
      * @var string[]
      */
     private static $_driverMap = [
-        'pdo_mysql'          => PDOMySQLDriver::class,
-        'pdo_sqlite'         => PDOSQLiteDriver::class,
-        'pdo_pgsql'          => PDOPgSQLDriver::class,
-        'pdo_oci'            => PDOOCIDriver::class,
-        'oci8'               => OCI8Driver::class,
-        'ibm_db2'            => IBMDB2Driver::class,
-        'pdo_sqlsrv'         => PDOSQLSrvDriver::class,
-        'mysqli'             => MySQLiDriver::class,
-        'drizzle_pdo_mysql'  => DrizzlePDOMySQLDriver::class,
-        'sqlanywhere'        => SQLAnywhereDriver::class,
-        'sqlsrv'             => SQLSrvDriver::class,
+        'pdo_mysql'          => PDO\MySQL\Driver::class,
+        'pdo_sqlite'         => PDO\SQLite\Driver::class,
+        'pdo_pgsql'          => PDO\PgSQL\Driver::class,
+        'pdo_oci'            => PDO\OCI\Driver::class,
+        'oci8'               => OCI8\Driver::class,
+        'ibm_db2'            => IBMDB2\Driver::class,
+        'pdo_sqlsrv'         => PDO\SQLSrv\Driver::class,
+        'mysqli'             => Mysqli\Driver::class,
+        'drizzle_pdo_mysql'  => DrizzlePDOMySql\Driver::class,
+        'sqlanywhere'        => SQLAnywhere\Driver::class,
+        'sqlsrv'             => SQLSrv\Driver::class,
     ];
 
     /**
@@ -177,13 +172,13 @@ final class DriverManager
         }
 
         // check for existing pdo object
-        if (isset($params['pdo']) && ! $params['pdo'] instanceof PDO) {
+        if (isset($params['pdo']) && ! $params['pdo'] instanceof \PDO) {
             throw DBALException::invalidPdoInstance();
         }
 
         if (isset($params['pdo'])) {
-            $params['pdo']->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-            $params['driver'] = 'pdo_' . $params['pdo']->getAttribute(PDO::ATTR_DRIVER_NAME);
+            $params['pdo']->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+            $params['driver'] = 'pdo_' . $params['pdo']->getAttribute(\PDO::ATTR_DRIVER_NAME);
         } else {
             self::_checkParams($params);
         }

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -135,7 +135,7 @@ class ConnectionTest extends DbalTestCase
 
     public function testGetDriver(): void
     {
-        self::assertInstanceOf(\Doctrine\DBAL\Driver\PDOMySql\Driver::class, $this->connection->getDriver());
+        self::assertInstanceOf(Driver\PDO\MySQL\Driver::class, $this->connection->getDriver());
     }
 
     public function testGetEventManager(): void

--- a/tests/Doctrine/Tests/DBAL/Driver/PDOMySql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDOMySql/DriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Driver\PDOMySql;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDOMySql\Driver;
+use Doctrine\DBAL\Driver\PDO\MySQL\Driver;
 use Doctrine\Tests\DBAL\Driver\AbstractMySQLDriverTest;
 
 class DriverTest extends AbstractMySQLDriverTest

--- a/tests/Doctrine/Tests/DBAL/Driver/PDOOracle/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDOOracle/DriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Driver\PDOOracle;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDOOracle\Driver;
+use Doctrine\DBAL\Driver\PDO\OCI\Driver;
 use Doctrine\Tests\DBAL\Driver\AbstractOracleDriverTest;
 
 class DriverTest extends AbstractOracleDriverTest

--- a/tests/Doctrine/Tests/DBAL/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDOPgSql/DriverTest.php
@@ -4,7 +4,7 @@ namespace Doctrine\Tests\DBAL\Driver\PDOPgSql;
 
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\PDO\Connection;
-use Doctrine\DBAL\Driver\PDOPgSql\Driver;
+use Doctrine\DBAL\Driver\PDO\PgSQL\Driver;
 use Doctrine\Tests\DBAL\Driver\AbstractPostgreSQLDriverTest;
 use Doctrine\Tests\TestUtil;
 use PDO;

--- a/tests/Doctrine/Tests/DBAL/Driver/PDOSqlite/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDOSqlite/DriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Driver\PDOSqlite;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDOSqlite\Driver;
+use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\Tests\DBAL\Driver\AbstractSQLiteDriverTest;
 
 class DriverTest extends AbstractSQLiteDriverTest

--- a/tests/Doctrine/Tests/DBAL/Driver/PDOSqlsrv/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDOSqlsrv/DriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Driver\PDOSqlsrv;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDOSqlsrv\Driver;
+use Doctrine\DBAL\Driver\PDO\SQLSrv\Driver;
 use Doctrine\Tests\DBAL\Driver\AbstractSQLServerDriverTest;
 
 class DriverTest extends AbstractSQLServerDriverTest

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -7,8 +7,8 @@ use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver as DrizzlePDOMySqlDriver;
-use Doctrine\DBAL\Driver\PDOMySql\Driver as PDOMySQLDriver;
-use Doctrine\DBAL\Driver\PDOSqlite\Driver as PDOSqliteDriver;
+use Doctrine\DBAL\Driver\PDO\MySQL\Driver as PDOMySQLDriver;
+use Doctrine\DBAL\Driver\PDO\SQLite\Driver as PDOSQLiteDriver;
 use Doctrine\DBAL\Driver\SQLSrv\Driver as SQLSrvDriver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -277,42 +277,42 @@ class DriverManagerTest extends DbalTestCase
                 'sqlite://localhost/foo/dbname.sqlite',
                 [
                     'path'   => 'foo/dbname.sqlite',
-                    'driver' => PDOSqliteDriver::class,
+                    'driver' => PDOSQLiteDriver::class,
                 ],
             ],
             'sqlite absolute URL with host' => [
                 'sqlite://localhost//tmp/dbname.sqlite',
                 [
                     'path'   => '/tmp/dbname.sqlite',
-                    'driver' => PDOSqliteDriver::class,
+                    'driver' => PDOSQLiteDriver::class,
                 ],
             ],
             'sqlite relative URL without host' => [
                 'sqlite:///foo/dbname.sqlite',
                 [
                     'path'   => 'foo/dbname.sqlite',
-                    'driver' => PDOSqliteDriver::class,
+                    'driver' => PDOSQLiteDriver::class,
                 ],
             ],
             'sqlite absolute URL without host' => [
                 'sqlite:////tmp/dbname.sqlite',
                 [
                     'path'   => '/tmp/dbname.sqlite',
-                    'driver' => PDOSqliteDriver::class,
+                    'driver' => PDOSQLiteDriver::class,
                 ],
             ],
             'sqlite memory' => [
                 'sqlite:///:memory:',
                 [
                     'memory' => true,
-                    'driver' => PDOSqliteDriver::class,
+                    'driver' => PDOSQLiteDriver::class,
                 ],
             ],
             'sqlite memory with host' => [
                 'sqlite://localhost/:memory:',
                 [
                     'memory' => true,
-                    'driver' => PDOSqliteDriver::class,
+                    'driver' => PDOSQLiteDriver::class,
                 ],
             ],
             'params parsed from URL override individual params' => [

--- a/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\Driver\OCI8\Driver as OCI8Driver;
-use Doctrine\DBAL\Driver\PDOOracle\Driver as PDOOracleDriver;
+use Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
@@ -23,7 +23,7 @@ class BlobTest extends DbalFunctionalTestCase
     {
         parent::setUp();
 
-        if ($this->connection->getDriver() instanceof PDOOracleDriver) {
+        if ($this->connection->getDriver() instanceof PDO\OCI\Driver) {
             // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
             // see http://php.net/manual/en/pdo.lobs.php#example-1035
             $this->markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Driver\IBMDB2\Driver as IBMDB2Driver;
 use Doctrine\DBAL\Driver\Mysqli\Driver as MySQLiDriver;
 use Doctrine\DBAL\Driver\OCI8\Driver as Oci8Driver;
 use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
-use Doctrine\DBAL\Driver\PDOOracle\Driver as PDOOracleDriver;
+use Doctrine\DBAL\Driver\PDO\OCI\Driver as PDOOCIDriver;
 use Doctrine\DBAL\Driver\SQLSrv\Driver as SQLSrvDriver;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
@@ -945,7 +945,7 @@ class DataAccessTest extends DbalFunctionalTestCase
             $this->markTestSkipped('Mysqli driver dont support this feature.');
         }
 
-        if (! $driver instanceof PDOOracleDriver) {
+        if (! $driver instanceof PDOOCIDriver) {
             return;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDO/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDO/ConnectionTest.php
@@ -4,9 +4,9 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDO;
 
 use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDO\Exception;
-use Doctrine\DBAL\Driver\PDOOracle\Driver as PDOOracleDriver;
-use Doctrine\DBAL\Driver\PDOPgSql\Driver as PDOPgSQLDriver;
-use Doctrine\DBAL\Driver\PDOSqlsrv\Driver as PDOSQLSRVDriver;
+use Doctrine\DBAL\Driver\PDO\OCI\Driver as PDOOCIDriver;
+use Doctrine\DBAL\Driver\PDO\PgSQL\Driver as PDOPgSQLDriver;
+use Doctrine\DBAL\Driver\PDO\SQLSrv\Driver as PDOSQLSrvDriver;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use PDO;
 
@@ -73,7 +73,7 @@ class ConnectionTest extends DbalFunctionalTestCase
     {
         $driver = $this->connection->getDriver();
 
-        if ($driver instanceof PDOSQLSRVDriver) {
+        if ($driver instanceof PDOSQLSrvDriver) {
             $this->markTestSkipped('pdo_sqlsrv does not allow setting PDO::ATTR_EMULATE_PREPARES at connection level.');
         }
 
@@ -81,7 +81,7 @@ class ConnectionTest extends DbalFunctionalTestCase
         // even though emulated prepared statements are disabled,
         // so an exception is thrown only eventually.
         if (
-            $driver instanceof PDOOracleDriver
+            $driver instanceof PDOOCIDriver
             || $driver instanceof PDOPgSQLDriver
         ) {
             self::markTestSkipped(sprintf(

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOMySql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOMySql/DriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional\Driver\PDOMySql;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDOMySql\Driver;
+use Doctrine\DBAL\Driver\PDO\MySQL\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 
 use function extension_loaded;

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOOracle/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOOracle/DriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional\Driver\PDOOracle;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDOOracle\Driver;
+use Doctrine\DBAL\Driver\PDO\OCI\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 
 use function extension_loaded;

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
@@ -4,7 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDOPgSql;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDOPgSql\Driver;
+use Doctrine\DBAL\Driver\PDO\PgSQL\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 use Doctrine\Tests\TestUtil;
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlite/DriverTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional\Driver\PDOSqlite;
 
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Driver\PDOSqlite\Driver;
+use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 
 use function extension_loaded;

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
@@ -4,7 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Driver\PDOSqlsrv;
 
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\PDO\Connection;
-use Doctrine\DBAL\Driver\PDOSqlsrv\Driver;
+use Doctrine\DBAL\Driver\PDO\SQLSrv\Driver;
 use Doctrine\Tests\DBAL\Functional\Driver\AbstractDriverTest;
 use Doctrine\Tests\TestUtil;
 use PDO;

--- a/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Functional;
 
-use Doctrine\DBAL\Driver\PDOOracle\Driver as PDOOracleDriver;
+use Doctrine\DBAL\Driver\PDO\OCI\Driver as PDOOCIDriver;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
@@ -27,7 +27,7 @@ class StatementTest extends DbalFunctionalTestCase
 
     public function testStatementIsReusableAfterClosingCursor(): void
     {
-        if ($this->connection->getDriver() instanceof PDOOracleDriver) {
+        if ($this->connection->getDriver() instanceof PDOOCIDriver) {
             $this->markTestIncomplete('See https://bugs.php.net/bug.php?id=77181');
         }
 
@@ -52,7 +52,7 @@ class StatementTest extends DbalFunctionalTestCase
 
     public function testReuseStatementWithLongerResults(): void
     {
-        if ($this->connection->getDriver() instanceof PDOOracleDriver) {
+        if ($this->connection->getDriver() instanceof PDOOCIDriver) {
             $this->markTestIncomplete('PDO_OCI doesn\'t support fetching blobs via PDOStatement::fetchAll()');
         }
 
@@ -89,7 +89,7 @@ class StatementTest extends DbalFunctionalTestCase
 
     public function testFetchLongBlob(): void
     {
-        if ($this->connection->getDriver() instanceof PDOOracleDriver) {
+        if ($this->connection->getDriver() instanceof PDOOCIDriver) {
             // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
             // see http://php.net/manual/en/pdo.lobs.php#example-1035
             $this->markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');
@@ -154,7 +154,7 @@ EOF
 
     public function testReuseStatementAfterClosingCursor(): void
     {
-        if ($this->connection->getDriver() instanceof PDOOracleDriver) {
+        if ($this->connection->getDriver() instanceof PDOOCIDriver) {
             $this->markTestIncomplete('See https://bugs.php.net/bug.php?id=77181');
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use DateTime;
-use Doctrine\DBAL\Driver\PDOOracle\Driver as PDOOracleDriver;
+use Doctrine\DBAL\Driver\PDO\OCI\Driver as PDOOCIDriver;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalFunctionalTestCase;
@@ -120,7 +120,7 @@ class TypeConversionTest extends DbalFunctionalTestCase
      */
     public function testIdempotentConversionToString(string $type, $originalValue): void
     {
-        if ($type === 'text' && $this->connection->getDriver() instanceof PDOOracleDriver) {
+        if ($type === 'text' && $this->connection->getDriver() instanceof PDOOCIDriver) {
             // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
             // see http://php.net/manual/en/pdo.lobs.php#example-1035
             $this->markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');

--- a/tests/Doctrine/Tests/DBAL/Functional/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Types/BinaryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\DBAL\Functional\Types;
 
 use Doctrine\DBAL\Driver\IBMDB2\Driver;
-use Doctrine\DBAL\Driver\PDOOracle\Driver as PDOOracleDriver;
+use Doctrine\DBAL\Driver\PDO\OCI\Driver as PDOOCIDriver;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\Tests\DbalFunctionalTestCase;
@@ -21,7 +21,7 @@ class BinaryTest extends DbalFunctionalTestCase
     {
         parent::setUp();
 
-        if ($this->connection->getDriver() instanceof PDOOracleDriver) {
+        if ($this->connection->getDriver() instanceof PDOOCIDriver) {
             $this->markTestSkipped('PDO_OCI doesn\'t support binding binary values');
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Now that we marked connection constructors internal in https://github.com/doctrine/dbal/pull/4139 and reworked PDO classes into a composition in https://github.com/doctrine/dbal/pull/4138, we effectively have `PDOSqlsrv\Driver::connect()` calling `PDO\Connection::__construct()` which is `@internal` to the `PDO` namespace. Psalm at level 4 may not like it (https://psalm.dev/r/d385c2021c, https://github.com/sebastianbergmann/phpunit/issues/4309).

The solution is to move all PDO-based components under the PDO namespace and thereby legitimize their usage of the internal PDO APIs. Additionally, it will make the driver namespace structure cleaner.