### PR TITLE
Add lock mode to query builder

### DIFF
--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -416,10 +416,8 @@ class QueryBuilder
 
     /**
      * Gets the current lock mode  for this query
-     *
-     * @return int|null
      */
-    public function getLockMode()
+    public function getLockMode(): ?int
     {
         return $this->lockMode;
     }
@@ -428,10 +426,8 @@ class QueryBuilder
      * Set lock mode use one of the constants from LockMode::class locks are only added to SELECT queries
      *
      * Optimistic locking *is not* supported by DBAL.
-     *
-     * @param int $lockMode
      */
-    public function setLockMode(int $lockMode)
+    public function setLockMode(int $lockMode): self
     {
         $this->lockMode = $lockMode;
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -1184,6 +1184,8 @@ class QueryBuilder
                 break;
         }
 
+        $lockSql = rtrim($lockSql, ' ');
+
         $query = 'SELECT ' . ($this->sqlParts['distinct'] ? 'DISTINCT ' : '') .
                   implode(', ', $this->sqlParts['select']);
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -22,6 +22,7 @@ use function implode;
 use function is_array;
 use function is_object;
 use function key;
+use function rtrim;
 use function strtoupper;
 use function substr;
 

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Query;
+
+use Doctrine\DBAL\LockMode;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+class QueryBuilderTest extends DbalFunctionalTestCase
+{
+    /** @var bool */
+    private static $generated = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (self::$generated !== false) {
+            return;
+        }
+
+        $table = new Table('lock_test_table');
+        $table->addColumn('primary_key', 'integer');
+        $table->addColumn('data', 'string');
+        $table->setPrimaryKey(['primary_key']);
+
+        $sm = $this->connection->getSchemaManager();
+        $sm->createTable($table);
+
+        $this->connection->insert('lock_test_table', [
+            'primary_key' => 1,
+            'data' => 'foo',
+        ]);
+
+        $this->connection->insert('lock_test_table', [
+            'primary_key' => 2,
+            'data' => 'bar',
+        ]);
+
+        $this->connection->insert('lock_test_table', [
+            'primary_key' => 3,
+            'data' => 'baz',
+        ]);
+
+        self::$generated = true;
+    }
+
+    public function testReadLock()
+    {
+        $sut = $this->connection->createQueryBuilder();
+        $query = $sut->select('lt.*')
+            ->from('lock_test_table')
+            ->setLockMode(LockMode::PESSIMISTIC_READ)
+            ->where($sut->expr()->eq('lt.data', '?'))
+            ->setParameter(0, 'foo', ParameterType::STRING);
+
+        $result = $query->execute();
+        $record = $result->fetchAllAssociative();
+        self::assertEquals(1, $record[0]['primary_key']);
+    }
+
+    public function testWriteLock()
+    {
+        $sut = $this->connection->createQueryBuilder();
+        $query = $sut->select('lt.*')
+            ->from('lock_test_table')
+            ->setLockMode(LockMode::PESSIMISTIC_WRITE)
+            ->where($sut->expr()->eq('lt.data', '?'))
+            ->setParameter(0, 'bar', ParameterType::STRING);
+
+        $result = $query->execute();
+        $record = $result->fetchAllAssociative();
+        self::assertEquals(2, $record[0]['primary_key']);
+    }
+}

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -50,7 +50,7 @@ class QueryBuilderTest extends DbalFunctionalTestCase
     {
         $sut = $this->connection->createQueryBuilder();
         $query = $sut->select('lt.*')
-            ->from('lock_test_table')
+            ->from('lock_test_table', 'lt')
             ->setLockMode(LockMode::PESSIMISTIC_READ)
             ->where($sut->expr()->eq('lt.data', '?'))
             ->setParameter(0, 'foo', ParameterType::STRING);

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -55,9 +55,13 @@ class QueryBuilderTest extends DbalFunctionalTestCase
             ->where($sut->expr()->eq('lt.data', '?'))
             ->setParameter(0, 'foo', ParameterType::STRING);
 
+        $this->connection->beginTransaction();
+
         $result = $query->execute();
         $record = $result->fetchAllAssociative();
         self::assertEquals(1, $record[0]['primary_key']);
+
+        $this->connection->rollBack();
     }
 
     public function testWriteLock(): void
@@ -69,8 +73,12 @@ class QueryBuilderTest extends DbalFunctionalTestCase
             ->where($sut->expr()->eq('lt.data', '?'))
             ->setParameter(0, 'bar', ParameterType::STRING);
 
