### PR TITLE
Improve forward compatibility between 2.x and 3.0

### DIFF
--- a/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
+++ b/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Doctrine\DBAL\ForwardCompatibility;
+
+use Doctrine\DBAL\Driver\ResultStatement as DriverResultStatement;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Exception\NoKeyValue;
+use Doctrine\DBAL\Result as BaseResult;
+use IteratorAggregate;
+use PDO;
+use Traversable;
+
+use function array_shift;
+use function method_exists;
+
+/**
+ * A wrapper around a Doctrine\DBAL\Driver\ResultStatement that adds 3.0 features
+ * defined in Result interface
+ */
+class Result implements IteratorAggregate, DriverResultStatement, BaseResult
+{
+    /** @var DriverResultStatement */
+    private $stmt;
+
+    public function __construct(DriverResultStatement $stmt)
+    {
+        $this->stmt = $stmt;
+    }
+
+    /**
+     * @return DriverResultStatement
+     */
+    public function getIterator()
+    {
+        return $this->stmt;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function closeCursor()
+    {
+        return $this->stmt->closeCursor();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function columnCount()
+    {
+        return $this->stmt->columnCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
+    {
+        return $this->stmt->setFetchMode($fetchMode, $arg2, $arg3);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetch($fetchMode = null, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
+    {
+        return $this->stmt->fetch($fetchMode, $cursorOrientation, $cursorOffset);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
+    {
+        return $this->stmt->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchColumn($columnIndex = 0)
+    {
+        return $this->stmt->fetchColumn($columnIndex);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchNumeric()
+    {
+        return $this->stmt->fetch(PDO::FETCH_NUM);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchAssociative()
+    {
+        return $this->stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchOne()
+    {
+        $row = $this->fetchNumeric();
+
+        if ($row === false) {
+            return false;
+        }
+
+        return $row[0];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchAllNumeric(): array
+    {
+        $rows = [];
+
+        while (($row = $this->fetchNumeric()) !== false) {
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchAllAssociative(): array
+    {
+        $rows = [];
+
+        while (($row = $this->fetchAssociative()) !== false) {
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchAllKeyValue(): array
+    {
+        $this->ensureHasKeyValue();
+        $data = [];
+
+        foreach ($this->fetchAllNumeric() as [$key, $value]) {
+            $data[$key] = $value;
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchAllAssociativeIndexed(): array
+    {
+        $data = [];
+
+        foreach ($this->fetchAllAssociative() as $row) {
+            $data[array_shift($row)] = $row;
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fetchFirstColumn(): array
+    {
+        $rows = [];
+
+        while (($row = $this->fetchOne()) !== false) {
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return Traversable<int,array<int,mixed>>
+     */
+    public function iterateNumeric(): Traversable
+    {
+        while (($row = $this->fetchNumeric()) !== false) {
+            yield $row;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Traversable<int,array<string,mixed>>
+     */
+    public function iterateAssociative(): Traversable
+    {
+        while (($row = $this->fetchAssociative()) !== false) {
+            yield $row;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Traversable<mixed,mixed>
+     */
+    public function iterateKeyValue(): Traversable
+    {
+        $this->ensureHasKeyValue();
+
+        foreach ($this->iterateNumeric() as [$key, $value]) {
+            yield $key => $value;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Traversable<mixed,array<string,mixed>>
+     */
+    public function iterateAssociativeIndexed(): Traversable
+    {
+        foreach ($this->iterateAssociative() as $row) {
+            yield array_shift($row) => $row;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Traversable<int,mixed>
+     */
+    public function iterateColumn(): Traversable
+    {
+        while (($value = $this->fetchOne()) !== false) {
+            yield $value;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function rowCount()
+    {
+        if (method_exists($this->stmt, 'rowCount')) {
+            return $this->stmt->rowCount();
+        }
+
+        throw Exception::notSupported('rowCount');
+    }
+
+    public function free(): void
+    {
+        $this->closeCursor();
+    }
+
+    private function ensureHasKeyValue(): void
+    {
+        $columnCount = $this->columnCount();
+
+        if ($columnCount < 2) {
+            throw NoKeyValue::fromColumnCount($columnCount);
+        }
+    }
+}

--- a/lib/Doctrine/DBAL/Portability/Connection.php
+++ b/lib/Doctrine/DBAL/Portability/Connection.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\ColumnCase;
 use Doctrine\DBAL\Connection as BaseConnection;
 use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
+use Doctrine\DBAL\ForwardCompatibility;
 use PDO;
 
 use function func_get_args;
@@ -96,7 +97,7 @@ class Connection extends BaseConnection
         $stmt = new Statement(parent::executeQuery($sql, $params, $types, $qcp), $this);
         $stmt->setFetchMode($this->defaultFetchMode);
 
-        return $stmt;
+        return new ForwardCompatibility\Result($stmt);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Result.php
+++ b/lib/Doctrine/DBAL/Result.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Doctrine\DBAL;
+
+use Doctrine\DBAL\Driver\Exception;
+use Traversable;
+
+/**
+ * This interfaces contains methods allowing forward compatibility with v3.0 Result
+ *
+ * @see https://github.com/doctrine/dbal/blob/3.0.x/src/Result.php
+ */
+interface Result extends Abstraction\Result
+{
+    /**
+     * Returns an array containing the values of the first column of the result.
+     *
+     * @return array<mixed,mixed>
+     *
+     * @throws Exception
+     */
+    public function fetchAllKeyValue(): array;
+
+    /**
+     * Returns an associative array with the keys mapped to the first column and the values being
+     * an associative array representing the rest of the columns and their values.
+     *
+     * @return array<mixed,array<string,mixed>>
+     *
+     * @throws Exception
+     */
+    public function fetchAllAssociativeIndexed(): array;
+
+    /**
+     * Returns an iterator over the result set with the values of the first column of the result
+     *
+     * @return Traversable<mixed,mixed>
+     *
+     * @throws Exception
+     */
+    public function iterateKeyValue(): Traversable;
+
+    /**
+     * Returns an iterator over the result set with the keys mapped to the first column and the values being
+     * an associative array representing the rest of the columns and their values.
+     *
+     * @return Traversable<mixed,array<string,mixed>>
+     *
+     * @throws Exception
+     */
+    public function iterateAssociativeIndexed(): Traversable;
+}

--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -4,7 +4,6 @@ namespace Doctrine\Tests\DBAL;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\EventManager;
-use Doctrine\DBAL\Cache\ArrayStatement;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
@@ -22,6 +21,7 @@ use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\DBAL\Logging\EchoSQLLogger;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Result;
 use Doctrine\Tests\DbalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
@@ -778,11 +778,11 @@ EOF
             ->will($this->returnValue(['cacheKey', 'realKey']));
 
         $driver = $this->createMock(Driver::class);
+        $result = (new Connection($this->params, $driver))
+            ->executeCacheQuery($query, $params, $types, $queryCacheProfileMock);
 
-        self::assertInstanceOf(
-            ArrayStatement::class,
-            (new Connection($this->params, $driver))->executeCacheQuery($query, $params, $types, $queryCacheProfileMock)
-        );
+        self::assertInstanceOf(Driver\ResultStatement::class, $result);
+        self::assertInstanceOf(Result::class, $result);
     }
 
     public function testShouldNotPassPlatformInParamsToTheQueryCacheProfileInExecuteCacheQuery(): void

--- a/tests/Doctrine/Tests/DBAL/ForwardCompatibility/ResultTest.php
+++ b/tests/Doctrine/Tests/DBAL/ForwardCompatibility/ResultTest.php
@@ -1,0 +1,349 @@
+<?php
+
+namespace Doctrine\Tests\DBAL\ForwardCompatibility;
+
+use Doctrine\DBAL\Cache\ArrayStatement;
+use Doctrine\DBAL\Driver\ResultStatement as DriverResultStatement;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\ForwardCompatibility\Result;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Traversable;
+
+use function iterator_to_array;
+
+class ResultTest extends TestCase
+{
+    /** @var Result */
+    private $instance;
+
+    public function setUp(): void
+    {
+        $this->instance = new Result(
+            new ArrayStatement([
+                [
+                    'row1col1' => 'row1col1value',
+                    'row1col2' => 'row1col2value',
+                    'row1col3' => 'row1col3value',
+                ],
+                [
+                    'row2col1' => 'row2col1value',
+                    'row2col2' => 'row2col2value',
+                    'row2col3' => 'row2col3value',
+                ],
+                [
+                    'row3col1' => 'row3col1value',
+                    'row3col2' => 'row3col2value',
+                    'row3col3' => 'row3col3value',
+                ],
+            ])
+        );
+    }
+
+    public function testIsTraversable(): void
+    {
+        $this->instance->setFetchMode(PDO::FETCH_ASSOC);
+
+        $data = [];
+
+        foreach ($this->instance as $row) {
+            $data[] = $row;
+        }
+
+        $this->assertInstanceOf(Traversable::class, $this->instance);
+        $this->assertSame(
+            [
+                [
+                    'row1col1' => 'row1col1value',
+                    'row1col2' => 'row1col2value',
+                    'row1col3' => 'row1col3value',
+                ],
+                [
+                    'row2col1' => 'row2col1value',
+                    'row2col2' => 'row2col2value',
+                    'row2col3' => 'row2col3value',
+                ],
+                [
+                    'row3col1' => 'row3col1value',
+                    'row3col2' => 'row3col2value',
+                    'row3col3' => 'row3col3value',
+                ],
+            ],
+            $data
+        );
+    }
+
+    public function testFetchWithPdoAssoc(): void
+    {
+        $this->assertSame(
+            [
+                'row1col1' => 'row1col1value',
+                'row1col2' => 'row1col2value',
+                'row1col3' => 'row1col3value',
+            ],
+            $this->instance->fetch(PDO::FETCH_ASSOC)
+        );
+    }
+
+    public function testFetchAllWithPdoAssoc(): void
+    {
+        $this->assertSame(
+            [
+                [
+                    'row1col1' => 'row1col1value',
+                    'row1col2' => 'row1col2value',
+                    'row1col3' => 'row1col3value',
+                ],
+                [
+                    'row2col1' => 'row2col1value',
+                    'row2col2' => 'row2col2value',
+                    'row2col3' => 'row2col3value',
+                ],
+                [
+                    'row3col1' => 'row3col1value',
+                    'row3col2' => 'row3col2value',
+                    'row3col3' => 'row3col3value',
+                ],
+            ],
+            $this->instance->fetchAll(PDO::FETCH_ASSOC)
+        );
+    }
+
+    public function testFetchColumn(): void
+    {
+        $this->assertSame(
+            'row1col2value',
+            $this->instance->fetchColumn(1)
+        );
+    }
+
+    public function testFetchNumeric(): void
+    {
+        $this->assertSame(
+            [
+                'row1col1value',
+                'row1col2value',
+                'row1col3value',
+            ],
+            $this->instance->fetchNumeric()
+        );
+    }
+
+    public function testFetchAssociative(): void
+    {
+        $this->assertSame(
+            [
+                'row1col1' => 'row1col1value',
+                'row1col2' => 'row1col2value',
+                'row1col3' => 'row1col3value',
+            ],
+            $this->instance->fetchAssociative()
+        );
+    }
+
+    public function testFetchOne(): void
+    {
+        $this->assertSame(
+            'row1col1value',
+            $this->instance->fetchOne()
+        );
+    }
+
+    public function testAllNumeric(): void
+    {
+        $this->assertSame(
+            [
+                [
+                    'row1col1value',
+                    'row1col2value',
+                    'row1col3value',
+                ],
+                [
+                    'row2col1value',
+                    'row2col2value',
+                    'row2col3value',
+                ],
+                [
+                    'row3col1value',
+                    'row3col2value',
+                    'row3col3value',
+                ],
+            ],
+            $this->instance->fetchAllNumeric()
+        );
+    }
+
+    public function testAllAssociative(): void
+    {
+        $this->assertSame(
+            [
+                [
+                    'row1col1' => 'row1col1value',
+                    'row1col2' => 'row1col2value',
+                    'row1col3' => 'row1col3value',
+                ],
+                [
+                    'row2col1' => 'row2col1value',
+                    'row2col2' => 'row2col2value',
+                    'row2col3' => 'row2col3value',
+                ],
+                [
+                    'row3col1' => 'row3col1value',
+                    'row3col2' => 'row3col2value',
+                    'row3col3' => 'row3col3value',
+                ],
+            ],
+            $this->instance->fetchAllAssociative()
+        );
+    }
+
+    public function testFetchAllKeyValue(): void
+    {
+        $this->assertSame(
+            [
+                'row1col1value' => 'row1col2value',
+                'row2col1value' => 'row2col2value',
+                'row3col1value' => 'row3col2value',
+            ],
+            $this->instance->fetchAllKeyValue()
+        );
+    }
+
+    public function testFetchAllAssociativeIndexed(): void
+    {
+        $this->assertSame(
+            [
+                'row1col1value' => [
+                    'row1col2' => 'row1col2value',
+                    'row1col3' => 'row1col3value',
+                ],
+                'row2col1value' => [
+                    'row2col2' => 'row2col2value',
+                    'row2col3' => 'row2col3value',
+                ],
+                'row3col1value' => [
+                    'row3col2' => 'row3col2value',
+                    'row3col3' => 'row3col3value',
+                ],
+            ],
+            $this->instance->fetchAllAssociativeIndexed()
+        );
+    }
+
+    public function testFetchFirstColumn(): void
+    {
+        $this->assertSame(
+            [
+                'row1col1value',
+                'row2col1value',
+                'row3col1value',
+            ],
+            $this->instance->fetchFirstColumn()
+        );
+    }
+
+    public function testIterateNumeric(): void
+    {
+        $this->assertSame(
+            [
+                [
+                    0 => 'row1col1value',
+                    1 => 'row1col2value',
+                    2 => 'row1col3value',
+                ],
+                [
+                    0 => 'row2col1value',
+                    1 => 'row2col2value',
+                    2 => 'row2col3value',
+                ],
+                [
+                    0 => 'row3col1value',
+                    1 => 'row3col2value',
+                    2 => 'row3col3value',
+                ],
+            ],
+            iterator_to_array($this->instance->iterateNumeric())
+        );
+    }
+
+    public function testIterateAssociative(): void
+    {
+        $this->assertSame(
+            [
+                [
+                    'row1col1' => 'row1col1value',
+                    'row1col2' => 'row1col2value',
+                    'row1col3' => 'row1col3value',
+                ],
+                [
+                    'row2col1' => 'row2col1value',
+                    'row2col2' => 'row2col2value',
+                    'row2col3' => 'row2col3value',
+                ],
+                [
+                    'row3col1' => 'row3col1value',
+                    'row3col2' => 'row3col2value',
+                    'row3col3' => 'row3col3value',
+                ],
+            ],
+            iterator_to_array($this->instance->iterateAssociative())
+        );
+    }
+
+    public function testIterateKeyValue(): void
+    {
+        $this->assertSame(
+            [
+                'row1col1value' => 'row1col2value',
+                'row2col1value' => 'row2col2value',
+                'row3col1value' => 'row3col2value',
+            ],
+            iterator_to_array($this->instance->iterateKeyValue())
+        );
+    }
+
+    public function testIterateAssociativeIndexed(): void
+    {
+        $this->assertSame(
+            [
+                'row1col1value' => [
+                    'row1col2' => 'row1col2value',
+                    'row1col3' => 'row1col3value',
+                ],
+                'row2col1value' => [
+                    'row2col2' => 'row2col2value',
+                    'row2col3' => 'row2col3value',
+                ],
+                'row3col1value' => [
+                    'row3col2' => 'row3col2value',
+                    'row3col3' => 'row3col3value',
+                ],
+            ],
+            iterator_to_array($this->instance->iterateAssociativeIndexed())
+        );
+    }
+
+    public function testIterateColumn(): void
+    {
+        $this->assertSame(
+            [
+                'row1col1value',
+                'row2col1value',
+                'row3col1value',
+            ],
+            iterator_to_array($this->instance->iterateColumn())
+        );
+    }
+
+    public function testRowCountIsSupportedByWrappedStatement(): void
+    {
+        $this->assertSame(3, $this->instance->rowCount());
+    }
+
+    public function testRowCountIsNotSupportedByWrappedStatement(): void
+    {
+        $this->expectExceptionObject(Exception::notSupported('rowCount'));
+        $instance = new Result($this->createMock(DriverResultStatement::class));
+        $instance->rowCount();
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/Connection.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/Connection.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional\Connection\BackwardCompatibility;
 
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection as BaseConnection;
+use Doctrine\DBAL\ForwardCompatibility;
 
 use function func_get_args;
 
@@ -17,7 +18,9 @@ class Connection extends BaseConnection
      */
     public function executeQuery($sql, array $params = [], $types = [], ?QueryCacheProfile $qcp = null)
     {
-        return new Statement(parent::executeQuery($sql, $params, $types, $qcp));
+        return new ForwardCompatibility\Result(
+            new Statement(parent::executeQuery($sql, $params, $types, $qcp))
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ResultCacheTest.php
@@ -4,8 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
-use Doctrine\DBAL\Cache\ResultCacheStatement;
-use Doctrine\DBAL\Driver\ResultStatement;
+use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\DBAL\Schema\Table;
@@ -238,25 +237,25 @@ class ResultCacheTest extends DbalFunctionalTestCase
     public static function fetchAllProvider(): iterable
     {
         yield 'fetchAll' => [
-            static function (ResultCacheStatement $statement): void {
+            static function (Driver\ResultStatement $statement): void {
                 $statement->fetchAll();
             },
         ];
 
         yield 'fetchAllAssociative' => [
-            static function (ResultCacheStatement $statement): void {
+            static function (Driver\Result $statement): void {
                 $statement->fetchAllAssociative();
             },
         ];
 
         yield 'fetchAllNumeric' => [
-            static function (ResultCacheStatement $statement): void {
+            static function (Driver\Result $statement): void {
                 $statement->fetchAllNumeric();
             },
         ];
 
         yield 'fetchFirstColumn' => [
-            static function (ResultCacheStatement $result): void {
+            static function (Driver\Result $result): void {
                 $result->fetchFirstColumn();
             },
         ];
@@ -358,7 +357,7 @@ class ResultCacheTest extends DbalFunctionalTestCase
     /**
      * @return array<int, mixed>
      */
-    private function hydrateStmt(ResultStatement $stmt, int $fetchMode = FetchMode::ASSOCIATIVE): array
+    private function hydrateStmt(Driver\ResultStatement $stmt, int $fetchMode = FetchMode::ASSOCIATIVE): array
     {
         $data = [];
 
@@ -372,7 +371,7 @@ class ResultCacheTest extends DbalFunctionalTestCase
     /**
      * @return array<int, mixed>
      */
-    private function hydrateStmtIterator(ResultStatement $stmt, int $fetchMode = FetchMode::ASSOCIATIVE): array
+    private function hydrateStmtIterator(Driver\ResultStatement $stmt, int $fetchMode = FetchMode::ASSOCIATIVE): array
     {
         $data = [];
         $stmt->setFetchMode($fetchMode);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #4280

#### Summary

The current Doctrine\DBAL\Connection executeQuery(...) and executeCacheQuery() return a ResultStatement interface object. This PR try to improve forward compatibility between v2.x & v3.0 by adding some of missing features to Result returned by Connection :
- fetchNumeric()
- fetchAssociative()
- fetchOne()
- fetchAllNumeric()
- fetchAllAssociative()
- fetchAllKeyValue()
- fetchAllAssociativeIndexed()
- fetchFirstColumn()
- iterateNumeric()
- iterateAssociative()
- iterateKeyValue()
- iterateAssociativeIndexed()
- iterateColumn()
- rowCount()
- columnCount()
- free()

I used this version as reference : https://github.com/doctrine/dbal/blob/3.0.x/src/Result.php 

#### Examples

##### Static analysis error
Here under, methods which throw a static analysis error in phpstan but actually work. This is all methods defined in Abstraction\Result interface :

```php
/** @var Doctrine\DBAL\Connection $connection */
$connection->executeQuery('SELECT "something"')->fetchNumeric();
$connection->executeQuery('SELECT "something"')->fetchAssociative();
$connection->executeQuery('SELECT "something"')->fetchOne();
$connection->executeQuery('SELECT "something"')->fetchAllNumeric();
$connection->executeQuery('SELECT "something"')->fetchAllAssociative();
$connection->executeQuery('SELECT "something"')->fetchFirstColumn();
$connection->executeQuery('SELECT "something"')->iterateNumeric();
$connection->executeQuery('SELECT "something"')->iterateAssociative();
$connection->executeQuery('SELECT "something"')->iterateNumeric();
$connection->executeQuery('SELECT "something"')->iterateColumn();
```

The outpout pattern when running phpstan is the following :
```text
Call to an undefined method Doctrine\DBAL\Driver\ResultStatement::fetchOne().
```

#### Not available methods
Here under, methods which throw undefined method fatal & static analyse errors. This is all methods added in Abstraction\V3Result interface :

```php
$connection->executeQuery('SELECT "something"')->fetchAllKeyValue();
$connection->executeQuery('SELECT "something"')->fetchAllAssociativeIndexed();
$connection->executeQuery('SELECT "something"')->iterateKeyValue();
$connection->executeQuery('SELECT "something"')->iterateAssociativeIndexed();
```

The output pattern when trying to use one of those methods :
```text
Fatal error: Uncaught Error: Call to undefined method Doctrine\DBAL\Driver\PDO\Statement::fetchAllKeyValue() in /var/www/test.php on line 41

Error: Call to undefined method Doctrine\DBAL\Driver\PDO\Statement::fetchAllKeyValue() in /var/www/test.php on line 41

Call Stack:
    0.0006     415576   1. {main}() /var/www/test.php:0
```

#### Implementation key points

The strategy is to :
- Add a new interfaces with missing V3 Result features
- Make Connection return an object implementing ResultStatement & V3Result interfaces
