### PR TITLE
Remove irrelevant deprecation message from console runner

### DIFF
--- a/src/Tools/Console/ConsoleRunner.php
+++ b/src/Tools/Console/ConsoleRunner.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Command\Command;
 class ConsoleRunner
 {
     /**
-     * Runs console with the given connection provider or helperset (deprecated).
+     * Runs console with the given connection provider.
      *
      * @param Command[] $commands
      *


### PR DESCRIPTION
This should have been removed as part of https://github.com/doctrine/dbal/pull/4059.