### PR TITLE
Remove Statement::bindParam($driverOptions)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 4.0
 
+## Removed the `$driverOptions` argument of `PDO\Statement::bindParam()` and `PDO\SQLSrv\Statement::bindParam()`
+
+The `$driverOptions` argument of `PDO\Statement::bindParam()` and `PDO\SQLSrv\Statement::bindParam()` has been removed. The specifics of binding a parameter to the statement should be specified using the `$type` argument.
+
 ## BC BREAK: Removed `Connection::$_schemaManager` and `Connection::getSchemaManager()`
 
 The `Connection` and `AbstractSchemaManager` classes used to have a reference on each other effectively making a circular reference. Use `createSchemaManager()` to instantiate a schema manager.

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -25,37 +25,34 @@ final class Statement implements StatementInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param string|int $param
-     * @param mixed      $variable
-     * @param int        $type
-     * @param int|null   $length
-     * @param mixed      $driverOptions The usage of the argument is deprecated.
      */
-    public function bindParam(
-        $param,
-        &$variable,
-        int $type = ParameterType::STRING,
-        ?int $length = null,
-        $driverOptions = null
-    ): void {
+    public function bindParam($param, &$variable, int $type = ParameterType::STRING, ?int $length = null): void
+    {
         switch ($type) {
             case ParameterType::LARGE_OBJECT:
             case ParameterType::BINARY:
-                if ($driverOptions === null) {
-                    $driverOptions = PDO::SQLSRV_ENCODING_BINARY;
-                }
-
+                $this->statement->bindParamWithDriverOptions(
+                    $param,
+                    $variable,
+                    $type,
+                    $length ?? 0,
+                    PDO::SQLSRV_ENCODING_BINARY
+                );
                 break;
 
             case ParameterType::ASCII:
-                $type          = ParameterType::STRING;
-                $length        = 0;
-                $driverOptions = PDO::SQLSRV_ENCODING_SYSTEM;
+                $this->statement->bindParamWithDriverOptions(
+                    $param,
+                    $variable,
+                    ParameterType::STRING,
+                    $length ?? 0,
+                    PDO::SQLSRV_ENCODING_SYSTEM
+                );
                 break;
-        }
 
-        $this->statement->bindParam($param, $variable, $type, $length, $driverOptions);
+            default:
+                $this->statement->bindParam($param, $variable, $type, $length);
+        }
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

Closes #4533. The `$driverOptions` argument can be only passed to `bindParamWithDriverOptions()` which is internal to the driver layer. This makes the API of the PDO statements consistent with the rest of the drivers.