### PR TITLE
Update SchemaDiff.php

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -116,7 +116,7 @@ class SchemaDiff
             }
         }
 
-        if ($platform->supportsForeignKeyConstraints() && $saveMode === false) {
+        if ($platform->supportsCreateDropForeignKeyConstraints() && $saveMode === false) {
             foreach ($this->orphanedForeignKeys as $orphanedForeignKey) {
                 $sql[] = $platform->getDropForeignKeySQL($orphanedForeignKey, $orphanedForeignKey->getLocalTable());
             }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

When I create migration for sqlite I have error:

Sqlite platform does not support alter foreign key, the table must be fully recreated using getAlterTableSQL.
