### PR TITLE
Deprecations in schema- and namespace-related APIs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.1
 
+## `PostgreSQLSchemaManager` methods marked internal.
+
+`PostgreSQLSchemaManager::getExistingSchemaSearchPaths()` and `::determineExistingSchemaSearchPaths()` have been marked internal.
+
 ## Deprecated `AbstractPlatform::getReservedKeywordsClass()`
 
 Instead of implementing `getReservedKeywordsClass()`, `AbstractPlatform` subclasses should implement

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,17 @@
 # Upgrade to 3.1
 
+## Deprecated schema- and namespace-related methods
+
+The usage of the following schema- and namespace-related methods is deprecated:
+
+- `AbstractPlatform::getListNamespacesSQL()`,
+- `AbstractSchemaManager::listNamespaceNames()`,
+- `AbstractSchemaManager::getPortableNamespacesList()`,
+- `AbstractSchemaManager::getPortableNamespaceDefinition()`,
+- `PostgreSQLSchemaManager::getSchemaNames()`.
+
+Use `AbstractSchemaManager::listSchemaNames()` instead.
+
 ## `PostgreSQLSchemaManager` methods marked internal.
 
 `PostgreSQLSchemaManager::getExistingSchemaSearchPaths()` and `::determineExistingSchemaSearchPaths()` have been marked internal.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -71,6 +71,11 @@
                 -->
                 <file name="src/Query/QueryBuilder.php"/>
                 <file name="src/Tools/Console/Command/ReservedWordsCommand.php"/>
+                <!--
+                    This suppression should be removed in 4.0.x
+                -->
+                <file name="src/Schema/AbstractSchemaManager.php" />
+                <file name="src/Schema/PostgreSQLSchemaManager.php" />
                 <directory name="tests" />
             </errorLevel>
         </DeprecatedMethod>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2750,6 +2750,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL statement for retrieving the namespaces defined in the database.
      *
