### PR TITLE
Update JetBrains PhpStorm stubs to v2020.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "8.2.0",
-        "jetbrains/phpstorm-stubs": "2019.3",
+        "jetbrains/phpstorm-stubs": "2020.2",
         "phpstan/phpstan": "0.12.81",
         "phpunit/phpunit": "9.5.0",
         "psalm/plugin-phpunit": "0.13.0",

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -298,7 +298,7 @@ class MysqliConnection implements ConnectionInterface, PingableConnection, Serve
     /**
      * Establish a secure connection
      *
-     * @param mixed[] $params
+     * @param array<string,string> $params
      *
      * @throws MysqliException
      */
@@ -315,11 +315,11 @@ class MysqliConnection implements ConnectionInterface, PingableConnection, Serve
         }
 
         $this->conn->ssl_set(
-            $params['ssl_key']    ?? null,
-            $params['ssl_cert']   ?? null,
-            $params['ssl_ca']     ?? null,
-            $params['ssl_capath'] ?? null,
-            $params['ssl_cipher'] ?? null
+            $params['ssl_key']    ?? '',
+            $params['ssl_cert']   ?? '',
+            $params['ssl_ca']     ?? '',
+            $params['ssl_capath'] ?? '',
+            $params['ssl_cipher'] ?? ''
         );
     }
 }

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -362,15 +362,6 @@
                 <file name="lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php"/>
             </errorLevel>
         </ReservedWord>
-        <TooFewArguments>
-            <errorLevel type="suppress">
-                <!--
-                    Requires a release of
-                    https://github.com/JetBrains/phpstorm-stubs/pull/727
-                -->
-                <file name="lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php"/>
-            </errorLevel>
-        </TooFewArguments>
         <TooManyArguments>
             <errorLevel type="suppress">
                 <!-- See https://github.com/doctrine/dbal/pull/3080 -->
@@ -385,11 +376,6 @@
         <UndefinedConstant>
             <errorLevel type="suppress">
                 <directory name="lib/Doctrine/DBAL/Driver/SQLAnywhere"/>
-                <!--
-                    Requires a release of
-                    https://github.com/JetBrains/phpstorm-stubs/pull/732
-                -->
-                <file name="tests/Doctrine/Tests/DBAL/Driver/PDOPgSql/DriverTest.php" />
             </errorLevel>
         </UndefinedConstant>
         <UndefinedFunction>
@@ -403,6 +389,19 @@
                 <file name="lib/Doctrine/DBAL/Tools/Dumper.php"/>
             </errorLevel>
         </UndefinedClass>
+        <UnimplementedInterfaceMethod>
+            <errorLevel type="suppress">
+                <!--
+                    Psalm doesn't support the proprietary annotations used in JeBrains PhpStorm stubs
+                    like #[PhpStormStubsElementAvailable(...)]. This suppression should be removed in 3.0.x,
+                    where https://github.com/doctrine/dbal/pull/4347 is no longer effective
+                -->
+                <file name="lib/Doctrine/DBAL/Driver/PDO/SQLSrv/Statement.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDO/Statement.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDOSqlsrv/Statement.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDOStatement.php"/>
+            </errorLevel>
+        </UnimplementedInterfaceMethod>
         <UnsafeInstantiation>
             <errorLevel type="suppress">
                 <!-- See https://github.com/doctrine/dbal/issues/4510 -->


### PR DESCRIPTION
The newly suppressed issues are not reproducible in my local setup. In order to run dockerized Pslam as on GitHub actions but with human-readable output, run the following:
```shell
$ docker run --rm -e INPUT_COMPOSER_REQUIRE_DEV=true -v $PWD:/app vimeo/psalm-github-actions:4.6.4
```