### PR TITLE
Deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "php": "^7.3 || ^8",
         "ext-pdo": "*",
         "doctrine/cache": "^1.0",
+        "doctrine/deprecations": "^0.5.3",
         "doctrine/event-manager": "^1.0"
     },
     "require-dev": {

--- a/lib/Doctrine/DBAL/Configuration.php
+++ b/lib/Doctrine/DBAL/Configuration.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\DBAL\Schema\AbstractAsset;
+use Doctrine\Deprecations\Deprecation;
 
 use function preg_match;
 
@@ -79,6 +80,12 @@ class Configuration
      */
     public function setFilterSchemaAssetsExpression($filterExpression)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3316',
+            'Configuration::setFilterSchemaAssetsExpression() is deprecated, use setSchemaAssetsFilter() instead.'
+        );
+
         $this->_attributes['filterSchemaAssetsExpression'] = $filterExpression;
         if ($filterExpression) {
             $this->_attributes['filterSchemaAssetsExpressionCallable']
@@ -97,6 +104,12 @@ class Configuration
      */
     public function getFilterSchemaAssetsExpression()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3316',
+            'Configuration::getFilterSchemaAssetsExpression() is deprecated, use getSchemaAssetsFilter() instead.'
+        );
+
         return $this->_attributes['filterSchemaAssetsExpression'] ?? null;
     }
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -2142,6 +2142,12 @@ class Connection implements DriverConnection
      */
     public function ping()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4119',
+            'Retry and reconnecting lost connections now happens automatically, ping() will be removed in DBAL 3.'
+        );
+
         $connection = $this->getWrappedConnection();
 
         if ($connection instanceof PingableConnection) {

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1582,6 +1582,12 @@ class Connection implements DriverConnection
      */
     public function errorCode()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3507',
+            'Connection::errorCode() is deprecated, use getCode() or getSQLState() on Exception instead.'
+        );
+
         return $this->getWrappedConnection()->errorCode();
     }
 
@@ -1592,6 +1598,12 @@ class Connection implements DriverConnection
      */
     public function errorInfo()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3507',
+            'Connection::errorInfo() is deprecated, use getCode() or getSQLState() on Exception instead.'
+        );
+
         return $this->getWrappedConnection()->errorInfo();
     }
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1376,6 +1376,12 @@ class Connection implements DriverConnection
      */
     public function project($sql, array $params, Closure $function)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3823',
+            'Connection::project() is deprecated without replacement, implement data projections in your own code.'
+        );
+
         $result = [];
         $stmt   = $this->executeQuery($sql, $params);
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 use Throwable;
 use Traversable;
 
@@ -542,6 +543,12 @@ class Connection implements DriverConnection
      */
     public function setFetchMode($fetchMode)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Default Fetch Mode configuration is deprecated, use explicit Connection::fetch*() APIs instead.'
+        );
+
         $this->defaultFetchMode = $fetchMode;
     }
 
@@ -561,6 +568,12 @@ class Connection implements DriverConnection
      */
     public function fetchAssoc($sql, array $params = [], array $types = [])
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Connection::fetchAssoc() is deprecated, use Connection::fetchAssociative() API instead.'
+        );
+
         return $this->executeQuery($sql, $params, $types)->fetch(FetchMode::ASSOCIATIVE);
     }
 
@@ -578,6 +591,12 @@ class Connection implements DriverConnection
      */
     public function fetchArray($sql, array $params = [], array $types = [])
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Connection::fetchArray() is deprecated, use Connection::fetchNumeric() API instead.'
+        );
+
         return $this->executeQuery($sql, $params, $types)->fetch(FetchMode::NUMERIC);
     }
 
@@ -598,6 +617,12 @@ class Connection implements DriverConnection
      */
     public function fetchColumn($sql, array $params = [], $column = 0, array $types = [])
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Connection::fetchColumn() is deprecated, use Connection::fetchOne() API instead.'
+        );
+
         return $this->executeQuery($sql, $params, $types)->fetchColumn($column);
     }
 

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -1399,6 +1399,12 @@ class Connection implements DriverConnection
      */
     public function query()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4163',
+            'Connection::query() is deprecated, use Connection::executeQuery() instead.'
+        );
+
         $connection = $this->getWrappedConnection();
 
         $args = func_get_args();
@@ -1441,6 +1447,12 @@ class Connection implements DriverConnection
      */
     public function executeUpdate($sql, array $params = [], array $types = [])
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4163',
+            'Connection::executeUpdate() is deprecated, use Connection::executeStatement() instead.'
+        );
+
         return $this->executeStatement($sql, $params, $types);
     }
 
@@ -1519,6 +1531,12 @@ class Connection implements DriverConnection
      */
     public function exec($sql)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4163',
