### PR TITLE
Add support for read-only SQLite databases

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -172,6 +172,10 @@ pdo_sqlite
 -  ``memory`` (boolean): True if the SQLite database should be
    in-memory (non-persistent). Mutually exclusive with ``path``.
    ``path`` takes precedence.
+-  ``driverOptions`` (array): Arbitrary options that are directly
+   passed to ``PDO`` including some custom DBAL options:
+      - ``readOnly`` (boolean): Whether to open the database in
+        read-only mode.
 
 pdo_mysql
 ^^^^^^^^^

--- a/src/Driver/PDO/SQLite/Driver.php
+++ b/src/Driver/PDO/SQLite/Driver.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Driver\PDO\SQLite;
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use PDO;
 
 use function array_merge;
 
@@ -30,6 +31,14 @@ final class Driver extends AbstractSQLiteDriver
                 $driverOptions['userDefinedFunctions']
             );
             unset($driverOptions['userDefinedFunctions']);
+        }
+
+        if (isset($driverOptions['readOnly'])) {
+            if ($driverOptions['readOnly']) {
+                $driverOptions[PDO::SQLITE_ATTR_OPEN_FLAGS] = PDO::SQLITE_OPEN_READONLY;
+            }
+
+            unset($driverOptions['readOnly']);
         }
 
         $connection = new Connection(

--- a/tests/Functional/Driver/PDO/SQLite/DriverTest.php
+++ b/tests/Functional/Driver/PDO/SQLite/DriverTest.php
@@ -3,8 +3,11 @@
 namespace Doctrine\DBAL\Tests\Functional\Driver\PDO\SQLite;
 
 use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\DBAL\Tests\Functional\Driver\AbstractDriverTest;
+
+use function array_merge;
 
 /**
  * @requires extension pdo_sqlite
@@ -20,6 +23,18 @@ class DriverTest extends AbstractDriverTest
         }
 
         self::markTestSkipped('pdo_sqlite only test.');
+    }
+
+    public function testConnectReadOnly(): void
+    {
+        $conn = $this->driver->connect(array_merge(
+            $this->connection->getParams(),
+            ['driverOptions' => ['readOnly' => true]]
+        ));
+
+        $this->expectException(Exception::class);
+        $this->expectDeprecationMessage('SQLSTATE[HY000]: General error: 8 attempt to write a readonly database');
+        $conn->exec('CREATE TABLE foo (ID INT NOT NULL PRIMARY KEY);');
     }
 
     public function testReturnsDatabaseNameWithoutDatabaseNameParameter(): void


### PR DESCRIPTION

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | n/a

#### Summary

Since PHP 7.3 it's posible to open SQLite databases in read-only
mode[1]. I figured that it makes sense to add a driverOption for
`pdo_sqlite` to support this.

The idea behind it is to declare `read_only: true` in e.g. a sf-bundle
config without having to use the constants in the config files.

[1] https://github.com/php/php-src/commit/ed2f6510da7c68b5690c60344cbb9fe73241592a