### PR TITLE
Remove workaround in PDOSqlsrv\Connection::quote()

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -3,11 +3,7 @@
 namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 
 use Doctrine\DBAL\Driver\PDOConnection;
-use Doctrine\DBAL\ParameterType;
 use PDO;
-use function is_string;
-use function strpos;
-use function substr;
 
 /**
  * Sqlsrv Connection implementation.
@@ -36,20 +32,5 @@ class Connection extends PDOConnection
         $stmt->execute([$name]);
 
         return $stmt->fetchColumn();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function quote($value, $type = ParameterType::STRING)
-    {
-        $val = parent::quote($value, $type);
-
-        // Fix for a driver version terminating all values with null byte
-        if (is_string($val) && strpos($val, "\0") !== false) {
-            $val = substr($val, 0, -1);
-        }
-
-        return $val;
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

The workaround for `PDOSqlsrv\Connection::quote()` added in https://github.com/doctrine/dbal/commit/fdcae5d321329973024e847f341b607685dc4c6c w/o any tests is no longer needed and breaks valid code:
```php
$conn = DriverManager::getConnection([
    'driver' => 'pdo_sqlsrv',
    'user' => 'sa',
    'password' => 'Passw0rd',
]);

var_dump(
    $conn->fetchColumn('SELECT ' . $conn->quote("\0"))
);

// SQLSTATE[42000]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Unclosed quotation mark after the character string '.'.
```
The expected result is:
```
string(1) "\000"
```
The workaround looks related to https://github.com/Microsoft/msphpsql/issues/538 which was fixed by https://github.com/microsoft/msphpsql/pull/550 in `pdo_sqlsrv` 5.1.1. The oldest `pdo_sqlsrv` version that supports PHP 7.2 is [5.2.1](https://github.com/microsoft/msphpsql/releases/tag/v5.2.1-preview).

No test provided since this is not a special case from the DBAL perspective and should be handled by the underlying driver.