### PR TITLE
Deduplicate explicitly passed args (driverOptions, user, password)

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -359,6 +359,10 @@ class Connection implements DriverConnection
         $user          = $this->params['user'] ?? null;
         $password      = $this->params['password'] ?? null;
 
+        unset($this->params['driverOptions']);
+        unset($this->params['user']);
+        unset($this->params['password']);
+
         $this->_conn = $this->_driver->connect($this->params, $user, $password, $driverOptions);
 
         $this->transactionNestingLevel = 0;

--- a/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
+++ b/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
@@ -238,6 +238,10 @@ class PrimaryReadReplicaConnection extends Connection
         $user     = $connectionParams['user'] ?? null;
         $password = $connectionParams['password'] ?? null;
 
+        unset($connectionParams['driverOptions']);
+        unset($connectionParams['user']);
+        unset($connectionParams['password']);
+
         return $this->_driver->connect($connectionParams, $user, $password, $driverOptions);
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes - when custom driver does not use the explicit param
| Fixed issues | no

#### Summary

arguments should not be duplicated when passed explicitly