+            'Connection::exec() is deprecated, use Connection::executeStatement() instead.'
+        );
+
         $connection = $this->getWrappedConnection();
 
         $logger = $this->_config->getSQLLogger();

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -258,6 +258,13 @@ class Connection implements DriverConnection
      */
     public function getHost()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Connection::getHost() is deprecated, get the database server host from application config ' .
+            'or as a last resort from internal Connection::getParams() API.'
+        );
+
         return $this->params['host'] ?? null;
     }
 
@@ -270,6 +277,13 @@ class Connection implements DriverConnection
      */
     public function getPort()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Connection::getPort() is deprecated, get the database server port from application config ' .
+            'or as a last resort from internal Connection::getParams() API.'
+        );
+
         return $this->params['port'] ?? null;
     }
 
@@ -282,6 +296,13 @@ class Connection implements DriverConnection
      */
     public function getUsername()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Connection::getUsername() is deprecated, get the username from application config ' .
+            'or as a last resort from internal Connection::getParams() API.'
+        );
+
         return $this->params['user'] ?? null;
     }
 
@@ -294,6 +315,13 @@ class Connection implements DriverConnection
      */
     public function getPassword()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Connection::getPassword() is deprecated, get the password from application config ' .
+            'or as a last resort from internal Connection::getParams() API.'
+        );
+
         return $this->params['password'] ?? null;
     }
 

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -5,12 +5,8 @@ namespace Doctrine\DBAL\Connections;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Driver;
+use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
-
-use function sprintf;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 /**
  * @deprecated Use PrimaryReadReplicaConnection instead
@@ -94,13 +90,12 @@ class MasterSlaveConnection extends PrimaryReadReplicaConnection
 
     private function deprecated(string $thing, string $instead): void
     {
-        @trigger_error(
-            sprintf(
-                '%s is deprecated since doctrine/dbal 2.11 and will be removed in 3.0, use %s instead.',
-                $thing,
-                $instead
-            ),
-            E_USER_DEPRECATED
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4054',
+            '%s is deprecated since doctrine/dbal 2.11 and will be removed in 3.0, use %s instead.',
+            $thing,
+            $instead
         );
     }
 }

--- a/lib/Doctrine/DBAL/Driver/AbstractException.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver;
 
+use Doctrine\Deprecations\Deprecation;
 use Exception as BaseException;
 
 /**
@@ -47,6 +48,13 @@ abstract class AbstractException extends BaseException implements DriverExceptio
      */
     public function getErrorCode()
     {
+        /** @psalm-suppress ImpureMethodCall */
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4112',
+            'Driver\AbstractException::getErrorCode() is deprecated, use getSQLState() or getCode() instead.'
+        );
+
         return $this->errorCode;
     }
 

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionFailed;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\PrepareFailed;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use stdClass;
 
 use function assert;
@@ -82,6 +83,12 @@ class DB2Connection implements ConnectionInterface, ServerInfoAwareConnection
      */
     public function requiresQueryForServerVersion()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4114',
+            'ServerInfoAwareConnection::requiresQueryForServerVersion() is deprecated and removed in DBAL 3.'
+        );
+
         return false;
     }
 

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Driver.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Driver.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Driver\IBMDB2;
 
 use Doctrine\DBAL\Driver\AbstractDB2Driver;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * IBM DB2 Driver.
@@ -35,6 +36,12 @@ class DB2Driver extends AbstractDB2Driver
      */
     public function getName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Driver::getName() is deprecated'
+        );
+
         return 'ibm_db2';
     }
 }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Driver.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Exception;
+use Doctrine\Deprecations\Deprecation;
 
 class Driver extends AbstractMySQLDriver
 {
@@ -24,6 +25,12 @@ class Driver extends AbstractMySQLDriver
      */
     public function getName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Driver::getName() is deprecated'
+        );
+
         return 'mysqli';
     }
 }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\Mysqli\Exception\InvalidOption;
 use Doctrine\DBAL\Driver\PingableConnection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use mysqli;
 
 use function assert;
@@ -135,6 +136,12 @@ class MysqliConnection implements ConnectionInterface, PingableConnection, Serve
      */
     public function requiresQueryForServerVersion()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4114',
+            'ServerInfoAwareConnection::requiresQueryForServerVersion() is deprecated and removed in DBAL 3.'
+        );
+
         return false;
     }
 

--- a/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/Driver.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Driver\OCI8;
 
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
 use Doctrine\DBAL\Exception;
+use Doctrine\Deprecations\Deprecation;
 
 use const OCI_NO_AUTO_COMMIT;
 
@@ -50,6 +51,12 @@ class Driver extends AbstractOracleDriver
      */
     public function getName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Driver::getName() is deprecated'
+        );
+
         return 'oci8';
     }
 }

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\OCI8\Exception\SequenceDoesNotExist;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use UnexpectedValueException;
 
 use function addcslashes;
@@ -103,6 +104,12 @@ class OCI8Connection implements ConnectionInterface, ServerInfoAwareConnection
      */
     public function requiresQueryForServerVersion()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4114',
