### PR TITLE
Require $platform in AbstractSchemaManager::__construct()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 3.0
 
+## BC BREAK: Changes schema manager instantiation.
+
+1. The `$platform` argument of all schema manager constructors is no longer optional.
+2. A new `$platform` argument has been added to the `Driver::getSchemaManager()` method.
+
 ## BC BREAK: Changes in driver classes
 
 1. All implementations of the `Driver` interface have been made final.

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1446,11 +1446,16 @@ class Connection implements DriverConnection
      * database schema through the connection.
      *
      * @return AbstractSchemaManager
+     *
+     * @throws DBALException
      */
     public function getSchemaManager()
     {
         if ($this->_schemaManager === null) {
-            $this->_schemaManager = $this->_driver->getSchemaManager($this);
+            $this->_schemaManager = $this->_driver->getSchemaManager(
+                $this,
+                $this->getDatabasePlatform()
+            );
         }
 
         return $this->_schemaManager;

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -39,7 +39,7 @@ interface Driver
      *
      * @return AbstractSchemaManager
      */
-    public function getSchemaManager(Connection $conn);
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform);
 
     /**
      * Gets the ExceptionConverter that can be used to convert driver-level exceptions into DBAL exceptions.

--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\API\IBMDB2\ExceptionConverter;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
 
@@ -25,9 +26,9 @@ abstract class AbstractDB2Driver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function getSchemaManager(Connection $conn)
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
-        return new DB2SchemaManager($conn);
+        return new DB2SchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverterInterface

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\API\MySQL;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
@@ -123,9 +124,9 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
      *
      * @return MySqlSchemaManager
      */
-    public function getSchemaManager(Connection $conn)
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
-        return new MySqlSchemaManager($conn);
+        return new MySqlSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Driver/AbstractOracleDriver.php
+++ b/src/Driver/AbstractOracleDriver.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\AbstractOracleDriver\EasyConnectString;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\API\OCI;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\OracleSchemaManager;
 
@@ -26,9 +27,9 @@ abstract class AbstractOracleDriver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function getSchemaManager(Connection $conn)
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
-        return new OracleSchemaManager($conn);
+        return new OracleSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\API\PostgreSQL;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Schema\PostgreSqlSchemaManager;
@@ -54,9 +55,9 @@ abstract class AbstractPostgreSQLDriver implements VersionAwarePlatformDriver
     /**
      * {@inheritdoc}
      */
-    public function getSchemaManager(Connection $conn)
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
-        return new PostgreSqlSchemaManager($conn);
+        return new PostgreSqlSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Driver/AbstractSQLServerDriver.php
+++ b/src/Driver/AbstractSQLServerDriver.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\API\SQLSrv\ExceptionConverter;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 
@@ -25,9 +26,9 @@ abstract class AbstractSQLServerDriver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function getSchemaManager(Connection $conn)
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
-        return new SQLServerSchemaManager($conn);
+        return new SQLServerSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverterInterface

--- a/src/Driver/AbstractSQLiteDriver.php
+++ b/src/Driver/AbstractSQLiteDriver.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\API\SQLite;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\SqliteSchemaManager;
 
@@ -25,9 +26,9 @@ abstract class AbstractSQLiteDriver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function getSchemaManager(Connection $conn)
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
-        return new SqliteSchemaManager($conn);
+        return new SqliteSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -44,13 +44,10 @@ abstract class AbstractSchemaManager
      */
     protected $_platform;
 
