### PR TITLE
CLOB type for ORACLEDB included.

### DIFF
--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -306,6 +306,16 @@ class OCI8Statement implements IteratorAggregate, StatementInterface, Result
             $variable =& $lob;
         }
 
+        if ($type === ParameterType::CLOB) {
+            $lob = oci_new_descriptor($this->_dbh, OCI_D_LOB);
+
+            assert($lob !== false);
+
+            $lob->writeTemporary($variable, OCI_TEMP_CLOB);
+
+            $variable = $lob;
+        }
+
         $this->boundValues[$param] =& $variable;
 
         return oci_bind_by_name(
@@ -328,6 +338,9 @@ class OCI8Statement implements IteratorAggregate, StatementInterface, Result
 
             case ParameterType::LARGE_OBJECT:
                 return OCI_B_BLOB;
+
+            case ParameterType::CLOB:
+                return OCI_B_CLOB;
 
             default:
                 return SQLT_CHR;

--- a/lib/Doctrine/DBAL/ParameterType.php
+++ b/lib/Doctrine/DBAL/ParameterType.php
@@ -55,6 +55,11 @@ final class ParameterType
     public const ASCII = 17;
 
     /**
+     * Represents a Character Large Object data type
+     */
+    public const CLOB = 18;
+
+    /**
      * This class cannot be instantiated.
      *
      * @codeCoverageIgnore


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3290

#### Summary

For oci there is a difference in the types BLOB and CLOB, the class OCI8Statement treated only the BLOB fields. For this, a new type was created in the ParameterType class, which in the OCI8Statement class is converted to OCI_B_CLOB.
For parameter bind with type CLOB, ParameterType :: CLOB must be used.

For CLOB fields smaller than the maximum size of the String type I had no problems, however for large texts it was returning an error, this made me implement this improvement.