### PR TITLE
Reintroduce support for PHP 7.1 and 7.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -58,6 +58,34 @@ jobs:
           name: "phpunit-sqlite-${{ matrix.deps }}-${{ matrix.php-version }}.coverage"
           path: "coverage.xml"
 
+  phpunit-lower-php-versions:
+    name: "PHPUnit with SQLite"
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.1"
+          - "7.2"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-version }}"
+          ini-values: "zend.assertions=1"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v1"
+
+      - name: "Run PHPUnit"
+        run: "vendor/bin/phpunit -c ci/github/phpunit/sqlite.xml"
+
   phpunit-oci8:
     name: "PHPUnit on OCI8"
     runs-on: "ubuntu-20.04"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": "^7.3 || ^8",
+        "php": "^7.1 || ^8",
         "ext-pdo": "*",
         "doctrine/cache": "^1.0",
         "doctrine/event-manager": "^1.0"
@@ -41,8 +41,8 @@
         "doctrine/coding-standard": "8.2.0",
         "jetbrains/phpstorm-stubs": "2019.3",
         "phpstan/phpstan": "0.12.80",
-        "phpunit/phpunit": "9.5.0",
-        "psalm/plugin-phpunit": "0.13.0",
+        "phpunit/phpunit": "^7.5.20|^8.5|9.5.0",
+        "psalm/plugin-phpunit": "0.14.0",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
         "vimeo/psalm": "4.5.2"
     },
