### PR TITLE
Replace DefaultExceptionConverter with driver-specific implementations

### DIFF
--- a/src/Driver/API/IBMDB2/ExceptionConverter.php
+++ b/src/Driver/API/IBMDB2/ExceptionConverter.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\DBAL\Driver\API;
+namespace Doctrine\DBAL\Driver\API\IBMDB2;
 
+use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception\DriverException;
 
-final class DefaultExceptionConverter implements ExceptionConverter
+final class ExceptionConverter implements ExceptionConverterInterface
 {
     public function convert(string $message, Exception $exception): DriverException
     {

--- a/src/Driver/API/SQLSrv/ExceptionConverter.php
+++ b/src/Driver/API/SQLSrv/ExceptionConverter.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\API\SQLSrv;
+
+use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
+use Doctrine\DBAL\Driver\Exception;
+use Doctrine\DBAL\Exception\DriverException;
+
+final class ExceptionConverter implements ExceptionConverterInterface
+{
+    public function convert(string $message, Exception $exception): DriverException
+    {
+        return new DriverException($message, $exception);
+    }
+}

--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -4,13 +4,13 @@ namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\API\DefaultExceptionConverter;
-use Doctrine\DBAL\Driver\API\ExceptionConverter;
+use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
+use Doctrine\DBAL\Driver\API\IBMDB2\ExceptionConverter;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for IBM DB2 based drivers.
+ * Abstract base implementation of the {@link Driver} interface for IBM DB2 based drivers.
  */
 abstract class AbstractDB2Driver implements Driver
 {
@@ -30,8 +30,8 @@ abstract class AbstractDB2Driver implements Driver
         return new DB2SchemaManager($conn);
     }
 
-    public function getExceptionConverter(): ExceptionConverter
+    public function getExceptionConverter(): ExceptionConverterInterface
     {
-        return new DefaultExceptionConverter();
+        return new ExceptionConverter();
     }
 }

--- a/src/Driver/AbstractSQLServerDriver.php
+++ b/src/Driver/AbstractSQLServerDriver.php
@@ -4,13 +4,13 @@ namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\API\DefaultExceptionConverter;
-use Doctrine\DBAL\Driver\API\ExceptionConverter;
+use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
+use Doctrine\DBAL\Driver\API\SQLSrv\ExceptionConverter;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for Microsoft SQL Server based drivers.
+ * Abstract base implementation of the {@link Driver} interface for Microsoft SQL Server based drivers.
  */
 abstract class AbstractSQLServerDriver implements Driver
 {
@@ -30,8 +30,8 @@ abstract class AbstractSQLServerDriver implements Driver
         return new SQLServerSchemaManager($conn);
     }
 
-    public function getExceptionConverter(): ExceptionConverter
+    public function getExceptionConverter(): ExceptionConverterInterface
     {
-        return new DefaultExceptionConverter();
+        return new ExceptionConverter();
     }
 }

--- a/tests/Driver/AbstractDB2DriverTest.php
+++ b/tests/Driver/AbstractDB2DriverTest.php
@@ -5,8 +5,8 @@ namespace Doctrine\DBAL\Tests\Driver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\AbstractDB2Driver;
-use Doctrine\DBAL\Driver\API\DefaultExceptionConverter;
-use Doctrine\DBAL\Driver\API\ExceptionConverter;
+use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
+use Doctrine\DBAL\Driver\API\IBMDB2\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -29,8 +29,8 @@ class AbstractDB2DriverTest extends AbstractDriverTest
         return new DB2SchemaManager($connection);
     }
 
-    protected function createExceptionConverter(): ExceptionConverter
+    protected function createExceptionConverter(): ExceptionConverterInterface
     {
-        return new DefaultExceptionConverter();
+        return new ExceptionConverter();
     }
 }

--- a/tests/Driver/AbstractSQLServerDriverTest.php
+++ b/tests/Driver/AbstractSQLServerDriverTest.php
@@ -4,8 +4,8 @@ namespace Doctrine\DBAL\Tests\Driver;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
-use Doctrine\DBAL\Driver\API\DefaultExceptionConverter;
-use Doctrine\DBAL\Driver\API\ExceptionConverter;
+use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
+use Doctrine\DBAL\Driver\API\SQLSrv\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -23,9 +23,9 @@ abstract class AbstractSQLServerDriverTest extends AbstractDriverTest
         return new SQLServerSchemaManager($connection);
     }
 
-    protected function createExceptionConverter(): ExceptionConverter
+    protected function createExceptionConverter(): ExceptionConverterInterface
     {
-        return new DefaultExceptionConverter();
+        return new ExceptionConverter();
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

In hindsight, the introduction of the `DefaultExceptionConverter` in #4136 wasn't the best idea. If the drivers that use it implement their own proper logic, this class will become unused but will have to be kept in place. It's better to have one copy with the same logic per driver that could be evolved independently w/o BC concerns.