### PR TITLE
Update column position on schema update for MySQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3367,6 +3367,14 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Does this platform support column reordering in alter table?
+     */
+    public function supportsUpdateColumnOrder(): bool
+    {
+        return false;
+    }
+
+    /**
      * Gets the format string, as accepted by the date() function, that describes
      * the format of a stored datetime value of this platform.
      *

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -1198,4 +1198,9 @@ SQL
     {
         return true;
     }
+
+    public function supportsUpdateColumnOrder(): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
finish after 4276

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #1411

#### Summary

This PR adds support to Comparator to detect columns that needs to be reordered.

Please help with the MySQL alter table impl., ie. to generate `FIRST` or `AFTER` after each alter column sql.