### PR TITLE
Clean up redundant implements

### DIFF
--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\DBAL\Driver\OCI8;
 
-use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\OCI8\Exception\ConnectionFailed;
 use Doctrine\DBAL\Driver\OCI8\Exception\Error;
@@ -26,7 +25,7 @@ use function str_replace;
 
 use const OCI_NO_AUTO_COMMIT;
 
-final class Connection implements ConnectionInterface, ServerInfoAwareConnection
+final class Connection implements ServerInfoAwareConnection
 {
     /** @var resource */
     protected $dbh;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

`ServerInfoAwareConnection` extends `Connection`, so it is redundant to implement both.

---

BTW, why was `ServerInfoAwareConnection` changed to extend `Connection`? I found the old design much better, when interfaces were independent, and connection classes could compose their own set of implementations. What if you need to introduce `SomethingElseAwareConnection` in the future? Will it extend `Connection` as well? Sure, you'll still be able to implement both of them and it will work, but will look weird if you ask me.