### PR TITLE
Deprecate duplicate and ambiguous wrapper connection methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.11
 
+## Deprecations in the wrapper `Connection` class
+
+1. The `executeUpdate()` method has been deprecated in favor of `executeStatement()`. 
+
 ## PDO-related classes outside of the PDO namespace are deprecated
 
 The following outside of the PDO namespace have been deprecated in favor of their counterparts in the PDO namespace:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,8 @@
 ## Deprecations in the wrapper `Connection` class
 
 1. The `executeUpdate()` method has been deprecated in favor of `executeStatement()`. 
+2. The `query()` method has been deprecated in favor of `executeQuery()`. 
+3. The `exec()` method has been deprecated in favor of `executeStatement()`. 
 
 ## PDO-related classes outside of the PDO namespace are deprecated
 

--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -142,7 +142,7 @@ use prepared statements:
     SQL query, bind the given params with their binding types and execute the query.
     This method returns the executed prepared statement for iteration and is useful
     for SELECT statements.
--   ``executeUpdate($sql, $params, $types)`` - Create a prepared statement for the passed
+-   ``executeStatement($sql, $params, $types)`` - Create a prepared statement for the passed
     SQL query, bind the given params with their binding types and execute the query.
     This method returns the number of affected rows by the executed query and is useful
     for UPDATE, DELETE and INSERT statements.
@@ -170,7 +170,7 @@ of this query using the fetch API of a statement:
 The fetch API of a prepared statement obviously works only for ``SELECT`` queries.
 
 If you find it tedious to write all the prepared statement code you can alternatively use
-the ``Doctrine\DBAL\Connection#executeQuery()`` and ``Doctrine\DBAL\Connection#executeUpdate()``
+the ``Doctrine\DBAL\Connection#executeQuery()`` and ``Doctrine\DBAL\Connection#executeStatement()``
 methods. See the API section below on details how to use them.
 
 Additionally there are lots of convenience methods for data-retrieval and manipulation
@@ -208,7 +208,7 @@ which means this code works independent of the database you are using.
 .. note::
 
     Be aware this type conversion only works with ``Statement#bindValue()``,
-    ``Connection#executeQuery()`` and ``Connection#executeUpdate()``. It
+    ``Connection#executeQuery()`` and ``Connection#executeStatement()``. It
     is not supported to pass a doctrine type name to ``Statement#bindParam()``,
     because this would not work with binding by reference.
 
@@ -286,7 +286,7 @@ This is much more complicated and is ugly to write generically.
 .. note::
 
     The parameter list support only works with ``Doctrine\DBAL\Connection::executeQuery()``
-    and ``Doctrine\DBAL\Connection::executeUpdate()``, NOT with the binding methods of
+    and ``Doctrine\DBAL\Connection::executeStatement()``, NOT with the binding methods of
     a prepared statement.
 
 API
@@ -319,7 +319,7 @@ Prepare a given SQL statement and return the
     )
     */
 
-executeUpdate()
+executeStatement()
 ~~~~~~~~~~~~~~~
 
 Executes a prepared statement with the given SQL and parameters and
@@ -328,7 +328,7 @@ returns the affected rows count:
 .. code-block:: php
 
     <?php
-    $count = $conn->executeUpdate('UPDATE user SET username = ? WHERE id = ?', array('jwage', 1));
+    $count = $conn->executeStatement('UPDATE user SET username = ? WHERE id = ?', array('jwage', 1));
     echo $count; // 1
 
 The ``$types`` variable contains the PDO or Doctrine Type constants

--- a/docs/en/reference/security.rst
+++ b/docs/en/reference/security.rst
@@ -135,7 +135,7 @@ are using just the DBAL there are also helper methods which simplify the usage q
     $sql = "SELECT * FROM users WHERE username = ?";
     $stmt = $connection->executeQuery($sql, array($_GET['username']));
 
