### PR TITLE
Add TypeRegistry constructor

### DIFF
--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -208,13 +208,13 @@ abstract class Type
 
     private static function createTypeRegistry(): TypeRegistry
     {
-        $registry = new TypeRegistry();
+        $instances = [];
 
         foreach (self::BUILTIN_TYPES_MAP as $name => $class) {
-            $registry->register($name, new $class());
+            $instances[$name] = new $class();
         }
 
-        return $registry;
+        return new TypeRegistry($instances);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/TypeRegistry.php
+++ b/lib/Doctrine/DBAL/Types/TypeRegistry.php
@@ -18,7 +18,15 @@ use function in_array;
 final class TypeRegistry
 {
     /** @var array<string, Type> Map of type names and their corresponding flyweight objects. */
-    private $instances = [];
+    private $instances;
+
+    /**
+     * @param array<string, Type> $instances
+     */
+    public function __construct(array $instances = [])
+    {
+        $this->instances = $instances;
+    }
 
     /**
      * Finds a type by the given name.

--- a/tests/Doctrine/Tests/DBAL/Types/TypeRegistryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/TypeRegistryTest.php
@@ -31,9 +31,10 @@ class TypeRegistryTest extends TestCase
         $this->testType      = new BlobType();
         $this->otherTestType = new BinaryType();
 
-        $this->registry = new TypeRegistry();
-        $this->registry->register(self::TEST_TYPE_NAME, $this->testType);
-        $this->registry->register(self::OTHER_TEST_TYPE_NAME, $this->otherTestType);
+        $this->registry = new TypeRegistry([
+            self::TEST_TYPE_NAME       => $this->testType,
+            self::OTHER_TEST_TYPE_NAME => $this->otherTestType,
+        ]);
     }
 
     public function testGet(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The `TypeRegistry::register()` method called from within `Type::createTypeRegistry()` can throw a `DBALException` which is neither handled nor declared via `@throws`.

The exception is only possible if the type with the given name is registered, but given that the registry is initialized form an associative array, such a situation is indeed impossible.

In order to make the API cleaner from the error handling standpoint, we may add a constructor that takes an array of types and does _not_ throw an exception.