### PR TITLE
Resolve exceptions in php8 related to php/php-src#6157

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1700,7 +1700,8 @@ class Connection implements DriverConnection
 
             try {
                 $result = $connection->commit();
-            } catch (\PDOException $e) {}
+            } catch (Throwable $e) {
+            }
 
             if ($logger) {
                 $logger->stopQuery();
@@ -1768,13 +1769,11 @@ class Connection implements DriverConnection
             }
 
             $this->transactionNestingLevel = 0;
-
             try {
                 $connection->rollBack();
-            } catch (\PDOException $e) {}
-
+            } catch (Throwable $e) {
+            }
             $this->isRollbackOnly = false;
-            
             if ($logger) {
                 $logger->stopQuery();
             }

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1698,7 +1698,9 @@ class Connection implements DriverConnection
                 $logger->startQuery('"COMMIT"');
             }
 
-            $result = $connection->commit();
+            try {
+                $result = $connection->commit();
+            } catch (\PDOException $e) {}
 
             if ($logger) {
                 $logger->stopQuery();
@@ -1766,8 +1768,13 @@ class Connection implements DriverConnection
             }
 
             $this->transactionNestingLevel = 0;
-            $connection->rollBack();
+
+            try {
+                $connection->rollBack();
+            } catch (\PDOException $e) {}
+
             $this->isRollbackOnly = false;
+            
             if ($logger) {
                 $logger->stopQuery();
             }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

In a Symfony project with Doctrine migrations and multiple transactions in a single command, the following exception in thrown with MySQL connections.

In Connection.php line 1761:
There is no active transaction 

In my understanding this is occurring because PHP 8 now throws an error when committing/rolling back a transaction which was already autocommitted. (php/php-src@990bb34).

