### PR TITLE
MsSql invalid behavior on comment when changing column requirement

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -532,7 +532,7 @@ SQL
                     );
                 } elseif ($hasFromComment && ! $hasComment) {
                     $commentsSql[] = $this->getDropColumnCommentSQL($diff->name, $column->getQuotedName($this));
-                } elseif ($hasComment) {
+                } elseif ($hasComment && ! $hasFromComment) {
                     $commentsSql[] = $this->getCreateColumnCommentSQL(
                         $diff->name,
                         $column->getQuotedName($this),

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -178,6 +178,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('create', 'integer', ['comment' => 'Doctrine 0wnz comments for reserved keyword columns!']);
         $table->addColumn('commented_type', 'object');
         $table->addColumn('commented_type_with_comment', 'array', ['comment' => 'Doctrine array type.']);
+        $table->addColumn('commented_not_null_column', 'integer', ['comment' => 'Funky comment','notnull' => true]);
         $table->setPrimaryKey(['id']);
 
         $this->schemaManager->createTable($table);
@@ -199,6 +200,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('Doctrine 0wnz comments for reserved keyword columns!', $columns['[create]']->getComment());
         self::assertNull($columns['commented_type']->getComment());
         self::assertEquals('Doctrine array type.', $columns['commented_type_with_comment']->getComment());
+        self::assertEquals('Funky comment.', $columns['commented_not_null_column']->getComment());
 
         $tableDiff            = new TableDiff('sqlsrv_column_comment');
         $tableDiff->fromTable = $table;
@@ -329,6 +331,13 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableDiff->removedColumns['comment_integer_0']
             = new Column('comment_integer_0', Type::getType('integer'), ['comment' => 0]);
 
+        $tableDiff->changedColumns['commented_not_null_column'] = new ColumnDiff(
+            'commented_not_null_column',
+            new Column('commented_not_null_column', Type::getType('integer'), ['comment' => 'Funky comment','notnull' => true]),
+            ['comment', 'notnull'],
+            new Column('commented_null_column', Type::getType('integer'), ['comment' => 'Funky comment','notnull' => false]),
+        );
+
         $this->schemaManager->alterTable($tableDiff);
 
         $columns = $this->schemaManager->listTableColumns('sqlsrv_column_comment');
@@ -356,6 +365,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('666', $columns['[select]']->getComment());
         self::assertNull($columns['added_commented_type']->getComment());
         self::assertEquals('666', $columns['added_commented_type_with_comment']->getComment());
+        self::assertEquals('Funky comment', $columns['commented_null_column']->getComment());
     }
 
     public function testPkOrdering(): void

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -178,7 +178,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('create', 'integer', ['comment' => 'Doctrine 0wnz comments for reserved keyword columns!']);
         $table->addColumn('commented_type', 'object');
         $table->addColumn('commented_type_with_comment', 'array', ['comment' => 'Doctrine array type.']);
-        $table->addColumn('commented_not_null_column', 'integer', ['comment' => 'Funky comment','notnull' => true]);
+        $table->addColumn('commented_not_null_column', 'integer', ['comment' => 'Funky comment', 'notnull' => true]);
         $table->setPrimaryKey(['id']);
 
         $this->schemaManager->createTable($table);
@@ -333,9 +333,9 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $tableDiff->changedColumns['commented_not_null_column'] = new ColumnDiff(
             'commented_not_null_column',
-            new Column('commented_not_null_column', Type::getType('integer'), ['comment' => 'Funky comment','notnull' => true]),
+            new Column('commented_not_null_column', Type::getType('integer'), ['comment' => 'Funky comment', 'notnull' => true]),
             ['comment', 'notnull'],
-            new Column('commented_null_column', Type::getType('integer'), ['comment' => 'Funky comment','notnull' => false]),
+            new Column('commented_null_column', Type::getType('integer'), ['comment' => 'Funky comment', 'notnull' => false]),
         );
 
         $this->schemaManager->alterTable($tableDiff);

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -184,7 +184,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->schemaManager->createTable($table);
 
         $columns = $this->schemaManager->listTableColumns('sqlsrv_column_comment');
-        self::assertCount(12, $columns);
+        self::assertCount(13, $columns);
         self::assertNull($columns['id']->getComment());
         self::assertNull($columns['comment_null']->getComment());
         self::assertNull($columns['comment_false']->getComment());
@@ -331,6 +331,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableDiff->removedColumns['comment_integer_0']
             = new Column('comment_integer_0', Type::getType('integer'), ['comment' => 0]);
 
+        // Change column requirements without changing comment
         $tableDiff->changedColumns['commented_not_null_column'] = new ColumnDiff(
             'commented_not_null_column',
             new Column(
@@ -349,7 +350,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->schemaManager->alterTable($tableDiff);
 
         $columns = $this->schemaManager->listTableColumns('sqlsrv_column_comment');
-        self::assertCount(23, $columns);
+        self::assertCount(24, $columns);
         self::assertEquals('primary', $columns['id']->getComment());
         self::assertNull($columns['comment_null']->getComment());
         self::assertEquals('false', $columns['comment_false']->getComment());

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -331,7 +331,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableDiff->removedColumns['comment_integer_0']
             = new Column('comment_integer_0', Type::getType('integer'), ['comment' => 0]);
 
-        // Change column requirements without changing comment
+        // Change column requirements without changing comment.
         $tableDiff->changedColumns['commented_not_null_column'] = new ColumnDiff(
             'commented_not_null_column',
             new Column(

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -200,7 +200,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('Doctrine 0wnz comments for reserved keyword columns!', $columns['[create]']->getComment());
         self::assertNull($columns['commented_type']->getComment());
         self::assertEquals('Doctrine array type.', $columns['commented_type_with_comment']->getComment());
-        self::assertEquals('Funky comment.', $columns['commented_not_null_column']->getComment());
+        self::assertEquals('Funky comment', $columns['commented_not_null_column']->getComment());
 
         $tableDiff            = new TableDiff('sqlsrv_column_comment');
         $tableDiff->fromTable = $table;

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -341,7 +341,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
             ),
             ['comment', 'notnull'],
             new Column(
-                'commented_null_column',
+                'commented_not_null_column',
                 Type::getType('integer'),
                 ['comment' => 'Funky comment', 'notnull' => false]
             ),
@@ -374,7 +374,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('666', $columns['[select]']->getComment());
         self::assertNull($columns['added_commented_type']->getComment());
         self::assertEquals('666', $columns['added_commented_type_with_comment']->getComment());
-        self::assertEquals('Funky comment', $columns['commented_null_column']->getComment());
+        self::assertEquals('Funky comment', $columns['commented_not_null_column']->getComment());
     }
 
     public function testPkOrdering(): void

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -333,9 +333,17 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $tableDiff->changedColumns['commented_not_null_column'] = new ColumnDiff(
             'commented_not_null_column',
-            new Column('commented_not_null_column', Type::getType('integer'), ['comment' => 'Funky comment', 'notnull' => true]),
+            new Column(
+                'commented_not_null_column',
+                Type::getType('integer'),
+                ['comment' => 'Funky comment', 'notnull' => true]
+            ),
             ['comment', 'notnull'],
-            new Column('commented_null_column', Type::getType('integer'), ['comment' => 'Funky comment', 'notnull' => false]),
+            new Column(
+                'commented_null_column',
+                Type::getType('integer'),
+                ['comment' => 'Funky comment', 'notnull' => false]
+            ),
         );
 
         $this->schemaManager->alterTable($tableDiff);

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1719,7 +1719,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         self::assertEquals(sprintf($pattern, $expectedSql, $expectedMin, $expectedMax), $sql);
     }
 
-    public function testAlterTableWithSchemaSameColumnComments()
+    public function testAlterTableWithSchemaSameColumnComments(): void
     {
         $tableDiff                          = new TableDiff('testschema.mytable');
         $tableDiff->changedColumns['quota'] = new ColumnDiff(

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1718,4 +1718,19 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
             . ') AS doctrine_tbl WHERE doctrine_rownum >= %d AND doctrine_rownum <= %d ORDER BY doctrine_rownum ASC';
         self::assertEquals(sprintf($pattern, $expectedSql, $expectedMin, $expectedMax), $sql);
     }
+
+    public function testAlterTableWithSchemaSameColumnComments()
+    {
+        $tableDiff                          = new TableDiff('testschema.mytable');
+        $tableDiff->changedColumns['quota'] = new ColumnDiff(
+            'quota',
+            new Column('quota', Type::getType('integer'), ['comment' => 'A comment', 'notnull' => true]),
+            ['comment', 'notnull'],
+            new Column('quota', Type::getType('integer'), ['comment' => 'A comment', 'notnull' => false])
+        );
+
+        $expectedSql = ['ALTER TABLE testschema.mytable ALTER COLUMN quota INT NOT NULL'];
+
+        self::assertEquals($expectedSql, $this->platform->getAlterTableSQL($tableDiff));
+    }
 }


### PR DESCRIPTION
MsSql invalid behavior on comment when changing column requirement

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Having a column with a comment, I change its requirement and doctrine try to comment this column, I get an error that the comment exists.
`Doctrine \ DBAL \ Driver \ PDOException: :( "SQLSTATE [42000]: [Microsoft] [ODBC Driver 13 for SQL Server] [SQL Server] Property cannot be added. Property 'MS_Description' already exists`
I have added tests for changing the requirement of a column with an existing comment
