### PR TITLE
Introduce fetch* methods in query builder

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -844,9 +844,9 @@ class Connection
      * to the first column and the values being an associative array representing the rest of the columns
      * and their values.
      *
-     * @param string                                           $query  SQL query
-     * @param list<mixed>|array<string, mixed>                 $params Query parameters
-     * @param array<int, int|string>|array<string, int|string> $types  Parameter types
+     * @param string                                                               $query  SQL query
+     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return array<mixed,array<string,mixed>>
      *

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -198,6 +198,108 @@ class QueryBuilder
     }
 
     /**
+     * Prepares and executes an SQL query and returns the first row of the result
+     * as an associative array.
+     *
+     * @return array<string, mixed>|false False is returned if no rows are found.
+     *
+     * @throws Exception
+     */
+    public function fetchAssociative()
+    {
+        return $this->connection->fetchAssociative($this->getSQL(), $this->params, $this->paramTypes);
+    }
+
+    /**
+     * Prepares and executes an SQL query and returns the first row of the result
+     * as a numerically indexed array.
+     *
+     * @return array<int, mixed>|false False is returned if no rows are found.
+     *
+     * @throws Exception
+     */
+    public function fetchNumeric()
+    {
+        return $this->connection->fetchNumeric($this->getSQL(), $this->params, $this->paramTypes);
+    }
+
+    /**
+     * Prepares and executes an SQL query and returns the value of a single column
+     * of the first row of the result.
+     *
+     * @return mixed|false False is returned if no rows are found.
+     *
+     * @throws Exception
+     */
+    public function fetchOne()
+    {
+        return $this->connection->fetchOne($this->getSQL(), $this->params, $this->paramTypes);
+    }
+
+    /**
+     * Prepares and executes an SQL query and returns the result as an array of numeric arrays.
+     *
+     * @return array<int,array<int,mixed>>
+     *
+     * @throws Exception
+     */
+    public function fetchAllNumeric(): array
+    {
+        return $this->connection->fetchAllNumeric($this->getSQL(), $this->params, $this->paramTypes);
+    }
+
+    /**
+     * Prepares and executes an SQL query and returns the result as an array of associative arrays.
+     *
+     * @return array<int,array<string,mixed>>
+     *
+     * @throws Exception
+     */
+    public function fetchAllAssociative(): array
+    {
+        return $this->connection->fetchAllAssociative($this->getSQL(), $this->params, $this->paramTypes);
+    }
+
+    /**
+     * Prepares and executes an SQL query and returns the result as an associative array with the keys
+     * mapped to the first column and the values mapped to the second column.
+     *
+     * @return array<mixed,mixed>
+     *
+     * @throws Exception
+     */
+    public function fetchAllKeyValue(): array
+    {
+        return $this->connection->fetchAllKeyValue($this->getSQL(), $this->params, $this->paramTypes);
+    }
+
+    /**
+     * Prepares and executes an SQL query and returns the result as an associative array with the keys mapped
+     * to the first column and the values being an associative array representing the rest of the columns
+     * and their values.
+     *
+     * @return array<mixed,array<string,mixed>>
+     *
+     * @throws Exception
+     */
+    public function fetchAllAssociativeIndexed(): array
+    {
+        return $this->connection->fetchAllAssociativeIndexed($this->getSQL(), $this->params, $this->paramTypes);
+    }
+
+    /**
+     * Prepares and executes an SQL query and returns the result as an array of the first column values.
+     *
+     * @return array<int,mixed>
+     *
+     * @throws Exception
+     */
+    public function fetchFirstColumn(): array
+    {
+        return $this->connection->fetchFirstColumn($this->getSQL(), $this->params, $this->paramTypes);
+    }
+
+    /**
      * Executes this query using the bound parameters and their types.
      *
      * @return Result|int

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -7,11 +7,14 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Query\QueryException;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class QueryBuilderTest extends TestCase
 {
-    /** @var Connection */
+    /** @var Connection&MockObject */
     protected $conn;
 
     protected function setUp(): void
@@ -948,5 +951,355 @@ class QueryBuilderTest extends TestCase
         );
 
         $qb->getSQL();
