### PR TITLE
[GH-4257] orphaned foreign key missing guard

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -116,7 +116,11 @@ class SchemaDiff
             }
         }
 
-        if ($platform->supportsForeignKeyConstraints() && $saveMode === false) {
+        if (
+            $platform->supportsForeignKeyConstraints() &&
+            $platform->supportsCreateDropForeignKeyConstraints() &&
+            $saveMode === false
+        ) {
             foreach ($this->orphanedForeignKeys as $orphanedForeignKey) {
                 $sql[] = $platform->getDropForeignKeySQL($orphanedForeignKey, $orphanedForeignKey->getLocalTable());
             }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4257 

#### Summary

Orphaned foreign keys lead to alter table statement in sqlite, which is not possible. Tables that are targets of foreign keys can be deleted in Sqlite, so skipping this block based on existing platform check works.

Fixes #4257 