### PR TITLE
Remove deprecated methods from the wrapper Connection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade to 3.0
 
+## BC BREAK: removed wrapper `Connection` methods
+
+The following methods of the `Connection` class have been removed:
+
+1. `query()`.
+
 ## BC BREAK: Changes in the wrapper-level API ancestry
 
 The wrapper-level `Connection` and `Statement` classes no longer implement the corresponding driver-level interfaces.
@@ -50,7 +56,6 @@ The following classes have been renamed:
 The following driver-level methods are allowed to throw a Driver\Exception:
 
 - `Connection::prepare()`
-- `Connection::query()`
 - `Connection::exec()`
 - `Connection::lastInsertId()`
 - `Connection::beginTransaction()`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,8 @@
 The following methods of the `Connection` class have been removed:
 
 1. `query()`.
+2. `exec()`.
+3. `executeUpdate()`.
 
 ## BC BREAK: Changes in the wrapper-level API ancestry
 
@@ -56,7 +58,6 @@ The following classes have been renamed:
 The following driver-level methods are allowed to throw a Driver\Exception:
 
 - `Connection::prepare()`
-- `Connection::exec()`
 - `Connection::lastInsertId()`
 - `Connection::beginTransaction()`
 - `Connection::commit()`

--- a/ci/continuousphp/bootstrap.php
+++ b/ci/continuousphp/bootstrap.php
@@ -12,5 +12,5 @@ use Doctrine\DBAL\DriverManager;
         'user' => 'ORACLE',
         'password' => 'ORACLE',
         'dbname' => 'XE',
-    ])->query('ALTER USER ORACLE IDENTIFIED BY ORACLE');
+    ])->executeStatement('ALTER USER ORACLE IDENTIFIED BY ORACLE');
 })();

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\Exception as DriverException;
-use Doctrine\DBAL\Driver\Result as DriverResult;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\Exception\ConnectionLost;
@@ -1026,31 +1025,6 @@ class Connection
         }
 
         return new Result($result, $this);
-    }
-
-    /**
-     * @deprecated Use {@link executeQuery()} instead.
-     *
-     * @throws DBALException
-     */
-    public function query(string $sql): DriverResult
-    {
-        $connection = $this->getWrappedConnection();
-
-        $logger = $this->_config->getSQLLogger();
-        if ($logger !== null) {
-            $logger->startQuery($sql);
-        }
-
-        try {
-            return $connection->query($sql);
-        } catch (DriverException $e) {
-            throw $this->convertExceptionDuringQuery($e, $sql);
-        } finally {
-            if ($logger !== null) {
-                $logger->stopQuery();
-            }
-        }
     }
 
     /**

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1084,31 +1084,6 @@ class Connection
     }
 
     /**
-     * @deprecated Use {@link executeStatement()} instead.
-     *
-     * @throws DBALException
-     */
-    public function exec(string $statement): int
-    {
-        $connection = $this->getWrappedConnection();
-
-        $logger = $this->_config->getSQLLogger();
-        if ($logger !== null) {
-            $logger->startQuery($statement);
-        }
-
-        try {
-            return $connection->exec($statement);
-        } catch (DriverException $e) {
-            throw $this->convertExceptionDuringQuery($e, $statement);
-        } finally {
-            if ($logger !== null) {
-                $logger->stopQuery();
-            }
-        }
-    }
-
-    /**
      * Returns the current transaction nesting level.
      *
      * @return int The nesting level. A value of 0 means there's no active transaction.

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1028,23 +1028,6 @@ class Connection
     }
 
     /**
-     * Executes an SQL INSERT/UPDATE/DELETE query with the given parameters
-     * and returns the number of affected rows.
-     *
-     * @deprecated Use {@link executeStatement()} instead.
-     *
-     * @param string                 $query  The SQL query.
-     * @param array<mixed>           $params The query parameters.
-     * @param array<int|string|null> $types  The parameter types.
-     *
-     * @throws DBALException
-     */
-    public function executeUpdate(string $query, array $params = [], array $types = []): int
-    {
-        return $this->executeStatement($query, $params, $types);
-    }
-
-    /**
      * Executes an SQL statement with the given parameters and returns the number of affected rows.
      *
      * Could be used for:
@@ -1410,7 +1393,7 @@ class Connection
             throw ConnectionException::savepointsNotSupported();
         }
 
-        $this->executeUpdate($this->platform->createSavePoint($savepoint));
+        $this->executeStatement($this->platform->createSavePoint($savepoint));
     }
 
     /**
@@ -1432,7 +1415,7 @@ class Connection
             return;
         }
 
-        $this->executeUpdate($this->platform->releaseSavePoint($savepoint));
+        $this->executeStatement($this->platform->releaseSavePoint($savepoint));
     }
 
     /**
@@ -1450,7 +1433,7 @@ class Connection
             throw ConnectionException::savepointsNotSupported();
         }
 
-        $this->executeUpdate($this->platform->rollbackSavePoint($savepoint));
+        $this->executeStatement($this->platform->rollbackSavePoint($savepoint));
     }
 
     /**

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -311,16 +311,6 @@ class PrimaryReadReplicaConnection extends Connection
     /**
      * {@inheritDoc}
      */
