### PR TITLE
Remove incomplete details of QueryBuilder::setParameter($type)

### DIFF
--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -269,7 +269,7 @@ class QueryBuilder
      *
      * @param int|string           $key   Parameter position or name
      * @param mixed                $value Parameter value
-     * @param int|string|Type|null $type  One of the {@link ParameterType} constants or DBAL type
+     * @param int|string|Type|null $type  Parameter type
      *
      * @return $this This QueryBuilder instance.
      */


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
The argument description doesn't mention a more flexible way to configure binding parameter type - use a constant from `Doctrine\DBAL\Types\Types`.

~~PR proposes to mention this way of type configuration~~
UPD: instead of mention all ways to configure parameter type, the description updated to the short form, which is consistent with a codebase