### PR TITLE
Fetch parent commits

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -121,6 +121,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -163,6 +165,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"


### PR DESCRIPTION
CI platforms do not run their jobs on the commit you push. Instead, they
run it on a merge commit so that both your changes and the latest
version of the target branch are taken into account.
Before uploading the coverage report, CodeCov's bash uploader attempts
to find the original commit hash, and succeeds on Travis and AppVeyor,
but not on Github, because the method it uses does not work unless the
parent commits are fetched too, which results in Github posting to CodeCov
with a different hash than Travis or AppVeyor.
Setting the fetch depth fixes that issue.