### PR TITLE
Documentation on `DBAL\Driver\Statement::bindValue` is incorrect

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/Statement.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Types\Type;
 
 /**
  * Statement interface.
@@ -19,12 +20,12 @@ interface Statement extends ResultStatement
      * As mentioned above, the named parameters are not natively supported by the mysqli driver, use executeQuery(),
      * fetchAll(), fetchArray(), fetchColumn(), fetchAssoc() methods to have the named parameter emulated by doctrine.
      *
-     * @param int|string $param Parameter identifier. For a prepared statement using named placeholders,
-     *                          this will be a parameter name of the form :name. For a prepared statement
-     *                          using question mark placeholders, this will be the 1-indexed position of the parameter.
-     * @param mixed      $value The value to bind to the parameter.
-     * @param int        $type  Explicit data type for the parameter using the {@link ParameterType}
-     *                          constants.
+     * @param int|string      $param Parameter identifier. For a prepared statement using named placeholders,
+     *                               this will be a parameter name of the form :name. For a prepared statement
+     *                               using question mark placeholders, this will be the 1-indexed position of the parameter.
+     * @param mixed           $value The value to bind to the parameter.
+     * @param int|string|Type $type  Explicit data type for the parameter using the {@link ParameterType}
+     *                               constants or a reference to a {@link Type} implementation.
      *
      * @return bool TRUE on success or FALSE on failure.
      */

--- a/lib/Doctrine/DBAL/Driver/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/Statement.php
@@ -3,7 +3,6 @@
 namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\ParameterType;
-use Doctrine\DBAL\Types\Type;
 
 /**
  * Statement interface.

--- a/lib/Doctrine/DBAL/Driver/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/Statement.php
@@ -20,12 +20,12 @@ interface Statement extends ResultStatement
      * As mentioned above, the named parameters are not natively supported by the mysqli driver, use executeQuery(),
      * fetchAll(), fetchArray(), fetchColumn(), fetchAssoc() methods to have the named parameter emulated by doctrine.
      *
-     * @param int|string      $param Parameter identifier. For a prepared statement using named placeholders,
-     *                               this will be a parameter name of the form :name. For a prepared statement
-     *                               using question mark placeholders, this will be the 1-indexed position of the parameter.
-     * @param mixed           $value The value to bind to the parameter.
-     * @param int|string|Type $type  Explicit data type for the parameter using the {@link ParameterType}
-     *                               constants or a reference to a {@link Type} implementation.
+     * @param int|string $param Parameter identifier. For a prepared statement using named placeholders,
+     *                          this will be a parameter name of the form :name. For a prepared statement
+     *                          using question mark placeholders, this will be the 1-indexed position of the parameter.
+     * @param mixed      $value The value to bind to the parameter.
+     * @param mixed      $type  Explicit data type for the parameter using the {@link ParameterType}
+     *                          constants or a reference to a {@link Type} implementation.
      *
      * @return bool TRUE on success or FALSE on failure.
      */


### PR DESCRIPTION
This change updates the documentation on the `bindValue` function. Per the implementation of `DBAL\Statement` this function can take a string, int, or `Type` instance.

Fixes #4210

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #4210

#### Summary

This change updates the documentation on the `bindValue` to fix problems with static analyzers. Since this doesn't appear to be a problem in 3.x versions of this library, I've only fixed the issue in 2.10.x.