-    public function delete($tableName, array $identifier, array $types = [])
-    {
-        $this->ensureConnectedToPrimary();
-
-        return parent::delete($tableName, $identifier, $types);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function close()
     {
         unset($this->connections['primary'], $this->connections['replica']);
@@ -329,33 +319,6 @@ class PrimaryReadReplicaConnection extends Connection
 
         $this->_conn       = null;
         $this->connections = ['primary' => null, 'replica' => null];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function update($tableName, array $data, array $identifier, array $types = [])
-    {
-        $this->ensureConnectedToPrimary();
-
-        return parent::update($tableName, $data, $identifier, $types);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function insert($tableName, array $data, array $types = [])
-    {
-        $this->ensureConnectedToPrimary();
-
-        return parent::insert($tableName, $data, $types);
-    }
-
-    public function exec(string $statement): int
-    {
-        $this->ensureConnectedToPrimary();
-
-        return parent::exec($statement);
     }
 
     /**

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -27,7 +27,7 @@ use function count;
  *
  * 1. Replica if primary was never picked before and ONLY if 'getWrappedConnection'
  *    or 'executeQuery' is used.
- * 2. Primary picked when 'exec', 'executeUpdate', 'executeStatement', 'insert', 'delete', 'update', 'createSavepoint',
+ * 2. Primary picked when 'executeStatement', 'insert', 'delete', 'update', 'createSavepoint',
  *    'releaseSavepoint', 'beginTransaction', 'rollback', 'commit' or 'prepare' is called.
  * 3. If Primary was picked once during the lifetime of the connection it will always get picked afterwards.
  * 4. One replica connection is randomly picked ONCE during a request.
@@ -254,18 +254,6 @@ class PrimaryReadReplicaConnection extends Connection
         }
 
         return $config;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated Use {@link executeStatement()} instead.
-     */
-    public function executeUpdate(string $query, array $params = [], array $types = []): int
-    {
-        $this->ensureConnectedToPrimary();
-
-        return parent::executeUpdate($query, $params, $types);
     }
 
     /**

--- a/src/Event/Listeners/SQLSessionInit.php
+++ b/src/Event/Listeners/SQLSessionInit.php
@@ -30,7 +30,7 @@ class SQLSessionInit implements EventSubscriber
      */
     public function postConnect(ConnectionEventArgs $args)
     {
-        $args->getConnection()->executeUpdate($this->sql);
+        $args->getConnection()->executeStatement($this->sql);
     }
 
     /**

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -278,7 +278,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
             foreach ($tableDiff->removedColumns as $col) {
                 $columnConstraintSql = $this->getColumnConstraintSQL($tableDiff->name, $col->getName());
                 foreach ($this->_conn->fetchAllAssociative($columnConstraintSql) as $constraint) {
-                    $this->_conn->exec(
+                    $this->_conn->executeStatement(
                         sprintf(
                             'ALTER TABLE %s DROP CONSTRAINT %s',
                             $tableDiff->name,

--- a/src/Schema/Synchronizer/AbstractSchemaSynchronizer.php
+++ b/src/Schema/Synchronizer/AbstractSchemaSynchronizer.php
@@ -28,7 +28,7 @@ abstract class AbstractSchemaSynchronizer implements SchemaSynchronizer
     {
         foreach ($sql as $s) {
             try {
-                $this->conn->exec($s);
+                $this->conn->executeStatement($s);
             } catch (Throwable $e) {
             }
         }
@@ -44,7 +44,7 @@ abstract class AbstractSchemaSynchronizer implements SchemaSynchronizer
     protected function processSql(array $sql)
     {
         foreach ($sql as $s) {
-            $this->conn->exec($s);
+            $this->conn->executeStatement($s);
         }
     }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -180,12 +180,6 @@ class ConnectionTest extends TestCase
             },
         ];
 
-        yield 'query' => [
-            static function (Connection $connection, string $statement): void {
-                $connection->query($statement);
-            },
-        ];
-
         yield 'executeQuery' => [
             static function (Connection $connection, string $statement): void {
                 $connection->executeQuery($statement);

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -174,12 +174,6 @@ class ConnectionTest extends TestCase
      */
     public static function getQueryMethods(): iterable
     {
-        yield 'exec' => [
-            static function (Connection $connection, string $statement): void {
-                $connection->exec($statement);
-            },
-        ];
-
         yield 'executeQuery' => [
             static function (Connection $connection, string $statement): void {
                 $connection->executeQuery($statement);

--- a/tests/Events/SQLSessionInitTest.php
+++ b/tests/Events/SQLSessionInitTest.php
@@ -17,7 +17,7 @@ class SQLSessionInitTest extends TestCase
     {
         $connectionMock = $this->createMock(Connection::class);
         $connectionMock->expects(self::once())
-                       ->method('executeUpdate')
+                       ->method('executeStatement')
                        ->with(self::equalTo("SET SEARCH_PATH TO foo, public, TIMEZONE TO 'Europe/Berlin'"));
 
         $eventArgs = new ConnectionEventArgs($connectionMock);

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -158,7 +158,7 @@ class BlobTest extends FunctionalTestCase
 
     private function assertBlobContains(string $text): void
     {
-        $rows = $this->connection->query('SELECT blobfield FROM blob_table')->fetchFirstColumn();
+        $rows = $this->connection->fetchFirstColumn('SELECT blobfield FROM blob_table');
 
         self::assertCount(1, $rows);
 

--- a/tests/Functional/Connection/ConnectionLostTest.php
+++ b/tests/Functional/Connection/ConnectionLostTest.php
@@ -30,7 +30,7 @@ class ConnectionLostTest extends FunctionalTestCase
 
     public function testConnectionLost(): void
     {
-        $this->connection->query('SET SESSION wait_timeout=1');
+        $this->connection->executeStatement('SET SESSION wait_timeout=1');
 
         sleep(2);
 

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -614,7 +614,6 @@ class DataAccessTest extends FunctionalTestCase
         $this->connection->beginTransaction();
         $this->connection->exec('DELETE FROM fetch_table');
         self::assertFalse($this->connection->fetchOne('SELECT test_int FROM fetch_table'));
-        self::assertFalse($this->connection->query('SELECT test_int FROM fetch_table')->fetchOne());
         $this->connection->rollBack();
     }
 

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -601,7 +601,7 @@ class DataAccessTest extends FunctionalTestCase
         $this->connection->insert('fetch_table', ['test_int' => 10, 'test_string' => 'foo']);
 
         $sql    = 'SELECT test_int FROM fetch_table';
-        $values = $this->connection->query($sql)->fetchFirstColumn();
+        $values = $this->connection->fetchFirstColumn($sql);
 
         self::assertEquals([1, 10], $values);
     }

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -546,7 +546,7 @@ class DataAccessTest extends FunctionalTestCase
      */
     public function testBitComparisonExpressionSupport(): void
     {
-        $this->connection->exec('DELETE FROM fetch_table');
+        $this->connection->executeStatement('DELETE FROM fetch_table');
         $platform = $this->connection->getDatabasePlatform();
         $bitmap   = [];
 
@@ -612,7 +612,7 @@ class DataAccessTest extends FunctionalTestCase
     public function testEmptyFetchOneReturnsFalse(): void
     {
         $this->connection->beginTransaction();
-        $this->connection->exec('DELETE FROM fetch_table');
+        $this->connection->executeStatement('DELETE FROM fetch_table');
         self::assertFalse($this->connection->fetchOne('SELECT test_int FROM fetch_table'));
         $this->connection->rollBack();
     }

--- a/tests/Functional/Driver/PDO/PgSQL/ConnectionTest.php
+++ b/tests/Functional/Driver/PDO/PgSQL/ConnectionTest.php
@@ -40,8 +40,7 @@ class ConnectionTest extends FunctionalTestCase
 
         self::assertEquals(
             $charset,
-            $connection->query('SHOW client_encoding')
-                ->fetchOne()
+            $connection->fetchOne('SHOW client_encoding')
         );
     }
 

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -86,7 +86,7 @@ class ExceptionTest extends FunctionalTestCase
     public function testForeignKeyConstraintViolationExceptionOnInsert(): void
     {
         if ($this->connection->getDatabasePlatform()->getName() === 'sqlite') {
-            $this->connection->exec('PRAGMA foreign_keys=ON');
+            $this->connection->executeStatement('PRAGMA foreign_keys=ON');
         }
 
         $this->setUpForeignKeyConstraintViolationExceptionTest();
@@ -231,7 +231,7 @@ class ExceptionTest extends FunctionalTestCase
         $table->setPrimaryKey(['id']);
 
         foreach ($schema->toSql($this->connection->getDatabasePlatform()) as $sql) {
-            $this->connection->exec($sql);
+            $this->connection->executeStatement($sql);
         }
 
         $this->expectException(Exception\NotNullConstraintViolationException::class);
@@ -246,7 +246,7 @@ class ExceptionTest extends FunctionalTestCase
         $table->addColumn('id', 'integer', []);
 
         foreach ($schema->toSql($this->connection->getDatabasePlatform()) as $sql) {
-            $this->connection->exec($sql);
+            $this->connection->executeStatement($sql);
         }
 
         $this->expectException(Exception\InvalidFieldNameException::class);
@@ -264,7 +264,7 @@ class ExceptionTest extends FunctionalTestCase
         $table2->addColumn('id', 'integer');
 
         foreach ($schema->toSql($this->connection->getDatabasePlatform()) as $sql) {
-            $this->connection->exec($sql);
+            $this->connection->executeStatement($sql);
         }
 
         $sql = 'SELECT id FROM ambiguous_list_table, ambiguous_list_table_2';
@@ -281,7 +281,7 @@ class ExceptionTest extends FunctionalTestCase
         $table->addUniqueIndex(['id']);
 
         foreach ($schema->toSql($this->connection->getDatabasePlatform()) as $sql) {
-            $this->connection->exec($sql);
+            $this->connection->executeStatement($sql);
         }
 
         $this->connection->insert('unique_field_table', ['id' => 5]);
@@ -345,7 +345,7 @@ EOT
 
         try {
             foreach ($schema->toSql($conn->getDatabasePlatform()) as $sql) {
-                $conn->exec($sql);
+                $conn->executeStatement($sql);
             }
         } finally {
             $this->cleanupReadOnlyFile($filename);
@@ -390,7 +390,7 @@ EOT
         $this->expectException(Exception\ConnectionException::class);
 
         foreach ($schema->toSql($conn->getDatabasePlatform()) as $sql) {
-            $conn->exec($sql);
+            $conn->executeStatement($sql);
         }
     }
 

--- a/tests/Functional/ModifyLimitQueryTest.php
+++ b/tests/Functional/ModifyLimitQueryTest.php
@@ -35,8 +35,15 @@ class ModifyLimitQueryTest extends FunctionalTestCase
             self::$tableCreated = true;
         }
 
-        $this->connection->exec($this->connection->getDatabasePlatform()->getTruncateTableSQL('modify_limit_table'));
-        $this->connection->exec($this->connection->getDatabasePlatform()->getTruncateTableSQL('modify_limit_table2'));
+        $platform = $this->connection->getDatabasePlatform();
+
+        $this->connection->executeStatement(
+            $platform->getTruncateTableSQL('modify_limit_table')
+        );
+
+        $this->connection->executeStatement(
+            $platform->getTruncateTableSQL('modify_limit_table2')
+        );
     }
 
     public function testModifyLimitQuerySimpleQuery(): void

--- a/tests/Functional/Platform/DateExpressionTest.php
+++ b/tests/Functional/Platform/DateExpressionTest.php
@@ -27,7 +27,7 @@ class DateExpressionTest extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform();
 
         $sql  = sprintf('SELECT %s FROM date_expr_test', $platform->getDateDiffExpression('date1', 'date2'));
-        $diff = $this->connection->query($sql)->fetchOne();
+        $diff = $this->connection->fetchOne($sql);
 
         self::assertEquals($expected, $diff);
     }

--- a/tests/Functional/Platform/DefaultExpressionTest.php
+++ b/tests/Functional/Platform/DefaultExpressionTest.php
@@ -69,9 +69,9 @@ class DefaultExpressionTest extends FunctionalTestCase
             )
         );
 
-        [$actualValue, $defaultValue] = $this->connection->query(
+        [$actualValue, $defaultValue] = $this->connection->fetchNumeric(
             'SELECT default_value, actual_value FROM default_expr_test'
-        )->fetchNumeric();
+        );
 
         self::assertEquals($actualValue, $defaultValue);
     }

--- a/tests/Functional/Platform/DefaultExpressionTest.php
+++ b/tests/Functional/Platform/DefaultExpressionTest.php
@@ -62,7 +62,7 @@ class DefaultExpressionTest extends FunctionalTestCase
         $table->addColumn('default_value', $type, ['default' => $defaultSql]);
         $this->connection->getSchemaManager()->dropAndCreateTable($table);
 
-        $this->connection->exec(
+        $this->connection->executeStatement(
             sprintf(
                 'INSERT INTO default_expr_test (actual_value) VALUES (%s)',
                 $defaultSql

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -48,7 +48,7 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
         $diff = (new Comparator())->compare($schema, $newSchema);
 
         foreach ($diff->toSql($this->getPlatform()) as $sql) {
-            $this->connection->exec($sql);
+            $this->connection->executeStatement($sql);
         }
 
         $validationSchema = $schemaManager->createSchema();

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -53,7 +53,7 @@ class PortabilityTest extends FunctionalTestCase
         $rows = $this->connection->fetchAllAssociative('SELECT * FROM portability_table');
         $this->assertFetchResultRows($rows);
 
-        $result = $this->connection->query('SELECT * FROM portability_table');
+        $result = $this->connection->executeQuery('SELECT * FROM portability_table');
 
         while (($row = $result->fetchAssociative())) {
             $this->assertFetchResultRow($row);
@@ -73,7 +73,7 @@ class PortabilityTest extends FunctionalTestCase
         $rows = $this->connection->fetchAllAssociative('SELECT * FROM portability_table');
         $this->assertFetchResultRows($rows);
 
-        $result = $this->connection->query('SELECT * FROM portability_table');
+        $result = $this->connection->executeQuery('SELECT * FROM portability_table');
         while (($row = $result->fetchAssociative())) {
             $this->assertFetchResultRow($row);
         }
@@ -120,7 +120,7 @@ class PortabilityTest extends FunctionalTestCase
      */
     public function testFetchColumn(string $field, array $expected): void
     {
-        $result = $this->connection->query('SELECT ' . $field . ' FROM portability_table');
+        $result = $this->connection->executeQuery('SELECT ' . $field . ' FROM portability_table');
 
         $column = $result->fetchFirstColumn();
         self::assertEquals($expected, $column);

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -145,9 +145,8 @@ class PortabilityTest extends FunctionalTestCase
 
     public function testFetchAllNullColumn(): void
     {
-        $result = $this->connection->query('SELECT Test_Null FROM portability_table');
+        $column = $this->connection->fetchFirstColumn('SELECT Test_Null FROM portability_table');
 
-        $column = $result->fetchFirstColumn();
         self::assertSame([null, null], $column);
     }
 }

--- a/tests/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Functional/PrimaryReadReplicaConnectionTest.php
@@ -189,48 +189,4 @@ class PrimaryReadReplicaConnectionTest extends FunctionalTestCase
         $conn->ensureConnectedToPrimary();
         self::assertTrue($conn->isConnectedToPrimary());
     }
-
-    public function testQueryOnPrimary(): void
-    {
-        $conn = $this->createPrimaryReadReplicaConnection();
-
-        $query = 'SELECT count(*) as num FROM primary_replica_table';
-
-        $result = $conn->query($query);
-
-        //Query must be executed only on Primary
-        self::assertTrue($conn->isConnectedToPrimary());
-
-        $data = $result->fetchAllAssociative();
-
-        self::assertArrayHasKey(0, $data);
-        self::assertArrayHasKey('num', $data[0]);
-
-        //Could be set in other fetchmodes
-        self::assertArrayNotHasKey(0, $data[0]);
-        self::assertEquals(1, $data[0]['num']);
-    }
-
-    public function testQueryOnReplica(): void
-    {
-        $conn = $this->createPrimaryReadReplicaConnection();
-        $conn->ensureConnectedToReplica();
-
-        $query = 'SELECT count(*) as num FROM primary_replica_table';
-
-        $result = $conn->query($query);
-
-        //Query must be executed only on Primary, even when we connect to the replica
-        self::assertTrue($conn->isConnectedToPrimary());
-
-        $data = $result->fetchAllAssociative();
-
-        self::assertArrayHasKey(0, $data);
-        self::assertArrayHasKey('num', $data[0]);
-
-        //Could be set in other fetchmodes
-        self::assertArrayNotHasKey(0, $data[0]);
-
-        self::assertEquals(1, $data[0]['num']);
-    }
 }

--- a/tests/Functional/Schema/ForeignKeyTest.php
+++ b/tests/Functional/Schema/ForeignKeyTest.php
@@ -26,7 +26,7 @@ class ForeignKeyTest extends FunctionalTestCase
         );
 
         foreach ($schema->toSql($this->connection->getDatabasePlatform()) as $sql) {
-            $this->connection->exec($sql);
+            $this->connection->executeStatement($sql);
         }
 
         self::assertCount(

--- a/tests/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySqlSchemaManagerTest.php
@@ -520,7 +520,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testEnsureTableOptionsAreReflectedInMetadata(): void
     {
-        $this->connection->query('DROP TABLE IF EXISTS test_table_metadata');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS test_table_metadata');
 
         $sql = <<<'SQL'
 CREATE TABLE test_table_metadata(
@@ -534,7 +534,7 @@ AUTO_INCREMENT=42
 PARTITION BY HASH (col1)
 SQL;
 
-        $this->connection->query($sql);
+        $this->connection->executeStatement($sql);
         $onlineTable = $this->schemaManager->listTableDetails('test_table_metadata');
 
         self::assertEquals('InnoDB', $onlineTable->getOption('engine'));
@@ -549,9 +549,9 @@ SQL;
 
     public function testEnsureTableWithoutOptionsAreReflectedInMetadata(): void
     {
-        $this->connection->query('DROP TABLE IF EXISTS test_table_empty_metadata');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS test_table_empty_metadata');
 
-        $this->connection->query('CREATE TABLE test_table_empty_metadata(col1 INT NOT NULL)');
+        $this->connection->executeStatement('CREATE TABLE test_table_empty_metadata(col1 INT NOT NULL)');
         $onlineTable = $this->schemaManager->listTableDetails('test_table_empty_metadata');
 
         self::assertNotEmpty($onlineTable->getOption('engine'));

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -28,7 +28,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         }
 
         TestUtil::getPrivilegedConnection()
-            ->exec('GRANT ALL PRIVILEGES TO ' . $GLOBALS['db_user']);
+            ->executeStatement('GRANT ALL PRIVILEGES TO ' . $GLOBALS['db_user']);
 
         self::$privilegesGranted = true;
     }

--- a/tests/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -66,10 +66,10 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testSupportDomainTypeFallback(): void
     {
         $createDomainTypeSQL = 'CREATE DOMAIN MyMoney AS DECIMAL(18,2)';
-        $this->connection->exec($createDomainTypeSQL);
+        $this->connection->executeStatement($createDomainTypeSQL);
 
         $createTableSQL = 'CREATE TABLE domain_type_test (id INT PRIMARY KEY, value MyMoney)';
-        $this->connection->exec($createTableSQL);
+        $this->connection->executeStatement($createTableSQL);
 
         $table = $this->connection->getSchemaManager()->listTableDetails('domain_type_test');
         self::assertInstanceOf(DecimalType::class, $table->getColumn('value')->getType());
@@ -154,7 +154,7 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
      */
     public function testTableWithSchema(): void
     {
-        $this->connection->exec('CREATE SCHEMA nested');
+        $this->connection->executeStatement('CREATE SCHEMA nested');
 
         $nestedRelatedTable = new Table('nested.schemarelated');
         $column             = $nestedRelatedTable->addColumn('id', 'integer');
@@ -190,10 +190,10 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testReturnQuotedAssets(): void
     {
         $sql = 'create table dbal91_something ( id integer  CONSTRAINT id_something PRIMARY KEY NOT NULL  ,"table"   integer );';
-        $this->connection->exec($sql);
+        $this->connection->executeStatement($sql);
 
         $sql = 'ALTER TABLE dbal91_something ADD CONSTRAINT something_input FOREIGN KEY( "table" ) REFERENCES dbal91_something ON UPDATE CASCADE;';
-        $this->connection->exec($sql);
+        $this->connection->executeStatement($sql);
 
         $table = $this->schemaManager->listTableDetails('dbal91_something');
 
@@ -349,8 +349,8 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testListTableDetailsWhenCurrentSchemaNameQuoted(): void
     {
-        $this->connection->exec('CREATE SCHEMA "001_test"');
-        $this->connection->exec('SET search_path TO "001_test"');
+        $this->connection->executeStatement('CREATE SCHEMA "001_test"');
+        $this->connection->executeStatement('SET search_path TO "001_test"');
 
         try {
             $this->testListQuotedTable();

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -86,7 +86,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         //TODO: SchemaDiff does not drop removed namespaces?
         try {
             //sql server versions below 2016 do not support 'IF EXISTS' so we have to catch the exception here
-            $this->connection->exec('DROP SCHEMA testschema');
+            $this->connection->executeStatement('DROP SCHEMA testschema');
         } catch (DBALException $e) {
             return;
         }
@@ -643,7 +643,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $diff->newNamespaces[] = 'testschema';
 
         foreach ($diff->toSql($this->schemaManager->getDatabasePlatform()) as $sql) {
-            $this->connection->exec($sql);
+            $this->connection->executeStatement($sql);
         }
 
         //test if table is create in namespace
@@ -1505,7 +1505,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $sqls = $diff->toSql($platform);
 
         foreach ($sqls as $sql) {
-            $this->connection->exec($sql);
+            $this->connection->executeStatement($sql);
         }
 
         $schema = new Schema([

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1440,17 +1440,17 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '1']);
 
-        $result = $this->connection->query('SELECT id FROM test_pk_auto_increment WHERE text = \'1\'');
-
-        $lastUsedIdBeforeDelete = (int) $result->fetchOne();
+        $lastUsedIdBeforeDelete = (int) $this->connection->fetchOne(
+            "SELECT id FROM test_pk_auto_increment WHERE text = '1'"
+        );
 
         $this->connection->query('DELETE FROM test_pk_auto_increment');
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '2']);
 
-        $result = $this->connection->query('SELECT id FROM test_pk_auto_increment WHERE text = \'2\'');
-
-        $lastUsedIdAfterDelete = (int) $result->fetchOne();
+        $lastUsedIdAfterDelete = (int) $this->connection->fetchOne(
+            "SELECT id FROM test_pk_auto_increment WHERE text = '2'"
+        );
 
         self::assertGreaterThan($lastUsedIdBeforeDelete, $lastUsedIdAfterDelete);
     }

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1444,7 +1444,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             "SELECT id FROM test_pk_auto_increment WHERE text = '1'"
         );
 
-        $this->connection->query('DELETE FROM test_pk_auto_increment');
+        $this->connection->executeStatement('DELETE FROM test_pk_auto_increment');
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '2']);
 

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -77,7 +77,7 @@ class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testListForeignKeysFromExistingDatabase(): void
     {
-        $this->connection->exec(<<<EOS
+        $this->connection->executeStatement(<<<EOS
 CREATE TABLE user (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     page INTEGER CONSTRAINT FK_1 REFERENCES page (key) DEFERRABLE INITIALLY DEFERRED,
@@ -165,7 +165,7 @@ CREATE TABLE dbal_1779 (
 )
 SQL;
 
-        $this->connection->exec($sql);
+        $this->connection->executeStatement($sql);
 
         $columns = $this->schemaManager->listTableColumns('dbal_1779');
 

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -238,9 +238,9 @@ SQL;
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '2']);
 
-        $result = $this->connection->query('SELECT id FROM test_pk_auto_increment WHERE text = "2"');
-
-        $lastUsedIdAfterDelete = (int) $result->fetchOne();
+        $lastUsedIdAfterDelete = (int) $this->connection->fetchOne(
+            'SELECT id FROM test_pk_auto_increment WHERE text = "2"'
+        );
 
         // with an empty table, non autoincrement rowid is always 1
         self::assertEquals(1, $lastUsedIdAfterDelete);

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -234,7 +234,7 @@ SQL;
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '1']);
 
-        $this->connection->query('DELETE FROM test_pk_auto_increment');
+        $this->connection->executeStatement('DELETE FROM test_pk_auto_increment');
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '2']);
 

--- a/tests/Functional/TableGeneratorTest.php
+++ b/tests/Functional/TableGeneratorTest.php
@@ -31,7 +31,7 @@ class TableGeneratorTest extends FunctionalTestCase
             $schema->visit($visitor);
 
             foreach ($schema->toSql($platform) as $sql) {
-                $this->connection->exec($sql);
+                $this->connection->executeStatement($sql);
             }
         } catch (Throwable $e) {
         }

--- a/tests/Functional/TemporaryTableTest.php
+++ b/tests/Functional/TemporaryTableTest.php
@@ -13,7 +13,9 @@ class TemporaryTableTest extends FunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->connection->exec($this->connection->getDatabasePlatform()->getDropTableSQL('nontemporary'));
+            $this->connection->executeStatement(
+                $this->connection->getDatabasePlatform()->getDropTableSQL('nontemporary')
+            );
         } catch (Throwable $e) {
         }
     }
