### PR TITLE
Remove test group configuration leftovers

### DIFF
--- a/tests/appveyor/mssql.sql2008r2sp2.sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2008r2sp2.sqlsrv.appveyor.xml
@@ -28,11 +28,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/appveyor/mssql.sql2012sp1.sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2012sp1.sqlsrv.appveyor.xml
@@ -28,11 +28,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
@@ -28,11 +28,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
@@ -28,11 +28,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/travis/ibm_db2.travis.xml
+++ b/tests/travis/ibm_db2.travis.xml
@@ -28,11 +28,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/travis/mariadb.docker.travis.xml
+++ b/tests/travis/mariadb.docker.travis.xml
@@ -28,11 +28,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/travis/mariadb.mysqli.docker.travis.xml
+++ b/tests/travis/mariadb.mysqli.docker.travis.xml
@@ -28,11 +28,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/travis/mysql.docker.travis.xml
+++ b/tests/travis/mysql.docker.travis.xml
@@ -28,11 +28,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/travis/mysqli-tls.docker.travis.xml
+++ b/tests/travis/mysqli-tls.docker.travis.xml
@@ -34,11 +34,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/travis/mysqli.docker.travis.xml
+++ b/tests/travis/mysqli.docker.travis.xml
@@ -28,11 +28,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/travis/pdo_sqlsrv.travis.xml
+++ b/tests/travis/pdo_sqlsrv.travis.xml
@@ -28,11 +28,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/travis/pgsql.travis.xml
+++ b/tests/travis/pgsql.travis.xml
@@ -27,11 +27,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/travis/sqlite.travis.xml
+++ b/tests/travis/sqlite.travis.xml
@@ -22,11 +22,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>

--- a/tests/travis/sqlsrv.travis.xml
+++ b/tests/travis/sqlsrv.travis.xml
@@ -28,11 +28,4 @@
             <directory suffix=".php">../../lib/Doctrine</directory>
         </include>
     </coverage>
-
-    <groups>
-        <exclude>
-            <group>performance</group>
-            <group>locking_functional</group>
-        </exclude>
-    </groups>
 </phpunit>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The `performance` test group was removed earlier in #3923 (this change should have been made at that time). All other groups were removed in #4172.

The `locking_functional` group seems to have never existed:
```
$ git log -G locking_functional -- tests/Doctrine/
```