### PR TITLE
Deprecate the functionality of dropping client connections when dropping a database

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 2.11
 
+## Deprecated the functionality of dropping client connections when dropping a database
+
+The corresponding `getDisallowDatabaseConnectionsSQL()` and `getCloseActiveDatabaseConnectionsSQL` methods
+of the `PostgreSqlPlatform` class have been deprecated.
+
 ## Deprecated `Synchronizer` package
 
 The `Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer` interface and all its implementations are deprecated.

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -442,6 +442,8 @@ SQL
      *
      * This is useful to force DROP DATABASE operations which could fail because of active connections.
      *
+     * @deprecated
+     *
      * @param string $database The name of the database to disallow new connections for.
      *
      * @return string
@@ -455,6 +457,8 @@ SQL
      * Returns the SQL statement for closing currently active connections on the given database.
      *
      * This is useful to force DROP DATABASE operations which could fail because of active connections.
+     *
+     * @deprecated
      *
      * @param string $database The name of the database to close currently active connections for.
      *


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

See https://github.com/doctrine/dbal/issues/4225#issuecomment-680654156.