### PR TITLE
Use explicit `@return` when implementing base PHP types

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\FetchMode;
 use InvalidArgumentException;
 use IteratorAggregate;
 use PDO;
+use Traversable;
 
 use function array_merge;
 use function array_values;
@@ -91,7 +92,7 @@ class ArrayStatement implements IteratorAggregate, ResultStatement, Result
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\FetchMode;
 use InvalidArgumentException;
 use IteratorAggregate;
 use PDO;
+use Traversable;
 
 use function array_map;
 use function array_merge;
@@ -105,7 +106,7 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement, Result
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -18,6 +18,7 @@ use ReflectionClass;
 use ReflectionObject;
 use ReflectionProperty;
 use stdClass;
+use Traversable;
 
 use function array_change_key_case;
 use function assert;
@@ -266,7 +267,7 @@ class DB2Statement implements IteratorAggregate, StatementInterface, Result
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -17,6 +17,7 @@ use IteratorAggregate;
 use mysqli;
 use mysqli_stmt;
 use PDO;
+use Traversable;
 
 use function array_combine;
 use function array_fill;
@@ -559,7 +560,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\ParameterType;
 use InvalidArgumentException;
 use IteratorAggregate;
 use PDO;
+use Traversable;
 
 use function array_key_exists;
 use function assert;
@@ -425,7 +426,7 @@ class OCI8Statement implements IteratorAggregate, StatementInterface, Result
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -14,6 +14,7 @@ use PDO;
 use ReflectionClass;
 use ReflectionObject;
 use stdClass;
+use Traversable;
 
 use function array_key_exists;
 use function assert;
@@ -316,7 +317,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement, Result
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use IteratorAggregate;
 use PDO;
+use Traversable;
 
 use function array_key_exists;
 use function count;
@@ -345,7 +346,7 @@ class SQLSrvStatement implements IteratorAggregate, StatementInterface, Result
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */

--- a/lib/Doctrine/DBAL/Driver/StatementIterator.php
+++ b/lib/Doctrine/DBAL/Driver/StatementIterator.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Driver;
 
 use IteratorAggregate;
+use Traversable;
 
 /**
  * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn().
@@ -18,7 +19,7 @@ class StatementIterator implements IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable
      */
     public function getIterator()
     {

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use IteratorAggregate;
 use PDO;
+use Traversable;
 
 use function array_change_key_case;
 use function assert;
@@ -130,7 +131,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -243,11 +243,9 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     }
 
     /**
-     * Required by interface IteratorAggregate.
+     * @return Traversable
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
-     *
-     * {@inheritdoc}
      */
     public function getIterator()
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

This PR replaces `{@inheritdoc}` that relate to internal PHP types by explicit `@return` annotations.

This removes the need to rely on external knowledge to get some understanding of the annotations.

Not that similar explicit annotations are already used in some places in the codebase.