### PR TITLE
Remove redundant phpstan param from DriverManager::getConnection()

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -119,7 +119,6 @@ final class DriverManager
      *
      * @throws Exception
      *
-     * @phpstan-param mixed[] $params
      * @psalm-return ($params is array{wrapperClass:mixed} ? T : Connection)
      * @template T of Connection
      */

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -36,7 +36,7 @@ class ConnectionTest extends DbalTestCase
     /** @var Connection */
     private $connection;
 
-    /** @var string[] */
+    /** @var array{wrapperClass?: class-string<Connection>} */
     protected $params = [
         'driver' => 'pdo_mysql',
         'host' => 'localhost',


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     |no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This effectively prevented phpstan from inferring type of `T` template.

> Unable to resolve the template type T in call to method static method Doctrine\DBAL\DriverManager::getConnection()
