### PR TITLE
Static analysis improvements

### DIFF
--- a/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
+++ b/lib/Doctrine/DBAL/Cache/QueryCacheProfile.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Cache;
 
 use Doctrine\Common\Cache\Cache;
+use Doctrine\DBAL\Types\Type;
 
 use function hash;
 use function serialize;
@@ -68,10 +69,10 @@ class QueryCacheProfile
     /**
      * Generates the real cache key from query, params, types and connection parameters.
      *
-     * @param string         $sql
-     * @param mixed[]        $params
-     * @param int[]|string[] $types
-     * @param mixed[]        $connectionParams
+     * @param string                                                               $sql
+     * @param array<int, mixed>|array<string, mixed>                               $params
+     * @param array<int, Type|int|string|null>|array<string, Type|int|string|null> $types
+     * @param array<string, mixed>                                                 $connectionParams
      *
      * @return string[]
      */

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -695,24 +695,24 @@ class Connection implements DriverConnection
     }
 
     /**
-     * Adds identifier condition to the query components
+     * Adds condition based on the criteria to the query components
      *
-     * @param mixed[]  $identifier Map of key columns to their values
+     * @param mixed[]  $criteria   Map of key columns to their values
      * @param string[] $columns    Column names
      * @param mixed[]  $values     Column values
      * @param string[] $conditions Key conditions
      *
      * @throws Exception
      */
