### PR TITLE
Deprecate Statement::bindParam($driverOptions)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,11 @@
 # Upgrade to 3.1
 
-## Deprecated `Connection::$_schemaManager` and `Connection::getSchemaManager()` 
+## Deprecated `$driverOptions` argument of `PDO\Statement::bindParam()` and `PDO\SQLSrv\Statement::bindParam()`
+
+The usage of the `$driverOptions` argument of `PDO\Statement::bindParam()` and `PDO\SQLSrv\Statement::bindParam()` is deprecated.
+To define parameter binding type as `ASCII`, `BINARY` or `BLOB`, use the corresponding `ParameterType::*` constant.
+
+## Deprecated `Connection::$_schemaManager` and `Connection::getSchemaManager()`
 
 The usage of `Connection::$_schemaManager` and `Connection::getSchemaManager()` is deprecated.
 Use `Connection::createSchemaManager()` instead.
@@ -484,7 +489,7 @@ Code that extends either of the classes needs to be adjusted in order to functio
 
 # Upgrade to 2.11
 
-## Deprecated `Abstraction\Result` 
+## Deprecated `Abstraction\Result`
 
 The usage of the `Doctrine\DBAL\Abstraction\Result` interface is deprecated. In DBAL 3.0, the statement result at the wrapper level will be represented by the `Doctrine\DBAL\Result` class.
 
@@ -503,9 +508,9 @@ The usage of the wrapper `Connection` and `Statement` classes as implementations
 
 ## Deprecations in the wrapper `Connection` class
 
-1. The `executeUpdate()` method has been deprecated in favor of `executeStatement()`. 
-2. The `query()` method has been deprecated in favor of `executeQuery()`. 
-3. The `exec()` method has been deprecated in favor of `executeStatement()`. 
+1. The `executeUpdate()` method has been deprecated in favor of `executeStatement()`.
+2. The `query()` method has been deprecated in favor of `executeQuery()`.
+3. The `exec()` method has been deprecated in favor of `executeStatement()`.
 
 Note that `PrimaryReplicaConnection::query()` ensures connection to the primary instance while `executeQuery()` doesn't.
 
@@ -620,7 +625,7 @@ Consumers of the Connection class should not rely on connection parameters store
 ## Deprecated `Portability\Connection::PORTABILITY_{PLATFORM}` constants
 
 The platform-specific portability mode flags are meant to be used only by the portability layer internally to optimize
-the user-provided mode for the current database platform. 
+the user-provided mode for the current database platform.
 
 ## Deprecated `MasterSlaveConnection` use `PrimaryReadReplicaConnection`
 

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -28,7 +28,7 @@ final class Statement implements StatementInterface
      * @param mixed      $variable
      * @param int        $type
      * @param int|null   $length
-     * @param mixed      $driverOptions
+     * @param mixed      $driverOptions The usage of the argument is deprecated.
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null, $driverOptions = null)
     {

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -58,7 +58,7 @@ final class Statement implements StatementInterface
      * @param mixed    $variable
      * @param int      $type
      * @param int|null $length
-     * @param mixed    $driverOptions
+     * @param mixed    $driverOptions The usage of the argument is deprecated.
      *
      * @return bool
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

See https://github.com/doctrine/dbal/issues/4533.

The parameter is only supported by the PDO-based drivers and only at the driver level. It's usage in PDO is barely [documented](https://www.php.net/manual/en/pdostatement.bindparam#refsect1-pdostatement.bindparam-parameters). The usage of the parameter is not covered by the existing tests.