### PR TITLE
Fix errors with case sensitive collation on mssql: not existing procedures and tables (sp_RENAME, SysObjects, SysColumns)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -219,7 +219,14 @@ jobs:
         - bash ./tests/travis/install-sqlsrv-dependencies.sh
         - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
         - bash ./tests/travis/install-mssql.sh
-
+    - stage: Test
+      php: 7.4
+      env: DB=pdo_sqlsrv
+      sudo: required
+      before_script:
+        - bash ./tests/travis/install-sqlsrv-dependencies.sh
+        - bash ./tests/travis/install-mssql-pdo_sqlsrv.sh
+        - bash ./tests/travis/install-mssql-cs.sh
     - stage: Test
       if: type = cron
       php: 7.2

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -574,7 +574,7 @@ SQL
 
             $oldColumnName = new Identifier($oldColumnName);
 
-            $sql[] = "sp_RENAME '" .
+            $sql[] = "sp_rename '" .
                 $diff->getName($this)->getQuotedName($this) . '.' . $oldColumnName->getQuotedName($this) .
                 "', '" . $column->getQuotedName($this) . "', 'COLUMN'";
 
@@ -605,7 +605,7 @@ SQL
         $newName = $diff->getNewName();
 
         if ($newName !== false) {
-            $sql[] = "sp_RENAME '" . $diff->getName($this)->getQuotedName($this) . "', '" . $newName->getName() . "'";
+            $sql[] = "sp_rename '" . $diff->getName($this)->getQuotedName($this) . "', '" . $newName->getName() . "'";
 
             /**
              * Rename table's default constraints names
@@ -784,7 +784,7 @@ SQL
     protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
     {
         return [sprintf(
-            "EXEC sp_RENAME N'%s.%s', N'%s', N'INDEX'",
+            "EXEC sp_rename N'%s.%s', N'%s', N'INDEX'",
             $tableName,
             $oldIndexName,
             $index->getQuotedName($this)

--- a/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SQLServerSchemaManager.php
@@ -302,11 +302,11 @@ class SQLServerSchemaManager extends AbstractSchemaManager
      */
     private function getColumnConstraintSQL($table, $column)
     {
-        return "SELECT SysObjects.[Name]
-            FROM SysObjects INNER JOIN (SELECT [Name],[ID] FROM SysObjects WHERE XType = 'U') AS Tab
-            ON Tab.[ID] = Sysobjects.[Parent_Obj]
-            INNER JOIN sys.default_constraints DefCons ON DefCons.[object_id] = Sysobjects.[ID]
-            INNER JOIN SysColumns Col ON Col.[ColID] = DefCons.[parent_column_id] AND Col.[ID] = Tab.[ID]
+        return "SELECT sysobjects.[Name]
+            FROM sysobjects INNER JOIN (SELECT [Name],[ID] FROM sysobjects WHERE XType = 'U') AS Tab
+            ON Tab.[ID] = sysobjects.[Parent_Obj]
+            INNER JOIN sys.default_constraints DefCons ON DefCons.[object_id] = sysobjects.[ID]
+            INNER JOIN syscolumns Col ON Col.[ColID] = DefCons.[parent_column_id] AND Col.[ID] = Tab.[ID]
             WHERE Col.[Name] = " . $this->_conn->quote($column) . ' AND Tab.[Name] = ' . $this->_conn->quote($table) . '
             ORDER BY Col.[Name]';
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -48,7 +48,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
             "ALTER TABLE mytable ADD CONSTRAINT DF_6B2BD609_78240498 DEFAULT 'def' FOR baz",
             'ALTER TABLE mytable ALTER COLUMN bloo BIT NOT NULL',
             "ALTER TABLE mytable ADD CONSTRAINT DF_6B2BD609_CECED971 DEFAULT '0' FOR bloo",
-            "sp_RENAME 'mytable', 'userlist'",
+            "sp_rename 'mytable', 'userlist'",
             "DECLARE @sql NVARCHAR(MAX) = N''; " .
             "SELECT @sql += N'EXEC sp_rename N''' + dc.name + ''', N''' " .
             "+ REPLACE(dc.name, '6B2BD609', 'E2B58069') + ''', ''OBJECT'';' " .
@@ -984,7 +984,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         self::assertEquals(
             [
                 // Renamed columns.
-                "sp_RENAME 'mytable.comment_float_0', 'comment_double_0', 'COLUMN'",
+                "sp_rename 'mytable.comment_float_0', 'comment_double_0', 'COLUMN'",
 
                 // Added columns.
                 'ALTER TABLE mytable ADD added_comment_none INT NOT NULL',
@@ -1164,7 +1164,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
      */
     protected function getAlterTableRenameIndexSQL(): array
     {
-        return ["EXEC sp_RENAME N'mytable.idx_foo', N'idx_bar', N'INDEX'"];
+        return ["EXEC sp_rename N'mytable.idx_foo', N'idx_bar', N'INDEX'"];
     }
 
     /**
@@ -1173,8 +1173,8 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     protected function getQuotedAlterTableRenameIndexSQL(): array
     {
         return [
-            "EXEC sp_RENAME N'[table].[create]', N'[select]', N'INDEX'",
-            "EXEC sp_RENAME N'[table].[foo]', N'[bar]', N'INDEX'",
+            "EXEC sp_rename N'[table].[create]', N'[select]', N'INDEX'",
+            "EXEC sp_rename N'[table].[foo]', N'[bar]', N'INDEX'",
         ];
     }
 
@@ -1223,15 +1223,15 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     protected function getQuotedAlterTableRenameColumnSQL(): array
     {
         return [
-            "sp_RENAME 'mytable.unquoted1', 'unquoted', 'COLUMN'",
-            "sp_RENAME 'mytable.unquoted2', '[where]', 'COLUMN'",
-            "sp_RENAME 'mytable.unquoted3', '[foo]', 'COLUMN'",
-            "sp_RENAME 'mytable.[create]', 'reserved_keyword', 'COLUMN'",
-            "sp_RENAME 'mytable.[table]', '[from]', 'COLUMN'",
-            "sp_RENAME 'mytable.[select]', '[bar]', 'COLUMN'",
-            "sp_RENAME 'mytable.quoted1', 'quoted', 'COLUMN'",
-            "sp_RENAME 'mytable.quoted2', '[and]', 'COLUMN'",
-            "sp_RENAME 'mytable.quoted3', '[baz]', 'COLUMN'",
+            "sp_rename 'mytable.unquoted1', 'unquoted', 'COLUMN'",
+            "sp_rename 'mytable.unquoted2', '[where]', 'COLUMN'",
+            "sp_rename 'mytable.unquoted3', '[foo]', 'COLUMN'",
+            "sp_rename 'mytable.[create]', 'reserved_keyword', 'COLUMN'",
+            "sp_rename 'mytable.[table]', '[from]', 'COLUMN'",
+            "sp_rename 'mytable.[select]', '[bar]', 'COLUMN'",
+            "sp_rename 'mytable.quoted1', 'quoted', 'COLUMN'",
+            "sp_rename 'mytable.quoted2', '[and]', 'COLUMN'",
+            "sp_rename 'mytable.quoted3', '[baz]', 'COLUMN'",
         ];
     }
 
@@ -1248,7 +1248,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
      */
     protected function getAlterTableRenameIndexInSchemaSQL(): array
     {
-        return ["EXEC sp_RENAME N'myschema.mytable.idx_foo', N'idx_bar', N'INDEX'"];
+        return ["EXEC sp_rename N'myschema.mytable.idx_foo', N'idx_bar', N'INDEX'"];
     }
 
     /**
@@ -1257,8 +1257,8 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     protected function getQuotedAlterTableRenameIndexInSchemaSQL(): array
     {
         return [
-            "EXEC sp_RENAME N'[schema].[table].[create]', N'[select]', N'INDEX'",
-            "EXEC sp_RENAME N'[schema].[table].[foo]', N'[bar]', N'INDEX'",
+            "EXEC sp_rename N'[schema].[table].[create]', N'[select]', N'INDEX'",
+            "EXEC sp_rename N'[schema].[table].[foo]', N'[bar]', N'INDEX'",
         ];
     }
 
@@ -1507,7 +1507,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     public function getAlterTableRenameColumnSQL(): array
     {
         return [
-            "sp_RENAME 'foo.bar', 'baz', 'COLUMN'",
+            "sp_rename 'foo.bar', 'baz', 'COLUMN'",
             'ALTER TABLE foo DROP CONSTRAINT DF_8C736521_76FF8CAA',
             'ALTER TABLE foo ADD CONSTRAINT DF_8C736521_78240498 DEFAULT 666 FOR baz',
         ];
@@ -1521,11 +1521,11 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         return [
             'ALTER TABLE [foo] DROP CONSTRAINT fk1',
             'ALTER TABLE [foo] DROP CONSTRAINT fk2',
-            "sp_RENAME '[foo].id', 'war', 'COLUMN'",
+            "sp_rename '[foo].id', 'war', 'COLUMN'",
             'ALTER TABLE [foo] ADD bloo INT NOT NULL',
             'ALTER TABLE [foo] DROP COLUMN baz',
             'ALTER TABLE [foo] ALTER COLUMN bar INT',
-            "sp_RENAME '[foo]', 'table'",
+            "sp_rename '[foo]', 'table'",
             "DECLARE @sql NVARCHAR(MAX) = N''; " .
             "SELECT @sql += N'EXEC sp_rename N''' + dc.name + ''', " .
             "N''' + REPLACE(dc.name, '8C736521', 'F6298F46') + ''', ''OBJECT'';' " .
@@ -1591,7 +1591,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
      */
     protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL(): array
     {
-        return ["EXEC sp_RENAME N'mytable.idx_foo', N'idx_foo_renamed', N'INDEX'"];
+        return ["EXEC sp_rename N'mytable.idx_foo', N'idx_foo_renamed', N'INDEX'"];
     }
 
     public function testModifyLimitQueryWithTopNSubQueryWithOrderBy(): void

--- a/tests/travis/install-mssql-cs.sh
+++ b/tests/travis/install-mssql-cs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo Setting up Microsoft SQL Server
+
+sudo docker pull microsoft/mssql-server-linux:2017-latest
+sudo docker run \
+    -e 'ACCEPT_EULA=Y' \
+    -e 'SA_PASSWORD=Doctrine2018' \
+    -e 'MSSQL_COLLATION=Latin1_General_100_CS_AS' \
+    -p 127.0.0.1:1433:1433 \
+    --name mssql \
+    -d \
+    microsoft/mssql-server-linux:2017-latest
+
+sudo docker exec -i mssql bash <<< 'until echo quit | /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -l 1 -U sa -P Doctrine2018 > /dev/null 2>&1 ; do sleep 1; done'
+
+echo SQL Server started


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Fix case sensitive issues on mssql:
- sp_RENAME -> sp_rename
- SysObjects -> sysobjects
- SysColumns -> syscolumns

Closes #4237 
