### PR TITLE
Test all extensions with PHP8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -76,6 +76,7 @@ jobs:
       matrix:
         php-version:
           - "7.4"
+          - "8.0"
 
     services:
       oracle:
@@ -125,6 +126,7 @@ jobs:
       matrix:
         php-version:
           - "7.4"
+          - "8.0"
 
     services:
       oracle:
@@ -315,7 +317,6 @@ jobs:
       matrix:
         php-version:
           - "7.4"
-          - "8.0"
         mysql-version:
           - "5.7"
           - "8.0"
@@ -344,6 +345,16 @@ jobs:
             php-version: "7.4"
             mysql-version: "8.0"
             extension: "mysqli"
+          - php-version: "8.0"
+            mysql-version: "8.0"
+            extension: "mysqli"
+            custom-entrypoint: >-
+              --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
+          - php-version: "8.0"
+            mysql-version: "8.0"
+            extension: "pdo_mysql"
+            custom-entrypoint: >-
+              --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
 
     services:
       mysql:
@@ -405,6 +416,7 @@ jobs:
         php-version:
           - "7.3"
           - "7.4"
+          - "8.0"
         extension:
           - "sqlsrv"
           - "pdo_sqlsrv"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -445,7 +445,7 @@ jobs:
           coverage: "pcov"
           ini-values: "zend.assertions=1"
           tools: "pecl"
-          extensions: "${{ matrix.extension }}-5.7.0preview"
+          extensions: "${{ matrix.extension }}-5.9.0preview1"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2"

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -25,6 +25,7 @@ class OCI8StatementTest extends DbalTestCase
      * @param mixed[] $params
      *
      * @dataProvider executeDataProvider
+     * @requires PHP < 8.0
      */
     public function testExecute(array $params): void
     {


### PR DESCRIPTION
Jobs that use other versions of PHP are temporarily removed so that it's
easier to focus and iterate.

Failures:
- [x] [OCI8 installs successfully, but might contain API changes?](https://github.com/doctrine/dbal/pull/4361/checks?check_run_id=1277115408#step:7:106)
- [x] [sqlsrv fails to install](https://github.com/doctrine/dbal/pull/4361/checks?check_run_id=1277115981#step:4:18)