-    /**
-     * Constructor. Accepts the Connection instance to manage the schema for.
-     */
-    public function __construct(Connection $conn, ?AbstractPlatform $platform = null)
+    public function __construct(Connection $connection, AbstractPlatform $platform)
     {
-        $this->_conn     = $conn;
-        $this->_platform = $platform ?? $this->_conn->getDatabasePlatform();
+        $this->_conn     = $connection;
+        $this->_platform = $platform;
     }
 
     /**

--- a/tests/Driver/AbstractDB2DriverTest.php
+++ b/tests/Driver/AbstractDB2DriverTest.php
@@ -26,7 +26,10 @@ class AbstractDB2DriverTest extends AbstractDriverTest
 
     protected function createSchemaManager(Connection $connection): AbstractSchemaManager
     {
-        return new DB2SchemaManager($connection);
+        return new DB2SchemaManager(
+            $connection,
+            $this->createPlatform()
+        );
     }
 
     protected function createExceptionConverter(): ExceptionConverterInterface

--- a/tests/Driver/AbstractDriverTest.php
+++ b/tests/Driver/AbstractDriverTest.php
@@ -83,7 +83,10 @@ abstract class AbstractDriverTest extends TestCase
     public function testReturnsSchemaManager(): void
     {
         $connection    = $this->getConnectionMock();
-        $schemaManager = $this->driver->getSchemaManager($connection);
+        $schemaManager = $this->driver->getSchemaManager(
+            $connection,
+            $this->createPlatform()
+        );
 
         self::assertEquals($this->createSchemaManager($connection), $schemaManager);
 

--- a/tests/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Driver/AbstractMySQLDriverTest.php
@@ -29,7 +29,10 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
 
     protected function createSchemaManager(Connection $connection): AbstractSchemaManager
     {
-        return new MySqlSchemaManager($connection);
+        return new MySqlSchemaManager(
+            $connection,
+            $this->createPlatform()
+        );
     }
 
     protected function createExceptionConverter(): ExceptionConverter

--- a/tests/Driver/AbstractOracleDriverTest.php
+++ b/tests/Driver/AbstractOracleDriverTest.php
@@ -26,7 +26,10 @@ class AbstractOracleDriverTest extends AbstractDriverTest
 
     protected function createSchemaManager(Connection $connection): AbstractSchemaManager
     {
-        return new OracleSchemaManager($connection);
+        return new OracleSchemaManager(
+            $connection,
+            $this->createPlatform()
+        );
     }
 
     protected function createExceptionConverter(): ExceptionConverter

--- a/tests/Driver/AbstractPostgreSQLDriverTest.php
+++ b/tests/Driver/AbstractPostgreSQLDriverTest.php
@@ -27,7 +27,10 @@ class AbstractPostgreSQLDriverTest extends AbstractDriverTest
 
     protected function createSchemaManager(Connection $connection): AbstractSchemaManager
     {
-        return new PostgreSqlSchemaManager($connection);
+        return new PostgreSqlSchemaManager(
+            $connection,
+            $this->createPlatform()
+        );
     }
 
     protected function createExceptionConverter(): ExceptionConverter

--- a/tests/Driver/AbstractSQLServerDriverTest.php
+++ b/tests/Driver/AbstractSQLServerDriverTest.php
@@ -20,7 +20,10 @@ abstract class AbstractSQLServerDriverTest extends AbstractDriverTest
 
     protected function createSchemaManager(Connection $connection): AbstractSchemaManager
     {
-        return new SQLServerSchemaManager($connection);
+        return new SQLServerSchemaManager(
+            $connection,
+            $this->createPlatform()
+        );
     }
 
     protected function createExceptionConverter(): ExceptionConverterInterface

--- a/tests/Driver/AbstractSQLiteDriverTest.php
+++ b/tests/Driver/AbstractSQLiteDriverTest.php
@@ -26,7 +26,10 @@ class AbstractSQLiteDriverTest extends AbstractDriverTest
 
     protected function createSchemaManager(Connection $connection): AbstractSchemaManager
     {
-        return new SqliteSchemaManager($connection);
+        return new SqliteSchemaManager(
+            $connection,
+            $this->createPlatform()
+        );
     }
 
     protected function createExceptionConverter(): ExceptionConverter

--- a/tests/Schema/DB2SchemaManagerTest.php
+++ b/tests/Schema/DB2SchemaManagerTest.php
@@ -33,9 +33,9 @@ final class DB2SchemaManagerTest extends TestCase
         $this->conn    = $this
             ->getMockBuilder(Connection::class)
             ->onlyMethods(['fetchAllAssociative', 'quote'])
-            ->setConstructorArgs([['platform' => $platform], $driverMock, new Configuration(), $eventManager])
+            ->setConstructorArgs([[], $driverMock, new Configuration(), $eventManager])
             ->getMock();
-        $this->manager = new DB2SchemaManager($this->conn);
+        $this->manager = new DB2SchemaManager($this->conn, $platform);
     }
 
     /**

--- a/tests/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Schema/MySqlSchemaManagerTest.php
@@ -34,9 +34,9 @@ class MySqlSchemaManagerTest extends TestCase
 
         $this->conn    = $this->getMockBuilder(Connection::class)
             ->onlyMethods(['fetchAllAssociative'])
-            ->setConstructorArgs([['platform' => $platform], $driverMock, new Configuration(), $eventManager])
+            ->setConstructorArgs([[], $driverMock, new Configuration(), $eventManager])
             ->getMock();
-        $this->manager = new MySqlSchemaManager($this->conn);
+        $this->manager = new MySqlSchemaManager($this->conn, $platform);
     }
 
     public function testCompositeForeignKeys(): void

--- a/tests/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Schema/SqliteSchemaManagerTest.php
@@ -17,9 +17,8 @@ class SqliteSchemaManagerTest extends TestCase
     public function testParseColumnCollation(?string $collation, string $column, string $sql): void
     {
         $conn = $this->createMock(Connection::class);
-        $conn->method('getDatabasePlatform')->willReturn(new SqlitePlatform());
 
-        $manager = new SqliteSchemaManager($conn);
+        $manager = new SqliteSchemaManager($conn, new SqlitePlatform());
         $ref     = new ReflectionMethod($manager, 'parseColumnCollationFromSQL');
         $ref->setAccessible(true);
 
@@ -58,9 +57,8 @@ class SqliteSchemaManagerTest extends TestCase
     public function testParseColumnCommentFromSQL(?string $comment, string $column, string $sql): void
     {
         $conn = $this->createMock(Connection::class);
-        $conn->method('getDatabasePlatform')->willReturn(new SqlitePlatform());
 
-        $manager = new SqliteSchemaManager($conn);
+        $manager = new SqliteSchemaManager($conn, new SqlitePlatform());
         $ref     = new ReflectionMethod($manager, 'parseColumnCommentFromSQL');
         $ref->setAccessible(true);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes

## Problem Statement

The `Connection::getDatabasePlatform()` method called from within `AbstractSchemaManager::__construct()` can throw a `DBALException` which is neither handled nor declared via `@throws`.

https://github.com/doctrine/dbal/blob/23e8d5d7094d62ba2401a1ffcf2125f6a2c8660e/src/Schema/AbstractSchemaManager.php#L47-L54

Not only the method throws a non-documented exception, the exception propagates undocumented to `Driver::getSchemaManager()` which instantiates a schema manager.

Implementations of the `Driver` interface cannot throw a `DBALException` because it doesn't belong to this level of abstraction.

## Solution

Instantiate the platform in the wrapper layer and avoid the potential exception. The wrapper connection remains as lazy as it was before.

### Additional notes

1. Although the code like `$this->driver->getSchemaManager($this, $this->getDatabasePlatform())` may look awkward, this weirdness is not caused by this change. The reason is that the wrapper connection is quite a god object, and the very fact that other components depend on it (e.g. instead of a driver connection) is the real issue.
2. No upgrade path is provided. On the one hand, schema managers are supposed to be accessed via the wrapper connection; on the other, adding a new argument to an interface method (even optional) is a BC break.