### PR TITLE
Ignore index prefix lengths for spatial indexes

### DIFF
--- a/lib/Doctrine/DBAL/Schema/Index.php
+++ b/lib/Doctrine/DBAL/Schema/Index.php
@@ -223,7 +223,7 @@ class Index extends AbstractAsset implements Constraint
                 return false;
             }
 
-            if (! $this->hasSameColumnLengths($other)) {
+            if (! $this->sameFlag('spatial', $other) && ! $this->hasSameColumnLengths($other)) {
                 return false;
             }
 
@@ -372,5 +372,15 @@ class Index extends AbstractAsset implements Constraint
 
         return array_filter($this->options['lengths'] ?? [], $filter)
             === array_filter($other->options['lengths'] ?? [], $filter);
+    }
+
+    /**
+     * Returns whether the index has the same flag as the other
+     *
+     * @param string $flag
+     */
+    private function sameFlag($flag, Index $other): bool
+    {
+        return $this->hasFlag($flag) && $other->hasFlag($flag);
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| BC Break     | no
| Fixed issues | #3561 <!-- use #NUM format to reference an issue -->

#### Summary

MySQL spatial indexes do not support index lengths and this check should be skipped.
If there are MSSQL or PGSQL experts - please comment.

This PR skips index lengths check if both indexes have a spatial flag.

I.e. when an index is created, MySQL 5.7 creates with 32 bytes prefix length. AWS Aurora (MySQL 5.7 compatible) - 24 bytes prefix length.
