### PR TITLE
Remove slash from const name in transactions documentation

### DIFF
--- a/docs/en/reference/transactions.rst
+++ b/docs/en/reference/transactions.rst
@@ -50,7 +50,7 @@ constants:
 
 The default transaction isolation level of a
 ``Doctrine\DBAL\Connection`` is chosen by the underlying platform
-but it is always at least READ\_COMMITTED.
+but it is always at least ``READ_COMMITTED``.
 
 Transaction Nesting
 -------------------


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

Hi!
I have just removed slash from const name to make it look better.

<img width="834" alt="Снимок экрана 2020-08-08 в 00 43 35" src="https://user-images.githubusercontent.com/17636915/89690912-54955b80-d910-11ea-8b5d-d21551907483.png">
