### PR TITLE
#4448 Fixed delete query with alias fails on most platforms

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3689,4 +3689,12 @@ abstract class AbstractPlatform
     {
         return '%_';
     }
+
+    /**
+     * Returns if the table alias has to be defined also in front of the FROM statement
+     */
+    public function getRequestsAdditionalDeleteQueryTableAliasBeforeFrom(): bool
+    {
+        return false;
+    }
 }

--- a/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php
@@ -1198,4 +1198,12 @@ SQL
     {
         return true;
     }
+
+    /**
+     * Returns if the table alias has to be defined also in front of the FROM statement
+     */
+    public function getRequestsAdditionalDeleteQueryTableAliasBeforeFrom(): bool
+    {
+        return true;
+    }
 }

--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -162,4 +162,12 @@ class SQLServer2012Platform extends SQLServer2008Platform
 
         return true;
     }
+
+    /**
+     * Returns if the table alias has to be defined also in front of the FROM statement
+     */
+    public function getRequestsAdditionalDeleteQueryTableAliasBeforeFrom(): bool
+    {
+        return true;
+    }
 }

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1256,10 +1256,14 @@ class QueryBuilder
      */
     private function getSQLForDelete()
     {
-        $table = $this->sqlParts['from']['table']
-            . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
+        $alias = $this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '';
 
-        return 'DELETE FROM ' . $table
+        $preFrom = $this->getConnection()->getDatabasePlatform()->getRequestsAdditionalDeleteQueryTableAliasBeforeFrom()
+            ? $alias
+            : '';
+        $table = $this->sqlParts['from']['table'] . $alias;
+
+        return 'DELETE' . $preFrom . ' FROM ' . $table
             . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '');
     }
 

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1261,7 +1261,7 @@ class QueryBuilder
         $preFrom = $this->getConnection()->getDatabasePlatform()->getRequestsAdditionalDeleteQueryTableAliasBeforeFrom()
             ? $alias
             : '';
-        $table = $this->sqlParts['from']['table'] . $alias;
+        $table   = $this->sqlParts['from']['table'] . $alias;
 
         return 'DELETE' . $preFrom . ' FROM ' . $table
             . ($this->sqlParts['where'] !== null ? ' WHERE ' . ((string) $this->sqlParts['where']) : '');


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4448

Fixed delete query with alias usage on the following platforms
- mysql
- mssql
- mariadb

The existing syntax works for PostgreSQL.

For backward compatible reasons this is also the default syntax for all platforms not especially configured. On SQLite there is no alias support in delete queries. For Oracle I could not find informations either.

I am open for a change of the method name in the platform classes. I just like to be clear at those points even if a name gets lengthy.