+            'ServerInfoAwareConnection::requiresQueryForServerVersion() is deprecated and removed in DBAL 3.'
+        );
+
         return false;
     }
 

--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\DBAL\Driver\PDO\Statement;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -113,6 +114,12 @@ class PDOConnection extends PDO implements ConnectionInterface, ServerInfoAwareC
      */
     public function requiresQueryForServerVersion()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4114',
+            'ServerInfoAwareConnection::requiresQueryForServerVersion() is deprecated and removed in DBAL 3.'
+        );
+
         return false;
     }
 

--- a/lib/Doctrine/DBAL/Driver/PDOException.php
+++ b/lib/Doctrine/DBAL/Driver/PDOException.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * @deprecated Use {@link Exception} instead
@@ -43,6 +44,13 @@ class PDOException extends \PDOException implements DriverException
      */
     public function getErrorCode()
     {
+        /** @psalm-suppress ImpureMethodCall */
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4112',
+            'Driver\AbstractException::getErrorCode() is deprecated, use getSQLState() or getCode() instead.'
+        );
+
         return $this->errorCode;
     }
 

--- a/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOIbm/Driver.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Driver\PDOIbm;
 
 use Doctrine\DBAL\Driver\AbstractDB2Driver;
 use Doctrine\DBAL\Driver\PDO\Connection;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Driver for the PDO IBM extension.
@@ -58,6 +59,12 @@ class Driver extends AbstractDB2Driver
      */
     public function getName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Driver::getName() is deprecated'
+        );
+
         return 'pdo_ibm';
     }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Driver\PDOMySql;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\Exception;
+use Doctrine\Deprecations\Deprecation;
 use PDOException;
 
 /**
@@ -73,6 +74,12 @@ class Driver extends AbstractMySQLDriver
      */
     public function getName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Driver::getName() is deprecated'
+        );
+
         return 'pdo_mysql';
     }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOOracle/Driver.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Driver\PDOOracle;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
 use Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\Exception;
+use Doctrine\Deprecations\Deprecation;
 use PDOException;
 
 /**
@@ -54,6 +55,12 @@ class Driver extends AbstractOracleDriver
      */
     public function getName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Driver::getName() is deprecated'
+        );
+
         return 'pdo_oracle';
     }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Driver\PDOPgSql;
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
 use Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\Exception;
+use Doctrine\Deprecations\Deprecation;
 use PDOException;
 
 use function defined;
@@ -116,6 +117,12 @@ class Driver extends AbstractPostgreSQLDriver
      */
     public function getName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Driver::getName() is deprecated'
+        );
+
         return 'pdo_pgsql';
     }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlite/Driver.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\Deprecations\Deprecation;
 use PDOException;
 
 use function array_merge;
@@ -81,6 +82,12 @@ class Driver extends AbstractSQLiteDriver
      */
     public function getName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Driver::getName() is deprecated'
+        );
+
         return 'pdo_sqlite';
     }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Driver.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Driver\PDOSqlsrv;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
 use Doctrine\DBAL\Driver\PDO;
+use Doctrine\Deprecations\Deprecation;
 
 use function is_int;
 use function sprintf;
@@ -95,6 +96,12 @@ class Driver extends AbstractSQLServerDriver
      */
     public function getName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Driver::getName() is deprecated'
+        );
+
         return 'pdo_sqlsrv';
     }
 }

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
 
@@ -13,10 +14,6 @@ use function array_slice;
 use function assert;
 use function func_get_args;
 use function is_array;
-use function sprintf;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 /**
  * The PDO implementation of the Statement interface.
@@ -274,10 +271,13 @@ class PDOStatement extends \PDOStatement implements StatementInterface, Result
     {
         if (! isset(self::PARAM_TYPE_MAP[$type])) {
             // TODO: next major: throw an exception
-            @trigger_error(sprintf(
-                'Using a PDO parameter type (%d given) is deprecated and will cause an error in Doctrine DBAL 3.0',
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/3088',
+                'Using a PDO parameter type (%d given) is deprecated, ' .
+                'use \Doctrine\DBAL\Types\Types constants instead.',
                 $type
-            ), E_USER_DEPRECATED);
+            );
 
             return $type;
         }
@@ -293,12 +293,13 @@ class PDOStatement extends \PDOStatement implements StatementInterface, Result
     private function convertFetchMode(int $fetchMode): int
     {
         if (! isset(self::FETCH_MODE_MAP[$fetchMode])) {
-            // TODO: next major: throw an exception
-            @trigger_error(sprintf(
-                'Using a PDO fetch mode or their combination (%d given)' .
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/3088',
+                'Using an unsupported PDO fetch mode or a bitmask of fetch modes (%d given)' .
                 ' is deprecated and will cause an error in Doctrine DBAL 3.0',
                 $fetchMode
-            ), E_USER_DEPRECATED);
+            );
 
             return $fetchMode;
         }

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Driver\SQLAnywhere;
 
 use Doctrine\DBAL\Driver\AbstractSQLAnywhereDriver;
 use Doctrine\DBAL\Exception;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_keys;
 use function array_map;
@@ -46,6 +47,12 @@ class Driver extends AbstractSQLAnywhereDriver
      */
     public function getName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Driver::getName() is deprecated'
