### PR TITLE
Fixed outdated links in AbstractMySQLDriver.php

### DIFF
--- a/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php
@@ -41,8 +41,8 @@ abstract class AbstractMySQLDriver implements Driver, ExceptionConverterDriver, 
      *
      * @deprecated
      *
-     * @link https://dev.mysql.com/doc/refman/8.0/en/client-error-reference.html
-     * @link https://dev.mysql.com/doc/refman/8.0/en/server-error-reference.html
+     * @link https://dev.mysql.com/doc/mysql-errors/8.0/en/client-error-reference.html
+     * @link https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
      */
     public function convertException($message, DeprecatedDriverException $exception)
     {


### PR DESCRIPTION
Message from old pages is "This page has moved or been replaced. The new page is located here..."

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

Fixed outdated links in phpdoc