### PR TITLE
Do not fetch result cache twice in case of cache miss

### DIFF
--- a/src/Cache/CachingResult.php
+++ b/src/Cache/CachingResult.php
@@ -43,18 +43,23 @@ class CachingResult implements Result
     /** @var array<int,array<string,mixed>>|null */
     private $data;
 
+    /** @var array<string, mixed> */
+    private $fetchedData;
+
     /**
-     * @param string $cacheKey
-     * @param string $realKey
-     * @param int    $lifetime
+     * @param string               $cacheKey
+     * @param string               $realKey
+     * @param int                  $lifetime
+     * @param array<string, mixed> $fetchedData
      */
-    public function __construct(Result $result, Cache $cache, $cacheKey, $realKey, $lifetime)
+    public function __construct(Result $result, Cache $cache, $cacheKey, $realKey, $lifetime, array $fetchedData)
     {
-        $this->result   = $result;
-        $this->cache    = $cache;
-        $this->cacheKey = $cacheKey;
-        $this->realKey  = $realKey;
-        $this->lifetime = $lifetime;
+        $this->result      = $result;
+        $this->cache       = $cache;
+        $this->cacheKey    = $cacheKey;
+        $this->realKey     = $realKey;
+        $this->lifetime    = $lifetime;
+        $this->fetchedData = $fetchedData;
     }
 
     /**
@@ -170,14 +175,8 @@ class CachingResult implements Result
             return;
         }
 
-        $data = $this->cache->fetch($this->cacheKey);
+        $this->fetchedData[$this->realKey] = $this->data;
 
-        if ($data === false) {
-            $data = [];
-        }
-
-        $data[$this->realKey] = $this->data;
-
-        $this->cache->save($this->cacheKey, $data, $this->lifetime);
+        $this->cache->save($this->cacheKey, $this->fetchedData, $this->lifetime);
     }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1013,6 +1013,8 @@ class Connection
             } elseif (array_key_exists($realKey, $data)) {
                 $result = new ArrayResult([]);
             }
+        } else {
+            $data = [];
         }
 
         if (! isset($result)) {
@@ -1021,7 +1023,8 @@ class Connection
                 $resultCache,
                 $cacheKey,
                 $realKey,
-                $qcp->getLifetime()
+                $qcp->getLifetime(),
+                $data
             );
         }
 

--- a/tests/Cache/CachingResultTest.php
+++ b/tests/Cache/CachingResultTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Cache;
+
+use Doctrine\Common\Cache\Cache;
+use Doctrine\DBAL\Cache\CachingResult;
+use Doctrine\DBAL\Driver\Result;
+use PHPUnit\Framework\TestCase;
+
+class CachingResultTest extends TestCase
+{
+    /** @var string */
+    private $cacheKey = 'cacheKey';
+
+    /** @var string */
+    private $realKey = 'realKey';
+
+    /** @var int */
+    private $lifetime = 3600;
+
+    /** @var array<string, mixed> */
+    private $resultData = ['id' => 123, 'field' => 'value'];
+
+    /** @var array<string, mixed> */
+    private $cachedData;
+
+    /** @var Cache */
+    private $cache;
+
+    /** @var Result */
+    private $result;
+
+    protected function setUp(): void
+    {
+        $this->result = $this->createMock(Result::class);
+        $this->result->expects(self::exactly(2))
+            ->method('fetchAssociative')
+            ->will($this->onConsecutiveCalls($this->resultData, false));
+
+        $this->cache = $this->createMock(Cache::class);
+        $this->cache->expects(self::exactly(1))
+            ->method('save')
+            ->willReturnCallback(function (string $id, $data, int $ttl): void {
+                $this->assertEquals($this->cacheKey, $id, 'The cache key should match the given one');
+                $this->assertEquals($this->lifetime, $ttl, 'The cache key ttl should match the given one');
+                $this->cachedData = $data;
+            });
+    }
+
+    public function testShouldSaveResultToCache(): void
+    {
+        $cachingResult = new CachingResult(
+            $this->result,
+            $this->cache,
+            $this->cacheKey,
+            $this->realKey,
+            $this->lifetime,
+            ['otherRealKey' => 'resultValue']
+        );
+
+        do {
+            $row = $cachingResult->fetchAssociative();
+        } while ($row !== false);
+
+        $this->assertContains(
+            $this->resultData,
+            $this->cachedData[$this->realKey],
+            'CachingResult should cache data from the given result'
+        );
+
+        $this->assertEquals(
+            'resultValue',
+            $this->cachedData['otherRealKey'],
+            'CachingResult should not change other keys from cache'
+        );
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #4178

#### Summary

It is https://github.com/doctrine/dbal/pull/4169 for 3.0.x version. BC Break doesn't really matters, as it's already broken by renaming of `CachingResult` class
