### PR TITLE
Mark testDropsDatabaseWithActiveConnections() as incomplete on OraclePlatform

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -94,8 +94,14 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
 
     public function testDropsDatabaseWithActiveConnections(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsCreateDropDatabase()) {
+        $platform = $this->schemaManager->getDatabasePlatform();
+
+        if (! $platform->supportsCreateDropDatabase()) {
             $this->markTestSkipped('Cannot drop Database client side with this Driver.');
+        }
+
+        if ($platform instanceof OraclePlatform) {
+            $this->markTestIncomplete('This functionality is not properly implemented in the Oracle platform.');
         }
 
         $this->schemaManager->dropAndCreateDatabase('test_drop_database');


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #4225

`testDropsDatabaseWithActiveConnections()` has been marked as incomplete on `OraclePlatform` based on the findings in https://github.com/doctrine/dbal/issues/4225#issuecomment-680208859.