### PR TITLE
Bump Psalm level to 2

### DIFF
--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -102,6 +102,8 @@ class Configuration
 
     /**
      * @param string $filterExpression
+     *
+     * @return callable(string|AbstractAsset)
      */
     private function buildSchemaAssetsFilterFromExpression($filterExpression): callable
     {

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -914,6 +914,7 @@ class Connection implements DriverConnection
     /**
      * {@inheritDoc}
      *
+     * @param mixed                $value
      * @param int|string|Type|null $type
      */
     public function quote($value, $type = ParameterType::STRING)

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -705,10 +705,10 @@ class Connection implements DriverConnection
     /**
      * Adds condition based on the criteria to the query components
      *
-     * @param mixed[]  $criteria   Map of key columns to their values
-     * @param string[] $columns    Column names
-     * @param mixed[]  $values     Column values
-     * @param string[] $conditions Key conditions
+     * @param array<string,mixed> $criteria   Map of key columns to their values
+     * @param string[]            $columns    Column names
+     * @param mixed[]             $values     Column values
+     * @param string[]            $conditions Key conditions
      *
      * @throws Exception
      */

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1803,11 +1803,13 @@ class Connection implements DriverConnection
      */
     public function createSavepoint($savepoint)
     {
-        if (! $this->getDatabasePlatform()->supportsSavepoints()) {
+        $platform = $this->getDatabasePlatform();
+
+        if (! $platform->supportsSavepoints()) {
             throw ConnectionException::savepointsNotSupported();
         }
 
-        $this->getWrappedConnection()->exec($this->platform->createSavePoint($savepoint));
+        $this->getWrappedConnection()->exec($platform->createSavePoint($savepoint));
     }
 
     /**
@@ -1821,15 +1823,17 @@ class Connection implements DriverConnection
      */
     public function releaseSavepoint($savepoint)
     {
-        if (! $this->getDatabasePlatform()->supportsSavepoints()) {
+        $platform = $this->getDatabasePlatform();
+
+        if (! $platform->supportsSavepoints()) {
             throw ConnectionException::savepointsNotSupported();
         }
 
-        if (! $this->platform->supportsReleaseSavepoints()) {
+        if (! $platform->supportsReleaseSavepoints()) {
             return;
         }
 
-        $this->getWrappedConnection()->exec($this->platform->releaseSavePoint($savepoint));
+        $this->getWrappedConnection()->exec($platform->releaseSavePoint($savepoint));
     }
 
     /**
@@ -1843,11 +1847,13 @@ class Connection implements DriverConnection
      */
     public function rollbackSavepoint($savepoint)
     {
-        if (! $this->getDatabasePlatform()->supportsSavepoints()) {
+        $platform = $this->getDatabasePlatform();
+
+        if (! $platform->supportsSavepoints()) {
             throw ConnectionException::savepointsNotSupported();
         }
 
-        $this->getWrappedConnection()->exec($this->platform->rollbackSavePoint($savepoint));
+        $this->getWrappedConnection()->exec($platform->rollbackSavePoint($savepoint));
     }
 
     /**

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -116,9 +116,9 @@ class Connection implements DriverConnection
     private $transactionNestingLevel = 0;
 
     /**
-     * The currently active transaction isolation level.
+     * The currently active transaction isolation level or NULL before it has been determined.
      *
-     * @var int
+     * @var int|null
      */
     private $transactionIsolationLevel;
 
@@ -139,10 +139,9 @@ class Connection implements DriverConnection
     private $params;
 
     /**
-     * The DatabasePlatform object that provides information about the
-     * database platform used by the connection.
+     * The database platform object used by the connection or NULL before it's initialized.
      *
-     * @var AbstractPlatform
+     * @var AbstractPlatform|null
      */
     private $platform;
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -336,7 +336,8 @@ class Connection implements DriverConnection
     public function getDatabasePlatform()
     {
         if ($this->platform === null) {
-            $this->detectDatabasePlatform();
+            $this->platform = $this->detectDatabasePlatform();
+            $this->platform->setEventManager($this->_eventManager);
         }
 
         return $this->platform;
@@ -391,19 +392,17 @@ class Connection implements DriverConnection
      *
      * @throws Exception If an invalid platform was specified for this connection.
      */
-    private function detectDatabasePlatform(): void
+    private function detectDatabasePlatform(): AbstractPlatform
     {
         $version = $this->getDatabasePlatformVersion();
 
         if ($version !== null) {
             assert($this->_driver instanceof VersionAwarePlatformDriver);
 
-            $this->platform = $this->_driver->createDatabasePlatformForVersion($version);
-        } else {
-            $this->platform = $this->_driver->getDatabasePlatform();
+            return $this->_driver->createDatabasePlatformForVersion($version);
         }
 
-        $this->platform->setEventManager($this->_eventManager);
+        return $this->_driver->getDatabasePlatform();
     }
 
     /**

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -59,7 +59,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
     /** @var mixed[] */
     protected $_rowBindedValues = [];
 
-    /** @var mixed[] */
+    /** @var mixed[]|null */
     protected $_bindedValues;
 
     /** @var string */

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -156,6 +156,8 @@ class OCI8Connection implements ConnectionInterface, ServerInfoAwareConnection
     /**
      * {@inheritdoc}
      *
+     * @param string|null $name
+     *
      * @return int|false
      */
     public function lastInsertId($name = null)

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -167,7 +167,7 @@ class OCI8Statement implements IteratorAggregate, StatementInterface, Result
             }
         } while ($result);
 
-        if ($currentLiteralDelimiter) {
+        if ($currentLiteralDelimiter !== null) {
             throw NonTerminatedStringLiteral::new($tokenOffset - 1);
         }
 
@@ -232,6 +232,8 @@ class OCI8Statement implements IteratorAggregate, StatementInterface, Result
      * @param string $currentLiteralDelimiter The delimiter of the current string literal
      *
      * @return bool Whether the token was found
+     *
+     * @param-out string|null $currentLiteralDelimiter
      */
     private static function findClosingQuote(
         $statement,
@@ -248,7 +250,7 @@ class OCI8Statement implements IteratorAggregate, StatementInterface, Result
             return false;
         }
 
-        $currentLiteralDelimiter = false;
+        $currentLiteralDelimiter = null;
         ++$tokenOffset;
 
         return true;

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
@@ -13,9 +13,14 @@ use Doctrine\DBAL\Driver\Result;
 class Connection extends PDO\Connection
 {
     /**
+     * {@inheritdoc}
+     *
      * @internal The connection can be only instantiated by its driver.
      *
-     * {@inheritdoc}
+     * @param string       $dsn
+     * @param string|null  $user
+     * @param string|null  $password
+     * @param mixed[]|null $options
      */
     public function __construct($dsn, $user = null, $password = null, ?array $options = null)
     {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -59,7 +59,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement, Result
     /** @var int Default fetch mode to use. */
     private $defaultFetchMode = FetchMode::MIXED;
 
-    /** @var resource The result set resource to fetch. */
+    /** @var resource|null The result set resource to fetch. */
     private $result;
 
     /** @var resource The prepared SQL statement to execute. */

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3635,6 +3635,8 @@ abstract class AbstractPlatform
      * @return string
      *
      * @throws Exception If not supported on this platform.
+     *
+     * @psalm-return class-string<KeywordList>
      */
     protected function getReservedKeywordsClass()
     {

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -142,7 +142,7 @@ abstract class AbstractPlatform
      */
     protected $doctrineTypeComments;
 
-    /** @var EventManager */
+    /** @var EventManager|null */
     protected $_eventManager;
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -169,7 +169,7 @@ abstract class AbstractPlatform
     /**
      * Gets the EventManager used by the Platform.
      *
-     * @return EventManager
+     * @return EventManager|null
      */
     public function getEventManager()
     {

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -905,12 +905,15 @@ SQL
 
         return $this->doConvertBooleans(
             $item,
-            static function ($boolean) {
-                if ($boolean === null) {
+            /**
+             * @param mixed $value
+             */
+            static function ($value) {
+                if ($value === null) {
                     return 'NULL';
                 }
 
-                return $boolean === true ? 'true' : 'false';
+                return $value === true ? 'true' : 'false';
             }
         );
     }
@@ -926,8 +929,11 @@ SQL
 
         return $this->doConvertBooleans(
             $item,
-            static function ($boolean) {
-                return $boolean === null ? null : (int) $boolean;
+            /**
+             * @param mixed $value
+             */
+            static function ($value) {
+                return $value === null ? null : (int) $value;
             }
         );
     }

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -41,7 +41,7 @@ class Connection extends BaseConnection
     /** @var int */
     private $portability = self::PORTABILITY_NONE;
 
-    /** @var int */
+    /** @var int|null */
     private $case;
 
     /**
@@ -81,7 +81,7 @@ class Connection extends BaseConnection
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getFetchCase()
     {

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -102,6 +102,8 @@ class Connection extends BaseConnection
     /**
      * {@inheritdoc}
      *
+     * @param string $sql
+     *
      * @return Statement
      */
     public function prepare($sql)

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -27,7 +27,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /** @var DriverStatement|ResultStatement */
     private $stmt;
 
-    /** @var int */
+    /** @var int|null */
     private $case;
 
     /** @var int */

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -83,7 +83,7 @@ class QueryBuilder
     /**
      * The complete SQL string for this query.
      *
-     * @var string
+     * @var string|null
      */
     private $sql;
 
@@ -120,7 +120,7 @@ class QueryBuilder
      *
      * @var int
      */
-    private $firstResult;
+    private $firstResult = 0;
 
     /**
      * The maximum number of results to retrieve or NULL to retrieve all results.

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -1219,7 +1219,7 @@ class QueryBuilder
      */
     private function isLimitQuery()
     {
-        return $this->maxResults !== null || $this->firstResult !== null;
+        return $this->maxResults !== null || $this->firstResult !== 0;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -19,7 +19,6 @@ use function assert;
 use function call_user_func_array;
 use function count;
 use function func_get_args;
-use function is_array;
 use function is_callable;
 use function preg_match;
 use function str_replace;
@@ -598,12 +597,7 @@ abstract class AbstractSchemaManager
      */
     public function alterTable(TableDiff $tableDiff)
     {
-        $queries = $this->_platform->getAlterTableSQL($tableDiff);
-        if (! is_array($queries) || ! count($queries)) {
-            return;
-        }
-
-        foreach ($queries as $ddlQuery) {
+        foreach ($this->_platform->getAlterTableSQL($tableDiff) as $ddlQuery) {
             $this->_execSql($ddlQuery);
         }
     }

--- a/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php
@@ -33,7 +33,7 @@ use const CASE_LOWER;
  */
 class PostgreSqlSchemaManager extends AbstractSchemaManager
 {
-    /** @var string[] */
+    /** @var string[]|null */
     private $existingSchemaPaths;
 
     /**

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -186,7 +186,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
              * @param array<string,mixed> $a
              * @param array<string,mixed> $b
              */
-            static function (array $a, array $b) {
+            static function (array $a, array $b): int {
                 if ($a['pk'] === $b['pk']) {
                     return $a['cid'] - $b['cid'];
                 }

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -180,13 +180,21 @@ class SqliteSchemaManager extends AbstractSchemaManager
             $this->_conn->quote($tableName)
         ));
 
-        usort($indexArray, static function ($a, $b) {
-            if ($a['pk'] === $b['pk']) {
-                return $a['cid'] - $b['cid'];
-            }
+        usort(
+            $indexArray,
+            /**
+             * @param array<string,mixed> $a
+             * @param array<string,mixed> $b
+             */
+            static function (array $a, array $b) {
+                if ($a['pk'] === $b['pk']) {
+                    return $a['cid'] - $b['cid'];
+                }
 
-            return $a['pk'] - $b['pk'];
-        });
+                return $a['pk'] - $b['pk'];
+            }
+        );
+
         foreach ($indexArray as $indexColumnRow) {
             if ($indexColumnRow['pk'] === '0') {
                 continue;

--- a/lib/Doctrine/DBAL/Schema/Table.php
+++ b/lib/Doctrine/DBAL/Schema/Table.php
@@ -676,7 +676,7 @@ class Table extends AbstractAsset
      */
     private function filterColumns(array $columnNames)
     {
-        return array_filter($this->_columns, static function ($columnName) use ($columnNames) {
+        return array_filter($this->_columns, static function (string $columnName) use ($columnNames) {
             return in_array($columnName, $columnNames, true);
         }, ARRAY_FILTER_USE_KEY);
     }

--- a/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/DropSchemaSqlCollector.php
@@ -32,7 +32,7 @@ class DropSchemaSqlCollector extends AbstractVisitor
     public function __construct(AbstractPlatform $platform)
     {
         $this->platform = $platform;
-        $this->clearQueries();
+        $this->initializeQueries();
     }
 
     /**
@@ -68,9 +68,7 @@ class DropSchemaSqlCollector extends AbstractVisitor
      */
     public function clearQueries()
     {
-        $this->constraints = new SplObjectStorage();
-        $this->sequences   = new SplObjectStorage();
-        $this->tables      = new SplObjectStorage();
+        $this->initializeQueries();
     }
 
     /**
@@ -97,5 +95,12 @@ class DropSchemaSqlCollector extends AbstractVisitor
         }
 
         return $sql;
+    }
+
+    private function initializeQueries(): void
+    {
+        $this->constraints = new SplObjectStorage();
+        $this->sequences   = new SplObjectStorage();
+        $this->tables      = new SplObjectStorage();
     }
 }

--- a/lib/Doctrine/DBAL/Schema/Visitor/RemoveNamespacedAssets.php
+++ b/lib/Doctrine/DBAL/Schema/Visitor/RemoveNamespacedAssets.php
@@ -20,7 +20,7 @@ use Doctrine\DBAL\Schema\Table;
  */
 class RemoveNamespacedAssets extends AbstractVisitor
 {
-    /** @var Schema */
+    /** @var Schema|null */
     private $schema;
 
     /**
@@ -36,6 +36,10 @@ class RemoveNamespacedAssets extends AbstractVisitor
      */
     public function acceptTable(Table $table)
     {
+        if ($this->schema === null) {
+            return;
+        }
+
         if ($table->isInDefaultNamespace($this->schema->getName())) {
             return;
         }
@@ -48,6 +52,10 @@ class RemoveNamespacedAssets extends AbstractVisitor
      */
     public function acceptSequence(Sequence $sequence)
     {
+        if ($this->schema === null) {
+            return;
+        }
+
         if ($sequence->isInDefaultNamespace($this->schema->getName())) {
             return;
         }
@@ -60,6 +68,10 @@ class RemoveNamespacedAssets extends AbstractVisitor
      */
     public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint)
     {
+        if ($this->schema === null) {
+            return;
+        }
+
         // The table may already be deleted in a previous
         // RemoveNamespacedAssets#acceptTable call. Removing Foreign keys that
         // point to nowhere.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -169,6 +169,35 @@
                 <file name="lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php"/>
             </errorLevel>
         </PossiblyNullArgument>
+        <PropertyNotSetInConstructor>
+            <errorLevel type="suppress">
+                <!-- See https://github.com/psalm/psalm-plugin-phpunit/issues/107 -->
+                <!-- See https://github.com/sebastianbergmann/phpunit/pull/4610 -->
+                <directory name="tests"/>
+                <!-- See https://github.com/doctrine/dbal/issues/4506 -->
+                <file name="lib/Doctrine/DBAL/Schema/ForeignKeyConstraint.php"/>
+                <!--
+                    This suppression should be removed in 3.0.x
+                    See https://github.com/doctrine/dbal/pull/3803
+                -->
+                <file name="lib/Doctrine/DBAL/Driver/PDO/SQLSrv/Statement.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDO/Statement.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDOSqlsrv/Statement.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/PDOStatement.php"/>
+                <!--
+                    This suppression should be removed in 4.0.x
+                    See https://github.com/doctrine/dbal/pull/3712
+                -->
+                <file name="lib/Doctrine/DBAL/Schema/Column.php"/>
+                <file name="lib/Doctrine/DBAL/Schema/Identifier.php"/>
+                <file name="lib/Doctrine/DBAL/Schema/Index.php"/>
+                <file name="lib/Doctrine/DBAL/Schema/Schema.php"/>
+                <file name="lib/Doctrine/DBAL/Schema/Sequence.php"/>
+                <file name="lib/Doctrine/DBAL/Schema/Table.php"/>
+                <file name="lib/Doctrine/DBAL/Schema/View.php"/>
+            </errorLevel>
+        </PropertyNotSetInConstructor>
+        <!-- This is necessary pre 4.0  -->
         <RedundantCastGivenDocblockType>
             <errorLevel type="suppress">
                 <!--

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -176,6 +176,8 @@
                     Fixing this issue requires an API change
                 -->
                 <file name="lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php"/>
+                <!-- See https://github.com/doctrine/dbal/issues/4503 -->
+                <file name="lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php"/>
             </errorLevel>
         </NullableReturnStatement>
         <ParamNameMismatch>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -271,6 +271,15 @@
                 <file name="tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php"/>
             </errorLevel>
         </RedundantConditionGivenDocblockType>
+        <ReferenceConstraintViolation>
+            <errorLevel type="suppress">
+                <!--
+                    This suppression should be removed in 4.0.x
+                    See https://github.com/doctrine/dbal/pull/3836
+                -->
+                <file name="lib/Doctrine/DBAL/Query/QueryBuilder.php"/>
+            </errorLevel>
+        </ReferenceConstraintViolation>
         <ReservedWord>
             <errorLevel type="suppress">
                 <!-- This file uses the mixed type in a PHP 8 forward compatibility layer. -->

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -123,6 +123,8 @@
             <errorLevel type="suppress">
                 <!-- See https://github.com/doctrine/dbal/pull/4082 -->
                 <file name="lib/Doctrine/DBAL/Driver/AbstractSQLiteDriver.php"/>
+                <!-- See https://github.com/doctrine/dbal/issues/4503 -->
+                <file name="lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php"/>
             </errorLevel>
         </InvalidNullableReturnType>
         <InvalidPropertyAssignmentValue>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -36,6 +36,36 @@
                 <file name="lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php"/>
             </errorLevel>
         </ConflictingReferenceConstraint>
+        <DocblockTypeContradiction>
+            <errorLevel type="suppress">
+                <!--
+                    These issues can be mostly divided in the following categories:
+                      1. Union types not supported at the language level (require dropping PHP 7 support)
+                      2. Associative arrays with typed elements used instead of classes (require breaking API changes)
+                -->
+                <file name="lib/Doctrine/DBAL/Connection.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php"/>
+                <file name="lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php"/>
+                <file name="lib/Doctrine/DBAL/DriverManager.php"/>
+                <file name="lib/Doctrine/DBAL/Platforms/AbstractPlatform.php"/>
+                <file name="lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php"/>
+                <file name="lib/Doctrine/DBAL/Platforms/MySqlPlatform.php"/>
+                <file name="lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php"/>
+                <file name="lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php"/>
+                <file name="lib/Doctrine/DBAL/Platforms/SqlitePlatform.php"/>
+                <file name="lib/Doctrine/DBAL/Schema/Column.php"/>
+                <!--
+                    These issues are fixed in 3.0
+                -->
+                <file name="tests/Doctrine/Tests/DBAL/Driver/PDO/ExceptionTest.php"/>
+                <file name="tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php"/>
+                <!--
+                    This issue is fixed in 4.0
+                -->
+                <file name="lib/Doctrine/DBAL/Schema/Index.php"/>
+            </errorLevel>
+        </DocblockTypeContradiction>
         <DuplicateClass>
             <errorLevel type="suppress">
                 <!-- These files contain a php 7 and a php 8 version of the same trait -->

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -169,6 +169,15 @@
                 <file name="lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php"/>
             </errorLevel>
         </PossiblyNullArgument>
+        <RedundantCastGivenDocblockType>
+            <errorLevel type="suppress">
+                <!--
+                    This suppression should be removed in 4.0.x
+                    where we have scalar argument types enforced
+                -->
+                <directory name="lib"/>
+            </errorLevel>
+        </RedundantCastGivenDocblockType>
         <RedundantCondition>
             <errorLevel type="suppress">
                 <!--

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -341,6 +341,14 @@
                 <file name="lib/Doctrine/DBAL/Tools/Dumper.php"/>
             </errorLevel>
         </UndefinedClass>
+        <UnsafeInstantiation>
+            <errorLevel type="suppress">
+                <!-- See https://github.com/doctrine/dbal/issues/4510 -->
+                <file name="lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php"/>
+                <!-- See https://github.com/doctrine/dbal/issues/4511 -->
+                <file name="lib/Doctrine/DBAL/DriverManager.php"/>
+            </errorLevel>
+        </UnsafeInstantiation>
         <InvalidArgument>
             <errorLevel type="suppress">
                 <!-- See https://github.com/doctrine/dbal/pull/3803 -->

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -197,8 +197,16 @@
         </PossiblyUndefinedArrayOffset>
         <PossiblyNullArgument>
             <errorLevel type="suppress">
-                <!-- See https://github.com/doctrine/dbal/pull/3488 -->
+                <!--
+                    This suppression should be removed in 3.0.x
+                    See https://github.com/doctrine/dbal/pull/3488
+                -->
                 <file name="lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php"/>
+                <!--
+                    This suppression should be removed in 3.0.x
+                    See https://github.com/doctrine/dbal/pull/4157
+                -->
+                <file name="lib/Doctrine/DBAL/Portability/Statement.php"/>
             </errorLevel>
         </PossiblyNullArgument>
         <PropertyNotSetInConstructor>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -225,6 +225,15 @@
                 <file name="lib/Doctrine/DBAL/Portability/Statement.php"/>
             </errorLevel>
         </PossiblyNullArgument>
+        <PossiblyNullIterator>
+            <errorLevel type="suppress">
+                <!--
+                    This suppression should be removed in 4.0.x
+                    See https://github.com/doctrine/dbal/pull/3712
+                -->
+                <file name="lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php"/>
+            </errorLevel>
+        </PossiblyNullIterator>
         <PropertyNotSetInConstructor>
             <errorLevel type="suppress">
                 <!-- See https://github.com/psalm/psalm-plugin-phpunit/issues/107 -->

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
-    errorLevel="3"
-    resolveFromConfigFile="true"
+    errorLevel="2"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -246,6 +246,29 @@
                 <file name="lib/Doctrine/DBAL/Version.php"/>
             </errorLevel>
         </RedundantCondition>
+        <RedundantConditionGivenDocblockType>
+            <errorLevel type="suppress">
+                <!--
+                    Requires a release of https://github.com/JetBrains/phpstorm-stubs/pull/1055
+                -->
+                <file name="lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php"/>
+                <!--
+                    Requires a release of https://github.com/JetBrains/phpstorm-stubs/pull/1053
+                -->
+                <file name="lib/Doctrine/DBAL/Driver/PDOStatement.php"/>
+                <!--
+                    Fixing these issues requires support of union types at the language level
+                    or breaking API changes.
+                -->
+                <file name="lib/Doctrine/DBAL/Platforms/DrizzlePlatform.php"/>
+                <file name="lib/Doctrine/DBAL/Platforms/MySqlPlatform.php"/>
+                <!--
+                    These issues are fixed in 3.0
+                -->
+                <file name="lib/Doctrine/DBAL/Tools/Console/ConsoleRunner.php"/>
+                <file name="tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php"/>
+            </errorLevel>
+        </RedundantConditionGivenDocblockType>
         <ReservedWord>
             <errorLevel type="suppress">
                 <!-- This file uses the mixed type in a PHP 8 forward compatibility layer. -->

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -147,6 +147,20 @@
                 <file name="lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php"/>
             </errorLevel>
         </MethodSignatureMismatch>
+        <MissingConstructor>
+            <errorLevel type="suppress">
+                <!--
+                    This suppression should be removed in 3.1.x
+                    See https://github.com/doctrine/dbal/issues/4512
+                -->
+                <file name="lib/Doctrine/DBAL/Driver/SQLSrv/LastInsertId.php"/>
+                <!--
+                    This suppression should be removed in 4.0.x
+                    See https://github.com/doctrine/dbal/pull/3712
+                -->
+                <file name="lib/Doctrine/DBAL/Schema/SchemaConfig.php"/>
+            </errorLevel>
+        </MissingConstructor>
         <NonInvariantDocblockPropertyType>
             <errorLevel type="suppress">
                 <!--

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -358,6 +358,7 @@
         <UnsafeInstantiation>
             <errorLevel type="suppress">
                 <!-- See https://github.com/doctrine/dbal/issues/4510 -->
+                <file name="lib/Doctrine/DBAL/Platforms/AbstractPlatform.php"/>
                 <file name="lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php"/>
                 <!-- See https://github.com/doctrine/dbal/issues/4511 -->
                 <file name="lib/Doctrine/DBAL/DriverManager.php"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -36,6 +36,46 @@
                 <file name="lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php"/>
             </errorLevel>
         </ConflictingReferenceConstraint>
+        <!--
+            The library uses its own deprecated APIs for backward compatibility.
+            This list of suppressed issues should be revisited each major release.
+        -->
+        <DeprecatedClass>
+            <errorLevel type="suppress">
+                <directory name="lib"/>
+                <directory name="tests"/>
+            </errorLevel>
+        </DeprecatedClass>
+        <DeprecatedConstant>
+            <errorLevel type="suppress">
+                <!--
+                    This suppression should be removed in 3.0.x
+                    See https://github.com/doctrine/dbal/pull/4082
+                -->
+                <file name="lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php"/>
+                <!--
+                    These suppressions should be removed in 3.0.x
+                    See https://github.com/doctrine/dbal/pull/4082
+                -->
+                <file name="lib/Doctrine/DBAL/Schema/PostgreSqlSchemaManager.php"/>
+                <file name="lib/Doctrine/DBAL/Types/JsonArrayType.php"/>
+                <file name="lib/Doctrine/DBAL/Types/Type.php"/>
+                <file name="tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php"/>
+                <file name="tests/Doctrine/Tests/DBAL/Types/JsonArrayTest.php"/>
+            </errorLevel>
+        </DeprecatedConstant>
+        <DeprecatedInterface>
+            <errorLevel type="suppress">
+                <directory name="lib"/>
+                <directory name="tests"/>
+            </errorLevel>
+        </DeprecatedInterface>
+        <DeprecatedMethod>
+            <errorLevel type="suppress">
+                <directory name="lib"/>
+                <directory name="tests"/>
+            </errorLevel>
+        </DeprecatedMethod>
         <DocblockTypeContradiction>
             <errorLevel type="suppress">
                 <!--

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -240,8 +240,7 @@ class ConnectionTest extends DbalFunctionalTestCase
     public function testTransactionalWithException(): void
     {
         try {
-            $this->connection->transactional(static function ($conn): void {
-                /** @var Connection $conn */
+            $this->connection->transactional(static function (Connection $conn): void {
                 $conn->executeQuery($conn->getDatabasePlatform()->getDummySelectSQL());
 
                 throw new RuntimeException('Ooops!');
@@ -255,8 +254,7 @@ class ConnectionTest extends DbalFunctionalTestCase
     public function testTransactionalWithThrowable(): void
     {
         try {
-            $this->connection->transactional(static function ($conn): void {
-                /** @var Connection $conn */
+            $this->connection->transactional(static function (Connection $conn): void {
                 $conn->executeQuery($conn->getDatabasePlatform()->getDummySelectSQL());
 
                 throw new Error('Ooops!');
@@ -269,8 +267,7 @@ class ConnectionTest extends DbalFunctionalTestCase
 
     public function testTransactional(): void
     {
-        $res = $this->connection->transactional(static function ($conn): void {
-            /** @var Connection $conn */
+        $res = $this->connection->transactional(static function (Connection $conn): void {
             $conn->executeQuery($conn->getDatabasePlatform()->getDummySelectSQL());
         });
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -29,17 +29,6 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         return $platform instanceof PostgreSQL94Platform;
     }
 
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        if (! $this->connection) {
-            return;
-        }
-
-        $this->connection->getConfiguration()->setSchemaAssetsFilter(null);
-    }
-
     public function testGetSearchPath(): void
     {
         $expected = ['public'];

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/PostgreSqlSchemaManagerTest.php
@@ -48,8 +48,6 @@ class PostgreSqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $names = $this->schemaManager->getSchemaNames();
 
-        self::assertIsArray($names);
-        self::assertNotEmpty($names);
         self::assertContains('public', $names, 'The public schema should be found.');
     }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SQLAnywhereSchemaManagerTest.php
@@ -47,7 +47,7 @@ class SQLAnywhereSchemaManagerTest extends SchemaManagerFunctionalTestCase
         );
 
         $tableIndexes = $this->schemaManager->listTableIndexes('test_create_advanced_index');
-        self::assertIsArray($tableIndexes);
+
         self::assertEquals('test', $tableIndexes['test']->getName());
         self::assertEquals(['test'], $tableIndexes['test']->getColumns());
         self::assertTrue($tableIndexes['test']->isUnique());

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -173,8 +173,6 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
 
         $sequences = $this->schemaManager->listSequences();
 
-        self::assertIsArray($sequences, 'listSequences() should return an array.');
-
         $foundSequence = null;
         foreach ($sequences as $sequence) {
             self::assertInstanceOf(Sequence::class, $sequence);
@@ -231,9 +229,6 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
     {
         $this->createTestTable('list_tables_test');
         $tables = $this->schemaManager->listTables();
-
-        self::assertIsArray($tables);
-        self::assertTrue(count($tables) > 0, "List Tables has to find at least one table named 'list_tables_test'.");
 
         $foundTable = false;
         foreach ($tables as $table) {
@@ -457,7 +452,6 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
 
         $this->schemaManager->dropAndCreateIndex($table->getIndex('test'), $table);
         $tableIndexes = $this->schemaManager->listTableIndexes('test_create_index');
-        self::assertIsArray($tableIndexes);
 
         self::assertEquals('test', strtolower($tableIndexes['test']->getName()));
         self::assertEquals(['test'], array_map('strtolower', $tableIndexes['test']->getColumns()));

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -82,6 +82,8 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
         } catch (DBALException $e) {
         }
 
+        $this->markConnectionNotReusable();
+
         parent::tearDown();
     }
 
@@ -361,16 +363,12 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
             ->expects($this->exactly(7))
             ->method('onSchemaColumnDefinition');
 
-        $oldEventManager = $this->schemaManager->getDatabasePlatform()->getEventManager();
-
         $eventManager = new EventManager();
         $eventManager->addEventListener([Events::onSchemaColumnDefinition], $listenerMock);
 
         $this->schemaManager->getDatabasePlatform()->setEventManager($eventManager);
 
         $this->schemaManager->listTableColumns('list_table_columns');
-
-        $this->schemaManager->getDatabasePlatform()->setEventManager($oldEventManager);
     }
 
     public function testListTableIndexesDispatchEvent(): void
@@ -386,16 +384,12 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
             ->expects($this->exactly(3))
             ->method('onSchemaIndexDefinition');
 
-        $oldEventManager = $this->schemaManager->getDatabasePlatform()->getEventManager();
-
         $eventManager = new EventManager();
         $eventManager->addEventListener([Events::onSchemaIndexDefinition], $listenerMock);
 
         $this->schemaManager->getDatabasePlatform()->setEventManager($eventManager);
 
         $this->schemaManager->listTableIndexes('list_table_indexes_test');
-
-        $this->schemaManager->getDatabasePlatform()->setEventManager($oldEventManager);
     }
 
     public function testDiffListTableColumns(): void

--- a/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
@@ -289,19 +289,28 @@ EOF
     {
         return [
             'fetch' => [
+                /**
+                 * @return mixed
+                 */
                 static function (Statement $stmt) {
                     return $stmt->fetch();
                 },
                 false,
             ],
+            /**
+             * @return mixed|false
+             */
             'fetch-column' => [
                 static function (Statement $stmt) {
                     return $stmt->fetchColumn();
                 },
                 false,
             ],
+            /**
+             * @return mixed[]
+             */
             'fetch-all' => [
-                static function (Statement $stmt) {
+                static function (Statement $stmt): array {
                     return $stmt->fetchAll();
                 },
                 [],

--- a/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TemporaryTableTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\DBAL\Functional;
 
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalFunctionalTestCase;
@@ -9,28 +10,6 @@ use Throwable;
 
 class TemporaryTableTest extends DbalFunctionalTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-        try {
-            $this->connection->exec($this->connection->getDatabasePlatform()->getDropTableSQL('nontemporary'));
-        } catch (Throwable $e) {
-        }
-    }
-
-    protected function tearDown(): void
-    {
-        if ($this->connection) {
-            try {
-                $tempTable = $this->connection->getDatabasePlatform()->getTemporaryTableName('my_temporary');
-                $this->connection->exec($this->connection->getDatabasePlatform()->getDropTemporaryTableSQL($tempTable));
-            } catch (Throwable $e) {
-            }
-        }
-
-        parent::tearDown();
-    }
-
     public function testDropTemporaryTableNotAutoCommitTransaction(): void
     {
         if (
@@ -52,11 +31,11 @@ class TemporaryTableTest extends DbalFunctionalTestCase
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
 
-        $this->connection->getSchemaManager()->createTable($table);
+        $this->connection->getSchemaManager()->dropAndCreateTable($table);
 
         $this->connection->beginTransaction();
         $this->connection->insert('nontemporary', ['id' => 1]);
-        $this->connection->exec($platform->getDropTemporaryTableSQL($tempTable));
+        $this->dropTemporaryTable('my_temporary');
         $this->connection->insert('nontemporary', ['id' => 2]);
 
         $this->connection->rollBack();
@@ -85,11 +64,12 @@ class TemporaryTableTest extends DbalFunctionalTestCase
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
 
-        $this->connection->getSchemaManager()->createTable($table);
+        $this->connection->getSchemaManager()->dropAndCreateTable($table);
 
         $this->connection->beginTransaction();
         $this->connection->insert('nontemporary', ['id' => 1]);
 
+        $this->dropTemporaryTable('my_temporary');
         $this->connection->exec($createTempTableSQL);
         $this->connection->insert('nontemporary', ['id' => 2]);
 
@@ -102,5 +82,18 @@ class TemporaryTableTest extends DbalFunctionalTestCase
 
         // In an event of an error this result has one row, because of an implicit commit
         self::assertEquals([], $this->connection->fetchAll('SELECT * FROM nontemporary'));
+    }
+
+    private function dropTemporaryTable(string $name): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $sql      = $platform->getDropTemporaryTableSQL(
+            $platform->getTemporaryTableName($name)
+        );
+
+        try {
+            $this->connection->executeStatement($sql);
+        } catch (Exception $e) {
+        }
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/WriteTest.php
@@ -168,7 +168,6 @@ class WriteTest extends DbalFunctionalTestCase
         self::assertEquals(1, $this->connection->insert('write_table', ['test_int' => 2, 'test_string' => 'bar']));
         $num = $this->lastInsertId();
 
-        self::assertNotNull($num, 'LastInsertId() should not be null.');
         self::assertGreaterThan(0, $num, 'LastInsertId() should be non-negative number.');
     }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -385,7 +385,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         ];
         $statements = $this->platform->getCreateTableSQL($table);
         //strip all the whitespace from the statements
-        array_walk($statements, static function (&$value): void {
+        array_walk($statements, static function (string &$value): void {
             $value = preg_replace('/\s+/', ' ', $value);
         });
         foreach ($targets as $key => $sql) {

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
@@ -176,7 +176,7 @@ class ExpressionBuilderTest extends DbalTestCase
     {
         $part = $this->expr->comparison($leftExpr, $operator, $rightExpr);
 
-        self::assertEquals($expected, (string) $part);
+        self::assertEquals($expected, $part);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
@@ -88,7 +88,7 @@ final class DB2SchemaManagerTest extends TestCase
     public function testListTableNamesFiltersAssetNamesCorrectlyWithCallable(): void
     {
         $accepted = ['T_FOO', 'T_BAR'];
-        $this->conn->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) use ($accepted) {
+        $this->conn->getConfiguration()->setSchemaAssetsFilter(static function (string $assetName) use ($accepted) {
             return in_array($assetName, $accepted);
         });
         $this->conn->expects($this->any())->method('quote');
@@ -113,7 +113,7 @@ final class DB2SchemaManagerTest extends TestCase
     public function testSettingNullExpressionWillResetCallable(): void
     {
         $accepted = ['T_FOO', 'T_BAR'];
-        $this->conn->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) use ($accepted) {
+        $this->conn->getConfiguration()->setSchemaAssetsFilter(static function (string $assetName) use ($accepted) {
             return in_array($assetName, $accepted);
         });
         $this->conn->expects($this->any())->method('quote');

--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -100,17 +100,24 @@ abstract class DbalFunctionalTestCase extends DbalTestCase
             $queries = '';
             $i       = count($this->sqlLoggerStack->queries);
             foreach (array_reverse($this->sqlLoggerStack->queries) as $query) {
-                $params   = array_map(static function ($p) {
-                    if (is_object($p)) {
-                        return get_class($p);
-                    }
+                $params = array_map(
+                    /**
+                     * @param mixed $p
+                     */
+                    static function ($p) {
+                        if (is_object($p)) {
+                            return get_class($p);
+                        }
 
-                    if (is_scalar($p)) {
-                        return "'" . $p . "'";
-                    }
+                        if (is_scalar($p)) {
+                            return "'" . $p . "'";
+                        }
 
-                    return var_export($p, true);
-                }, $query['params'] ?: []);
+                        return var_export($p, true);
+                    },
+                    $query['params'] ?: []
+                );
+
                 $queries .= $i . ". SQL: '" . $query['sql'] . "' Params: " . implode(', ', $params) . PHP_EOL;
                 $i--;
             }

--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -32,7 +32,7 @@ abstract class DbalFunctionalTestCase extends DbalTestCase
     /** @var Connection */
     protected $connection;
 
-    /** @var DebugStack */
+    /** @var DebugStack|null */
     protected $sqlLoggerStack;
 
     /**
@@ -96,7 +96,7 @@ abstract class DbalFunctionalTestCase extends DbalTestCase
             throw $t;
         }
 
-        if (isset($this->sqlLoggerStack->queries) && count($this->sqlLoggerStack->queries)) {
+        if ($this->sqlLoggerStack !== null && count($this->sqlLoggerStack->queries) > 0) {
             $queries = '';
             $i       = count($this->sqlLoggerStack->queries);
             foreach (array_reverse($this->sqlLoggerStack->queries) as $query) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         |improvement
| BC Break     | no

This patch shouldn't contain any breaking changes but I cannot confirm that with `roave-backward-compatibility-check`:
```
$ roave-backward-compatibility-check --from=upstream/2.12.x
Comparing from 1d6771f300bfdf5578634a3e1f0a8fe067775d16 to a1986e07dbb63b46a446f186cdf93db6c89eadb9...
Loading composer repositories with package information
<warning>Warning from https://repo.packagist.org: You are using an outdated version of Composer. Composer 2 is now available and you should upgrade. See https://getcomposer.org/2</warning>
Updating dependencies
Package operations: 2 installs, 0 updates, 0 removals
  - Installing doctrine/cache (1.10.2): Loading from cache
  - Installing doctrine/event-manager (1.1.1): Loading from cache
Writing lock file
2 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Loading composer repositories with package information
<warning>Warning from https://repo.packagist.org: You are using an outdated version of Composer. Composer 2 is now available and you should upgrade. See https://getcomposer.org/2</warning>
Updating dependencies
Package operations: 2 installs, 0 updates, 0 removals
  - Installing doctrine/cache (1.10.2): Loading from cache
  - Installing doctrine/event-manager (1.1.1): Loading from cache
Writing lock file
2 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
fish: 'roave-backward-compatibility-ch…' terminated by signal SIGSEGV (Address boundary error)
```

Fails with a segfault on PHP 7.4.15, both on Linux and macOS.