+     * @deprecated Use {@link AbstractSchemaManager::listSchemaNames()} instead.
+     *
      * @return string
      *
      * @throws Exception If not supported on this platform.

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1362,6 +1362,14 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Returns the SQL snippet to drop a schema.
+     */
+    public function getDropSchemaSQL(string $schemaName): string
+    {
+        return 'DROP SCHEMA ' . $schemaName;
+    }
+
+    /**
      * Returns the SQL snippet to drop an existing table.
      *
      * @param Table|string $table

--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -227,6 +227,8 @@ class PostgreSQL94Platform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use {@link PostgreSQLSchemaManager::listSchemaNames()} instead.
      */
     public function getListNamespacesSQL()
     {

--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -1160,6 +1160,8 @@ class SQLServer2012Platform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use {@link SQLServerSchemaManager::listSchemaNames()} instead.
      */
     public function getListNamespacesSQL()
     {

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -107,6 +107,8 @@ abstract class AbstractSchemaManager
     /**
      * Returns a list of all namespaces in the current database.
      *
+     * @deprecated Use {@link listSchemaNames()} instead.
+     *
      * @return string[]
      *
      * @throws Exception
@@ -118,6 +120,18 @@ abstract class AbstractSchemaManager
         $namespaces = $this->_conn->fetchAllAssociative($sql);
 
         return $this->getPortableNamespacesList($namespaces);
+    }
+
+    /**
+     * Returns a list of the names of all schemata in the current database.
+     *
+     * @return list<string>
+     *
+     * @throws Exception
+     */
+    public function listSchemaNames(): array
+    {
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**
@@ -701,6 +715,8 @@ abstract class AbstractSchemaManager
     /**
      * Converts a list of namespace names from the native DBMS data definition to a portable Doctrine definition.
      *
+     * @deprecated Use {@link listSchemaNames()} instead.
+     *
      * @param array<int, array<string, mixed>> $namespaces The list of namespace names
      *                                                     in the native DBMS data definition.
      *
@@ -729,6 +745,8 @@ abstract class AbstractSchemaManager
 
     /**
      * Converts a namespace definition from the native DBMS data definition to a portable Doctrine definition.
+     *
+     * @deprecated Use {@link listSchemaNames()} instead.
      *
      * @param array<string, mixed> $namespace The native DBMS namespace definition.
      *
@@ -1067,10 +1085,10 @@ abstract class AbstractSchemaManager
      */
     public function createSchema()
     {
-        $namespaces = [];
+        $schemaNames = [];
 
         if ($this->_platform->supportsSchemas()) {
-            $namespaces = $this->listNamespaceNames();
+            $schemaNames = $this->listNamespaceNames();
         }
 
         $sequences = [];
@@ -1081,7 +1099,7 @@ abstract class AbstractSchemaManager
 
         $tables = $this->listTables();
 
-        return new Schema($tables, $sequences, $this->createSchemaConfig(), $namespaces);
+        return new Schema($tables, $sequences, $this->createSchemaConfig(), $schemaNames);
     }
 
     /**

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -342,6 +342,16 @@ abstract class AbstractSchemaManager
     }
 
     /**
+     * Drops a schema.
+     *
+     * @throws Exception
+     */
+    public function dropSchema(string $schemaName): void
+    {
+        $this->_execSql($this->_platform->getDropSchemaSQL($schemaName));
+    }
+
+    /**
      * Drops the given table.
      *
      * @param string $name The name of the table to drop.

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -73,6 +73,8 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
      *
      * This is a PostgreSQL only function.
      *
+     * @internal The method should be only used from within the PostgreSQLSchemaManager class hierarchy.
+     *
      * @return string[]
      */
     public function getExistingSchemaSearchPaths()
@@ -88,6 +90,8 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
      * Sets or resets the order of the existing schemas in the current search path of the user.
      *
      * This is a PostgreSQL only function.
+     *
+     * @internal The method should be only used from within the PostgreSQLSchemaManager class hierarchy.
      *
      * @return void
      */

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -38,14 +38,29 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
     /**
      * Gets all the existing schema names.
      *
+     * @deprecated Use {@link listSchemaNames()} instead.
+     *
      * @return string[]
      *
      * @throws Exception
      */
     public function getSchemaNames()
     {
+        return $this->listNamespaceNames();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function listSchemaNames(): array
+    {
         return $this->_conn->fetchFirstColumn(
-            "SELECT nspname FROM pg_namespace WHERE nspname !~ '^pg_.*' AND nspname != 'information_schema'"
+            <<<'SQL'
+SELECT schema_name
+FROM   information_schema.schemata
+WHERE  schema_name NOT LIKE 'pg\_%'
+AND    schema_name != 'information_schema'
+SQL
         );
     }
 
@@ -97,7 +112,7 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
      */
     public function determineExistingSchemaSearchPaths()
     {
-        $names = $this->getSchemaNames();
+        $names = $this->listSchemaNames();
         $paths = $this->getSchemaSearchPaths();
 
         $this->existingSchemaPaths = array_filter($paths, static function ($v) use ($names): bool {
@@ -271,6 +286,8 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@link PostgreSQLSchemaManager::listSchemaNames()} instead.
      */
     protected function getPortableNamespaceDefinition(array $namespace)
     {

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -22,6 +22,20 @@ use function strtok;
 class SQLServerSchemaManager extends AbstractSchemaManager
 {
     /**
+     * {@inheritDoc}
+     */
+    public function listSchemaNames(): array
+    {
+        return $this->_conn->fetchFirstColumn(
+            <<<'SQL'
+SELECT name
+FROM   sys.schemas
+WHERE  name NOT IN('guest', 'INFORMATION_SCHEMA', 'sys')
+SQL
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function _getPortableSequenceDefinition($sequence)
@@ -199,6 +213,8 @@ class SQLServerSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@link SQLServerSchemaManager::listSchemaNames()} instead.
      */
     protected function getPortableNamespaceDefinition(array $namespace)
     {

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -38,7 +38,6 @@ use function array_values;
 use function count;
 use function current;
 use function get_class;
-use function in_array;
 use function sprintf;
 use function strcasecmp;
 use function strlen;
@@ -159,26 +158,40 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertContains('test_create_database', $databases);
     }
 
-    public function testListNamespaceNames(): void
+    /**
+     * @dataProvider listSchemaNamesMethodProvider
+     */
+    public function testListSchemaNames(callable $method): void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsSchemas()) {
             self::markTestSkipped('Platform does not support schemas.');
         }
 
-        // Currently dropping schemas is not supported, so we have to workaround here.
-        $namespaces = $this->schemaManager->listNamespaceNames();
-        $namespaces = array_map('strtolower', $namespaces);
+        $this->schemaManager->tryMethod('dropSchema', 'test_create_schema');
 
-        if (! in_array('test_create_schema', $namespaces, true)) {
-            $this->connection->executeStatement(
-                $this->schemaManager->getDatabasePlatform()->getCreateSchemaSQL('test_create_schema')
-            );
+        $this->connection->executeStatement(
+            $this->schemaManager->getDatabasePlatform()->getCreateSchemaSQL('test_create_schema')
+        );
 
-            $namespaces = $this->schemaManager->listNamespaceNames();
-            $namespaces = array_map('strtolower', $namespaces);
-        }
+        self::assertContains('test_create_schema', $method($this->schemaManager));
+    }
 
-        self::assertContains('test_create_schema', $namespaces);
+    /**
+     * @return iterable<list<mixed>>
+     */
+    public static function listSchemaNamesMethodProvider(): iterable
+    {
+        yield [
+            static function (AbstractSchemaManager $schemaManager): array {
+                return $schemaManager->listNamespaceNames();
+            },
+        ];
+
+        yield [
+            static function (AbstractSchemaManager $schemaManager): array {
+                return $schemaManager->listSchemaNames();
+            },
+        ];
     }
 
     public function testListTables(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement, deprecation
| BC Break     | no

See #4503.

1. `PostgreSQLSchemaManager::getExistingSchemaSearchPaths()` and `::determineExistingSchemaSearchPaths()` have been marked internal and will be made protected in `4.0.0`. They are only used by the schema manager itself and are not part of the API.
2. `AbstractSchemaManager::dropSchema()` has been added to implement the test properly.
3. `AbstractSchemaManager::listSchemaNames()` has been added as a replacement for `AbstractSchemaManager::listNamespaceNames()` and `PostgreSQLSchemaManager::getSchemaNames()`.

**Reasoning behind the naming changes**:

The "namespace" term is [internal](https://www.postgresql.org/docs/13/catalog-pg-namespace.html) to PostgreSQL and isn't part of the ANSI SQL vocabulary:

> A namespace is the structure underlying SQL schemas

Schemas are supported by most if not all platforms supported by the DBAL.

**Reasoning behind the design changes**:

The new `AbstractSchemaManager::listSchemaNames()` method have been implemented directly in the schema manager instead of using the `getListSchemataSQL()` → `getPortableSchemaList()` → `getPortableSchemaDefinition()` approach. This approach has the following flaws:

1. Although `getListSchemataSQL(): string` would be part of the abstract API, it could be used only within a given platform or even its version, so it's not really part of the abstraction. Also, such methods are untestable unless tested as part of the schema manager.
2. `getPortableSchemaDefinition()` would expect a `list<string,mixed>` and return a `list<string>` but again, it couldn't accept a row set from another platform. Furthermore, neither the API nor default the default implementation of such methods make any sense: https://github.com/doctrine/dbal/blob/f18aee0a2b209662370de14f3a5268553c9b239e/src/Schema/AbstractSchemaManager.php#L710-L718

`AbstractSchemaManager::dropSchema()` has been implemented using the implementation from `AbstractPlatform` in order to be able to reuse it go generate migrations.