### PR TITLE
Deprecate Connection::getExpressionBuilder()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,13 +2,13 @@
 
 ## Deprecated `Connection::$_schemaManager` and `Connection::getSchemaManager()` 
 
-The usage of `Connection::$_schemaManager` and `Connection::getSchemaManager()` are deprecated.
+The usage of `Connection::$_schemaManager` and `Connection::getSchemaManager()` is deprecated.
 Use `Connection::createSchemaManager()` instead.
 
-## Deprecated `Connection::$_expr`
+## Deprecated `Connection::$_expr` and `Connection::getExpressionBuilder()`
 
-The usage of `Connection::$_expr` by extending classes is deprecated. Use `Connection::getExpressionBuilder()` instead.
-Do not rely on the same builder instance being returned by each invocation.
+The usage of `Connection::$_expr` and `Connection::getExpressionBuilder()` is deprecated.
+Use `Connection::createExpressionBuilder()` instead.
 
 # Upgrade to 3.0
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -193,7 +193,7 @@ class Connection
         $this->_config       = $config;
         $this->_eventManager = $eventManager;
 
-        $this->_expr = new Query\Expression\ExpressionBuilder($this);
+        $this->_expr = $this->createExpressionBuilder();
 
         $this->autoCommit = $config->getAutoCommit();
     }
@@ -280,7 +280,17 @@ class Connection
     }
 
     /**
+     * Creates an expression builder for the connection.
+     */
+    public function createExpressionBuilder(): ExpressionBuilder
+    {
+        return new ExpressionBuilder($this);
+    }
+
+    /**
      * Gets the ExpressionBuilder for the connection.
+     *
+     * @deprecated Use {@link createExpressionBuilder()} instead.
      *
      * @return ExpressionBuilder
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

See https://github.com/doctrine/dbal/pull/4517, https://github.com/doctrine/dbal/pull/4518#issuecomment-787209557.