### PR TITLE
Deprecate DBAL\DBALException in favor of DBAL\Exception

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -84,6 +84,10 @@ The non-interface methods of driver-level classes have been marked internal:
 - `OCI8Connection::getExecuteMode()`
 - `OCI8Statement::convertPositionalToNamedPlaceholders()`
 
+## Deprecated `DBALException`
+
+The `Doctrine\DBAL\DBALException` class has been deprecated in favor of `Doctrine\DBAL\Exception`.
+
 ## Inconsistently and ambiguously named driver-level classes are deprecated
 
 The following classes under the `Driver` namespace have been deprecated in favor of their consistently named counterparts:

--- a/lib/Doctrine/DBAL/Abstraction/Result.php
+++ b/lib/Doctrine/DBAL/Abstraction/Result.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Abstraction;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Result as DriverResult;
+use Doctrine\DBAL\Exception;
 use Traversable;
 
 /**
@@ -19,7 +19,7 @@ interface Result extends DriverResult
      *
      * @return Traversable<int,array<int,mixed>>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function iterateNumeric(): Traversable;
 
@@ -28,7 +28,7 @@ interface Result extends DriverResult
      *
      * @return Traversable<int,array<string,mixed>>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function iterateAssociative(): Traversable;
 
@@ -37,7 +37,7 @@ interface Result extends DriverResult
      *
      * @return Traversable<int,mixed>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function iterateColumn(): Traversable;
 }

--- a/lib/Doctrine/DBAL/Cache/CacheException.php
+++ b/lib/Doctrine/DBAL/Cache/CacheException.php
@@ -2,12 +2,12 @@
 
 namespace Doctrine\DBAL\Cache;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 
 /**
  * @psalm-immutable
  */
