### PR TITLE
Update Psalm to 4.5.2

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -50,6 +50,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions:4.1.1
+        uses: docker://vimeo/psalm-github-actions:4.5.2
         with:
           composer_require_dev: true

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "phpunit/phpunit": "9.5.0",
         "psalm/plugin-phpunit": "0.13.0",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-        "vimeo/psalm": "4.3.1"
+        "vimeo/psalm": "4.5.2"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -74,7 +74,8 @@ class MysqliConnection implements ConnectionInterface, PingableConnection, Serve
         $this->setSecureConnection($params);
         $this->setDriverOptions($driverOptions);
 
-        set_error_handler(static function () {
+        set_error_handler(static function (): bool {
+            return false;
         });
         try {
             if (! $this->conn->real_connect($params['host'], $username, $password, $dbname, $port, $socket, $flags)) {

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -376,7 +376,7 @@ class SQLAnywherePlatform extends AbstractPlatform
      */
     public function getConcatExpression()
     {
-        return 'STRING(' . implode(', ', (array) func_get_args()) . ')';
+        return 'STRING(' . implode(', ', func_get_args()) . ')';
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/DB2SchemaManager.php
@@ -94,7 +94,7 @@ class DB2SchemaManager extends AbstractSchemaManager
             'fixed'         => (bool) $fixed,
             'default'       => $default,
             'autoincrement' => (bool) $tableColumn['autoincrement'],
-            'notnull'       => (bool) ($tableColumn['nulls'] === 'N'),
+            'notnull'       => $tableColumn['nulls'] === 'N',
             'scale'         => null,
             'precision'     => null,
             'comment'       => isset($tableColumn['comment']) && $tableColumn['comment'] !== ''

--- a/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/OracleSchemaManager.php
@@ -195,7 +195,7 @@ class OracleSchemaManager extends AbstractSchemaManager
         }
 
         $options = [
-            'notnull'    => (bool) ($tableColumn['nullable'] === 'N'),
+            'notnull'    => $tableColumn['nullable'] === 'N',
             'fixed'      => (bool) $fixed,
             'unsigned'   => (bool) $unsigned,
             'default'    => $tableColumn['data_default'],

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -376,7 +376,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
 
         $options = [
             'length'   => $length,
-            'unsigned' => (bool) $unsigned,
+            'unsigned' => $unsigned,
             'fixed'    => $fixed,
             'notnull'  => $notnull,
             'default'  => $default,

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -115,6 +115,15 @@
                 <file name="lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php"/>
             </errorLevel>
         </MethodSignatureMismatch>
+        <NonInvariantDocblockPropertyType>
+            <errorLevel type="suppress">
+                <!--
+                   This suppression should be removed in 3.0.x
+                   https://github.com/doctrine/dbal/pull/4007
+                -->
+                <file name="tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/Statement.php"/>
+            </errorLevel>
+        </NonInvariantDocblockPropertyType>
         <NullableReturnStatement>
             <errorLevel type="suppress">
                 <!--

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -18,14 +18,12 @@ use Doctrine\DBAL\Types\Types;
 use function array_map;
 use function array_pop;
 use function array_unshift;
+use function assert;
 use function count;
 use function strtolower;
 
 class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
-    /** @var PostgreSqlSchemaManager */
-    protected $schemaManager;
-
     protected function supportsPlatform(AbstractPlatform $platform): bool
     {
         return $platform instanceof PostgreSQL94Platform;
@@ -57,6 +55,8 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testGetSchemaNames(): void
     {
+        assert($this->schemaManager instanceof PostgreSqlSchemaManager);
+
         $names = $this->schemaManager->getSchemaNames();
 
         self::assertIsArray($names);

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractMySQLPlatformTestCase.php
@@ -13,11 +13,11 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 
 use function array_shift;
 
+/**
+ * @extends AbstractPlatformTestCase<MySqlPlatform>
+ */
 abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 {
-    /** @var MySqlPlatform */
-    protected $platform;
-
     public function testModifyLimitQueryWitoutLimit(): void
     {
         $sql = $this->platform->modifyLimitQuery('SELECT n FROM Foo', null, 10);

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php
@@ -24,11 +24,17 @@ use function implode;
 use function sprintf;
 use function str_repeat;
 
+/**
+ * @template T of AbstractPlatform
+ */
 abstract class AbstractPlatformTestCase extends DbalTestCase
 {
-    /** @var AbstractPlatform */
+    /** @var T */
     protected $platform;
 
+    /**
+     * @return T
+     */
     abstract public function createPlatform(): AbstractPlatform;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractPostgreSqlPlatformTestCase.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\DBAL\Platforms;
 
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
@@ -17,16 +16,12 @@ use UnexpectedValueException;
 
 use function sprintf;
 
+/**
+ * @template T of PostgreSqlPlatform
+ * @extends AbstractPlatformTestCase<T>
+ */
 abstract class AbstractPostgreSqlPlatformTestCase extends AbstractPlatformTestCase
 {
-    /** @var PostgreSqlPlatform */
-    protected $platform;
-
-    /**
-     * @return PostgreSqlPlatform
-     */
-    abstract public function createPlatform(): AbstractPlatform;
-
     public function getGenerateTableSql(): string
     {
         return 'CREATE TABLE test (id SERIAL NOT NULL, test VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))';

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -14,11 +14,11 @@ use Doctrine\DBAL\Types\Type;
 
 use function sprintf;
 
+/**
+ * @extends AbstractPlatformTestCase<SQLServerPlatform>
+ */
 abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCase
 {
-    /** @var SQLServerPlatform */
-    protected $platform;
-
     public function getGenerateTableSql(): string
     {
         return 'CREATE TABLE test (id INT IDENTITY NOT NULL, test NVARCHAR(255), PRIMARY KEY (id))';

--- a/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/DB2PlatformTest.php
@@ -12,11 +12,11 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
+/**
+ * @extends AbstractPlatformTestCase<DB2Platform>
+ */
 class DB2PlatformTest extends AbstractPlatformTestCase
 {
-    /** @var DB2Platform */
-    protected $platform;
-
     public function createPlatform(): AbstractPlatform
     {
         return new DB2Platform();

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -21,11 +21,11 @@ use function sprintf;
 use function strtoupper;
 use function uniqid;
 
+/**
+ * @extends AbstractPlatformTestCase<OraclePlatform>
+ */
 class OraclePlatformTest extends AbstractPlatformTestCase
 {
-    /** @var OraclePlatform */
-    protected $platform;
-
     /**
      * @return mixed[][]
      */
@@ -80,9 +80,6 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         $platform->assertValidIdentifier($identifier);
     }
 
-    /**
-     * @return OraclePlatform
-     */
     public function createPlatform(): AbstractPlatform
     {
         return new OraclePlatform();

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL92PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSQL92PlatformTest.php
@@ -6,16 +6,11 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL92Platform;
 use Doctrine\DBAL\Types\Types;
 
+/**
+ * @extends AbstractPostgreSqlPlatformTestCase<PostgreSQL92Platform>
+ */
 class PostgreSQL92PlatformTest extends AbstractPostgreSqlPlatformTestCase
 {
-    /** @var PostgreSQL92Platform */
-    protected $platform;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return PostgreSQL92Platform
-     */
     public function createPlatform(): AbstractPlatform
     {
         return new PostgreSQL92Platform();

--- a/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/PostgreSqlPlatformTest.php
@@ -6,6 +6,9 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Table;
 
+/**
+ * @extends AbstractPostgreSqlPlatformTestCase<PostgreSqlPlatform>
+ */
 class PostgreSqlPlatformTest extends AbstractPostgreSqlPlatformTestCase
 {
     public function createPlatform(): AbstractPlatform

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywhere11PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywhere11PlatformTest.php
@@ -7,9 +7,6 @@ use Doctrine\DBAL\Platforms\SQLAnywhere11Platform;
 
 class SQLAnywhere11PlatformTest extends SQLAnywherePlatformTest
 {
-    /** @var SQLAnywhere11Platform */
-    protected $platform;
-
     public function createPlatform(): AbstractPlatform
     {
         return new SQLAnywhere11Platform();

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywhere12PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywhere12PlatformTest.php
@@ -9,9 +9,6 @@ use Doctrine\DBAL\Schema\Sequence;
 
 class SQLAnywhere12PlatformTest extends SQLAnywhere11PlatformTest
 {
-    /** @var SQLAnywhere12Platform */
-    protected $platform;
-
     public function createPlatform(): AbstractPlatform
     {
         return new SQLAnywhere12Platform();

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLAnywherePlatformTest.php
@@ -23,11 +23,11 @@ use function mt_rand;
 use function strlen;
 use function substr;
 
+/**
+ * @extends AbstractPlatformTestCase<SQLAnywherePlatform>
+ */
 class SQLAnywherePlatformTest extends AbstractPlatformTestCase
 {
-    /** @var SQLAnywherePlatform */
-    protected $platform;
-
     public function createPlatform(): AbstractPlatform
     {
         return new SQLAnywherePlatform();

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -11,14 +11,11 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Type;
 
+/**
+ * @extends AbstractPlatformTestCase<SqlitePlatform>
+ */
 class SqlitePlatformTest extends AbstractPlatformTestCase
 {
-    /** @var SqlitePlatform */
-    protected $platform;
-
-    /**
-     * @return SqlitePlatform
-     */
     public function createPlatform(): AbstractPlatform
     {
         return new SqlitePlatform();

--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -25,7 +25,7 @@ abstract class DbalFunctionalTestCase extends DbalTestCase
     /**
      * Shared connection when a TestCase is run alone (outside of it's functional suite)
      *
-     * @var Connection
+     * @var Connection|null
      */
     private static $sharedConnection;
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The hierarchy of the platform tests is now template-driven. The same is not possible for the schema manager tests because they instantiate the schema manager indirectly via the connection (worked around with an assertion).

The rest of the changes is minor/insignificant.