### PR TITLE
SQLite: Escape numbers as keywords

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/Keywords/SQLiteKeywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/SQLiteKeywords.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use function is_numeric;
+
 /**
  * SQLite Keywordlist.
  */
@@ -13,6 +15,14 @@ class SQLiteKeywords extends KeywordList
     public function getName()
     {
         return 'SQLite';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isKeyword($word)
+    {
+        return parent::isKeyword($word) || is_numeric($word);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4243

#### Summary
This fixes #4243 by escaping numbers