### PR TITLE
Add Statement::fetchAllKeyValue() and ::iterateKeyValue()

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -379,6 +379,25 @@ Execute the query and fetch all results into an array:
     )
     */
 
+fetchAllKeyValue()
+~~~~~~~~~~~~~~~~~~
+
+Execute the query and fetch the first two columns into an associative array as keys and values respectively:
+
+.. code-block:: php
+
+    <?php
+    $users = $conn->fetchAllKeyValue('SELECT username, password FROM user');
+
+    /*
+    array(
+      'jwage' => 'changeme',
+    )
+    */
+
+.. note::
+   All additional columns will be ignored and are only allowed to be selected by DBAL for its internal purposes.
+
 fetchNumeric()
 ~~~~~~~~~~~~~~
 
@@ -424,6 +443,21 @@ Retrieve associative array of the first result row.
     */
 
 There are also convenience methods for data manipulation queries:
+
+iterateKeyValue()
+~~~~~~~~~~~~~~~~~
+
+Execute the query and iterate over the first two columns as keys and values respectively:
+
+.. code-block:: php
+
+    <?php
+    foreach ($conn->iterateKeyValue('SELECT username, password FROM user') as $username => $password) {
+        // ...
+    }
+
+.. note::
+   All additional columns will be ignored and are only allowed to be selected by DBAL for its internal purposes.
 
 delete()
 ~~~~~~~~~

--- a/lib/Doctrine/DBAL/Exception/NoKeyValue.php
+++ b/lib/Doctrine/DBAL/Exception/NoKeyValue.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\DBAL\Exception;
+
+use Doctrine\DBAL\Exception;
+
+use function sprintf;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class NoKeyValue extends Exception
+{
+    public static function fromColumnCount(int $columnCount): self
+    {
+        return new self(
+            sprintf(
+                'Fetching as key-value pairs requires the result to contain at least 2 columns, %d given.',
+                $columnCount
+            )
+        );
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Connection/FetchTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Connection/FetchTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Connection;
 
+use Doctrine\DBAL\Exception\NoKeyValue;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use Doctrine\Tests\TestUtil;
 
@@ -77,6 +79,53 @@ class FetchTest extends DbalFunctionalTestCase
         ], $this->connection->fetchAllAssociative($this->query));
     }
 
+    public function testFetchAllKeyValue(): void
+    {
+        self::assertEquals([
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ], $this->connection->fetchAllKeyValue($this->query));
+    }
+
+    public function testStatementFetchAllKeyValue(): void
+    {
+        $stmt = $this->connection->prepare($this->query);
+        $stmt->execute();
+
+        self::assertEquals([
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ], $stmt->fetchAllKeyValue());
+    }
+
+    /**
+     * This test covers the requirement for the statement result to have at least two columns,
+     * not exactly two as PDO requires.
+     */
+    public function testFetchAllKeyValueWithLimit(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SQLServer2012Platform) {
+            self::markTestSkipped('See https://github.com/doctrine/dbal/issues/2374');
+        }
+
+        $query = $platform->modifyLimitQuery($this->query, 1, 1);
+
+        self::assertEquals(['bar' => 2], $this->connection->fetchAllKeyValue($query));
+    }
+
+    public function testFetchAllKeyValueOneColumn(): void
+    {
+        $sql = $this->connection->getDatabasePlatform()
+            ->getDummySelectSQL();
+
+        $this->expectException(NoKeyValue::class);
+        $this->connection->fetchAllKeyValue($sql);
+    }
+
     public function testFetchFirstColumn(): void
     {
         self::assertEquals([
@@ -111,6 +160,36 @@ class FetchTest extends DbalFunctionalTestCase
                 'b' => 3,
             ],
         ], iterator_to_array($this->connection->iterateAssociative($this->query)));
+    }
+
+    public function testIterateKeyValue(): void
+    {
+        self::assertEquals([
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ], iterator_to_array($this->connection->iterateKeyValue($this->query)));
+    }
+
+    public function testStatementKeyValue(): void
+    {
+        $stmt = $this->connection->prepare($this->query);
+        $stmt->execute();
+
+        self::assertEquals([
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ], iterator_to_array($stmt->iterateKeyValue()));
+    }
+
+    public function testIterateKeyValueOneColumn(): void
+    {
+        $sql = $this->connection->getDatabasePlatform()
+            ->getDummySelectSQL();
+
+        $this->expectException(NoKeyValue::class);
+        iterator_to_array($this->connection->iterateKeyValue($sql));
     }
 
     public function testIterateColumn(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

This is a backport of https://github.com/doctrine/dbal/pull/4293 to provide a better upgrade path from `PDO::FETCH_KEY_PAIR`.