@@ -51,10 +51,7 @@
     },
     "bin": ["bin/doctrine-dbal"],
     "config": {
-        "sort-packages": true,
-        "platform": {
-            "php": "7.3.0"
-        }
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": { "Doctrine\\DBAL\\": "lib/Doctrine/DBAL" }

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -229,13 +229,12 @@ class SQLServerPlatform extends AbstractPlatform
         }
 
         return sprintf(
-            <<<SQL
+            "
                 IF EXISTS (SELECT * FROM sysobjects WHERE name = '%s')
                     ALTER TABLE %s DROP CONSTRAINT %s
                 ELSE
                     DROP INDEX %s ON %s
-                SQL
-            ,
+            ",
             $index,
             $table,
             $index,
@@ -1691,12 +1690,11 @@ class SQLServerPlatform extends AbstractPlatform
     protected function getCommentOnTableSQL(string $tableName, ?string $comment): string
     {
         return sprintf(
-            <<<'SQL'
+            "
                 EXEC sys.sp_addextendedproperty @name=N'MS_Description',
                   @value=N%s, @level0type=N'SCHEMA', @level0name=N'dbo',
                   @level1type=N'TABLE', @level1name=N%s
-                SQL
-            ,
+            ",
             $this->quoteStringLiteral((string) $comment),
             $this->quoteStringLiteral($tableName)
         );
@@ -1705,7 +1703,7 @@ class SQLServerPlatform extends AbstractPlatform
     public function getListTableMetadataSQL(string $table): string
     {
         return sprintf(
-            <<<'SQL'
+            "
                 SELECT
                   p.value AS [table_comment]
                 FROM
@@ -1713,8 +1711,7 @@ class SQLServerPlatform extends AbstractPlatform
                   INNER JOIN sys.extended_properties AS p ON p.major_id=tbl.object_id AND p.minor_id=0 AND p.class=1
                 WHERE
                   (tbl.name=N%s and SCHEMA_NAME(tbl.schema_id)=N'dbo' and p.name=N'MS_Description')
-                SQL
-            ,
+            ",
             $this->quoteStringLiteral($table)
         );
     }

--- a/tests/Doctrine/Tests/DBAL/AssertionCompatibility.php
+++ b/tests/Doctrine/Tests/DBAL/AssertionCompatibility.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Doctrine\Tests\DBAL;
+
+trait AssertionCompatibility
+{
+    /**
+     * @param array<mixed> $arguments
+     *
+     * @return mixed
+     */
+    public static function __callStatic(string $name, array $arguments)
+    {
+        if ($name === 'assertMatchesRegularExpression') {
+            self::assertRegExp(...$arguments);
+        } elseif ($name === 'assertFileDoesNotExist') {
+            self::assertFileNotExists(...$arguments);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<mixed> $arguments
+     *
+     * @return mixed
+     */
+    public function __call(string $method, array $arguments)
+    {
+        if ($method === 'createStub') {
+            return $this->getMockBuilder(...$arguments)
+                ->disableOriginalConstructor()
+                ->disableOriginalClone()
+                ->disableArgumentCloning()
+                ->disallowMockingUnknownTypes()
+                ->getMock();
+        }
+
+        return null;
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Connection/LoggingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Connection/LoggingTest.php
@@ -8,10 +8,13 @@ use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Tests\DBAL\AssertionCompatibility;
 use PHPUnit\Framework\TestCase;
 
 final class LoggingTest extends TestCase
 {
+    use AssertionCompatibility;
+
     public function testLogExecuteQuery(): void
     {
         $driverConnection = $this->createStub(DriverConnection::class);

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -65,7 +65,7 @@ class ConnectionTest extends DbalTestCase
 
         $platform = $this->getMockForAbstractClass(AbstractPlatform::class);
 
-        return $this->getMockBuilder(Connection::class)
+        return (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['executeStatement'])
             ->setConstructorArgs([['platform' => $platform], $driverMock])
             ->getMock();
@@ -528,7 +528,7 @@ EOF
             ->with(FetchMode::ASSOCIATIVE)
             ->will($this->returnValue($result));
 
-        $conn = $this->getMockBuilder(Connection::class)
+        $conn = (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['executeQuery'])
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
@@ -563,7 +563,7 @@ EOF
             ->with(FetchMode::NUMERIC)
             ->will($this->returnValue($result));
 
-        $conn = $this->getMockBuilder(Connection::class)
+        $conn = (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['executeQuery'])
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
@@ -599,7 +599,7 @@ EOF
             ->with($column)
             ->will($this->returnValue($result));
 
-        $conn = $this->getMockBuilder(Connection::class)
+        $conn = (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['executeQuery'])
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
@@ -633,7 +633,7 @@ EOF
             ->method('fetchAll')
             ->will($this->returnValue($result));
 
-        $conn = $this->getMockBuilder(Connection::class)
+        $conn = (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['executeQuery'])
             ->setConstructorArgs([[], $driverMock])
             ->getMock();
@@ -709,9 +709,9 @@ EOF
             ->method('prepare')
             ->will($this->returnValue($stmtMock));
 
-        $conn = $this->getMockBuilder(Connection::class)
-            ->setConstructorArgs([['pdo' => $pdoMock, 'platform' => $platformMock], $driverMock])
+        $conn = (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['connect'])
+            ->setConstructorArgs([['pdo' => $pdoMock, 'platform' => $platformMock], $driverMock])
             ->getMock();
 
         $conn->expects($this->once())->method('connect');

--- a/tests/Doctrine/Tests/DBAL/Connections/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Connections/MasterSlaveConnectionTest.php
@@ -4,10 +4,13 @@ namespace Doctrine\Tests\DBAL\Connections;
 
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\Driver;
+use Doctrine\Tests\DBAL\AssertionCompatibility;
 use Doctrine\Tests\DbalTestCase;
 
 class MasterSlaveConnectionTest extends DbalTestCase
 {
+    use AssertionCompatibility;
+
     public function testConnectionParamsRemainAvailable(): void
     {
         $constructionParams = [

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -39,7 +39,7 @@ class OCI8StatementTest extends DbalTestCase
             ->withConsecutive(
                 [1, $params[0]],
                 [2, $params[1]],
-                [3, $params[2]],
+                [3, $params[2]]
             );
 
         // the return value is irrelevant to the test

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -22,13 +22,14 @@ use function file_exists;
 use function posix_geteuid;
 use function posix_getpwuid;
 use function sprintf;
+use function strtoupper;
+use function substr;
 use function sys_get_temp_dir;
 use function touch;
 use function unlink;
 use function version_compare;
 
 use const PHP_OS;
-use const PHP_OS_FAMILY;
 
 /**
  * @psalm-import-type Params from DriverManager
@@ -306,7 +307,7 @@ class ExceptionTest extends DbalFunctionalTestCase
         }
 
         // mode 0 is considered read-only on Windows
-        $mode = PHP_OS_FAMILY === 'Windows' ? 0000 : 0444;
+        $mode = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? 0000 : 0444;
 
         $filename = sprintf('%s/%s', sys_get_temp_dir(), 'doctrine_failed_connection_' . $mode . '.db');
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -343,7 +343,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
                 'commented_req_change_column',
                 Type::getType('integer'),
                 ['comment' => 'Some comment', 'notnull' => false]
-            ),
+            )
         );
 
         $tableDiff->removedColumns['comment_integer_0']

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -12,11 +12,14 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Tests\DBAL\AssertionCompatibility;
 
 use function dirname;
 
 class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
+    use AssertionCompatibility;
+
     protected function supportsPlatform(AbstractPlatform $platform): bool
     {
         return $platform instanceof SqlitePlatform;

--- a/tests/Doctrine/Tests/DBAL/MockBuilderProxy.php
+++ b/tests/Doctrine/Tests/DBAL/MockBuilderProxy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Doctrine\Tests\DBAL;
+
+use PHPUnit\Framework\MockObject\MockBuilder;
+
+use function method_exists;
+
+/**
+ * @template T
+ */
+class MockBuilderProxy
+{
+    /** @var MockBuilder<T> */
+    private $originalMockBuilder;
+
+    /**
+     * @param MockBuilder<T> $originalMockBuilder
+     */
+    public function __construct(MockBuilder $originalMockBuilder)
+    {
+        $this->originalMockBuilder = $originalMockBuilder;
+    }
+
+    /**
+     * @param array<string> $methods
+     *
+     * @return MockBuilder<T>
+     */
+    public function onlyMethods(array $methods): MockBuilder
+    {
+        if (method_exists(MockBuilder::class, 'onlyMethods')) {
+            return $this->originalMockBuilder->onlyMethods($methods);
+        }
+
+        return $this->originalMockBuilder->setMethods($methods);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\DBAL\MockBuilderProxy;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
@@ -1163,10 +1164,10 @@ class ComparatorTest extends TestCase
     public function testComparesNamespaces(): void
     {
         $comparator = new Comparator();
-        $fromSchema = $this->getMockBuilder(Schema::class)
+        $fromSchema = (new MockBuilderProxy($this->getMockBuilder(Schema::class)))
             ->onlyMethods(['getNamespaces', 'hasNamespace'])
             ->getMock();
-        $toSchema   = $this->getMockBuilder(Schema::class)
+        $toSchema   = (new MockBuilderProxy($this->getMockBuilder(Schema::class)))
             ->onlyMethods(['getNamespaces', 'hasNamespace'])
             ->getMock();
 

--- a/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
+use Doctrine\Tests\DBAL\MockBuilderProxy;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -29,8 +30,8 @@ final class DB2SchemaManagerTest extends TestCase
         $eventManager  = new EventManager();
         $driverMock    = $this->createMock(Driver::class);
         $platform      = $this->createMock(DB2Platform::class);
-        $this->conn    = $this
-            ->getMockBuilder(Connection::class)
+        $this->conn    = (new MockBuilderProxy($this
+            ->getMockBuilder(Connection::class)))
             ->onlyMethods(['fetchAllAssociative', 'quote'])
             ->setConstructorArgs([['platform' => $platform], $driverMock, new Configuration(), $eventManager])
             ->getMock();

--- a/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/MySqlSchemaManagerTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\MySqlSchemaManager;
+use Doctrine\Tests\DBAL\MockBuilderProxy;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -32,7 +33,7 @@ class MySqlSchemaManagerTest extends TestCase
         $platform->method('getListTableForeignKeysSQL')
             ->willReturn('');
 
-        $this->conn    = $this->getMockBuilder(Connection::class)
+        $this->conn    = (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['fetchAllAssociative'])
             ->setConstructorArgs([['platform' => $platform], $driverMock, new Configuration(), $eventManager])
             ->getMock();

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Visitor\CreateSchemaSqlCollector;
+use Doctrine\Tests\DBAL\MockBuilderProxy;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -22,7 +23,7 @@ class CreateSchemaSqlCollectorTest extends TestCase
     {
         parent::setUp();
 
-        $this->platformMock = $this->getMockBuilder(AbstractPlatform::class)
+        $this->platformMock = (new MockBuilderProxy($this->getMockBuilder(AbstractPlatform::class)))
             ->onlyMethods(
                 [
                     'getCreateForeignKeySQL',

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/DropSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/DropSchemaSqlCollectorTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
+use Doctrine\Tests\DBAL\MockBuilderProxy;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +23,7 @@ class DropSchemaSqlCollectorTest extends TestCase
         $keyConstraintOne = $this->getStubKeyConstraint('first');
         $keyConstraintTwo = $this->getStubKeyConstraint('second');
 
-        $platform = $this->getMockBuilder(AbstractPlatform::class)
+        $platform = (new MockBuilderProxy($this->getMockBuilder(AbstractPlatform::class)))
             ->onlyMethods(['getDropForeignKeySQL'])
             ->getMockForAbstractClass();
 

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
@@ -4,13 +4,14 @@ namespace Doctrine\Tests\DBAL\Schema\Visitor;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Tests\DBAL\MockBuilderProxy;
 use PHPUnit\Framework\TestCase;
 
 class SchemaSqlCollectorTest extends TestCase
 {
     public function testCreateSchema(): void
     {
-        $platformMock = $this->getMockBuilder(MySqlPlatform::class)
+        $platformMock = (new MockBuilderProxy($this->getMockBuilder(MySqlPlatform::class)))
             ->onlyMethods(['getCreateTableSql', 'getCreateSequenceSql', 'getCreateForeignKeySql'])
             ->getMock();
         $platformMock->expects($this->exactly(2))
@@ -32,7 +33,7 @@ class SchemaSqlCollectorTest extends TestCase
 
     public function testDropSchema(): void
     {
-        $platformMock = $this->getMockBuilder(MySqlPlatform::class)
+        $platformMock = (new MockBuilderProxy($this->getMockBuilder(MySqlPlatform::class)))
             ->onlyMethods(['getDropTableSql', 'getDropSequenceSql', 'getDropForeignKeySql'])
             ->getMock();
         $platformMock->expects($this->exactly(2))

--- a/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL\Sharding;
 use Doctrine\DBAL\Sharding\PoolingShardConnection;
 use Doctrine\DBAL\Sharding\PoolingShardManager;
 use Doctrine\DBAL\Sharding\ShardChoser\ShardChoser;
+use Doctrine\Tests\DBAL\MockBuilderProxy;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +16,7 @@ class PoolingShardManagerTest extends TestCase
      */
     private function createConnectionMock(): PoolingShardConnection
     {
-        return $this->getMockBuilder(PoolingShardConnection::class)
+        return (new MockBuilderProxy($this->getMockBuilder(PoolingShardConnection::class)))
             ->onlyMethods(['connect', 'getParams', 'fetchAllAssociative'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -113,7 +114,7 @@ class PoolingShardManagerTest extends TestCase
              ->with($sql, $params, $types)
              ->willReturnOnConsecutiveCalls(
                  [['id' => 1]],
-                 [['id' => 2]],
+                 [['id' => 2]]
              );
 
         $shardManager = new PoolingShardManager($conn);
@@ -145,7 +146,7 @@ class PoolingShardManagerTest extends TestCase
             ->with($sql, $params, $types)
             ->willReturnOnConsecutiveCalls(
                 [['id' => 1]],
-                [['id' => 2]],
+                [['id' => 2]]
             );
 
         $shardManager = new PoolingShardManager($conn);

--- a/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/SQLAzureShardManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/SQLAzure/SQLAzureShardManagerTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL\Sharding\SQLAzure;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Sharding\ShardingException;
 use Doctrine\DBAL\Sharding\SQLAzure\SQLAzureShardManager;
+use Doctrine\Tests\DBAL\MockBuilderProxy;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -120,7 +121,7 @@ class SQLAzureShardManagerTest extends TestCase
      */
     private function createConnection(array $params): Connection
     {
-        $conn = $this->getMockBuilder(Connection::class)
+        $conn = (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['getParams', 'exec', 'isTransactionActive'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Doctrine/Tests/DBAL/Sharding/ShardChoser/MultiTenantShardChoserTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/ShardChoser/MultiTenantShardChoserTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Sharding\ShardChoser;
 
 use Doctrine\DBAL\Sharding\PoolingShardConnection;
 use Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser;
+use Doctrine\Tests\DBAL\MockBuilderProxy;
 use PHPUnit\Framework\TestCase;
 
 class MultiTenantShardChoserTest extends TestCase
@@ -19,7 +20,7 @@ class MultiTenantShardChoserTest extends TestCase
 
     private function createConnectionMock(): PoolingShardConnection
     {
-        return $this->getMockBuilder(PoolingShardConnection::class)
+        return (new MockBuilderProxy($this->getMockBuilder(PoolingShardConnection::class)))
             ->onlyMethods(['connect', 'getParams', 'fetchAll'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -28,7 +28,7 @@ class StatementTest extends DbalTestCase
 
     protected function setUp(): void
     {
-        $this->pdoStatement = $this->getMockBuilder(PDOStatement::class)
+        $this->pdoStatement = (new MockBuilderProxy($this->getMockBuilder(PDOStatement::class)))
             ->onlyMethods(['execute', 'bindParam', 'bindValue', 'fetchAll'])
             ->getMock();
 

--- a/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Doctrine/Tests/DBAL/Tools/Console/RunSqlCommandTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\DBAL\Tools\Console;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
 use Doctrine\DBAL\Tools\Console\ConsoleRunner;
+use Doctrine\Tests\DBAL\AssertionCompatibility;
 use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class RunSqlCommandTest extends TestCase
 {
+    use AssertionCompatibility;
+
     /** @var CommandTester */
     private $commandTester;
     /** @var RunSqlCommand */

--- a/tests/Doctrine/Tests/DBAL/Types/ConversionExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/ConversionExceptionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\Tests\DBAL\AssertionCompatibility;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Throwable;
@@ -11,6 +12,8 @@ use function tmpfile;
 
 class ConversionExceptionTest extends TestCase
 {
+    use AssertionCompatibility;
+
     public function testConversionFailedPreviousException(): void
     {
         $previous = $this->createMock(Throwable::class);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | /improvement
| BC Break     | no

#### Summary

While working on the ORM support for PHP 8 (2.8 branch) realized i had to update PHP to 7.3 because DBAL requires it. Some investigation uncovered that this constraint is arbitrarily set, only minor syntax breaks in tests folder, not even in lib/src lead to errors. Straightforward to support with PHPUnit 7, 8 and 9 as well.

This PR makes DBAL 2.11 compatible with PHP 7.1 and 7.2 again in preparation for a future DBAL in the 2.x branch that includes the doctrine/deprecations component.

Individual parts:
- Downgrade some code for PHP 7.1/7.2
- Add support for PHP 7.1, 7.2, run tests only on SQLite for these two platforms without pcov because PHPUnit has no support.
- Introduce `LegacyAssertions` and `MockBuilderProxy` to support running testsuite on phpunit 7 to 9