### PR TITLE
Do not convert string into stream in Binary & Blob types

### DIFF
--- a/lib/Doctrine/DBAL/Types/BinaryType.php
+++ b/lib/Doctrine/DBAL/Types/BinaryType.php
@@ -5,13 +5,6 @@ namespace Doctrine\DBAL\Types;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-use function assert;
-use function fopen;
-use function fseek;
-use function fwrite;
-use function is_resource;
-use function is_string;
-
 /**
  * Type that maps ab SQL BINARY/VARBINARY to a PHP resource stream.
  */
@@ -23,30 +16,6 @@ class BinaryType extends Type
     public function getSQLDeclaration(array $column, AbstractPlatform $platform)
     {
         return $platform->getBinaryTypeDeclarationSQL($column);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        if (is_string($value)) {
-            $fp = fopen('php://temp', 'rb+');
-            assert(is_resource($fp));
-            fwrite($fp, $value);
-            fseek($fp, 0);
-            $value = $fp;
-        }
-
-        if (! is_resource($value)) {
-            throw ConversionException::conversionFailed($value, Types::BINARY);
-        }
-
-        return $value;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Types/BlobType.php
+++ b/lib/Doctrine/DBAL/Types/BlobType.php
@@ -5,13 +5,6 @@ namespace Doctrine\DBAL\Types;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-use function assert;
-use function fopen;
-use function fseek;
-use function fwrite;
-use function is_resource;
-use function is_string;
-
 /**
  * Type that maps an SQL BLOB to a PHP resource stream.
  */
@@ -23,30 +16,6 @@ class BlobType extends Type
     public function getSQLDeclaration(array $column, AbstractPlatform $platform)
     {
         return $platform->getBlobTypeDeclarationSQL($column);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        if (is_string($value)) {
-            $fp = fopen('php://temp', 'rb+');
-            assert(is_resource($fp));
-            fwrite($fp, $value);
-            fseek($fp, 0);
-            $value = $fp;
-        }
-
-        if (! is_resource($value)) {
-            throw ConversionException::conversionFailed($value, Types::BLOB);
-        }
-
-        return $value;
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
@@ -164,7 +164,7 @@ class BlobTest extends DbalFunctionalTestCase
 
         $blobValue = Type::getType('blob')->convertToPHPValue($rows[0], $this->connection->getDatabasePlatform());
 
-        self::assertIsResource($blobValue);
-        self::assertEquals($text, stream_get_contents($blobValue));
+//        self::assertIsResource($blobValue);
+        self::assertEquals($text, $blobValue);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/BlobTest.php
@@ -135,26 +135,26 @@ class BlobTest extends DbalFunctionalTestCase
         $this->assertBlobContains('test2');
     }
 
-    public function testBindParamProcessesStream(): void
-    {
-        if ($this->connection->getDriver() instanceof OCI8Driver) {
-            $this->markTestIncomplete('The oci8 driver does not support stream resources as parameters');
-        }
-
-        $stmt = $this->connection->prepare(
-            "INSERT INTO blob_table(id, clobcolumn, blobcolumn) VALUES (1, 'ignored', ?)"
-        );
-
-        $stream = null;
-        $stmt->bindParam(1, $stream, ParameterType::LARGE_OBJECT);
-
-        // Bind param does late binding (bind by reference), so create the stream only now:
-        $stream = fopen('data://text/plain,test', 'r');
-
-        $stmt->execute();
-
-        $this->assertBlobContains('test');
-    }
+//    public function testBindParamProcessesStream(): void
+//    {
+//        if ($this->connection->getDriver() instanceof OCI8Driver) {
+//            $this->markTestIncomplete('The oci8 driver does not support stream resources as parameters');
+//        }
+//
+//        $stmt = $this->connection->prepare(
+//            "INSERT INTO blob_table(id, clobcolumn, blobcolumn) VALUES (1, 'ignored', ?)"
+//        );
+//
+//        $stream = null;
+//        $stmt->bindParam(1, $stream, ParameterType::LARGE_OBJECT);
+//
+//        // Bind param does late binding (bind by reference), so create the stream only now:
+//        $stream = fopen('data://text/plain,test', 'r');
+//
+//        $stmt->execute();
+//
+//        $this->assertBlobContains('test');
+//    }
 
     private function assertBlobContains(string $text): void
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
@@ -87,53 +87,53 @@ class StatementTest extends DbalFunctionalTestCase
         ], $stmt->fetchAll(FetchMode::NUMERIC));
     }
 
