### PR TITLE
Remove parameters and types unset after statement execution

### DIFF
--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -170,9 +170,6 @@ class Statement implements IteratorAggregate, DriverStatement
             $logger->stopQuery();
         }
 
-        $this->params = [];
-        $this->types  = [];
-
         return $stmt;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes: #4161.

The code that unsets the parameters was introduced as part of the original implementation in `2.0.0-beta1`:

https://github.com/doctrine/dbal/blob/354ede1e04a8d99bbc1a58d2206d29ebf9ddab4e/lib/Doctrine/DBAL/Statement.php#L124-L131

No test is provided since there's no reason for the code being removed to exist in the first place.