@@ -23,7 +25,9 @@ class TemporaryTableTest extends FunctionalTestCase
         if ($this->connection) {
             try {
                 $tempTable = $this->connection->getDatabasePlatform()->getTemporaryTableName('my_temporary');
-                $this->connection->exec($this->connection->getDatabasePlatform()->getDropTemporaryTableSQL($tempTable));
+                $this->connection->executeStatement(
+                    $this->connection->getDatabasePlatform()->getDropTemporaryTableSQL($tempTable)
+                );
             } catch (Throwable $e) {
             }
         }
@@ -56,7 +60,9 @@ class TemporaryTableTest extends FunctionalTestCase
 
         $this->connection->beginTransaction();
         $this->connection->insert('nontemporary', ['id' => 1]);
-        $this->connection->exec($platform->getDropTemporaryTableSQL($tempTable));
+        $this->connection->executeStatement(
+            $platform->getDropTemporaryTableSQL($tempTable)
+        );
         $this->connection->insert('nontemporary', ['id' => 2]);
 
         $this->connection->rollBack();
@@ -90,13 +96,15 @@ class TemporaryTableTest extends FunctionalTestCase
         $this->connection->beginTransaction();
         $this->connection->insert('nontemporary', ['id' => 1]);
 
-        $this->connection->exec($createTempTableSQL);
+        $this->connection->executeStatement($createTempTableSQL);
         $this->connection->insert('nontemporary', ['id' => 2]);
 
         $this->connection->rollBack();
 
         try {
-            $this->connection->exec($platform->getDropTemporaryTableSQL($tempTable));
+            $this->connection->executeStatement(
+                $platform->getDropTemporaryTableSQL($tempTable)
+            );
         } catch (Throwable $e) {
         }
 

