### PR TITLE
Suppress Psalm issues regarding mysqli_init()

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -340,6 +340,10 @@
                 -->
                 <file name="lib/Doctrine/DBAL/Tools/Console/ConsoleRunner.php"/>
                 <file name="tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php"/>
+                <!--
+                    See https://github.com/vimeo/psalm/issues/5305
+                -->
+                <file name="lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php"/>
             </errorLevel>
         </RedundantConditionGivenDocblockType>
         <ReferenceConstraintViolation>


### PR DESCRIPTION
The Psalm build is currently [failing](https://github.com/doctrine/dbal/runs/2009509433) on CI because #4513 wasn't rebased on top of #4524 before the merge. The Psalm issue is reported as https://github.com/vimeo/psalm/issues/5305.