### PR TITLE
Use individual properties in Configuration

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -400,6 +400,12 @@ public function convert(Doctrine\DBAL\Driver\Exception $exception, ?Doctrine\DBA
 
 The constructor of `Doctrine\DBAL\Exception\DriverException` is now `@internal`.
 
+## BC Break: `Configuration`
+
+- all `Configuration` methods are now typed
+- `Configuration::setSchemaAssetsFilter()` now returns `void`
+- `Configuration::$_attributes` has been removed; use individual properties in subclasses instead
+
 # Upgrade to 2.12
 
 ## Deprecated non-zero based positional parameter keys

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -15,61 +15,71 @@ class Configuration
     private $middlewares = [];
 
     /**
-     * The attributes that are contained in the configuration.
-     * Values are default values.
+     * The SQL logger in use. If null, SQL logging is disabled.
      *
-     * @var mixed[]
+     * @var SQLLogger|null
      */
-    protected $_attributes = [];
+    protected $sqlLogger;
+
+    /**
+     * The cache driver implementation that is used for query result caching.
+     *
+     * @var Cache|null
+     */
+    protected $resultCacheImpl;
+
+    /**
+     * The callable to use to filter schema assets.
+     *
+     * @var callable|null
+     */
+    protected $schemaAssetsFilter;
+
+    /**
+     * The default auto-commit mode for connections.
+     *
+     * @var bool
+     */
+    protected $autoCommit = true;
 
     /**
      * Sets the SQL logger to use. Defaults to NULL which means SQL logging is disabled.
-     *
-     * @return void
      */
-    public function setSQLLogger(?SQLLogger $logger = null)
+    public function setSQLLogger(?SQLLogger $logger = null): void
     {
-        $this->_attributes['sqlLogger'] = $logger;
+        $this->sqlLogger = $logger;
     }
 
     /**
      * Gets the SQL logger that is used.
-     *
-     * @return SQLLogger|null
      */
-    public function getSQLLogger()
+    public function getSQLLogger(): ?SQLLogger
     {
-        return $this->_attributes['sqlLogger'] ?? null;
+        return $this->sqlLogger;
     }
 
     /**
      * Gets the cache driver implementation that is used for query result caching.
-     *
-     * @return Cache|null
      */
-    public function getResultCacheImpl()
+    public function getResultCacheImpl(): ?Cache
     {
-        return $this->_attributes['resultCacheImpl'] ?? null;
+        return $this->resultCacheImpl;
     }
 
     /**
      * Sets the cache driver implementation that is used for query result caching.
-     *
-     * @return void
      */
-    public function setResultCacheImpl(Cache $cacheImpl)
+    public function setResultCacheImpl(Cache $cacheImpl): void
     {
-        $this->_attributes['resultCacheImpl'] = $cacheImpl;
+        $this->resultCacheImpl = $cacheImpl;
     }
 
     /**
      * Sets the callable to use to filter schema assets.
      */
-    public function setSchemaAssetsFilter(?callable $callable = null): ?callable
+    public function setSchemaAssetsFilter(?callable $callable = null): void
     {
-        $this->_attributes['filterSchemaAssetsExpression'] = null;
-
-        return $this->_attributes['filterSchemaAssetsExpressionCallable'] = $callable;
+        $this->schemaAssetsFilter = $callable;
     }
 
     /**
@@ -77,7 +87,7 @@ class Configuration
      */
     public function getSchemaAssetsFilter(): ?callable
     {
-        return $this->_attributes['filterSchemaAssetsExpressionCallable'] ?? null;
+        return $this->schemaAssetsFilter;
     }
 
     /**
@@ -89,13 +99,11 @@ class Configuration
      *
      * @see   getAutoCommit
      *
-     * @param bool $autoCommit True to enable auto-commit mode; false to disable it.
-     *
-     * @return void
+     * @param bool $autoCommit True to enable auto-commit mode; false to disable it
      */
-    public function setAutoCommit($autoCommit)
+    public function setAutoCommit(bool $autoCommit): void
     {
-        $this->_attributes['autoCommit'] = (bool) $autoCommit;
+        $this->autoCommit = $autoCommit;
     }
 
     /**
@@ -105,9 +113,9 @@ class Configuration
      *
      * @return bool True if auto-commit mode is enabled by default for connections, false otherwise.
      */
-    public function getAutoCommit()
+    public function getAutoCommit(): bool
     {
-        return $this->_attributes['autoCommit'] ?? true;
+        return $this->autoCommit;
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | -

#### Summary

This PR moves away from a global `Configuration::$_attributes` associative array, towards individual properties.
