### PR TITLE
Update PHPStan to 0.12.80

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "doctrine/coding-standard": "8.2.0",
         "jetbrains/phpstorm-stubs": "2019.3",
-        "phpstan/phpstan": "0.12.55",
+        "phpstan/phpstan": "0.12.80",
         "phpunit/phpunit": "9.5.0",
         "psalm/plugin-phpunit": "0.13.0",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
 use mysqli;
 
+use function assert;
 use function floor;
 use function func_get_args;
 use function in_array;
@@ -69,7 +70,10 @@ class MysqliConnection implements ConnectionInterface, PingableConnection, Serve
 
         $flags = $driverOptions[static::OPTION_FLAGS] ?? null;
 
-        $this->conn = mysqli_init();
+        $conn = mysqli_init();
+        assert($conn !== false);
+
+        $this->conn = $conn;
 
         $this->setSecureConnection($params);
         $this->setDriverOptions($driverOptions);

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -257,7 +257,9 @@ final class DriverManager
     private static function createDriver(array $params): Driver
     {
         if (isset($params['driverClass'])) {
-            if (! in_array(Driver::class, class_implements($params['driverClass'], true))) {
+            $interfaces = class_implements($params['driverClass'], true);
+
+            if ($interfaces === false || ! in_array(Driver::class, $interfaces)) {
                 throw Exception::invalidDriverClass($params['driverClass']);
             }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #4523

While `mysqli_init()`can return false according to the [PHP source code](https://github.com/php/php-src/blob/da011a312a6c6cd7ff12fe1aa0de1e33fba2f167/ext/mysqli/mysqli_api.c#L1455) and the [MySQL API documentation](https://dev.mysql.com/doc/c-api/8.0/en/mysql-init.html) (the same should be for `mysqlnd`), it's unclear how to reproduce such a case:
```
php -dmemory_limit=1M -r 'while (($x[] = mysqli_init()) !== false) {}'

Fatal error: Allowed memory size of 2097152 bytes exhausted (tried to allocate 12288 bytes) in Command line code on line 1
```
We shouldn't suppress this issue (since it's a valid one) and we cannot handle the case when `false` is returned (because there's no way to test it), hence the assertion.