### PR TITLE
Deprecate Abstraction\Result

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 2.11
 
+## Deprecated `Abstraction\Result` 
+
+The usage of the `Doctrine\DBAL\Abstraction\Result` interface is deprecated. In DBAL 3.0, the statement result at the wrapper level will be represented by the `Doctrine\DBAL\Result` class.
+
 ## Deprecated the functionality of dropping client connections when dropping a database
 
 The corresponding `getDisallowDatabaseConnectionsSQL()` and `getCloseActiveDatabaseConnectionsSQL` methods

--- a/lib/Doctrine/DBAL/Abstraction/Result.php
+++ b/lib/Doctrine/DBAL/Abstraction/Result.php
@@ -11,6 +11,8 @@ use Traversable;
 /**
  * Abstraction-level result statement execution result. Provides additional methods on top
  * of the driver-level interface.
+ *
+ * @deprecated
  */
 interface Result extends DriverResult
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

## Problem #​1: The wrapper Result methods are effectively documented as `@throws Driver\Exception`

In #4019 where the `Result` interfaces were first introduced, the idea was to have the `Abstraction\Result` extend `Driver\Result` since from the methods and parameters standpoint, the former is currently a superset of the latter.

The above didn't take into account exception handling. Specifically, the fact that the `Driver\Exception` is not a sub-type of `Exception`. It creates the following confusion:
```php
interface Driver\Result
{
    /**
     * @throws Driver\Exception
     */
    function fetch();
}

interface Abstraction\Result extends Driver\Result
{
}

class Result implements Abstraction\Result
{
    /**
     * @throws Exception
     */
    function fetch() {
        try {
            $this->driverResult->fetch();
        } catch (Driver\Exception $e) {
             throw new Exception();
        }
    }
}
```
Despite the fact that `Result::fetch()` catches `Driver\Exception` from the driver result and only throws `Exception`, it inherits the `@throws Driver\Exception` annotation from `Driver\Result`. It means that the callers of `Result::fetch()` should be able to handle `Exception` despite the fact that it will never be thrown:

![Screen Shot 2020-09-23 at 12 34 48 PM](https://user-images.githubusercontent.com/59683/94063225-a26d0280-fd9c-11ea-81fb-5a1850f86981.png)

## Problem #​2: Adding `fetch*()` and `iterate*()` methods to the wrapper Result requires a breaking change

See #4293. Since the wrapper Result is exposed by the Statement as `Abstraction\Result` interface, making the new methods available to the consumers requires adding them to the interface which is a breaking change.

## Solution

Unlike the driver level where the interfaces have multiple implementations and are meant for extensibility of the driver layer, the wrapper layer is essentially a set of convenience methods packed into a class which is not meant to have multiple implementations by definition.

The solution is to remove the interface and use the classes directly, similarly to the wrapper `Connection` and `Statement` classes.

I believe it's acceptable to introduce this deprecation in a patch release of `2.11.x`:
1. This release series is mostly about deprecations.
2. The API being deprecated was introduced in `2.11.0`, so it's unlikely that there is existing code that relies on this behavior.
3. There's no other usage of the interface other than for forward compatibility with 3.0.
4. If not done in `2.11.x`, we'll have to release `2.12.0` or postpone the BC break until `4.0`.

See the drafted removal PR for `3.0.x`: https://github.com/doctrine/dbal/pull/4294.