### PR TITLE
Fix handling existing SQL Server column comment when other properties change

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -532,7 +532,7 @@ SQL
                     );
                 } elseif ($hasFromComment && ! $hasComment) {
                     $commentsSql[] = $this->getDropColumnCommentSQL($diff->name, $column->getQuotedName($this));
-                } elseif ($hasComment) {
+                } elseif (! $hasFromComment && $hasComment) {
                     $commentsSql[] = $this->getCreateColumnCommentSQL(
                         $diff->name,
                         $column->getQuotedName($this),

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1718,4 +1718,19 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
             . ') AS doctrine_tbl WHERE doctrine_rownum >= %d AND doctrine_rownum <= %d ORDER BY doctrine_rownum ASC';
         self::assertEquals(sprintf($pattern, $expectedSql, $expectedMin, $expectedMax), $sql);
     }
+
+    public function testAlterTableWithSchemaSameColumnComments(): void
+    {
+        $tableDiff                          = new TableDiff('testschema.mytable');
+        $tableDiff->changedColumns['quota'] = new ColumnDiff(
+            'quota',
+            new Column('quota', Type::getType('integer'), ['comment' => 'A comment', 'notnull' => true]),
+            ['notnull'],
+            new Column('quota', Type::getType('integer'), ['comment' => 'A comment', 'notnull' => false])
+        );
+
+        $expectedSql = ['ALTER TABLE testschema.mytable ALTER COLUMN quota INT NOT NULL'];
+
+        self::assertEquals($expectedSql, $this->platform->getAlterTableSQL($tableDiff));
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4313

#### Summary
Fix case when schema updater tries to add a property that already exists and has not changed.

I use fix mentioned by @msyfurukawa in #3416
Closes #3416