### PR TITLE
Mark driver classes final

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,9 +1,10 @@
 # Upgrade to 3.0
 
-## BC BREAK: Changes in PDO driver classes
+## BC BREAK: Changes in driver classes
 
-1. The `PDO\Connection` and `PDO\Statement` classes have been made final.
-2. The `PDOSqlsrv\Connection` and `PDOSqlsrv\Statement` classes have been made final and no longer extend the corresponding PDO classes.
+1. All implementations of the `Driver` interface have been made final.
+2. The `PDO\Connection` and `PDO\Statement` classes have been made final.
+3. The `PDOSqlsrv\Connection` and `PDOSqlsrv\Statement` classes have been made final and no longer extend the corresponding PDO classes.
 
 ## BC BREAK: Changes in driver-level exception handling
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,7 @@
 1. All implementations of the `Driver` interface have been made final.
 2. The `PDO\Connection` and `PDO\Statement` classes have been made final.
 3. The `PDOSqlsrv\Connection` and `PDOSqlsrv\Statement` classes have been made final and no longer extend the corresponding PDO classes.
+4. The `SQLSrv\LastInsertId` class has been made final.
 
 ## BC BREAK: Changes in driver-level exception handling
 

--- a/src/Driver/Mysqli/Driver.php
+++ b/src/Driver/Mysqli/Driver.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Driver\Mysqli\Initializer\Secure;
 
 use function count;
 
-class Driver extends AbstractMySQLDriver
+final class Driver extends AbstractMySQLDriver
 {
     /**
      * {@inheritdoc}

--- a/src/Driver/OCI8/Driver.php
+++ b/src/Driver/OCI8/Driver.php
@@ -9,7 +9,7 @@ use const OCI_NO_AUTO_COMMIT;
 /**
  * A Doctrine DBAL driver for the Oracle OCI8 PHP extensions.
  */
-class Driver extends AbstractOracleDriver
+final class Driver extends AbstractOracleDriver
 {
     /**
      * {@inheritdoc}

--- a/src/Driver/PDOMySql/Driver.php
+++ b/src/Driver/PDOMySql/Driver.php
@@ -9,7 +9,7 @@ use PDO;
 /**
  * PDO MySql driver.
  */
-class Driver extends AbstractMySQLDriver
+final class Driver extends AbstractMySQLDriver
 {
     /**
      * {@inheritdoc}

--- a/src/Driver/PDOOracle/Driver.php
+++ b/src/Driver/PDOOracle/Driver.php
@@ -14,7 +14,7 @@ use PDO;
  * which leads us to the recommendation to use the "oci8" driver to connect
  * to Oracle instead.
  */
-class Driver extends AbstractOracleDriver
+final class Driver extends AbstractOracleDriver
 {
     /**
      * {@inheritdoc}

--- a/src/Driver/PDOPgSql/Driver.php
+++ b/src/Driver/PDOPgSql/Driver.php
@@ -11,7 +11,7 @@ use function defined;
 /**
  * Driver that connects through pdo_pgsql.
  */
-class Driver extends AbstractPostgreSQLDriver
+final class Driver extends AbstractPostgreSQLDriver
 {
     /**
      * {@inheritdoc}

--- a/src/Driver/PDOSqlite/Driver.php
+++ b/src/Driver/PDOSqlite/Driver.php
@@ -11,7 +11,7 @@ use function array_merge;
 /**
  * The PDO Sqlite driver.
  */
-class Driver extends AbstractSQLiteDriver
+final class Driver extends AbstractSQLiteDriver
 {
     /** @var mixed[] */
     protected $_userDefinedFunctions = [

--- a/src/Driver/PDOSqlsrv/Driver.php
+++ b/src/Driver/PDOSqlsrv/Driver.php
@@ -14,7 +14,7 @@ use function sprintf;
 /**
  * The PDO-based Sqlsrv driver.
  */
-class Driver extends AbstractSQLServerDriver
+final class Driver extends AbstractSQLServerDriver
 {
     /**
      * {@inheritdoc}

--- a/src/Driver/SQLSrv/Driver.php
+++ b/src/Driver/SQLSrv/Driver.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
 /**
  * Driver for ext/sqlsrv.
  */
-class Driver extends AbstractSQLServerDriver
+final class Driver extends AbstractSQLServerDriver
 {
     /**
      * {@inheritdoc}

--- a/src/Driver/SQLSrv/LastInsertId.php
+++ b/src/Driver/SQLSrv/LastInsertId.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 /**
  * Last Id Data Container.
  */
-class LastInsertId
+final class LastInsertId
 {
     /** @var int */
     private $id;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

At this point, all classes under the `Driver` namespace are either `abstract` or `final`.