### PR TITLE
Deprecate the Synchronizer package

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.11
 
+## Deprecated `Synchronizer` package
+
+The `Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer` interface and all its implementations are deprecated.
+
 ## Deprecated usage of wrapper-level components as implementations of driver-level interfaces
 
 The usage of the wrapper `Connection` and `Statement` classes as implementations of the `Driver\Connection` and `Driver\Statement` interfaces is deprecated.

--- a/docs/en/reference/sharding.rst
+++ b/docs/en/reference/sharding.rst
@@ -269,8 +269,8 @@ you have to sort the data in the application.
     $sql = "SELECT * FROM customers";
     $rows = $shardManager->queryAll($sql, $params);
 
-Schema Operations: SchemaSynchronizer Interface
------------------------------------------------
+Schema Operations: SchemaSynchronizer Interface (deprecated)
+------------------------------------------------------------
 
 Schema Operations in a sharding architecture are tricky. You have to perform
 them on all databases instances (shards) at the same time. Also Doctrine

--- a/lib/Doctrine/DBAL/Schema/Synchronizer/AbstractSchemaSynchronizer.php
+++ b/lib/Doctrine/DBAL/Schema/Synchronizer/AbstractSchemaSynchronizer.php
@@ -7,6 +7,8 @@ use Throwable;
 
 /**
  * Abstract schema synchronizer with methods for executing batches of SQL.
+ *
+ * @deprecated
  */
 abstract class AbstractSchemaSynchronizer implements SchemaSynchronizer
 {

--- a/lib/Doctrine/DBAL/Schema/Synchronizer/SchemaSynchronizer.php
+++ b/lib/Doctrine/DBAL/Schema/Synchronizer/SchemaSynchronizer.php
@@ -7,6 +7,8 @@ use Doctrine\DBAL\Schema\Schema;
 /**
  * The synchronizer knows how to synchronize a schema with the configured
  * database.
+ *
+ * @deprecated
  */
 interface SchemaSynchronizer
 {

--- a/lib/Doctrine/DBAL/Schema/Synchronizer/SingleDatabaseSynchronizer.php
+++ b/lib/Doctrine/DBAL/Schema/Synchronizer/SingleDatabaseSynchronizer.php
@@ -12,6 +12,8 @@ use function count;
 
 /**
  * Schema Synchronizer for Default DBAL Connection.
+ *
+ * @deprecated
  */
 class SingleDatabaseSynchronizer extends AbstractSchemaSynchronizer
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

#### Summary

The `SchemaSynchronizer` API was introduced as part of the support for sharding (#162) which is now deprecated (https://github.com/doctrine/dbal/pull/3905). This code hasn't received any functional changes in the last 8 years (12f381f1254f756114267e1a1e71d0a783bfaf1c) and doesn't seem to be used by any open source projects.

According to the tests and the implementation, `SingleDatabaseSynchronizer` is just a wrapper over other schema-related APIs and doesn't provide any additional functionality.