### PR TITLE
Exclude duplicate SQL statements from migrations (schemadiff->toSql)

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -163,9 +163,10 @@ class SchemaDiff
 
         foreach ($this->changedTables as $tableDiff) {
             foreach ($platform->getAlterTableSQL($tableDiff) as $alterTableSQL) {
-                if (!in_array($alterTableSQL, $sql)) {
-                    $sql[] = $alterTableSQL;
+                if (in_array($alterTableSQL, $sql)) {
+                    continue;
                 }
+                $sql[] = $alterTableSQL;
             }
         }
 

--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -162,7 +162,11 @@ class SchemaDiff
         }
 
         foreach ($this->changedTables as $tableDiff) {
-            $sql = array_merge($sql, $platform->getAlterTableSQL($tableDiff));
+            foreach ($platform->getAlterTableSQL($tableDiff) as $alterTableSQL) {
+                if (!in_array($alterTableSQL, $sql)) {
+                    $sql[] = $alterTableSQL;
+                }
+            }
         }
 
         return $sql;

--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 use function array_merge;
+use function in_array;
 
 /**
  * Schema Diff.
@@ -166,6 +167,7 @@ class SchemaDiff
                 if (in_array($alterTableSQL, $sql)) {
                     continue;
                 }
+
                 $sql[] = $alterTableSQL;
             }
         }

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
@@ -164,7 +164,8 @@ class SchemaDiffTest extends TestCase
         $newTable->addColumn('id', 'integer');
         $diff->newTables['new_name_table'] = $newTable;
         $tableChange                       = new TableDiff('changing_table');
-        $changedFK                         = new ForeignKeyConstraint(['foreign_id'], 'new_name_table', ['id'], 'fk-to-update');
+
+        $changedFK = new ForeignKeyConstraint(['foreign_id'], 'new_name_table', ['id'], 'fk-to-update');
         $changedFK->setLocalTable($tableToChange);
         $tableChange->changedForeignKeys[]     = $changedFK;
         $tableChange->fromTable                = $tableToChange;

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Schema;
 
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -12,6 +13,8 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+
+use function array_unique;
 
 class SchemaDiffTest extends TestCase
 {
@@ -145,27 +148,26 @@ class SchemaDiffTest extends TestCase
      * Schema difference after a name change of a foreign table of
      * a unidirectional one-to-one relationship
      *
-     * @return SchemaDiff
-     * @throws \Doctrine\DBAL\Exception
+     * @throws Exception
      */
     public function createSchemaDiff2(): SchemaDiff
     {
-        $diff                                  = new SchemaDiff();
-        $oldTable                              = new Table('old_name_table');
+        $diff     = new SchemaDiff();
+        $oldTable = new Table('old_name_table');
         $oldTable->addColumn('id', 'integer');
-        $tableToChange                         = new Table('changing_table');
+        $tableToChange = new Table('changing_table');
         $tableToChange->addColumn('foreign_id', 'integer');
         $tableToChange->addForeignKeyConstraint('old_name_table', ['foreign_id'], ['id'], [], 'fk-to-update');
-        $fromSchema                            = new Schema([$oldTable, $tableToChange]);
-        $diff->fromSchema                      = $fromSchema;
-        $newTable                              = new Table('new_name_table');
+        $fromSchema       = new Schema([$oldTable, $tableToChange]);
+        $diff->fromSchema = $fromSchema;
+        $newTable         = new Table('new_name_table');
         $newTable->addColumn('id', 'integer');
-        $diff->newTables['new_name_table']     = $newTable;
-        $tableChange                           = new TableDiff('changing_table');
-        $changedFK                             = new ForeignKeyConstraint(['foreign_id'], 'new_name_table', ['id'], 'fk-to-update');
+        $diff->newTables['new_name_table'] = $newTable;
+        $tableChange                       = new TableDiff('changing_table');
+        $changedFK                         = new ForeignKeyConstraint(['foreign_id'], 'new_name_table', ['id'], 'fk-to-update');
         $changedFK->setLocalTable($tableToChange);
         $tableChange->changedForeignKeys[]     = $changedFK;
-        $tableChange->fromTable = $tableToChange;
+        $tableChange->fromTable                = $tableToChange;
         $diff->changedTables['changing_table'] = $tableChange;
         $diff->removedTables['old_name_table'] = new Table('old_name_table');
         $diff->orphanedForeignKeys[]           = $tableToChange->getForeignKey('fk-to-update');


### PR DESCRIPTION
This is a bug fix for the command doctrine:migrations:diff. A simple way to reproduce the buggy behaviour is to
1) create two entities and a unidirectional one-to-one relationship between them, 
2) update the database schema, 
3) rename the table that is foreign in the key constraint, 
4) run migrations:diff. 
The result is a migration that always fails because of a duplicate drop statement for the same foreign key.

Things taken into consideration in the bug fix:
 - The to-be-orphan foreign key must be dropped before the table is dropped.
 - A new key cannot be created before the new table has been created.
 - When the new key is created, the old key must not be dropped again because it has already been dropped.

Regarding the correctness of the result, it is the latter SQL drop statement that should be removed to achieve a executable migration and desired schema update. It is currently added in the code that adds ALTER TABLE statements based on a TableDiff but unaware of the other parts of SchemaDiff. So I reckon the best place for the 
fix is in SchemaDiff.php where all the SQL statements are gathered. I've added new condition for the incoming ALTER TABLE statements: only include them if not yet included. This condition would also apply to other kind of statements but I haven't come across any bugs in any other SQL statements.

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | none raised

#### Summary

Added a check to prevent migrations:diff from adding duplicate alter table statements to a migration script.