### PR TITLE
Document the shape of the connection parameters array

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -432,23 +432,21 @@ class Connection implements DriverConnection
 
                 // The database to connect to might not yet exist.
                 // Retry detection without database name connection parameter.
-                $databaseName           = $this->params['dbname'];
-                $this->params['dbname'] = null;
+                $params = $this->params;
+
+                unset($this->params['dbname']);
 
                 try {
                     $this->connect();
                 } catch (Throwable $fallbackException) {
                     // Either the platform does not support database-less connections
                     // or something else went wrong.
-                    // Reset connection parameters and rethrow the original exception.
-                    $this->params['dbname'] = $databaseName;
-
                     throw $originalException;
+                } finally {
+                    $this->params = $params;
                 }
 
-                // Reset connection parameters.
-                $this->params['dbname'] = $databaseName;
-                $serverVersion          = $this->getServerVersion();
+                $serverVersion = $this->getServerVersion();
 
                 // Close "temporary" connection to allow connecting to the real database again.
                 $this->close();

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -37,6 +37,8 @@ use function key;
  * A wrapper around a Doctrine\DBAL\Driver\Connection that adds features like
  * events, transaction isolation levels, configuration, emulated transaction nesting,
  * lazy connecting and more.
+ *
+ * @psalm-import-type Params from DriverManager
  */
 class Connection implements DriverConnection
 {
@@ -130,9 +132,11 @@ class Connection implements DriverConnection
     /**
      * The parameters used during creation of the Connection instance.
      *
-     * @var mixed[]
+     * @var array<string,mixed>
+     * @phpstan-var array<string,mixed>
+     * @psalm-var Params
      */
-    private $params = [];
+    private $params;
 
     /**
      * The DatabasePlatform object that provides information about the
@@ -171,12 +175,15 @@ class Connection implements DriverConnection
      *
      * @internal The connection can be only instantiated by the driver manager.
      *
-     * @param mixed[]            $params       The connection parameters.
-     * @param Driver             $driver       The driver to use.
-     * @param Configuration|null $config       The configuration, optional.
-     * @param EventManager|null  $eventManager The event manager, optional.
+     * @param array<string,mixed> $params       The connection parameters.
+     * @param Driver              $driver       The driver to use.
+     * @param Configuration|null  $config       The configuration, optional.
+     * @param EventManager|null   $eventManager The event manager, optional.
      *
      * @throws Exception
+     *
+     * @phpstan-param array<string,mixed> $params
+     * @psalm-param Params $params
      */
     public function __construct(
         array $params,
@@ -222,7 +229,10 @@ class Connection implements DriverConnection
      *
      * @internal
      *
-     * @return mixed[]
+     * @return array<string,mixed>
+     *
+     * @phpstan-return array<string,mixed>
+     * @psalm-return Params
      */
     public function getParams()
     {

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -14,6 +14,8 @@ use const E_USER_DEPRECATED;
 
 /**
  * @deprecated Use PrimaryReadReplicaConnection instead
+ *
+ * @psalm-import-type Params from \Doctrine\DBAL\DriverManager
  */
 class MasterSlaveConnection extends PrimaryReadReplicaConnection
 {
@@ -22,9 +24,12 @@ class MasterSlaveConnection extends PrimaryReadReplicaConnection
      *
      * @internal The connection can be only instantiated by the driver manager.
      *
-     * @param mixed[] $params
+     * @param array<string,mixed> $params
      *
      * @throws InvalidArgumentException
+     *
+     * @phpstan-param array<string,mixed> $params
+     * @psalm-param Params $params
      */
     public function __construct(
         array $params,

--- a/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
+++ b/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
@@ -111,9 +111,12 @@ class PrimaryReadReplicaConnection extends Connection
             throw new InvalidArgumentException('You have to configure at least one replica.');
         }
 
-        $params['primary']['driver'] = $params['driver'];
-        foreach ($params['replica'] as $replicaKey => $replica) {
-            $params['replica'][$replicaKey]['driver'] = $params['driver'];
+        if (isset($params['driver'])) {
+            $params['primary']['driver'] = $params['driver'];
+
+            foreach ($params['replica'] as $replicaKey => $replica) {
+                $params['replica'][$replicaKey]['driver'] = $params['driver'];
+            }
         }
 
         $this->keepReplica = (bool) ($params['keepReplica'] ?? false);

--- a/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
+++ b/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
@@ -56,6 +56,7 @@ use function func_get_args;
  *
  * Instantiation through the DriverManager looks like:
  *
+ * @psalm-import-type Params from \Doctrine\DBAL\DriverManager
  * @example
  *
  * $conn = DriverManager::getConnection(array(
@@ -93,9 +94,12 @@ class PrimaryReadReplicaConnection extends Connection
      *
      * @internal The connection can be only instantiated by the driver manager.
      *
-     * @param mixed[] $params
+     * @param array<string,mixed> $params
      *
      * @throws InvalidArgumentException
+     *
+     * @phpstan-param array<string,mixed> $params
+     * @psalm-param Params $params
      */
     public function __construct(
         array $params,

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -36,10 +36,8 @@ final class DriverManager
      *
      * To add your own driver use the 'driverClass' parameter to
      * {@link DriverManager::getConnection()}.
-     *
-     * @var string[]
      */
-    private static $_driverMap = [
+    private const DRIVER_MAP = [
         'pdo_mysql'          => PDO\MySQL\Driver::class,
         'pdo_sqlite'         => PDO\SQLite\Driver::class,
         'pdo_pgsql'          => PDO\PgSQL\Driver::class,
@@ -86,7 +84,7 @@ final class DriverManager
      *
      * $params must contain at least one of the following.
      *
-     * Either 'driver' with one of the array keys of {@link $_driverMap},
+     * Either 'driver' with one of the array keys of {@link DRIVER_MAP},
      * OR 'driverClass' that contains the full class name (with namespace) of the
      * driver class to instantiate.
      *
@@ -184,7 +182,7 @@ final class DriverManager
             self::_checkParams($params);
         }
 
-        $className = $params['driverClass'] ?? self::$_driverMap[$params['driver']];
+        $className = $params['driverClass'] ?? self::DRIVER_MAP[$params['driver']];
 
         $driver = new $className();
 
@@ -208,7 +206,7 @@ final class DriverManager
      */
     public static function getAvailableDrivers(): array
     {
-        return array_keys(self::$_driverMap);
+        return array_keys(self::DRIVER_MAP);
     }
 
     /**
@@ -230,8 +228,8 @@ final class DriverManager
         // check validity of parameters
 
         // driver
-        if (isset($params['driver']) && ! isset(self::$_driverMap[$params['driver']])) {
-            throw Exception::unknownDriver($params['driver'], array_keys(self::$_driverMap));
+        if (isset($params['driver']) && ! isset(self::DRIVER_MAP[$params['driver']])) {
+            throw Exception::unknownDriver($params['driver'], array_keys(self::DRIVER_MAP));
         }
 
         if (

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -27,15 +27,54 @@ use function strpos;
 use function substr;
 
 /**
- * Factory for creating Doctrine\DBAL\Connection instances.
+ * Factory for creating {@link Connection} instances.
+ *
+ * @psalm-type OverrideParams = array{
+ *     charset?: string,
+ *     dbname?: string,
+ *     default_dbname?: string,
+ *     driver?: key-of<self::DRIVER_MAP>,
+ *     driverClass?: class-string<Driver>,
+ *     driverOptions?: array<mixed>,
+ *     host?: string,
+ *     password?: string,
+ *     path?: string,
+ *     pdo?: \PDO,
+ *     platform?: Platforms\AbstractPlatform,
+ *     port?: int,
+ *     user?: string,
+ * }
+ * @psalm-type Params = array{
+ *     charset?: string,
+ *     dbname?: string,
+ *     default_dbname?: string,
+ *     driver?: key-of<self::DRIVER_MAP>,
+ *     driverClass?: class-string<Driver>,
+ *     driverOptions?: array<mixed>,
+ *     host?: string,
+ *     keepSlave?: bool,
+ *     keepReplica?: bool,
+ *     master?: OverrideParams,
+ *     memory?: bool,
+ *     password?: string,
+ *     path?: string,
+ *     pdo?: \PDO,
+ *     platform?: Platforms\AbstractPlatform,
+ *     port?: int,
+ *     primary?: OverrideParams,
+ *     replica?: array<OverrideParams>,
+ *     sharding?: array<string,mixed>,
+ *     slaves?: array<OverrideParams>,
+ *     user?: string,
+ *     wrapperClass?: class-string<Connection>,
+ * }
  */
 final class DriverManager
 {
     /**
      * List of supported drivers and their mappings to the driver classes.
      *
-     * To add your own driver use the 'driverClass' parameter to
-     * {@link DriverManager::getConnection()}.
+     * To add your own driver use the 'driverClass' parameter to {@link DriverManager::getConnection()}.
      */
     private const DRIVER_MAP = [
         'pdo_mysql'          => PDO\MySQL\Driver::class,
@@ -111,12 +150,14 @@ final class DriverManager
      * <b>driverClass</b>:
      * The driver class to use.
      *
-     * @param array{wrapperClass?: class-string<T>} $params
-     * @param Configuration|null                    $config       The configuration to use.
-     * @param EventManager|null                     $eventManager The event manager to use.
+     * @param array<string,mixed> $params
+     * @param Configuration|null  $config       The configuration to use.
+     * @param EventManager|null   $eventManager The event manager to use.
      *
      * @throws Exception
      *
+     * @phpstan-param array<string,mixed> $params
+     * @psalm-param Params $params
      * @psalm-return ($params is array{wrapperClass:mixed} ? T : Connection)
      * @template T of Connection
      */
@@ -209,6 +250,9 @@ final class DriverManager
      * @param array<string,mixed> $params
      *
      * @throws Exception
+     *
+     * @phpstan-param array<string,mixed> $params
+     * @psalm-param Params $params
      */
     private static function createDriver(array $params): Driver
     {
@@ -254,6 +298,11 @@ final class DriverManager
      *                 URL extracted into indidivual parameter parts.
      *
      * @throws Exception
+     *
+     * @phpstan-param array<string,mixed> $params
+     * @phpstan-return array<string,mixed>
+     * @psalm-param Params $params
+     * @psalm-return Params
      */
     private static function parseDatabaseUrl(array $params): array
     {

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -302,15 +302,18 @@ class OracleSchemaManager extends AbstractSchemaManager
             $database = $this->_conn->getDatabase();
         }
 
-        $params   = $this->_conn->getParams();
-        $username = $database;
-        $password = $params['password'];
+        $statement = 'CREATE USER ' . $database;
 
-        $query = 'CREATE USER ' . $username . ' IDENTIFIED BY ' . $password;
-        $this->_conn->executeStatement($query);
+        $params = $this->_conn->getParams();
 
-        $query = 'GRANT DBA TO ' . $username;
-        $this->_conn->executeStatement($query);
+        if (isset($params['password'])) {
+            $statement .= ' IDENTIFIED BY ' . $params['password'];
+        }
+
+        $this->_conn->executeStatement($statement);
+
+        $statement = 'GRANT DBA TO ' . $database;
+        $this->_conn->executeStatement($statement);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -52,13 +52,12 @@ class SqliteSchemaManager extends AbstractSchemaManager
      */
     public function createDatabase($database)
     {
-        $params  = $this->_conn->getParams();
-        $driver  = $params['driver'];
-        $options = [
-            'driver' => $driver,
-            'path' => $database,
-        ];
-        $conn    = DriverManager::getConnection($options);
+        $params = $this->_conn->getParams();
+
+        $params['path'] = $database;
+        unset($params['memory']);
+
+        $conn = DriverManager::getConnection($params);
         $conn->connect();
         $conn->close();
     }

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -12,6 +12,10 @@
         <directory name="tests/Doctrine/Tests" />
         <ignoreFiles>
             <directory name="vendor" />
+
+            <!-- See https://github.com/doctrine/dbal/pull/3906 -->
+            <directory name="lib/Doctrine/DBAL/Sharding" />
+            <directory name="tests/Doctrine/Tests/DBAL/Sharding" />
         </ignoreFiles>
     </projectFiles>
     <stubs>
@@ -85,10 +89,19 @@
                 <file name="lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php"/>
             </errorLevel>
         </ImplementedReturnTypeMismatch>
+        <InvalidNullableReturnType>
+            <errorLevel type="suppress">
+                <!-- See https://github.com/doctrine/dbal/pull/4082 -->
+                <file name="lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php"/>
+            </errorLevel>
+        </InvalidNullableReturnType>
         <InvalidPropertyAssignmentValue>
             <errorLevel type="suppress">
                 <!-- Fixing this issue requires an API change -->
                 <file name="lib/Doctrine/DBAL/Driver/PDOException.php"/>
+
+                <!-- See https://github.com/doctrine/dbal/pull/3548 -->
+                <file name="lib/Doctrine/DBAL/Connection.php"/>
             </errorLevel>
         </InvalidPropertyAssignmentValue>
         <MethodSignatureMismatch>
@@ -128,6 +141,19 @@
                 <file name="lib/Doctrine/DBAL/SQLParserUtils.php"/>
             </errorLevel>
         </PossiblyInvalidOperand>
+        <PossiblyUndefinedArrayOffset>
+            <errorLevel type="suppress">
+                <!-- See https://github.com/doctrine/dbal/pull/3606 -->
+                <file name="lib/Doctrine/DBAL/Driver/AbstractDB2Driver.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php"/>
+
+                <!-- See https://github.com/psalm/psalm-plugin-phpunit/pull/82 -->
+                <file name="tests/Doctrine/Tests/DBAL/Connections/MasterSlaveConnectionTest.php"/>
+                <file name="tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php"/>
+                <file name="tests/Doctrine/Tests/DBAL/Functional/PrimaryReadReplicaConnectionTest.php"/>
+                <file name="tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php"/>
+            </errorLevel>
+        </PossiblyUndefinedArrayOffset>
         <PossiblyNullArgument>
             <errorLevel type="suppress">
                 <!-- See https://github.com/doctrine/dbal/pull/3488 -->
@@ -196,6 +222,13 @@
                 <file name="lib/Doctrine/DBAL/Tools/Dumper.php"/>
             </errorLevel>
         </UndefinedClass>
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <!-- See https://github.com/doctrine/dbal/pull/3803 -->
+                <file name="tests/Doctrine/Tests/DBAL/ConnectionTest.php"/>
+                <file name="tests/Doctrine/Tests/DBAL/DriverManagerTest.php"/>
+            </errorLevel>
+        </InvalidArgument>
         <InvalidReturnType>
             <errorLevel type="suppress">
                 <!-- lastInsertId has a return type that does not match the one defined in the interface-->

--- a/tests/Doctrine/Tests/DBAL/Connections/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Connections/MasterSlaveConnectionTest.php
@@ -17,14 +17,14 @@ class MasterSlaveConnectionTest extends DbalTestCase
                 'host' => 'master.host',
                 'user' => 'root',
                 'password' => 'password',
-                'port' => '1234',
+                'port' => 1234,
             ],
             'slaves' => [
                 [
                     'host' => 'slave1.host',
                     'user' => 'root',
                     'password' => 'password',
-                    'port' => '1234',
+                    'port' => 1234,
                 ],
             ],
         ];
@@ -33,6 +33,7 @@ class MasterSlaveConnectionTest extends DbalTestCase
 
         $connectionParams = $connection->getParams();
         foreach ($constructionParams as $key => $value) {
+            self::assertArrayHasKey($key, $connectionParams);
             self::assertSame($value, $connectionParams[$key]);
         }
     }

--- a/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/DriverManagerTest.php
@@ -162,7 +162,10 @@ class DriverManagerTest extends DbalTestCase
         ];
 
         foreach ($expected as $key => $value) {
+            self::assertArrayHasKey($key, $params['primary']);
             self::assertEquals($value, $params['primary'][$key]);
+
+            self::assertArrayHasKey($key, $params['replica']['replica1']);
             self::assertEquals($value, $params['replica']['replica1'][$key]);
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
@@ -36,9 +36,17 @@ class DriverTest extends AbstractDriverTest
         ?string $defaultDatabaseName,
         ?string $expectedDatabaseName
     ): void {
-        $params                   = $this->connection->getParams();
-        $params['dbname']         = $databaseName;
-        $params['default_dbname'] = $defaultDatabaseName;
+        $params = $this->connection->getParams();
+
+        if ($databaseName !== null) {
+            $params['dbname'] = $databaseName;
+        } else {
+            unset($params['dbname']);
+        }
+
+        if ($defaultDatabaseName !== null) {
+            $params['default_dbname'] = $defaultDatabaseName;
+        }
 
         $connection = new Connection(
             $params,

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -31,6 +31,9 @@ use function version_compare;
 use const PHP_OS;
 use const PHP_OS_FAMILY;
 
+/**
+ * @psalm-import-type Params from DriverManager
+ */
 class ExceptionTest extends DbalFunctionalTestCase
 {
     protected function setUp(): void
@@ -351,6 +354,8 @@ EOT
      * @param array<string, mixed> $params
      *
      * @dataProvider getConnectionParams
+     *
+     * @psalm-param Params $params
      */
     public function testConnectionException(array $params): void
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -14,6 +14,9 @@ use function sprintf;
 
 use const CASE_LOWER;
 
+/**
+ * @psalm-import-type Params from \Doctrine\DBAL\DriverManager
+ */
 class MasterSlaveConnectionTest extends DbalFunctionalTestCase
 {
     protected function setUp(): void
@@ -52,6 +55,8 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
 
     /**
      * @return mixed[]
+     *
+     * @psalm-return Params
      */
     private function createMasterSlaveConnectionParams(bool $keepSlave = false): array
     {
@@ -74,6 +79,8 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
         foreach ($charsets as $charset) {
             $params                      = $this->createMasterSlaveConnectionParams();
             $params['master']['charset'] = $charset;
+
+            self::assertArrayHasKey('slaves', $params);
 
             foreach ($params['slaves'] as $index => $slaveParams) {
                 if (! isset($slaveParams['charset'])) {

--- a/tests/Doctrine/Tests/DBAL/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PrimaryReadReplicaConnectionTest.php
@@ -16,6 +16,7 @@ use const CASE_LOWER;
 
 /**
  * @group DBAL-20
+ * @psalm-import-type Params from \Doctrine\DBAL\DriverManager
  */
 class PrimaryReadReplicaConnectionTest extends DbalFunctionalTestCase
 {
@@ -55,6 +56,8 @@ class PrimaryReadReplicaConnectionTest extends DbalFunctionalTestCase
 
     /**
      * @return mixed[]
+     *
+     * @psalm-return Params
      */
     private function createPrimaryReadReplicaConnectionParams(bool $keepReplica = false): array
     {
@@ -77,6 +80,8 @@ class PrimaryReadReplicaConnectionTest extends DbalFunctionalTestCase
         foreach ($charsets as $charset) {
             $params                       = $this->createPrimaryReadReplicaConnectionParams();
             $params['primary']['charset'] = $charset;
+
+            self::assertArrayHasKey('replica', $params);
 
             foreach ($params['replica'] as $index => $replicaParams) {
                 if (! isset($replicaParams['charset'])) {

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Types\Types;
 
 use function array_map;
 use function array_pop;
+use function array_unshift;
 use function count;
 use function strtolower;
 
@@ -43,10 +44,15 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testGetSearchPath(): void
     {
+        $expected = ['public'];
+
         $params = $this->connection->getParams();
 
-        $paths = $this->schemaManager->getSchemaSearchPaths();
-        self::assertEquals([$params['user'], 'public'], $paths);
+        if (isset($params['user'])) {
+            array_unshift($expected, $params['user']);
+        }
+
+        self::assertEquals($expected, $this->schemaManager->getSchemaSearchPaths());
     }
 
     public function testGetSchemaNames(): void

--- a/tests/Doctrine/Tests/DBAL/Schema/MySqlInheritCharsetTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/MySqlInheritCharsetTest.php
@@ -17,6 +17,9 @@ use PHPUnit\Framework\TestCase;
 
 use function array_merge;
 
+/**
+ * @psalm-import-type Params from \Doctrine\DBAL\DriverManager
+ */
 class MySqlInheritCharsetTest extends TestCase
 {
     public function testInheritTableOptionsFromDatabase(): void
@@ -73,17 +76,19 @@ class MySqlInheritCharsetTest extends TestCase
     }
 
     /**
-     * @param string[] $overrideOptions
+     * @param array<string,mixed> $params
      *
      * @return string[]
+     *
+     * @psalm-param Params $params
      */
-    private function getTableOptionsForOverride(array $overrideOptions = []): array
+    private function getTableOptionsForOverride(array $params = []): array
     {
         $eventManager = new EventManager();
         $driverMock   = $this->createMock(Driver::class);
         $platform     = new MySqlPlatform();
-        $connOptions  = array_merge(['platform' => $platform], $overrideOptions);
-        $conn         = new Connection($connOptions, $driverMock, new Configuration(), $eventManager);
+        $params       = array_merge(['platform' => $platform], $params);
+        $conn         = new Connection($params, $driverMock, new Configuration(), $eventManager);
         $manager      = new MySqlSchemaManager($conn, $platform);
 
         $schemaConfig = $manager->createSchemaConfig();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

This pull request documents the shape of the connection parameters array and addresses some issues discovered by the static analysis. It also enforces documentation of the newly added parameters (I hope it's not going to happen) and identifies a certain potential for improvement:

1. Parameters currently is a mess of DBAL-level (host, port), wrapper-level (primary/replica, sharding), and driver-level (charset, memory) elements.
2. There's no way to tell whether a given parameter is currently used or not (e.g. due to a typo or being driver/wrapper-specific).

Notes:

1. The `OverrideParams` type is added temporarily until Psalm implements the support for self-referencing types (https://github.com/vimeo/psalm/issues/4653#issuecomment-731768265).
2. PHPStan currently interprets `@psalm-*` annotations but doesn't understand user-defined types. Therefore, each added annotation has to be doubled with a `@phpstan-` one with a simpler type.
3. What the hell is `default_dbname` and why was it introduced in https://github.com/doctrine/dbal/pull/2284?