### PR TITLE
Add Statement::fetchAllIndexedAssociative() and ::iterateIndexedAssociative()

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -398,6 +398,26 @@ Execute the query and fetch the first two columns into an associative array as k
 .. note::
    All additional columns will be ignored and are only allowed to be selected by DBAL for its internal purposes.
 
+fetchAllAssociativeIndexed()
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Execute the query and fetch the data as an associative array where the key represents the first column and the value is
+an associative array of the rest of the columns and their values:
+
+.. code-block:: php
+
+    <?php
+    $users = $conn->fetchAllAssociativeIndexed('SELECT id, username, password FROM user');
+
+    /*
+    array(
+        1 => array(
+          'username' => 'jwage',
+          'password' => 'changeme',
+        )
+    )
+    */
+
 fetchNumeric()
 ~~~~~~~~~~~~~~
 
@@ -458,6 +478,19 @@ Execute the query and iterate over the first two columns as keys and values resp
 
 .. note::
    All additional columns will be ignored and are only allowed to be selected by DBAL for its internal purposes.
+
+iterateAssociativeIndexed()
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Execute the query and iterate over the result with the key representing the first column and the value being
+an associative array of the rest of the columns and their values:
+
+.. code-block:: php
+
+    <?php
+    foreach ($conn->iterateAssociativeIndexed('SELECT id, username, password FROM user') as $id => $data) {
+        // ...
+    }
 
 delete()
 ~~~~~~~~~

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -13,6 +13,7 @@ use PDO;
 use Throwable;
 use Traversable;
 
+use function array_shift;
 use function is_array;
 use function is_string;
 
@@ -399,6 +400,25 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     }
 
     /**
+     * Returns an associative array with the keys mapped to the first column and the values being
+     * an associative array representing the rest of the columns and their values.
+     *
+     * @return array<mixed,array<string,mixed>>
+     *
+     * @throws Exception
+     */
+    public function fetchAllAssociativeIndexed(): array
+    {
+        $data = [];
+
+        foreach ($this->fetchAll(FetchMode::ASSOCIATIVE) as $row) {
+            $data[array_shift($row)] = $row;
+        }
+
+        return $data;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @throws Exception
@@ -480,6 +500,21 @@ class Statement implements IteratorAggregate, DriverStatement, Result
 
         foreach ($this->iterateNumeric() as [$key, $value]) {
             yield $key => $value;
+        }
+    }
+
+    /**
+     * Returns an iterator over the result set with the keys mapped to the first column and the values being
+     * an associative array representing the rest of the columns and their values.
+     *
+     * @return Traversable<mixed,array<string,mixed>>
+     *
+     * @throws Exception
+     */
+    public function iterateAssociativeIndexed(): Traversable
+    {
+        while (($row = $this->stmt->fetch(FetchMode::ASSOCIATIVE)) !== false) {
+            yield array_shift($row) => $row;
         }
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Connection/FetchTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Connection/FetchTest.php
@@ -126,6 +126,27 @@ class FetchTest extends DbalFunctionalTestCase
         $this->connection->fetchAllKeyValue($sql);
     }
 
+    public function testFetchAllAssociativeIndexed(): void
+    {
+        self::assertEquals([
+            'foo' => ['b' => 1],
+            'bar' => ['b' => 2],
+            'baz' => ['b' => 3],
+        ], $this->connection->fetchAllAssociativeIndexed($this->query));
+    }
+
+    public function testStatementFetchAllAssociativeIndexed(): void
+    {
+        $stmt = $this->connection->prepare($this->query);
+        $stmt->execute();
+
+        self::assertEquals([
+            'foo' => ['b' => 1],
+            'bar' => ['b' => 2],
+            'baz' => ['b' => 3],
+        ], $stmt->fetchAllAssociativeIndexed());
+    }
+
     public function testFetchFirstColumn(): void
     {
         self::assertEquals([
@@ -171,7 +192,7 @@ class FetchTest extends DbalFunctionalTestCase
         ], iterator_to_array($this->connection->iterateKeyValue($this->query)));
     }
 
-    public function testStatementKeyValue(): void
+    public function testStatementIterateKeyValue(): void
     {
         $stmt = $this->connection->prepare($this->query);
         $stmt->execute();
@@ -190,6 +211,27 @@ class FetchTest extends DbalFunctionalTestCase
 
         $this->expectException(NoKeyValue::class);
         iterator_to_array($this->connection->iterateKeyValue($sql));
+    }
+
+    public function testIterateAssociativeIndexed(): void
+    {
+        self::assertEquals([
+            'foo' => ['b' => 1],
+            'bar' => ['b' => 2],
+            'baz' => ['b' => 3],
+        ], iterator_to_array($this->connection->iterateAssociativeIndexed($this->query)));
+    }
+
+    public function testStatementIterateAssociativeIndexed(): void
+    {
+        $stmt = $this->connection->prepare($this->query);
+        $stmt->execute();
+
+        self::assertEquals([
+            'foo' => ['b' => 1],
+            'bar' => ['b' => 2],
+            'baz' => ['b' => 3],
+        ], iterator_to_array($stmt->iterateAssociativeIndexed()));
     }
 
     public function testIterateColumn(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Closes #4206.

The fetch mode is analogous to the PDO's `FETCH_GROUP|FETCH_UNIQUE|FETCH_ASSOC`. Based on the `fetchIndexed()` name proposed in https://github.com/doctrine/dbal/issues/4206#issuecomment-706617488, I decided to name the method as `fetchAllIndexedAssociative()` for the following reasons:
1. It should have the "all" prefix for consistency with the rest of `fetchAll*()` methods.
2. It should have an "associative" suffix to be more specific and allow for the future addition of `fetchAllIndexedNumeric()` (although it's less likely to be requested).
3. It's more developer-friendly than `fetchAllAssociativeIndexed()` from the code completion standpoint since it shares fewer leading characters with `fetchAllAssociative()`.