### PR TITLE
Increase indent in definition lists

### DIFF
--- a/docs/en/explanation/implicit-indexes.rst
+++ b/docs/en/explanation/implicit-indexes.rst
@@ -6,13 +6,13 @@ with names such as ``IDX_885DBAFAA76ED395``? In this document, we will
 distinguish three types of indexes:
 
 user-defined indexes
-  indexes you did ask for
+    indexes you did ask for
 
 DBAL-defined indexes
-  indexes you did not ask for, created on your behalf by the DBAL
+    indexes you did not ask for, created on your behalf by the DBAL
 
 RDBMS-defined indexes
-  indexes you did not ask for, created on your behalf by the RDBMS
+    indexes you did not ask for, created on your behalf by the RDBMS
 
 RDBMS-defined indexes can be created by some database platforms when you
 create a foreign key: they will create an index on the referencing


### PR DESCRIPTION
Although the official docs [1] show examples of definition list with an
indent of 2 spaces, it seems that doctrine/rst-parser has been written
with an indent of 4 spaces in mind. [2]

This should ensure the definition lists are properly parsed as such,
right now they are parsed as paragraphs.

[1] https://docutils.sourceforge.io/docs/user/rst/quickref.html#definition-lists
[2] https://github.com/doctrine/rst-parser/blob/d97da75a8a2cab33453711f01b90303f5c3845db/lib/Parser/LineDataParser.php#L154

Please tell me if you think I should report this as a bug to `doctrine/rst-parser` instead, or if you think we are just dealing with what could be called Doctrine-flavored RST here.