### PR TITLE
Deprecate inappropriate usage of prepared statement parameters

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,36 @@
 # Upgrade to 2.12
 
+## Deprecated non-zero based positional parameter keys
+
+The usage of one-based and other non-zero-based keys when binding positional parameters is deprecated.
+
+It is recommended to not use any array keys so that the value of the parameter array complies with the [`list<>`](https://psalm.dev/docs/annotating_code/type_syntax/array_types/) type constraint.
+
+```php
+// This is valid (implicit zero-based parameter indexes)
+$conn->fetchNumeric('SELECT ?, ?', [1, 2]);
+
+// This is invalid (one-based parameter indexes)
+$conn->fetchNumeric('SELECT ?, ?', [1 => 1, 2 => 2]);
+
+// This is invalid (arbitrary parameter indexes)
+$conn->fetchNumeric('SELECT ?, ?', [-31 => 1, 5 => 2]);
+
+// This is invalid (non-sequential parameter indexes)
+$conn->fetchNumeric('SELECT ?, ?', [0 => 1, 3 => 2]);
+```
+
+## Deprecated skipping prepared statement parameters
+
+Some underlying drivers currently allow skipping prepared statement parameters. For instance:
+
+```php
+$conn->fetchOne('SELECT ?');
+// NULL
+```
+
+This behavior should not be relied upon and may change in future versions.
+
 ## Deprecated colon prefix for prepared statement parameters
 
 The usage of the colon prefix when binding named parameters is deprecated.

--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -91,9 +91,11 @@ are then replaced by their actual values in a second step (execute).
     $stmt->bindValue(1, $id);
     $stmt->execute();
 
-Placeholders in prepared statements are either simple positional question marks (?) or named labels starting with
-a double-colon (:name1). You cannot mix the positional and the named approach. The approach
-using question marks is called positional, because the values are bound in order from left to right
+Placeholders in prepared statements are either simple positional question marks (``?``) or named labels starting with
+a colon (e.g. ``:name1``). You cannot mix the positional and the named approach. You have to bind a parameter
+to each placeholder.
+
+The approach using question marks is called positional, because the values are bound in order from left to right
 to any question mark found in the previously prepared SQL query. That is why you specify the
 position of the variable to bind into the ``bindValue()`` method:
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

#### Summary

The current SQL parser implementation allows certain usages that are rather a side effects of the existing implementation than something that the implementation was purposefully designed for.

1. The keys of positional parameters and their types can be anything and do not have to correspond to the positions of the placeholders in the statement. This is achieved by sorting them: https://github.com/doctrine/dbal/blob/99f9c7e4179065d742cbf35ed4a3685a20aba642/lib/Doctrine/DBAL/SQLParserUtils.php#L152-L153 and then discarding keys: https://github.com/doctrine/dbal/blob/99f9c7e4179065d742cbf35ed4a3685a20aba642/lib/Doctrine/DBAL/SQLParserUtils.php#L177-L178 And is even covered by a test: https://github.com/doctrine/dbal/blob/99f9c7e4179065d742cbf35ed4a3685a20aba642/tests/Doctrine/Tests/DBAL/SQLParserUtilsTest.php#L313-L333   
2. The parser allows omitting parameters.
3. The parser allows mixing positional and named parameters in the same statement (this is currently forbidden by the documentation and wouldn't be a BC break): https://github.com/doctrine/dbal/blob/99f9c7e4179065d742cbf35ed4a3685a20aba642/docs/en/reference/data-retrieval-and-manipulation.rst#L95

The behavior above should be deprecated in order to allow future rework of the parser w/o introducing breaking changes.