### PR TITLE
QueryBuilder must use 0-based positional parameter keys

### DIFF
--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -1330,8 +1330,8 @@ class QueryBuilder
      */
     public function createPositionalParameter($value, $type = ParameterType::STRING)
     {
-        $this->boundCounter++;
         $this->setParameter($this->boundCounter, $value, $type);
+        $this->boundCounter++;
 
         return '?';
     }

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -679,8 +679,8 @@ class QueryBuilderTest extends TestCase
         );
 
         self::assertEquals('SELECT u.* FROM users u WHERE u.name = ?', (string) $qb);
-        self::assertEquals(10, $qb->getParameter(1));
-        self::assertEquals(ParameterType::INTEGER, $qb->getParameterType(1));
+        self::assertEquals(10, $qb->getParameter(0));
+        self::assertEquals(ParameterType::INTEGER, $qb->getParameterType(0));
     }
 
     public function testReferenceJoinFromJoin(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #4421.

Although this bug exists in `2.x`, I don't think we have to fix it in a patch release. It's sufficient to fix it in `3.0.x`.