### PR TITLE
Implementation CHAR_LENGTH expression for Mysql

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -770,7 +770,7 @@ abstract class AbstractPlatform
      *
      * @throws Exception If not supported on this platform.
      */
-    public function getCharLengthExpression(string $column): string
+    public function getCharLengthExpression($column)
     {
         throw Exception::notSupported(__METHOD__);
     }

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -762,6 +762,20 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Returns the SQL snippet to get the length of a string (in characters).
+     *
+     * @param string $column
+     *
+     * @return string
+     *
+     * @throws Exception If not supported on this platform.
+     */
+    public function getCharLengthExpression(string $column): string
+    {
+        throw Exception::notSupported(__METHOD__);
+    }
+
+    /**
      * Returns the SQL snippet to get the squared value of a column.
      *
      * @param string $column The column to use.

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -130,6 +130,14 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getCharLengthExpression(string $column): string
+    {
+        return 'CHAR_LENGTH(' . $column . ')';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getListDatabasesSQL()
     {
         return 'SHOW DATABASES';

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -130,7 +130,7 @@ class MySqlPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCharLengthExpression(string $column): string
+    public function getCharLengthExpression($column)
     {
         return 'CHAR_LENGTH(' . $column . ')';
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\Functional\Platform;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Tests\DbalFunctionalTestCase;
+use Doctrine\DBAL\Driver\Exception as DriverException;
+
+class CharLengthExpressionTest extends DbalFunctionalTestCase
+{
+
+    /**
+     * @throws Exception
+     */
+    public function testCharLengthExpressionNotSupport(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if (!$platform instanceof SqlitePlatform) {
+            self::markTestSkipped('Test is for sqlite only');
+        }
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Operation \'Doctrine\DBAL\Platforms\AbstractPlatform::getCharLengthExpression\' is not supported by platform');
+        $platform->getCharLengthExpression('testColumn');
+    }
+
+    /**
+     * @throws Exception
+     * @throws DriverException
+     */
+    public function testCharLengthExpression(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if (!$platform instanceof MySqlPlatform) {
+            self::markTestSkipped('Test is for sqlite only');
+        }
+
+        $table = new Table('char_length_expression_test');
+        $table->addColumn('testColumn1', Types::STRING);
+        $table->addColumn('testColumn2', Types::STRING);
+        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $this->connection->insert('date_expr_test', [
+            'testColumn1' => '€',
+            'testColumn2' => 'str',
+        ]);
+
+        $sql = sprintf('SELECT %s FROM char_length_expression_test', $platform->getCharLengthExpression('testColumn1'));
+        self::assertSame(1, $this->connection->executeQuery($sql)->fetchOne());
+        $sql = sprintf('SELECT %s FROM char_length_expression_test', $platform->getCharLengthExpression('testColumn2'));
+        self::assertSame(3, $this->connection->executeQuery($sql)->fetchOne());
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\DBAL\Functional\Platform;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Table;
@@ -49,12 +50,12 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
             'testColumn2' => 'str',
         ]);
 
