### PR TITLE
Mark SQLParserUtils internal

### DIFF
--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -26,6 +26,8 @@ use const PREG_OFFSET_CAPTURE;
 
 /**
  * Utility class that parses sql statements with regard to types and parameters.
+ *
+ * @internal
  */
 class SQLParserUtils
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

`SQLParserUtils` is not meant for external usage and will be removed in #4397 in favor of another API. In order to be able to finish this change after the 3.0 release, we need to make sure the class is not part of the public API.