--- a/tests/Functional/Ticket/DBAL202Test.php
+++ b/tests/Functional/Ticket/DBAL202Test.php
@@ -19,7 +19,7 @@ class DBAL202Test extends FunctionalTestCase
         }
 
         if ($this->connection->getSchemaManager()->tablesExist('DBAL202')) {
-            $this->connection->exec('DELETE FROM DBAL202');
+            $this->connection->executeStatement('DELETE FROM DBAL202');
         } else {
             $table = new Table('DBAL202');
             $table->addColumn('id', 'integer');

--- a/tests/Functional/Ticket/DBAL202Test.php
+++ b/tests/Functional/Ticket/DBAL202Test.php
@@ -36,7 +36,7 @@ class DBAL202Test extends FunctionalTestCase
         $stmt->execute();
         $this->connection->rollBack();
 
-        self::assertEquals(0, $this->connection->query('SELECT COUNT(1) FROM DBAL202')->fetchOne());
+        self::assertEquals(0, $this->connection->fetchOne('SELECT COUNT(1) FROM DBAL202'));
     }
 
     public function testStatementCommit(): void
@@ -46,6 +46,6 @@ class DBAL202Test extends FunctionalTestCase
         $stmt->execute();
         $this->connection->commit();
 
-        self::assertEquals(1, $this->connection->query('SELECT COUNT(1) FROM DBAL202')->fetchOne());
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM DBAL202'));
     }
 }