-        $sql = sprintf(
+        $sql  = sprintf(
             'SELECT %s as c1, %s as c2 FROM char_length_expression_test',
             $platform->getCharLengthExpression('testColumn1'),
             $platform->getCharLengthExpression('testColumn2')
         );
-        $stmt = $this->connection->executeQuery($sql)->fetchAssociative();
+        $stmt = $this->connection->executeQuery($sql)->fetch(FetchMode::ASSOCIATIVE);
         self::assertSame(1, $stmt['c1']);
         self::assertSame(3, $stmt['c2']);
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -36,7 +36,7 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
     {
         $platform = $this->connection->getDatabasePlatform();
         if (!$platform instanceof MySqlPlatform) {
-            self::markTestSkipped('Test is for sqlite only');
+            self::markTestSkipped('Test is for mysql only');
         }
 
         $table = new Table('char_length_expression_test');

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Tests\DBAL\Functional\Platform;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Table;
@@ -43,20 +42,10 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
 
         $table = new Table('char_length_expression_test');
         $table->addColumn('testColumn1', Types::STRING);
-        $table->addColumn('testColumn2', Types::STRING);
         $this->connection->getSchemaManager()->dropAndCreateTable($table);
-        $this->connection->insert('char_length_expression_test', [
-            'testColumn1' => '€',
-            'testColumn2' => 'str',
-        ]);
+        $this->connection->insert('char_length_expression_test', ['testColumn1' => '€']);
 
-        $sql  = sprintf(
-            'SELECT %s as c1, %s as c2 FROM char_length_expression_test',
-            $platform->getCharLengthExpression('testColumn1'),
-            $platform->getCharLengthExpression('testColumn2')
-        );
-        $stmt = $this->connection->executeQuery($sql)->fetch(FetchMode::ASSOCIATIVE);
-        self::assertSame(1, (int) $stmt['c1']);
-        self::assertSame(3, (int) $stmt['c2']);
+        $sql = sprintf('SELECT %s FROM char_length_expression_test', $platform->getCharLengthExpression('testColumn1'));
+        self::assertSame(1, $this->connection->query($sql)->fetchColumn());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -19,8 +19,8 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
     public function testCharLengthExpressionNotSupport(): void
     {
         $platform = $this->connection->getDatabasePlatform();
-        if (! $platform instanceof SqlitePlatform) {
-            self::markTestSkipped('Test is for sqlite only');
+        if ($platform instanceof MySqlPlatform) {
+            self::markTestSkipped('Test is not for mysql');
         }
 
         $this->expectException(Exception::class);

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Platform;
 
-use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -26,15 +25,13 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(
-            'Operation \'Doctrine\DBAL\Platforms\AbstractPlatform::getCharLengthExpression\' 
-            is not supported by platform'
+            'Operation \'Doctrine\DBAL\Platforms\AbstractPlatform::getCharLengthExpression\' is not supported by platform'
         );
         $platform->getCharLengthExpression('testColumn');
     }
 
     /**
      * @throws Exception
-     * @throws DriverException
      */
     public function testCharLengthExpression(): void
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -36,6 +36,7 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
     public function testCharLengthExpression(): void
     {
         $platform = $this->connection->getDatabasePlatform();
+
         if (! $platform instanceof MySqlPlatform) {
             self::markTestSkipped('Test is for mysql only');
         }
@@ -46,6 +47,6 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
         $this->connection->insert('char_length_expression_test', ['testColumn1' => '€']);
 
         $sql = sprintf('SELECT %s FROM char_length_expression_test', $platform->getCharLengthExpression('testColumn1'));
-        self::assertSame(1, $this->connection->query($sql)->fetchColumn());
+        self::assertSame('1', $this->connection->query($sql)->fetchColumn());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -25,7 +25,7 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(
-            'Operation \'Doctrine\DBAL\Platforms\AbstractPlatform::getCharLengthExpression\' is not supported by platform'
+            "Operation 'Doctrine\DBAL\Platforms\AbstractPlatform::getCharLengthExpression' is not supported by platform"
         );
         $platform->getCharLengthExpression('testColumn');
     }
@@ -49,9 +49,13 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
             'testColumn2' => 'str',
         ]);
 
-        $sql = sprintf('SELECT %s FROM char_length_expression_test', $platform->getCharLengthExpression('testColumn1'));
-        self::assertSame(1, $this->connection->executeQuery($sql)->fetchColumn());
-        $sql = sprintf('SELECT %s FROM char_length_expression_test', $platform->getCharLengthExpression('testColumn2'));
-        self::assertSame(3, $this->connection->executeQuery($sql)->fetchColumn());
+        $sql = sprintf(
+            'SELECT %s as c1, %s as c2 FROM char_length_expression_test',
+            $platform->getCharLengthExpression('testColumn1'),
+            $platform->getCharLengthExpression('testColumn2')
+        );
+        $stmt = $this->connection->executeQuery($sql)->fetchAssociative();
+        self::assertSame(1, $stmt['c1']);
+        self::assertSame(3, $stmt['c2']);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -56,7 +56,7 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
             $platform->getCharLengthExpression('testColumn2')
         );
         $stmt = $this->connection->executeQuery($sql)->fetch(FetchMode::ASSOCIATIVE);
