### PR TITLE
Reintroduce parts of Legacy API for some more time

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1737,4 +1737,37 @@ class Connection
 
         return $exception;
     }
+
+    /**
+     * BC layer for a wide-spread use-case of old DBAL APIs
+     *
+     * @deprecated This API is deprecated and will be removed after 2022
+     *
+     * @param array<mixed>           $params The query parameters
+     * @param array<int|string|null> $types  The parameter types
+     */
+    public function executeUpdate(string $sql, array $params = [], array $types = []): int
+    {
+        return $this->executeStatement($sql, $params, $types);
+    }
+
+    /**
+     * BC layer for a wide-spread use-case of old DBAL APIs
+     *
+     * @deprecated This API is deprecated and will be removed after 2022
+     */
+    public function query(string $sql): Result
+    {
+        return $this->executeQuery($sql);
+    }
+
+    /**
+     * BC layer for a wide-spread use-case of old DBAL APIs
+     *
+     * @deprecated This API is deprecated and will be removed after 2022
+     */
+    public function exec(string $sql): int
+    {
+        return $this->executeStatement($sql);
+    }
 }

--- a/src/FetchMode.php
+++ b/src/FetchMode.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\DBAL;
+
+/**
+ * Legacy Class that keeps BC for using the legacy APIs fetch()/fetchAll().
+ */
+class FetchMode
+{
+    /** @link PDO::FETCH_ASSOC */
+    public const ASSOCIATIVE = 2;
+    /** @link PDO::FETCH_NUM */
+    public const NUMERIC = 3;
+    /** @link PDO::FETCH_COLUMN */
+    public const COLUMN = 7;
+}

--- a/src/Result.php
+++ b/src/Result.php
@@ -7,7 +7,10 @@ namespace Doctrine\DBAL;
 use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Driver\Result as DriverResult;
 use Doctrine\DBAL\Exception\NoKeyValue;
+use LogicException;
 use Traversable;
+
+use function func_num_args;
 
 class Result
 {
@@ -241,5 +244,61 @@ class Result
         if ($columnCount < 2) {
             throw NoKeyValue::fromColumnCount($columnCount);
         }
+    }
+
+    /**
+     * BC layer for a wide-spread use-case of old DBAL APIs
+     *
+     * @deprecated This API is deprecated and will be removed after 2022
+     *
+     * @return mixed
+     */
+    public function fetch(int $mode = FetchMode::ASSOCIATIVE)
+    {
+        if (func_num_args() > 1) {
+            throw new LogicException('Only invocations with one argument are still supported by this legecy API.');
+        }
+
+        if ($mode === FetchMode::ASSOCIATIVE) {
+            return $this->fetchAssociative();
+        }
+
+        if ($mode === FetchMode::NUMERIC) {
+            return $this->fetchNumeric();
+        }
+
+        if ($mode === FetchMode::COLUMN) {
+            return $this->fetchOne();
+        }
+
+        throw new LogicException('Only fetch modes declared on Doctrine\DBAL\FetchMode are supported by legacy API.');
+    }
+
+    /**
+     * BC layer for a wide-spread use-case of old DBAL APIs
+     *
+     * @deprecated This API is deprecated and will be removed after 2022
+     *
+     * @return list<mixed>
+     */
+    public function fetchAll(int $mode = FetchMode::ASSOCIATIVE): array
+    {
+        if (func_num_args() > 1) {
+            throw new LogicException('Only invocations with one argument are still supported by this legecy API.');
+        }
+
+        if ($mode === FetchMode::ASSOCIATIVE) {
+            return $this->fetchAllAssociative();
+        }
+
+        if ($mode === FetchMode::NUMERIC) {
+            return $this->fetchAllNumeric();
+        }
+
+        if ($mode === FetchMode::COLUMN) {
+            return $this->fetchFirstColumn();
+        }
+
+        throw new LogicException('Only fetch modes declared on Doctrine\DBAL\FetchMode are supported by legacy API.');
     }
 }

