### PR TITLE
Fix ExceptionTest::testConnectionExceptionSqLite() on macOS

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -29,6 +29,7 @@ use function unlink;
 use function version_compare;
 
 use const PHP_OS;
+use const PHP_OS_FAMILY;
 
 class ExceptionTest extends DbalFunctionalTestCase
 {
@@ -303,7 +304,7 @@ class ExceptionTest extends DbalFunctionalTestCase
         }
 
         // mode 0 is considered read-only on Windows
-        $mode = PHP_OS === 'Linux' ? 0444 : 0000;
+        $mode = PHP_OS_FAMILY === 'Windows' ? 0000 : 0444;
 
         $filename = sprintf('%s/%s', sys_get_temp_dir(), 'doctrine_failed_connection_' . $mode . '.db');
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The test fails on macOS:
```
$ phpunit --filter testConnectionExceptionSqLite tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
PHPUnit 9.3.2 by Sebastian Bergmann and contributors.

F                                                                                   1 / 1 (100%)

Time: 00:00.023, Memory: 10.00 MB

There was 1 failure:

1) Doctrine\Tests\DBAL\Functional\ExceptionTest::testConnectionExceptionSqLite
Failed asserting that exception of type "Doctrine\DBAL\Exception\ConnectionException" matches expected exception "Doctrine\DBAL\Exception\ReadOnlyException". Message was: "An exception occurred in driver: SQLSTATE[HY000] [14] unable to open database file" at
/Users/smorozov/Projects/dbal/lib/Doctrine/DBAL/Driver/PDO/Exception.php:18
/Users/smorozov/Projects/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:41
/Users/smorozov/Projects/dbal/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php:42
/Users/smorozov/Projects/dbal/lib/Doctrine/DBAL/Connection.php:360
/Users/smorozov/Projects/dbal/lib/Doctrine/DBAL/Connection.php:1753
/Users/smorozov/Projects/dbal/lib/Doctrine/DBAL/Connection.php:1390
/Users/smorozov/Projects/dbal/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php:342
.

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```
According to the currently implemented logic, as non-Linux, macOS falls under the Windows category, therefore, the test changes the DB file mode to `0` which causes the error.