+    }
+
+    /**
+     * @param list<mixed>|array<string, mixed>                                     $parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     *
+     * @dataProvider fetchProvider
+     */
+    public function testFetchAssociative(
+        string $select,
+        string $from,
+        string $where,
+        array $parameters,
+        array $parameterTypes,
+        string $expectedSql
+    ): void {
+        $qb = new QueryBuilder($this->conn);
+
+        $this->conn->expects(self::once())
+            ->method('fetchAssociative')
+            ->with($expectedSql, $parameters, $parameterTypes)
+            ->willReturn(['username' => 'jwage', 'password' => 'changeme']);
+
+        $row = $qb->select($select)
+            ->from($from)
+            ->where($where)
+            ->setParameters($parameters, $parameterTypes)
+            ->fetchAssociative();
+
+        self::assertEquals(['username' => 'jwage', 'password' => 'changeme'], $row);
+    }
+
+    /**
+     * @param list<mixed>|array<string, mixed>                                     $parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     *
+     * @dataProvider fetchProvider
+     */
+    public function testFetchNumeric(
+        string $select,
+        string $from,
+        string $where,
+        array $parameters,
+        array $parameterTypes,
+        string $expectedSql
+    ): void {
+        $qb = new QueryBuilder($this->conn);
+
+        $this->conn->expects(self::once())
+            ->method('fetchNumeric')
+            ->with($expectedSql, $parameters, $parameterTypes)
+            ->willReturn(['jwage', 'changeme']);
+
+        $row = $qb->select($select)
+            ->from($from)
+            ->where($where)
+            ->setParameters($parameters, $parameterTypes)
+            ->fetchNumeric();
+
+        self::assertEquals(['jwage', 'changeme'], $row);
+    }
+
+    /**
+     * @param list<mixed>|array<string, mixed>                                     $parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     *
+     * @dataProvider fetchProvider
+     */
+    public function testFetchOne(
+        string $select,
+        string $from,
+        string $where,
+        array $parameters,
+        array $parameterTypes,
+        string $expectedSql
+    ): void {
+        $qb = new QueryBuilder($this->conn);
+
+        $this->conn->expects(self::once())
+            ->method('fetchOne')
+            ->with($expectedSql, $parameters, $parameterTypes)
+            ->willReturn('jwage');
+
+        $username = $qb->select($select)
+            ->from($from)
+            ->where($where)
+            ->setParameters($parameters, $parameterTypes)
+            ->fetchOne();
+
+        self::assertEquals('jwage', $username);
+    }
+
+    /**
+     * @param list<mixed>|array<string, mixed>                                     $parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     *
+     * @dataProvider fetchProvider
+     */
+    public function testFetchAllAssociative(
+        string $select,
+        string $from,
+        string $where,
+        array $parameters,
+        array $parameterTypes,
+        string $expectedSql
+    ): void {
+        $qb = new QueryBuilder($this->conn);
+
+        $this->conn->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with($expectedSql, $parameters, $parameterTypes)
+            ->willReturn(
+                [
+                    ['username' => 'jwage', 'password' => 'changeme'],
+                    ['username' => 'support', 'password' => 'p@ssword'],
+                ]
+            );
+
+        $results = $qb->select($select)
+            ->from($from)
+            ->where($where)
+            ->setParameters($parameters, $parameterTypes)
+            ->fetchAllAssociative();
+
+        self::assertEquals(
+            [
+                ['username' => 'jwage', 'password' => 'changeme'],
+                ['username' => 'support', 'password' => 'p@ssword'],
+            ],
+            $results
+        );
+    }
+
+    /**
+     * @param list<mixed>|array<string, mixed>                                     $parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     *
+     * @dataProvider fetchProvider
+     */
+    public function testFetchAllNumeric(
+        string $select,
+        string $from,
+        string $where,
+        array $parameters,
+        array $parameterTypes,
+        string $expectedSql
+    ): void {
+        $qb = new QueryBuilder($this->conn);
+
+        $this->conn->expects(self::once())
+            ->method('fetchAllNumeric')
+            ->with($expectedSql, $parameters, $parameterTypes)
+            ->willReturn(
+                [
+                    ['jwage', 'changeme'],
+                    ['support', 'p@ssword'],
+                ]
+            );
+
+        $results = $qb->select($select)
+            ->from($from)
+            ->where($where)
+            ->setParameters($parameters, $parameterTypes)
+            ->fetchAllNumeric();
+
+        self::assertEquals(
+            [
+                ['jwage', 'changeme'],
+                ['support', 'p@ssword'],
+            ],
+            $results
+        );
+    }
+
+    /**
+     * @param list<mixed>|array<string, mixed>                                     $parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     *
+     * @dataProvider fetchProvider
+     */
+    public function testFetchAllKeyValue(
+        string $select,
+        string $from,
+        string $where,
+        array $parameters,
+        array $parameterTypes,
+        string $expectedSql
+    ): void {
+        $qb = new QueryBuilder($this->conn);
+
+        $this->conn->expects(self::once())
+            ->method('fetchAllKeyValue')
+            ->with($expectedSql, $parameters, $parameterTypes)
+            ->willReturn(
+                [
+                    'jwage' => 'changeme',
+                    'support' => 'p@ssw0rd',
+                ]
+            );
+
+        $results = $qb->select($select)
+            ->from($from)
+            ->where($where)
+            ->setParameters($parameters, $parameterTypes)
+            ->fetchAllKeyValue();
+
+        self::assertEquals(
+            [
+                'jwage' => 'changeme',
+                'support' => 'p@ssw0rd',
+            ],
+            $results
+        );
+    }
+
+    /**
+     * @param list<mixed>|array<string, mixed>                                     $parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     *
+     * @dataProvider fetchProvider
+     */
+    public function testFetchAllAssociativeIndexed(
+        string $select,
+        string $from,
+        string $where,
+        array $parameters,
+        array $parameterTypes,
+        string $expectedSql
+    ): void {
+        $qb = new QueryBuilder($this->conn);
+
+        $this->conn->expects(self::once())
+            ->method('fetchAllAssociativeIndexed')
+            ->with($expectedSql, $parameters, $parameterTypes)
+            ->willReturn(
+                [
+                    1 => [
+                        'username' => 'jwage',
+                        'password' => 'changeme',
+                    ],
+                ]
+            );
+
+        $results = $qb->select($select)
+            ->from($from)
+            ->where($where)
+            ->setParameters($parameters, $parameterTypes)
+            ->fetchAllAssociativeIndexed();
+
+        self::assertEquals(
+            [
+                1 => [
+                    'username' => 'jwage',
+                    'password' => 'changeme',
+                ],
+            ],
+            $results
+        );
+    }
+
+    /**
+     * @param list<mixed>|array<string, mixed>                                     $parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     *
+     * @dataProvider fetchProvider
+     */
+    public function testFetchFirstColumn(
+        string $select,
+        string $from,
+        string $where,
+        array $parameters,
+        array $parameterTypes,
+        string $expectedSql
+    ): void {
+        $qb = new QueryBuilder($this->conn);
+
+        $this->conn->expects(self::once())
+            ->method('fetchFirstColumn')
+            ->with($expectedSql, $parameters, $parameterTypes)
+            ->willReturn(
+                [
+                    'jwage',
+                    'support',
+                ]
+            );
+
+        $results = $qb->select($select)
+            ->from($from)
+            ->where($where)
+            ->setParameters($parameters, $parameterTypes)
+            ->fetchFirstColumn();
+
+        self::assertEquals(
+            [
+                'jwage',
+                'support',
+            ],
+            $results
+        );
+    }
+
+    /**
+     * @return iterable<
+     *     string,
+     *     array{
+     *          string,
+     *          string,
+     *          string,
+     *          list<mixed>|array<string, mixed>,
+     *          array<int, int|string|Type|null>|array<string, int|string|Type|null>,
+     *          string
+     *  }>
+     */
+    public static function fetchProvider(): iterable
+    {
+        yield 'select *, no parameters' => [
+            '*',
+            'user',
+            'username LIKE "jw*"',
+            [],
+            [],
+            'SELECT * FROM user WHERE username LIKE "jw*"',
+        ];
+
+        yield 'select *, positional parameter' => [
+            '*',
+            'user',
+            'username = ?',
+            ['jwage'],
+            ['username' => Types::STRING],
+            'SELECT * FROM user WHERE username = ?',
+        ];
+
+        yield 'select multiple, named parameter' => [
+            'id, username, password',
+            'user',
+            'username = :username',
+            ['username' => 'jwage'],
+            ['username' => Types::STRING],
+            'SELECT id, username, password FROM user WHERE username = :username',
+        ];
+
+        yield 'select multiple, named parameters' => [
+            'id, username',
+            'user',
+            'password = :password AND username != :username AND id != :id',
+            ['password' => 'changeme', 'username' => 'support', 'id' => 42],
+            ['password' => Types::STRING, 'username' => Types::STRING, 'id' => Types::INTEGER],
+            'SELECT id, username FROM user WHERE password = :password AND username != :username AND id != :id',
+        ];
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #4461 

#### Summary

Added new `fetch*` methods (all non-deprecated fetch* methods from Connection class) to allow the use of better typing in fetching data.

Please let me know if I should write some tests and what to use in the description of the methods.