### PR TITLE
Run CI on push to any branch and schedule all workflows hourly

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -2,13 +2,9 @@ name: "Coding Standards"
 
 on:
   pull_request:
-    branches:
-      - "*.x"
-      - "master"
   push:
-    branches:
-      - "*.x"
-      - "master"
+  schedule:
+    - cron: "42 * * * *"
 
 jobs:
   coding-standards:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,17 +1,10 @@
-
 name: "Continuous Integration"
 
 on:
   pull_request:
-    branches:
-      - "*.x"
-      - "master"
   push:
-    branches:
-      - "*.x"
-      - "master"
   schedule:
-    - cron: "42 3 * * *"
+    - cron: "42 * * * *"
 
 jobs:
   phpunit-smoke-check:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,15 +1,10 @@
-
 name: "Static Analysis"
 
 on:
   pull_request:
-    branches:
-      - "*.x"
-      - "master"
   push:
-    branches:
-      - "*.x"
-      - "master"
+  schedule:
+    - cron: "42 * * * *"
 
 jobs:
   static-analysis-phpstan:


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | no

#### Summary

- triggering on push to any branch is important to allow testing before PR is made
- test default branch hourly is important to provided actual build state for the default branch