### PR TITLE
Added filtered index support for SQL Server

### DIFF
--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
@@ -403,5 +404,25 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertCount(2, $columns);
         self::assertEquals('colB', $columns[0]);
         self::assertEquals('colA', $columns[1]);
+    }
+
+    public function testPartialIndexes(): void
+    {
+        $offlineTable = new Table('person');
+        $offlineTable->addColumn('id', 'integer');
+        $offlineTable->addColumn('name', 'string');
+        $offlineTable->addColumn('email', 'string');
+        $offlineTable->addIndex(['id', 'name'], 'simple_partial_index', [], ['where' => '([id] IS NULL)']);
+
+        $this->schemaManager->dropAndCreateTable($offlineTable);
+
+        $onlineTable = $this->schemaManager->listTableDetails('person');
+
+        $comparator = new Comparator();
+
+        self::assertFalse($comparator->diffTable($offlineTable, $onlineTable));
+        self::assertTrue($onlineTable->hasIndex('simple_partial_index'));
+        self::assertTrue($onlineTable->getIndex('simple_partial_index')->hasOption('where'));
+        self::assertSame('([id] IS NULL)', $onlineTable->getIndex('simple_partial_index')->getOption('where'));
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3038

#### Summary

Added support for filtered (or partial) indexes in SQL Server (supported since version 2008).

The implementation has the following limitation (same as with other platforms like PostgreSQL, see #3871):
The given "where" option may be modified by the server. So when reading it again for comparison, the result may differ, which can result in an unnecessary update when creating a migration. This depends on how the "where" option is defined and especially occurrs in case of unique indexes (but not unique constraints), because for each indexed column in SQL Server a "IS NOT NULL" filter is added automatically by DBAL (for compatibility with other platforms and the SQL standard). This has to be solved globally (i.e. by saving the original value as a comment or adding a normalization step before the comparison) and is independent of this pull request.
