### PR TITLE
Add Result::fetchAllKeyValue() and ::iterateKeyValue()

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -379,6 +379,25 @@ Execute the query and fetch all results into an array:
     )
     */
 
+fetchAllKeyValue()
+~~~~~~~~~~~~~~~~~~
+
+Execute the query and fetch the first two columns into an associative array as keys and values respectively:
+
+.. code-block:: php
+
+    <?php
+    $users = $conn->fetchAllKeyValue('SELECT username, password FROM user');
+
+    /*
+    array(
+      'jwage' => 'changeme',
+    )
+    */
+
+.. note::
+   All additional columns will be ignored and are only allowed to be selected by DBAL for its internal purposes.
+
 fetchNumeric()
 ~~~~~~~~~~~~~~
 
@@ -424,6 +443,21 @@ Retrieve associative array of the first result row.
     */
 
 There are also convenience methods for data manipulation queries:
+
+iterateKeyValue()
+~~~~~~~~~~~~~~~~~
+
+Execute the query and iterate over the first two columns as keys and values respectively:
+
+.. code-block:: php
+
+    <?php
+    foreach ($conn->iterateKeyValue('SELECT username, password FROM user') as $username => $password) {
+        // ...
+    }
+
+.. note::
+   All additional columns will be ignored and are only allowed to be selected by DBAL for its internal purposes.
 
 delete()
 ~~~~~~~~~

--- a/src/Abstraction/Result.php
+++ b/src/Abstraction/Result.php
@@ -15,6 +15,17 @@ use Traversable;
 interface Result extends DriverResult
 {
     /**
+     * Returns an associative array with the keys mapped to the first column and the values mapped to the second column.
+     *
+     * The result must contain at least two columns.
+     *
+     * @return array<mixed,mixed>
+     *
+     * @throws Exception
+     */
+    public function fetchAllKeyValue(): array;
+
+    /**
      * Returns an iterator over the result set rows represented as numeric arrays.
      *
      * @return Traversable<int,array<int,mixed>>
@@ -31,6 +42,18 @@ interface Result extends DriverResult
      * @throws Exception
      */
     public function iterateAssociative(): Traversable;
+
+    /**
+     * Returns an iterator over the result set with the keys mapped to the first column
+     * and the values mapped to the second column.
+     *
+     * The result must contain at least two columns.
+     *
+     * @return Traversable<mixed,mixed>
+     *
+     * @throws Exception
+     */
+    public function iterateKeyValue(): Traversable;
 
     /**
      * Returns an iterator over the values of the first column of the result set.

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -818,6 +818,23 @@ class Connection
     }
 
     /**
+     * Prepares and executes an SQL query and returns the result as an associative array with the keys
+     * mapped to the first column and the values mapped to the second column.
+     *
+     * @param string                                           $query  The SQL query.
+     * @param array<int, mixed>|array<string, mixed>           $params The query parameters.
+     * @param array<int, int|string>|array<string, int|string> $types  The query parameter types.
+     *
+     * @return array<mixed,mixed>
+     *
+     * @throws Exception
+     */
+    public function fetchAllKeyValue(string $query, array $params = [], array $types = []): array
+    {
+        return $this->executeQuery($query, $params, $types)->fetchAllKeyValue();
+    }
+
+    /**
      * Prepares and executes an SQL query and returns the result as an array of the first column values.
      *
      * @param string                                           $query  The SQL query.
@@ -884,6 +901,23 @@ class Connection
         } catch (DriverException $e) {
             throw $this->convertExceptionDuringQuery($e, $query, $params, $types);
         }
+    }
+
+    /**
+     * Prepares and executes an SQL query and returns the result as an iterator with the keys
+     * mapped to the first column and the values mapped to the second column.
+     *
+     * @param string                                           $query  The SQL query.
+     * @param array<int, mixed>|array<string, mixed>           $params The query parameters.
+     * @param array<int, int|string>|array<string, int|string> $types  The query parameter types.
+     *
+     * @return Traversable<mixed,mixed>
+     *
+     * @throws Exception
+     */
+    public function iterateKeyValue(string $query, array $params = [], array $types = []): Traversable
+    {
+        return $this->executeQuery($query, $params, $types)->iterateKeyValue();
     }
 
     /**

--- a/src/Exception/NoKeyValue.php
+++ b/src/Exception/NoKeyValue.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\DBAL\Exception;
+
+use Doctrine\DBAL\Exception;
+
+use function sprintf;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class NoKeyValue extends Exception
+{
+    public static function fromColumnCount(int $columnCount): self
+    {
+        return new self(
+            sprintf(
+                'Fetching as key-value pairs requires the result to contain at least 2 columns, %d given.',
+                $columnCount
+            )
+        );
+    }
+}

--- a/src/Result.php
+++ b/src/Result.php
@@ -158,14 +158,28 @@ final class Result implements ResultInterface
         }
     }
 
+    /**
+     * @throws Exception
+     */
     public function rowCount(): int
     {
-        return $this->result->rowCount();
+        try {
+            return $this->result->rowCount();
+        } catch (DriverException $e) {
+            throw $this->connection->convertException($e);
+        }
     }
 
+    /**
+     * @throws Exception
+     */
     public function columnCount(): int
     {
-        return $this->result->columnCount();
+        try {
+            return $this->result->columnCount();
+        } catch (DriverException $e) {
+            throw $this->connection->convertException($e);
+        }
     }
 
     public function free(): void

--- a/tests/Functional/Connection/FetchTest.php
+++ b/tests/Functional/Connection/FetchTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Connection;
 
+use Doctrine\DBAL\Exception\NoKeyValue;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 
@@ -77,6 +79,41 @@ class FetchTest extends FunctionalTestCase
         ], $this->connection->fetchAllAssociative($this->query));
     }
 
