### PR TITLE
Add enum to doctrineTypeMapping in MySqlPlatform

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -1084,6 +1084,7 @@ SQL
             'string'        => 'string',
             'char'          => 'string',
             'date'          => 'date',
+            'enum'          => 'string',
             'datetime'      => 'datetime',
             'timestamp'     => 'datetime',
             'time'          => 'time',
@@ -1100,7 +1101,6 @@ SQL
             'binary'        => 'binary',
             'varbinary'     => 'binary',
             'set'           => 'simple_array',
-            'enum'          => 'string'
         ];
     }
 

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -1100,6 +1100,7 @@ SQL
             'binary'        => 'binary',
             'varbinary'     => 'binary',
             'set'           => 'simple_array',
+            'enum'          => 'string'
         ];
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

When creating a diff with a DB that uses enum in some table columns, the diff fails because 'enum' is not in the doctrineTypeMapping array. This solves this issue.
