### PR TITLE
[GH-3318] Bugfix: Wraps exceptions in DBAL\Exception in PrimaryReplicaConnection

### DIFF
--- a/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
+++ b/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
@@ -16,6 +16,9 @@ use function array_rand;
 use function assert;
 use function count;
 use function func_get_args;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * Primary-Replica Connection
@@ -436,6 +439,13 @@ class PrimaryReadReplicaConnection extends Connection
             $statement = $this->_conn->query(...$args);
         } catch (Throwable $e) {
             if (! $this->wrapNativeExceptionsBugfix) {
+                @trigger_error(
+                    'Throwing native driver exception from PrimaryReplicaConnection is deprecated since ' .
+                    'doctrine/dbal 2.12 and will be removed in 3.0, use with ' .
+                    '"optinToWrapNativeExceptionsBugfix"=true parameter instead.',
+                    E_USER_DEPRECATED
+                );
+
                 throw $e;
             }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PrimaryReadReplicaConnectionTest.php
@@ -3,6 +3,8 @@
 namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\Table;
@@ -242,5 +244,26 @@ class PrimaryReadReplicaConnectionTest extends DbalFunctionalTestCase
         self::assertArrayNotHasKey(0, $data[0]);
 
         self::assertEquals(1, $data[0]['num']);
+    }
+
+    public function testNoOptinToWrapExceptionsBugfixThrowsNativeException(): void
+    {
+        $connection = DriverManager::getConnection($this->createPrimaryReadReplicaConnectionParams());
+
+        $this->expectException(Exception::class);
+
+        $connection->query('lets force an exception');
+    }
+
+    public function testOptinToWrapExceptionsInteadOfNativeExceptions(): void
+    {
+        $params                                      = $this->createPrimaryReadReplicaConnectionParams();
+        $params['optinToWrapNativeExceptionsBugfix'] = true;
+
+        $connection = DriverManager::getConnection($params);
+
+        $this->expectException(DBALException::class);
+
+        $connection->query('lets force an exception');
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3118

#### Summary

This PR fixes #3118, fixes #2769 and supersedes #4248.

It introduces a new parameter to `PrimaryReplicaConnection` that allows opt into this bugfix, because it is also considered a BC break, because its existence probably forced people to introduce workarounds.

Usage:

```
$params = $this->createPrimaryReadReplicaConnectionParams();
$params['optinToWrapNativeExceptionsBugfix'] = true;

$connection = DriverManager::getConnection($params);
```

If you don't opt into this bugfix via flag a deprecation message will be shown, as this bug is fixed probably unintentionally in 3.0 already.