### PR TITLE
rebase: MSSQL adds a redundant ORDER BY clause when with subquery with ORDER BY

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -480,10 +480,12 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
         self::assertEquals($expectedSql, $sql);
     }
 
-    public function testModifyLimitQueryWithManyOrderBy(): void
+    public function testModifyLimitQueryWithOrderByWithSubqueryWithOrderBy(): void
     {
-        $querySql    = 'SELECT col1 FROM test ORDER BY ( SELECT col2 from test ORDER BY col2 )';
-        $expectedSql = 'SELECT col1 FROM test ORDER BY ( SELECT col2 from test ORDER BY col2 ) OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY';
+        $subquery    = 'SELECT col2 from test ORDER BY col2 OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY';
+        $querySql    = 'SELECT col1 FROM test ORDER BY ( ' . $subquery . ' )';
+        $expectedSql = 'SELECT col1 FROM test ORDER BY ( ' . $subquery . ' )'
+            . ' OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY';
         $sql         = $this->platform->modifyLimitQuery($querySql, 10);
         self::assertEquals($expectedSql, $sql);
     }

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -479,4 +479,12 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
         $sql         = $this->platform->modifyLimitQuery($querySql, 10);
         self::assertEquals($expectedSql, $sql);
     }
+
+    public function testModifyLimitQueryWithManyOrderBy(): void
+    {
+        $querySql    = 'SELECT col1 FROM test ORDER BY ( SELECT col2 from test ORDER BY col2 )';
+        $expectedSql = 'SELECT col1 FROM test ORDER BY ( SELECT col2 from test ORDER BY col2 ) OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY';
+        $sql         = $this->platform->modifyLimitQuery($querySql, 10);
+        self::assertEquals($expectedSql, $sql);
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4437

#### Summary

Rebased #4438
<!-- Provide a summary of your change. -->
