### PR TITLE
Deprecate colon prefix for prepared statement parameters

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,22 @@
 # Upgrade to 2.12
 
+## Deprecated colon prefix for prepared statement parameters
+
+The usage of the colon prefix when binding named parameters is deprecated.
+
+```php
+$sql  = 'SELECT * FROM users WHERE name = :name OR username = :username';
+$stmt = $conn->prepare($sql);
+
+// The usage of the leading colon is deprecated
+$stmt->bindValue(':name', $name);
+
+// Only the parameter name should be passed
+$stmt->bindValue('username', $username);
+
+$stmt->execute();
+```
+
 ## PDO signature changes with php 8
 
 In php 8.0, the method signatures of two PDO classes which are extended by DBAL have changed. This affects the following classes:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

#### Summary

The syntax with the leading colon exists for [compatibility with PDO](https://github.com/doctrine/dbal/pull/309/files#r3887636) which is no longer the goal. Essentially, the colon is part of the SQL syntax for parameter placeholders, not part of the parameter name. It has certain downsides:
1. It's ambiguous as it allows to bind both `'param'` and `':param'` to the same statement w/o the explicitly specified precedence.
2. It requires extra effort when fixing certain issues (e.g. https://github.com/doctrine/dbal/issues/2897 is not fixed for named types because of the leading colon).

Apart from that, as part of fixing #4383 (or soon after that), I'd like to use the same SQL parser for the wrapper layer and the OCI8 statement. At that time, I'd like to not have to deal with supporting both syntaxes.