### PR TITLE
#4437 MSSQL adds a redundant ORDER BY clause when with subquery with …

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -479,4 +479,14 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
         $sql         = $this->platform->modifyLimitQuery($querySql, 10);
         self::assertEquals($expectedSql, $sql);
     }
+
+    public function testModifyLimitQueryWithOrderByWithSubqueryWithOrderBy(): void
+    {
+        $subquery    = 'SELECT col2 from test ORDER BY col2 OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY';
+        $querySql    = 'SELECT col1 FROM test ORDER BY ( ' . $subquery . ' )';
+        $expectedSql = 'SELECT col1 FROM test ORDER BY ( ' . $subquery . ' )'
+            . ' OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY';
+        $sql         = $this->platform->modifyLimitQuery($querySql, 10);
+        self::assertEquals($expectedSql, $sql);
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4437

#### Summary

Currently, it is checking the last ORDER BY clause if after this clause the number of open brackets is different from the number of closed brackets, then it adds an ORDER BY clause. 
I changed the logic so that ORDER BY was added when, among all ORDER BY instances found in the query, the condition that number of open brackets is different than number of closed brackets for a particular clause is met.
Overall, I check every occurrence of ORDER BY, not just the last.

<!-- Provide a summary of your change. -->
