### PR TITLE
[Mysql] ignore index length for spatial indexes

### DIFF
--- a/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php
@@ -91,7 +91,10 @@ class MySqlSchemaManager extends AbstractSchemaManager
                 $v['flags'] = ['SPATIAL'];
             }
 
-            $v['length'] = isset($v['sub_part']) ? (int) $v['sub_part'] : null;
+            // Ignore prohibited prefix `length` for spatial index
+            if (strpos($v['index_type'], 'SPATIAL') === false) {
+                $v['length'] = isset($v['sub_part']) ? (int) $v['sub_part'] : null;
+            }
 
             $tableIndexes[$k] = $v;
         }

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/MySqlSchemaManagerTest.php
@@ -111,6 +111,7 @@ class MySqlSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $indexes = $this->schemaManager->listTableIndexes('spatial_index');
         self::assertArrayHasKey('s_index', $indexes);
         self::assertTrue($indexes['s_index']->hasFlag('spatial'));
+        self::assertSame([0 => null], $indexes['s_index']->getOption('lengths'));
     }
 
     public function testIndexWithLength(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3561

#### Summary

Skips index length option for SPATIAL index on MySql (cf initial issue and this PR #3970 for more details)
