### PR TITLE
Deprecate AbstractPlatform::getReservedKeywordsClass()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade to 3.1
 
+## Deprecated `AbstractPlatform::getReservedKeywordsClass()`
+
+Instead of implementing `getReservedKeywordsClass()`, `AbstractPlatform` subclasses should implement
+`createReservedKeywordsList()`.
+
 ## Deprecated `$driverOptions` argument of `PDO\Statement::bindParam()` and `PDO\SQLSrv\Statement::bindParam()`
 
 The usage of the `$driverOptions` argument of `PDO\Statement::bindParam()` and `PDO\SQLSrv\Statement::bindParam()` is deprecated.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -55,6 +55,10 @@
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
                 <!--
+                    This suppression should be removed in 4.0.0.
+                -->
+                <file name="src/Platforms/AbstractPlatform.php"/>
+                <!--
                     This suppression should be removed in 4.0.x
                     See https://github.com/doctrine/dbal/pull/3865
                 -->

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3480,24 +3480,36 @@ abstract class AbstractPlatform
     final public function getReservedKeywordsList()
     {
         // Check for an existing instantiation of the keywords class.
-        if ($this->_keywords !== null) {
-            return $this->_keywords;
+        if ($this->_keywords === null) {
+            // Store the instance so it doesn't need to be generated on every request.
+            $this->_keywords = $this->createReservedKeywordsList();
         }
 
+        return $this->_keywords;
+    }
+
+    /**
+     * Creates an instance of the reserved keyword list of this platform.
+     *
+     * This method will become @abstract in DBAL 4.0.0.
+     *
+     * @throws Exception
+     */
+    protected function createReservedKeywordsList(): KeywordList
+    {
         $class    = $this->getReservedKeywordsClass();
         $keywords = new $class();
         if (! $keywords instanceof KeywordList) {
             throw Exception::notSupported(__METHOD__);
         }
 
-        // Store the instance so it doesn't need to be generated on every request.
-        $this->_keywords = $keywords;
-
         return $keywords;
     }
 
     /**
      * Returns the class name of the reserved keywords list.
+     *
+     * @deprecated Implement {@link createReservedKeywordsList()} instead.
      *
      * @return string
      *

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -896,6 +896,8 @@ class DB2Platform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Implement {@link createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/MariaDb1027Platform.php
+++ b/src/Platforms/MariaDb1027Platform.php
@@ -21,6 +21,9 @@ final class MariaDb1027Platform extends MySQLPlatform
         return 'LONGTEXT';
     }
 
+    /**
+     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     */
     protected function getReservedKeywordsClass(): string
     {
         return Keywords\MariaDb102Keywords::class;

--- a/src/Platforms/MySQL57Platform.php
+++ b/src/Platforms/MySQL57Platform.php
@@ -59,6 +59,8 @@ class MySQL57Platform extends MySQLPlatform
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Implement {@link createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/MySQL80Platform.php
+++ b/src/Platforms/MySQL80Platform.php
@@ -9,6 +9,8 @@ class MySQL80Platform extends MySQL57Platform
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Implement {@link createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -1105,6 +1105,8 @@ SQL
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Implement {@link createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -1160,6 +1160,8 @@ SQL
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Implement {@link createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/PostgreSQL100Platform.php
+++ b/src/Platforms/PostgreSQL100Platform.php
@@ -11,6 +11,9 @@ use Doctrine\DBAL\Platforms\Keywords\PostgreSQL100Keywords;
  */
 class PostgreSQL100Platform extends PostgreSQL94Platform
 {
+    /**
+     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     */
     protected function getReservedKeywordsClass(): string
     {
         return PostgreSQL100Keywords::class;

--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -1174,6 +1174,8 @@ SQL
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Implement {@link createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -1554,6 +1554,8 @@ class SQLServer2012Platform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Implement {@link createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -684,6 +684,8 @@ class SqlitePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Implement {@link createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

See #4510. With the new API, each platform will be responsible for instantiating its keyword list, so there will be no need to enforce the constructor signature.