-class CacheException extends DBALException
+class CacheException extends Exception
 {
     /**
      * @return CacheException

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -20,7 +20,6 @@ use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Types\Type;
-use Exception;
 use Throwable;
 use Traversable;
 
@@ -406,7 +405,7 @@ class Connection implements DriverConnection
      *
      * @return string|null
      *
-     * @throws Exception
+     * @throws Throwable
      */
     private function getDatabasePlatformVersion()
     {
@@ -1470,7 +1469,6 @@ class Connection implements DriverConnection
      *
      * @return mixed The value returned by $func
      *
-     * @throws Exception
      * @throws Throwable
      */
     public function transactional(Closure $func)
@@ -1481,10 +1479,6 @@ class Connection implements DriverConnection
             $this->commit();
 
             return $res;
-        } catch (Exception $e) {
-            $this->rollBack();
-
-            throw $e;
         } catch (Throwable $e) {
             $this->rollBack();
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -174,7 +174,7 @@ class Connection implements DriverConnection
      * @param Configuration|null $config       The configuration, optional.
      * @param EventManager|null  $eventManager The event manager, optional.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function __construct(
         array $params,
@@ -192,7 +192,7 @@ class Connection implements DriverConnection
 
         if (isset($params['platform'])) {
             if (! $params['platform'] instanceof Platforms\AbstractPlatform) {
-                throw DBALException::invalidPlatformType($params['platform']);
+                throw Exception::invalidPlatformType($params['platform']);
             }
 
             $this->platform = $params['platform'];
@@ -320,7 +320,7 @@ class Connection implements DriverConnection
      *
      * @return AbstractPlatform
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function getDatabasePlatform()
     {
@@ -378,7 +378,7 @@ class Connection implements DriverConnection
      *
      * Evaluates custom platform class and version in order to set the correct platform.
      *
-     * @throws DBALException If an invalid platform was specified for this connection.
+     * @throws Exception If an invalid platform was specified for this connection.
      */
     private function detectDatabasePlatform(): void
     {
@@ -549,7 +549,7 @@ class Connection implements DriverConnection
      *
      * @return mixed[]|false False is returned if no rows are found.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchAssoc($sql, array $params = [], array $types = [])
     {
@@ -586,7 +586,7 @@ class Connection implements DriverConnection
      *
      * @return mixed|false False is returned if no rows are found.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchColumn($sql, array $params = [], $column = 0, array $types = [])
     {
@@ -603,7 +603,7 @@ class Connection implements DriverConnection
      *
      * @return array<string, mixed>|false False is returned if no rows are found.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchAssociative(string $query, array $params = [], array $types = [])
     {
@@ -630,7 +630,7 @@ class Connection implements DriverConnection
      *
      * @return array<int, mixed>|false False is returned if no rows are found.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchNumeric(string $query, array $params = [], array $types = [])
     {
@@ -657,7 +657,7 @@ class Connection implements DriverConnection
      *
      * @return mixed|false False is returned if no rows are found.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchOne(string $query, array $params = [], array $types = [])
     {
@@ -702,7 +702,7 @@ class Connection implements DriverConnection
      * @param mixed[]  $values     Column values
      * @param string[] $conditions Key conditions
      *
-     * @throws DBALException
+     * @throws Exception
      */
     private function addIdentifierCondition(
         array $identifier,
@@ -735,8 +735,7 @@ class Connection implements DriverConnection
      *
      * @return int The number of affected rows.
      *
-     * @throws DBALException
-     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function delete($table, array $identifier, array $types = [])
     {
@@ -805,7 +804,7 @@ class Connection implements DriverConnection
      *
      * @return int The number of affected rows.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function update($table, array $data, array $identifier, array $types = [])
     {
@@ -840,7 +839,7 @@ class Connection implements DriverConnection
      *
      * @return int The number of affected rows.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function insert($table, array $data, array $types = [])
     {
@@ -941,7 +940,7 @@ class Connection implements DriverConnection
      *
      * @return array<int,array<int,mixed>>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchAllNumeric(string $query, array $params = [], array $types = []): array
     {
@@ -967,7 +966,7 @@ class Connection implements DriverConnection
      *
      * @return array<int,array<string,mixed>>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchAllAssociative(string $query, array $params = [], array $types = []): array
     {
@@ -993,7 +992,7 @@ class Connection implements DriverConnection
      *
      * @return array<int,mixed>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchFirstColumn(string $query, array $params = [], array $types = []): array
     {
@@ -1019,7 +1018,7 @@ class Connection implements DriverConnection
      *
      * @return Traversable<int,array<int,mixed>>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function iterateNumeric(string $query, array $params = [], array $types = []): Traversable
     {
@@ -1048,7 +1047,7 @@ class Connection implements DriverConnection
      *
      * @return Traversable<int,array<string,mixed>>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function iterateAssociative(string $query, array $params = [], array $types = []): Traversable
     {
@@ -1076,7 +1075,7 @@ class Connection implements DriverConnection
      *
      * @return Traversable<int,mixed>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function iterateColumn(string $query, array $params = [], array $types = []): Traversable
     {
@@ -1102,7 +1101,7 @@ class Connection implements DriverConnection
      *
      * @return Statement The prepared statement.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function prepare($sql)
     {
@@ -1130,7 +1129,7 @@ class Connection implements DriverConnection
      *
      * @return ResultStatement The executed statement.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function executeQuery($sql, array $params = [], $types = [], ?QueryCacheProfile $qcp = null)
     {
@@ -1264,7 +1263,7 @@ class Connection implements DriverConnection
      *
      * @return \Doctrine\DBAL\Driver\Statement
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function query()
     {
@@ -1306,7 +1305,7 @@ class Connection implements DriverConnection
      *
      * @return int The number of affected rows.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function executeUpdate($sql, array $params = [], array $types = [])
     {
@@ -1331,7 +1330,7 @@ class Connection implements DriverConnection
      *
      * @return int The number of affected rows.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function executeStatement($sql, array $params = [], array $types = [])
     {
@@ -1384,7 +1383,7 @@ class Connection implements DriverConnection
      *
      * @return int The number of affected rows.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function exec($sql)
     {
@@ -2008,14 +2007,14 @@ class Connection implements DriverConnection
      * @param array<int, mixed>|array<string, mixed>           $params
      * @param array<int, int|string>|array<string, int|string> $types
      *
-     * @throws DBALException
+     * @throws Exception
      *
      * @psalm-return never-return
      */
     public function handleExceptionDuringQuery(Throwable $e, string $sql, array $params = [], array $types = []): void
     {
         $this->throw(
-            DBALException::driverExceptionDuringQuery(
+            Exception::driverExceptionDuringQuery(
                 $this->_driver,
                 $e,
                 $sql,
@@ -2027,14 +2026,14 @@ class Connection implements DriverConnection
     /**
      * @internal
      *
-     * @throws DBALException
+     * @throws Exception
      *
      * @psalm-return never-return
      */
     public function handleDriverException(Throwable $e): void
     {
         $this->throw(
-            DBALException::driverException(
+            Exception::driverException(
                 $this->_driver,
                 $e
             )
@@ -2044,11 +2043,11 @@ class Connection implements DriverConnection
     /**
      * @internal
      *
-     * @throws DBALException
+     * @throws Exception
      *
      * @psalm-return never-return
      */
-    private function throw(DBALException $e): void
+    private function throw(Exception $e): void
     {
         if ($e instanceof ConnectionLost) {
             $this->close();

--- a/lib/Doctrine/DBAL/ConnectionException.php
+++ b/lib/Doctrine/DBAL/ConnectionException.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL;
 /**
  * @psalm-immutable
  */
-class ConnectionException extends DBALException
+class ConnectionException extends Exception
 {
     /**
      * @return ConnectionException

--- a/lib/Doctrine/DBAL/DBALException.php
+++ b/lib/Doctrine/DBAL/DBALException.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
-use Exception;
 use Throwable;
 
 use function array_map;
@@ -24,18 +23,20 @@ use function spl_object_hash;
 use function sprintf;
 
 /**
+ * @deprecated Use {@link Exception} instead
+ *
  * @psalm-immutable
  */
-class DBALException extends Exception
+class DBALException extends \Exception
 {
     /**
      * @param string $method
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function notSupported($method)
     {
-        return new self(sprintf("Operation '%s' is not supported by platform.", $method));
+        return new Exception(sprintf("Operation '%s' is not supported by platform.", $method));
     }
 
     /**
@@ -43,7 +44,7 @@ class DBALException extends Exception
      */
     public static function invalidPlatformSpecified(): self
     {
-        return new self(
+        return new Exception(
             "Invalid 'platform' option specified, need to give an instance of " . AbstractPlatform::class . '.'
         );
     }
@@ -54,7 +55,7 @@ class DBALException extends Exception
     public static function invalidPlatformType($invalidPlatform): self
     {
         if (is_object($invalidPlatform)) {
-            return new self(
+            return new Exception(
                 sprintf(
                     "Option 'platform' must be a subtype of '%s', instance of '%s' given",
                     AbstractPlatform::class,
@@ -63,7 +64,7 @@ class DBALException extends Exception
             );
         }
 
-        return new self(
+        return new Exception(
             sprintf(
                 "Option 'platform' must be an object and subtype of '%s'. Got '%s'",
                 AbstractPlatform::class,
@@ -78,11 +79,11 @@ class DBALException extends Exception
      * @param string $version        The invalid platform version given.
      * @param string $expectedFormat The expected platform version format.
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function invalidPlatformVersionSpecified($version, $expectedFormat)
     {
-        return new self(
+        return new Exception(
             sprintf(
                 'Invalid platform version "%s" specified. ' .
                 'The platform version has to be specified in the format: "%s".',
@@ -95,11 +96,11 @@ class DBALException extends Exception
     /**
      * @deprecated Passing a PDO instance in connection parameters is deprecated.
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function invalidPdoInstance()
     {
-        return new self(
+        return new Exception(
             "The 'pdo' option was used in DriverManager::getConnection() but no " .
             'instance of PDO was given.'
         );
@@ -108,12 +109,12 @@ class DBALException extends Exception
     /**
      * @param string|null $url The URL that was provided in the connection parameters (if any).
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function driverRequired($url = null)
     {
         if ($url) {
-            return new self(
+            return new Exception(
                 sprintf(
                     "The options 'driver' or 'driverClass' are mandatory if a connection URL without scheme " .
                     'is given to DriverManager::getConnection(). Given URL: %s',
@@ -122,7 +123,7 @@ class DBALException extends Exception
             );
         }
 
-        return new self("The options 'driver' or 'driverClass' are mandatory if no PDO " .
+        return new Exception("The options 'driver' or 'driverClass' are mandatory if no PDO " .
             'instance is given to DriverManager::getConnection().');
     }
 
@@ -130,11 +131,11 @@ class DBALException extends Exception
      * @param string   $unknownDriverName
      * @param string[] $knownDrivers
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function unknownDriver($unknownDriverName, array $knownDrivers)
     {
-        return new self("The given 'driver' " . $unknownDriverName . ' is unknown, ' .
+        return new Exception("The given 'driver' " . $unknownDriverName . ' is unknown, ' .
             'Doctrine currently supports only the following drivers: ' . implode(', ', $knownDrivers));
     }
 
@@ -144,7 +145,7 @@ class DBALException extends Exception
      * @param string  $sql
      * @param mixed[] $params
      *
-     * @return self
+     * @return Exception
      */
     public static function driverExceptionDuringQuery(Driver $driver, Throwable $driverEx, $sql, array $params = [])
     {
@@ -161,7 +162,7 @@ class DBALException extends Exception
     /**
      * @deprecated
      *
-     * @return self
+     * @return Exception
      */
     public static function driverException(Driver $driver, Throwable $driverEx)
     {
@@ -169,7 +170,7 @@ class DBALException extends Exception
     }
 
     /**
-     * @return self
+     * @return Exception
      */
     private static function wrapException(Driver $driver, Throwable $driverEx, string $msg)
     {
@@ -181,7 +182,7 @@ class DBALException extends Exception
             return $driver->convertException($msg, $driverEx);
         }
 
-        return new self($msg, 0, $driverEx);
+        return new Exception($msg, 0, $driverEx);
     }
 
     /**
@@ -213,22 +214,22 @@ class DBALException extends Exception
     /**
      * @param string $wrapperClass
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function invalidWrapperClass($wrapperClass)
     {
-        return new self("The given 'wrapperClass' " . $wrapperClass . ' has to be a ' .
+        return new Exception("The given 'wrapperClass' " . $wrapperClass . ' has to be a ' .
             'subtype of \Doctrine\DBAL\Connection.');
     }
 
     /**
      * @param string $driverClass
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function invalidDriverClass($driverClass)
     {
-        return new self(
+        return new Exception(
             "The given 'driverClass' " . $driverClass . ' has to implement the ' . Driver::class . ' interface.'
         );
     }
@@ -236,49 +237,49 @@ class DBALException extends Exception
     /**
      * @param string $tableName
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function invalidTableName($tableName)
     {
-        return new self('Invalid table name specified: ' . $tableName);
+        return new Exception('Invalid table name specified: ' . $tableName);
     }
 
     /**
      * @param string $tableName
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function noColumnsSpecifiedForTable($tableName)
     {
-        return new self('No columns specified for table ' . $tableName);
+        return new Exception('No columns specified for table ' . $tableName);
     }
 
     /**
-     * @return DBALException
+     * @return Exception
      */
     public static function limitOffsetInvalid()
     {
-        return new self('Invalid Offset in Limit Query, it has to be larger than or equal to 0.');
+        return new Exception('Invalid Offset in Limit Query, it has to be larger than or equal to 0.');
     }
 
     /**
      * @param string $name
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function typeExists($name)
     {
-        return new self('Type ' . $name . ' already exists.');
+        return new Exception('Type ' . $name . ' already exists.');
     }
 
     /**
      * @param string $name
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function unknownColumnType($name)
     {
-        return new self('Unknown column type "' . $name . '" requested. Any Doctrine type that you use has ' .
+        return new Exception('Unknown column type "' . $name . '" requested. Any Doctrine type that you use has ' .
             'to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the ' .
             'known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database ' .
             'introspection then you might have forgotten to register all database types for a Doctrine Type. Use ' .
@@ -290,23 +291,23 @@ class DBALException extends Exception
     /**
      * @param string $name
      *
-     * @return DBALException
+     * @return Exception
      */
     public static function typeNotFound($name)
     {
-        return new self('Type to be overwritten ' . $name . ' does not exist.');
+        return new Exception('Type to be overwritten ' . $name . ' does not exist.');
     }
 
     public static function typeNotRegistered(Type $type): self
     {
-        return new self(
+        return new Exception(
             sprintf('Type of the class %s@%s is not registered.', get_class($type), spl_object_hash($type))
         );
     }
 
     public static function typeAlreadyRegistered(Type $type): self
     {
-        return new self(
+        return new Exception(
             sprintf('Type of the class %s@%s is already registered.', get_class($type), spl_object_hash($type))
         );
     }

--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -3,9 +3,9 @@
 namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\ConnectionLost;
 use Doctrine\DBAL\Exception\DeadlockException;
@@ -131,7 +131,7 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
     /**
      * {@inheritdoc}
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function createDatabasePlatformForVersion($version)
     {
@@ -160,7 +160,7 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
      *
      * @param string $versionString Version string returned by the driver, i.e. '5.7.10'
      *
-     * @throws DBALException
+     * @throws Exception
      */
     private function getOracleMysqlVersionNumber(string $versionString): string
     {
@@ -171,7 +171,7 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
                 $versionParts
             )
         ) {
-            throw DBALException::invalidPlatformVersionSpecified(
+            throw Exception::invalidPlatformVersionSpecified(
                 $versionString,
                 '<major_version>.<minor_version>.<patch_version>'
             );
@@ -194,7 +194,7 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
      *
      * @param string $versionString Version string as returned by mariadb server, i.e. '5.5.5-Mariadb-10.0.8-xenial'
      *
-     * @throws DBALException
+     * @throws Exception
      */
     private function getMariaDbMysqlVersionNumber(string $versionString): string
     {
@@ -205,7 +205,7 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
                 $versionParts
             )
         ) {
-            throw DBALException::invalidPlatformVersionSpecified(
+            throw Exception::invalidPlatformVersionSpecified(
                 $versionString,
                 '^(?:5\.5\.5-)?(mariadb-)?<major_version>.<minor_version>.<patch_version>'
             );

--- a/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php
@@ -3,9 +3,9 @@
 namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\DriverException;
@@ -102,7 +102,7 @@ abstract class AbstractPostgreSQLDriver implements Driver, ExceptionConverterDri
     public function createDatabasePlatformForVersion($version)
     {
         if (! preg_match('/^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?/', $version, $versionParts)) {
-            throw DBALException::invalidPlatformVersionSpecified(
+            throw Exception::invalidPlatformVersionSpecified(
                 $version,
                 '<major_version>.<minor_version>.<patch_version>'
             );

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
@@ -3,9 +3,9 @@
 namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\DriverException;
@@ -103,7 +103,7 @@ abstract class AbstractSQLAnywhereDriver implements Driver, ExceptionConverterDr
                 $versionParts
             )
         ) {
-            throw DBALException::invalidPlatformVersionSpecified(
+            throw Exception::invalidPlatformVersionSpecified(
                 $version,
                 '<major_version>.<minor_version>.<patch_version>.<build_version>'
             );

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLServerDriver.php
@@ -3,9 +3,9 @@
 namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\DriverException as TheDriverException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\SQLServer2005Platform;
 use Doctrine\DBAL\Platforms\SQLServer2008Platform;
@@ -35,7 +35,7 @@ abstract class AbstractSQLServerDriver implements Driver, VersionAwarePlatformDr
                 $versionParts
             )
         ) {
-            throw DBALException::invalidPlatformVersionSpecified(
+            throw Exception::invalidPlatformVersionSpecified(
                 $version,
                 '<major_version>.<minor_version>.<patch_version>.<build_version>'
             );

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\DBAL\Driver\Mysqli;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Doctrine\DBAL\Exception;
 
 class Driver extends AbstractMySQLDriver
 {
@@ -15,7 +15,7 @@ class Driver extends AbstractMySQLDriver
         try {
             return new Connection($params, (string) $username, (string) $password, $driverOptions);
         } catch (MysqliException $e) {
-            throw DBALException::driverException($this, $e);
+            throw Exception::driverException($this, $e);
         }
     }
 

--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\DBAL\Driver\OCI8;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
+use Doctrine\DBAL\Exception;
 
 use const OCI_NO_AUTO_COMMIT;
 
@@ -27,7 +27,7 @@ class Driver extends AbstractOracleDriver
                 $params['persistent'] ?? false
             );
         } catch (OCI8Exception $e) {
-            throw DBALException::driverException($this, $e);
+            throw Exception::driverException($this, $e);
         }
     }
 

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\DBAL\Driver\PDOMySql;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Driver\PDO;
+use Doctrine\DBAL\Exception;
 use PDOException;
 
 /**
@@ -27,7 +27,7 @@ class Driver extends AbstractMySQLDriver
                 $driverOptions
             );
         } catch (PDOException $e) {
-            throw DBALException::driverException($this, $e);
+            throw Exception::driverException($this, $e);
         }
 
         return $conn;

--- a/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\DBAL\Driver\PDOOracle;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
 use Doctrine\DBAL\Driver\PDO;
+use Doctrine\DBAL\Exception;
 use PDOException;
 
 /**
@@ -32,7 +32,7 @@ class Driver extends AbstractOracleDriver
                 $driverOptions
             );
         } catch (PDOException $e) {
-            throw DBALException::driverException($this, $e);
+            throw Exception::driverException($this, $e);
         }
     }
 

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\DBAL\Driver\PDOPgSql;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
 use Doctrine\DBAL\Driver\PDO;
+use Doctrine\DBAL\Exception;
 use PDOException;
 
 use function defined;
@@ -48,7 +48,7 @@ class Driver extends AbstractPostgreSQLDriver
 
             return $pdo;
         } catch (PDOException $e) {
-            throw DBALException::driverException($this, $e);
+            throw Exception::driverException($this, $e);
         }
     }
 

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\DBAL\Driver\PDOSqlite;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use Doctrine\DBAL\Driver\PDO;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use PDOException;
 
@@ -45,7 +45,7 @@ class Driver extends AbstractSQLiteDriver
                 $driverOptions
             );
         } catch (PDOException $ex) {
-            throw DBALException::driverException($this, $ex);
+            throw Exception::driverException($this, $ex);
         }
 
         foreach ($this->_userDefinedFunctions as $fn => $data) {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\DBAL\Driver\SQLAnywhere;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\AbstractSQLAnywhereDriver;
+use Doctrine\DBAL\Exception;
 
 use function array_keys;
 use function array_map;
@@ -17,7 +17,7 @@ class Driver extends AbstractSQLAnywhereDriver
     /**
      * {@inheritdoc}
      *
-     * @throws DBALException If there was a problem establishing the connection.
+     * @throws Exception If there was a problem establishing the connection.
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
@@ -35,7 +35,7 @@ class Driver extends AbstractSQLAnywhereDriver
                 $params['persistent'] ?? false
             );
         } catch (SQLAnywhereException $e) {
-            throw DBALException::driverException($this, $e);
+            throw Exception::driverException($this, $e);
         }
     }
 

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -117,7 +117,7 @@ final class DriverManager
      * @param Configuration|null                    $config       The configuration to use.
      * @param EventManager|null                     $eventManager The event manager to use.
      *
-     * @throws DBALException
+     * @throws Exception
      *
      * @phpstan-param mixed[] $params
      * @psalm-return ($params is array{wrapperClass:mixed} ? T : Connection)
@@ -175,7 +175,7 @@ final class DriverManager
 
         // check for existing pdo object
         if (isset($params['pdo']) && ! $params['pdo'] instanceof \PDO) {
-            throw DBALException::invalidPdoInstance();
+            throw Exception::invalidPdoInstance();
         }
 
         if (isset($params['pdo'])) {
@@ -192,7 +192,7 @@ final class DriverManager
         $wrapperClass = Connection::class;
         if (isset($params['wrapperClass'])) {
             if (! is_subclass_of($params['wrapperClass'], $wrapperClass)) {
-                throw DBALException::invalidWrapperClass($params['wrapperClass']);
+                throw Exception::invalidWrapperClass($params['wrapperClass']);
             }
 
             $wrapperClass = $params['wrapperClass'];
@@ -216,7 +216,7 @@ final class DriverManager
      *
      * @param mixed[] $params The list of parameters.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     private static function _checkParams(array $params): void
     {
@@ -224,21 +224,21 @@ final class DriverManager
 
         // driver
         if (! isset($params['driver']) && ! isset($params['driverClass'])) {
-            throw DBALException::driverRequired();
+            throw Exception::driverRequired();
         }
 
         // check validity of parameters
 
         // driver
         if (isset($params['driver']) && ! isset(self::$_driverMap[$params['driver']])) {
-            throw DBALException::unknownDriver($params['driver'], array_keys(self::$_driverMap));
+            throw Exception::unknownDriver($params['driver'], array_keys(self::$_driverMap));
         }
 
         if (
             isset($params['driverClass'])
             && ! in_array(Driver::class, class_implements($params['driverClass'], true))
         ) {
-            throw DBALException::invalidDriverClass($params['driverClass']);
+            throw Exception::invalidDriverClass($params['driverClass']);
         }
     }
 
@@ -262,7 +262,7 @@ final class DriverManager
      * @return mixed[] A modified list of parameters with info from a database
      *                 URL extracted into indidivual parameter parts.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     private static function parseDatabaseUrl(array $params): array
     {
@@ -277,7 +277,7 @@ final class DriverManager
         $url = parse_url($url);
 
         if ($url === false) {
-            throw new DBALException('Malformed parameter "url".');
+            throw new Exception('Malformed parameter "url".');
         }
 
         $url = array_map('rawurldecode', $url);
@@ -417,7 +417,7 @@ final class DriverManager
      *
      * @return mixed[] The resolved connection parameters.
      *
-     * @throws DBALException If parsing failed or resolution is not possible.
+     * @throws Exception If parsing failed or resolution is not possible.
      */
     private static function parseDatabaseUrlScheme(array $url, array $params): array
     {
@@ -442,7 +442,7 @@ final class DriverManager
         // If a schemeless connection URL is given, we require a default driver or default custom driver
         // as connection parameter.
         if (! isset($params['driverClass']) && ! isset($params['driver'])) {
-            throw DBALException::driverRequired($params['url']);
+            throw Exception::driverRequired($params['url']);
         }
 
         return $params;

--- a/lib/Doctrine/DBAL/Exception.php
+++ b/lib/Doctrine/DBAL/Exception.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\DBAL;
+
+/**
+ * @psalm-immutable
+ */
+class Exception extends DBALException
+{
+}

--- a/lib/Doctrine/DBAL/Exception/DriverException.php
+++ b/lib/Doctrine/DBAL/Exception/DriverException.php
@@ -2,15 +2,15 @@
 
 namespace Doctrine\DBAL\Exception;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
+use Doctrine\DBAL\Exception;
 
 /**
  * Base class for all errors detected in the driver.
  *
  * @psalm-immutable
  */
-class DriverException extends DBALException
+class DriverException extends Exception
 {
     /**
      * The previous DBAL driver exception.

--- a/lib/Doctrine/DBAL/Exception/DriverException.php
+++ b/lib/Doctrine/DBAL/Exception/DriverException.php
@@ -4,7 +4,6 @@ namespace Doctrine\DBAL\Exception;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\DriverException as DeprecatedDriverException;
-use Exception;
 
 /**
  * Base class for all errors detected in the driver.
@@ -26,13 +25,7 @@ class DriverException extends DBALException
      */
     public function __construct($message, DeprecatedDriverException $driverException)
     {
-        $exception = null;
-
-        if ($driverException instanceof Exception) {
-            $exception = $driverException;
-        }
-
-        parent::__construct($message, 0, $exception);
+        parent::__construct($message, 0, $driverException);
 
         $this->driverException = $driverException;
     }

--- a/lib/Doctrine/DBAL/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/DBAL/Exception/InvalidArgumentException.php
@@ -2,14 +2,14 @@
 
 namespace Doctrine\DBAL\Exception;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 
 /**
  * Exception to be thrown when invalid arguments are passed to any DBAL API
  *
  * @psalm-immutable
  */
-class InvalidArgumentException extends DBALException
+class InvalidArgumentException extends Exception
 {
     /**
      * @return self

--- a/lib/Doctrine/DBAL/Id/TableGenerator.php
+++ b/lib/Doctrine/DBAL/Id/TableGenerator.php
@@ -3,9 +3,9 @@
 namespace Doctrine\DBAL\Id;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\LockMode;
 use Throwable;
 
@@ -66,12 +66,12 @@ class TableGenerator
     /**
      * @param string $generatorTableName
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function __construct(Connection $conn, $generatorTableName = 'sequences')
     {
         if ($conn->getDriver() instanceof Driver\PDOSqlite\Driver) {
-            throw new DBALException('Cannot use TableGenerator with SQLite.');
+            throw new Exception('Cannot use TableGenerator with SQLite.');
         }
 
         $this->conn = DriverManager::getConnection(
@@ -90,7 +90,7 @@ class TableGenerator
      *
      * @return int
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function nextValue($sequence)
     {
@@ -134,7 +134,7 @@ class TableGenerator
                 $rows = $this->conn->executeStatement($sql, [$sequence, $row['sequence_value']]);
 
                 if ($rows !== 1) {
-                    throw new DBALException('Race-condition detected while updating sequence. Aborting generation');
+                    throw new Exception('Race-condition detected while updating sequence. Aborting generation');
                 }
             } else {
                 $this->conn->insert(
@@ -148,7 +148,7 @@ class TableGenerator
         } catch (Throwable $e) {
             $this->conn->rollBack();
 
-            throw new DBALException(
+            throw new Exception(
                 'Error occurred while generating ID with TableGenerator, aborted generation: ' . $e->getMessage(),
                 0,
                 $e

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3,7 +3,6 @@
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\Common\EventManager;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Event\SchemaAlterTableAddColumnEventArgs;
 use Doctrine\DBAL\Event\SchemaAlterTableChangeColumnEventArgs;
 use Doctrine\DBAL\Event\SchemaAlterTableEventArgs;
@@ -13,6 +12,7 @@ use Doctrine\DBAL\Event\SchemaCreateTableColumnEventArgs;
 use Doctrine\DBAL\Event\SchemaCreateTableEventArgs;
 use Doctrine\DBAL\Event\SchemaDropTableEventArgs;
 use Doctrine\DBAL\Events;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
@@ -343,11 +343,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
-        throw DBALException::notSupported('VARCHARs not supported by Platform.');
+        throw Exception::notSupported('VARCHARs not supported by Platform.');
     }
 
     /**
@@ -358,11 +358,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
     {
-        throw DBALException::notSupported('BINARY/VARBINARY column types are not supported by this platform.');
+        throw Exception::notSupported('BINARY/VARBINARY column types are not supported by this platform.');
     }
 
     /**
@@ -398,7 +398,7 @@ abstract class AbstractPlatform
      *
      * @return void
      *
-     * @throws DBALException If the type is not found.
+     * @throws Exception If the type is not found.
      */
     public function registerDoctrineTypeMapping($dbType, $doctrineType)
     {
@@ -407,7 +407,7 @@ abstract class AbstractPlatform
         }
 
         if (! Types\Type::hasType($doctrineType)) {
-            throw DBALException::typeNotFound($doctrineType);
+            throw Exception::typeNotFound($doctrineType);
         }
 
         $dbType                             = strtolower($dbType);
@@ -429,7 +429,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function getDoctrineTypeMapping($dbType)
     {
@@ -440,7 +440,7 @@ abstract class AbstractPlatform
         $dbType = strtolower($dbType);
 
         if (! isset($this->doctrineTypeMapping[$dbType])) {
-            throw new DBALException(
+            throw new Exception(
                 'Unknown database type ' . $dbType . ' requested, ' . static::class . ' may not support it.'
             );
         }
@@ -639,11 +639,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getRegexpExpression()
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -653,11 +653,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getGuidExpression()
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -885,11 +885,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getLocateExpression($str, $substr, $startPos = false)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -1056,11 +1056,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateDiffExpression($date1, $date2)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -1071,7 +1071,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateAddSecondsExpression($date, $seconds)
     {
@@ -1086,7 +1086,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateSubSecondsExpression($date, $seconds)
     {
@@ -1101,7 +1101,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateAddMinutesExpression($date, $minutes)
     {
@@ -1116,7 +1116,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateSubMinutesExpression($date, $minutes)
     {
@@ -1131,7 +1131,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateAddHourExpression($date, $hours)
     {
@@ -1146,7 +1146,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateSubHourExpression($date, $hours)
     {
@@ -1161,7 +1161,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateAddDaysExpression($date, $days)
     {
@@ -1176,7 +1176,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateSubDaysExpression($date, $days)
     {
@@ -1191,7 +1191,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateAddWeeksExpression($date, $weeks)
     {
@@ -1206,7 +1206,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateSubWeeksExpression($date, $weeks)
     {
@@ -1221,7 +1221,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateAddMonthExpression($date, $months)
     {
@@ -1236,7 +1236,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateSubMonthExpression($date, $months)
     {
@@ -1251,7 +1251,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateAddQuartersExpression($date, $quarters)
     {
@@ -1266,7 +1266,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateSubQuartersExpression($date, $quarters)
     {
@@ -1281,7 +1281,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateAddYearsExpression($date, $years)
     {
@@ -1296,7 +1296,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateSubYearsExpression($date, $years)
     {
@@ -1314,11 +1314,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     protected function getDateArithmeticIntervalExpression($date, $operator, $interval, $unit)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -1541,7 +1541,7 @@ abstract class AbstractPlatform
      *
      * @return string[] The sequence of SQL statements.
      *
-     * @throws DBALException
+     * @throws Exception
      * @throws InvalidArgumentException
      */
     public function getCreateTableSQL(Table $table, $createFlags = self::CREATE_INDEXES)
@@ -1553,7 +1553,7 @@ abstract class AbstractPlatform
         }
 
         if (count($table->getColumns()) === 0) {
-            throw DBALException::noColumnsSpecifiedForTable($table->getName());
+            throw Exception::noColumnsSpecifiedForTable($table->getName());
         }
 
         $tableName                    = $table->getQuotedName($this);
@@ -1682,12 +1682,12 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getInlineColumnCommentSQL($comment)
     {
         if (! $this->supportsInlineColumnComments()) {
-            throw DBALException::notSupported(__METHOD__);
+            throw Exception::notSupported(__METHOD__);
         }
 
         return 'COMMENT ' . $this->quoteStringLiteral($comment);
@@ -1755,11 +1755,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getCreateSequenceSQL(Sequence $sequence)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -1767,11 +1767,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getAlterSequenceSQL(Sequence $sequence)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -1895,11 +1895,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getCreateSchemaSQL($schemaName)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -1964,11 +1964,11 @@ abstract class AbstractPlatform
      *
      * @return string[]
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getAlterTableSQL(TableDiff $diff)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2793,11 +2793,11 @@ abstract class AbstractPlatform
     /**
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getListDatabasesSQL()
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2805,11 +2805,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getListNamespacesSQL()
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2817,11 +2817,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getListSequencesSQL($database)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2829,11 +2829,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getListTableConstraintsSQL($table)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2842,31 +2842,31 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getListTableColumnsSQL($table, $database = null)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getListTablesSQL()
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getListUsersSQL()
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2876,11 +2876,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getListViewsSQL($database)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2898,11 +2898,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getListTableIndexesSQL($table, $database = null)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2910,11 +2910,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getListTableForeignKeysSQL($table)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2923,11 +2923,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getCreateViewSQL($name, $sql)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2935,11 +2935,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDropViewSQL($name)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2949,11 +2949,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDropSequenceSQL($sequence)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2961,11 +2961,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getSequenceNextValSQL($sequence)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2975,11 +2975,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getCreateDatabaseSQL($database)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -2989,11 +2989,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getSetTransactionIsolationSQL($level)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -3004,11 +3004,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateTimeTypeDeclarationSQL(array $column)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -3031,11 +3031,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDateTypeDeclarationSQL(array $column)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -3046,11 +3046,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getTimeTypeDeclarationSQL(array $column)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -3124,11 +3124,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getIdentitySequenceName($tableName, $columnName)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -3269,11 +3269,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     public function getDefaultSchemaName()
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -3423,7 +3423,7 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException
+     * @throws Exception
      */
     final public function modifyLimitQuery($query, $limit, $offset = null)
     {
@@ -3434,14 +3434,14 @@ abstract class AbstractPlatform
         $offset = (int) $offset;
 
         if ($offset < 0) {
-            throw new DBALException(sprintf(
+            throw new Exception(sprintf(
                 'Offset must be a positive integer or zero, %d given',
                 $offset
             ));
         }
 
         if ($offset > 0 && ! $this->supportsLimitOffset()) {
-            throw new DBALException(sprintf(
+            throw new Exception(sprintf(
                 'Platform %s does not support offset values in limit queries.',
                 $this->getName()
             ));
@@ -3605,7 +3605,7 @@ abstract class AbstractPlatform
      *
      * @return KeywordList
      *
-     * @throws DBALException If no keyword list is specified.
+     * @throws Exception If no keyword list is specified.
      */
     final public function getReservedKeywordsList()
     {
@@ -3617,7 +3617,7 @@ abstract class AbstractPlatform
         $class    = $this->getReservedKeywordsClass();
         $keywords = new $class();
         if (! $keywords instanceof KeywordList) {
-            throw DBALException::notSupported(__METHOD__);
+            throw Exception::notSupported(__METHOD__);
         }
 
         // Store the instance so it doesn't need to be generated on every request.
@@ -3631,11 +3631,11 @@ abstract class AbstractPlatform
      *
      * @return string
      *
-     * @throws DBALException If not supported on this platform.
+     * @throws Exception If not supported on this platform.
      */
     protected function getReservedKeywordsClass()
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
@@ -481,7 +481,7 @@ class DB2Platform extends AbstractPlatform
     public function getIndexDeclarationSQL($name, Index $index)
     {
         // Index declaration in statements like CREATE TABLE is not supported.
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
@@ -40,12 +40,12 @@ class OraclePlatform extends AbstractPlatform
      *
      * @return void
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public static function assertValidIdentifier($identifier)
     {
         if (! preg_match('(^(([a-zA-Z]{1}[a-zA-Z0-9_$#]{0,})|("[^"]+"))$)', $identifier)) {
-            throw new DBALException('Invalid Oracle identifier');
+            throw new Exception('Invalid Oracle identifier');
         }
     }
 

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
@@ -691,7 +691,7 @@ class SQLAnywherePlatform extends AbstractPlatform
     public function getIndexDeclarationSQL($name, Index $index)
     {
         // Index declaration in statements like CREATE TABLE is not supported.
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Constraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -697,7 +697,7 @@ class SqlitePlatform extends AbstractPlatform
     protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff)
     {
         if (! $diff->fromTable instanceof Table) {
-            throw new DBALException(
+            throw new Exception(
                 'Sqlite platform requires for alter table the table diff with reference to original table schema'
             );
         }
@@ -720,7 +720,7 @@ class SqlitePlatform extends AbstractPlatform
     protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff)
     {
         if (! $diff->fromTable instanceof Table) {
-            throw new DBALException(
+            throw new Exception(
                 'Sqlite platform requires for alter table the table diff with reference to original table schema'
             );
         }
@@ -805,7 +805,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getCreatePrimaryKeySQL(Index $index, $table)
     {
-        throw new DBALException('Sqlite platform does not support alter primary key.');
+        throw new Exception('Sqlite platform does not support alter primary key.');
     }
 
     /**
@@ -813,7 +813,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, $table)
     {
-        throw new DBALException(
+        throw new Exception(
             'Sqlite platform does not support alter foreign key, '
             . 'the table must be fully recreated using getAlterTableSQL.'
         );
@@ -824,7 +824,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getDropForeignKeySQL($foreignKey, $table)
     {
-        throw new DBALException(
+        throw new Exception(
             'Sqlite platform does not support alter foreign key, '
             . 'the table must be fully recreated using getAlterTableSQL.'
         );
@@ -835,7 +835,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getCreateConstraintSQL(Constraint $constraint, $table)
     {
-        throw new DBALException('Sqlite platform does not support alter constraint.');
+        throw new Exception('Sqlite platform does not support alter constraint.');
     }
 
     /**
@@ -875,7 +875,7 @@ class SqlitePlatform extends AbstractPlatform
 
         $fromTable = $diff->fromTable;
         if (! $fromTable instanceof Table) {
-            throw new DBALException(
+            throw new Exception(
                 'Sqlite platform requires for alter table the table diff with reference to original table schema'
             );
         }

--- a/lib/Doctrine/DBAL/Query/QueryException.php
+++ b/lib/Doctrine/DBAL/Query/QueryException.php
@@ -2,14 +2,14 @@
 
 namespace Doctrine\DBAL\Query;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 
 use function implode;
 
 /**
  * @psalm-immutable
  */
-class QueryException extends DBALException
+class QueryException extends Exception
 {
     /**
      * @param string   $alias

--- a/lib/Doctrine/DBAL/SQLParserUtilsException.php
+++ b/lib/Doctrine/DBAL/SQLParserUtilsException.php
@@ -9,7 +9,7 @@ use function sprintf;
  *
  * @psalm-immutable
  */
-class SQLParserUtilsException extends DBALException
+class SQLParserUtilsException extends Exception
 {
     /**
      * @param string $paramName

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -4,10 +4,10 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ConnectionException;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Event\SchemaColumnDefinitionEventArgs;
 use Doctrine\DBAL\Event\SchemaIndexDefinitionEventArgs;
 use Doctrine\DBAL\Events;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Throwable;
 
@@ -776,11 +776,11 @@ abstract class AbstractSchemaManager
      *
      * @return Sequence
      *
-     * @throws DBALException
+     * @throws Exception
      */
     protected function _getPortableSequenceDefinition($sequence)
     {
-        throw DBALException::notSupported('Sequences');
+        throw Exception::notSupported('Sequences');
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/SchemaException.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaException.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Schema;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 
 use function implode;
 use function sprintf;
@@ -10,7 +10,7 @@ use function sprintf;
 /**
  * @psalm-immutable
  */
-class SchemaException extends DBALException
+class SchemaException extends Exception
 {
     public const TABLE_DOESNT_EXIST       = 10;
     public const TABLE_ALREADY_EXISTS     = 20;

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\DBAL\Schema;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
@@ -455,7 +455,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
      *
      * @return TableDiff
      *
-     * @throws DBALException
+     * @throws Exception
      */
     private function getTableDiffForAlterForeignKey($table)
     {
@@ -463,7 +463,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
             $tableDetails = $this->tryMethod('listTableDetails', $table);
 
             if ($tableDetails === false) {
-                throw new DBALException(
+                throw new Exception(
                     sprintf('Sqlite schema manager requires to modify foreign keys table definition "%s".', $table)
                 );
             }

--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Schema;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 use Doctrine\DBAL\Types\Type;
 
@@ -51,7 +51,7 @@ class Table extends AbstractAsset
      * @param int                    $idGeneratorType
      * @param mixed[]                $options
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function __construct(
         $name,
@@ -62,7 +62,7 @@ class Table extends AbstractAsset
         array $options = []
     ) {
         if (strlen($name) === 0) {
-            throw DBALException::invalidTableName($name);
+            throw Exception::invalidTableName($name);
         }
 
         $this->_setName($name);
@@ -316,11 +316,11 @@ class Table extends AbstractAsset
      *
      * @return void
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function renameColumn($oldName, $name)
     {
-        throw new DBALException('Table#renameColumn() was removed, because it drops and recreates ' .
+        throw new Exception('Table#renameColumn() was removed, because it drops and recreates ' .
             'the column instead. There is no fix available, because a schema diff cannot reliably detect if a ' .
             'column was renamed or one column was created and another one dropped.');
     }
@@ -727,14 +727,14 @@ class Table extends AbstractAsset
      *
      * @return string[]
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function getPrimaryKeyColumns()
     {
         $primaryKey = $this->getPrimaryKey();
 
         if ($primaryKey === null) {
-            throw new DBALException('Table ' . $this->getName() . ' has no primary key.');
+            throw new Exception('Table ' . $this->getName() . ' has no primary key.');
         }
 
         return $primaryKey->getColumns();

--- a/lib/Doctrine/DBAL/Sharding/ShardingException.php
+++ b/lib/Doctrine/DBAL/Sharding/ShardingException.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Sharding;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 
 /**
  * Sharding related Exceptions
@@ -11,7 +11,7 @@ use Doctrine\DBAL\DBALException;
  *
  * @psalm-immutable
  */
-class ShardingException extends DBALException
+class ShardingException extends Exception
 {
     /**
      * @return ShardingException

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -143,7 +143,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      *
      * @return bool TRUE on success, FALSE on failure.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function execute($params = null)
     {
@@ -280,7 +280,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /**
      * {@inheritdoc}
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchNumeric()
     {
@@ -298,7 +298,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /**
      * {@inheritdoc}
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchAssociative()
     {
@@ -316,7 +316,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /**
      * {@inheritDoc}
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchOne()
     {
@@ -334,7 +334,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /**
      * {@inheritdoc}
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchAllNumeric(): array
     {
@@ -352,7 +352,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /**
      * {@inheritdoc}
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchAllAssociative(): array
     {
@@ -370,7 +370,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /**
      * {@inheritdoc}
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function fetchFirstColumn(): array
     {
@@ -390,7 +390,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      *
      * @return Traversable<int,array<int,mixed>>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function iterateNumeric(): Traversable
     {
@@ -414,7 +414,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      *
      * @return Traversable<int,array<string,mixed>>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function iterateAssociative(): Traversable
     {
@@ -438,7 +438,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      *
      * @return Traversable<int,mixed>
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function iterateColumn(): Traversable
     {

--- a/lib/Doctrine/DBAL/Types/ConversionException.php
+++ b/lib/Doctrine/DBAL/Types/ConversionException.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Types;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Throwable;
 
 use function get_class;
@@ -19,7 +19,7 @@ use function substr;
  *
  * @psalm-immutable
  */
-class ConversionException extends DBALException
+class ConversionException extends Exception
 {
     /**
      * Thrown when a Database to Doctrine Type Conversion fails.

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Types;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
@@ -225,7 +225,7 @@ abstract class Type
      *
      * @return Type
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public static function getType($name)
     {
@@ -240,7 +240,7 @@ abstract class Type
      *
      * @return void
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public static function addType($name, $className)
     {
@@ -267,7 +267,7 @@ abstract class Type
      *
      * @return void
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public static function overrideType($name, $className)
     {

--- a/lib/Doctrine/DBAL/Types/TypeRegistry.php
+++ b/lib/Doctrine/DBAL/Types/TypeRegistry.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Types;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 
 use function array_search;
 use function in_array;
@@ -31,12 +31,12 @@ final class TypeRegistry
     /**
      * Finds a type by the given name.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function get(string $name): Type
     {
         if (! isset($this->instances[$name])) {
-            throw DBALException::unknownColumnType($name);
+            throw Exception::unknownColumnType($name);
         }
 
         return $this->instances[$name];
@@ -45,14 +45,14 @@ final class TypeRegistry
     /**
      * Finds a name for the given type.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function lookupName(Type $type): string
     {
         $name = $this->findTypeName($type);
 
         if ($name === null) {
-            throw DBALException::typeNotRegistered($type);
+            throw Exception::typeNotRegistered($type);
         }
 
         return $name;
@@ -69,16 +69,16 @@ final class TypeRegistry
     /**
      * Registers a custom type to the type map.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function register(string $name, Type $type): void
     {
         if (isset($this->instances[$name])) {
-            throw DBALException::typeExists($name);
+            throw Exception::typeExists($name);
         }
 
         if ($this->findTypeName($type) !== null) {
-            throw DBALException::typeAlreadyRegistered($type);
+            throw Exception::typeAlreadyRegistered($type);
         }
 
         $this->instances[$name] = $type;
@@ -87,16 +87,16 @@ final class TypeRegistry
     /**
      * Overrides an already defined type to use a different implementation.
      *
-     * @throws DBALException
+     * @throws Exception
      */
     public function override(string $name, Type $type): void
     {
         if (! isset($this->instances[$name])) {
-            throw DBALException::typeNotFound($name);
+            throw Exception::typeNotFound($name);
         }
 
         if (! in_array($this->findTypeName($type), [$name, null], true)) {
-            throw DBALException::typeAlreadyRegistered($type);
+            throw Exception::typeAlreadyRegistered($type);
         }
 
         $this->instances[$name] = $type;

--- a/lib/Doctrine/DBAL/VersionAwarePlatformDriver.php
+++ b/lib/Doctrine/DBAL/VersionAwarePlatformDriver.php
@@ -22,7 +22,7 @@ interface VersionAwarePlatformDriver
      *
      * @return AbstractPlatform
      *
-     * @throws DBALException If the given version string could not be evaluated.
+     * @throws Exception If the given version string could not be evaluated.
      */
     public function createDatabasePlatformForVersion($version);
 }

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -9,13 +9,13 @@ use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ConnectionException;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Events;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Logging\DebugStack;
@@ -23,7 +23,6 @@ use Doctrine\DBAL\Logging\EchoSQLLogger;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Tests\DbalTestCase;
-use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
@@ -183,7 +182,7 @@ class ConnectionTest extends DbalTestCase
      */
     public function testDriverExceptionIsWrapped(string $method): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage(<<<EOF
 An exception occurred while executing 'MUUHAAAAHAAAA':
 
@@ -833,7 +832,7 @@ EOF
 
         $driver = $this->createMock(Driver::class);
 
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         new Connection($connectionParams, $driver);
     }
@@ -843,8 +842,8 @@ EOF
         $driverMock = $this->createMock(FutureVersionAwarePlatformDriver::class);
 
         $connection        = new Connection(['dbname' => 'foo'], $driverMock);
-        $originalException = new Exception('Original exception');
-        $fallbackException = new Exception('Fallback exception');
+        $originalException = new \Exception('Original exception');
+        $fallbackException = new \Exception('Fallback exception');
 
         $driverMock->method('connect')
             ->will(self::onConsecutiveCalls(

--- a/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/DBALExceptionTest.php
@@ -2,12 +2,11 @@
 
 namespace Doctrine\Tests\DBAL;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\DriverException as InnerDriverException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\Tests\DbalTestCase;
-use Exception;
 use stdClass;
 
 use function chr;
@@ -19,7 +18,7 @@ class DBALExceptionTest extends DbalTestCase
     public function testDriverExceptionDuringQueryAcceptsBinaryData(): void
     {
         $driver = $this->createMock(Driver::class);
-        $e      = DBALException::driverExceptionDuringQuery($driver, new Exception(), '', ['ABC', chr(128)]);
+        $e      = Exception::driverExceptionDuringQuery($driver, new \Exception(), '', ['ABC', chr(128)]);
         self::assertStringContainsString('with params ["ABC", "\x80"]', $e->getMessage());
     }
 
@@ -27,9 +26,9 @@ class DBALExceptionTest extends DbalTestCase
     {
         $driver = $this->createMock(Driver::class);
 
-        $e = DBALException::driverExceptionDuringQuery(
+        $e = Exception::driverExceptionDuringQuery(
             $driver,
-            new Exception(),
+            new \Exception(),
             'INSERT INTO file (`content`) VALUES (?)',
             [1 => fopen(__FILE__, 'r')]
         );
@@ -44,16 +43,16 @@ class DBALExceptionTest extends DbalTestCase
         $inner = $this->createMock(InnerDriverException::class);
 
         $ex = new DriverException('', $inner);
-        $e  = DBALException::driverExceptionDuringQuery($driver, $ex, '');
+        $e  = Exception::driverExceptionDuringQuery($driver, $ex, '');
         self::assertSame($ex, $e);
     }
 
     public function testDriverRequiredWithUrl(): void
     {
         $url       = 'mysql://localhost';
-        $exception = DBALException::driverRequired($url);
+        $exception = Exception::driverRequired($url);
 
-        self::assertInstanceOf(DBALException::class, $exception);
+        self::assertInstanceOf(Exception::class, $exception);
         self::assertSame(
             sprintf(
                 "The options 'driver' or 'driverClass' are mandatory if a connection URL without scheme " .
@@ -66,7 +65,7 @@ class DBALExceptionTest extends DbalTestCase
 
     public function testInvalidPlatformTypeObject(): void
     {
-        $exception = DBALException::invalidPlatformType(new stdClass());
+        $exception = Exception::invalidPlatformType(new stdClass());
 
         self::assertSame(
             "Option 'platform' must be a subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform', "
@@ -77,7 +76,7 @@ class DBALExceptionTest extends DbalTestCase
 
     public function testInvalidPlatformTypeScalar(): void
     {
-        $exception = DBALException::invalidPlatformType('some string');
+        $exception = Exception::invalidPlatformType('some string');
 
         self::assertSame(
             "Option 'platform' must be an object and subtype of 'Doctrine\DBAL\Platforms\AbstractPlatform'. "

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
@@ -3,10 +3,10 @@
 namespace Doctrine\Tests\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\DriverException as DriverExceptionInterface;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\ConstraintViolationException;
 use Doctrine\DBAL\Exception\DatabaseObjectExistsException;
@@ -138,7 +138,7 @@ abstract class AbstractDriverTest extends DbalTestCase
             $this->markTestSkipped('This test is only intended for version aware platform drivers.');
         }
 
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $this->driver->createDatabasePlatformForVersion('foo');
     }
 

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -4,13 +4,13 @@ namespace Doctrine\Tests\DBAL;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver as DrizzlePDOMySqlDriver;
 use Doctrine\DBAL\Driver\PDO\MySQL\Driver as PDOMySQLDriver;
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver as PDOSQLiteDriver;
 use Doctrine\DBAL\Driver\SQLSrv\Driver as SQLSrvDriver;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Sharding\PoolingShardConnection;
 use Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser;
@@ -30,7 +30,7 @@ class DriverManagerTest extends DbalTestCase
      */
     public function testInvalidPdoInstance(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         DriverManager::getConnection(['pdo' => 'test']);
     }
 
@@ -61,14 +61,14 @@ class DriverManagerTest extends DbalTestCase
 
     public function testCheckParams(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         DriverManager::getConnection([]);
     }
 
     public function testInvalidDriver(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         DriverManager::getConnection(['driver' => 'invalid_driver']);
     }
@@ -111,7 +111,7 @@ class DriverManagerTest extends DbalTestCase
      */
     public function testInvalidWrapperClass(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $options = [
             'pdo' => new PDO('sqlite::memory:'),
@@ -123,7 +123,7 @@ class DriverManagerTest extends DbalTestCase
 
     public function testInvalidDriverClass(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $options = ['driverClass' => stdClass::class];
 
@@ -227,7 +227,7 @@ class DriverManagerTest extends DbalTestCase
         $options = is_array($url) ? $url : ['url' => $url];
 
         if ($expected === false) {
-            $this->expectException(DBALException::class);
+            $this->expectException(Exception::class);
         }
 
         $conn = DriverManager::getConnection($options);

--- a/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php
@@ -4,13 +4,13 @@ namespace Doctrine\Tests\DBAL\Functional;
 
 use DateTime;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\IBMDB2\Driver as IBMDB2Driver;
 use Doctrine\DBAL\Driver\Mysqli\Driver as MySQLiDriver;
 use Doctrine\DBAL\Driver\OCI8\Driver as Oci8Driver;
 use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
 use Doctrine\DBAL\Driver\PDO\OCI\Driver as PDOOCIDriver;
 use Doctrine\DBAL\Driver\SQLSrv\Driver as SQLSrvDriver;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -267,7 +267,7 @@ class DataAccessTest extends DbalFunctionalTestCase
         $datetime       = new DateTime($datetimeString);
         $sql            = 'SELECT test_int, test_datetime FROM fetch_table WHERE test_int = ? AND test_datetime = ?';
 
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $fetch($this->connection, $sql, [1, $datetime]);
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\BlobType;
@@ -19,7 +19,7 @@ class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
      */
     public function testListDatabases(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $this->schemaManager->listDatabases();
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL630Test.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Ticket;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\PDO\Connection;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use PDO;
@@ -28,7 +28,7 @@ class DBAL630Test extends DbalFunctionalTestCase
         try {
             $this->connection->exec('CREATE TABLE dbal630 (id SERIAL, bool_col BOOLEAN NOT NULL);');
             $this->connection->exec('CREATE TABLE dbal630_allow_nulls (id SERIAL, bool_col BOOLEAN);');
-        } catch (DBALException $e) {
+        } catch (Exception $e) {
         }
 
         $this->running = true;

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -3,8 +3,8 @@
 namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\Common\EventManager;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Events;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Schema\Column;
@@ -90,7 +90,7 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
 
     public function testGetUnknownDoctrineMappingType(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $this->platform->getDoctrineTypeMapping('foobar');
     }
 
@@ -102,7 +102,7 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
 
     public function testRegisterUnknownDoctrineMappingType(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $this->platform->registerDoctrineTypeMapping('foo', 'bar');
     }
 
@@ -151,7 +151,7 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
     {
         $table = new Table('test');
 
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $sql = $this->platform->getCreateTableSQL($table);
     }
 
@@ -724,7 +724,7 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
         $index = new Index('select', ['foo']);
 
         if (! $this->supportsInlineIndexDeclaration()) {
-            $this->expectException(DBALException::class);
+            $this->expectException(Exception::class);
         }
 
         self::assertSame(
@@ -752,7 +752,7 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
 
     public function testGetCreateSchemaSQL(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $this->platform->getCreateSchemaSQL('schema');
     }
@@ -783,7 +783,7 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
 
     public function testReturnsIdentitySequenceName(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $this->platform->getIdentitySequenceName('mytable', 'mycolumn');
     }
@@ -810,7 +810,7 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
 
     public function testReturnsBinaryTypeDeclarationSQL(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $this->platform->getBinaryTypeDeclarationSQL([]);
     }
@@ -1218,7 +1218,7 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
             $this->markTestSkipped(sprintf('%s supports inline column comments.', get_class($this->platform)));
         }
 
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage(
             "Operation '" . AbstractPlatform::class . "::getInlineColumnCommentSQL' is not supported by platform."
         );
@@ -1247,7 +1247,7 @@ abstract class AbstractPlatformTestCase extends DbalTestCase
 
     public function testReturnsGuidTypeDeclarationSQL(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $this->platform->getGuidTypeDeclarationSQL([]);
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Platforms;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
@@ -61,7 +61,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
 
     public function testDoesNotSupportRegexp(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $this->platform->getRegexpExpression();
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -469,9 +469,6 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         $this->expectCteWithMaxRowNum($alteredSql, 1, $sql);
     }
 
-    /**
-     * @throws DBALException
-     */
     public function testModifyLimitSubqueryWithJoinAndSubqueryOrderedByColumnFromBaseTable(): void
     {
         $querySql   = 'SELECT DISTINCT id_0, name_1 '
@@ -493,9 +490,6 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         $this->expectCteWithMaxRowNum($alteredSql, 5, $sql);
     }
 
-    /**
-     * @throws DBALException
-     */
     public function testModifyLimitSubqueryWithJoinAndSubqueryOrderedByColumnFromJoinTable(): void
     {
         $querySql   = 'SELECT DISTINCT id_0, name_1 '
@@ -517,9 +511,6 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         $this->expectCteWithMaxRowNum($alteredSql, 5, $sql);
     }
 
-    /**
-     * @throws DBALException
-     */
     public function testModifyLimitSubqueryWithJoinAndSubqueryOrderedByColumnsFromBothTables(): void
     {
         $querySql   = 'SELECT DISTINCT id_0, name_1, foo_2 '

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Platforms;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Column;
@@ -74,7 +74,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
      */
     public function testInvalidIdentifiers(string $identifier): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $platform = $this->createPlatform();
         $platform->assertValidIdentifier($identifier);
@@ -120,7 +120,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
 
     public function testRLike(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         self::assertEquals('RLIKE', $this->platform->getRegexpExpression());
     }
@@ -156,7 +156,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
 
     public function testCreateDatabaseThrowsException(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         self::assertEquals('CREATE DATABASE foobar', $this->platform->getCreateDatabaseSQL('foobar'));
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Platforms;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLAnywherePlatform;
@@ -522,7 +522,7 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
 
     public function testDoesNotSupportIndexDeclarationInCreateAlterTableStatements(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $this->platform->getIndexDeclarationSQL('index', new Index('index', []));
     }
@@ -712,7 +712,7 @@ class SQLAnywherePlatformTest extends AbstractPlatformTestCase
 
     public function testDoesNotSupportRegexp(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $this->platform->getRegexpExpression();
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Platforms;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\Sequence;
@@ -370,9 +369,6 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
         self::assertEquals($sql, $expected);
     }
 
-    /**
-     * @throws DBALException
-     */
     public function testModifyLimitSubqueryWithJoinAndSubqueryOrderedByColumnFromBaseTable(): void
     {
         $querySql   = 'SELECT DISTINCT id_0, name_1 '
@@ -393,9 +389,6 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
         self::assertEquals($alteredSql, $sql);
     }
 
-    /**
-     * @throws DBALException
-     */
     public function testModifyLimitSubqueryWithJoinAndSubqueryOrderedByColumnFromJoinTable(): void
     {
         $querySql   = 'SELECT DISTINCT id_0, name_1 '
@@ -416,9 +409,6 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
         self::assertEquals($alteredSql, $sql);
     }
 
-    /**
-     * @throws DBALException
-     */
     public function testModifyLimitSubqueryWithJoinAndSubqueryOrderedByColumnsFromBothTables(): void
     {
         $querySql   = 'SELECT DISTINCT id_0, name_1, foo_2 '

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Platforms;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Column;
@@ -256,14 +256,14 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
 
     public function testGeneratesForeignKeyCreationSql(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         parent::testGeneratesForeignKeyCreationSql();
     }
 
     public function testGeneratesConstraintCreationSql(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         parent::testGeneratesConstraintCreationSql();
     }
@@ -345,7 +345,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
      */
     public function testAlterTableAddComplexColumns(TableDiff $diff): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $this->platform->getAlterTableSQL($diff);
     }

--- a/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Schema;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Column;
@@ -20,7 +20,7 @@ class TableTest extends DbalTestCase
 {
     public function testCreateWithInvalidTableName(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         new Table('');
     }

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -4,15 +4,14 @@ namespace Doctrine\Tests\DBAL;
 
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Statement;
 use Doctrine\Tests\DbalTestCase;
-use Exception;
 use PDOStatement;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -133,7 +132,7 @@ class StatementTest extends DbalTestCase
 
         $this->conn->expects($this->any())
             ->method('handleExceptionDuringQuery')
-            ->will($this->throwException(new DBALException()));
+            ->will($this->throwException(new Exception()));
 
         $logger->expects($this->once())
             ->method('startQuery');
@@ -143,11 +142,11 @@ class StatementTest extends DbalTestCase
 
         $this->pdoStatement->expects($this->once())
             ->method('execute')
-            ->will($this->throwException(new Exception('Mock test exception')));
+            ->will($this->throwException(new \Exception('Mock test exception')));
 
         $statement = new Statement('', $this->conn);
 
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
 
         $statement->execute();
     }

--- a/tests/Doctrine/Tests/DBAL/Types/TypeRegistryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/TypeRegistryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\DBAL\Types;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\StringType;
@@ -42,7 +42,7 @@ class TypeRegistryTest extends TestCase
         self::assertSame($this->testType, $this->registry->get(self::TEST_TYPE_NAME));
         self::assertSame($this->otherTestType, $this->registry->get(self::OTHER_TEST_TYPE_NAME));
 
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $this->registry->get('unknown');
     }
 
@@ -65,7 +65,7 @@ class TypeRegistryTest extends TestCase
             $this->registry->lookupName($this->otherTestType)
         );
 
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $this->registry->lookupName(new TextType());
     }
 
@@ -90,7 +90,7 @@ class TypeRegistryTest extends TestCase
     {
         $this->registry->register('some', new TextType());
 
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $this->registry->register('some', new TextType());
     }
 
@@ -100,7 +100,7 @@ class TypeRegistryTest extends TestCase
 
         $this->registry->register('some', $newType);
 
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $this->registry->register('other', $newType);
     }
 
@@ -132,13 +132,13 @@ class TypeRegistryTest extends TestCase
         $this->registry->register('first', $newType);
         $this->registry->register('second', new StringType());
 
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $this->registry->override('second', $newType);
     }
 
     public function testOverrideWithUnknownType(): void
     {
-        $this->expectException(DBALException::class);
+        $this->expectException(Exception::class);
         $this->registry->override('unknown', new TextType());
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

Similarly to the deprecation of `Driver\DriverException` in favor of `Driver\Exception` #4100, the `DBAL\DBALException` name is unnecessarily verbose and is being deprecated in favor of `DBAL\Exception`.

There's no BC break according to `roave-backward-compatibility-check`.