-    private function addIdentifierCondition(
-        array $identifier,
+    private function addCriteriaCondition(
+        array $criteria,
         array &$columns,
         array &$values,
         array &$conditions
     ): void {
         $platform = $this->getDatabasePlatform();
 
-        foreach ($identifier as $columnName => $value) {
+        foreach ($criteria as $columnName => $value) {
             if ($value === null) {
                 $conditions[] = $platform->getIsNullExpression($columnName);
                 continue;
@@ -729,23 +729,23 @@ class Connection implements DriverConnection
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param string                                                               $table      Table name
-     * @param array<string, mixed>                                                 $identifier Deletion criteria
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types      Parameter types
+     * @param string                                                               $table    Table name
+     * @param array<string, mixed>                                                 $criteria Deletion criteria
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
      *
      * @return int The number of affected rows.
      *
      * @throws Exception
      */
-    public function delete($table, array $identifier, array $types = [])
+    public function delete($table, array $criteria, array $types = [])
     {
-        if (empty($identifier)) {
+        if (empty($criteria)) {
             throw InvalidArgumentException::fromEmptyCriteria();
         }
 
         $columns = $values = $conditions = [];
 
-        $this->addIdentifierCondition($identifier, $columns, $values, $conditions);
+        $this->addCriteriaCondition($criteria, $columns, $values, $conditions);
 
         return $this->executeStatement(
             'DELETE FROM ' . $table . ' WHERE ' . implode(' AND ', $conditions),
@@ -797,16 +797,16 @@ class Connection implements DriverConnection
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param string                                                               $table      Table name
-     * @param array<string, mixed>                                                 $data       Column-value pairs
-     * @param array<string, mixed>                                                 $identifier Update criteria
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types      Parameter types
+     * @param string                                                               $table    Table name
+     * @param array<string, mixed>                                                 $data     Column-value pairs
+     * @param array<string, mixed>                                                 $criteria Update criteria
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
      *
      * @return int The number of affected rows.
      *
      * @throws Exception
      */
-    public function update($table, array $data, array $identifier, array $types = [])
+    public function update($table, array $data, array $criteria, array $types = [])
     {
         $columns = $values = $conditions = $set = [];
 
@@ -816,7 +816,7 @@ class Connection implements DriverConnection
             $set[]     = $columnName . ' = ?';
         }
 
-        $this->addIdentifierCondition($identifier, $columns, $values, $conditions);
+        $this->addCriteriaCondition($criteria, $columns, $values, $conditions);
 
         if (is_string(key($types))) {
             $types = $this->extractTypeValues($columns, $types);

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -543,11 +543,11 @@ class Connection implements DriverConnection
      *
      * @deprecated Use fetchAssociative()
      *
-     * @param string         $sql    The query SQL
-     * @param mixed[]        $params The query parameters
-     * @param int[]|string[] $types  The query parameter types
+     * @param string                                                               $sql    SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
-     * @return mixed[]|false False is returned if no rows are found.
+     * @return array<string, mixed>|false False is returned if no rows are found.
      *
      * @throws Exception
      */
@@ -562,11 +562,11 @@ class Connection implements DriverConnection
      *
      * @deprecated Use fetchNumeric()
      *
-     * @param string         $sql    The query SQL
-     * @param mixed[]        $params The query parameters
-     * @param int[]|string[] $types  The query parameter types
+     * @param string                                                               $sql    SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
-     * @return mixed[]|false False is returned if no rows are found.
+     * @return array<int, mixed>|false False is returned if no rows are found.
      */
     public function fetchArray($sql, array $params = [], array $types = [])
     {
@@ -579,10 +579,10 @@ class Connection implements DriverConnection
      *
      * @deprecated Use fetchOne() instead.
      *
-     * @param string         $sql    The query SQL
-     * @param mixed[]        $params The query parameters
-     * @param int            $column The 0-indexed column number to retrieve
-     * @param int[]|string[] $types  The query parameter types
+     * @param string                                                               $sql    SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param int                                                                  $column 0-indexed column number
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return mixed|false False is returned if no rows are found.
      *
@@ -597,9 +597,9 @@ class Connection implements DriverConnection
      * Prepares and executes an SQL query and returns the first row of the result
      * as an associative array.
      *
-     * @param string                                           $query  The SQL query.
-     * @param array<int, mixed>|array<string, mixed>           $params The prepared statement params.
-     * @param array<int, int|string>|array<string, int|string> $types  The query parameter types.
+     * @param string                                                               $query  SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return array<string, mixed>|false False is returned if no rows are found.
      *
@@ -624,9 +624,9 @@ class Connection implements DriverConnection
      * Prepares and executes an SQL query and returns the first row of the result
      * as a numerically indexed array.
      *
-     * @param string                                           $query  The SQL query to be executed.
-     * @param array<int, mixed>|array<string, mixed>           $params The prepared statement params.
-     * @param array<int, int|string>|array<string, int|string> $types  The query parameter types.
+     * @param string                                                               $query  SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return array<int, mixed>|false False is returned if no rows are found.
      *
@@ -651,9 +651,9 @@ class Connection implements DriverConnection
      * Prepares and executes an SQL query and returns the value of a single column
      * of the first row of the result.
      *
-     * @param string                                           $query  The SQL query to be executed.
-     * @param array<int, mixed>|array<string, mixed>           $params The prepared statement params.
-     * @param array<int, int|string>|array<string, int|string> $types  The query parameter types.
+     * @param string                                                               $query  SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return mixed|false False is returned if no rows are found.
      *
@@ -729,9 +729,9 @@ class Connection implements DriverConnection
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param string         $table      The expression of the table on which to delete.
-     * @param mixed[]        $identifier The deletion criteria. An associative array containing column-value pairs.
-     * @param int[]|string[] $types      The types of identifiers.
+     * @param string                                                               $table      Table name
+     * @param array<string, mixed>                                                 $identifier Deletion criteria
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types      Parameter types
      *
      * @return int The number of affected rows.
      *
@@ -797,10 +797,10 @@ class Connection implements DriverConnection
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param string         $table      The expression of the table to update quoted or unquoted.
-     * @param mixed[]        $data       An associative array containing column-value pairs.
-     * @param mixed[]        $identifier The update criteria. An associative array containing column-value pairs.
-     * @param int[]|string[] $types      Types of the merged $data and $identifier arrays in that order.
+     * @param string                                                               $table      Table name
+     * @param array<string, mixed>                                                 $data       Column-value pairs
+     * @param array<string, mixed>                                                 $identifier Update criteria
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types      Parameter types
      *
      * @return int The number of affected rows.
      *
@@ -833,9 +833,9 @@ class Connection implements DriverConnection
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param string         $table The expression of the table to insert data into, quoted or unquoted.
-     * @param mixed[]        $data  An associative array containing column-value pairs.
-     * @param int[]|string[] $types Types of the inserted data.
+     * @param string                                                               $table Table name
+     * @param array<string, mixed>                                                 $data  Column-value pairs
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types Parameter types
      *
      * @return int The number of affected rows.
      *
@@ -868,10 +868,10 @@ class Connection implements DriverConnection
     /**
      * Extract ordered type list from an ordered column list and type map.
      *
-     * @param int[]|string[] $columnList
-     * @param int[]|string[] $types
+     * @param array<int, string>                                                   $columnList
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
      *
-     * @return int[]|string[]
+     * @return array<int, int|string|Type|null>|array<string, int|string|Type|null>
      */
     private function extractTypeValues(array $columnList, array $types)
     {
@@ -936,9 +936,9 @@ class Connection implements DriverConnection
     /**
      * Prepares and executes an SQL query and returns the result as an array of numeric arrays.
      *
-     * @param string                                           $query  The SQL query.
-     * @param array<int, mixed>|array<string, mixed>           $params The query parameters.
-     * @param array<int, int|string>|array<string, int|string> $types  The query parameter types.
+     * @param string                                                               $query  SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return array<int,array<int,mixed>>
      *
@@ -962,9 +962,9 @@ class Connection implements DriverConnection
     /**
      * Prepares and executes an SQL query and returns the result as an array of associative arrays.
      *
-     * @param string                                           $query  The SQL query.
-     * @param array<int, mixed>|array<string, mixed>           $params The query parameters.
-     * @param array<int, int|string>|array<string, int|string> $types  The query parameter types.
+     * @param string                                                               $query  SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return array<int,array<string,mixed>>
      *
@@ -988,9 +988,9 @@ class Connection implements DriverConnection
     /**
      * Prepares and executes an SQL query and returns the result as an array of the first column values.
      *
-     * @param string                                           $query  The SQL query.
-     * @param array<int, mixed>|array<string, mixed>           $params The query parameters.
-     * @param array<int, int|string>|array<string, int|string> $types  The query parameter types.
+     * @param string                                                               $query  SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return array<int,mixed>
      *
@@ -1014,9 +1014,9 @@ class Connection implements DriverConnection
     /**
      * Prepares and executes an SQL query and returns the result as an iterator over rows represented as numeric arrays.
      *
-     * @param string                                           $query  The SQL query.
-     * @param array<int, mixed>|array<string, mixed>           $params The query parameters.
-     * @param array<int, int|string>|array<string, int|string> $types  The query parameter types.
+     * @param string                                                               $query  SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return Traversable<int,array<int,mixed>>
      *
@@ -1043,9 +1043,9 @@ class Connection implements DriverConnection
      * Prepares and executes an SQL query and returns the result as an iterator over rows represented
      * as associative arrays.
      *
-     * @param string                                           $query  The SQL query.
-     * @param array<int, mixed>|array<string, mixed>           $params The query parameters.
-     * @param array<int, int|string>|array<string, int|string> $types  The query parameter types.
+     * @param string                                                               $query  SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return Traversable<int,array<string,mixed>>
      *
@@ -1071,9 +1071,9 @@ class Connection implements DriverConnection
     /**
      * Prepares and executes an SQL query and returns the result as an iterator over the first column values.
      *
-     * @param string                                           $query  The SQL query.
-     * @param array<int, mixed>|array<string, mixed>           $params The query parameters.
-     * @param array<int, int|string>|array<string, int|string> $types  The query parameter types.
+     * @param string                                                               $query  SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return Traversable<int,mixed>
      *
@@ -1124,10 +1124,9 @@ class Connection implements DriverConnection
      * If the query is parametrized, a prepared statement is used.
      * If an SQLLogger is configured, the execution is logged.
      *
-     * @param string                 $sql    The SQL query to execute.
-     * @param mixed[]                $params The parameters to bind to the query, if any.
-     * @param int[]|string[]         $types  The types the previous parameters are in.
-     * @param QueryCacheProfile|null $qcp    The query cache profile, optional.
+     * @param string                                                               $sql    SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return ResultStatement The executed statement.
      *
@@ -1181,10 +1180,9 @@ class Connection implements DriverConnection
     /**
      * Executes a caching query.
      *
-     * @param string            $sql    The SQL query to execute.
-     * @param mixed[]           $params The parameters to bind to the query, if any.
-     * @param int[]|string[]    $types  The types the previous parameters are in.
-     * @param QueryCacheProfile $qcp    The query cache profile.
+     * @param string                                                               $sql    SQL query
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return ResultStatement
      *
@@ -1301,9 +1299,9 @@ class Connection implements DriverConnection
      *
      * @deprecated Use {@link executeStatement()} instead.
      *
-     * @param string                 $sql    The SQL query.
-     * @param array<mixed>           $params The query parameters.
-     * @param array<int|string|null> $types  The parameter types.
+     * @param string                                                               $sql    SQL statement
+     * @param array<int, mixed>|array<string, mixed>                               $params Statement parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return int The number of affected rows.
      *
@@ -1326,9 +1324,9 @@ class Connection implements DriverConnection
      *
      * This method supports PDO binding types as well as DBAL mapping types.
      *
-     * @param string                 $sql    The statement SQL
-     * @param array<mixed>           $params The query parameters
-     * @param array<int|string|null> $types  The parameter types
+     * @param string                                                               $sql    SQL statement
+     * @param array<int, mixed>|array<string, mixed>                               $params Statement parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return int The number of affected rows.
      *
@@ -1842,9 +1840,9 @@ class Connection implements DriverConnection
      * @internal Duck-typing used on the $stmt parameter to support driver statements as well as
      *           raw PDOStatement instances.
      *
-     * @param \Doctrine\DBAL\Driver\Statement $stmt   The statement to bind the values to.
-     * @param mixed[]                         $params The map/list of named/positional parameters.
-     * @param int[]|string[]                  $types  The parameter types (PDO binding types or DBAL mapping types).
+     * @param \Doctrine\DBAL\Driver\Statement                                      $stmt   Prepared statement
+     * @param array<int, mixed>|array<string, mixed>                               $params Statement parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return void
      */
@@ -1911,10 +1909,10 @@ class Connection implements DriverConnection
      * @internal This is a purely internal method. If you rely on this method, you are advised to
      *           copy/paste the code as this method may change, or be removed without prior notice.
      *
-     * @param mixed[]        $params
-     * @param int[]|string[] $types
+     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
-     * @return mixed[]
+     * @return array<int, int|string|Type|null>|array<string, int|string|Type|null>
      */
     public function resolveParams(array $params, array $types)
     {
@@ -2006,8 +2004,8 @@ class Connection implements DriverConnection
     /**
      * @internal
      *
-     * @param array<int, mixed>|array<string, mixed>           $params
-     * @param array<int, int|string>|array<string, int|string> $types
+     * @param array<int, mixed>|array<string, mixed>                               $params
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
      *
      * @throws Exception
      *

--- a/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
+++ b/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
@@ -317,11 +317,11 @@ class PrimaryReadReplicaConnection extends Connection
     /**
      * {@inheritDoc}
      */
-    public function delete($table, array $identifier, array $types = [])
+    public function delete($table, array $criteria, array $types = [])
     {
         $this->ensureConnectedToPrimary();
 
-        return parent::delete($table, $identifier, $types);
+        return parent::delete($table, $criteria, $types);
     }
 
     /**
@@ -340,11 +340,11 @@ class PrimaryReadReplicaConnection extends Connection
     /**
      * {@inheritDoc}
      */
-    public function update($table, array $data, array $identifier, array $types = [])
+    public function update($table, array $data, array $criteria, array $types = [])
     {
         $this->ensureConnectedToPrimary();
 
-        return parent::update($table, $data, $identifier, $types);
+        return parent::update($table, $data, $criteria, $types);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Logging/SQLLogger.php
+++ b/lib/Doctrine/DBAL/Logging/SQLLogger.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Logging;
 
+use Doctrine\DBAL\Types\Type;
+
 /**
  * Interface for SQL loggers.
  */
@@ -10,9 +12,9 @@ interface SQLLogger
     /**
      * Logs a SQL statement somewhere.
      *
-     * @param string                 $sql    The SQL to be executed.
-     * @param mixed[]|null           $params The SQL parameters.
-     * @param array<int|string|null> $types  The SQL parameter types.
+     * @param string                                                                    $sql    SQL statement
+     * @param array<int, mixed>|array<string, mixed>|null                               $params Statement parameters
+     * @param array<int, Type|int|string|null>|array<string, Type|int|string|null>|null $types  Parameter types
      *
      * @return void
      */

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
+use Doctrine\DBAL\Types\Type;
 
 use function array_filter;
 use function array_key_exists;
@@ -88,14 +89,14 @@ class QueryBuilder
     /**
      * The query parameters.
      *
-     * @var mixed[]
+     * @var array<int, mixed>|array<string, mixed>
      */
     private $params = [];
 
     /**
      * The parameter type map of this query.
      *
-     * @var int[]|string[]
+     * @var array<int, int|string|Type|null>|array<string, int|string|Type|null>
      */
     private $paramTypes = [];
 
@@ -263,9 +264,9 @@ class QueryBuilder
      *         ->setParameter(':user_id', 1);
      * </code>
      *
-     * @param string|int      $key   The parameter position or name.
-     * @param mixed           $value The parameter value.
-     * @param string|int|null $type  One of the {@link ParameterType} constants.
+     * @param int|string           $key   Parameter position or name
+     * @param mixed                $value Parameter value
+     * @param int|string|Type|null $type  One of the {@link ParameterType} constants or DBAL type
      *
      * @return $this This QueryBuilder instance.
      */
@@ -294,8 +295,8 @@ class QueryBuilder
      *         ));
      * </code>
      *
-     * @param mixed[]        $params The query parameters to set.
-     * @param int[]|string[] $types  The query parameters types to set.
+     * @param array<int, mixed>|array<string, mixed>                               $params Parameters to set
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return $this This QueryBuilder instance.
      */
@@ -310,7 +311,7 @@ class QueryBuilder
     /**
      * Gets all defined query parameters for the query being constructed indexed by parameter index or name.
      *
-     * @return mixed[] The currently defined query parameters indexed by parameter index or name.
+     * @return array<int, mixed>|array<string, mixed> The currently defined query parameters
      */
     public function getParameters()
     {
@@ -332,7 +333,8 @@ class QueryBuilder
     /**
      * Gets all defined query parameter types for the query being constructed indexed by parameter index or name.
      *
-     * @return int[]|string[] The currently defined query parameter types indexed by parameter index or name.
+     * @return array<int, int|string|Type|null>|array<string, int|string|Type|null> The currently defined
+     *                                                                              query parameter types
      */
     public function getParameterTypes()
     {
@@ -342,9 +344,9 @@ class QueryBuilder
     /**
      * Gets a (previously set) query parameter type of the query being constructed.
      *
-     * @param mixed $key The key (index or name) of the bound parameter type.
+     * @param int|string $key The key of the bound parameter type
      *
-     * @return mixed The value of the bound parameter type.
+     * @return int|string|Type|null The value of the bound parameter type
      */
     public function getParameterType($key)
     {
@@ -1291,9 +1293,9 @@ class QueryBuilder
      *
      * @link http://www.zetacomponents.org
      *
-     * @param mixed  $value
-     * @param mixed  $type
-     * @param string $placeHolder The name to bind with. The string must start with a colon ':'.
+     * @param mixed                $value
+     * @param int|string|Type|null $type
+     * @param string               $placeHolder The name to bind with. The string must start with a colon ':'.
      *
      * @return string the placeholder name used.
      */
@@ -1326,8 +1328,8 @@ class QueryBuilder
      *     ->orWhere('u.username = ' . $qb->createPositionalParameter('Bar', ParameterType::STRING))
      * </code>
      *
-     * @param mixed $value
-     * @param int   $type
+     * @param mixed                $value
+     * @param int|string|Type|null $type
      *
      * @return string
      */

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL;
 
+use Doctrine\DBAL\Types\Type;
+
 use function array_fill;
 use function array_fill_keys;
 use function array_key_exists;
@@ -128,9 +130,9 @@ class SQLParserUtils
     /**
      * For a positional query this method can rewrite the sql statement with regard to array parameters.
      *
-     * @param string                 $query  The SQL query to execute.
-     * @param mixed[]                $params The parameters to bind to the query.
-     * @param array<string|int|null> $types  The types the previous parameters are in.
+     * @param string                                                               $query  SQL query
+     * @param mixed[]                                                              $params Query parameters
+     * @param array<int, Type|int|string|null>|array<string, Type|int|string|null> $types  Parameter types
      *
      * @return mixed[]
      *

--- a/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
@@ -33,6 +33,7 @@ use function array_keys;
 use function assert;
 use function count;
 use function implode;
+use function is_array;
 use function is_string;
 use function trigger_error;
 
@@ -149,7 +150,14 @@ EOT
     {
         $conn = $this->getConnection($input);
 
-        $keywordLists = (array) $input->getOption('list');
+        $keywordLists = $input->getOption('list');
+
+        if (is_string($keywordLists)) {
+            $keywordLists = [$keywordLists];
+        } elseif (! is_array($keywordLists)) {
+            $keywordLists = [];
+        }
+
         if (! $keywordLists) {
             $keywordLists = [
                 'mysql',

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/Db2SchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/Db2SchemaManagerTest.php
@@ -2,11 +2,18 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\BooleanType;
 
 class Db2SchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
+    protected function supportsPlatform(AbstractPlatform $platform): bool
+    {
+        return $platform instanceof DB2Platform;
+    }
+
     public function testGetBooleanColumn(): void
     {
         $table = new Table('boolean_column_test');

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/DrizzleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/DrizzleSchemaManagerTest.php
@@ -2,11 +2,18 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DrizzlePlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\BinaryType;
 
 class DrizzleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
+    protected function supportsPlatform(AbstractPlatform $platform): bool
+    {
+        return $platform instanceof DrizzlePlatform;
+    }
+
     public function testListTableWithBinary(): void
     {
         $tableName = 'test_binary_table';

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
 use DateTime;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Comparator;
@@ -15,6 +16,11 @@ use Doctrine\Tests\Types\MySqlPointType;
 
 class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
+    protected function supportsPlatform(AbstractPlatform $platform): bool
+    {
+        return $platform instanceof MySqlPlatform;
+    }
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/OracleSchemaManagerTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\BinaryType;
@@ -14,6 +16,11 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
     /** @var bool */
     private static $privilegesGranted = false;
+
+    protected function supportsPlatform(AbstractPlatform $platform): bool
+    {
+        return $platform instanceof OraclePlatform;
+    }
 
     protected function setUp(): void
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -25,6 +25,11 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
     /** @var PostgreSqlSchemaManager */
     protected $schemaManager;
 
+    protected function supportsPlatform(AbstractPlatform $platform): bool
+    {
+        return $platform instanceof PostgreSQL94Platform;
+    }
+
     protected function tearDown(): void
     {
         parent::tearDown();

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
@@ -2,12 +2,19 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SQLAnywherePlatform;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\View;
 
 class SQLAnywhereSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
+    protected function supportsPlatform(AbstractPlatform $platform): bool
+    {
+        return $platform instanceof SQLAnywherePlatform;
+    }
+
     public function testCreateAndListViews(): void
     {
         $this->createTestTable('view_test_table');

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Schema;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Table;
@@ -12,9 +14,9 @@ use function current;
 
 class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
-    protected function getPlatformName(): string
+    protected function supportsPlatform(AbstractPlatform $platform): bool
     {
-        return 'mssql';
+        return $platform instanceof SQLServer2012Platform;
     }
 
     public function testDropColumnConstraints(): void

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -6,6 +6,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Events;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -38,11 +39,9 @@ use function array_search;
 use function array_values;
 use function count;
 use function current;
-use function end;
-use function explode;
+use function get_class;
 use function in_array;
 use function sprintf;
-use function str_replace;
 use function strcasecmp;
 use function strlen;
 use function strtolower;
@@ -53,23 +52,16 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
     /** @var AbstractSchemaManager */
     protected $schemaManager;
 
-    protected function getPlatformName(): string
-    {
-        $class     = static::class;
-        $e         = explode('\\', $class);
-        $testClass = end($e);
-
-        return strtolower(str_replace('SchemaManagerTest', '', $testClass));
-    }
+    abstract protected function supportsPlatform(AbstractPlatform $platform): bool;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $dbms = $this->getPlatformName();
+        $platform = $this->connection->getDatabasePlatform();
 
-        if ($this->connection->getDatabasePlatform()->getName() !== $dbms) {
-            $this->markTestSkipped(static::class . ' requires the use of ' . $dbms);
+        if (! $this->supportsPlatform($platform)) {
+            $this->markTestSkipped(sprintf('Skipping since connected to %s', get_class($platform)));
         }
 
         $this->schemaManager = $this->connection->getSchemaManager();

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\Tests\DBAL\Functional\Schema;
 
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\BlobType;
@@ -14,6 +16,11 @@ use function dirname;
 
 class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
+    protected function supportsPlatform(AbstractPlatform $platform): bool
+    {
+        return $platform instanceof SqlitePlatform;
+    }
+
     /**
      * SQLITE does not support databases.
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

During merging up #4319 to `master` (currently only prepared locally), some new Psalm and PHPStan failures occurred. Instead of just fixing them in the merge commit, I'd like to fix them in the earliest possible version.

1. Psalm flags `(array)` casting in `ReservedWordsCommand` as a type error because `getOption()` may return a boolean which will be cast to `[false]` or `[true]` neither of which is a valid list of platforms: https://github.com/doctrine/dbal/blob/e7c4149a13f1267380a8061452816a1a33909dc1/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php#L152
2. `SchemaManagerFunctionalTestCase` has really creepy magic that requires an assertion for PHPStan but Psalm considers this assertion redundant: https://github.com/doctrine/dbal/blob/4eba1bac58f62d593911026f272930ab077d2c56/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php#L54-L62
   Due to this magic, the test must be named exactly like the platform it's supposed to test or otherwise, it will be skipped. It's better to implement the logic of which test tests which platform explicitly.
3. The type of the prepared statement parameter type argument is specified inconsistently across the codebase. The valid type of the type is `int|string|Type|null` which is one of the ParameterType constants, DBAL type name, DBAL type object, or NULL respectively.
4. The `$identifier` argument in `Connection::update()` and `::delete()` methods have been renamed to `$criteria` which it actually is. Otherwise, an "identifier" implies that a single record will be identified.