### PR TITLE
Adds exception thrown by execute() method

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\ResultStatement;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
@@ -200,6 +201,8 @@ class QueryBuilder
      * Executes this query using the bound parameters and their types.
      *
      * @return ResultStatement|int
+     *
+     * @throws Exception
      */
     public function execute()
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement (minor)
| BC Break     | no
| Fixed issues | n/a

#### Summary

My IDE was telling me I was trying to catch a non-existent exception, however it's clear by digging down a level that the Exception is throw by this class, so this simply annotates that.

Perhaps this should catch it and throw a QueryException?  Happy to update if it should be.  Please just let me know.

Also, I raised this against the 2.12 branch which is the latest branch I could find this file in, as I'm currently using 2.11.1.  I hope this was OK?