+        );
+
         return 'sqlanywhere';
     }
 

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 use function func_get_args;
@@ -198,6 +199,12 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
      */
     public function requiresQueryForServerVersion()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4114',
+            'ServerInfoAwareConnection::requiresQueryForServerVersion() is deprecated and removed in DBAL 3.'
+        );
+
         return true;
     }
 

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/Driver.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Driver for ext/sqlsrv.
@@ -57,6 +58,12 @@ class Driver extends AbstractSQLServerDriver
      */
     public function getName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'Driver::getName() is deprecated'
+        );
+
         return 'sqlsrv';
     }
 }

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvConnection.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 
 use function func_get_args;
 use function is_float;
@@ -77,6 +78,12 @@ class SQLSrvConnection implements ConnectionInterface, ServerInfoAwareConnection
      */
     public function requiresQueryForServerVersion()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4114',
+            'ServerInfoAwareConnection::requiresQueryForServerVersion() is deprecated and removed in DBAL 3.'
+        );
+
         return false;
     }
 

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Driver\OCI8;
 use Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\Driver\SQLAnywhere;
 use Doctrine\DBAL\Driver\SQLSrv;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_keys;
 use function array_merge;
@@ -217,6 +218,12 @@ final class DriverManager
         }
 
         if (isset($params['pdo'])) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/3554',
+                'Passing a user provided PDO instance directly to Doctrine is deprecated.'
+            );
+
             $params['pdo']->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
             $params['driver'] = 'pdo_' . $params['pdo']->getAttribute(\PDO::ATTR_DRIVER_NAME);
         }

--- a/lib/Doctrine/DBAL/Event/ConnectionEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/ConnectionEventArgs.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Event Arguments used when a Driver connection is established inside {@link Connection}.
@@ -36,6 +37,13 @@ class ConnectionEventArgs extends EventArgs
      */
     public function getDriver()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'ConnectionEventArgs::getDriver() is deprecated, ' .
+            'use ConnectionEventArgs::getConnection()->getDriver() instead.'
+        );
+
         return $this->connection->getDriver();
     }
 
@@ -46,6 +54,13 @@ class ConnectionEventArgs extends EventArgs
      */
     public function getDatabasePlatform()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'ConnectionEventArgs::getDatabasePlatform() is deprecated, ' .
+            'use ConnectionEventArgs::getConnection()->getDatabasePlatform() instead.'
+        );
+
         return $this->connection->getDatabasePlatform();
     }
 
@@ -56,6 +71,13 @@ class ConnectionEventArgs extends EventArgs
      */
     public function getSchemaManager()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'ConnectionEventArgs::getSchemaManager() is deprecated, ' .
+            'use ConnectionEventArgs::getConnection()->getSchemaManager() instead.'
+        );
+
         return $this->connection->getSchemaManager();
     }
 }

--- a/lib/Doctrine/DBAL/Event/SchemaAlterTableAddColumnEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaAlterTableAddColumnEventArgs.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Event;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function func_get_args;
@@ -67,6 +68,15 @@ class SchemaAlterTableAddColumnEventArgs extends SchemaEventArgs
      */
     public function addSql($sql)
     {
+        if (is_array($sql)) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/3580',
+                'Passing multiple SQL statements as an array to SchemaAlterTableAddColumnEventaArrgs::addSql() ' .
+                'is deprecated. Pass each statement as an individual argument instead.'
+            );
+        }
+
         $this->sql = array_merge($this->sql, is_array($sql) ? $sql : func_get_args());
 
         return $this;

--- a/lib/Doctrine/DBAL/Event/SchemaColumnDefinitionEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaColumnDefinitionEventArgs.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Event;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Event Arguments used when the portable column definition is generated inside {@link AbstractPlatform}.
@@ -103,6 +104,13 @@ class SchemaColumnDefinitionEventArgs extends SchemaEventArgs
      */
     public function getDatabasePlatform()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'SchemaColumnDefinitionEventArgs::getDatabasePlatform() is deprecated, ' .
+            'use SchemaColumnDefinitionEventArgs::getConnection()->getDatabasePlatform() instead.'
+        );
+
         return $this->connection->getDatabasePlatform();
     }
 }

--- a/lib/Doctrine/DBAL/Event/SchemaIndexDefinitionEventArgs.php
+++ b/lib/Doctrine/DBAL/Event/SchemaIndexDefinitionEventArgs.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Event;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Event Arguments used when the portable index definition is generated inside {@link AbstractSchemaManager}.
@@ -83,10 +84,19 @@ class SchemaIndexDefinitionEventArgs extends SchemaEventArgs
     }
 
     /**
+     * @deprecated Use SchemaIndexDefinitionEventArgs::getConnection() and Connection::getDatabasePlatform() instead.
+     *
      * @return AbstractPlatform
      */
     public function getDatabasePlatform()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3580',
