### PR TITLE
Upgrade Psalm to 4.6.4

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,4 +1,3 @@
-
 name: "Static Analysis"
 
 on:
@@ -50,6 +49,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions:4.5.2
+        uses: docker://vimeo/psalm-github-actions:4.6.4
         with:
           composer_require_dev: true

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "phpunit/phpunit": "9.5.0",
         "psalm/plugin-phpunit": "0.13.0",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-        "vimeo/psalm": "4.5.2"
+        "vimeo/psalm": "4.6.4"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -341,7 +341,8 @@
                 <file name="lib/Doctrine/DBAL/Tools/Console/ConsoleRunner.php"/>
                 <file name="tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php"/>
                 <!--
-                    See https://github.com/vimeo/psalm/issues/5305
+                    Requires a release of
+                    https://github.com/JetBrains/phpstorm-stubs/commit/43ce0bb13e927b9eb69cc06c16ab22f548c4735b
                 -->
                 <file name="lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php"/>
             </errorLevel>
@@ -381,12 +382,6 @@
                 <file name="lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php"/>
             </errorLevel>
         </TooManyArguments>
-        <TypeDoesNotContainType>
-            <errorLevel type="suppress">
-                <!-- See https://github.com/vimeo/psalm/issues/4274 -->
-                <file name="lib/Doctrine/DBAL/Schema/Index.php"/>
-            </errorLevel>
-        </TypeDoesNotContainType>
         <UndefinedConstant>
             <errorLevel type="suppress">
                 <directory name="lib/Doctrine/DBAL/Driver/SQLAnywhere"/>


### PR DESCRIPTION
This upgrade should unblock https://github.com/doctrine/dbal/pull/4465. Additionally, I'd like to explore the possibility of getting rid of PhpStorm stubs (https://github.com/doctrine/dbal/issues/4468) since both PHPStan and Psalm now have their own, and upon a given failure, it's hard to tell where exactly the wrong stub is. Sometimes (like here) the stub is wrong in more than one place.