### PR TITLE
Add some missing @throws annotations and fix thrown exceptions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -35,6 +35,10 @@ The following classes have been renamed:
 3. The `PDOSqlsrv\Connection` and `PDOSqlsrv\Statement` classes have been made final and no longer extend the corresponding PDO classes.
 4. The `SQLSrv\LastInsertId` class has been made final.
 
+## BC BREAK: Changes in wrapper-level exceptions
+
+1. `DBALException::invalidTableName()` has been replaced with the `InvalidTableName` class.
+
 ## BC BREAK: Changes in driver-level exception handling
 
 1. The `convertException()` method has been removed from the `Driver` interface. The logic of exception conversion has been moved to the `ExceptionConverter` interface. The drivers now must implement the `getExceptionConverter()` method.

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1188,7 +1188,7 @@ class Connection
      *
      * @return void
      *
-     * @throws ConnectionException
+     * @throws DBALException
      */
     public function setNestTransactionsWithSavepoints($nestTransactionsWithSavepoints)
     {
@@ -1262,8 +1262,7 @@ class Connection
     /**
      * @return bool
      *
-     * @throws ConnectionException If the commit failed due to no active transaction or
-     *                                            because the transaction was marked for rollback only.
+     * @throws DBALException
      */
     public function commit()
     {
@@ -1336,7 +1335,7 @@ class Connection
      *
      * @return bool
      *
-     * @throws ConnectionException If the rollback operation failed.
+     * @throws DBALException
      */
     public function rollBack()
     {
@@ -1388,7 +1387,7 @@ class Connection
      *
      * @return void
      *
-     * @throws ConnectionException
+     * @throws DBALException
      */
     public function createSavepoint($savepoint)
     {
@@ -1406,7 +1405,7 @@ class Connection
      *
      * @return void
      *
-     * @throws ConnectionException
+     * @throws DBALException
      */
     public function releaseSavepoint($savepoint)
     {
@@ -1428,7 +1427,7 @@ class Connection
      *
      * @return void
      *
-     * @throws ConnectionException
+     * @throws DBALException
      */
     public function rollbackSavepoint($savepoint)
     {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -401,6 +401,8 @@ class Connection
      * Returns the database server version if the underlying driver supports it.
      *
      * @return string|null
+     *
+     * @throws DBALException
      */
     private function getServerVersion()
     {
@@ -626,6 +628,8 @@ class Connection
      * @param int $level The level to set.
      *
      * @return int
+     *
+     * @throws DBALException
      */
     public function setTransactionIsolation($level)
     {
@@ -638,6 +642,8 @@ class Connection
      * Gets the currently active transaction isolation level.
      *
      * @return int The current transaction isolation level.
+     *
+     * @throws DBALException
      */
     public function getTransactionIsolation()
     {
@@ -1226,6 +1232,8 @@ class Connection
 
     /**
      * @return bool
+     *
+     * @throws DBALException
      */
     public function beginTransaction()
     {
@@ -1314,6 +1322,8 @@ class Connection
 
     /**
      * Commits all current nesting transactions.
+     *
+     * @throws DBALException
      */
     private function commitAll(): void
     {
@@ -1442,6 +1452,8 @@ class Connection
      * Gets the wrapped driver connection.
      *
      * @return DriverConnection
+     *
+     * @throws DBALException
      */
     public function getWrappedConnection()
     {
@@ -1513,6 +1525,8 @@ class Connection
      * @param string $type  The name of the DBAL mapping type.
      *
      * @return mixed The converted value.
+     *
+     * @throws DBALException
      */
     public function convertToDatabaseValue($value, $type)
     {
@@ -1527,6 +1541,8 @@ class Connection
      * @param string $type  The name of the DBAL mapping type.
      *
      * @return mixed The converted type.
+     *
+     * @throws DBALException
      */
     public function convertToPHPValue($value, $type)
     {
@@ -1540,6 +1556,8 @@ class Connection
      * @param DriverStatement $stmt   The statement to bind the values to.
      * @param mixed[]         $params The map/list of named/positional parameters.
      * @param int[]|string[]  $types  The parameter types (PDO binding types or DBAL mapping types).
+     *
+     * @throws DBALException
      */
     private function _bindTypedValues(DriverStatement $stmt, array $params, array $types): void
     {
@@ -1581,6 +1599,8 @@ class Connection
      * @param int|string|null $type  The type to bind (PDO or DBAL).
      *
      * @return mixed[] [0] => the (escaped) value, [1] => the binding type.
+     *
+     * @throws DBALException
      */
     private function getBindingInfo($value, $type)
     {

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -98,6 +98,7 @@ class PrimaryReadReplicaConnection extends Connection
      *
      * @param mixed[] $params
      *
+     * @throws DBALException
      * @throws InvalidArgumentException
      */
     public function __construct(array $params, Driver $driver, ?Configuration $config = null, ?EventManager $eventManager = null)

--- a/src/DBALException.php
+++ b/src/DBALException.php
@@ -131,16 +131,6 @@ class DBALException extends Exception
      *
      * @return DBALException
      */
-    public static function invalidTableName($tableName)
-    {
-        return new self('Invalid table name specified: ' . $tableName);
-    }
-
-    /**
-     * @param string $tableName
-     *
-     * @return DBALException
-     */
     public static function noColumnsSpecifiedForTable($tableName)
     {
         return new self('No columns specified for table ' . $tableName);

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -60,6 +60,8 @@ final class Connection implements ServerInfoAwareConnection
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @return Statement
      */
     public function prepare(string $sql): StatementInterface

--- a/src/Event/Listeners/OracleSessionInit.php
+++ b/src/Event/Listeners/OracleSessionInit.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Event\Listeners;
 
 use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Events;
 
@@ -44,6 +45,8 @@ class OracleSessionInit implements EventSubscriber
 
     /**
      * @return void
+     *
+     * @throws DBALException
      */
     public function postConnect(ConnectionEventArgs $args)
     {

--- a/src/Event/Listeners/SQLSessionInit.php
+++ b/src/Event/Listeners/SQLSessionInit.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Event\Listeners;
 
 use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Events;
 
@@ -24,11 +25,12 @@ class SQLSessionInit implements EventSubscriber
 
     /**
      * @return void
+     *
+     * @throws DBALException
      */
     public function postConnect(ConnectionEventArgs $args)
     {
-        $conn = $args->getConnection();
-        $conn->exec($this->sql);
+        $args->getConnection()->executeUpdate($this->sql);
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2165,6 +2165,8 @@ abstract class AbstractPlatform
      *          a string that defines the complete column
      *
      * @return string DBMS specific SQL code portion that should be used to declare the column.
+     *
+     * @throws DBALException
      */
     public function getColumnDeclarationSQL($name, array $field)
     {

--- a/src/Platforms/MySqlPlatform.php
+++ b/src/Platforms/MySqlPlatform.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
@@ -694,6 +695,8 @@ SQL
 
     /**
      * @return string[]
+     *
+     * @throws DBALException
      */
     private function getPreAlterTableAlterPrimaryKeySQL(TableDiff $diff, Index $index)
     {
@@ -733,6 +736,8 @@ SQL
      * @param TableDiff $diff The table diff to gather the SQL for.
      *
      * @return string[]
+     *
+     * @throws DBALException
      */
     private function getPreAlterTableAlterIndexForeignKeySQL(TableDiff $diff)
     {

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -963,6 +963,8 @@ class SqlitePlatform extends AbstractPlatform
 
     /**
      * @return string[]|false
+     *
+     * @throws DBALException
      */
     private function getSimpleAlterTableSQL(TableDiff $diff)
     {

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Query;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
@@ -202,6 +203,8 @@ class QueryBuilder
      * for insert, update and delete statements.
      *
      * @return Result|int
+     *
+     * @throws DBALException
      */
     public function execute()
     {

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -1162,6 +1162,8 @@ class QueryBuilder
 
     /**
      * @return string[]
+     *
+     * @throws QueryException
      */
     private function getFromClauses()
     {

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -3,7 +3,6 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Event\SchemaColumnDefinitionEventArgs;
 use Doctrine\DBAL\Event\SchemaIndexDefinitionEventArgs;
@@ -93,6 +92,8 @@ abstract class AbstractSchemaManager
      * Lists the available databases for this connection.
      *
      * @return string[]
+     *
+     * @throws DBALException
      */
     public function listDatabases()
     {
@@ -107,6 +108,8 @@ abstract class AbstractSchemaManager
      * Returns a list of all namespaces in the current database.
      *
      * @return string[]
+     *
+     * @throws DBALException
      */
     public function listNamespaceNames()
     {
@@ -123,6 +126,8 @@ abstract class AbstractSchemaManager
      * @param string|null $database
      *
      * @return Sequence[]
+     *
+     * @throws DBALException
      */
     public function listSequences($database = null)
     {
@@ -151,6 +156,8 @@ abstract class AbstractSchemaManager
      * @param string|null $database
      *
      * @return Column[]
+     *
+     * @throws DBALException
      */
     public function listTableColumns($table, $database = null)
     {
@@ -173,6 +180,8 @@ abstract class AbstractSchemaManager
      * @param string $table The name of the table.
      *
      * @return Index[]
+     *
+     * @throws DBALException
      */
     public function listTableIndexes($table)
     {
@@ -191,6 +200,8 @@ abstract class AbstractSchemaManager
      * @param string|string[] $tableNames
      *
      * @return bool
+     *
+     * @throws DBALException
      */
     public function tablesExist($tableNames)
     {
@@ -203,6 +214,8 @@ abstract class AbstractSchemaManager
      * Returns a list of all tables in the current database.
      *
      * @return string[]
+     *
+     * @throws DBALException
      */
     public function listTableNames()
     {
@@ -236,6 +249,8 @@ abstract class AbstractSchemaManager
      * Lists the tables for this connection.
      *
      * @return Table[]
+     *
+     * @throws DBALException
      */
     public function listTables()
     {
@@ -253,6 +268,8 @@ abstract class AbstractSchemaManager
      * @param string $tableName
      *
      * @return Table
+     *
+     * @throws DBALException
      */
     public function listTableDetails($tableName)
     {
@@ -271,6 +288,8 @@ abstract class AbstractSchemaManager
      * Lists the views this connection has.
      *
      * @return View[]
+     *
+     * @throws DBALException
      */
     public function listViews()
     {
@@ -288,6 +307,8 @@ abstract class AbstractSchemaManager
      * @param string|null $database
      *
      * @return ForeignKeyConstraint[]
+     *
+     * @throws DBALException
      */
     public function listTableForeignKeys($table, $database = null)
     {
@@ -311,6 +332,8 @@ abstract class AbstractSchemaManager
      * @param string $database The name of the database to drop.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropDatabase($database)
     {
@@ -323,6 +346,8 @@ abstract class AbstractSchemaManager
      * @param string $tableName The name of the table to drop.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropTable($tableName)
     {
@@ -336,6 +361,8 @@ abstract class AbstractSchemaManager
      * @param Table|string $table The name of the table.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropIndex($index, $table)
     {
@@ -352,6 +379,8 @@ abstract class AbstractSchemaManager
      * @param Table|string $table The name of the table.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropConstraint(Constraint $constraint, $table)
     {
@@ -365,6 +394,8 @@ abstract class AbstractSchemaManager
      * @param Table|string                $table      The name of the table with the foreign key.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropForeignKey($foreignKey, $table)
     {
@@ -377,6 +408,8 @@ abstract class AbstractSchemaManager
      * @param string $name The name of the sequence to drop.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropSequence($name)
     {
@@ -389,6 +422,8 @@ abstract class AbstractSchemaManager
      * @param string $name The name of the view.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropView($name)
     {
@@ -403,6 +438,8 @@ abstract class AbstractSchemaManager
      * @param string $database The name of the database to create.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function createDatabase($database)
     {
@@ -413,6 +450,8 @@ abstract class AbstractSchemaManager
      * Creates a new table.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function createTable(Table $table)
     {
@@ -427,7 +466,7 @@ abstract class AbstractSchemaManager
      *
      * @return void
      *
-     * @throws ConnectionException If something fails at database level.
+     * @throws DBALException
      */
     public function createSequence($sequence)
     {
@@ -440,6 +479,8 @@ abstract class AbstractSchemaManager
      * @param Table|string $table
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function createConstraint(Constraint $constraint, $table)
     {
@@ -452,6 +493,8 @@ abstract class AbstractSchemaManager
      * @param Table|string $table The name of the table on which the index is to be created.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function createIndex(Index $index, $table)
     {
@@ -465,6 +508,8 @@ abstract class AbstractSchemaManager
      * @param Table|string         $table      The name of the table on which the foreign key is to be created.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function createForeignKey(ForeignKeyConstraint $foreignKey, $table)
     {
@@ -475,6 +520,8 @@ abstract class AbstractSchemaManager
      * Creates a new view.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function createView(View $view)
     {
@@ -492,6 +539,8 @@ abstract class AbstractSchemaManager
      * @param Table|string $table
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropAndCreateConstraint(Constraint $constraint, $table)
     {
@@ -505,6 +554,8 @@ abstract class AbstractSchemaManager
      * @param Table|string $table The name of the table on which the index is to be created.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropAndCreateIndex(Index $index, $table)
     {
@@ -519,6 +570,8 @@ abstract class AbstractSchemaManager
      * @param Table|string         $table      The name of the table on which the foreign key is to be created.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropAndCreateForeignKey(ForeignKeyConstraint $foreignKey, $table)
     {
@@ -531,7 +584,7 @@ abstract class AbstractSchemaManager
      *
      * @return void
      *
-     * @throws ConnectionException If something fails at database level.
+     * @throws DBALException
      */
     public function dropAndCreateSequence(Sequence $sequence)
     {
@@ -543,6 +596,8 @@ abstract class AbstractSchemaManager
      * Drops and creates a new table.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropAndCreateTable(Table $table)
     {
@@ -556,6 +611,8 @@ abstract class AbstractSchemaManager
      * @param string $database The name of the database to create.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropAndCreateDatabase($database)
     {
@@ -567,6 +624,8 @@ abstract class AbstractSchemaManager
      * Drops and creates a new view.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function dropAndCreateView(View $view)
     {
@@ -580,6 +639,8 @@ abstract class AbstractSchemaManager
      * Alters an existing tables schema.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function alterTable(TableDiff $tableDiff)
     {
@@ -597,6 +658,8 @@ abstract class AbstractSchemaManager
      * @param string $newName The new name of the table.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     public function renameTable($name, $newName)
     {
@@ -700,6 +763,8 @@ abstract class AbstractSchemaManager
      * @param mixed[][] $sequences
      *
      * @return Sequence[]
+     *
+     * @throws DBALException
      */
     protected function _getPortableSequencesList($sequences)
     {
@@ -734,6 +799,8 @@ abstract class AbstractSchemaManager
      * @param mixed[][] $tableColumns
      *
      * @return Column[]
+     *
+     * @throws DBALException
      */
     protected function _getPortableTableColumnList($table, $database, $tableColumns)
     {
@@ -773,6 +840,8 @@ abstract class AbstractSchemaManager
      * @param mixed[] $tableColumn
      *
      * @return Column
+     *
+     * @throws DBALException
      */
     abstract protected function _getPortableTableColumnDefinition($tableColumn);
 
@@ -783,6 +852,8 @@ abstract class AbstractSchemaManager
      * @param string|null $tableName
      *
      * @return Index[]
+     *
+     * @throws DBALException
      */
     protected function _getPortableTableIndexesList($tableIndexRows, $tableName = null)
     {
@@ -959,6 +1030,8 @@ abstract class AbstractSchemaManager
      * @param string[]|string $sql
      *
      * @return void
+     *
+     * @throws DBALException
      */
     protected function _execSql($sql)
     {
@@ -971,6 +1044,8 @@ abstract class AbstractSchemaManager
      * Creates a schema instance for the current database.
      *
      * @return Schema
+     *
+     * @throws DBALException
      */
     public function createSchema()
     {
@@ -995,6 +1070,8 @@ abstract class AbstractSchemaManager
      * Creates the configuration for this schema.
      *
      * @return SchemaConfig
+     *
+     * @throws DBALException
      */
     public function createSchemaConfig()
     {
@@ -1031,6 +1108,8 @@ abstract class AbstractSchemaManager
      * returns the name of the currently connected database.
      *
      * @return string[]
+     *
+     * @throws DBALException
      */
     public function getSchemaSearchPaths()
     {

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -58,6 +58,8 @@ class Column extends AbstractAsset
      *
      * @param string  $columnName
      * @param mixed[] $options
+     *
+     * @throws SchemaException
      */
     public function __construct($columnName, Type $type, array $options = [])
     {
@@ -70,6 +72,8 @@ class Column extends AbstractAsset
      * @param mixed[] $options
      *
      * @return Column
+     *
+     * @throws SchemaException
      */
     public function setOptions(array $options)
     {

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -22,6 +22,8 @@ class Comparator
 {
     /**
      * @return SchemaDiff
+     *
+     * @throws SchemaException
      */
     public static function compareSchemas(Schema $fromSchema, Schema $toSchema)
     {
@@ -38,6 +40,8 @@ class Comparator
      * stored in $toSchema.
      *
      * @return SchemaDiff
+     *
+     * @throws SchemaException
      */
     public function compare(Schema $fromSchema, Schema $toSchema)
     {
@@ -188,6 +192,8 @@ class Comparator
      * If there are no differences this method returns the boolean false.
      *
      * @return TableDiff|false
+     *
+     * @throws SchemaException
      */
     public function diffTable(Table $table1, Table $table2)
     {

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Types\Type;
 
@@ -37,6 +38,8 @@ class DB2SchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritdoc}
+     *
+     * @throws DBALException
      */
     protected function _getPortableTableColumnDefinition($tableColumn)
     {

--- a/src/Schema/Exception/InvalidTableName.php
+++ b/src/Schema/Exception/InvalidTableName.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/**
+ * @psalm-immutable
+ */
+final class InvalidTableName extends SchemaException
+{
+    public static function new(string $tableName): self
+    {
+        return new self(sprintf('Invalid table name specified "%s".', $tableName));
+    }
+}

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -297,6 +297,8 @@ class OracleSchemaManager extends AbstractSchemaManager
      * @param string $table
      *
      * @return bool
+     *
+     * @throws DBALException
      */
     public function dropAutoincrement($table)
     {
@@ -347,6 +349,8 @@ class OracleSchemaManager extends AbstractSchemaManager
      * @param string $user The name of the user to kill sessions for.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     private function killUserSessions($user)
     {

--- a/src/Schema/PostgreSqlSchemaManager.php
+++ b/src/Schema/PostgreSqlSchemaManager.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Types\Type;
@@ -39,6 +40,8 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
      * Gets all the existing schema names.
      *
      * @return string[]
+     *
+     * @throws DBALException
      */
     public function getSchemaNames()
     {
@@ -46,11 +49,7 @@ class PostgreSqlSchemaManager extends AbstractSchemaManager
     }
 
     /**
-     * Returns an array of schema search paths.
-     *
-     * This is a PostgreSQL only function.
-     *
-     * @return string[]
+     * {@inheritDoc}
      */
     public function getSchemaSearchPaths()
     {

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -319,6 +319,8 @@ class SQLServerSchemaManager extends AbstractSchemaManager
      * @param string $database The name of the database to close currently active connections for.
      *
      * @return void
+     *
+     * @throws DBALException
      */
     private function closeActiveDatabaseConnections($database)
     {
@@ -334,6 +336,8 @@ class SQLServerSchemaManager extends AbstractSchemaManager
 
     /**
      * @param string $tableName
+     *
+     * @throws DBALException
      */
     public function listTableDetails($tableName): Table
     {

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -58,6 +58,8 @@ class Schema extends AbstractAsset
      * @param Table[]    $tables
      * @param Sequence[] $sequences
      * @param string[]   $namespaces
+     *
+     * @throws SchemaException
      */
     public function __construct(
         array $tables = [],
@@ -316,6 +318,8 @@ class Schema extends AbstractAsset
      * @param string $tableName
      *
      * @return Table
+     *
+     * @throws SchemaException
      */
     public function createTable($tableName)
     {
@@ -336,6 +340,8 @@ class Schema extends AbstractAsset
      * @param string $newTableName
      *
      * @return Schema
+     *
+     * @throws SchemaException
      */
     public function renameTable($oldTableName, $newTableName)
     {
@@ -354,6 +360,8 @@ class Schema extends AbstractAsset
      * @param string $tableName
      *
      * @return Schema
+     *
+     * @throws SchemaException
      */
     public function dropTable($tableName)
     {
@@ -372,6 +380,8 @@ class Schema extends AbstractAsset
      * @param int    $initialValue
      *
      * @return Sequence
+     *
+     * @throws SchemaException
      */
     public function createSequence($sequenceName, $allocationSize = 1, $initialValue = 1)
     {
@@ -422,6 +432,8 @@ class Schema extends AbstractAsset
 
     /**
      * @return string[]
+     *
+     * @throws SchemaException
      */
     public function getMigrateToSql(Schema $toSchema, AbstractPlatform $platform)
     {
@@ -433,6 +445,8 @@ class Schema extends AbstractAsset
 
     /**
      * @return string[]
+     *
+     * @throws SchemaException
      */
     public function getMigrateFromSql(Schema $fromSchema, AbstractPlatform $platform)
     {

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -501,6 +501,9 @@ CREATE\sTABLE # Match "CREATE TABLE"
         return $comment === '' ? null : $comment;
     }
 
+    /**
+     * @throws DBALException
+     */
     private function getCreateTableSQL(string $table): string
     {
         $sql = $this->_conn->fetchOne(
@@ -528,6 +531,8 @@ SQL
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @param string $tableName
      */
     public function listTableDetails($tableName): Table

--- a/src/Schema/Synchronizer/AbstractSchemaSynchronizer.php
+++ b/src/Schema/Synchronizer/AbstractSchemaSynchronizer.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Schema\Synchronizer;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Throwable;
 
 /**
@@ -37,6 +38,8 @@ abstract class AbstractSchemaSynchronizer implements SchemaSynchronizer
      * @param string[] $sql
      *
      * @return void
+     *
+     * @throws DBALException
      */
     protected function processSql(array $sql)
     {

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 use Doctrine\DBAL\Types\Type;
 
@@ -51,12 +52,12 @@ class Table extends AbstractAsset
      * @param int                    $idGeneratorType
      * @param mixed[]                $options
      *
-     * @throws DBALException
+     * @throws SchemaException
      */
     public function __construct($tableName, array $columns = [], array $indexes = [], array $fkConstraints = [], $idGeneratorType = 0, array $options = [])
     {
         if (strlen($tableName) === 0) {
-            throw DBALException::invalidTableName($tableName);
+            throw InvalidTableName::new($tableName);
         }
 
         $this->_setName($tableName);

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -104,6 +104,8 @@ class Table extends AbstractAsset
      * @param string|false $indexName
      *
      * @return self
+     *
+     * @throws SchemaException
      */
     public function setPrimaryKey(array $columnNames, $indexName = false)
     {
@@ -128,6 +130,8 @@ class Table extends AbstractAsset
      * @param mixed[]     $options
      *
      * @return self
+     *
+     * @throws SchemaException
      */
     public function addIndex(array $columnNames, $indexName = null, array $flags = [], array $options = [])
     {
@@ -146,6 +150,8 @@ class Table extends AbstractAsset
      * Drops the primary key from this table.
      *
      * @return void
+     *
+     * @throws SchemaException
      */
     public function dropPrimaryKey()
     {
@@ -182,6 +188,8 @@ class Table extends AbstractAsset
      * @param mixed[]     $options
      *
      * @return self
+     *
+     * @throws SchemaException
      */
     public function addUniqueIndex(array $columnNames, $indexName = null, array $options = [])
     {
@@ -293,6 +301,8 @@ class Table extends AbstractAsset
      * @param mixed[] $options
      *
      * @return Column
+     *
+     * @throws SchemaException
      */
     public function addColumn($columnName, $typeName, array $options = [])
     {
@@ -310,6 +320,8 @@ class Table extends AbstractAsset
      * @param mixed[] $options
      *
      * @return self
+     *
+     * @throws SchemaException
      */
     public function changeColumn($columnName, array $options)
     {
@@ -346,6 +358,8 @@ class Table extends AbstractAsset
      * @param string|null  $name
      *
      * @return self
+     *
+     * @throws SchemaException
      */
     public function addForeignKeyConstraint($foreignTable, array $localColumnNames, array $foreignColumnNames, array $options = [], $name = null)
     {
@@ -452,6 +466,8 @@ class Table extends AbstractAsset
 
     /**
      * @return void
+     *
+     * @throws SchemaException
      */
     protected function _addForeignKeyConstraint(ForeignKeyConstraint $constraint)
     {
@@ -745,6 +761,8 @@ class Table extends AbstractAsset
 
     /**
      * @return void
+     *
+     * @throws SchemaException
      */
     public function visit(Visitor $visitor)
     {

--- a/src/Schema/Visitor/Visitor.php
+++ b/src/Schema/Visitor/Visitor.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 
@@ -16,6 +17,8 @@ interface Visitor
 {
     /**
      * @return void
+     *
+     * @throws SchemaException
      */
     public function acceptSchema(Schema $schema);
 
@@ -31,6 +34,8 @@ interface Visitor
 
     /**
      * @return void
+     *
+     * @throws SchemaException
      */
     public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint);
 

--- a/src/Tools/Console/Command/ReservedWordsCommand.php
+++ b/src/Tools/Console/Command/ReservedWordsCommand.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Tools\Console\Command;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\Keywords\DB2Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MariaDb102Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords;
@@ -113,6 +114,8 @@ EOT
 
     /**
      * {@inheritdoc}
+     *
+     * @throws DBALException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Tools\Console\Command;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Tools\Console\ConnectionProvider;
 use Doctrine\DBAL\Tools\Dumper;
 use LogicException;
@@ -57,6 +58,8 @@ EOT
 
     /**
      * {@inheritdoc}
+     *
+     * @throws DBALException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Tools/Console/ConsoleRunner.php
+++ b/src/Tools/Console/ConsoleRunner.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tools\Console;
 
 use Doctrine\DBAL\Tools\Console\Command\ReservedWordsCommand;
 use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
+use Exception;
 use PackageVersions\Versions;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -19,6 +20,8 @@ class ConsoleRunner
      * @param Command[] $commands
      *
      * @return void
+     *
+     * @throws Exception
      */
     public static function run(ConnectionProvider $connectionProvider, $commands = [])
     {

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -64,6 +64,8 @@ abstract class Type
      * @param AbstractPlatform $platform The currently used database platform.
      *
      * @return mixed The database representation of the value.
+     *
+     * @throws ConversionException
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -78,6 +80,8 @@ abstract class Type
      * @param AbstractPlatform $platform The currently used database platform.
      *
      * @return mixed The PHP representation of the value.
+     *
+     * @throws ConversionException
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/tests/Events/SQLSessionInitTest.php
+++ b/tests/Events/SQLSessionInitTest.php
@@ -17,7 +17,7 @@ class SQLSessionInitTest extends TestCase
     {
         $connectionMock = $this->createMock(Connection::class);
         $connectionMock->expects(self::once())
-                       ->method('exec')
+                       ->method('executeUpdate')
                        ->with(self::equalTo("SET SEARCH_PATH TO foo, public, TIMEZONE TO 'Europe/Berlin'"));
 
         $eventArgs = new ConnectionEventArgs($connectionMock);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

Roughly half of the error handling issues reported by PhpStorm have been fixed. The following categories of issues still need fixing:

1. Wrapper-level components implement the driver-level interfaces which are allowed to throw a driver-level exception but the consumers don't catch them because they are in fact impossible. This will be addressed in https://github.com/doctrine/dbal/pull/4159.
2. The lazy platform detection via `Connection::getDatabasePlatform()` can fail at literally any point in time.
3. The "not supported" exceptions thrown in `AbstractPlatform::get*DeclarationSQL()` and similar methods should have a special type that could be declared as unchecked (e.g. `LogicalException`). Those are not meant to be handled at runtime (see the [details](https://stackoverflow.com/questions/35586882/php-or-other-strategy-to-deal-with-exceptions-that-cannot-occur/35615934#35615934)).
4. Similarly to the issue addressed in https://github.com/doctrine/dbal/pull/4145, there are issues with `Type::getType()` that technically may thrown an exception but practically doesn't and those cases are reported as not handling the exception (need a specialized exception-less API).
5. The `Schema` namespace depends on the `Type` one internally but doesn't handle its exceptions and therefore may throw a generic `DBALException`.
6. The wrapper-level components that wrap the driver ones should be more specific about the exception they throw and when possible declare it as the wrapper-level `DriverException` instead of the generic `DBALException`.