### PR TITLE
Trigger Github workflow for merges

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,8 +1,7 @@
 
 name: "Continuous Integration"
 
-on:
-  pull_request:
+on: ["pull_request", "push"]
 
 jobs:
   static-analysis-phpstan:


### PR DESCRIPTION
A merge is viewed by Github as a push to the branch where the merge
occurs, see https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359/2
This means we should have coverage reports for merge commits from
Github, which should result in saner numbers.

I will rebase #4180 after that.