### PR TITLE
Manually merge 2.10.x into 2.11.x

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,8 +1,7 @@
 
 name: "Continuous Integration"
 
-on:
-  pull_request:
+on: ["pull_request", "push"]
 
 jobs:
   static-analysis-phpstan:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,8 +1,7 @@
 
 name: "Continuous Integration"
 
-on:
-  pull_request:
+on: ["pull_request", "push"]
 
 jobs:
   static-analysis-phpstan:
@@ -121,6 +120,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -163,6 +164,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -121,6 +121,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -163,6 +165,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 | [Master][Master] | [2.10][2.10] |
 |:----------------:|:----------:|
 | [![Build status][Master image]][Master] | [![Build status][2.10 image]][2.10] |
+| [![GitHub Actions][GA master image]][GA master] | [![GitHub Actions][GA 2.10 image]][GA 2.10] |
 | [![Code Coverage][Coverage image]][CodeCov Master] | [![Code Coverage][Coverage 2.10 image]][CodeCov 2.10] |
 | [![AppVeyor][AppVeyor master image]][AppVeyor master] | [![AppVeyor][AppVeyor 2.10 image]][AppVeyor 2.10] |
 
@@ -20,6 +21,8 @@ Powerful database abstraction layer with many features for database schema intro
   [CodeCov Master]: https://codecov.io/gh/doctrine/dbal/branch/master
   [AppVeyor master]: https://ci.appveyor.com/project/doctrine/dbal/branch/master
   [AppVeyor master image]: https://ci.appveyor.com/api/projects/status/i88kitq8qpbm0vie/branch/master?svg=true
+  [GA master]: https://github.com/doctrine/dbal/actions?query=workflow%3A%22Continuous+Integration%22+branch%3Amaster
+  [GA master image]: https://github.com/doctrine/dbal/workflows/Continuous%20Integration/badge.svg
 
   [2.10 image]: https://img.shields.io/travis/doctrine/dbal/2.10.x.svg?style=flat-square
   [Coverage 2.10 image]: https://codecov.io/gh/doctrine/dbal/branch/2.10.x/graph/badge.svg
@@ -27,3 +30,5 @@ Powerful database abstraction layer with many features for database schema intro
   [CodeCov 2.10]: https://codecov.io/gh/doctrine/dbal/branch/2.10.x
   [AppVeyor 2.10]: https://ci.appveyor.com/project/doctrine/dbal/branch/2.10.x
   [AppVeyor 2.10 image]: https://ci.appveyor.com/api/projects/status/i88kitq8qpbm0vie/branch/2.10.x?svg=true
+  [GA 2.10]: https://github.com/doctrine/dbal/actions?query=workflow%3A%22Continuous+Integration%22+branch%3A2.10.x
+  [GA 2.10 image]: https://github.com/doctrine/dbal/workflows/Continuous%20Integration/badge.svg?branch=2.10.x

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 | [Master][Master] | [2.10][2.10] |
 |:----------------:|:----------:|
 | [![Build status][Master image]][Master] | [![Build status][2.10 image]][2.10] |
-| [![Build Status][ContinuousPHP image]][ContinuousPHP] | [![Build Status][ContinuousPHP 2.10 image]][ContinuousPHP] |
 | [![Code Coverage][Coverage image]][CodeCov Master] | [![Code Coverage][Coverage 2.10 image]][CodeCov 2.10] |
 | [![AppVeyor][AppVeyor master image]][AppVeyor master] | [![AppVeyor][AppVeyor 2.10 image]][AppVeyor 2.10] |
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 |:----------------:|:----------:|
 | [![Build status][Master image]][Master] | [![Build status][2.10 image]][2.10] |
 | [![GitHub Actions][GA master image]][GA master] | [![GitHub Actions][GA 2.10 image]][GA 2.10] |
-| [![Code Coverage][Coverage image]][CodeCov Master] | [![Code Coverage][Coverage 2.10 image]][CodeCov 2.10] |
 | [![AppVeyor][AppVeyor master image]][AppVeyor master] | [![AppVeyor][AppVeyor 2.10 image]][AppVeyor 2.10] |
+| [![Code Coverage][Coverage image]][CodeCov Master] | [![Code Coverage][Coverage 2.10 image]][CodeCov 2.10] |
 
 Powerful database abstraction layer with many features for database schema introspection, schema management and PDO abstraction.
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 | [Master][Master] | [2.10][2.10] |
 |:----------------:|:----------:|
 | [![Build status][Master image]][Master] | [![Build status][2.10 image]][2.10] |
-| [![Build Status][ContinuousPHP image]][ContinuousPHP] | [![Build Status][ContinuousPHP 2.10 image]][ContinuousPHP] |
-| [![Code Coverage][Coverage image]][CodeCov Master] | [![Code Coverage][Coverage 2.10 image]][CodeCov 2.10] |
+| [![GitHub Actions][GA master image]][GA master] | [![GitHub Actions][GA 2.10 image]][GA 2.10] |
 | [![AppVeyor][AppVeyor master image]][AppVeyor master] | [![AppVeyor][AppVeyor 2.10 image]][AppVeyor 2.10] |
+| [![Code Coverage][Coverage image]][CodeCov Master] | [![Code Coverage][Coverage 2.10 image]][CodeCov 2.10] |
 
 Powerful database abstraction layer with many features for database schema introspection, schema management and PDO abstraction.
 
