### PR TITLE
Rework handling shared connection in the test suite

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/Connection/ConnectionLostTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Connection/ConnectionLostTest.php
@@ -21,13 +21,6 @@ class ConnectionLostTest extends DbalFunctionalTestCase
         $this->markTestSkipped('Currently only supported with MySQL');
     }
 
-    protected function tearDown(): void
-    {
-        $this->resetSharedConn();
-
-        parent::tearDown();
-    }
-
     public function testConnectionLost(): void
     {
         $this->connection->query('SET SESSION wait_timeout=1');

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -22,20 +22,15 @@ use function unlink;
 
 class ConnectionTest extends DbalFunctionalTestCase
 {
-    protected function setUp(): void
-    {
-        $this->resetSharedConn();
-        parent::setUp();
-    }
-
     protected function tearDown(): void
     {
         if (file_exists('/tmp/test_nesting.sqlite')) {
             unlink('/tmp/test_nesting.sqlite');
         }
 
+        $this->markConnectionNotReusable();
+
         parent::tearDown();
-        $this->resetSharedConn();
     }
 
     public function testGetWrappedConnection(): void

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/IBMDB2/ConnectionTest.php
@@ -32,7 +32,9 @@ class ConnectionTest extends DbalFunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->resetSharedConn();
+        $this->markConnectionNotReusable();
+
+        parent::tearDown();
     }
 
     public function testConnectionFailure(): void

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDO/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDO/ConnectionTest.php
@@ -42,7 +42,7 @@ class ConnectionTest extends DbalFunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->resetSharedConn();
+        $this->markConnectionNotReusable();
 
         parent::tearDown();
     }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -16,22 +16,21 @@ use Doctrine\Tests\Types\MySqlPointType;
 
 class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        Type::addType('point', MySqlPointType::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->markConnectionNotReusable();
+
+        parent::tearDown();
+    }
+
     protected function supportsPlatform(AbstractPlatform $platform): bool
     {
         return $platform instanceof MySqlPlatform;
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        if (Type::hasType('point')) {
-            return;
-        }
-
-        $this->resetSharedConn();
-
-        Type::addType('point', MySqlPointType::class);
     }
 
     public function testSwitchPrimaryKeyColumns(): void

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -69,7 +69,9 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
+        if ($this->schemaManager->tablesExist(['json_array_test'])) {
+            $this->schemaManager->dropTable('json_array_test');
+        }
 
         $this->schemaManager->tryMethod('dropTable', 'testschema.my_table_in_namespace');
 
@@ -78,8 +80,9 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
             //sql server versions below 2016 do not support 'IF EXISTS' so we have to catch the exception here
             $this->connection->exec('DROP SCHEMA testschema');
         } catch (DBALException $e) {
-            return;
         }
+
+        parent::tearDown();
     }
 
     public function testDropsDatabaseWithActiveConnections(): void
@@ -1287,18 +1290,6 @@ abstract class SchemaManagerFunctionalTestCase extends DbalFunctionalTestCase
         self::assertCount(2, $indexes);
         self::assertArrayHasKey('explicit_fk1_idx', $indexes);
         self::assertArrayHasKey('idx_3d6c147fdc58d6c', $indexes);
-    }
-
-    /**
-     * @after
-     */
-    public function removeJsonArrayTable(): void
-    {
-        if (! $this->schemaManager->tablesExist(['json_array_test'])) {
-            return;
-        }
-
-        $this->schemaManager->dropTable('json_array_test');
     }
 
     public function testComparatorShouldReturnFalseWhenLegacyJsonArrayColumnHasComment(): void

--- a/tests/Doctrine/Tests/DBAL/Functional/TransactionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TransactionTest.php
@@ -21,13 +21,6 @@ class TransactionTest extends DbalFunctionalTestCase
         $this->markTestSkipped('Restricted to MySQL.');
     }
 
-    protected function tearDown(): void
-    {
-        $this->resetSharedConn();
-
-        parent::tearDown();
-    }
-
     public function testCommitFalse(): void
     {
         $this->connection->query('SET SESSION wait_timeout=1');
@@ -42,6 +35,8 @@ class TransactionTest extends DbalFunctionalTestCase
             /* For PDO, we are using ERRMODE EXCEPTION, so this catch should be
              * necessary as the equivalent of the error control operator above.
              * This seems to be the case only since PHP 8 */
+        } finally {
+            $this->connection->close();
         }
     }
 }

--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -35,19 +35,27 @@ abstract class DbalFunctionalTestCase extends DbalTestCase
     /** @var DebugStack */
     protected $sqlLoggerStack;
 
-    protected function resetSharedConn(): void
-    {
-        if (! self::$sharedConnection) {
-            return;
-        }
+    /**
+     * Whether the shared connection could be reused by subsequent tests.
+     *
+     * @var bool
+     */
+    private $isConnectionReusable = true;
 
-        self::$sharedConnection->close();
-        self::$sharedConnection = null;
+    /**
+     * Mark shared connection not reusable for subsequent tests.
+     *
+     * Should be called by the tests that modify configuration configuration
+     * or alter the connection state in another way that may impact other tests.
+     */
+    protected function markConnectionNotReusable(): void
+    {
+        $this->isConnectionReusable = false;
     }
 
     protected function setUp(): void
     {
-        if (! isset(self::$sharedConnection)) {
+        if (self::$sharedConnection === null) {
             self::$sharedConnection = TestUtil::getConnection();
         }
 
@@ -62,6 +70,24 @@ abstract class DbalFunctionalTestCase extends DbalTestCase
         while ($this->connection->isTransactionActive()) {
             $this->connection->rollBack();
         }
+
+        if ($this->isConnectionReusable) {
+            return;
+        }
+
+        if (self::$sharedConnection !== null) {
+            self::$sharedConnection->close();
+            self::$sharedConnection = null;
+        }
+
+        // Make sure the connection is no longer available to the test.
+        // Otherwise, there is a chance that a teardown method of the test will reconnect
+        // (e.g. to drop a table), and then this reopened connection will remain open and attached to the PHPUnit result
+        // until the end of the suite leaking connection resources, while subsequent tests will use
+        // the newly established shared connection.
+        unset($this->connection);
+
+        $this->isConnectionReusable = true;
     }
 
     protected function onNotSuccessfulTest(Throwable $t): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4520

1. Replace the imperative `resetSharedConn()` with the declarative `markConnectionNotReusable()`. This way, the need to disconnect can be communicated from any point in the test, not only in `tearDown()`. It will also guarantee that the disconnect will happen at most once if requested.
2. Unsetting the `connection` property on an integration test helps ensure that the connection won't be leaked by a consequent teardown procedure (https://github.com/sebastianbergmann/phpunit/issues/3039).
3. `TransactionTest#testCommitFalse()` should close the connection since the wrapper connection doesn't handle lost connection during a commit (https://github.com/doctrine/dbal/issues/4522). Doing this in `2.x` might be a breaking change. Otherwise, the `tearDown()` procedure that tries to roll back the transaction will fail due to the "server gone away" error.
4. The `@after` tests combined with `markConnectionNotReusable()` called from `tearDown()` will no longer work since this is where the connection might leak.