### PR TITLE
Added filtered index support for SQL Server

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -465,7 +465,17 @@ SQL
             $fields[] = $field . ' IS NOT NULL';
         }
 
-        return $sql . ' WHERE ' . implode(' AND ', $fields);
+        if (count($fields) > 0) {
+            if ($this->supportsPartialIndexes() && $index->hasOption('where')) {
+                $sql .= ' AND ';
+            } else {
+                $sql .= ' WHERE ';
+            }
+
+            $sql .= implode(' AND ', $fields);
+        }
+
+        return $sql;
     }
 
     /**
@@ -1015,7 +1025,7 @@ SQL
      *
      * @return string
      */
-    private function getTableWhereClause($table, $schemaColumn, $tableColumn)
+    protected function getTableWhereClause($table, $schemaColumn, $tableColumn)
     {
         if (strpos($table, '.') !== false) {
             [$schema, $table] = explode('.', $table);

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2008PlatformTest.php
@@ -4,6 +4,9 @@ namespace Doctrine\Tests\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2008Platform;
+use Doctrine\DBAL\Schema\Index;
+
+use function substr_count;
 
 class SQLServer2008PlatformTest extends AbstractSQLServerPlatformTestCase
 {
@@ -15,5 +18,24 @@ class SQLServer2008PlatformTest extends AbstractSQLServerPlatformTestCase
     public function testGeneratesTypeDeclarationForDateTimeTz(): void
     {
         self::assertEquals('DATETIMEOFFSET(6)', $this->platform->getDateTimeTzTypeDeclarationSQL([]));
+    }
+
+    public function testSupportsPartialIndexes(): void
+    {
+        self::assertTrue($this->platform->supportsPartialIndexes());
+    }
+
+    /**
+     * Tests if automatically added conditions for the unique constraint are correctly merged
+     * with optional where conditions.
+     */
+    public function testGeneratesPartialUniqueConstraintSqlWithSingleWherePart(): void
+    {
+        $where       = 'test IS NULL AND test2 IS NOT NULL';
+        $uniqueIndex = new Index('name', ['test', 'test2'], true, false, [], ['where' => $where]);
+
+        $sql = $this->platform->getUniqueConstraintDeclarationSQL('name', $uniqueIndex);
+
+        self::assertEquals(1, substr_count($sql, 'WHERE '));
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3038

#### Summary

Added support for filtered (or partial) indexes in SQL Server (supported since version 2008). This is the second version after the closed pull request #4240. It contains the implementation for SQL Server only. I will try to add the implementation for SQLite later, in a separate pull request.

The implementation has the following limitation (same as with other platforms like PostgreSQL, see #3871):
The given "where" option may be modified by the server. So when reading it again for comparison, the result may differ, which can result in an unnecessary update when creating a migration. This depends on how the "where" option is defined and especially occurrs in case of unique constraints, because for each indexed column in SQL Server a "IS NOT NULL" filter is added automatically by DBAL (for compatibility with other platforms and the SQL standard). This has to be solved globally (i.e. by saving the original value as a comment or adding a normalization step before the comparison) and is independent of this pull request.
