### PR TITLE
Added partial index support for SQL Server and SQLite

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2008Platform.php
@@ -11,6 +11,15 @@ namespace Doctrine\DBAL\Platforms;
 class SQLServer2008Platform extends SQLServer2005Platform
 {
     /**
+     * {@inheritdoc}
+     */
+    public function supportsPartialIndexes()
+    {
+        // Partial indexes are supported as "filtered indexes" since version 2008.
+        return true;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getListTablesSQL()

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -463,7 +463,17 @@ SQL
             $fields[] = $field . ' IS NOT NULL';
         }
 
-        return $sql . ' WHERE ' . implode(' AND ', $fields);
+        if (count($fields) > 0) {
+            if ($this->supportsPartialIndexes() && $index->hasOption('where')) {
+                $sql .= ' AND ';
+            } else {
+                $sql .= ' WHERE ';
+            }
+
+            $sql .= implode(' AND ', $fields);
+        }
+
+        return $sql;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -554,6 +554,16 @@ class SqlitePlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function supportsPartialIndexes()
+    {
+        // Partial indexes are supported since version 3.8.0 (2013-08-26),
+        // see https://www.sqlite.org/partialindex.html
+        return true;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getName()

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
@@ -4,6 +4,9 @@ namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2008Platform;
+use Doctrine\DBAL\Schema\Index;
+
+use function substr_count;
 
 class SQLServer2008PlatformTest extends AbstractSQLServerPlatformTestCase
 {
@@ -15,5 +18,24 @@ class SQLServer2008PlatformTest extends AbstractSQLServerPlatformTestCase
     public function testGeneratesTypeDeclarationForDateTimeTz(): void
     {
         self::assertEquals('DATETIMEOFFSET(6)', $this->platform->getDateTimeTzTypeDeclarationSQL([]));
+    }
+
+    public function testSupportsPartialIndexes(): void
+    {
+        self::assertTrue($this->platform->supportsPartialIndexes());
+    }
+
+    /**
+     * Tests if automatically added conditions for the unique constraint are correctly merged
+     * with optional where conditions.
+     */
+    public function testGeneratesPartialUniqueConstraintSqlWithSingleWherePart(): void
+    {
+        $where       = 'test IS NULL AND test2 IS NOT NULL';
+        $uniqueIndex = new Index('name', ['test', 'test2'], true, false, [], ['where' => $where]);
+
+        $sql = $this->platform->getUniqueConstraintDeclarationSQL('name', $uniqueIndex);
+
+        self::assertEquals(1, substr_count($sql, 'WHERE '));
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -807,4 +807,9 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             $this->platform->getCreateTableSQL($table)
         );
     }
+
+    public function testSupportsPartialIndexes(): void
+    {
+        self::assertTrue($this->platform->supportsPartialIndexes());
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3038

#### Summary

Added support for partial indexes in SQL Server (supported since version 2008) and SQLite (supported since version 3.8.0). Also had to adjust the unique constraint generation in SQL Server so that the WHERE part is correctly added.