+            'SchemaIndexDefinitionEventArgs::getDatabasePlatform() is deprecated, ' .
+            'use SchemaIndexDefinitionEventArgs::getConnection()->getDatabasePlatform() instead.'
+        );
+
         return $this->connection->getDatabasePlatform();
     }
 }

--- a/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
+++ b/lib/Doctrine/DBAL/Logging/EchoSQLLogger.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Logging;
 
+use Doctrine\Deprecations\Deprecation;
+
 use function var_dump;
 
 use const PHP_EOL;
@@ -13,6 +15,15 @@ use const PHP_EOL;
  */
 class EchoSQLLogger implements SQLLogger
 {
+    public function __construct()
+    {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3935',
+            'EchoSQLLogger is deprecated without replacement, move the code into your project if you rely on it.'
+        );
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/lib/Doctrine/DBAL/Logging/LoggerChain.php
+++ b/lib/Doctrine/DBAL/Logging/LoggerChain.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Logging;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * Chains multiple SQLLogger.
  */
@@ -27,6 +29,12 @@ class LoggerChain implements SQLLogger
      */
     public function addLogger(SQLLogger $logger)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3572',
+            'LoggerChain::addLogger() is deprecated, use LoggerChain constructor instead.'
+        );
+
         $this->loggers[] = $logger;
     }
 

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3511,6 +3511,12 @@ abstract class AbstractPlatform
      */
     public function fixSchemaElementName($schemaElementName)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4132',
+            'AbstractPlatform::fixSchemaElementName is deprecated with no replacement and removed in DBAL 3.0'
+        );
+
         return $schemaElementName;
     }
 

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -2670,6 +2670,12 @@ abstract class AbstractPlatform
      */
     public function prefersSequences()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4229',
+            'AbstractPlatform::prefersSequences() is deprecated without replacement and removed in DBAL 3.0'
+        );
+
         return false;
     }
 
@@ -3241,6 +3247,12 @@ abstract class AbstractPlatform
      */
     public function supportsForeignKeyOnUpdate()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4229',
+            'AbstractPlatform::supportsForeignKeyOnUpdate() is deprecated without replacement and removed in DBAL 3.0'
+        );
+
         return $this->supportsForeignKeyConstraints();
     }
 
@@ -3496,6 +3508,13 @@ abstract class AbstractPlatform
      */
     public function getSQLResultCasing($column)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4229',
+            'AbstractPlatform::getSQLResultCasing is deprecated without replacement and removed in DBAL 3.' .
+            'Use Portability\Connection with PORTABILITY_FIX_CASE to get portable result cases.'
+        );
+
         return $column;
     }
 

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -26,6 +26,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 use UnexpectedValueException;
 
@@ -54,9 +55,6 @@ use function strlen;
 use function strpos;
 use function strtolower;
 use function strtoupper;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 /**
  * Base class for all DatabasePlatforms. The DatabasePlatforms are the central
@@ -301,12 +299,14 @@ abstract class AbstractPlatform
 
         if ($column['length'] > $maxLength) {
             if ($maxLength > 0) {
-                @trigger_error(sprintf(
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/issues/3187',
                     'Binary column length %d is greater than supported by the platform (%d).'
                     . ' Reduce the column length or use a BLOB column instead.',
                     $column['length'],
                     $maxLength
-                ), E_USER_DEPRECATED);
+                );
             }
 
             return $this->getBlobTypeDeclarationSQL($column);

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\BinaryType;
+use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 use function array_merge;
@@ -1104,6 +1105,12 @@ SQL
      */
     public function fixSchemaElementName($schemaElementName)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4132',
+            'AbstractPlatform::fixSchemaElementName is deprecated with no replacement and removed in DBAL 3.0'
+        );
+
         if (strlen($schemaElementName) > 30) {
             // Trim it
             return substr($schemaElementName, 0, 30);

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -974,6 +974,12 @@ SQL
      */
     public function prefersSequences()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4229',
+            'AbstractPlatform::prefersSequences() is deprecated without replacement and removed in DBAL 3.0'
+        );
+
         return true;
     }
 
@@ -1142,6 +1148,12 @@ SQL
      */
     public function supportsForeignKeyOnUpdate()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4229',
+            'AbstractPlatform::supportsForeignKeyOnUpdate() is deprecated without replacement and removed in DBAL 3.0'
+        );
+
         return false;
     }
 

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 use UnexpectedValueException;
 
 use function array_diff;
@@ -215,6 +216,12 @@ class PostgreSqlPlatform extends AbstractPlatform
      */
     public function prefersSequences()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4229',