--- a/tests/Functional/LegacyAPITest.php
+++ b/tests/Functional/LegacyAPITest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use LogicException;
+
+use function array_change_key_case;
+use function array_map;
+
+use const CASE_LOWER;
+
+class LegacyAPITest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $table = new Table('legacy_table');
+        $table->addColumn('test_int', 'integer');
+        $table->addColumn('test_string', 'string');
+        $table->setPrimaryKey(['test_int']);
+
+        $sm = $this->connection->getSchemaManager();
+        $sm->dropAndCreateTable($table);
+
+        $this->connection->insert('legacy_table', [
+            'test_int' => 1,
+            'test_string' => 'foo',
+        ]);
+    }
+
+    public function tearDown(): void
+    {
+        $this->connection->executeStatement('DELETE FROM legacy_table WHERE test_int > 1');
+    }
+
+    public function testFetchWithAssociativeMode(): void
+    {
+        $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
+
+        $stmt = $this->connection->executeQuery($sql);
+        $row  = array_change_key_case($stmt->fetch(FetchMode::ASSOCIATIVE), CASE_LOWER);
+        self::assertEquals(1, $row['test_int']);
+    }
+
+    public function testFetchWithNumericMode(): void
+    {
+        $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
+
+        $stmt = $this->connection->executeQuery($sql);
+        $row  = $stmt->fetch(FetchMode::NUMERIC);
+        self::assertEquals(1, $row[0]);
+    }
+
+    public function testFetchWithColumnMode(): void
+    {
+        $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
+
+        $stmt = $this->connection->executeQuery($sql);
+        $row  = $stmt->fetch(FetchMode::COLUMN);
+        self::assertEquals(1, $row);
+    }
+
+    public function testFetchWithTooManyArguments(): void
+    {
+        $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
+
+        $stmt = $this->connection->executeQuery($sql);
+
+        $this->expectException(LogicException::class);
+
+        $stmt->fetch(FetchMode::COLUMN, 2);
+    }
+
+    public function testFetchWithUnsupportedFetchMode(): void
+    {
+        $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
+
+        $stmt = $this->connection->executeQuery($sql);
+
+        $this->expectException(LogicException::class);
+
+        $stmt->fetch(1);
+    }
+
+    public function testFetchAllWithAssociativeModes(): void
+    {
+        $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
+
+        $stmt = $this->connection->executeQuery($sql);
+
+        $rows = $stmt->fetchAll(FetchMode::ASSOCIATIVE);
+        $rows = array_map(static function ($row) {
+            return array_change_key_case($row, CASE_LOWER);
+        }, $rows);
+
+        self::assertEquals([['test_int' => 1]], $rows);
+    }
+
+    public function testFetchAllWithNumericModes(): void
+    {
+        $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
+
+        $stmt = $this->connection->executeQuery($sql);
+        $rows = $stmt->fetchAll(FetchMode::NUMERIC);
+        self::assertEquals([[0 => 1]], $rows);
+    }
+
+    public function testFetchAllWithColumnMode(): void
+    {
+        $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
+
+        $stmt = $this->connection->executeQuery($sql);
+        $rows = $stmt->fetchAll(FetchMode::COLUMN);
+        self::assertEquals([1], $rows);
+    }
+
+    public function testFetchAllWithTooManyArguments(): void
+    {
+        $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
+
+        $stmt = $this->connection->executeQuery($sql);
+
+        $this->expectException(LogicException::class);
+
+        $stmt->fetchAll(FetchMode::COLUMN, 2);
+    }
+
+    public function testFetchAllWithUnsupportedFetchMode(): void
+    {
+        $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
+
+        $stmt = $this->connection->executeQuery($sql);
+
+        $this->expectException(LogicException::class);
+
+        $stmt->fetchAll(1);
+    }
+
+    public function testExecuteUpdate(): void
+    {
+        $this->connection->executeUpdate(
+            'INSERT INTO legacy_table (test_int, test_string) VALUES (?, ?)',
+            [2, 'bar'],
+            ['integer', 'string']
+        );
+
+        $sql = 'SELECT test_string FROM legacy_table';
+
+        $stmt = $this->connection->executeQuery($sql);
+        $rows = $stmt->fetchAll(FetchMode::COLUMN);
+        self::assertEquals(['foo', 'bar'], $rows);
+    }
+
+    public function testQuery(): void
+    {
+        $stmt = $this->connection->query('SELECT test_string FROM legacy_table WHERE test_int = 1');
+
+        $this->assertEquals('foo', $stmt->fetchOne());
+    }
+
+    public function testExec(): void
+    {
+        $this->connection->insert('legacy_table', [
+            'test_int' => 2,
+            'test_string' => 'bar',
+        ]);
+
+        $count = $this->connection->exec('DELETE FROM legacy_table WHERE test_int > 1');
+
+        $this->assertEquals(1, $count);
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

With this PR we are re-introducing the PDO compatible API and common APIs of the DBAL "hotpath" again to keep them for a bit longer. This is too give users more time to migrate off of them, especially since many libraries and frameworks expose Doctrine DBAL via their plugin APIs.