--- a/tests/Functional/Ticket/DBAL630Test.php
+++ b/tests/Functional/Ticket/DBAL630Test.php
@@ -26,8 +26,8 @@ class DBAL630Test extends FunctionalTestCase
         }
 
         try {
-            $this->connection->exec('CREATE TABLE dbal630 (id SERIAL, bool_col BOOLEAN NOT NULL);');
-            $this->connection->exec('CREATE TABLE dbal630_allow_nulls (id SERIAL, bool_col BOOLEAN);');
+            $this->connection->executeStatement('CREATE TABLE dbal630 (id SERIAL, bool_col BOOLEAN NOT NULL);');
+            $this->connection->executeStatement('CREATE TABLE dbal630_allow_nulls (id SERIAL, bool_col BOOLEAN);');
         } catch (DBALException $e) {
         }
 

--- a/tests/Functional/Ticket/DBAL752Test.php
+++ b/tests/Functional/Ticket/DBAL752Test.php
@@ -23,7 +23,7 @@ class DBAL752Test extends FunctionalTestCase
 
     public function testUnsignedIntegerDetection(): void
     {
-        $this->connection->exec(<<<SQL
+        $this->connection->executeStatement(<<<SQL
 CREATE TABLE dbal752_unsigneds (
     small SMALLINT,
     small_unsigned SMALLINT UNSIGNED,

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -29,7 +29,7 @@ class TransactionTest extends FunctionalTestCase
 
     public function testCommitFalse(): void
     {
-        $this->connection->query('SET SESSION wait_timeout=1');
+        $this->connection->executeStatement('SET SESSION wait_timeout=1');
 
         self::assertTrue($this->connection->beginTransaction());
 

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -277,7 +277,7 @@ class WriteTest extends FunctionalTestCase
         }
 
         foreach ($platform->getCreateTableSQL($table) as $sql) {
-            $this->connection->exec($sql);
+            $this->connection->executeStatement($sql);
         }
 
         $seqName = $platform->usesSequenceEmulatedIdentityColumns()
@@ -286,11 +286,11 @@ class WriteTest extends FunctionalTestCase
 
         $sql = $platform->getEmptyIdentityInsertSQL('test_empty_identity', 'id');
 
-        $this->connection->exec($sql);
+        $this->connection->executeStatement($sql);
 
         $firstId = $this->lastInsertId($seqName);
 
-        $this->connection->exec($sql);
+        $this->connection->executeStatement($sql);
 
         $secondId = $this->lastInsertId($seqName);
 

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -174,8 +174,9 @@ class WriteTest extends FunctionalTestCase
             return strtolower($sequence->getName()) === 'write_table_id_seq';
         }));
 
-        $result          = $this->connection->query($this->connection->getDatabasePlatform()->getSequenceNextValSQL('write_table_id_seq'));
-        $nextSequenceVal = $result->fetchOne();
+        $nextSequenceVal = $this->connection->fetchOne(
+            $this->connection->getDatabasePlatform()->getSequenceNextValSQL('write_table_id_seq')
+        );
 
         $lastInsertId = $this->lastInsertId('write_table_id_seq');
 

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -106,7 +106,7 @@ class TestUtil
             $stmts  = $schema->toDropSql($testConn->getDatabasePlatform());
 
             foreach ($stmts as $stmt) {
-                $testConn->exec($stmt);
+                $testConn->executeStatement($stmt);
             }
         }
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