+            'AbstractPlatform::prefersSequences() is deprecated without replacement and removed in DBAL 3.0'
+        );
+
         return true;
     }
 

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
+use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 use function array_merge;
@@ -72,6 +73,12 @@ class SQLAnywherePlatform extends AbstractPlatform
      */
     public function fixSchemaElementName($schemaElementName)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4132',
+            'AbstractPlatform::fixSchemaElementName is deprecated with no replacement and removed in DBAL 3.0'
+        );
+
         $maxIdentifierLength = $this->getMaxIdentifierLength();
 
         if (strlen($schemaElementName) > $maxIdentifierLength) {

--- a/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
+++ b/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Query\Expression;
 
 use Countable;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function count;
@@ -48,6 +49,12 @@ class CompositeExpression implements Countable
         $this->type = $type;
 
         $this->addMultiple($parts);
+
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3864',
+            'Do not use CompositeExpression constructor directly, use static and() and or() factory methods.'
+        );
     }
 
     /**
@@ -79,6 +86,12 @@ class CompositeExpression implements Countable
      */
     public function addMultiple(array $parts = [])
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3844',
+            'CompositeExpression::addMultiple() is deprecated, use CompositeExpression::with() instead.'
+        );
+
         foreach ($parts as $part) {
             $this->add($part);
         }
@@ -97,6 +110,12 @@ class CompositeExpression implements Countable
      */
     public function add($part)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3844',
+            'CompositeExpression::add() is deprecated, use CompositeExpression::with() instead.'
+        );
+
         if (empty($part)) {
             return $this;
         }

--- a/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
+++ b/lib/Doctrine/DBAL/Query/Expression/ExpressionBuilder.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Query\Expression;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\Deprecations\Deprecation;
 
 use function func_get_arg;
 use function func_get_args;
@@ -71,6 +72,12 @@ class ExpressionBuilder
      */
     public function andX($x = null)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3851',
+            'ExpressionBuilder::andX() is deprecated, use ExpressionBuilder::and() instead.'
+        );
+
         return new CompositeExpression(CompositeExpression::TYPE_AND, func_get_args());
     }
 
@@ -84,6 +91,12 @@ class ExpressionBuilder
      */
     public function orX($x = null)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3851',
+            'ExpressionBuilder::orX() is deprecated, use ExpressionBuilder::or() instead.'
+        );
+
         return new CompositeExpression(CompositeExpression::TYPE_OR, func_get_args());
     }
 

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
 use function array_key_exists;
@@ -483,6 +484,15 @@ class QueryBuilder
             return $this;
         }
 
+        if (is_array($select)) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/3837',
+                'Passing an array for the first argument to QueryBuilder::select is deprecated, ' .
+                'pass each value as an individual variadic argument instead.'
+            );
+        }
+
         $selects = is_array($select) ? $select : func_get_args();
 
         return $this->add('select', $selects);
@@ -531,6 +541,15 @@ class QueryBuilder
 
         if (empty($select)) {
             return $this;
+        }
+
+        if (is_array($select)) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/3837',
+                'Passing an array for the first argument to QueryBuilder::addSelect is deprecated, ' .
+                'pass each value as an individual variadic argument instead.'
+            );
         }
 
         $selects = is_array($select) ? $select : func_get_args();
@@ -911,6 +930,15 @@ class QueryBuilder
             return $this;
         }
 
+        if (is_array($groupBy)) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/3837',
+                'Passing an array for the first argument to QueryBuilder::groupBy is deprecated, ' .
+                'pass each value as an individual variadic argument instead.'
+            );
+        }
+
         $groupBy = is_array($groupBy) ? $groupBy : func_get_args();
 
         return $this->add('groupBy', $groupBy, false);
@@ -938,6 +966,15 @@ class QueryBuilder
     {
         if (empty($groupBy)) {
             return $this;
+        }
+
+        if (is_array($groupBy)) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/3837',
+                'Passing an array for the first argument to QueryBuilder::addGroupBy is deprecated, ' .
+                'pass each value as an individual variadic argument instead.'
+            );
         }
 
         $groupBy = is_array($groupBy) ? $groupBy : func_get_args();

--- a/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Event\SchemaIndexDefinitionEventArgs;
 use Doctrine\DBAL\Events;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 use Throwable;
 
 use function array_filter;
@@ -20,6 +21,7 @@ use function call_user_func_array;
 use function count;
 use function func_get_args;
 use function is_callable;
+use function is_string;
 use function preg_match;
 use function str_replace;
 use function strtolower;
@@ -197,6 +199,15 @@ abstract class AbstractSchemaManager
      */
     public function tablesExist($names)
     {
+        if (is_string($names)) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/3580',
+                'The usage of a string $tableNames in AbstractSchemaManager::tablesExist is deprecated. ' .
+                'Pass a one-element array instead.'
+            );
+        }
+
         $names = array_map('strtolower', (array) $names);
 
         return count($names) === count(array_intersect($names, array_map('strtolower', $this->listTableNames())));

