### PR TITLE
[2.12] PHP 8 compatibility

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,6 +23,7 @@ jobs:
         php-version:
           - "7.3"
           - "7.4"
+          - "8.0"
         deps:
           - "fixed"
         include:
@@ -183,6 +184,9 @@ jobs:
           - "11"
           - "12"
           - "13"
+        include:
+          - php-version: "8.0"
+            postgres-version: "13"
 
     services:
       postgres:
@@ -247,6 +251,13 @@ jobs:
         extension:
           - "mysqli"
           - "pdo_mysql"
+        include:
+          - php-version: "8.0"
+            mariadb-version: "10.5"
+            extension: "mysqli"
+          - php-version: "8.0"
+            mariadb-version: "10.5"
+            extension: "pdo_mysql"
 
     services:
       mariadb:
@@ -304,6 +315,7 @@ jobs:
       matrix:
         php-version:
           - "7.4"
+          - "8.0"
         mysql-version:
           - "5.7"
           - "8.0"

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,18 @@
+# Upgrade to 2.12
+
+## PDO signature changes with php 8
+
+In php 8.0, the method signatures of two PDO classes which are extended by DBAL have changed. This affects the following classes:
+
+* `Doctrine\DBAL\Driver\PDOConnection`
+* `Doctrine\DBAL\Driver\PDOStatement`
+
+Code that extends either of the classes needs to be adjusted in order to function properly on php 8. The updated method signatures are:
+
+* `PDOConnection::query(?string $query = null, ?int $fetchMode = null, mixed ...$fetchModeArgs)`
+* `PDOStatement::setFetchMode($mode, ...$args)`
+* `PDOStatement::fetchAll($mode = null, ...$args)`
+
 # Upgrade to 2.11
 
 ## Deprecated `Abstraction\Result` 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8",
         "ext-pdo": "*",
         "doctrine/cache": "^1.0",
         "doctrine/event-manager": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9b5b86a282f25dc5f24bc422885e9c0",
+    "content-hash": "0e4428b976a1e1835abdff64014ad723",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -3922,7 +3922,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8",
         "ext-pdo": "*"
     },
     "platform-dev": [],

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -11,7 +11,6 @@ use PDOException;
 use PDOStatement;
 
 use function assert;