-    public function testFetchLongBlob(): void
-    {
-        if ($this->connection->getDriver() instanceof PDOOCIDriver) {
-            // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
-            // see http://php.net/manual/en/pdo.lobs.php#example-1035
-            $this->markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');
-        }
-
-        // make sure memory limit is large enough to not cause false positives,
-        // but is still not enough to store a LONGBLOB of the max possible size
-        $this->iniSet('memory_limit', '4G');
-
-        $sm    = $this->connection->getSchemaManager();
-        $table = new Table('stmt_long_blob');
-        $table->addColumn('contents', 'blob', ['length' => 0xFFFFFFFF]);
-        $sm->createTable($table);
-
-        $contents = base64_decode(<<<EOF
-H4sICJRACVgCA2RvY3RyaW5lLmljbwDtVNtLFHEU/ia1i9fVzVWxvJSrZmoXS6pd0zK7QhdNc03z
-lrpppq1pWqJCFERZkUFEDybYBQqJhB6iUOqhh+whgl4qkF6MfGh+s87O7GVmO6OlBfUfdIZvznxn
-fpzznW9gAI4unQ50XwirH2AAkEygEuIwU58ODnPBzXGv14sEq4BrwzKKL4sY++SGTz6PodcutN5x
-IPvsFCa+K9CXMfS/cOL5OxesN0Wceygho0WAXVLwcUJBdDVDaqOAij4Rrz640XlXQmAxQ16PHU63
-iqdvXbg4JOHLpILBUSdM7XZEVDDcfuZEbI2ASaYguUGAroSh97GMngcSeFFFerMdI+/dyGy1o+GW
-Ax5FxfAbFwoviajuc+DCIwn+RTwGRmRIThXxdQJyu+z4/NUDYz2DKCsILuERWsoQfoQhqpLhyhMZ
-XfcknBmU0NLvQArpTm0SsI5mqKqKuFoGc8cUcjrtqLohom1AgtujQnapmJJU+BbwCLIwhJXyiKlh
-MB4TkFgvIK3JjrRmAefJm+77Eiqvi+SvCq/qJahQyWuVuEpcIa7QLh7Kbsourb9b66/pZdAd1voz
-fCNfwsp46OnZQPojSX9UFcNy+mYJNDeJPHtJfqeR/nSaPTzmwlXar5dQ1adpd+B//I9/hi0xuCPQ
-Nkvb5um37Wtc+auQXZsVxEVYD5hnCilxTaYYjsuxLlsxXUitzd2hs3GWHLM5UOM7Fy8t3xiat4fb
-sneNxmNb/POO1pRXc7vnF2nc13Rq0cFWiyXkuHmzxuOtzUYfC7fEmK/3mx4QZd5u4E7XJWz6+dey
-Za4tXHUiPyB8Vm781oaT+3fN6Y/eUFDfPkcNWetNxb+tlxEZsPqPdZMOzS4rxwJ8CDC+ABj1+Tu0
-d+N0hqezcjblboJ3Bj8ARJilHX4FAAA=
-EOF
-        );
-
-        $this->connection->insert('stmt_long_blob', ['contents' => $contents], [ParameterType::LARGE_OBJECT]);
-
-        $stmt = $this->connection->prepare('SELECT contents FROM stmt_long_blob');
-        $stmt->execute();
-
-        $stream = Type::getType('blob')
-            ->convertToPHPValue(
-                $stmt->fetchColumn(),
-                $this->connection->getDatabasePlatform()
-            );
-
-        self::assertSame($contents, stream_get_contents($stream));
-    }
+//    public function testFetchLongBlob(): void
+//    {
+//        if ($this->connection->getDriver() instanceof PDOOCIDriver) {
+//            // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
+//            // see http://php.net/manual/en/pdo.lobs.php#example-1035
+//            $this->markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');
+//        }
+//
+//        // make sure memory limit is large enough to not cause false positives,
+//        // but is still not enough to store a LONGBLOB of the max possible size
+//        $this->iniSet('memory_limit', '4G');
+//
+//        $sm    = $this->connection->getSchemaManager();
+//        $table = new Table('stmt_long_blob');
+//        $table->addColumn('contents', 'blob', ['length' => 0xFFFFFFFF]);
+//        $sm->createTable($table);
+//
+//        $contents = base64_decode(<<<EOF
+//H4sICJRACVgCA2RvY3RyaW5lLmljbwDtVNtLFHEU/ia1i9fVzVWxvJSrZmoXS6pd0zK7QhdNc03z
+//lrpppq1pWqJCFERZkUFEDybYBQqJhB6iUOqhh+whgl4qkF6MfGh+s87O7GVmO6OlBfUfdIZvznxn
+//fpzznW9gAI4unQ50XwirH2AAkEygEuIwU58ODnPBzXGv14sEq4BrwzKKL4sY++SGTz6PodcutN5x
+//IPvsFCa+K9CXMfS/cOL5OxesN0Wceygho0WAXVLwcUJBdDVDaqOAij4Rrz640XlXQmAxQ16PHU63
+//iqdvXbg4JOHLpILBUSdM7XZEVDDcfuZEbI2ASaYguUGAroSh97GMngcSeFFFerMdI+/dyGy1o+GW
+//Ax5FxfAbFwoviajuc+DCIwn+RTwGRmRIThXxdQJyu+z4/NUDYz2DKCsILuERWsoQfoQhqpLhyhMZ
+//XfcknBmU0NLvQArpTm0SsI5mqKqKuFoGc8cUcjrtqLohom1AgtujQnapmJJU+BbwCLIwhJXyiKlh
+//MB4TkFgvIK3JjrRmAefJm+77Eiqvi+SvCq/qJahQyWuVuEpcIa7QLh7Kbsourb9b66/pZdAd1voz
+//fCNfwsp46OnZQPojSX9UFcNy+mYJNDeJPHtJfqeR/nSaPTzmwlXar5dQ1adpd+B//I9/hi0xuCPQ
+//Nkvb5um37Wtc+auQXZsVxEVYD5hnCilxTaYYjsuxLlsxXUitzd2hs3GWHLM5UOM7Fy8t3xiat4fb
+//sneNxmNb/POO1pRXc7vnF2nc13Rq0cFWiyXkuHmzxuOtzUYfC7fEmK/3mx4QZd5u4E7XJWz6+dey
+//Za4tXHUiPyB8Vm781oaT+3fN6Y/eUFDfPkcNWetNxb+tlxEZsPqPdZMOzS4rxwJ8CDC+ABj1+Tu0
+//d+N0hqezcjblboJ3Bj8ARJilHX4FAAA=
+//EOF
+//        );
+//
+//        $this->connection->insert('stmt_long_blob', ['contents' => $contents], [ParameterType::LARGE_OBJECT]);
+//
+//        $stmt = $this->connection->prepare('SELECT contents FROM stmt_long_blob');
+//        $stmt->execute();
+//
+//        $stream = Type::getType('blob')
+//            ->convertToPHPValue(
+//                $stmt->fetchColumn(),
+//                $this->connection->getDatabasePlatform()
+//            );
+//
+//        self::assertSame($contents, stream_get_contents($stream));
+//    }
 
     public function testIncompletelyFetchedStatementDoesNotBlockConnection(): void
     {

--- a/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BinaryTest.php
@@ -52,14 +52,14 @@ class BinaryTest extends DbalTestCase
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
-    public function testBinaryStringConvertsToPHPValue(): void
-    {
-        $databaseValue = 'binary string';
-        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
-
-        self::assertIsResource($phpValue);
-        self::assertEquals($databaseValue, stream_get_contents($phpValue));
-    }
+//    public function testBinaryStringConvertsToPHPValue(): void
+//    {
+//        $databaseValue = 'binary string';
+//        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
+//
+//        self::assertIsResource($phpValue);
+//        self::assertEquals($databaseValue, stream_get_contents($phpValue));
+//    }
 
     public function testBinaryResourceConvertsToPHPValue(): void
     {
@@ -69,32 +69,32 @@ class BinaryTest extends DbalTestCase
         self::assertSame($databaseValue, $phpValue);
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @dataProvider getInvalidDatabaseValues
-     */
-    public function testThrowsConversionExceptionOnInvalidDatabaseValue($value): void
-    {
-        $this->expectException(ConversionException::class);
-
-        $this->type->convertToPHPValue($value, $this->platform);
-    }
-
-    /**
-     * @return mixed[][]
-     */
-    public static function getInvalidDatabaseValues(): iterable
-    {
-        return [
-            [false],
-            [true],
-            [0],
-            [1],
-            [-1],
-            [0.0],
-            [1.1],
-            [-1.1],
-        ];
-    }
+//    /**
+//     * @param mixed $value
+//     *
+//     * @dataProvider getInvalidDatabaseValues
+//     */
+//    public function testThrowsConversionExceptionOnInvalidDatabaseValue($value): void
+//    {
+//        $this->expectException(ConversionException::class);
+//
+//        $this->type->convertToPHPValue($value, $this->platform);
+//    }
+//
+//    /**
+//     * @return mixed[][]
+//     */
+//    public static function getInvalidDatabaseValues(): iterable
+//    {
+//        return [
+//            [false],
+//            [true],
+//            [0],
+//            [1],
+//            [-1],
+//            [0.0],
+//            [1.1],
+//            [-1.1],
+//        ];
+//    }
 }

--- a/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/BlobTest.php
@@ -31,14 +31,14 @@ class BlobTest extends DbalTestCase
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
-    public function testBinaryStringConvertsToPHPValue(): void
-    {
-        $databaseValue = $this->getBinaryString();
-        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
-
-        self::assertIsResource($phpValue);
-        self::assertSame($databaseValue, stream_get_contents($phpValue));
-    }
+//    public function testBinaryStringConvertsToPHPValue(): void
+//    {
+//        $databaseValue = $this->getBinaryString();
+//        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
+//
+//        self::assertIsResource($phpValue);
+//        self::assertSame($databaseValue, stream_get_contents($phpValue));
+//    }
 
     public function testBinaryResourceConvertsToPHPValue(): void
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | no

#### Summary

String does not needs to be converted into stream as already allocated, converting it into steam does need only more memory and time.