### PR TITLE
Ensure the default is declared in the same statement for new columns

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -484,11 +484,14 @@ SQL
             }
 
             $columnDef    = $column->toArray();
-            $queryParts[] = 'ADD ' . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnDef);
-
+            $addColumnSql = 'ADD ' . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnDef);
             if (isset($columnDef['default'])) {
-                $queryParts[] = $this->getAlterTableAddDefaultConstraintClause($diff->name, $column);
+                $addColumnSql .= ' CONSTRAINT ' .
+                    $this->generateDefaultConstraintName($diff->name, $column->getQuotedName($this)) .
+                    $this->getDefaultValueDeclarationSQL($columnDef);
             }
+
+            $queryParts[] = $addColumnSql;
 
             $comment = $this->getColumnComment($column);
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/AddColumnWithDefaultTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/AddColumnWithDefaultTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Functional\Platform;
+
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+class AddColumnWithDefaultTest extends DbalFunctionalTestCase
+{
+    public function testAddColumnWithDefault(): void
+    {
+        $schemaManager = $this->connection->getSchemaManager();
+
+        $table = new Table('add_default_test');
+
+        $table->addColumn('original_field', Types::STRING);
+        $schemaManager->dropAndCreateTable($table);
+
+        $this->connection->executeStatement("INSERT INTO add_default_test (original_field) VALUES ('one')");
+
+        $tableDiff                      = new TableDiff('add_default_test');
+        $tableDiff->fromTable           = $table;
+        $tableDiff->addedColumns['foo'] = new Column('new_field', Type::getType('string'), ['default' => 'DEFAULT']);
+
+        $schemaManager->alterTable($tableDiff);
+
+        $query  = 'SELECT original_field, new_field FROM add_default_test';
+        $result = $this->connection->executeQuery($query)->fetch(FetchMode::NUMERIC);
+        self::assertSame(['one', 'DEFAULT'], $result);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1404,8 +1404,8 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
                     [new Column('removecolumn', Type::getType('string'), ['default' => 'foo'])]
                 ),
                 [
-                    'ALTER TABLE mytable ADD addcolumn NVARCHAR(255) NOT NULL',
-                    "ALTER TABLE mytable ADD CONSTRAINT DF_6B2BD609_4AD86123 DEFAULT 'foo' FOR addcolumn",
+                    'ALTER TABLE mytable ADD addcolumn NVARCHAR(255) NOT NULL ' .
+                    "CONSTRAINT DF_6B2BD609_4AD86123 DEFAULT 'foo'",
                     'ALTER TABLE mytable DROP COLUMN removecolumn',
                     'ALTER TABLE mytable DROP CONSTRAINT DF_6B2BD609_9BADD926',
                     'ALTER TABLE mytable ALTER COLUMN mycolumn NVARCHAR(255) NOT NULL',
@@ -1428,8 +1428,8 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
                     [new Column('`removecolumn`', Type::getType('string'), ['default' => 'foo'])]
                 ),
                 [
-                    'ALTER TABLE [mytable] ADD [addcolumn] NVARCHAR(255) NOT NULL',
-                    "ALTER TABLE [mytable] ADD CONSTRAINT DF_6B2BD609_4AD86123 DEFAULT 'foo' FOR [addcolumn]",
+                    'ALTER TABLE [mytable] ADD [addcolumn] NVARCHAR(255) NOT NULL ' .
+                    "CONSTRAINT DF_6B2BD609_4AD86123 DEFAULT 'foo'",
                     'ALTER TABLE [mytable] DROP COLUMN [removecolumn]',
                     'ALTER TABLE [mytable] DROP CONSTRAINT DF_6B2BD609_9BADD926',
                     'ALTER TABLE [mytable] ALTER COLUMN [mycolumn] NVARCHAR(255) NOT NULL',
@@ -1452,8 +1452,8 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
                     [new Column('drop', Type::getType('string'), ['default' => 'foo'])]
                 ),
                 [
-                    'ALTER TABLE [table] ADD [add] NVARCHAR(255) NOT NULL',
-                    "ALTER TABLE [table] ADD CONSTRAINT DF_F6298F46_FD1A73E7 DEFAULT 'foo' FOR [add]",
+                    'ALTER TABLE [table] ADD [add] NVARCHAR(255) NOT NULL ' .
+                    "CONSTRAINT DF_F6298F46_FD1A73E7 DEFAULT 'foo'",
                     'ALTER TABLE [table] DROP COLUMN [drop]',
                     'ALTER TABLE [table] DROP CONSTRAINT DF_F6298F46_4BF2EAC0',
                     'ALTER TABLE [table] ALTER COLUMN [select] NVARCHAR(255) NOT NULL',
@@ -1476,8 +1476,8 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
                     [new Column('`drop`', Type::getType('string'), ['default' => 'foo'])]
                 ),
                 [
-                    'ALTER TABLE [table] ADD [add] NVARCHAR(255) NOT NULL',
-                    "ALTER TABLE [table] ADD CONSTRAINT DF_F6298F46_FD1A73E7 DEFAULT 'foo' FOR [add]",
+                    'ALTER TABLE [table] ADD [add] NVARCHAR(255) NOT NULL ' .
+                    "CONSTRAINT DF_F6298F46_FD1A73E7 DEFAULT 'foo'",
                     'ALTER TABLE [table] DROP COLUMN [drop]',
                     'ALTER TABLE [table] DROP CONSTRAINT DF_F6298F46_4BF2EAC0',
                     'ALTER TABLE [table] ALTER COLUMN [select] NVARCHAR(255) NOT NULL',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2265

#### Summary

When adding columns to tables that already contain data, SQL Server requires that the default constraint is declared in the same statement, Doctrine currently generates a separate `ADD CONSTRAINT` statement, which means the add column statement errors with something like:
```
SQLSTATE [42000, 4901]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]
ALTER TABLE only allows columns to be added that can contain nulls, or have a DEFAULT
definition specified, or the column being added is an identity or timestamp column,
or alternatively if none of the previous conditions are satisfied the table must be
empty to allow addition of this column. Column 'addcolumn' cannot be added
to non-empty table 'mytable' because it does not satisfy these conditions.
```