### PR TITLE
Use DISCONNECT with POST_TRANSACTION over KILL 

### DIFF
--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -389,7 +389,7 @@ SQL;
 
             $this->_execSql(
                 sprintf(
-                    "ALTER SYSTEM KILL SESSION '%s, %s' IMMEDIATE",
+                    "ALTER SYSTEM DISCONNECT SESSION '%s, %s' POST_TRANSACTION",
                     $activeUserSession['sid'],
                     $activeUserSession['serial#']
                 )


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4225 

#### Summary

The Oracle docs say the following:
> The POST_TRANSACTION clause waits for ongoing transactions to complete
> before disconnecting the session, while the IMMEDIATE clause disconnects
> the session and ongoing transactions are rolled back immediately.

See https://oracle-base.com/articles/misc/killing-oracle-sessions
