### PR TITLE
Run the test suite with assertions off

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-          ini-values: "zend.assertions=1"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2"
@@ -94,7 +93,6 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           extensions: "oci8"
           coverage: "pcov"
-          ini-values: "zend.assertions=1"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2"
@@ -143,7 +141,6 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           extensions: "pdo_oci"
           coverage: "pcov"
-          ini-values: "zend.assertions=1"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2"
@@ -207,7 +204,6 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-          ini-values: "zend.assertions=1"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2"
@@ -272,7 +268,6 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-          ini-values: "zend.assertions=1"
           extensions: "${{ matrix.extension }}"
 
       - name: "Cache dependencies installed with composer"
@@ -357,7 +352,6 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-          ini-values: "zend.assertions=1"
           extensions: "${{ matrix.extension }}"
 
       - name: "Cache dependencies installed with composer"
@@ -431,7 +425,6 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-          ini-values: "zend.assertions=1"
           tools: "pecl"
           extensions: "${{ matrix.extension }}-5.7.0preview"
 
@@ -495,7 +488,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-          ini-values: "zend.assertions=1,extension=ibm_db2.so, ibm_db2.instance_name=db2inst1"
+          ini-values: "extension=ibm_db2.so, ibm_db2.instance_name=db2inst1"
 
       - name: "Install ibm_db2 extension"
         run: "ci/github/ext/install-ibm_db2.sh ${{ matrix.php-version }}"


### PR DESCRIPTION

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

Enabling assertions to get more coverage was a bad idea, because these
are supposed to be disabled in production, which means you could have
code working in the CI, and not working in production. We do not want
that.

See https://github.com/doctrine/dbal/issues/4359