### PR TITLE
Deprecated usage of wrapper components as implementations of driver-level interfaces

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.11
 
+## Deprecated usage of wrapper-level components as implementations of driver-level interfaces
+
+The usage of the wrapper `Connection` and `Statement` classes as implementations of the `Driver\Connection` and `Driver\Statement` interfaces is deprecated.
+
 ## Deprecations in the wrapper `Connection` class
 
 1. The `executeUpdate()` method has been deprecated in favor of `executeStatement()`. 
@@ -8,7 +12,7 @@
 
 ## PDO-related classes outside of the PDO namespace are deprecated
 
-The following outside of the PDO namespace have been deprecated in favor of their counterparts in the PDO namespace:
+The following PDO-related classes outside of the PDO namespace have been deprecated in favor of their counterparts in the PDO namespace:
 
 - `PDOMySql\Driver` → `PDO\MySQL\Driver`
 - `PDOOracle\Driver` → `PDO\OCI\Driver`


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

See https://github.com/doctrine/dbal/pull/4159.