--- a/lib/Doctrine/DBAL/Schema/Column.php
+++ b/lib/Doctrine/DBAL/Schema/Column.php
@@ -3,14 +3,11 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function is_numeric;
 use function method_exists;
-use function sprintf;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 /**
  * Object representation of a database column.
@@ -80,11 +77,13 @@ class Column extends AbstractAsset
             $method = 'set' . $name;
             if (! method_exists($this, $method)) {
                 // next major: throw an exception
-                @trigger_error(sprintf(
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/2846',
                     'The "%s" column option is not supported,' .
-                    ' setting it is deprecated and will cause an error in Doctrine DBAL 3.0',
+                    ' setting unknown options is deprecated and will cause an error in Doctrine DBAL 3.0',
                     $name
-                ), E_USER_DEPRECATED);
+                );
 
                 continue;
             }

--- a/lib/Doctrine/DBAL/Schema/Synchronizer/AbstractSchemaSynchronizer.php
+++ b/lib/Doctrine/DBAL/Schema/Synchronizer/AbstractSchemaSynchronizer.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Schema\Synchronizer;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\Deprecations\Deprecation;
 use Throwable;
 
 /**
@@ -18,6 +19,12 @@ abstract class AbstractSchemaSynchronizer implements SchemaSynchronizer
     public function __construct(Connection $conn)
     {
         $this->conn = $conn;
+
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4213',
+            'SchemaSynchronizer API is deprecated without a replacement and will be removed in DBAL 3.0'
+        );
     }
 
     /**

--- a/lib/Doctrine/DBAL/Sharding/PoolingShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/PoolingShardManager.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Sharding;
 
 use Doctrine\DBAL\Sharding\ShardChoser\ShardChoser;
+use Doctrine\Deprecations\Deprecation;
 use RuntimeException;
 
 /**
@@ -23,6 +24,12 @@ class PoolingShardManager implements ShardManager
 
     public function __construct(PoolingShardConnection $conn)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3595',
+            'Native Sharding support in DBAL is removed without replacement.'
+        );
+
         $params       = $conn->getParams();
         $this->conn   = $conn;
         $this->choser = $params['shardChoser'];

--- a/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
+++ b/lib/Doctrine/DBAL/Sharding/SQLAzure/SQLAzureShardManager.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Sharding\ShardingException;
 use Doctrine\DBAL\Sharding\ShardManager;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 use RuntimeException;
 
 use function sprintf;
@@ -40,6 +41,12 @@ class SQLAzureShardManager implements ShardManager
      */
     public function __construct(Connection $conn)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3595',
+            'Native Sharding support in DBAL is removed without replacement.'
+        );
+
         $this->conn = $conn;
         $params     = $conn->getParams();
 

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -190,6 +190,12 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      */
     public function closeCursor()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4049',
+            'Statement::closeCursor() is deprecated, use Result::free() instead.'
+        );
+
         return $this->stmt->closeCursor();
     }
 

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -212,6 +212,12 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      */
     public function errorCode()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3507',
+            'Connection::errorCode() is deprecated, use getCode() or getSQLState() on Exception instead.'
+        );
+
         return $this->stmt->errorCode();
     }
 
@@ -222,6 +228,12 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      */
     public function errorInfo()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3507',
+            'Connection::errorInfo() is deprecated, use getCode() or getSQLState() on Exception instead.'
+        );
+
         return $this->stmt->errorInfo();
     }
 

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\Exception\NoKeyValue;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 use IteratorAggregate;
 use PDO;
 use PDOStatement;
@@ -231,6 +232,12 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      */
     public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Statement::setFetchMode() is deprecated, use explicit Statement::fetch*() APIs instead.'
+        );
+
         if ($arg2 === null) {
             return $this->stmt->setFetchMode($fetchMode);
         }
@@ -251,6 +258,13 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      */
     public function getIterator()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Statement::getIterator() is deprecated, use Statement::iterateNumeric(), iterateAssociative() ' .
+            'or iterateColumn() instead.'
+        );
+
         return $this->stmt;
     }
 
@@ -261,6 +275,12 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      */
     public function fetch($fetchMode = null, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Statement::fetch() is deprecated, use Statement::fetchNumeric(), fetchAssociative() or fetchOne() instead.'
+        );
+
         return $this->stmt->fetch($fetchMode);
     }
 
@@ -271,6 +291,13 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Statement::fetchAll() is deprecated, use Statement::fetchAllNumeric(), fetchAllAssociative() or ' .
+            'fetchFirstColumn() instead.'
+        );
+
         if ($ctorArgs !== null) {
             return $this->stmt->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
         }
@@ -289,6 +316,12 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      */
     public function fetchColumn($columnIndex = 0)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Statement::fetchColumn() is deprecated, use Statement::fetchOne() instead.'
+        );
+
         return $this->stmt->fetchColumn($columnIndex);
     }
 

