### PR TITLE
Rename MySql... to MySQL... and PostgreSqlSchemaManager to PostgreSQLSchemaManager

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -187,7 +187,7 @@ The `Doctrine\DBAL\Driver::getName()` has been removed.
  * Removed `AbstractPlatform::getSQLResultCasing()`, `::prefersSequences()` and `::supportsForeignKeyOnUpdate()` methods.
  * Removed `PostgreSqlPlatform::getDisallowDatabaseConnectionsSQL()` and `::getCloseActiveDatabaseConnectionsSQL()` methods.
  * Removed `MysqlSessionInit` listener.
- * Removed `MysqlPlatform::getCollationFieldDeclaration()`.
+ * Removed `MySQLPlatform::getCollationFieldDeclaration()`.
  * Removed `AbstractPlatform::getIdentityColumnNullInsertSQL()`.
  * Removed `AbstractPlatform::fixSchemaElementName()`.
  * Removed `Table::addUnnamedForeignKeyConstraint()` and `Table::addNamedForeignKeyConstraint()`.

--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -33,7 +33,7 @@ can be found as follows:
 MySQL
 ^^^^^
 
--  ``MySqlPlatform`` for version 5.0 and above.
+-  ``MySQLPlatform`` for version 5.0 and above.
 -  ``MySQL57Platform`` for version 5.7 (5.7.9 GA) and above.
 -  ``MySQL80Platform`` for version 8.0 (8.0 GA) and above.
 

--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -807,7 +807,7 @@ method to add new database types or overwrite existing ones.
 .. note::
 
     You can only map a database type to exactly one Doctrine type.
-    Database vendors that allow to define custom types like PostgreSql
+    Database vendors that allow to define custom types like PostgreSQL
     can help to overcome this issue.
 
 Custom Mapping Types

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -10,8 +10,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\DBAL\Schema\MySqlSchemaManager;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 
 use function preg_match;
@@ -112,21 +112,21 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
     /**
      * {@inheritdoc}
      *
-     * @return MySqlPlatform
+     * @return MySQLPlatform
      */
     public function getDatabasePlatform()
     {
-        return new MySqlPlatform();
+        return new MySQLPlatform();
     }
 
     /**
      * {@inheritdoc}
      *
-     * @return MySqlSchemaManager
+     * @return MySQLSchemaManager
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
-        return new MySqlSchemaManager($conn, $platform);
+        return new MySQLSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
-use Doctrine\DBAL\Schema\PostgreSqlSchemaManager;
+use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 
 use function preg_match;
@@ -57,7 +57,7 @@ abstract class AbstractPostgreSQLDriver implements VersionAwarePlatformDriver
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
-        return new PostgreSqlSchemaManager($conn, $platform);
+        return new PostgreSQLSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Driver/PDO/MySQL/Driver.php
+++ b/src/Driver/PDO/MySQL/Driver.php
@@ -28,7 +28,7 @@ final class Driver extends AbstractMySQLDriver
     }
 
     /**
-     * Constructs the MySql PDO DSN.
+     * Constructs the MySQL PDO DSN.
      *
      * @param mixed[] $params
      *

--- a/src/Platforms/MariaDb1027Platform.php
+++ b/src/Platforms/MariaDb1027Platform.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Types\Types;
  *
  * Note: Should not be used with versions prior to 10.2.7.
  */
