### PR TITLE
Add missing instanceof check

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -89,6 +89,15 @@
                 <file name="src/Schema/AbstractSchemaManager.php"/>
             </errorLevel>
         </PossiblyNullArgument>
+        <RedundantCondition>
+            <errorLevel type="suppress">
+                <!--
+                    Requires a release of
+                    https://github.com/sebastianbergmann/phpunit/commit/9c60d7d9fd3bfa80fa4aeab7090e1bbe0830dbcd
+                -->
+                <file name="tests/Driver/API/ExceptionConverterTest.php"/>
+            </errorLevel>
+        </RedundantCondition>
         <TooFewArguments>
             <errorLevel type="suppress">
                 <!--

--- a/tests/Driver/API/ExceptionConverterTest.php
+++ b/tests/Driver/API/ExceptionConverterTest.php
@@ -51,6 +51,7 @@ abstract class ExceptionConverterTest extends TestCase
 
         $dbalException = $this->converter->convert($driverException, $query);
 
+        self::assertInstanceOf($expectedClass, $dbalException);
         self::assertSame($driverException->getCode(), $dbalException->getCode());
         self::assertSame($driverException->getSQLState(), $dbalException->getSQLState());
         self::assertSame($driverException, $dbalException->getPrevious());


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

The `$expectedClass` variable is currently unused. It should be used for an `instanceof` check.