-        self::assertSame(1, $stmt['c1']);
-        self::assertSame(3, $stmt['c2']);
+        self::assertSame('1', $stmt['c1']);
+        self::assertSame('3', $stmt['c2']);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -56,7 +56,7 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
             $platform->getCharLengthExpression('testColumn2')
         );
         $stmt = $this->connection->executeQuery($sql)->fetch(FetchMode::ASSOCIATIVE);
-        self::assertSame('1', $stmt['c1']);
-        self::assertSame('3', $stmt['c2']);
+        self::assertSame(1, (int) $stmt['c1']);
+        self::assertSame(3, (int) $stmt['c2']);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -4,7 +4,6 @@ namespace Doctrine\Tests\DBAL\Functional\Platform;
 
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalFunctionalTestCase;

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -44,9 +44,10 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
         $table = new Table('char_length_expression_test');
         $table->addColumn('testColumn1', Types::STRING);
         $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $this->connection->executeQuery('SET CHARACTER SET utf8');
         $this->connection->insert('char_length_expression_test', ['testColumn1' => '€']);
 
         $sql = sprintf('SELECT %s FROM char_length_expression_test', $platform->getCharLengthExpression('testColumn1'));
-        self::assertSame('1', $this->connection->query($sql)->fetchColumn());
+        self::assertSame(1, (int) $this->connection->query($sql)->fetchColumn());
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/CharLengthExpressionTest.php
@@ -2,29 +2,33 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Platform;
 
+use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalFunctionalTestCase;
-use Doctrine\DBAL\Driver\Exception as DriverException;
+
+use function sprintf;
 
 class CharLengthExpressionTest extends DbalFunctionalTestCase
 {
-
     /**
      * @throws Exception
      */
     public function testCharLengthExpressionNotSupport(): void
     {
         $platform = $this->connection->getDatabasePlatform();
-        if (!$platform instanceof SqlitePlatform) {
+        if (! $platform instanceof SqlitePlatform) {
             self::markTestSkipped('Test is for sqlite only');
         }
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Operation \'Doctrine\DBAL\Platforms\AbstractPlatform::getCharLengthExpression\' is not supported by platform');
+        $this->expectExceptionMessage(
+            'Operation \'Doctrine\DBAL\Platforms\AbstractPlatform::getCharLengthExpression\' 
+            is not supported by platform'
+        );
         $platform->getCharLengthExpression('testColumn');
     }
 
@@ -35,7 +39,7 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
     public function testCharLengthExpression(): void
     {
         $platform = $this->connection->getDatabasePlatform();
-        if (!$platform instanceof MySqlPlatform) {
+        if (! $platform instanceof MySqlPlatform) {
             self::markTestSkipped('Test is for mysql only');
         }
 
@@ -43,14 +47,14 @@ class CharLengthExpressionTest extends DbalFunctionalTestCase
         $table->addColumn('testColumn1', Types::STRING);
         $table->addColumn('testColumn2', Types::STRING);
         $this->connection->getSchemaManager()->dropAndCreateTable($table);
-        $this->connection->insert('date_expr_test', [
+        $this->connection->insert('char_length_expression_test', [
             'testColumn1' => '€',
             'testColumn2' => 'str',
         ]);
 
         $sql = sprintf('SELECT %s FROM char_length_expression_test', $platform->getCharLengthExpression('testColumn1'));
-        self::assertSame(1, $this->connection->executeQuery($sql)->fetchOne());
+        self::assertSame(1, $this->connection->executeQuery($sql)->fetchColumn());
         $sql = sprintf('SELECT %s FROM char_length_expression_test', $platform->getCharLengthExpression('testColumn2'));
-        self::assertSame(3, $this->connection->executeQuery($sql)->fetchOne());
+        self::assertSame(3, $this->connection->executeQuery($sql)->fetchColumn());
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #4388 

#### Summary
Added new method to `Doctrine\DBAL\Platforms\AbstractPlatform` - `getCharLengthExpression`, implemented only for `Doctrine\DBAL\Platforms\MySqlPlatform`. Method makes it possible to get the length in characters.

