### PR TITLE
Fix php8 mysql mariadb

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/TransactionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TransactionTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\Tests\DbalFunctionalTestCase;
+use PDOException;
 
 use function sleep;
 
@@ -35,6 +36,12 @@ class TransactionTest extends DbalFunctionalTestCase
 
         sleep(2); // during the sleep mysql will close the connection
 
-        $this->assertFalse(@$this->connection->commit()); // we will ignore `MySQL server has gone away` warnings
+        try {
+            $this->assertFalse(@$this->connection->commit()); // we will ignore `MySQL server has gone away` warnings
+        } catch (PDOException $e) {
+            /* For PDO, we are using ERRMODE EXCEPTION, so this catch should be
+             * necessary as the equivalent of the error control operator above.
+             * This seems to be the case only since PHP 8 */
+        }
     }
 }


### PR DESCRIPTION
The only thing that I could find that looks related is this: https://github.com/php/php-src/commit/50752401a7c16f8e1f4bbe7ef52bc8fb5b17418f

I think getting a warning in lower PHP versions instead of an exception although we configure PDO to throw might be a bug, and I think the commit above might have for side effect to fix that bug.