@@ -21,6 +21,8 @@ Powerful database abstraction layer with many features for database schema intro
   [CodeCov Master]: https://codecov.io/gh/doctrine/dbal/branch/master
   [AppVeyor master]: https://ci.appveyor.com/project/doctrine/dbal/branch/master
   [AppVeyor master image]: https://ci.appveyor.com/api/projects/status/i88kitq8qpbm0vie/branch/master?svg=true
+  [GA master]: https://github.com/doctrine/dbal/actions?query=workflow%3A%22Continuous+Integration%22+branch%3Amaster
+  [GA master image]: https://github.com/doctrine/dbal/workflows/Continuous%20Integration/badge.svg
 
   [2.10 image]: https://img.shields.io/travis/doctrine/dbal/2.10.x.svg?style=flat-square
   [Coverage 2.10 image]: https://codecov.io/gh/doctrine/dbal/branch/2.10.x/graph/badge.svg
@@ -28,3 +30,5 @@ Powerful database abstraction layer with many features for database schema intro
   [CodeCov 2.10]: https://codecov.io/gh/doctrine/dbal/branch/2.10.x
   [AppVeyor 2.10]: https://ci.appveyor.com/project/doctrine/dbal/branch/2.10.x
   [AppVeyor 2.10 image]: https://ci.appveyor.com/api/projects/status/i88kitq8qpbm0vie/branch/2.10.x?svg=true
+  [GA 2.10]: https://github.com/doctrine/dbal/actions?query=workflow%3A%22Continuous+Integration%22+branch%3A2.10.x
+  [GA 2.10 image]: https://github.com/doctrine/dbal/workflows/Continuous%20Integration/badge.svg?branch=2.10.x

--- a/ci/github/phpunit.oci8.xml
+++ b/ci/github/phpunit.oci8.xml
@@ -33,10 +33,4 @@
             <directory suffix=".php">../../lib</directory>
         </whitelist>
     </filter>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/ci/github/phpunit.pdo-oci.xml
+++ b/ci/github/phpunit.pdo-oci.xml
@@ -33,10 +33,4 @@
             <directory suffix=".php">../../lib</directory>
         </whitelist>
     </filter>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/lib/Doctrine/DBAL/ColumnCase.php
+++ b/lib/Doctrine/DBAL/ColumnCase.php
@@ -25,6 +25,8 @@ final class ColumnCase
 
     /**
      * This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -77,6 +77,8 @@ final class DriverManager
 
     /**
      * Private constructor. This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -72,6 +72,8 @@ final class DriverManager
 
     /**
      * Private constructor. This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/Events.php
+++ b/lib/Doctrine/DBAL/Events.php
@@ -11,6 +11,8 @@ final class Events
 {
     /**
      * Private constructor. This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/FetchMode.php
+++ b/lib/Doctrine/DBAL/FetchMode.php
@@ -64,6 +64,8 @@ final class FetchMode
 
     /**
      * This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/FetchMode.php
+++ b/lib/Doctrine/DBAL/FetchMode.php
@@ -66,6 +66,8 @@ final class FetchMode
 
     /**
      * This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/LockMode.php
+++ b/lib/Doctrine/DBAL/LockMode.php
@@ -14,6 +14,8 @@ class LockMode
 
     /**
      * Private constructor. This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     final private function __construct()
     {

--- a/lib/Doctrine/DBAL/ParameterType.php
+++ b/lib/Doctrine/DBAL/ParameterType.php
@@ -51,6 +51,8 @@ final class ParameterType
 
     /**
      * This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/Platforms/DateIntervalUnit.php
+++ b/lib/Doctrine/DBAL/Platforms/DateIntervalUnit.php
@@ -22,6 +22,9 @@ final class DateIntervalUnit
 
     public const YEAR = 'YEAR';
 
+    /**
+     * @codeCoverageIgnore
+     */
     private function __construct()
     {
     }

--- a/lib/Doctrine/DBAL/Platforms/TrimMode.php
+++ b/lib/Doctrine/DBAL/Platforms/TrimMode.php
@@ -14,6 +14,9 @@ final class TrimMode
 
     public const BOTH = 3;
 
+    /**
+     * @codeCoverageIgnore
+     */
     private function __construct()
     {
     }

--- a/lib/Doctrine/DBAL/Tools/Dumper.php
+++ b/lib/Doctrine/DBAL/Tools/Dumper.php
@@ -40,6 +40,8 @@ final class Dumper
 {
     /**
      * Private constructor (prevents instantiation).
+     *
+     * @codeCoverageIgnore
      */
     private function __construct()
     {

--- a/lib/Doctrine/DBAL/TransactionIsolationLevel.php
+++ b/lib/Doctrine/DBAL/TransactionIsolationLevel.php
@@ -26,6 +26,9 @@ final class TransactionIsolationLevel
      */
     public const SERIALIZABLE = 4;
 
+    /**
+     * @codeCoverageIgnore
+     */
     private function __construct()
     {
     }

--- a/lib/Doctrine/DBAL/Types/Types.php
+++ b/lib/Doctrine/DBAL/Types/Types.php
@@ -37,6 +37,9 @@ final class Types
     /** @deprecated json_array type is deprecated, use {@see self::JSON} instead. */
     public const JSON_ARRAY = 'json_array';
 
+    /**
+     * @codeCoverageIgnore
+     */
     private function __construct()
     {
     }


### PR DESCRIPTION
On top of the changes from `2.10.x`, contains the removal of the handling of the obsolete performance test group.