### PR TITLE
Properly format scalar values in ConversionException

### DIFF
--- a/src/Types/ConversionException.php
+++ b/src/Types/ConversionException.php
@@ -13,6 +13,7 @@ use function is_scalar;
 use function sprintf;
 use function strlen;
 use function substr;
+use function var_export;
 
 /**
  * Conversion Exception is thrown when the database to PHP conversion fails.
@@ -73,21 +74,18 @@ class ConversionException extends Exception
         array $possibleTypes,
         ?Throwable $previous = null
     ) {
-        $actualType = is_object($value) ? get_class($value) : gettype($value);
-
-        if (is_scalar($value)) {
+        if (is_scalar($value) || $value === null) {
             return new self(sprintf(
-                "Could not convert PHP value '%s' of type '%s' to type '%s'. Expected one of the following types: %s",
-                $value,
-                $actualType,
+                'Could not convert PHP value %s to type %s. Expected one of the following types: %s',
+                var_export($value, true),
                 $toType,
                 implode(', ', $possibleTypes)
             ), 0, $previous);
         }
 
         return new self(sprintf(
-            "Could not convert PHP value of type '%s' to type '%s'. Expected one of the following types: %s",
-            $actualType,
+            'Could not convert PHP value of type %s to type %s. Expected one of the following types: %s',
+            is_object($value) ? get_class($value) : gettype($value),
             $toType,
             implode(', ', $possibleTypes)
         ), 0, $previous);

--- a/tests/Types/ConversionExceptionTest.php
+++ b/tests/Types/ConversionExceptionTest.php
@@ -26,14 +26,13 @@ class ConversionExceptionTest extends TestCase
      *
      * @dataProvider scalarsProvider
      */
-    public function testConversionFailedInvalidTypeWithScalar($scalarValue): void
+    public function testConversionFailedInvalidTypeWithScalar($scalarValue, string $expected): void
     {
         $exception = ConversionException::conversionFailedInvalidType($scalarValue, 'foo', ['bar', 'baz']);
 
         self::assertInstanceOf(ConversionException::class, $exception);
-        self::assertMatchesRegularExpression(
-            '/^Could not convert PHP value \'.*\' of type \'(string|boolean|float|double|integer)\' to type \'foo\'. '
-            . 'Expected one of the following types: bar, baz$/',
+        self::assertStringContainsString(
+            $expected,
             $exception->getMessage()
         );
     }
@@ -49,7 +48,7 @@ class ConversionExceptionTest extends TestCase
 
         self::assertInstanceOf(ConversionException::class, $exception);
         self::assertMatchesRegularExpression(
-            '/^Could not convert PHP value of type \'(.*)\' to type \'foo\'. '
+            '/^Could not convert PHP value of type (.*) to type foo. '
             . 'Expected one of the following types: bar, baz$/',
             $exception->getMessage()
         );
@@ -82,8 +81,6 @@ class ConversionExceptionTest extends TestCase
     {
         return [
             [[]],
-            [['foo']],
-            [null],
             [new stdClass()],
             [tmpfile()],
         ];
@@ -95,13 +92,13 @@ class ConversionExceptionTest extends TestCase
     public static function scalarsProvider(): iterable
     {
         return [
-            [''],
-            ['foo'],
-            [123],
-            [-123],
-            [12.34],
-            [true],
-            [false],
+            ['foo', "PHP value 'foo'"],
+            [123, 'PHP value 123'],
+            [-123, 'PHP value -123'],
+            [12.34, 'PHP value 12.34'],
+            [true, 'PHP value true'],
+            [false, 'PHP value false'],
+            [null, 'PHP value NULL'],
         ];
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #4318.