### PR TITLE
Add cursor support for OCI8

### DIFF
--- a/src/Driver/OCI8/Cursor.php
+++ b/src/Driver/OCI8/Cursor.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\OCI8;
+
+class Cursor extends Statement
+{
+    public function __construct($dbh, ExecutionMode $executionMode, $sth = null)
+    {
+        $this->_dbh          = $dbh;
+        $this->executionMode = $executionMode;
+        $this->_sth          = $sth ?: oci_new_cursor($dbh);
+    }
+
+    public function getStatement()
+    {
+        return $this->_sth;
+    }
+}

--- a/src/Driver/OCI8/Cursor.php
+++ b/src/Driver/OCI8/Cursor.php
@@ -2,15 +2,28 @@
 
 namespace Doctrine\DBAL\Driver\OCI8;
 
+use Doctrine\DBAL\Driver\OCI8\Exception\Error;
+
 class Cursor extends Statement
 {
-    public function __construct($dbh, ExecutionMode $executionMode, $sth = null)
+    /**
+     * @param resource $dbh The connection resource
+     */
+    public function __construct($dbh, ExecutionMode $executionMode)
     {
-        $this->_dbh          = $dbh;
-        $this->executionMode = $executionMode;
-        $this->_sth          = $sth ?: oci_new_cursor($dbh);
+        parent::__construct($dbh, $query = '', $executionMode);
+
+        $stmt = oci_new_cursor($dbh);
+        if ($stmt === false) {
+            throw Error::new($dbh);
+        }
+
+        $this->_sth = $stmt;
     }
 
+    /**
+     * @return resource
+     */
     public function getStatement()
     {
         return $this->_sth;

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -89,12 +89,13 @@ class Statement implements StatementInterface
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
     {
-        if (ParameterType::CURSOR === $type) {
+        if ($type === ParameterType::CURSOR) {
             $variable = new Cursor($this->_dbh, $this->executionMode);
-            $stmt = $variable->getStatement();
+            $stmt     = $variable->getStatement();
+
             return oci_bind_by_name(
                 $this->_sth,
-                $param,
+                (string) $param,
                 $stmt,
                 $length ?? -1,
                 $this->convertParameterType($type)

--- a/src/ParameterType.php
+++ b/src/ParameterType.php
@@ -30,6 +30,11 @@ final class ParameterType
     public const LARGE_OBJECT = 3;
 
     /**
+     * Represents a recordset type.
+     */
+    public const CURSOR = 4;
+
+    /**
      * Represents a boolean data type.
      *
      * @see \PDO::PARAM_BOOL

--- a/src/Types/CursorType.php
+++ b/src/Types/CursorType.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use LogicException;
 use PDO;
 
 /**
@@ -15,7 +16,7 @@ class CursorType extends Type
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform)
     {
-        throw new \LogicException('Doctrine does not support SQL declarations for cursors.');
+        throw new LogicException('Doctrine does not support SQL declarations for cursors.');
     }
 
     /**

--- a/src/Types/CursorType.php
+++ b/src/Types/CursorType.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use PDO;
+
+/**
+ * Represents a cursor in the database.
+ */
+class CursorType extends Type
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform)
+    {
+        throw new \LogicException('Doctrine does not support SQL declarations for cursors.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return Types::CURSOR;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBindingType()
+    {
+        return PDO::PARAM_STMT;
+    }
+}

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -26,6 +26,7 @@ abstract class Type
         Types::BINARY               => BinaryType::class,
         Types::BLOB                 => BlobType::class,
         Types::BOOLEAN              => BooleanType::class,
+        Types::CURSOR               => CursorType::class,
         Types::DATE_MUTABLE         => DateType::class,
         Types::DATE_IMMUTABLE       => DateImmutableType::class,
         Types::DATEINTERVAL         => DateIntervalType::class,

--- a/src/Types/Types.php
+++ b/src/Types/Types.php
@@ -15,6 +15,7 @@ final class Types
     public const BINARY               = 'binary';
     public const BLOB                 = 'blob';
     public const BOOLEAN              = 'boolean';
+    public const CURSOR               = 'cursor';
     public const DATE_MUTABLE         = 'date';
     public const DATE_IMMUTABLE       = 'date_immutable';
     public const DATEINTERVAL         = 'dateinterval';


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no

#### Summary

Its PR add support bind cursors for OCI8 driver.
Example usage:

```
$conn = Doctrine\DBAL\DriverManager::getConnection($params, $config);

$stmt = $conn->prepare('BEGIN proc_name(o_result => :o_result); END;');
$stmt->bindParam('o_result', $cursor, ParameterType::CURSOR);
$stmt->execute();

/** @var $result Doctrine\DBAL\Driver\OCI8\Result */
$result = $cursor->execute();
$rows = $result->fetchAllAssociative();
```