### PR TITLE
Restore PDOStatement::quote() for backward compatibility

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\DBAL\Driver\PDO\Statement;
+use Doctrine\DBAL\ParameterType;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -99,6 +100,14 @@ class PDOConnection extends PDO implements ConnectionInterface, ServerInfoAwareC
         } catch (PDOException $exception) {
             throw Exception::new($exception);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function quote($value, $type = ParameterType::STRING)
+    {
+        return parent::quote($value, $type);
     }
 
     /**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -110,6 +110,11 @@
         <exclude-pattern>lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php</exclude-pattern>
     </rule>
 
+    <!-- The override opts out the caller from the strict mode for backward compatibility -->
+    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod.Found">
+        <exclude-pattern>lib/Doctrine/DBAL/Driver/PDOConnection.php</exclude-pattern>
+    </rule>
+
     <!-- See https://github.com/slevomat/coding-standard/issues/770 -->
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
         <exclude-pattern>lib/Doctrine/DBAL/Driver/ExceptionConverterDriver.php</exclude-pattern>

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDO/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDO/ConnectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\DBAL\Functional\Driver\PDO;
 
 use Doctrine\DBAL\Driver\PDO\Connection;
@@ -99,5 +101,13 @@ class ConnectionTest extends DbalFunctionalTestCase
         $this->expectException(Exception::class);
 
         $this->driverConnection->query('foo');
+    }
+
+    /**
+     * This test ensures backward compatibility with DBAL 2.x and should be removed in 3.0.
+     */
+    public function testQuoteInteger(): void
+    {
+        self::assertSame("'1'", $this->connection->getWrappedConnection()->quote(1));
     }
 }


### PR DESCRIPTION
Fixes #4281.