--- a/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
@@ -23,6 +23,7 @@ use Doctrine\DBAL\Platforms\Keywords\SQLServer2008Keywords;
 use Doctrine\DBAL\Platforms\Keywords\SQLServer2012Keywords;
 use Doctrine\DBAL\Platforms\Keywords\SQLServerKeywords;
 use Doctrine\DBAL\Tools\Console\ConnectionProvider;
+use Doctrine\Deprecations\Deprecation;
 use Exception;
 use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
@@ -36,9 +37,6 @@ use function count;
 use function implode;
 use function is_array;
 use function is_string;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 class ReservedWordsCommand extends Command
 {
@@ -74,9 +72,10 @@ class ReservedWordsCommand extends Command
             return;
         }
 
-        @trigger_error(
-            'Not passing a connection provider as the first constructor argument is deprecated',
-            E_USER_DEPRECATED
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3956',
+            'Not passing a connection provider as the first constructor argument is deprecated'
         );
     }
 

--- a/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tools\Console\Command;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Tools\Console\ConnectionProvider;
 use Doctrine\DBAL\Tools\Dumper;
+use Doctrine\Deprecations\Deprecation;
 use Exception;
 use LogicException;
 use RuntimeException;
@@ -18,9 +19,6 @@ use function assert;
 use function is_numeric;
 use function is_string;
 use function stripos;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 /**
  * Task for executing arbitrary SQL that can come from a file or directly from
@@ -39,9 +37,10 @@ class RunSqlCommand extends Command
             return;
         }
 
-        @trigger_error(
-            'Not passing a connection provider as the first constructor argument is deprecated',
-            E_USER_DEPRECATED
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3956',
+            'Not passing a connection provider as the first constructor argument is deprecated'
         );
     }
 

--- a/lib/Doctrine/DBAL/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/DBAL/Tools/Console/ConsoleRunner.php
@@ -8,15 +8,13 @@ use Doctrine\DBAL\Tools\Console\Command\ReservedWordsCommand;
 use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\DBAL\Version;
+use Doctrine\Deprecations\Deprecation;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
 use TypeError;
 
 use function sprintf;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 /**
  * Handles running the Console Tools inside Symfony Console context.
@@ -53,11 +51,13 @@ class ConsoleRunner
 
         $connectionProvider = null;
         if ($helperSetOrConnectionProvider instanceof HelperSet) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/3956',
                 'Passing an instance of "%s" as the first argument is deprecated. Pass an instance of "%s" instead.',
                 HelperSet::class,
                 ConnectionProvider::class
-            ), E_USER_DEPRECATED);
+            );
             $connectionProvider = null;
             $cli->setHelperSet($helperSetOrConnectionProvider);
         } elseif ($helperSetOrConnectionProvider instanceof ConnectionProvider) {

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Types;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
 use function get_class;
@@ -173,6 +174,12 @@ abstract class Type
      */
     public function getDefaultLength(AbstractPlatform $platform)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3255',
+            'Type::getDefaultLength() is deprecated, use AbstractPlatform directly.'
+        );
+
         return null;
     }
 

--- a/lib/Doctrine/DBAL/Types/Type.php
+++ b/lib/Doctrine/DBAL/Types/Type.php
@@ -315,6 +315,12 @@ abstract class Type
      */
     public function __toString()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/3258',
+            'Type::__toString() is deprecated, use Type::getName() or get_class($type) instead.'
+        );
+
         $type     = static::class;
         $position = strrpos($type, '\\');
 

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/CompositeExpressionTest.php
@@ -3,12 +3,18 @@
 namespace Doctrine\Tests\DBAL\Query\Expression;
 
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\Tests\DbalTestCase;
 
 class CompositeExpressionTest extends DbalTestCase
 {
+    use VerifyDeprecations;
+
     public function testCount(): void
     {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/issues/3844');
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/3864');
+
         $expr = CompositeExpression::or('u.group_id = 1');
 
         self::assertCount(1, $expr);
@@ -20,6 +26,9 @@ class CompositeExpressionTest extends DbalTestCase
 
     public function testAdd(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/3864');
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/issues/3844');
+
         $expr = CompositeExpression::or('u.group_id = 1');
 
         self::assertCount(1, $expr);
@@ -68,6 +77,8 @@ class CompositeExpressionTest extends DbalTestCase
      */
     public function testCompositeUsageAndGeneration(string $type, array $parts, string $expects): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/3864');
+
         $expr = new CompositeExpression($type, $parts);
 
         self::assertEquals($expects, (string) $expr);


### PR DESCRIPTION
Turns all the possible deprecated APIs into using the doctrine/deprecations API.

This includes deprecations on everything that can be done with code at runtime and is missing only the deprecation of `fetch` methods on the `Statement` class, which need this PR https://github.com/doctrine/dbal/pull/4529 for forwards compatibility to suggest a migration from `Statement::fetch*` to `Connection::executeQuery->fetch*()`