### PR TITLE
Throw QueryException on improperly initialized from clause

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1186,6 +1186,16 @@ class QueryBuilder
     }
 
     /**
+     * @throws QueryException
+     */
+    private function assertHasSingleFromClause(): void
+    {
+        if (! array_key_exists('table', $this->sqlParts['from'])) {
+            throw QueryException::uninitializedTableName();
+        }
+    }
+
+    /**
      * @param string[] $knownAliases
      *
      * @throws QueryException
@@ -1211,9 +1221,13 @@ class QueryBuilder
      * Converts this instance into an INSERT string in SQL.
      *
      * @return string
+     *
+     * @throws QueryException
      */
     private function getSQLForInsert()
     {
+        $this->assertHasSingleFromClause();
+
         return 'INSERT INTO ' . $this->sqlParts['from']['table'] .
         ' (' . implode(', ', array_keys($this->sqlParts['values'])) . ')' .
         ' VALUES(' . implode(', ', $this->sqlParts['values']) . ')';
@@ -1223,9 +1237,13 @@ class QueryBuilder
      * Converts this instance into an UPDATE string in SQL.
      *
      * @return string
+     *
+     * @throws QueryException
      */
     private function getSQLForUpdate()
     {
+        $this->assertHasSingleFromClause();
+
         $table = $this->sqlParts['from']['table']
             . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
 
@@ -1238,9 +1256,13 @@ class QueryBuilder
      * Converts this instance into a DELETE string in SQL.
      *
      * @return string
+     *
+     * @throws QueryException
      */
     private function getSQLForDelete()
     {
+        $this->assertHasSingleFromClause();
+
         $table = $this->sqlParts['from']['table']
             . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
 

--- a/lib/Doctrine/DBAL/Query/QueryException.php
+++ b/lib/Doctrine/DBAL/Query/QueryException.php
@@ -36,4 +36,9 @@ class QueryException extends Exception
             'in FROM and JOIN clause table. The currently registered ' .
             'aliases are: ' . implode(', ', $registeredAliases) . '.');
     }
+
+    public static function uninitializedTableName(): self
+    {
+        return new self('There is no currently registered table name.');
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -462,6 +462,18 @@ class QueryBuilderTest extends DbalTestCase
         self::assertSame($qb2, $qb);
     }
 
+    public function testUpdateImproperFromThrowsException(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->update()
+            ->from('users');
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage(
+            'There is no currently registered table name.'
+        );
+        self::assertEquals('', $qb->getSQL());
+    }
+
     public function testDelete(): void
     {
         $qb = new QueryBuilder($this->conn);
@@ -487,6 +499,18 @@ class QueryBuilderTest extends DbalTestCase
            ->where('u.foo = ?');
 
         self::assertEquals('DELETE FROM users u WHERE u.foo = ?', (string) $qb);
+    }
+
+    public function testDeleteImproperFromThrowsException(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->delete()
+            ->from('users');
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage(
+            'There is no currently registered table name.'
+        );
+        self::assertEquals('', $qb->getSQL());
     }
 
     public function testEmptyDelete(): void
@@ -566,6 +590,18 @@ class QueryBuilderTest extends DbalTestCase
 
         self::assertEquals(QueryBuilder::INSERT, $qb->getType());
         self::assertSame($qb2, $qb);
+    }
+
+    public function testInsertImproperFromThrowsException(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->insert()
+            ->from('users');
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage(
+            'There is no currently registered table name.'
+        );
+        self::assertEquals('', $qb->getSQL());
     }
 
     public function testGetConnection(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3601

#### Summary

Throw a QueryException when using the query builder improperly.
