### PR TITLE
Fix Example Code

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -309,8 +309,8 @@ Prepare a given SQL statement and return the
 
     <?php
     $statement = $conn->prepare('SELECT * FROM user');
-    $statement->execute();
-    $users = $statement->fetchAllAssociative();
+    $resultSet = $statement->execute();
+    $users = $resultSet->fetchAllAssociative();
 
     /*
     array(


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

The example executes the function `fetchAllAssociative` on the Statement object but this object doesn't have this function. Instead, the function should be executed on the returned result set.
