### PR TITLE
Generate alter add/change column with explicit position for MySQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -672,7 +672,7 @@ SQL
         }
 
         if (! $columnFound) {
-            throw new InvalidArgumentException('Column name not found');
+            throw new InvalidArgumentException('Column name "' . $columnName . '" not found');
         }
 
         return $prevColumn === null ? ' FIRST' : ' AFTER ' . $prevColumn->getQuotedName($this);

--- a/lib/Doctrine/DBAL/Schema/Comparator.php
+++ b/lib/Doctrine/DBAL/Schema/Comparator.php
@@ -199,6 +199,7 @@ class Comparator
         $changes                     = 0;
         $tableDifferences            = new TableDiff($fromTable->getName());
         $tableDifferences->fromTable = $fromTable;
+        $tableDifferences->toTable   = $toTable;
 
         $fromTableColumns = $fromTable->getColumns();
         $toTableColumns   = $toTable->getColumns();

--- a/lib/Doctrine/DBAL/Schema/TableDiff.php
+++ b/lib/Doctrine/DBAL/Schema/TableDiff.php
@@ -95,6 +95,9 @@ class TableDiff
     /** @var Table|null */
     public $fromTable;
 
+    /** @var Table|null */
+    public $toTable;
+
     /**
      * Constructs an TableDiff object.
      *
@@ -114,7 +117,8 @@ class TableDiff
         $addedIndexes = [],
         $changedIndexes = [],
         $removedIndexes = [],
-        ?Table $fromTable = null
+        ?Table $fromTable = null,
+        ?Table $toTable = null
     ) {
         $this->name           = $tableName;
         $this->addedColumns   = $addedColumns;
@@ -124,6 +128,7 @@ class TableDiff
         $this->changedIndexes = $changedIndexes;
         $this->removedIndexes = $removedIndexes;
         $this->fromTable      = $fromTable;
+        $this->toTable        = $toTable;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -272,7 +272,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $diff = $fromSchema->getMigrateToSql($toSchema, $this->connection->getDatabasePlatform());
         self::assertContains(
             'ALTER TABLE test_column_charset_change CHANGE col_string'
-                . ' col_string VARCHAR(100) CHARACTER SET ascii NOT NULL',
+                . ' col_string VARCHAR(100) CHARACTER SET ascii NOT NULL FIRST',
             $diff
         );
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -415,7 +415,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
         self::assertEquals(
             [
-                'ALTER TABLE alter_primary_key MODIFY id INT NOT NULL',
+                'ALTER TABLE alter_primary_key MODIFY id INT NOT NULL AFTER foo',
                 'ALTER TABLE alter_primary_key DROP PRIMARY KEY',
                 'ALTER TABLE alter_primary_key ADD PRIMARY KEY (foo)',
             ],
@@ -440,7 +440,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
         self::assertEquals(
             [
-                'ALTER TABLE drop_primary_key MODIFY id INT NOT NULL',
+                'ALTER TABLE drop_primary_key MODIFY id INT NOT NULL FIRST',
                 'ALTER TABLE drop_primary_key DROP PRIMARY KEY',
             ],
             $this->platform->getAlterTableSQL($diff)
@@ -465,7 +465,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
         self::assertSame(
             [
-                'ALTER TABLE tbl MODIFY id INT NOT NULL',
+                'ALTER TABLE tbl MODIFY id INT NOT NULL FIRST',
                 'ALTER TABLE tbl DROP PRIMARY KEY',
                 'ALTER TABLE tbl ADD PRIMARY KEY (id)',
             ],
@@ -491,7 +491,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
         self::assertSame(
             [
-                'ALTER TABLE tbl MODIFY id INT NOT NULL',
+                'ALTER TABLE tbl MODIFY id INT NOT NULL FIRST',
                 'ALTER TABLE tbl DROP PRIMARY KEY',
                 'ALTER TABLE tbl ADD PRIMARY KEY (id, foo)',
             ],
@@ -514,7 +514,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
         $sql = $this->platform->getAlterTableSQL($diff);
 
-        self::assertEquals(['ALTER TABLE foo ADD id INT AUTO_INCREMENT NOT NULL, ADD PRIMARY KEY (id)'], $sql);
+        self::assertEquals(['ALTER TABLE foo ADD id INT AUTO_INCREMENT NOT NULL FIRST, ADD PRIMARY KEY (id)'], $sql);
     }
 
     public function testNamedPrimaryKey(): void
@@ -549,7 +549,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertSame(
             [
                 'ALTER TABLE yolo DROP PRIMARY KEY',
-                'ALTER TABLE yolo ADD pkc2 INT NOT NULL',
+                'ALTER TABLE yolo ADD pkc2 INT NOT NULL AFTER pkc1',
                 'ALTER TABLE yolo ADD PRIMARY KEY (pkc1, pkc2)',
             ],
             $this->platform->getAlterTableSQL($diff)
@@ -781,15 +781,15 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     protected function getQuotedAlterTableRenameColumnSQL(): array
     {
         return ['ALTER TABLE mytable ' .
-            "CHANGE unquoted1 unquoted INT NOT NULL COMMENT 'Unquoted 1', " .
-            "CHANGE unquoted2 `where` INT NOT NULL COMMENT 'Unquoted 2', " .
-            "CHANGE unquoted3 `foo` INT NOT NULL COMMENT 'Unquoted 3', " .
-            "CHANGE `create` reserved_keyword INT NOT NULL COMMENT 'Reserved keyword 1', " .
-            "CHANGE `table` `from` INT NOT NULL COMMENT 'Reserved keyword 2', " .
-            "CHANGE `select` `bar` INT NOT NULL COMMENT 'Reserved keyword 3', " .
-            "CHANGE quoted1 quoted INT NOT NULL COMMENT 'Quoted 1', " .
-            "CHANGE quoted2 `and` INT NOT NULL COMMENT 'Quoted 2', " .
-            "CHANGE quoted3 `baz` INT NOT NULL COMMENT 'Quoted 3'",
+            "CHANGE unquoted1 unquoted INT NOT NULL COMMENT 'Unquoted 1' FIRST, " .
+            "CHANGE unquoted2 `where` INT NOT NULL COMMENT 'Unquoted 2' AFTER unquoted, " .
+            "CHANGE unquoted3 `foo` INT NOT NULL COMMENT 'Unquoted 3' AFTER `where`, " .
+            "CHANGE `create` reserved_keyword INT NOT NULL COMMENT 'Reserved keyword 1' AFTER `foo`, " .
+            "CHANGE `table` `from` INT NOT NULL COMMENT 'Reserved keyword 2' AFTER reserved_keyword, " .
+            "CHANGE `select` `bar` INT NOT NULL COMMENT 'Reserved keyword 3' AFTER `from`, " .
+            "CHANGE quoted1 quoted INT NOT NULL COMMENT 'Quoted 1' AFTER `bar`, " .
+            "CHANGE quoted2 `and` INT NOT NULL COMMENT 'Quoted 2' AFTER quoted, " .
+            "CHANGE quoted3 `baz` INT NOT NULL COMMENT 'Quoted 3' AFTER `and`",
         ];
     }
 
@@ -799,12 +799,12 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     protected function getQuotedAlterTableChangeColumnLengthSQL(): array
     {
         return ['ALTER TABLE mytable ' .
-            "CHANGE unquoted1 unquoted1 VARCHAR(255) NOT NULL COMMENT 'Unquoted 1', " .
-            "CHANGE unquoted2 unquoted2 VARCHAR(255) NOT NULL COMMENT 'Unquoted 2', " .
-            "CHANGE unquoted3 unquoted3 VARCHAR(255) NOT NULL COMMENT 'Unquoted 3', " .
-            "CHANGE `create` `create` VARCHAR(255) NOT NULL COMMENT 'Reserved keyword 1', " .
-            "CHANGE `table` `table` VARCHAR(255) NOT NULL COMMENT 'Reserved keyword 2', " .
-            "CHANGE `select` `select` VARCHAR(255) NOT NULL COMMENT 'Reserved keyword 3'",
+            "CHANGE unquoted1 unquoted1 VARCHAR(255) NOT NULL COMMENT 'Unquoted 1' FIRST, " .
+            "CHANGE unquoted2 unquoted2 VARCHAR(255) NOT NULL COMMENT 'Unquoted 2' AFTER unquoted1, " .
+            "CHANGE unquoted3 unquoted3 VARCHAR(255) NOT NULL COMMENT 'Unquoted 3' AFTER unquoted2, " .
+            "CHANGE `create` `create` VARCHAR(255) NOT NULL COMMENT 'Reserved keyword 1' AFTER unquoted3, " .
+            "CHANGE `table` `table` VARCHAR(255) NOT NULL COMMENT 'Reserved keyword 2' AFTER `create`, " .
+            "CHANGE `select` `select` VARCHAR(255) NOT NULL COMMENT 'Reserved keyword 3' AFTER `table`",
         ];
     }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -146,6 +146,7 @@ class ComparatorTest extends TestCase
         );
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
+        $expected->changedTables['bugdb']->toTable   = $schema2->getTable('bugdb');
 
         self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
     }
@@ -183,6 +184,7 @@ class ComparatorTest extends TestCase
         );
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
+        $expected->changedTables['bugdb']->toTable   = $schema2->getTable('bugdb');
 
         self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
     }
@@ -313,6 +315,7 @@ class ComparatorTest extends TestCase
         );
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
+        $expected->changedTables['bugdb']->toTable   = $schema2->getTable('bugdb');
 
         self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
     }
@@ -365,6 +368,7 @@ class ComparatorTest extends TestCase
         );
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
+        $expected->changedTables['bugdb']->toTable   = $schema2->getTable('bugdb');
 
         self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
     }
@@ -428,6 +432,7 @@ class ComparatorTest extends TestCase
         );
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
+        $expected->changedTables['bugdb']->toTable   = $schema2->getTable('bugdb');
 
         self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
     }
@@ -476,6 +481,7 @@ class ComparatorTest extends TestCase
         );
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
+        $expected->changedTables['bugdb']->toTable   = $schema2->getTable('bugdb');
 
         self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
     }
@@ -670,6 +676,7 @@ class ComparatorTest extends TestCase
         $c                                        = new Comparator();
         $tableDiff                                = new TableDiff('foo');
         $tableDiff->fromTable                     = $tableA;
+        $tableDiff->toTable                       = $tableB;
         $tableDiff->renamedIndexes['foo_bar_idx'] = new Index('bar_foo_idx', ['id']);
 
         self::assertEquals(
@@ -1041,6 +1048,7 @@ class ComparatorTest extends TestCase
 
         $tableDiff            = $expected->changedTables['foo'] = new TableDiff('foo');
         $tableDiff->fromTable = $tableFoo;
+        $tableDiff->toTable   = $table;
 
         $columnDiff = $tableDiff->changedColumns['id'] = new ColumnDiff('id', $table->getColumn('id'));
 
@@ -1066,6 +1074,7 @@ class ComparatorTest extends TestCase
 
         $tableDiff            = $expected->changedTables['foo'] = new TableDiff('foo');
         $tableDiff->fromTable = $tableFoo;
+        $tableDiff->toTable   = $table;
 
         $columnDiff = $tableDiff->changedColumns['id'] = new ColumnDiff('id', $table->getColumn('id'));
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | Alter add/change column now has now explicit position, so new/updated column is updated to the same position like when the table is created freshly.<br>- https://github.com/doctrine/orm/issues/8258<br>- https://github.com/doctrine/migrations/issues/558<br>- https://stackoverflow.com/questions/34873327/doctrine-migration-add-column-after-other-one<br>- https://stackoverflow.com/questions/24148568/doctrineschemaupdate-doesnt-respect-column-order
