### PR TITLE
MasterSlaveConnection::query() throws driver-specific exceptions (e.g. PDOException etc)

### DIFF
--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Events;
 use InvalidArgumentException;
 
 use function array_rand;
-use function assert;
 use function count;
 use function func_get_args;
 
@@ -354,24 +353,8 @@ class MasterSlaveConnection extends Connection
     public function query()
     {
         $this->connect('master');
-        assert($this->_conn instanceof DriverConnection);
 
-        $args = func_get_args();
-
-        $logger = $this->getConfiguration()->getSQLLogger();
-        if ($logger) {
-            $logger->startQuery($args[0]);
-        }
-
-        $statement = $this->_conn->query(...$args);
-
-        $statement->setFetchMode($this->defaultFetchMode);
-
-        if ($logger) {
-            $logger->stopQuery();
-        }
-
-        return $statement;
+        return parent::query(...func_get_args());
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Connection/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Connection/MasterSlaveConnectionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Connection;
+
+use Doctrine\DBAL\Connections\MasterSlaveConnection;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\Tests\DbalTestCase;
+
+class MasterSlaveConnectionTest extends DbalTestCase
+{
+    /**
+     * @return array<int, array<int, mixed>>
+     */
+    public static function getQueryMethods(): iterable
+    {
+        return [
+            ['exec'],
+            ['query'],
+            ['executeQuery'],
+            ['executeUpdate'],
+            ['prepare'],
+        ];
+    }
+
+    /**
+     * @requires extension pdo_sqlite
+     * @dataProvider getQueryMethods
+     */
+    public function testDriverExceptionIsWrapped(string $method): void
+    {
+        $this->expectException(DBALException::class);
+        $this->expectExceptionMessage(
+            <<<EOF
+An exception occurred while executing 'MUUHAAAAHAAAA':
+
+SQLSTATE[HY000]: General error: 1 near "MUUHAAAAHAAAA"
+EOF
+        );
+
+        $connection = DriverManager::getConnection(
+            [
+                'wrapperClass' => MasterSlaveConnection::class,
+                'memory' => true,
+                'driver' => 'pdo_sqlite',
+                'master' => [],
+                'slaves' => ['slave1' => ['driver' => 'pdo_sqlite']],
+            ]
+        );
+
+        $connection->$method('MUUHAAAAHAAAA');
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no, but it depends*
| Fixed issues | #2769, #3118

#### Summary
This PR fixes how driver exceptions are handled in Doctrine/DBAL/Connections/MasterSlaveConnection::query() and prevents driver-specific exceptions from bubbling. Driver exception conversion was added in https://github.com/doctrine/dbal/commit/4cc70c177bfe4872f446b7de3f13e4df24ad9c8a, but somehow `MasterSlaveConnection` was forgotten.
This PR reduces code duplication by calling the parent method, so no more chance of forgetting to apply some change to `MasterSlaveConnection` if `Doctrine\DBAL\Connection::query()` is modified. At the end of the day except for the proper exception handling parent's method behavior is the same.

#### Alternative PRs

Unlike #3313, this PR addresses only the core issue - exception not being converted. That PR suggests catching `PDOException` in addition to `DBALException`, which is completely unnecessary if exception is properly converted. Also unlike #3313, this PR adds a localized unit test, while the other PR tests merely a side-effect on the `ping` method.

#### BC Break
Any bug fix is a change of behavior, which can be a potential BC break for someone. Any of the 3rd party code that relies on current buggy behavior which in fact violates the contract would get broken by this change.
So in practice it's a BC break for some projects that probably tried to implement some workarounds for this bug. But ignoring exploitation of undocumented/buggy behavior when making stuff work according to the spec is a common thing when evaluating if a change breaks BC. The only exception that is supposed to be thrown out of the `query` method is `DBALException` as advertised in the docblock. Therefore I wouldn't consider it a BC break.

#### Other
I can see 2.11.x branch has some significant changes around the code affected by this PR. I could create a separate PR for 2.11 if you consider this solution good enough.