### PR TITLE
Fix regression in QueryBuilder::and|orWhere()

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -12,6 +12,7 @@ use function array_filter;
 use function array_key_exists;
 use function array_keys;
 use function array_unshift;
+use function count;
 use function func_get_args;
 use function func_num_args;
 use function implode;
@@ -834,7 +835,9 @@ class QueryBuilder
         $where = $this->getQueryPart('where');
 
         if ($where instanceof CompositeExpression && $where->getType() === CompositeExpression::TYPE_AND) {
-            $where = $where->with(...$args);
+            if (count($args) > 0) {
+                $where = $where->with(...$args);
+            }
         } else {
             array_unshift($args, $where);
             $where = CompositeExpression::and(...$args);
@@ -868,7 +871,9 @@ class QueryBuilder
         $where = $this->getQueryPart('where');
 
         if ($where instanceof CompositeExpression && $where->getType() === CompositeExpression::TYPE_OR) {
-            $where = $where->with(...$args);
+            if (count($args) > 0) {
+                $where = $where->with(...$args);
+            }
         } else {
             array_unshift($args, $where);
             $where = CompositeExpression::or(...$args);

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -950,6 +950,19 @@ class QueryBuilderTest extends DbalTestCase
         $qb->getSQL();
     }
 
+    public function testWhereExpressionAndWhereEmptyString(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('id')
+            ->from('foo')
+            ->where('a = b');
+
+        $qb->andWhere('');
+
+        self::assertSame('SELECT id FROM foo WHERE a = b', $qb->getSQL());
+    }
+
     public function testAndWhereEmptyStringStartingWithEmptyExpression(): void
     {
         $qb = new QueryBuilder($this->conn);
@@ -973,6 +986,19 @@ class QueryBuilderTest extends DbalTestCase
         $qb->andWhere('', 'c = d');
 
         self::assertSame('SELECT id FROM foo WHERE (a = b) AND (c = d)', $qb->getSQL());
+    }
+
+    public function testWhereExpressionOrWhereEmptyString(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('id')
+            ->from('foo')
+            ->orWhere('a = b');
+
+        $qb->orWhere('');
+
+        self::assertSame('SELECT id FROM foo WHERE a = b', $qb->getSQL());
     }
 
     public function testOrWhereEmptyStringStartingWithEmptyExpression(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | yes/no
| Fixed issues | #4282

#### Summary

#4286 fixed only half of the regression.

Using `andWhere('')` or `orWhere('')` after a non-empty where condition has already been set results in an error.

See https://github.com/doctrine/dbal/issues/4282#issuecomment-705661983