### PR TITLE
Remove internal flag from TypeRegistry

### DIFF
--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -195,9 +195,6 @@ abstract class Type
      */
     abstract public function getName();
 
-    /**
-     * @internal This method is only to be used within DBAL for forward compatibility purposes. Do not use directly.
-     */
     final public static function getTypeRegistry(): TypeRegistry
     {
         if (self::$typeRegistry === null) {

--- a/lib/Doctrine/DBAL/Types/TypeRegistry.php
+++ b/lib/Doctrine/DBAL/Types/TypeRegistry.php
@@ -12,8 +12,6 @@ use function in_array;
 /**
  * The type registry is responsible for holding a map of all known DBAL types.
  * The types are stored using the flyweight pattern so that one type only exists as exactly one instance.
- *
- * @internal TypeRegistry exists for forward compatibility, its API should not be considered stable.
  */
 final class TypeRegistry
 {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

This class is almost 2 years old and never received BC breaking change. We need to rely on its API so we can build DI integration in DoctrineBundle

I've chosen 2.12 because since there are no changes here between 2.12 and higher, it doesn't matter, unless we intend to do BC break in this class in 2.x but not 3.x (super unlikely). But it does matter for SA analysis for people still using DBAL 2.x.

Related: https://github.com/doctrine/dbal/issues/2841, https://github.com/doctrine/DoctrineBundle/issues/1246