### PR TITLE
Update incompatible method signatures in PDO Connection and Statement definition to comply with LSP violations RFC in PHP 8.

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -62,8 +62,11 @@ class ArrayStatement implements IteratorAggregate, ResultStatement
     /**
      * {@inheritdoc}
      */
-    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchMode, ...$args)
     {
+        $arg2 = $args[0] ?? null;
+        $arg3 = $args[1] ?? null;
+
         if ($arg2 !== null || $arg3 !== null) {
             throw new InvalidArgumentException('Caching layer does not support 2nd/3rd argument to setFetchMode()');
         }
@@ -117,7 +120,7 @@ class ArrayStatement implements IteratorAggregate, ResultStatement
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
+    public function fetchAll($fetchMode = null, ...$args)
     {
         $rows = [];
         while ($row = $this->fetch($fetchMode)) {

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -107,7 +107,7 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
     /**
      * {@inheritdoc}
      */
-    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
+    public function setFetchMode($fetchMode, ...$args)
     {
         $this->defaultFetchMode = $fetchMode;
 
@@ -167,8 +167,11 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
+    public function fetchAll($fetchMode = null, ...$args)
     {
+        $fetchArgument = $args[0] ?? null;
+        $ctorArgs      = $args[1] ?? null;
+
         $data = $this->statement->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
 
         if ($fetchMode === FetchMode::COLUMN) {

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1013,7 +1013,7 @@ class Connection implements DriverConnection
      *
      * @throws DBALException
      */
-    public function query()
+    public function query(string $query, ?int $fetchMode = null, ...$fetchModeArgs)
     {
         $connection = $this->getWrappedConnection();
 

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -351,7 +351,7 @@ class MasterSlaveConnection extends Connection
     /**
      * {@inheritDoc}
      */
-    public function query()
+    public function query(string $query, ?int $fetchMode = null, ...$fetchModeArgs)
     {
         $this->connect('master');
         assert($this->_conn instanceof DriverConnection);

--- a/lib/Doctrine/DBAL/Driver/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/Connection.php
@@ -26,17 +26,14 @@ interface Connection
      *
      * @return Statement
      */
-    public function query();
+    public function query(string $query, ?int $fetchMode = null, ...$fetchModeArgs);
 
     /**
      * Quotes a string for use in a query.
      *
-     * @param mixed $value
-     * @param int   $type
-     *
      * @return mixed
      */
-    public function quote($value, $type = ParameterType::STRING);
+    public function quote(string $value, int $type = ParameterType::STRING);
 
     /**
      * Executes an SQL statement and return the number of affected rows.

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -93,7 +93,7 @@ class DB2Connection implements Connection, ServerInfoAwareConnection
     /**
      * {@inheritdoc}
      */
-    public function query()
+    public function query(string $query, ?int $fetchMode = null, ...$fetchModeArgs)
     {
         $args = func_get_args();
         $sql  = $args[0];

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -78,7 +78,7 @@ class PDOConnection extends PDO implements Connection, ServerInfoAwareConnection
      *
      * @return \PDOStatement
      */
-    public function query()
+    public function query(string $query, ?int $fetchMode = null, ...$fetchModeArgs)
     {
         $args = func_get_args();
 

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -49,8 +49,11 @@ class PDOStatement extends \PDOStatement implements Statement
     /**
      * {@inheritdoc}
      */
-    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
+    public function setFetchMode(int $fetchMode, ...$args)
     {
+        $arg2 = $args[0] ?? null;
+        $arg3 = $args[1] ?? null;
+
         $fetchMode = $this->convertFetchMode($fetchMode);
 
         // This thin wrapper is necessary to shield against the weird signature
@@ -153,12 +156,13 @@ class PDOStatement extends \PDOStatement implements Statement
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
+    public function fetchAll(?int $fetchMode = null, ...$args)
     {
-        $args = func_get_args();
+        $fetchArgument = $args[0] ?? null;
+        $ctorArgs      = $args[1] ?? null;
 
-        if (isset($args[0])) {
-            $args[0] = $this->convertFetchMode($args[0]);
+        if ($fetchMode) {
+            $fetchMode = $this->convertFetchMode($fetchMode);
         }
 
         if ($fetchMode === null && $fetchArgument === null && $ctorArgs === null) {

--- a/lib/Doctrine/DBAL/Driver/ResultStatement.php
+++ b/lib/Doctrine/DBAL/Driver/ResultStatement.php
@@ -29,13 +29,11 @@ interface ResultStatement extends Traversable
     /**
      * Sets the fetch mode to use while iterating this statement.
      *
-     * @param int   $fetchMode The fetch mode must be one of the {@link FetchMode} constants.
-     * @param mixed $arg2
-     * @param mixed $arg3
+     * @param int $fetchMode The fetch mode must be one of the {@link FetchMode} constants.
      *
      * @return bool
      */
-    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null);
+    public function setFetchMode(int $fetchMode, ...$args);
 
     /**
      * Returns the next row of a result set.
@@ -67,26 +65,13 @@ interface ResultStatement extends Traversable
     /**
      * Returns an array containing all of the result set rows.
      *
-     * @param int|null     $fetchMode     Controls how the next row will be returned to the caller.
-     *                                    The value must be one of the {@link FetchMode} constants,
-     *                                    defaulting to {@link FetchMode::MIXED}.
-     * @param int|null     $fetchArgument This argument has a different meaning depending on the value
-     *                                    of the $fetchMode parameter:
-     *                                    * {@link FetchMode::COLUMN}:
-     *                                      Returns the indicated 0-indexed column.
-     *                                    * {@link FetchMode::CUSTOM_OBJECT}:
-     *                                      Returns instances of the specified class, mapping the columns of each row
-     *                                      to named properties in the class.
-     *                                    * {@link PDO::FETCH_FUNC}: Returns the results of calling
-     *                                      the specified function, using each row's
-     *                                      columns as parameters in the call.
-     * @param mixed[]|null $ctorArgs      Controls how the next row will be returned to the caller.
-     *                                    The value must be one of the {@link FetchMode} constants,
-     *                                    defaulting to {@link FetchMode::MIXED}.
+     * @param int|null $fetchMode Controls how the next row will be returned to the caller.
+     *                            The value must be one of the {@link FetchMode} constants,
+     *                            defaulting to {@link FetchMode::MIXED}.
      *
      * @return mixed[]
      */
-    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null);
+    public function fetchAll(?int $fetchMode = null, ...$args);
 
     /**
      * Returns a single column from the next row of a result set or FALSE if there are no more rows.


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | n/a <!-- use #NUM format to reference an issue -->

#### Summary

### Update incompatible method signatures in PDO Connection and Statement definition to comply with LSP violations RFC in PHP 8. [https://wiki.php.net/rfc/lsp_errors](https://wiki.php.net/rfc/lsp_errors)

The issue can be reproduced and verified with the [Symfony Demo](https://github.com/symfony/demo) project.

Build PHP 8 and setup the Symfony Demo project, we will see the fetal error be thrown which complains the incompatible method signature. After applying the change in this PR, the errors will be fixed and CRUD works.

I ran unit tests with PHP 8, while it seems this case is not covered.
