### PR TITLE
Removed quote_ident() from Query, to list tablenames

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -262,7 +262,7 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function getListTablesSQL()
     {
-        return "SELECT quote_ident(table_name) AS table_name,
+        return "SELECT table_name AS table_name,
                        table_schema AS schema_name
                 FROM   information_schema.tables
                 WHERE  table_schema NOT LIKE 'pg\_%'


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
Database : **PostgreSQL**

I've removed quote_ident() from query to list tablename.
I am using PostgreSQL, Ive created table in capital letters "DNS_feature"
Facing the issue during **SchemaManager** to get the list of tablename exist in database
**Exist Table Names**
![image](https://user-images.githubusercontent.com/40670677/95014060-f19b1900-0661-11eb-9181-0df51a240459.png)

It list all the tables but with Capital letters it added quotation mark because of **quote_ident()** function
![image](https://user-images.githubusercontent.com/40670677/95014108-4dfe3880-0662-11eb-84e1-b5535c200a2a.png)

It must return tablename like **DNS_feature** but it list **"DNS_feature"**

So, Pls accept my pull request and issue will resolve

Thank you,