### PR TITLE
[GH-4243] more sqlite schema manager fixes

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -408,8 +408,8 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $list = [];
         foreach ($tableForeignKeys as $value) {
             $value = array_change_key_case($value, CASE_LOWER);
-            $name  = $value['constraint_name'];
-            if (! isset($list[$name])) {
+            $id    = $value['id'];
+            if (! isset($list[$id])) {
                 if (! isset($value['on_delete']) || $value['on_delete'] === 'RESTRICT') {
                     $value['on_delete'] = null;
                 }
@@ -418,8 +418,8 @@ class SqliteSchemaManager extends AbstractSchemaManager
                     $value['on_update'] = null;
                 }
 
-                $list[$name] = [
-                    'name' => $name,
+                $list[$id] = [
+                    'name' => $value['constraint_name'],
                     'local' => [],
                     'foreign' => [],
                     'foreignTable' => $value['table'],
@@ -430,8 +430,8 @@ class SqliteSchemaManager extends AbstractSchemaManager
                 ];
             }
 
-            $list[$name]['local'][]   = $value['from'];
-            $list[$name]['foreign'][] = $value['to'];
+            $list[$id]['local'][]   = $value['from'];
+            $list[$id]['foreign'][] = $value['to'];
         }
 
         $result = [];

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -1317,4 +1317,36 @@ class ComparatorTest extends TestCase
         self::assertCount(1, $actual->changedTables['table2']->addedForeignKeys, 'FK to table3 should be added.');
         self::assertEquals('table3', $actual->changedTables['table2']->addedForeignKeys[0]->getForeignTableName());
     }
+
+    public function testCompareForeignKeysOfTable(): void
+    {
+        $fromTable = new Table('table');
+        $fromTable->addColumn('id', 'integer');
+        $fromTable->addColumn('reference1_id1', 'integer');
+        $fromTable->addColumn('reference1_id2', 'integer');
+        $fromTable->addColumn('reference2_id', 'integer');
+        $fromTable->addColumn('reference3_id1', 'integer');
+        $fromTable->addColumn('reference3_id2', 'integer');
+        $fromTable->addColumn('reference4_id', 'integer');
+
+        $fromTable->addForeignKeyConstraint('table_ref1', ['reference1_id1'], ['id1'], [], 'fk1');
+        $fromTable->addForeignKeyConstraint('table_ref2', ['reference2_id'], ['id']);
+
+        $toTable = clone $fromTable;
+        $toTable->removeForeignKey('fk1');
+        $toTable->addForeignKeyConstraint(
+            'table_ref1',
+            ['reference1_id1', 'reference1_id2'],
+            ['id1', 'id2'],
+            [],
+            'fk1'
+        );
+        $toTable->addForeignKeyConstraint('table_ref3', ['reference3_id1', 'reference3_id2'], ['id1', 'id2']);
+        $toTable->addForeignKeyConstraint('table_ref4', ['reference4_id'], ['id']);
+
+        $tableDiff = (new Comparator())->diffTable($fromTable, $toTable);
+
+        self::assertCount(2, $tableDiff->addedForeignKeys);
+        self::assertCount(1, $tableDiff->changedForeignKeys);
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4243 

#### Summary

The previous fix #4246 did not fully fix the bug, because it missed handling of `constraint_name` == NULL in a downstream function. This lead to foreign keys without name grouped together.

Patch includes one regression example copied from Taylor in the original Laravel issue, but could use another one from @greg0ire example with the documents table, pending the original SQL to create it from Laravel blueprint.