### PR TITLE
#4295 Keep master, slaves, keepReplica params in MasterSlaveConnection

### DIFF
--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -38,21 +38,18 @@ class MasterSlaveConnection extends PrimaryReadReplicaConnection
             $this->deprecated('Params key "master"', '"primary"');
 
             $params['primary'] = $params['master'];
-            unset($params['master']);
         }
 
         if (isset($params['slaves'])) {
             $this->deprecated('Params key "slaves"', '"replica"');
 
             $params['replica'] = $params['slaves'];
-            unset($params['slaves']);
         }
 
         if (isset($params['keepSlave'])) {
             $this->deprecated('Params key "keepSlave"', '"keepReplica"');
 
             $params['keepReplica'] = $params['keepSlave'];
-            unset($params['keepSlave']);
         }
 
         parent::__construct($params, $driver, $config, $eventManager);

--- a/tests/Doctrine/Tests/DBAL/Connections/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Connections/MasterSlaveConnectionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Connections;
+
+use Doctrine\DBAL\Connections\MasterSlaveConnection;
+use Doctrine\DBAL\Driver;
+use Doctrine\Tests\DbalTestCase;
+
+class MasterSlaveConnectionTest extends DbalTestCase
+{
+    public function testConnectionParamsRemainAvailable(): void
+    {
+        $constructionParams = [
+            'driver' => 'pdo_mysql',
+            'keepSlave' => true,
+            'master' => [
+                'host' => 'master.host',
+                'user' => 'root',
+                'password' => 'password',
+                'port' => '1234',
+            ],
+            'slaves' => [
+                [
+                    'host' => 'slave1.host',
+                    'user' => 'root',
+                    'password' => 'password',
+                    'port' => '1234',
+                ],
+            ],
+        ];
+
+        $connection = new MasterSlaveConnection($constructionParams, $this->createStub(Driver::class));
+
+        $connectionParams = $connection->getParams();
+        foreach ($constructionParams as $key => $value) {
+            self::assertSame($value, $connectionParams[$key]);
+        }
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4295

#### Summary

Ensure `Doctrine\DBAL\Connections\MasterSlaveConnection` `$params` are not stripped as `Doctrine\DBAL\Connection::getParams` is public and used by other libraries (e.g. `doctrine/doctrine-bundle`).


