### PR TITLE
Expose support for transactional DDL or lack thereof

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3119,6 +3119,14 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Whether it is safe to wrap DDL statements in transactions
+     */
+    public function supportsTransactionalDDL(): bool
+    {
+        return true;
+    }
+
+    /**
      * Whether the platform supports savepoints.
      *
      * @return bool

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -338,6 +338,14 @@ class MySQLPlatform extends AbstractPlatform
     }
 
     /**
+     * @see https://dev.mysql.com/doc/internals/en/transactions-current-situation.html
+     */
+    public function supportsTransactionalDDL(): bool
+    {
+        return false;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getListTablesSQL()


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | n/a
#### Summary

Clients may need that information, notably in the context of SQL
migrations.

At the moment, I only know about this being an issue with MySQL, there might be more platforms having issues with this.

The MySQL docs I linked in the code say the following:

>  Similarly, DDL statements are not transactional, and therefore a transaction is (almost) never started for a DDL statement. But there's a difference between a DDL statement and an administrative statement: the DDL statement always commits the current transaction (if any) before proceeding; the administrative statement doesn't. 

I did not add unit tests for this method since there is no complexity, do tell me if you feel they are needed anyway.