-use function func_get_args;
 
 /**
  * PDO implementation of the Connection interface.
@@ -21,6 +20,8 @@ use function func_get_args;
  */
 class PDOConnection extends PDO implements ConnectionInterface, ServerInfoAwareConnection
 {
+    use PDOQueryImplementation;
+
     /**
      * @internal The connection can be only instantiated by its driver.
      *
@@ -85,25 +86,6 @@ class PDOConnection extends PDO implements ConnectionInterface, ServerInfoAwareC
 
     /**
      * {@inheritdoc}
-     *
-     * @return PDOStatement
-     */
-    public function query()
-    {
-        $args = func_get_args();
-
-        try {
-            $stmt = parent::query(...$args);
-            assert($stmt instanceof PDOStatement);
-
-            return $stmt;
-        } catch (PDOException $exception) {
-            throw Exception::new($exception);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
      */
     public function quote($value, $type = ParameterType::STRING)
     {
@@ -132,5 +114,21 @@ class PDOConnection extends PDO implements ConnectionInterface, ServerInfoAwareC
     public function requiresQueryForServerVersion()
     {
         return false;
+    }
+
+    /**
+     * @param mixed ...$args
+     */
+    private function doQuery(...$args): PDOStatement
+    {
+        try {
+            $stmt = parent::query(...$args);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
+
+        assert($stmt instanceof PDOStatement);
+
+        return $stmt;
     }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php
+++ b/lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Doctrine\DBAL\Driver;
+
+use PDOStatement;
+
+use function func_get_args;
+
+use const PHP_VERSION_ID;
+
+if (PHP_VERSION_ID >= 80000) {
+    /**
+     * @internal
+     */
+    trait PDOQueryImplementation
+    {
+        /**
+         * @return PDOStatement
+         */
+        public function query(?string $query = null, ?int $fetchMode = null, mixed ...$fetchModeArgs)
+        {
+            return $this->doQuery($query, $fetchMode, ...$fetchModeArgs);
+        }
+    }
+} else {
+    /**
+     * @internal
+     */
+    trait PDOQueryImplementation
+    {
+        /**
+         * @return PDOStatement
+         */
+        public function query()
+        {
+            return $this->doQuery(...func_get_args());
+        }
+    }
+}

--- a/lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Doctrine\DBAL\Driver;
+
+use function func_get_args;
+
+use const PHP_VERSION_ID;
+
+if (PHP_VERSION_ID >= 80000) {
+    /**
+     * @internal
+     */
+    trait PDOStatementImplementations
+    {
+        /**
+         * @deprecated Use one of the fetch- or iterate-related methods.
+         *
+         * @param int   $mode
+         * @param mixed ...$args
+         *
+         * @return bool
+         */
+        public function setFetchMode($mode, ...$args)
+        {
+            return $this->doSetFetchMode($mode, ...$args);
+        }
+
+        /**
+         * @deprecated Use fetchAllNumeric(), fetchAllAssociative() or fetchFirstColumn() instead.
+         *
+         * @param int|null $mode
+         * @param mixed    ...$args
+         *
+         * @return mixed[]
+         */
+        public function fetchAll($mode = null, ...$args)
+        {
+            return $this->doFetchAll($mode, ...$args);
+        }
+    }
+} else {
+    /**
+     * @internal
+     */
+    trait PDOStatementImplementations
+    {
+        /**
+         * @deprecated Use one of the fetch- or iterate-related methods.
+         *
+         * @param int   $fetchMode
+         * @param mixed $arg2
+         * @param mixed $arg3
+         */
+        public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null): bool
+        {
+            return $this->doSetFetchMode(...func_get_args());
+        }
+
+        /**
+         * @deprecated Use fetchAllNumeric(), fetchAllAssociative() or fetchFirstColumn() instead.
+         *
+         * @param int|null $fetchMode
+         * @param mixed    $fetchArgument
+         * @param mixed    $ctorArgs
+         *
+         * @return mixed[]
+         */
+        public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
+        {
+            return $this->doFetchAll(...func_get_args());
+        }
+    }
+}

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use IteratorAggregate;
 use PDO;
+use PDOStatement;
 use Throwable;
 use Traversable;
 
@@ -134,6 +135,10 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     {
         $this->params[$param] = $variable;
         $this->types[$param]  = $type;
+
+        if ($this->stmt instanceof PDOStatement) {
+            $length = $length ?? 0;
+        }
 
         return $this->stmt->bindParam($param, $variable, $type, $length);
     }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -22,6 +22,7 @@
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants.DisallowedLateStaticBindingForConstant"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.ControlStructureSpacing.IncorrectLinesCountAfterLastControlStructure"/>
+        <exclude name="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator.RequiredNullCoalesceEqualOperator"/>
 
         <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
         <!-- https://github.com/slevomat/coding-standard/issues/867 -->
@@ -29,6 +30,11 @@
         <!-- See https://github.com/squizlabs/PHP_CodeSniffer/issues/2937 -->
         <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNoNewline"/>
         <exclude name="Squiz.NamingConventions.ValidVariableName.PublicHasUnderscore"/>
+    </rule>
+
+    <rule ref="Generic.Classes.DuplicateClassName.Found">
+        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php</exclude-pattern>
+        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php</exclude-pattern>
     </rule>
 
     <!-- Disable the rules that will require PHP 7.4 -->
@@ -57,6 +63,8 @@
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php</exclude-pattern>
+        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php</exclude-pattern>
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 
@@ -113,6 +121,11 @@
     <!-- The override opts out the caller from the strict mode for backward compatibility -->
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod.Found">
         <exclude-pattern>lib/Doctrine/DBAL/Driver/PDOConnection.php</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod">
+        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOConnection.php</exclude-pattern>
+        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOStatement.php</exclude-pattern>
     </rule>
 
     <!-- See https://github.com/slevomat/coding-standard/issues/770 -->

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,6 +32,13 @@
                 <file name="lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php"/>
             </errorLevel>
         </ConflictingReferenceConstraint>
+        <DuplicateClass>
+            <errorLevel type="suppress">
+                <!-- These files contain a php 7 and a php 8 version of the same trait -->
+                <file name="lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php"/>
+            </errorLevel>
+        </DuplicateClass>
         <FalsableReturnStatement>
             <errorLevel type="suppress">
                 <!--
@@ -68,6 +75,8 @@
 
                 <!-- See https://github.com/doctrine/dbal/pull/3080 -->
                 <file name="lib/Doctrine/DBAL/Driver/PDOConnection.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php"/>
 
                 <!-- See https://github.com/doctrine/dbal/issues/4156 -->
                 <file name="lib/Doctrine/DBAL/Portability/Connection.php"/>
@@ -89,6 +98,8 @@
                     Doctrine\DBAL\Driver\Connection
                 -->
                 <file name="lib/Doctrine/DBAL/Driver/PDOConnection.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php"/>
             </errorLevel>
         </MethodSignatureMismatch>
         <NullableReturnStatement>
@@ -99,6 +110,16 @@
                 <file name="lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php"/>
             </errorLevel>
         </NullableReturnStatement>
+        <ParamNameMismatch>
+            <errorLevel type="suppress">
+                <!--
+                    These traits contain implementations for different PHP versions in order to handle a signature
+                    change. At least one of the implementations won't match the signature expected by Psalm.
+                -->
+                <file name="lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php"/>
+            </errorLevel>
+        </ParamNameMismatch>
         <PossiblyInvalidOperand>
             <errorLevel type="suppress">
                 <!--
@@ -113,6 +134,12 @@
                 <file name="lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php"/>
             </errorLevel>
         </PossiblyNullArgument>
+        <ReservedWord>
+            <errorLevel type="suppress">
+                <!-- This file uses the mixed type in a PHP 8 forward compatibility layer. -->
+                <file name="lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php"/>
+            </errorLevel>
+        </ReservedWord>
         <TooFewArguments>
             <errorLevel type="suppress">
                 <!--


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | kinda
| Fixed issues | N/A

#### Summary

This PR makes DBAL 2.12 compatible with PHP 8.

The main problem with PHP 8 is that certain PDO classes have changed their method signatures in PHP 8. Since DBAL extends those classes, those changed signatures have to be applied to those child classes as well. That is of course a BC break if the calling code itself extends DBAL's classes.

With this PR, I suggest to move the affected methods into traits that exist in a php 7 and a php 8 version. This way, the BC break introduced with php 8 is handed down if and only if we're actually on php 8.

I am aware that DBAL 3.0 is supposed to become the php 8 compatible version. So why am I so eager to fix the 2.x series?

I'm really looking forward to 3.0 because it moves away from the tight coupling to PDO which makes perfect sense – especially if we look at the problem this PR aims to fix. But DBAL 3 has no stable release yet and ORM has not been migrated to DBAL 3 yet. PHP 8 on the other hand has just reached RC2 and plans the first stable release in six weeks. I really doubt that the ecosystem around Doctrine will be ready for php 8 if we make DBAL 3 a precondition for php 8.

Finally, I'd really like to test the applications I am working on with php 8 and this small change I'm proposing here unblocks me for the moment.