### PR TITLE
Remove implicit ext-json dependency

### DIFF
--- a/tests/Connection/ExceptionHandlingTest.php
+++ b/tests/Connection/ExceptionHandlingTest.php
@@ -35,7 +35,7 @@ final class ExceptionHandlingTest extends TestCase
     {
         $this->exceptionConverter->expects(self::once())
             ->method('convert')
-            ->with(self::stringContains('with params ["ABC", "\x80"]'));
+            ->with(self::stringContains('with params [\'ABC\', "\x80"]'));
 
         $this->connection->convertExceptionDuringQuery(
             $this->createMock(DriverException::class),


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

The codebase contains [calls to `json_encode()`](https://github.com/doctrine/dbal/blob/master/src/Connection.php#L1632), yet this is not documented in the requirements.

The `json` extension [can be disabled](https://stackoverflow.com/a/61230713/759866) in PHP 7!