### PR TITLE
SQLite: Fix wrongly detected reference constraint name on schema change

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -149,7 +149,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
                 $id = $value['id'];
 
                 $tableForeignKeys[$key] = array_merge($tableForeignKeys[$key], [
-                    'constraint_name' => isset($names[$id]) && $names[$id] !== '' ? $names[$id] : $id,
+                    'constraint_name' => isset($names[$id]) && $names[$id] !== '' ? $names[$id] : null,
                     'deferrable'      => isset($deferrable[$id]) && strtolower($deferrable[$id]) === 'deferrable',
                     'deferred'        => isset($deferred[$id]) && strtolower($deferred[$id]) === 'deferred',
                 ]);

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -101,7 +101,7 @@ EOS
                 ['parent'],
                 'user',
                 ['id'],
-                '1',
+                null,
                 ['onUpdate' => 'NO ACTION', 'onDelete' => 'CASCADE', 'deferrable' => false, 'deferred' => false]
             ),
             new Schema\ForeignKeyConstraint(


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no?
| Fixed issues | #4243

#### Summary
This fixes #4243 as other parts of the code expect the constraint name to be `null`, for example `\Doctrine\DBAL\Schema\ForeignKeyConstraint::__construct` if no actual name exists