+        $this->connection->beginTransaction();
+
         $result = $query->execute();
         $record = $result->fetchAllAssociative();
         self::assertEquals(2, $record[0]['primary_key']);
+
+        $this->connection->rollBack();
     }
 }

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -57,9 +57,11 @@ class QueryBuilderTest extends FunctionalTestCase
 
         $this->connection->beginTransaction();
 
-        $result = $query->execute();
-        $record = $result->fetchAllAssociative();
-        self::assertEquals(1, $record[0]['primary_key']);
+        $row = $query->execute()->fetchAssociative();
+
+        self::assertIsArray($row);
+        $row = array_change_key_case($row, CASE_LOWER);
+        self::assertEquals(['primary_key' => 1, 'data' => 'foo'], $row);
 
         $this->connection->rollBack();
     }
@@ -75,9 +77,11 @@ class QueryBuilderTest extends FunctionalTestCase
 
         $this->connection->beginTransaction();
 
-        $result = $query->execute();
-        $record = $result->fetchAllAssociative();
-        self::assertEquals(2, $record[0]['primary_key']);
+        $row = $query->execute()->fetchAssociative();
+
+        self::assertIsArray($row);
+        $row = array_change_key_case($row, CASE_LOWER);
+        self::assertEquals(['primary_key' => 2, 'data' => 'bar'], $row);
 
         $this->connection->rollBack();
     }

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -5,9 +5,9 @@ namespace Doctrine\Tests\DBAL\Functional\Query;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\Tests\DbalFunctionalTestCase;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
 
-class QueryBuilderTest extends DbalFunctionalTestCase
+class QueryBuilderTest extends FunctionalTestCase
 {
     /** @var bool */
     private static $generated = false;

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -46,9 +46,9 @@ class QueryBuilderTest extends DbalFunctionalTestCase
         self::$generated = true;
     }
 
-    public function testReadLock()
+    public function testReadLock(): void
     {
-        $sut = $this->connection->createQueryBuilder();
+        $sut   = $this->connection->createQueryBuilder();
         $query = $sut->select('lt.*')
             ->from('lock_test_table', 'lt')
             ->setLockMode(LockMode::PESSIMISTIC_READ)
@@ -60,11 +60,11 @@ class QueryBuilderTest extends DbalFunctionalTestCase
         self::assertEquals(1, $record[0]['primary_key']);
     }
 
-    public function testWriteLock()
+    public function testWriteLock(): void
     {
-        $sut = $this->connection->createQueryBuilder();
+        $sut   = $this->connection->createQueryBuilder();
         $query = $sut->select('lt.*')
-            ->from('lock_test_table')
+            ->from('lock_test_table', 'lt')
             ->setLockMode(LockMode::PESSIMISTIC_WRITE)
             ->where($sut->expr()->eq('lt.data', '?'))
             ->setParameter(0, 'bar', ParameterType::STRING);

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -157,7 +157,7 @@ class QueryBuilderTest extends TestCase
             ->setLockMode(LockMode::PESSIMISTIC_WRITE)
             ->where($expr->and($expr->eq('u.nickname', '?')));
 
-        self::assertEquals('SELECT u.id FROM users u WITH (XLOCK) WHERE u.nickname = ?', (string) $qb);
+        self::assertEquals('SELECT u.id FROM users u WITH (UPDLOCK, ROWLOCK) WHERE u.nickname = ?', (string) $qb);
     }
 
     public function testSelectWithLeftJoin(): void

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tests\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Query\QueryException;
@@ -23,6 +24,12 @@ class QueryBuilderTest extends TestCase
         $this->conn->expects(self::any())
                    ->method('getExpressionBuilder')
                    ->will(self::returnValue($expressionBuilder));
+
+        $platform = new SqlitePlatform();
+
+        $this->conn->expects(self::any())
+                   ->method('getDatabasePlatform')
+                   ->will(self::returnValue($platform));
     }
 
     public function testSimpleSelectWithoutFrom(): void

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
-use Doctrine\DBAL\Platforms\SQLAnywhere16Platform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
@@ -148,7 +147,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectWithWriteLockTableHint(): void
     {
-        $platform = new SQLAnywhere16Platform();
+        $platform = new SQLServer2012Platform();
 
         $qb   = new QueryBuilder($this->createMockConnection($platform));
         $expr = $qb->expr();


### PR DESCRIPTION
This is a prototype of adding the ability to add locks when building a query using the query builder in a platform agnostic way. For the most part, this mimics the way that it is done in the ORM query builder. 

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | N/A

#### Summary

- Adds get/set lock mode to query builder.
- Query builder will append the correct lock SQL based on the current database platform.
