### PR TITLE
Remove unmaintained branches from the project metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -22,43 +22,36 @@
         },
         {
             "name": "2.11",
-            "branchName": "2.11.x",
             "slug": "2.11",
             "maintained": false
         },
         {
             "name": "2.10",
-            "branchName": "2.10.x",
             "slug": "2.10",
             "maintained": false
         },
         {
             "name": "2.9",
-            "branchName": "2.9",
             "slug": "2.9",
             "maintained": false
         },
         {
             "name": "2.8",
-            "branchName": "2.8",
             "slug": "2.8",
             "maintained": false
         },
         {
             "name": "2.7",
-            "branchName": "2.7",
             "slug": "2.7",
             "maintained": false
         },
         {
             "name": "2.6",
-            "branchName": "2.6",
             "slug": "2.6",
             "maintained": false
         },
         {
             "name": "2.5",
-            "branchName": "2.5",
             "slug": "2.5",
             "maintained": false
         }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

As of https://github.com/doctrine/doctrine-website/pull/372, the branch name is no longer necessary to locate a version. Therefore, the branch names of the unmaintained releases (and later, the branches themselves) can be removed. ~~Additionally, the slugs that exactly correspond to the release name can be omitted ([ref](https://github.com/doctrine/doctrine-website/blob/6076042066ba16db8fdc10271010693f656e2104/lib/Model/ProjectVersion.php#L61)).~~