### PR TITLE
Fix BC break: QueryBuilder::andWhere() etc. should ignore empty strings

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 
+use function array_filter;
 use function array_key_exists;
 use function array_keys;
 use function array_unshift;
@@ -829,6 +830,7 @@ class QueryBuilder
     public function andWhere($where)
     {
         $args  = func_get_args();
+        $args  = array_filter($args); // https://github.com/doctrine/dbal/issues/4282
         $where = $this->getQueryPart('where');
 
         if ($where instanceof CompositeExpression && $where->getType() === CompositeExpression::TYPE_AND) {
@@ -862,6 +864,7 @@ class QueryBuilder
     public function orWhere($where)
     {
         $args  = func_get_args();
+        $args  = array_filter($args); // https://github.com/doctrine/dbal/issues/4282
         $where = $this->getQueryPart('where');
 
         if ($where instanceof CompositeExpression && $where->getType() === CompositeExpression::TYPE_OR) {
@@ -1010,6 +1013,7 @@ class QueryBuilder
     public function andHaving($having)
     {
         $args   = func_get_args();
+        $args   = array_filter($args); // https://github.com/doctrine/dbal/issues/4282
         $having = $this->getQueryPart('having');
 
         if ($having instanceof CompositeExpression && $having->getType() === CompositeExpression::TYPE_AND) {
@@ -1033,6 +1037,7 @@ class QueryBuilder
     public function orHaving($having)
     {
         $args   = func_get_args();
+        $args   = array_filter($args); // https://github.com/doctrine/dbal/issues/4282
         $having = $this->getQueryPart('having');
 
         if ($having instanceof CompositeExpression && $having->getType() === CompositeExpression::TYPE_OR) {

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -949,4 +949,104 @@ class QueryBuilderTest extends DbalTestCase
 
         $qb->getSQL();
     }
+
+    public function testAndWhereEmptyStringStartingWithEmptyExpression(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('id')
+            ->from('foo');
+
+        $qb->andWhere('', 'a = b');
+
+        self::assertSame('SELECT id FROM foo WHERE a = b', $qb->getSQL());
+    }
+
+    public function testAndWhereEmptyStringStartingWithNonEmptyExpression(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('id')
+            ->from('foo')
+            ->where('a = b');
+
+        $qb->andWhere('', 'c = d');
+
+        self::assertSame('SELECT id FROM foo WHERE (a = b) AND (c = d)', $qb->getSQL());
+    }
+
+    public function testOrWhereEmptyStringStartingWithEmptyExpression(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('id')
+            ->from('foo');
+
+        $qb->orWhere('', 'a = b');
+
+        self::assertSame('SELECT id FROM foo WHERE a = b', $qb->getSQL());
+    }
+
+    public function testOrWhereEmptyStringStartingWithNonEmptyExpression(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('id')
+            ->from('foo')
+            ->where('a = b');
+
+        $qb->orWhere('', 'c = d');
+
+        self::assertSame('SELECT id FROM foo WHERE (a = b) OR (c = d)', $qb->getSQL());
+    }
+
+    public function testAndHavingEmptyStringStartingWithEmptyExpression(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('id')
+            ->from('foo');
+
+        $qb->andHaving('', 'a = b');
+
+        self::assertSame('SELECT id FROM foo HAVING a = b', $qb->getSQL());
+    }
+
+    public function testAndHavingEmptyStringStartingWithNonEmptyExpression(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('id')
+            ->from('foo')
+            ->having('a = b');
+
+        $qb->andHaving('', 'c = d');
+
+        self::assertSame('SELECT id FROM foo HAVING (a = b) AND (c = d)', $qb->getSQL());
+    }
+
+    public function testOrHavingEmptyStringStartingWithEmptyExpression(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('id')
+            ->from('foo');
+
+        $qb->orHaving('', 'a = b');
+
+        self::assertSame('SELECT id FROM foo HAVING a = b', $qb->getSQL());
+    }
+
+    public function testOrHavingEmptyStringStartingWithNonEmptyExpression(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('id')
+            ->from('foo')
+            ->having('a = b');
+
+        $qb->orHaving('', 'c = d');
+
+        self::assertSame('SELECT id FROM foo HAVING (a = b) OR (c = d)', $qb->getSQL());
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4282

#### Summary

The previous behaviour of these methods has been restored: they now ignore empty strings passed as parameters.