-final class MariaDb1027Platform extends MySqlPlatform
+final class MariaDb1027Platform extends MySQLPlatform
 {
     /**
      * {@inheritdoc}

--- a/src/Platforms/MySQL57Platform.php
+++ b/src/Platforms/MySQL57Platform.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Types\Types;
 /**
  * Provides the behavior, features and SQL dialect of the MySQL 5.7 (5.7.9 GA) database platform.
  */
-class MySQL57Platform extends MySqlPlatform
+class MySQL57Platform extends MySQLPlatform
 {
     /**
      * {@inheritdoc}

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -29,13 +29,13 @@ use function strtoupper;
 use function trim;
 
 /**
- * The MySqlPlatform provides the behavior, features and SQL dialect of the
+ * The MySQLPlatform provides the behavior, features and SQL dialect of the
  * MySQL database platform. This platform represents a MySQL 5.0 or greater platform that
  * uses the InnoDB storage engine.
  *
  * @todo   Rename: MySQLPlatform
  */
-class MySqlPlatform extends AbstractPlatform
+class MySQLPlatform extends AbstractPlatform
 {
     public const LENGTH_LIMIT_TINYTEXT   = 255;
     public const LENGTH_LIMIT_TEXT       = 65535;
@@ -303,7 +303,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      *
-     * MySql prefers "autoincrement" identity columns since sequences can only
+     * MySQL prefers "autoincrement" identity columns since sequences can only
      * be emulated with a table.
      */
     public function prefersIdentityColumns()
@@ -314,7 +314,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      *
-     * MySql supports this through AUTO_INCREMENT columns.
+     * MySQL supports this through AUTO_INCREMENT columns.
      */
     public function supportsIdentityColumns()
     {
@@ -1006,7 +1006,7 @@ SQL
         }
 
         if ($index instanceof Index && $index->isPrimary()) {
-            // mysql primary keys are always named "PRIMARY",
+            // MySQL primary keys are always named "PRIMARY",
             // so we cannot use them in statements because of them being keyword.
             return $this->getDropPrimaryKeySQL($table);
         }

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
@@ -21,9 +21,9 @@ use function strtr;
 use const CASE_LOWER;
 
 /**
- * Schema manager for the MySql RDBMS.
+ * Schema manager for the MySQL RDBMS.
  */
-class MySqlSchemaManager extends AbstractSchemaManager
+class MySQLSchemaManager extends AbstractSchemaManager
 {
     /**
      * @see https://mariadb.com/kb/en/library/string-literals/#escape-sequences
@@ -163,27 +163,27 @@ class MySqlSchemaManager extends AbstractSchemaManager
                 break;
 
             case 'tinytext':
-                $length = MySqlPlatform::LENGTH_LIMIT_TINYTEXT;
+                $length = MySQLPlatform::LENGTH_LIMIT_TINYTEXT;
                 break;
 
             case 'text':
-                $length = MySqlPlatform::LENGTH_LIMIT_TEXT;
+                $length = MySQLPlatform::LENGTH_LIMIT_TEXT;
                 break;
 
             case 'mediumtext':
-                $length = MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT;
+                $length = MySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT;
                 break;
 
             case 'tinyblob':
-                $length = MySqlPlatform::LENGTH_LIMIT_TINYBLOB;
+                $length = MySQLPlatform::LENGTH_LIMIT_TINYBLOB;
                 break;
 
             case 'blob':
-                $length = MySqlPlatform::LENGTH_LIMIT_BLOB;
+                $length = MySQLPlatform::LENGTH_LIMIT_BLOB;
                 break;
 
             case 'mediumblob':
-                $length = MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB;
+                $length = MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB;
                 break;
 
             case 'tinyint':
@@ -331,7 +331,7 @@ class MySqlSchemaManager extends AbstractSchemaManager
         $table = parent::listTableDetails($name);
 
         $platform = $this->_platform;
-        assert($platform instanceof MySqlPlatform);
+        assert($platform instanceof MySQLPlatform);
         $sql = $platform->getListTableMetadataSQL($name);
 
         $tableOptions = $this->_conn->fetchAssociative($sql);

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -30,7 +30,7 @@ use const CASE_LOWER;
 /**
  * PostgreSQL Schema Manager.
  */
-class PostgreSqlSchemaManager extends AbstractSchemaManager
+class PostgreSQLSchemaManager extends AbstractSchemaManager
 {
     /** @var string[] */
     private $existingSchemaPaths;

--- a/tests/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Driver/AbstractMySQLDriverTest.php
@@ -11,9 +11,9 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Doctrine\DBAL\Schema\MySqlSchemaManager;
+use Doctrine\DBAL\Schema\MySQLSchemaManager;
 
 class AbstractMySQLDriverTest extends AbstractDriverTest
 {
@@ -24,12 +24,12 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
 
     protected function createPlatform(): AbstractPlatform
     {
-        return new MySqlPlatform();
+        return new MySQLPlatform();
     }
 
     protected function createSchemaManager(Connection $connection): AbstractSchemaManager
     {
-        return new MySqlSchemaManager(
+        return new MySQLSchemaManager(
             $connection,
             $this->createPlatform()
         );
@@ -46,20 +46,20 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
     protected function getDatabasePlatformsForVersions(): array
     {
         return [
-            ['5.6.9', MySqlPlatform::class],
+            ['5.6.9', MySQLPlatform::class],
             ['5.7', MySQL57Platform::class],
-            ['5.7.0', MySqlPlatform::class],
-            ['5.7.8', MySqlPlatform::class],
+            ['5.7.0', MySQLPlatform::class],
+            ['5.7.8', MySQLPlatform::class],
             ['5.7.9', MySQL57Platform::class],
             ['5.7.10', MySQL57Platform::class],
             ['8', MySQL80Platform::class],
             ['8.0', MySQL80Platform::class],
             ['8.0.11', MySQL80Platform::class],
             ['6', MySQL57Platform::class],
-            ['10.0.15-MariaDB-1~wheezy', MySqlPlatform::class],
-            ['5.5.5-10.1.25-MariaDB', MySqlPlatform::class],
-            ['10.1.2a-MariaDB-a1~lenny-log', MySqlPlatform::class],
-            ['5.5.40-MariaDB-1~wheezy', MySqlPlatform::class],
+            ['10.0.15-MariaDB-1~wheezy', MySQLPlatform::class],
+            ['5.5.5-10.1.25-MariaDB', MySQLPlatform::class],
+            ['10.1.2a-MariaDB-a1~lenny-log', MySQLPlatform::class],
+            ['5.5.40-MariaDB-1~wheezy', MySQLPlatform::class],
             ['5.5.5-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
             ['10.2.8-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
             ['10.2.8-MariaDB-1~lenny-log', MariaDb1027Platform::class],

--- a/tests/Driver/AbstractPostgreSQLDriverTest.php
+++ b/tests/Driver/AbstractPostgreSQLDriverTest.php
@@ -11,7 +11,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Doctrine\DBAL\Schema\PostgreSqlSchemaManager;
+use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 
 class AbstractPostgreSQLDriverTest extends AbstractDriverTest
 {
@@ -27,7 +27,7 @@ class AbstractPostgreSQLDriverTest extends AbstractDriverTest
 
     protected function createSchemaManager(Connection $connection): AbstractSchemaManager
     {
-        return new PostgreSqlSchemaManager(
+        return new PostgreSQLSchemaManager(
             $connection,
             $this->createPlatform()
         );

--- a/tests/Functional/Connection/ConnectionLostTest.php
+++ b/tests/Functional/Connection/ConnectionLostTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Tests\Functional\Connection;
 
 use Doctrine\DBAL\Exception\ConnectionLost;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
 use function sleep;
@@ -14,7 +14,7 @@ class ConnectionLostTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
             return;
         }
 

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
@@ -369,7 +369,7 @@ EOT
             self::markTestSkipped('Does not work on Travis');
         }
 
-        if ($platform instanceof MySqlPlatform && isset($params['user'])) {
+        if ($platform instanceof MySQLPlatform && isset($params['user'])) {
             $wrappedConnection = $this->connection->getWrappedConnection();
             assert($wrappedConnection instanceof ServerInfoAwareConnection);
 

--- a/tests/Functional/Platform/DefaultExpressionTest.php
+++ b/tests/Functional/Platform/DefaultExpressionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Platform;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -19,7 +19,7 @@ class DefaultExpressionTest extends FunctionalTestCase
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        if ($platform instanceof MySqlPlatform) {
+        if ($platform instanceof MySQLPlatform) {
             self::markTestSkipped('Not supported on MySQL');
         }
 
@@ -32,7 +32,7 @@ class DefaultExpressionTest extends FunctionalTestCase
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        if ($platform instanceof MySqlPlatform) {
+        if ($platform instanceof MySQLPlatform) {
             self::markTestSkipped('Not supported on MySQL');
         }
 

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Tests\Functional\Platform;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
@@ -15,7 +15,7 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
     {
         parent::setUp();
 
-        if ($this->getPlatform() instanceof MySqlPlatform) {
+        if ($this->getPlatform() instanceof MySQLPlatform) {
             return;
         }
 

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 use DateTime;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
@@ -14,11 +14,11 @@ use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
-class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
+class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
     protected function supportsPlatform(AbstractPlatform $platform): bool
     {
-        return $platform instanceof MySqlPlatform;
+        return $platform instanceof MySQLPlatform;
     }
 
     protected function setUp(): void
@@ -297,14 +297,14 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableName = 'lob_type_columns';
         $table     = new Table($tableName);
 
-        $table->addColumn('col_tinytext', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYTEXT]);
-        $table->addColumn('col_text', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
-        $table->addColumn('col_mediumtext', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
+        $table->addColumn('col_tinytext', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TINYTEXT]);
+        $table->addColumn('col_text', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TEXT]);
+        $table->addColumn('col_mediumtext', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
         $table->addColumn('col_longtext', 'text');
 
-        $table->addColumn('col_tinyblob', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYBLOB]);
-        $table->addColumn('col_blob', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_BLOB]);
-        $table->addColumn('col_mediumblob', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
+        $table->addColumn('col_tinyblob', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TINYBLOB]);
+        $table->addColumn('col_blob', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_BLOB]);
+        $table->addColumn('col_mediumblob', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
         $table->addColumn('col_longblob', 'blob');
 
         $this->schemaManager->dropAndCreateTable($table);

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
-use Doctrine\DBAL\Schema\PostgreSqlSchemaManager;
+use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\BlobType;
@@ -21,9 +21,9 @@ use function count;
 use function preg_match;
 use function strtolower;
 
-class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
+class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
-    /** @var PostgreSqlSchemaManager */
+    /** @var PostgreSQLSchemaManager */
     protected $schemaManager;
 
     protected function supportsPlatform(AbstractPlatform $platform): bool

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Functional;
 
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
 use function sleep;
@@ -13,7 +13,7 @@ class TransactionTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
             return;
         }
 

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Tests\Platforms;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
@@ -15,7 +15,7 @@ use function array_shift;
 
 abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 {
-    /** @var MySqlPlatform */
+    /** @var MySQLPlatform */
     protected $platform;
 
     public function testModifyLimitQueryWitoutLimit(): void

--- a/tests/Platforms/MySQLPlatformTest.php
+++ b/tests/Platforms/MySQLPlatformTest.php
@@ -3,14 +3,14 @@
 namespace Doctrine\DBAL\Tests\Platforms;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\TransactionIsolationLevel;
 
-class MySqlPlatformTest extends AbstractMySQLPlatformTestCase
+class MySQLPlatformTest extends AbstractMySQLPlatformTestCase
 {
     public function createPlatform(): AbstractPlatform
     {
-        return new MySqlPlatform();
+        return new MySQLPlatform();
     }
 
     public function testHasCorrectDefaultTransactionIsolationLevel(): void

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Schema;
 
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\Column;
@@ -105,7 +105,7 @@ class ColumnTest extends TestCase
         $string = Type::getType('string');
         $column = new Column('`bar`', $string, []);
 
-        $mysqlPlatform  = new MySqlPlatform();
+        $mysqlPlatform  = new MySQLPlatform();
         $sqlitePlatform = new SqlitePlatform();
 
         self::assertEquals('bar', $column->getName());

--- a/tests/Schema/MySQLInheritCharsetTest.php
+++ b/tests/Schema/MySQLInheritCharsetTest.php
@@ -9,16 +9,16 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\MySqlSchemaManager;
+use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
 
 use function array_merge;
 
-class MySqlInheritCharsetTest extends TestCase
+class MySQLInheritCharsetTest extends TestCase
 {
     public function testInheritTableOptionsFromDatabase(): void
     {
@@ -39,7 +39,7 @@ class MySqlInheritCharsetTest extends TestCase
 
     public function testTableOptions(): void
     {
-        $platform = new MySqlPlatform();
+        $platform = new MySQLPlatform();
 
         // default, no overrides
         $table = new Table('foobar', [new Column('aa', Type::getType('integer'))]);
@@ -86,10 +86,10 @@ class MySqlInheritCharsetTest extends TestCase
         $driverMock->method('connect')
             ->willReturn($this->createMock(DriverConnection::class));
 
-        $platform    = new MySqlPlatform();
+        $platform    = new MySQLPlatform();
         $connOptions = array_merge(['platform' => $platform], $overrideOptions);
         $conn        = new Connection($connOptions, $driverMock, new Configuration(), $eventManager);
-        $manager     = new MySqlSchemaManager($conn, $platform);
+        $manager     = new MySQLSchemaManager($conn, $platform);
 
         $schemaConfig = $manager->createSchemaConfig();
 

--- a/tests/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Schema/MySQLSchemaManagerTest.php
@@ -6,16 +6,16 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
-use Doctrine\DBAL\Schema\MySqlSchemaManager;
+use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 use function array_map;
 
-class MySqlSchemaManagerTest extends TestCase
+class MySQLSchemaManagerTest extends TestCase
 {
     /** @var AbstractSchemaManager */
     private $manager;
@@ -28,7 +28,7 @@ class MySqlSchemaManagerTest extends TestCase
         $eventManager = new EventManager();
         $driverMock   = $this->createMock(Driver::class);
 
-        $platform = $this->createMock(MySqlPlatform::class);
+        $platform = $this->createMock(MySQLPlatform::class);
         $platform->method('getListTableForeignKeysSQL')
             ->willReturn('');
 
@@ -36,7 +36,7 @@ class MySqlSchemaManagerTest extends TestCase
             ->onlyMethods(['fetchAllAssociative'])
             ->setConstructorArgs([[], $driverMock, new Configuration(), $eventManager])
             ->getMock();
-        $this->manager = new MySqlSchemaManager($this->conn, $platform);
+        $this->manager = new MySQLSchemaManager($this->conn, $platform);
     }
 
     public function testCompositeForeignKeys(): void

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Tests\Schema\Platforms;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +19,7 @@ class MySQLSchemaTest extends TestCase
     protected function setUp(): void
     {
         $this->comparator = new Comparator();
-        $this->platform   = new MySqlPlatform();
+        $this->platform   = new MySQLPlatform();
     }
 
     public function testSwitchPrimaryKeyOrder(): void

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -552,7 +552,7 @@ class TableTest extends TestCase
     {
         $table = new Table('`bar`');
 
-        $mysqlPlatform  = new MySqlPlatform();
+        $mysqlPlatform  = new MySQLPlatform();
         $sqlitePlatform = new SqlitePlatform();
 
         self::assertEquals('bar', $table->getName());
@@ -596,7 +596,7 @@ class TableTest extends TestCase
     {
         $table = new Table('`test`.`test`');
         self::assertEquals('test.test', $table->getName());
-        self::assertEquals('`test`.`test`', $table->getQuotedName(new MySqlPlatform()));
+        self::assertEquals('`test`.`test`', $table->getQuotedName(new MySQLPlatform()));
     }
 
     public function testFullQualifiedTableName(): void

--- a/tests/Schema/Visitor/RemoveNamespacedAssetsTest.php
+++ b/tests/Schema/Visitor/RemoveNamespacedAssetsTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Schema\Visitor;
 
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets;
@@ -44,7 +44,7 @@ class RemoveNamespacedAssetsTest extends TestCase
 
         $schema->visit(new RemoveNamespacedAssets());
 
-        $sql = $schema->toSql(new MySqlPlatform());
+        $sql = $schema->toSql(new MySQLPlatform());
         self::assertCount(1, $sql, 'Just one CREATE TABLE statement, no foreign key and table to foo.bar');
     }
 
@@ -64,7 +64,7 @@ class RemoveNamespacedAssetsTest extends TestCase
 
         $schema->visit(new RemoveNamespacedAssets());
 
-        $sql = $schema->toSql(new MySqlPlatform());
+        $sql = $schema->toSql(new MySQLPlatform());
         self::assertCount(1, $sql, 'Just one CREATE TABLE statement, no foreign key and table to foo.bar');
     }
 }

--- a/tests/Schema/Visitor/SchemaSqlCollectorTest.php
+++ b/tests/Schema/Visitor/SchemaSqlCollectorTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Schema\Visitor;
 
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use PHPUnit\Framework\TestCase;
 
@@ -10,7 +10,7 @@ class SchemaSqlCollectorTest extends TestCase
 {
     public function testCreateSchema(): void
     {
-        $platformMock = $this->getMockBuilder(MySqlPlatform::class)
+        $platformMock = $this->getMockBuilder(MySQLPlatform::class)
             ->onlyMethods(['getCreateTableSql', 'getCreateSequenceSql', 'getCreateForeignKeySql'])
             ->getMock();
         $platformMock->expects(self::exactly(2))
@@ -32,7 +32,7 @@ class SchemaSqlCollectorTest extends TestCase
 
     public function testDropSchema(): void
     {
-        $platformMock = $this->getMockBuilder(MySqlPlatform::class)
+        $platformMock = $this->getMockBuilder(MySQLPlatform::class)
             ->onlyMethods(['getDropTableSql', 'getDropSequenceSql', 'getDropForeignKeySql'])
             ->getMock();
         $platformMock->expects(self::exactly(2))


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes (class names are case insensitive, but it the class will not load with autoload if referenced first with the old case)
| Fixed issues | todo from `MySqlPlatform` class

#### Summary

Renamed classes:
- `Doctrine\DBAL\Platforms\MySqlPlatform` -> `Doctrine\DBAL\Platforms\MySQLPlatform`
- `Doctrine\DBAL\Schema\MySqlSchemaManager` -> `Doctrine\DBAL\Schema\MySQLSchemaManager`
- `Doctrine\DBAL\Schema\PostgreSqlSchemaManager` -> `Doctrine\DBAL\Schema\PostgreSQLSchemaManager`
- test classes

PS: I am a huge fan of PascalCase defined with snake case, ie. if `mysql_platform` is the most sensual form, then the class should be named `MysqlPlatform`. But to keep things consistent, I only fixed one TODO from code and make `MySql` to be consistent with other names.