### PR TITLE
Deprecate more AbstractPlatform methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -50,6 +50,7 @@ The following PDO-related classes outside of the PDO namespace have been depreca
 1. `fixSchemaElementName()`.
 2. `getSQLResultCasing()`.
 3. `prefersSequences()`.
+4. `supportsForeignKeyOnUpdate()`.
 
 ##`ServerInfoAwareConnection::requiresQueryForServerVersion()` is deprecated.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,9 +45,10 @@ The following PDO-related classes outside of the PDO namespace have been depreca
 1. `DBALException::invalidPlatformType()` is deprecated as unused as of v2.7.0.
 2. `DBALException::invalidPdoInstance()` as passing a PDO instance via configuration is deprecated.
 
-## `AbstractPlatform::fixSchemaElementName()` is deprecated.
+## Deprecated `AbstractPlatform` methods.
 
-The method is not used anywhere except for tests.
+1. `fixSchemaElementName()`.
+2. `getSQLResultCasing()`.
 
 ##`ServerInfoAwareConnection::requiresQueryForServerVersion()` is deprecated.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -49,6 +49,7 @@ The following PDO-related classes outside of the PDO namespace have been depreca
 
 1. `fixSchemaElementName()`.
 2. `getSQLResultCasing()`.
+3. `prefersSequences()`.
 
 ##`ServerInfoAwareConnection::requiresQueryForServerVersion()` is deprecated.
 

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3481,6 +3481,8 @@ abstract class AbstractPlatform
     /**
      * Gets the character casing of a column in an SQL result set of this platform.
      *
+     * @deprecated
+     *
      * @param string $column The column name for which to get the correct character casing.
      *
      * @return string The column name in the character casing used in SQL result sets.

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2651,6 +2651,8 @@ abstract class AbstractPlatform
      * Whether the platform prefers sequences for ID generation.
      * Subclasses should override this method to return TRUE if they prefer sequences.
      *
+     * @deprecated
+     *
      * @return bool
      */
     public function prefersSequences()

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3232,6 +3232,8 @@ abstract class AbstractPlatform
     /**
      * Whether this platform supports onUpdate in foreign key constraints.
      *
+     * @deprecated
+     *
      * @return bool
      */
     public function supportsForeignKeyOnUpdate()

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -864,6 +864,8 @@ class DB2Platform extends AbstractPlatform
      * {@inheritDoc}
      *
      * DB2 returns all column names in SQL result sets in uppercase.
+     *
+     * @deprecated
      */
     public function getSQLResultCasing($column)
     {

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -1055,6 +1055,8 @@ SQL
      * {@inheritDoc}
      *
      * Oracle returns all column names in SQL result sets in uppercase.
+     *
+     * @deprecated
      */
     public function getSQLResultCasing($column)
     {

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -1130,6 +1130,8 @@ SQL
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function supportsForeignKeyOnUpdate()
     {

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -968,6 +968,8 @@ SQL
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function prefersSequences()
     {

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -210,6 +210,8 @@ class PostgreSqlPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function prefersSequences()
     {

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -1090,6 +1090,8 @@ SQL
      * {@inheritDoc}
      *
      * PostgreSQL returns all column names in SQL result sets in lowercase.
+     *
+     * @deprecated
      */
     public function getSQLResultCasing($column)
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

1. `AbstractPlatform::getSQLResultCasing()` is not used anywhere and is a blatant lie per se. On the platforms like Oracle, the column case depends on whether it's quoted or not, not on the actual column name.
2. `AbstractPlatform::prefersSequences()` is not used anywhere and defines a poor abstraction. A platform shouldn't “prefer” anything, it should “do” something in terms of its abstraction (e.g. create an autoincrement column).
3. `AbstractPlatform::supportsForeignKeyOnUpdate()` is only overridden in `OraclePlatform` and is used only in `AbstractPlatform::getAdvancedForeignKeyOptionsSQL()`. But this method is also overridden in `OraclePlatform`, and the overridden implementation doesn't call it.