### PR TITLE
Fail on extension / tool installation failure

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,6 +13,9 @@ on:
   schedule:
     - cron: "42 3 * * *"
 
+env:
+  fail-fast: true
+
 jobs:
   phpunit-smoke-check:
     name: "PHPUnit with SQLite"


### PR DESCRIPTION


|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

This leverages a new feature of shivammathur/setup-php that allows to
fail the build if an extension or tool fails to install.