-There is also ``executeUpdate`` which does not return a statement but the number of affected rows.
+There is also ``executeStatement`` which does not return a statement but the number of affected rows.
 
 Besides binding parameters you can also pass the type of the variable. This allows Doctrine or the underlying
 vendor to not only escape but also cast the value to the correct type. See the docs on querying and DQL in the

--- a/docs/en/reference/sharding_azure_tutorial.rst
+++ b/docs/en/reference/sharding_azure_tutorial.rst
@@ -263,7 +263,7 @@ operation for us:
         'LastName' => 'Brehm',
     ));
 
-    $conn->executeUpdate("DECLARE @orderId INT
+    $conn->executeStatement("DECLARE @orderId INT
 
         DECLARE @customerId INT
 

--- a/docs/examples/sharding/insert_data.php
+++ b/docs/examples/sharding/insert_data.php
@@ -90,7 +90,7 @@ $conn->insert("Customers", array(
     'LastName' => 'Brehm',
 ));
 
-$conn->executeUpdate("
+$conn->executeStatement("
     DECLARE @orderId INT
 
     DECLARE @customerId INT

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1249,6 +1249,8 @@ class Connection implements DriverConnection
     /**
      * Executes an SQL statement, returning a result set as a Statement object.
      *
+     * @deprecated Use {@link executeQuery()} instead.
+     *
      * @return \Doctrine\DBAL\Driver\Statement
      *
      * @throws DBALException
@@ -1359,6 +1361,8 @@ class Connection implements DriverConnection
 
     /**
      * Executes an SQL statement and return the number of affected rows.
+     *
+     * @deprecated Use {@link executeStatement()} instead.
      *
      * @param string $statement
      *

--- a/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
+++ b/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
@@ -26,7 +26,7 @@ use function func_get_args;
  *
  * 1. Replica if primary was never picked before and ONLY if 'getWrappedConnection'
  *    or 'executeQuery' is used.
- * 2. Primary picked when 'exec', 'executeUpdate', 'insert', 'delete', 'update', 'createSavepoint',
+ * 2. Primary picked when 'exec', 'executeUpdate', 'executeStatement', 'insert', 'delete', 'update', 'createSavepoint',
  *    'releaseSavepoint', 'beginTransaction', 'rollback', 'commit', 'query' or
  *    'prepare' is called.
  * 3. If Primary was picked once during the lifetime of the connection it will always get picked afterwards.
@@ -41,7 +41,7 @@ use function func_get_args;
  * Be aware that Connection#executeQuery is a method specifically for READ
  * operations only.
  *
- * Use Connection#executeUpdate for any SQL statement that changes/updates
+ * Use Connection#executeStatement for any SQL statement that changes/updates
  * state in the database (UPDATE, INSERT, DELETE or DDL statements).
  *
  * This connection is limited to replica operations using the
@@ -256,12 +256,24 @@ class PrimaryReadReplicaConnection extends Connection
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use {@link executeStatement()} instead.
      */
     public function executeUpdate($query, array $params = [], array $types = [])
     {
         $this->ensureConnectedToPrimary();
 
         return parent::executeUpdate($query, $params, $types);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function executeStatement($query, array $params = [], array $types = [])
+    {
+        $this->ensureConnectedToPrimary();
+
+        return parent::executeStatement($query, $params, $types);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/MysqlSessionInit.php
@@ -45,7 +45,7 @@ class MysqlSessionInit implements EventSubscriber
     public function postConnect(ConnectionEventArgs $args)
     {
         $collation = $this->collation ? ' COLLATE ' . $this->collation : '';
-        $args->getConnection()->executeUpdate('SET NAMES ' . $this->charset . $collation);
+        $args->getConnection()->executeStatement('SET NAMES ' . $this->charset . $collation);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Event/Listeners/OracleSessionInit.php
+++ b/lib/Doctrine/DBAL/Event/Listeners/OracleSessionInit.php
@@ -61,7 +61,7 @@ class OracleSessionInit implements EventSubscriber
         }
 
         $sql = 'ALTER SESSION SET ' . implode(' ', $vars);
-        $args->getConnection()->executeUpdate($sql);
+        $args->getConnection()->executeStatement($sql);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Id/TableGenerator.php
+++ b/lib/Doctrine/DBAL/Id/TableGenerator.php
@@ -131,7 +131,7 @@ class TableGenerator
                 $sql  = 'UPDATE ' . $this->generatorTableName . ' ' .
                        'SET sequence_value = sequence_value + sequence_increment_by ' .
                        'WHERE sequence_name = ? AND sequence_value = ?';
-                $rows = $this->conn->executeUpdate($sql, [$sequenceName, $row['sequence_value']]);
+                $rows = $this->conn->executeStatement($sql, [$sequenceName, $row['sequence_value']]);
 
                 if ($rows !== 1) {
                     throw new DBALException('Race-condition detected while updating sequence. Aborting generation');

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -196,9 +196,6 @@ class QueryBuilder
     /**
      * Executes this query using the bound parameters and their types.
      *
-     * Uses {@see Connection::executeQuery} for select statements and {@see Connection::executeUpdate}
-     * for insert, update and delete statements.
-     *
      * @return ResultStatement|int
      */
     public function execute()
@@ -207,7 +204,7 @@ class QueryBuilder
             return $this->connection->executeQuery($this->getSQL(), $this->params, $this->paramTypes);
         }
 
-        return $this->connection->executeUpdate($this->getSQL(), $this->params, $this->paramTypes);
+        return $this->connection->executeStatement($this->getSQL(), $this->params, $this->paramTypes);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -1033,7 +1033,7 @@ abstract class AbstractSchemaManager
     protected function _execSql($sql)
     {
         foreach ((array) $sql as $query) {
-            $this->_conn->executeUpdate($query);
+            $this->_conn->executeStatement($query);
         }
     }
 

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -307,10 +307,10 @@ class OracleSchemaManager extends AbstractSchemaManager
         $password = $params['password'];
 
         $query = 'CREATE USER ' . $username . ' IDENTIFIED BY ' . $password;
-        $this->_conn->executeUpdate($query);
+        $this->_conn->executeStatement($query);
 
         $query = 'GRANT DBA TO ' . $username;
-        $this->_conn->executeUpdate($query);
+        $this->_conn->executeStatement($query);
     }
 
     /**
@@ -324,7 +324,7 @@ class OracleSchemaManager extends AbstractSchemaManager
 
         $sql = $this->_platform->getDropAutoincrementSql($table);
         foreach ($sql as $query) {
-            $this->_conn->executeUpdate($query);
+            $this->_conn->executeStatement($query);
         }
 
         return true;

--- a/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
@@ -87,7 +87,7 @@ EOT
         if (stripos($sql, 'select') === 0 || $input->getOption('force-fetch')) {
             $resultSet = $conn->fetchAllAssociative($sql);
         } else {
-            $resultSet = $conn->executeUpdate($sql);
+            $resultSet = $conn->executeStatement($sql);
         }
 
         $output->write(Dumper::dump($resultSet, (int) $depth));

--- a/tests/Doctrine/Tests/DBAL/Connection/LoggingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Connection/LoggingTest.php
@@ -22,13 +22,13 @@ final class LoggingTest extends TestCase
             ->executeQuery('SELECT * FROM table');
     }
 
-    public function testLogExecuteUpdate(): void
+    public function testLogExecuteStatement(): void
     {
         $this->createConnection(
             $this->createStub(DriverConnection::class),
             'UPDATE table SET foo = ?'
         )
-            ->executeUpdate('UPDATE table SET foo = ?');
+            ->executeStatement('UPDATE table SET foo = ?');
     }
 
     public function testLogPrepareExecute(): void

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -54,7 +54,7 @@ class ConnectionTest extends DbalTestCase
     /**
      * @return Connection|MockObject
      */
-    private function getExecuteUpdateMockConnection()
+    private function getExecuteStatementMockConnection()
     {
         $driverMock = $this->createMock(Driver::class);
 
@@ -67,7 +67,7 @@ class ConnectionTest extends DbalTestCase
         $platform = $this->getMockForAbstractClass(AbstractPlatform::class);
 
         return $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['executeUpdate'])
+            ->onlyMethods(['executeStatement'])
             ->setConstructorArgs([['platform' => $platform], $driverMock])
             ->getMock();
     }
@@ -203,7 +203,7 @@ class ConnectionTest extends DbalTestCase
             ['exec'],
             ['query'],
             ['executeQuery'],
-            ['executeUpdate'],
+            ['executeStatement'],
             ['prepare'],
         ];
     }
@@ -372,10 +372,10 @@ class ConnectionTest extends DbalTestCase
 
     public function testEmptyInsert(): void
     {
-        $conn = $this->getExecuteUpdateMockConnection();
+        $conn = $this->getExecuteStatementMockConnection();
 
         $conn->expects($this->once())
-            ->method('executeUpdate')
+            ->method('executeStatement')
             ->with('INSERT INTO footable () VALUES ()');
 
         $conn->insert('footable', []);
@@ -386,10 +386,10 @@ class ConnectionTest extends DbalTestCase
      */
     public function testUpdateWithDifferentColumnsInDataAndIdentifiers(): void
     {
-        $conn = $this->getExecuteUpdateMockConnection();
+        $conn = $this->getExecuteStatementMockConnection();
 
         $conn->expects($this->once())
-            ->method('executeUpdate')
+            ->method('executeStatement')
             ->with(
                 'UPDATE TestTable SET text = ?, is_edited = ? WHERE id = ? AND name = ?',
                 [
@@ -430,10 +430,10 @@ class ConnectionTest extends DbalTestCase
      */
     public function testUpdateWithSameColumnInDataAndIdentifiers(): void
     {
-        $conn = $this->getExecuteUpdateMockConnection();
+        $conn = $this->getExecuteStatementMockConnection();
 
         $conn->expects($this->once())
-            ->method('executeUpdate')
+            ->method('executeStatement')
             ->with(
                 'UPDATE TestTable SET text = ?, is_edited = ? WHERE id = ? AND is_edited = ?',
                 [
@@ -473,10 +473,10 @@ class ConnectionTest extends DbalTestCase
      */
     public function testUpdateWithIsNull(): void
     {
-        $conn = $this->getExecuteUpdateMockConnection();
+        $conn = $this->getExecuteStatementMockConnection();
 
         $conn->expects($this->once())
-            ->method('executeUpdate')
+            ->method('executeStatement')
             ->with(
                 'UPDATE TestTable SET text = ?, is_edited = ? WHERE id IS NULL AND name = ?',
                 [
@@ -515,10 +515,10 @@ class ConnectionTest extends DbalTestCase
      */
     public function testDeleteWithIsNull(): void
     {
-        $conn = $this->getExecuteUpdateMockConnection();
+        $conn = $this->getExecuteStatementMockConnection();
 
         $conn->expects($this->once())
-            ->method('executeUpdate')
+            ->method('executeStatement')
             ->with(
                 'DELETE FROM TestTable WHERE id IS NULL AND name = ?',
                 ['foo'],
@@ -725,7 +725,7 @@ class ConnectionTest extends DbalTestCase
             ['insert', ['tbl', ['data' => 'foo']]],
             ['update', ['tbl', ['data' => 'bar'], ['id' => 12345]]],
             ['prepare', ['select * from dual']],
-            ['executeUpdate', ['insert into tbl (id) values (?)'], [123]],
+            ['executeStatement', ['insert into tbl (id) values (?)'], [123]],
         ];
     }
 

--- a/tests/Doctrine/Tests/DBAL/Events/MysqlSessionInitTest.php
+++ b/tests/Doctrine/Tests/DBAL/Events/MysqlSessionInitTest.php
@@ -14,7 +14,7 @@ class MysqlSessionInitTest extends DbalTestCase
     {
         $connectionMock = $this->createMock(Connection::class);
         $connectionMock->expects($this->once())
-                       ->method('executeUpdate')
+                       ->method('executeStatement')
                        ->with($this->equalTo('SET NAMES foo COLLATE bar'));
 
         $eventArgs = new ConnectionEventArgs($connectionMock);

--- a/tests/Doctrine/Tests/DBAL/Events/OracleSessionInitTest.php
+++ b/tests/Doctrine/Tests/DBAL/Events/OracleSessionInitTest.php
@@ -16,7 +16,7 @@ class OracleSessionInitTest extends DbalTestCase
     {
         $connectionMock = $this->createMock(Connection::class);
         $connectionMock->expects($this->once())
-                       ->method('executeUpdate')
+                       ->method('executeStatement')
                        ->with($this->isType('string'));
 
         $eventArgs = new ConnectionEventArgs($connectionMock);
@@ -35,7 +35,7 @@ class OracleSessionInitTest extends DbalTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $connectionMock->expects($this->once())
-            ->method('executeUpdate')
+            ->method('executeStatement')
             ->with($this->stringContains(sprintf('%s = %s', $name, $value)));
 
         $eventArgs = new ConnectionEventArgs($connectionMock);

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -437,12 +437,12 @@ class DataAccessTest extends DbalFunctionalTestCase
     /**
      * @group DDC-697
      */
-    public function testExecuteUpdateBindDateTimeType(): void
+    public function testExecuteStatementBindDateTimeType(): void
     {
         $datetime = new DateTime('2010-02-02 20:20:20');
 
         $sql          = 'INSERT INTO fetch_table (test_int, test_string, test_datetime) VALUES (?, ?, ?)';
-        $affectedRows = $this->connection->executeUpdate($sql, [
+        $affectedRows = $this->connection->executeStatement($sql, [
             1 => 50,
             2 => 'foo',
             3 => $datetime,
@@ -800,7 +800,7 @@ class DataAccessTest extends DbalFunctionalTestCase
     public function testFetchAllStyleColumn(): void
     {
         $sql = 'DELETE FROM fetch_table';
-        $this->connection->executeUpdate($sql);
+        $this->connection->executeStatement($sql);
 
         $this->connection->insert('fetch_table', ['test_int' => 1, 'test_string' => 'foo']);
         $this->connection->insert('fetch_table', ['test_int' => 10, 'test_string' => 'foo']);
@@ -903,7 +903,7 @@ class DataAccessTest extends DbalFunctionalTestCase
      */
     public function testFetchColumnNullValue(): void
     {
-        $this->connection->executeUpdate(
+        $this->connection->executeStatement(
             'INSERT INTO fetch_table (test_int, test_string) VALUES (?, ?)',
             [2, 'foo']
         );

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/OCI8/ConnectionTest.php
@@ -40,7 +40,7 @@ class ConnectionTest extends DbalFunctionalTestCase
 
         $schemaManager->dropAndCreateTable($table);
 
-        $this->connection->executeUpdate('INSERT INTO DBAL2595 (foo) VALUES (1)');
+        $this->connection->executeStatement('INSERT INTO DBAL2595 (foo) VALUES (1)');
 
         $schema   = $this->connection->getDatabase();
         $sequence = $platform->getIdentitySequenceName($schema . '.DBAL2595', 'id');

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -201,7 +201,7 @@ class ExceptionTest extends DbalFunctionalTestCase
         $this->expectException(Exception\ForeignKeyConstraintViolationException::class);
 
         try {
-            $this->connection->executeUpdate($platform->getTruncateTableSQL('constraint_error_table'));
+            $this->connection->executeStatement($platform->getTruncateTableSQL('constraint_error_table'));
         } catch (Exception\ForeignKeyConstraintViolationException $exception) {
             $this->tearDownForeignKeyConstraintViolationExceptionTest();
 

--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -43,7 +43,7 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
         } catch (Throwable $e) {
         }
 
-        $this->connection->executeUpdate('DELETE FROM master_slave_table');
+        $this->connection->executeStatement('DELETE FROM master_slave_table');
         $this->connection->insert('master_slave_table', ['test_int' => 1]);
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PrimaryReadReplicaConnectionTest.php
@@ -43,7 +43,7 @@ class PrimaryReadReplicaConnectionTest extends DbalFunctionalTestCase
         } catch (Throwable $e) {
         }
 
-        $this->connection->executeUpdate('DELETE FROM primary_replica_table');
+        $this->connection->executeStatement('DELETE FROM primary_replica_table');
         $this->connection->insert('primary_replica_table', ['test_int' => 1]);
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -458,7 +458,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->dropAndCreateTable($table);
 
-        $this->connection->executeUpdate(
+        $this->connection->executeStatement(
             'INSERT INTO test_column_defaults_are_valid () VALUES()'
         );
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -224,7 +224,7 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
         $namespaces = array_map('strtolower', $namespaces);
 
         if (! in_array('test_create_schema', $namespaces)) {
-            $this->connection->executeUpdate($this->schemaManager->getDatabasePlatform()->getCreateSchemaSQL('test_create_schema'));
+            $this->connection->executeStatement($this->schemaManager->getDatabasePlatform()->getCreateSchemaSQL('test_create_schema'));
 
             $namespaces = $this->schemaManager->listNamespaceNames();
             $namespaces = array_map('strtolower', $namespaces);

--- a/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
@@ -49,7 +49,7 @@ class TemporaryTableTest extends DbalFunctionalTestCase
 
         $createTempTableSQL = $platform->getCreateTemporaryTableSnippetSQL() . ' ' . $tempTable . ' ('
                 . $platform->getColumnDeclarationListSQL($columnDefinitions) . ')';
-        $this->connection->executeUpdate($createTempTableSQL);
+        $this->connection->executeStatement($createTempTableSQL);
 
         $table = new Table('nontemporary');
         $table->addColumn('id', 'integer');

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
@@ -48,7 +48,7 @@ class DBAL630Test extends DbalFunctionalTestCase
 
     public function testBooleanConversionSqlLiteral(): void
     {
-        $this->connection->executeUpdate('INSERT INTO dbal630 (bool_col) VALUES(false)');
+        $this->connection->executeStatement('INSERT INTO dbal630 (bool_col) VALUES(false)');
         $id = $this->connection->lastInsertId('dbal630_id_seq');
         self::assertNotEmpty($id);
 
@@ -59,7 +59,7 @@ class DBAL630Test extends DbalFunctionalTestCase
 
     public function testBooleanConversionBoolParamRealPrepares(): void
     {
-        $this->connection->executeUpdate(
+        $this->connection->executeStatement(
             'INSERT INTO dbal630 (bool_col) VALUES(?)',
             ['false'],
             [ParameterType::BOOLEAN]

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -32,39 +32,39 @@ class WriteTest extends DbalFunctionalTestCase
         } catch (Throwable $e) {
         }
 
-        $this->connection->executeUpdate('DELETE FROM write_table');
+        $this->connection->executeStatement('DELETE FROM write_table');
     }
 
     /**
      * @group DBAL-80
      */
-    public function testExecuteUpdateFirstTypeIsNull(): void
+    public function testExecuteStatementFirstTypeIsNull(): void
     {
         $sql = 'INSERT INTO write_table (test_string, test_int) VALUES (?, ?)';
-        $this->connection->executeUpdate($sql, ['text', 1111], [null, ParameterType::INTEGER]);
+        $this->connection->executeStatement($sql, ['text', 1111], [null, ParameterType::INTEGER]);
 
         $sql = 'SELECT * FROM write_table WHERE test_string = ? AND test_int = ?';
         self::assertTrue((bool) $this->connection->fetchColumn($sql, ['text', 1111]));
     }
 
-    public function testExecuteUpdate(): void
+    public function testExecuteStatement(): void
     {
         $sql      = 'INSERT INTO write_table (test_int) VALUES ( ' . $this->connection->quote(1) . ')';
-        $affected = $this->connection->executeUpdate($sql);
+        $affected = $this->connection->executeStatement($sql);
 
-        self::assertEquals(1, $affected, 'executeUpdate() should return the number of affected rows!');
+        self::assertEquals(1, $affected, 'executeStatement() should return the number of affected rows!');
     }
 
-    public function testExecuteUpdateWithTypes(): void
+    public function testExecuteStatementWithTypes(): void
     {
         $sql      = 'INSERT INTO write_table (test_int, test_string) VALUES (?, ?)';
-        $affected = $this->connection->executeUpdate(
+        $affected = $this->connection->executeStatement(
             $sql,
             [1, 'foo'],
             [ParameterType::INTEGER, ParameterType::STRING]
         );
 
-        self::assertEquals(1, $affected, 'executeUpdate() should return the number of affected rows!');
+        self::assertEquals(1, $affected, 'executeStatement() should return the number of affected rows!');
     }
 
     public function testPrepareRowCountReturnsAffectedRows(): void

--- a/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
@@ -79,7 +79,7 @@ class RunSqlCommandTest extends TestCase
 
     public function testUpdateStatementsPrintsAffectedLines(): void
     {
-        $this->expectConnectionExecuteUpdate();
+        $this->expectConnectionExecuteStatement();
 
         $this->commandTester->execute([
             'command' => $this->command->getName(),
@@ -90,11 +90,11 @@ class RunSqlCommandTest extends TestCase
         self::assertDoesNotMatchRegularExpression('@array.*1.*@', $this->commandTester->getDisplay());
     }
 
-    private function expectConnectionExecuteUpdate(): void
+    private function expectConnectionExecuteStatement(): void
     {
         $this->connectionMock
             ->expects($this->once())
-            ->method('executeUpdate')
+            ->method('executeStatement')
             ->willReturn(42);
 
         $this->connectionMock
@@ -111,7 +111,7 @@ class RunSqlCommandTest extends TestCase
 
         $this->connectionMock
             ->expects($this->never())
-            ->method('executeUpdate');
+            ->method('executeStatement');
     }
 
     public function testStatementsWithFetchResultPrintsResult(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

### Deprecation of `Connection::query()` and `::exec()`

Once the wrapper connection has been freed from the responsibilities of the driver connection (https://github.com/doctrine/dbal/pull/4159), the `query()` and `exec()` methods that effectively (and poorly) duplicate `executeQuery()` and `executeUpdate()` can be deprecated.

### Deprecation of `Connection::executeUpdate()` in favor of `::executeStatement()`

The name of the `executeUpdate()` method is quote misleading since apart from the `UPDATE` statements, it should be used for `INSERT`, `DELETE` and all sorts of DML, DDL, TCL and other statements. As generic alternative `executeStatement()` looks more intuitive.

### Notes in conjunction with PrimaryReplicaConnection

Note that `PrimaryReplicaConnection::query()` ensured connection to the primary instance while `executeQuery()` doesn't.

Depending on the desired behavior:

- If the statement doesn't have to be executed on the primary instance, use `executeQuery()`.
- If the statement has to be executed on the primary instance and yields rows (e.g. `SELECT`), prepend `executeQuery()` with `ensureConnectedToPrimary()`.
- Otherwise, use `executeStatement()`.