### PR TITLE
Configuration should not be internal

### DIFF
--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -11,8 +11,8 @@ use function preg_match;
 /**
  * Configuration container for the Doctrine DBAL.
  *
- * @internal When adding a new configuration option just write a getter/setter
- *           pair and add the option to the _attributes array with a proper default value.
+ * Internal note: When adding a new configuration option just write a getter/setter
+ *                pair and add the option to the _attributes array with a proper default value.
  */
 class Configuration
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues  | none

#### Summary

The `Configuration` class is currently marked as `@internal`, even though this markup was actually intended to be used as an internal note, not for marking the whole class for internal use.

I think the [phpdoc documentation](https://docs.phpdoc.org/latest/references/phpdoc/tags/internal.html) is unclear on the subject:

> The @internal tag is used to denote that associated Structural Elements are elements internal to this application or library. It may also be used inside a long description to insert a piece of text that is only applicable for the developers of this software.

But as a matter of fact, Psalm considers the class internal and reports a violation:

> ERROR: InternalMethod - src/Bootstrap.php:305:26 - The method Doctrine\DBAL\Configuration::setSQLLogger is internal to Doctrine but called from Acme\Bootstrap (see https://psalm.dev/175)
                $config->setSQLLogger(new FileLogger(\_\_DIR\_\_ . '/../sql-log.txt'));

I think we should be on the safe side and only use `@internal` to mark a class or method for internal use, and not for internal notes that can easily be formulated in other ways.