#### Summary

1. Calls like `$conn->query()->fetch*()` have been reworked to `$conn->fetch*()` before the method removal.
2. The rest of the calls to `$conn->query()` have been replaced with `$conn->executeQuery()` and `$conn->executeStatement()` depending on whether the statement yields rows.
3. Calls to `$conn->exec()` and `$conn->executeUpdate()` have been replaced with `$conn->executeStatement()`.
4. The overridden versions of the `insert()`, `update()` and `delete()` methods have been removed form `PrimaryReplicaConnection` since they all are implemented via `executeStatement()` in the parent class which ensures connection to the primary instance.

**TODO**:
- [x] Unlike `PrimaryReplicaConnection::query()`, `PrimaryReplicaConnection::executeQuery()` doesn't automatically connect to the primary instance. I have no idea why the method semantics are different in the first place. It looks like a design flaw to me. This should be reflected in the deprecation note in `2.11.x`.
   > Note that `PrimaryReplicaConnection::query()` ensures connection to the primary instance while `executeQuery()` doesn't.
   > 
   > Depending on the desired behavior:
   > 
   > - If the statement doesn't have to be executed on the primary instance, use `executeQuery()`.
   > - If the statement has to be executed on the primary instance and yields rows (e.g. `SELECT`), prepend `executeQuery()` with `ensureConnectedToPrimary()`.
   > - Otherwise, use `executeStatement()`.

   Updated the upgrade notes in https://github.com/doctrine/dbal/pull/4175.