### PR TITLE
Do not query result cache twice in case of cache miss

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1207,10 +1207,19 @@ class Connection implements DriverConnection
             } elseif (array_key_exists($realKey, $data)) {
                 $stmt = new ArrayStatement([]);
             }
+        } else {
+            $data = [];
         }
 
         if (! isset($stmt)) {
-            $stmt = new ResultCacheStatement($this->executeQuery($sql, $params, $types), $resultCache, $cacheKey, $realKey, $qcp->getLifetime());
+            $stmt = new ResultCacheStatement(
+                $this->executeQuery($sql, $params, $types),
+                $resultCache,
+                $cacheKey,
+                $realKey,
+                $qcp->getLifetime(),
+                $data
+            );
         }
 
         $stmt->setFetchMode($this->defaultFetchMode);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #4178 

#### Summary

If the data is not found in the query cache, it will be queried again to append a new key to it. This PR removes the second fetching by passing the first result to ResultCacheStatement.

First cache fetch at `Connection::executeCacheQuery()`: https://github.com/doctrine/dbal/blob/8c9e92ab38825be2f525d50fb1d9a0ab8ca0e1bd/lib/Doctrine/DBAL/Connection.php#L1201
Second cache fetch at `ResultCacheStatement::saveToCache()`: https://github.com/doctrine/dbal/blob/8c9e92ab38825be2f525d50fb1d9a0ab8ca0e1bd/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php#L339