### PR TITLE
Remove --ignore-platform-reqs from PHP 8.0 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,7 @@ before_script:
     fi
 
 install:
-  - |
-    if [[ $TRAVIS_PHP_VERSION = "nightly" ]]; then
-      export COMPOSER_FLAGS="--ignore-platform-reqs"
-    fi
-  - travis_retry composer -n install --prefer-dist $COMPOSER_FLAGS
+  - travis_retry composer -n install --prefer-dist
 
 script:
   - ./vendor/bin/phpunit --configuration ci/travis/$DB.travis.xml --coverage-clover clover.xml


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The incompatible with PHP 8 `phpdocumentor/reflection-docblock 5.1.0` was updated as a PHPUnit dependency as part of https://github.com/doctrine/dbal/pull/4201.