+    public function testFetchAllKeyValue(): void
+    {
+        self::assertEquals([
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ], $this->connection->fetchAllKeyValue($this->query));
+    }
+
+    /**
+     * This test covers the requirement for the statement result to have at least two columns,
+     * not exactly two as PDO requires.
+     */
+    public function testFetchAllKeyValueWithLimit(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SQLServer2012Platform) {
+            self::markTestSkipped('See https://github.com/doctrine/dbal/issues/2374');
+        }
+
+        $query = $platform->modifyLimitQuery($this->query, 1, 1);
+
+        self::assertEquals(['bar' => 2], $this->connection->fetchAllKeyValue($query));
+    }
+
+    public function testFetchAllKeyValueOneColumn(): void
+    {
+        $sql = $this->connection->getDatabasePlatform()
+            ->getDummySelectSQL();
+
+        $this->expectException(NoKeyValue::class);
+        $this->connection->fetchAllKeyValue($sql);
+    }
+
     public function testFetchFirstColumn(): void
     {
         self::assertEquals([
@@ -111,6 +148,24 @@ class FetchTest extends FunctionalTestCase
                 'b' => 3,
             ],
         ], iterator_to_array($this->connection->iterateAssociative($this->query)));
+    }
+
+    public function testIterateKeyValue(): void
+    {
+        self::assertEquals([
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ], iterator_to_array($this->connection->iterateKeyValue($this->query)));
+    }
+
+    public function testIterateKeyValueOneColumn(): void
+    {
+        $sql = $this->connection->getDatabasePlatform()
+            ->getDummySelectSQL();
+
+        $this->expectException(NoKeyValue::class);
+        iterator_to_array($this->connection->iterateKeyValue($sql));
     }
 
     public function testIterateColumn(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Fixes #4289.

The behavior of the newly added methods is a replacement of `PDO::FETCH_KEY_PAIR` which is implemented at the wrapper level and is available for all supported drivers.

Unlike PDO which requires the result to have exactly two columns, DBAL will require at least two columns in order to allow the ROWNUM columns used by the platforms that do not natively support LIIMIT queries (Oracle, IBM DB2).