### PR TITLE
Fix identifier escaping when used as string literal for T-SQL

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -360,21 +360,18 @@ class SQLServerPlatform extends AbstractPlatform
     protected function getCreateColumnCommentSQL($tableName, $columnName, $comment)
     {
         if (strpos($tableName, '.') !== false) {
-            [$schemaSQL, $tableSQL] = explode('.', $tableName);
-            $schemaSQL              = $this->quoteStringLiteral($schemaSQL);
-            $tableSQL               = $this->quoteStringLiteral($tableSQL);
+            [$schemaName, $tableName] = explode('.', $tableName, 2);
         } else {
-            $schemaSQL = "'dbo'";
-            $tableSQL  = $this->quoteStringLiteral($tableName);
+            $schemaName = $this->getDefaultSchemaName();
         }
 
         return $this->getAddExtendedPropertySQL(
             'MS_Description',
-            $comment,
+            (string) $comment,
             'SCHEMA',
-            $schemaSQL,
+            $schemaName,
             'TABLE',
-            $tableSQL,
+            $tableName,
             'COLUMN',
             $columnName
         );
@@ -724,21 +721,18 @@ class SQLServerPlatform extends AbstractPlatform
     protected function getAlterColumnCommentSQL($tableName, $columnName, $comment)
     {
         if (strpos($tableName, '.') !== false) {
-            [$schemaSQL, $tableSQL] = explode('.', $tableName);
-            $schemaSQL              = $this->quoteStringLiteral($schemaSQL);
-            $tableSQL               = $this->quoteStringLiteral($tableSQL);
+            [$schemaName, $tableName] = explode('.', $tableName, 2);
         } else {
-            $schemaSQL = "'dbo'";
-            $tableSQL  = $this->quoteStringLiteral($tableName);
+            $schemaName = $this->getDefaultSchemaName();
         }
 
         return $this->getUpdateExtendedPropertySQL(
             'MS_Description',
-            $comment,
+            (string) $comment,
             'SCHEMA',
-            $schemaSQL,
+            $schemaName,
             'TABLE',
-            $tableSQL,
+            $tableName,
             'COLUMN',
             $columnName
         );
@@ -763,20 +757,17 @@ class SQLServerPlatform extends AbstractPlatform
     protected function getDropColumnCommentSQL($tableName, $columnName)
     {
         if (strpos($tableName, '.') !== false) {
-            [$schemaSQL, $tableSQL] = explode('.', $tableName);
-            $schemaSQL              = $this->quoteStringLiteral($schemaSQL);
-            $tableSQL               = $this->quoteStringLiteral($tableSQL);
+            [$schemaName, $tableName] = explode('.', $tableName, 2);
         } else {
-            $schemaSQL = "'dbo'";
-            $tableSQL  = $this->quoteStringLiteral($tableName);
+            $schemaName = $this->getDefaultSchemaName();
         }
 
         return $this->getDropExtendedPropertySQL(
             'MS_Description',
             'SCHEMA',
-            $schemaSQL,
+            $schemaName,
             'TABLE',
-            $tableSQL,
+            $tableName,
             'COLUMN',
             $columnName
         );
@@ -1689,14 +1680,19 @@ class SQLServerPlatform extends AbstractPlatform
 
     protected function getCommentOnTableSQL(string $tableName, ?string $comment): string
     {
-        return sprintf(
-            "
-                EXEC sys.sp_addextendedproperty @name=N'MS_Description',
-                  @value=N%s, @level0type=N'SCHEMA', @level0name=N'dbo',
-                  @level1type=N'TABLE', @level1name=N%s
-            ",
-            $this->quoteStringLiteral((string) $comment),
-            $this->quoteStringLiteral($tableName)
+        if (strpos($tableName, '.') !== false) {
+            [$schemaName, $tableName] = explode('.', $tableName, 2);
+        } else {
+            $schemaName = $this->getDefaultSchemaName();
+        }
+
+        return $this->getAddExtendedPropertySQL(
+            'MS_Description',
+            (string) $comment,
+            'SCHEMA',
+            $schemaName,
+            'TABLE',
+            $tableName
         );
     }
 

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -799,11 +799,11 @@ class SQLServerPlatform extends AbstractPlatform
      * @link http://msdn.microsoft.com/en-us/library/ms180047%28v=sql.90%29.aspx
      *
      * @param string      $name       The name of the property to add.
-     * @param string      $value      The value of the property to add.
-     * @param string      $level0Type The type of the object at level 0 the property belongs to.
-     * @param string      $level0Name The name of the object at level 0 the property belongs to.
-     * @param string      $level1Type The type of the object at level 1 the property belongs to.
-     * @param string      $level1Name The name of the object at level 1 the property belongs to.
+     * @param string|null $value      The value of the property to add.
+     * @param string|null $level0Type The type of the object at level 0 the property belongs to.
+     * @param string|null $level0Name The name of the object at level 0 the property belongs to.
+     * @param string|null $level1Type The type of the object at level 1 the property belongs to.
+     * @param string|null $level1Name The name of the object at level 1 the property belongs to.
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
      *
@@ -811,20 +811,20 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getAddExtendedPropertySQL(
         $name,
-        $value,
-        string $level0Type,
-        string $level0Name,
-        string $level1Type,
-        string $level1Name,
-        ?string $level2Type = null,
-        ?string $level2Name = null
+        $value = null,
+        $level0Type = null,
+        $level0Name = null,
+        $level1Type = null,
+        $level1Name = null,
+        $level2Type = null,
+        $level2Name = null
     ) {
         return 'EXEC sp_addextendedproperty'
             . ' N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral((string) $value)
-            . ', N' . $this->quoteStringLiteral($level0Type)
-            . ', ' . $this->quoteSingleIdentifierAsStringLiteral($level0Name)
-            . ', N' . $this->quoteStringLiteral($level1Type)
-            . ', ' . $this->quoteSingleIdentifierAsStringLiteral($level1Name)
+            . ', N' . $this->quoteStringLiteral((string) $level0Type)
+            . ', ' . $this->quoteSingleIdentifierAsStringLiteral((string) $level0Name)
+            . ', N' . $this->quoteStringLiteral((string) $level1Type)
+            . ', ' . $this->quoteSingleIdentifierAsStringLiteral((string) $level1Name)
             . ($level2Type !== null || $level2Name !== null
                 ? ', N' . $this->quoteStringLiteral((string) $level2Type)
                   . ', ' . $this->quoteSingleIdentifierAsStringLiteral((string) $level2Name)
@@ -838,10 +838,10 @@ class SQLServerPlatform extends AbstractPlatform
      * @link http://technet.microsoft.com/en-gb/library/ms178595%28v=sql.90%29.aspx
      *
      * @param string      $name       The name of the property to drop.
-     * @param string      $level0Type The type of the object at level 0 the property belongs to.
-     * @param string      $level0Name The name of the object at level 0 the property belongs to.
-     * @param string      $level1Type The type of the object at level 1 the property belongs to.
-     * @param string      $level1Name The name of the object at level 1 the property belongs to.
+     * @param string|null $level0Type The type of the object at level 0 the property belongs to.
+     * @param string|null $level0Name The name of the object at level 0 the property belongs to.
+     * @param string|null $level1Type The type of the object at level 1 the property belongs to.
+     * @param string|null $level1Name The name of the object at level 1 the property belongs to.
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
      *
@@ -849,19 +849,19 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getDropExtendedPropertySQL(
         $name,
-        string $level0Type,
-        string $level0Name,
-        string $level1Type,
-        string $level1Name,
-        ?string $level2Type = null,
-        ?string $level2Name = null
+        $level0Type = null,
+        $level0Name = null,
+        $level1Type = null,
+        $level1Name = null,
+        $level2Type = null,
+        $level2Name = null
     ) {
         return 'EXEC sp_dropextendedproperty'
             . ' N' . $this->quoteStringLiteral($name)
-            . ', N' . $this->quoteStringLiteral($level0Type)
-            . ', ' . $this->quoteSingleIdentifierAsStringLiteral($level0Name)
-            . ', N' . $this->quoteStringLiteral($level1Type)
-            . ', ' . $this->quoteSingleIdentifierAsStringLiteral($level1Name)
+            . ', N' . $this->quoteStringLiteral((string) $level0Type)
+            . ', ' . $this->quoteSingleIdentifierAsStringLiteral((string) $level0Name)
+            . ', N' . $this->quoteStringLiteral((string) $level1Type)
+            . ', ' . $this->quoteSingleIdentifierAsStringLiteral((string) $level1Name)
             . ($level2Type !== null || $level2Name !== null
                 ? ', N' . $this->quoteStringLiteral((string) $level2Type)
                   . ', ' . $this->quoteSingleIdentifierAsStringLiteral((string) $level2Name)
@@ -875,11 +875,11 @@ class SQLServerPlatform extends AbstractPlatform
      * @link http://msdn.microsoft.com/en-us/library/ms186885%28v=sql.90%29.aspx
      *
      * @param string      $name       The name of the property to update.
-     * @param string      $value      The value of the property to update.
-     * @param string      $level0Type The type of the object at level 0 the property belongs to.
-     * @param string      $level0Name The name of the object at level 0 the property belongs to.
-     * @param string      $level1Type The type of the object at level 1 the property belongs to.
-     * @param string      $level1Name The name of the object at level 1 the property belongs to.
+     * @param string|null $value      The value of the property to update.
+     * @param string|null $level0Type The type of the object at level 0 the property belongs to.
+     * @param string|null $level0Name The name of the object at level 0 the property belongs to.
+     * @param string|null $level1Type The type of the object at level 1 the property belongs to.
+     * @param string|null $level1Name The name of the object at level 1 the property belongs to.
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
      *
@@ -887,20 +887,20 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getUpdateExtendedPropertySQL(
         $name,
-        $value,
-        string $level0Type,
-        string $level0Name,
-        string $level1Type,
-        string $level1Name,
-        ?string $level2Type = null,
-        ?string $level2Name = null
+        $value = null,
+        $level0Type = null,
+        $level0Name = null,
+        $level1Type = null,
+        $level1Name = null,
+        $level2Type = null,
+        $level2Name = null
     ) {
         return 'EXEC sp_updateextendedproperty'
             . ' N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral((string) $value)
-            . ', N' . $this->quoteStringLiteral($level0Type)
-            . ', ' . $this->quoteSingleIdentifierAsStringLiteral($level0Name)
-            . ', N' . $this->quoteStringLiteral($level1Type)
-            . ', ' . $this->quoteSingleIdentifierAsStringLiteral($level1Name)
+            . ', N' . $this->quoteStringLiteral((string) $level0Type)
+            . ', ' . $this->quoteSingleIdentifierAsStringLiteral((string) $level0Name)
+            . ', N' . $this->quoteStringLiteral((string) $level1Type)
+            . ', ' . $this->quoteSingleIdentifierAsStringLiteral((string) $level1Name)
             . ($level2Type !== null || $level2Name !== null
                 ? ', N' . $this->quoteStringLiteral((string) $level2Type)
                   . ', ' . $this->quoteSingleIdentifierAsStringLiteral((string) $level2Name)

--- a/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL4283Test.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Ticket/DBAL4283Test.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Ticket;
+
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+use function array_map;
+use function explode;
+use function implode;
+use function trim;
+
+class DBAL4283Test extends DbalFunctionalTestCase
+{
+    /**
+     * Quote name with double quotes for data provider.
+     */
+    protected function doubleQuoteName(string $name): string
+    {
+        return '"' . $name . '"';
+    }
+
+    /**
+     * Quote name using target platform.
+     */
+    protected function quoteName(string $name): string
+    {
+        return implode('.', array_map(function ($name) {
+            return $this->connection->getDatabasePlatform()->quoteSingleIdentifier(trim($name, '"'));
+        }, explode('.', $name)));
+    }
+
+    /**
+     * @dataProvider columnNameProvider
+     */
+    public function testColumnCommnentOperations(string $columnName): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+            if ($columnName === 'basic') {
+                // Oracle platform does not support other than UC column names
+                $columnName = 'BASIC';
+            } else {
+                $this->markTestSkipped('Oracle platform does not support quoted column names');
+            }
+
+            // Oracle platform does not support other than UC table names
+            $tableName = 'DBAL4283TBL';
+        } elseif ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+            // PostgreSQL platform does not support quoted table names
+            $tableName = 'dbal4283tbl';
+        } else {
+            $tableName = 'dbal4283Tbl';
+        }
+
+        $tableNameQuoted = $this->quoteName($tableName);
+
+        $table1 = new Table($tableNameQuoted);
+        $table1->addColumn('id', 'integer');
+        $table1->addColumn($columnName, 'integer', ['comment' => 'aaa@email']);
+        $this->connection->getSchemaManager()->dropAndCreateTable($table1);
+
+        self::assertEquals(
+            'aaa@email',
+            $this->connection->getSchemaManager()->listTableDetails($tableName)
+                ->getColumn($columnName)->getComment()
+        );
+
+        $table2 = new Table($tableNameQuoted);
+        $table2->addColumn('id', 'integer');
+        $table2->addColumn($columnName, 'integer', ['comment' => 'bbb@email']);
+        $diffAlterComment = (new Comparator())->diffTable($table1, $table2);
+        self::assertNotFalse($diffAlterComment);
+        $this->connection->getSchemaManager()->alterTable($diffAlterComment);
+
+        self::assertEquals(
+            'bbb@email',
+            $this->connection->getSchemaManager()->listTableDetails($tableName)
+                ->getColumn($columnName)->getComment()
+        );
+
+        $table3 = new Table($tableNameQuoted);
+        $table3->addColumn('id', 'integer');
+        $table3->addColumn($columnName, 'integer');
+        $diffDropComment = (new Comparator())->diffTable($table2, $table3);
+        self::assertNotFalse($diffDropComment);
+        $this->connection->getSchemaManager()->alterTable($diffDropComment);
+
+        self::assertNull(
+            $this->connection->getSchemaManager()->listTableDetails($tableName)
+                ->getColumn($columnName)->getComment()
+        );
+    }
+
+    /**
+     * @return iterable<array{0: string}>
+     */
+    public function columnNameProvider(): iterable
+    {
+        return [
+            ['basic'],
+            [$this->doubleQuoteName('basic')],
+            ['MixedCaseUnquoted'],
+            [$this->doubleQuoteName('MixedCaseQuoted')],
+            [$this->doubleQuoteName('and')],
+            [$this->doubleQuoteName('name_with-dash')],
+            [$this->doubleQuoteName('name_with,comma')],
+            [$this->doubleQuoteName('name_with:semicolon')],
+            [$this->doubleQuoteName('name_with|vertical_bar')],
+            [$this->doubleQuoteName('name_with space')],
+        ];
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -656,7 +656,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         $expectedSql = [
             'CREATE TABLE testschema.test (id INT NOT NULL, PRIMARY KEY (id))',
             "EXEC sp_addextendedproperty N'MS_Description', N'This is a comment', "
-                . "N'SCHEMA', 'testschema', N'TABLE', 'test', N'COLUMN', id",
+                . "N'SCHEMA', 'testschema', N'TABLE', 'test', N'COLUMN', 'id'",
         ];
 
         self::assertEquals($expectedSql, $this->platform->getCreateTableSQL($table));
@@ -670,7 +670,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         $expectedSql = [
             'ALTER TABLE testschema.mytable ADD quota INT NOT NULL',
             "EXEC sp_addextendedproperty N'MS_Description', N'A comment', "
-                . "N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', quota",
+                . "N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', 'quota'",
         ];
 
         self::assertEquals($expectedSql, $this->platform->getAlterTableSQL($tableDiff));
@@ -688,7 +688,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
 
         $expectedSql = [
             "EXEC sp_dropextendedproperty N'MS_Description'"
-                . ", N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', quota",
+                . ", N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', 'quota'",
         ];
 
         self::assertEquals($expectedSql, $this->platform->getAlterTableSQL($tableDiff));
@@ -705,7 +705,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         );
 
         $expectedSql = ["EXEC sp_updateextendedproperty N'MS_Description', N'B comment', "
-                . "N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', quota",
+                . "N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', 'quota'",
         ];
 
         self::assertEquals($expectedSql, $this->platform->getAlterTableSQL($tableDiff));
@@ -719,7 +719,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         return [
             'CREATE TABLE test (id INT NOT NULL, PRIMARY KEY (id))',
             "EXEC sp_addextendedproperty N'MS_Description', N'This is a comment', "
-                . "N'SCHEMA', 'dbo', N'TABLE', 'test', N'COLUMN', id",
+                . "N'SCHEMA', 'dbo', N'TABLE', 'test', N'COLUMN', 'id'",
         ];
     }
 
@@ -731,7 +731,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         return [
             'ALTER TABLE mytable ADD quota INT NOT NULL',
             "EXEC sp_addextendedproperty N'MS_Description', N'A comment', "
-                . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', quota",
+                . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'quota'",
         ];
     }
 
@@ -743,7 +743,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         return [
             'CREATE TABLE test (id INT NOT NULL, data VARCHAR(MAX) NOT NULL, PRIMARY KEY (id))',
             "EXEC sp_addextendedproperty N'MS_Description', N'(DC2Type:array)', "
-                . "N'SCHEMA', 'dbo', N'TABLE', 'test', N'COLUMN', data",
+                . "N'SCHEMA', 'dbo', N'TABLE', 'test', N'COLUMN', 'data'",
         ];
     }
 
@@ -785,26 +785,26 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
                     . 'comment_with_string_literal_char NVARCHAR(255) NOT NULL, '
                     . 'PRIMARY KEY (id))',
                 "EXEC sp_addextendedproperty N'MS_Description', "
-                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_integer_0",
+                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_integer_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
-                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_float_0",
+                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_float_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
-                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_string_0",
+                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_string_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
-                    . "N'Doctrine 0wnz you!', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment",
+                    . "N'Doctrine 0wnz you!', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
                     . "N'Doctrine 0wnz comments for explicitly quoted columns!', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [comment_quoted]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_quoted'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
                     . "N'Doctrine 0wnz comments for reserved keyword columns!', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [create]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'create'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
-                    . "N'(DC2Type:object)', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', commented_type",
+                    . "N'(DC2Type:object)', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'commented_type'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
                     . "N'Doctrine array type.(DC2Type:array)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', commented_type_with_comment",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'commented_type_with_comment'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'O''Reilly', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_with_string_literal_char",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_with_string_literal_char'",
             ],
             $this->platform->getCreateTableSQL($table)
         );
@@ -1000,45 +1000,45 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
 
                 // Added columns.
                 "EXEC sp_addextendedproperty N'MS_Description', N'0', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_comment_integer_0",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment_integer_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'0', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_comment_float_0",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment_float_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'0', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_comment_string_0",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment_string_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'Doctrine', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_comment",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'rulez', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [added_comment_quoted]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment_quoted'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'666', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [select]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'select'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'(DC2Type:object)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_commented_type",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_commented_type'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'666(DC2Type:array)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_commented_type_with_comment",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_commented_type_with_comment'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'''''', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_comment_with_string_literal_char",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment_with_string_literal_char'",
 
                 // Changed columns.
                 "EXEC sp_addextendedproperty N'MS_Description', N'primary', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', id",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'id'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'false', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_false",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_false'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'(DC2Type:object)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_empty_string",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_empty_string'",
                 "EXEC sp_dropextendedproperty N'MS_Description', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_string_0",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_string_0'",
                 "EXEC sp_dropextendedproperty N'MS_Description', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment'",
                 "EXEC sp_updateextendedproperty N'MS_Description', N'Doctrine array.(DC2Type:array)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [comment_quoted]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_quoted'",
                 "EXEC sp_updateextendedproperty N'MS_Description', N'(DC2Type:object)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [create]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'create'",
                 "EXEC sp_updateextendedproperty N'MS_Description', N'foo', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', commented_type",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'commented_type'",
                 "EXEC sp_updateextendedproperty N'MS_Description', N'(DC2Type:array)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', commented_type_with_comment",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'commented_type_with_comment'",
                 "EXEC sp_updateextendedproperty N'MS_Description', N'''', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_with_string_literal_char",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_with_string_literal_char'",
             ],
             $this->platform->getAlterTableSQL($tableDiff)
         );


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4283

#### Summary

Alternative to closes https://github.com/doctrine/dbal/pull/4284 to fix it correctly and with proper functional tests.

The issue was that MSSQL expects string literal (quoted by `'`) for `EXEC sp_addextendedproperty` instead of identifier name (quoted by `[]`).