### PR TITLE
Fix Third parameter not allowed for PDO::FETCH_COLUMN

### DIFF
--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -264,7 +264,15 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
-        return $this->stmt->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
+        if ($ctorArgs !== null) {
+            return $this->stmt->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
+        }
+
+        if ($fetchArgument !== null) {
+            return $this->stmt->fetchAll($fetchMode, $fetchArgument);
+        }
+
+        return $this->stmt->fetchAll($fetchMode);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/ExternalPDOInstanceTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExternalPDOInstanceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDO\SQLite\Driver as PDOSqliteDriver;
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalTestCase;
+use Doctrine\Tests\TestUtil;
+use PDO;
+
+class ExternalPDOInstanceTest extends DbalTestCase
+{
+    /** @var Connection */
+    protected $connection;
+
+    protected function setUp(): void
+    {
+        if (! TestUtil::getConnection()->getDriver() instanceof PDOSqliteDriver) {
+            $this->markTestSkipped('External PDO instance tests are only run on PDO SQLite for now');
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+
+        $this->connection = new Connection(['pdo' => $pdo], new PDOSqliteDriver());
+
+        $table = new Table('stmt_fetch_all');
+        $table->addColumn('a', 'integer');
+        $table->addColumn('b', 'integer');
+
+        $this->connection->getSchemaManager()->createTable($table);
+
+        $this->connection->insert('stmt_fetch_all', [
+            'a' => 1,
+            'b' => 2,
+        ]);
+    }
+
+    public function testFetchAllWithOneArgument(): void
+    {
+        $stmt = $this->connection->prepare('SELECT a, b FROM stmt_fetch_all');
+        $stmt->execute();
+
+        self::assertEquals([[1, 2]], $stmt->fetchAll(FetchMode::NUMERIC));
+    }
+
+    public function testFetchAllWithTwoArguments(): void
+    {
+        $stmt = $this->connection->prepare('SELECT a, b FROM stmt_fetch_all');
+        $stmt->execute();
+
+        self::assertEquals([2], $stmt->fetchAll(FetchMode::COLUMN, 1));
+    }
+
+    public function testFetchAllWithThreeArguments(): void
+    {
+        $stmt = $this->connection->prepare('SELECT a, b FROM stmt_fetch_all');
+        $stmt->execute();
+
+        [$obj] = $stmt->fetchAll(FetchMode::CUSTOM_OBJECT, StatementTestModel::class, ['foo', 'bar']);
+
+        $this->assertInstanceOf(StatementTestModel::class, $obj);
+
+        self::assertEquals(1, $obj->a);
+        self::assertEquals(2, $obj->b);
+        self::assertEquals('foo', $obj->x);
+        self::assertEquals('bar', $obj->y);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/StatementTestModel.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/StatementTestModel.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional;
+
+class StatementTestModel
+{
+    public function __construct(string $x, string $y)
+    {
+        $this->x = $x;
+        $this->y = $y;
+    }
+
+    /** @var int */
+    public $a;
+
+    /** @var int */
+    public $b;
+
+    /** @var string */
+    public $x;
+
+    /** @var string */
+    public $y;
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3975 

#### Summary

I'm getting the following error with PHP 7.4 (tested on 7.4.5 and 7.4.8):

> PDOException: SQLSTATE[HY000]: General error: Third parameter not allowed for PDO::FETCH_COLUMN in (...)/vendor/doctrine/dbal/lib/Doctrine/DBAL/Statement.php:256

This only affects `PDOStatement`, that does not seem to accept `null` anymore to skip the 3rd parameter.

This fix calls the method with 2 parameters only, when the third argument is `null`.
