### PR TITLE
Fix bound params being ignored on execution

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use function array_merge;
 
 use function is_string;
 

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -162,7 +162,7 @@ class Statement
     public function execute($params = null): Result
     {
         if ($params !== null) {
-            $this->params = $params;
+            $this->params = array_merge($this->params, $params);
         }
 
         $logger = $this->conn->getConfiguration()->getSQLLogger();
@@ -172,7 +172,7 @@ class Statement
 
         try {
             return new Result(
-                $this->stmt->execute($params),
+                $this->stmt->execute($this->$params),
                 $this->conn
             );
         } catch (Exception $ex) {

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -172,7 +172,7 @@ class Statement
 
         try {
             return new Result(
-                $this->stmt->execute($this->$params),
+                $this->stmt->execute($this->params),
                 $this->conn
             );
         } catch (Exception $ex) {

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -6,8 +6,8 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
-use function array_merge;
 
+use function array_merge;
 use function is_string;
 
 /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Didn't find an issue regarding this

#### Summary

I'm working with a Symfony project right now, where multiple parameters are bound to a prepared statement. I was running into the problem that the most recently bound parameter was applied to all placeholders in the query, while in the Symfony logs all parameters were shown correctly.

I identified the problem to be in src/Statement.php in the execute-function, as the Statement objects params seem to be ignored during execution. Only the params that are supplied through the arguments into the function on call are passed through. After changing this behaviour, so that the objects params get passed through and are, if applicable, merged with params passed as an argument beforehand, the issue was fixed for me.

The project I'm working on is on a slightly older version of this library (3.0), but the problem seems to persist in this version still. The fix should break no existing behaviour, unless somebody has bound some parameters to their Statements and relied on this unintentional behaviour for whatever reason. If this behaviour is intentional though, I'd be glad to hear the reason for ignoring bound params.

Best regards!