### PR TITLE
Update test DB config: rename privileged db and require explicit driver

### DIFF
--- a/ci/github/phpunit/oci8.xml
+++ b/ci/github/phpunit/oci8.xml
@@ -15,11 +15,11 @@
         <var name="db_dbname" value="XE"/>
         <var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit"/>
 
-        <var name="tmpdb_driver" value="oci8"/>
-        <var name="tmpdb_host" value="localhost"/>
-        <var name="tmpdb_user" value="system"/>
-        <var name="tmpdb_password" value="oracle"/>
-        <var name="tmpdb_dbname" value="XE"/>
+        <var name="privileged_db_driver" value="oci8"/>
+        <var name="privileged_db_host" value="localhost"/>
+        <var name="privileged_db_user" value="system"/>
+        <var name="privileged_db_password" value="oracle"/>
+        <var name="privileged_db_dbname" value="XE"/>
     </php>
 
     <testsuites>

--- a/ci/github/phpunit/pdo_oci.xml
+++ b/ci/github/phpunit/pdo_oci.xml
@@ -15,11 +15,11 @@
         <var name="db_dbname" value="XE"/>
         <var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit"/>
 
-        <var name="tmpdb_driver" value="pdo_oci"/>
-        <var name="tmpdb_host" value="localhost"/>
-        <var name="tmpdb_user" value="system"/>
-        <var name="tmpdb_password" value="oracle"/>
-        <var name="tmpdb_dbname" value="XE"/>
+        <var name="privileged_db_driver" value="pdo_oci"/>
+        <var name="privileged_db_host" value="localhost"/>
+        <var name="privileged_db_user" value="system"/>
+        <var name="privileged_db_password" value="oracle"/>
+        <var name="privileged_db_dbname" value="XE"/>
     </php>
 
     <testsuites>

--- a/ci/github/phpunit/sqlite.xml
+++ b/ci/github/phpunit/sqlite.xml
@@ -7,6 +7,12 @@
          failOnRisky="true"
          failOnWarning="true"
 >
+    <php>
+        <!-- use an in-memory sqlite database -->
+        <var name="db_driver" value="pdo_sqlite"/>
+        <var name="db_memory" value="true"/>
+    </php>
+
     <testsuites>
         <testsuite name="Doctrine DBAL Test Suite">
             <directory>../../../tests</directory>

--- a/ci/github/phpunit/sqlite.xml
+++ b/ci/github/phpunit/sqlite.xml
@@ -8,7 +8,6 @@
          failOnWarning="true"
 >
     <php>
-        <!-- use an in-memory sqlite database -->
         <var name="db_driver" value="pdo_sqlite"/>
         <var name="db_memory" value="true"/>
     </php>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,24 +22,37 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <!-- Test connection parameters -->
-        <!-- Uncomment, otherwise SQLite runs
+        <!-- "Real" test database -->
+        <var name="db_driver" value="pdo_sqlite"/>
+        <var name="db_memory" value="true"/>
+        <!-- to use another database driver / credentials, provide them like so:
         <var name="db_driver" value="pdo_mysql"/>
         <var name="db_host" value="localhost" />
-        <var name="db_port" value="3306"/>
         <var name="db_user" value="root" />
         <var name="db_password" value="" />
         <var name="db_dbname" value="doctrine_tests" />
-        -->
+        <var name="db_port" value="3306"/>-->
         <!--<var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit">-->
 
-        <!-- Privileged user connection parameters. Used to create and drop the test database -->
-        <var name="tmpdb_driver" value="pdo_mysql"/>
-        <var name="tmpdb_host" value="localhost" />
-        <var name="tmpdb_port" value="3306"/>
-        <var name="tmpdb_user" value="root" />
-        <var name="tmpdb_password" value="" />
-        <var name="tmpdb_dbname" value="doctrine_tests_tmp" />
+        <!--
+         At the start of each test run, we will drop and recreate the test database.
+
+         By default we assume that the `db_` config above has unrestricted access to the provided database
+         platform.
+
+         If you prefer, you can provide a restricted user above and a separate `privileged_db` config
+         block to provide details of a privileged connection to use for the setup / teardown actions.
+
+         Note that these configurations are not merged - if you specify a `privileged_db_driver` then
+         you must also specify all the other options that your driver requires.
+
+        <var name="privileged_db_driver" value="pdo_mysql"/>
+        <var name="privileged_db_host" value="localhost" />
+        <var name="privileged_db_user" value="root" />
+        <var name="privileged_db_password" value="" />
+        <var name="privileged_db_dbname" value="doctrine_tests_tmp" />
+        <var name="privileged_db_port" value="3306"/>
+        -->
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,10 +28,11 @@
         <!-- to use another database driver / credentials, provide them like so:
         <var name="db_driver" value="pdo_mysql"/>
         <var name="db_host" value="localhost" />
+        <var name="db_port" value="3306"/>
         <var name="db_user" value="root" />
         <var name="db_password" value="" />
         <var name="db_dbname" value="doctrine_tests" />
-        <var name="db_port" value="3306"/>-->
+        -->
         <!--<var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit">-->
 
         <!--

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -459,5 +459,15 @@
                 <file name="lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php"/>
             </errorLevel>
         </InvalidReturnStatement>
+        <MoreSpecificReturnType>
+            <errorLevel type="suppress">
+                <file name="tests/Doctrine/Tests/TestUtil.php"/>
+            </errorLevel>
+        </MoreSpecificReturnType>
+        <LessSpecificReturnStatement>
+            <errorLevel type="suppress">
+                <file name="tests/Doctrine/Tests/TestUtil.php"/>
+            </errorLevel>
+        </LessSpecificReturnStatement>
     </issueHandlers>
 </psalm>

--- a/tests/Doctrine/Tests/DBAL/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/PDOPgSql/DriverTest.php
@@ -82,7 +82,7 @@ class DriverTest extends AbstractPostgreSQLDriverTest
      */
     private function connect(array $driverOptions): Connection
     {
-        $params = TestUtil::getConnectionParams();
+        $params = TestUtil::getTestConnectionParameters();
 
         $connection = $this->createDriver()->connect(
             $params,

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/Mysqli/ConnectionTest.php
@@ -54,7 +54,7 @@ class ConnectionTest extends DbalFunctionalTestCase
      */
     private function getConnection(array $driverOptions): Connection
     {
-        $params = TestUtil::getConnectionParams();
+        $params = TestUtil::getTestConnectionParameters();
 
         if (isset($params['driverOptions'])) {
             $driverOptions = array_merge($params['driverOptions'], $driverOptions);

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOPgSql/DriverTest.php
@@ -66,7 +66,7 @@ class DriverTest extends AbstractDriverTest
      */
     public static function getDatabaseParameter(): iterable
     {
-        $params            = TestUtil::getConnectionParams();
+        $params            = TestUtil::getTestConnectionParameters();
         $realDatabaseName  = $params['dbname'] ?? '';
         $dummyDatabaseName = $realDatabaseName . 'a';
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Driver/PDOSqlsrv/DriverTest.php
@@ -42,7 +42,7 @@ class DriverTest extends AbstractDriverTest
      */
     private function getConnection(array $driverOptions): Connection
     {
-        $params = TestUtil::getConnectionParams();
+        $params = TestUtil::getTestConnectionParameters();
 
         if (isset($params['driverOptions'])) {
             $driverOptions = array_merge($params['driverOptions'], $driverOptions);

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -141,7 +141,7 @@ class TestUtil
     {
         if (! isset($GLOBALS['db_driver'])) {
             throw new UnexpectedValueException(
-                'You must provide database connection params including a db_driver value. See phpunit.xml.dist for details'
+                'You must provide db connection params including a db_driver value. See phpunit.xml.dist for details'
             );
         }
 

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -27,46 +27,6 @@ use const STDOUT;
 
 /**
  * TestUtil is a class with static utility methods used during tests.
- *
- * @psalm-type OverrideParams = array{
- *     charset?: string,
- *     dbname?: string,
- *     default_dbname?: string,
- *     driver?: key-of<\Doctrine\DBAL\DriverManager::DRIVER_MAP>,
- *     driverClass?: class-string<\Doctrine\DBAL\Driver>,
- *     driverOptions?: array<mixed>,
- *     host?: string,
- *     password?: string,
- *     path?: string,
- *     pdo?: \PDO,
- *     platform?: \Doctrine\DBAL\Platforms\AbstractPlatform,
- *     port?: int,
- *     user?: string,
- * }
- * @psalm-type ConnectionParams = array{
- *     charset?: string,
- *     dbname?: string,
- *     default_dbname?: string,
- *     driver?: key-of<\Doctrine\DBAL\DriverManager::DRIVER_MAP>,
- *     driverClass?: class-string<\Doctrine\DBAL\Driver>,
- *     driverOptions?: array<mixed>,
- *     host?: string,
- *     keepSlave?: bool,
- *     keepReplica?: bool,
- *     master?: OverrideParams,
- *     memory?: bool,
- *     password?: string,
- *     path?: string,
- *     pdo?: \PDO,
- *     platform?: \Doctrine\DBAL\Platforms\AbstractPlatform,
- *     port?: int,
- *     primary?: OverrideParams,
- *     replica?: array<OverrideParams>,
- *     sharding?: array<string,mixed>,
- *     slaves?: array<OverrideParams>,
- *     user?: string,
- *     wrapperClass?: class-string<Connection>,
- * }
  */
 class TestUtil
 {
@@ -97,6 +57,7 @@ class TestUtil
             self::$initialized = true;
         }
 
+        /** @psalm-suppress ArgumentTypeCoercion */
         $conn = DriverManager::getConnection(self::getTestConnectionParameters());
 
         self::addDbEventSubscribers($conn);
@@ -106,6 +67,7 @@ class TestUtil
 
     public static function getPrivilegedConnection(): Connection
     {
+        /** @psalm-suppress ArgumentTypeCoercion */
         return DriverManager::getConnection(self::getPrivilegedConnectionParameters());
     }
 
@@ -114,6 +76,7 @@ class TestUtil
         $testConnParams = self::getTestConnectionParameters();
         $privConnParams = self::getPrivilegedConnectionParameters();
 
+        /** @psalm-suppress ArgumentTypeCoercion */
         $testConn = DriverManager::getConnection($testConnParams);
 
         // Note, writes direct to STDOUT to prevent phpunit detecting output - otherwise this would cause either an
@@ -121,6 +84,7 @@ class TestUtil
         fwrite(STDOUT, sprintf("\nUsing DB driver %s\n", get_class($testConn->getDriver())));
 
         // Connect as a privileged user to create and drop the test database.
+        /** @psalm-suppress ArgumentTypeCoercion */
         $privConn = DriverManager::getConnection($privConnParams);
 
         $platform = $privConn->getDatabasePlatform();
@@ -161,8 +125,6 @@ class TestUtil
 
     /**
      * @return array<string,mixed>
-     *
-     * @psalm-return ConnectionParams
      */
     private static function getPrivilegedConnectionParameters(): array
     {
@@ -178,8 +140,6 @@ class TestUtil
 
     /**
      * @return array<string,mixed>
-     *
-     * @psalm-return ConnectionParams
      */
     public static function getTestConnectionParameters(): array
     {
@@ -196,8 +156,6 @@ class TestUtil
      * @param array<string,mixed> $configuration
      *
      * @return array<string,mixed>
-     *
-     * @psalm-return ConnectionParams
      */
     private static function mapConnectionParameters(array $configuration, string $prefix): array
     {

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -28,12 +28,27 @@ use const STDERR;
 /**
  * TestUtil is a class with static utility methods used during tests.
  *
+ * @psalm-type OverrideParams = array{
+ *     charset?: string,
+ *     dbname?: string,
+ *     default_dbname?: string,
+ *     driver?: key-of<\Doctrine\DBAL\DriverManager::DRIVER_MAP>,
+ *     driverClass?: class-string<\Doctrine\DBAL\Driver>,
+ *     driverOptions?: array<mixed>,
+ *     host?: string,
+ *     password?: string,
+ *     path?: string,
+ *     pdo?: \PDO,
+ *     platform?: \Doctrine\DBAL\Platforms\AbstractPlatform,
+ *     port?: int,
+ *     user?: string,
+ * }
  * @psalm-type ConnectionParams = array{
  *     charset?: string,
  *     dbname?: string,
  *     default_dbname?: string,
- *     driver?: key-of<self::DRIVER_MAP>,
- *     driverClass?: class-string<Driver>,
+ *     driver?: key-of<\Doctrine\DBAL\DriverManager::DRIVER_MAP>,
+ *     driverClass?: class-string<\Doctrine\DBAL\Driver>,
  *     driverOptions?: array<mixed>,
  *     host?: string,
  *     keepSlave?: bool,
@@ -43,7 +58,7 @@ use const STDERR;
  *     password?: string,
  *     path?: string,
  *     pdo?: \PDO,
- *     platform?: Platforms\AbstractPlatform,
+ *     platform?: \Doctrine\DBAL\Platforms\AbstractPlatform,
  *     port?: int,
  *     primary?: OverrideParams,
  *     replica?: array<OverrideParams>,

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -120,7 +120,7 @@ class TestUtil
     }
 
     /**
-     * @psalm-return array<string, mixed>
+     * @return array<string,mixed>
      */
     private static function getPrivilegedConnectionParameters(): array
     {
@@ -135,7 +135,7 @@ class TestUtil
     }
 
     /**
-     * @psalm-return array<string, mixed>
+     * @return array<string,mixed>
      */
     public static function getTestConnectionParameters(): array
     {

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -27,6 +27,31 @@ use const STDERR;
 
 /**
  * TestUtil is a class with static utility methods used during tests.
+ *
+ * @psalm-type ConnectionParams = array{
+ *     charset?: string,
+ *     dbname?: string,
+ *     default_dbname?: string,
+ *     driver?: key-of<self::DRIVER_MAP>,
+ *     driverClass?: class-string<Driver>,
+ *     driverOptions?: array<mixed>,
+ *     host?: string,
+ *     keepSlave?: bool,
+ *     keepReplica?: bool,
+ *     master?: OverrideParams,
+ *     memory?: bool,
+ *     password?: string,
+ *     path?: string,
+ *     pdo?: \PDO,
+ *     platform?: Platforms\AbstractPlatform,
+ *     port?: int,
+ *     primary?: OverrideParams,
+ *     replica?: array<OverrideParams>,
+ *     sharding?: array<string,mixed>,
+ *     slaves?: array<OverrideParams>,
+ *     user?: string,
+ *     wrapperClass?: class-string<Connection>,
+ * }
  */
 class TestUtil
 {
@@ -121,6 +146,7 @@ class TestUtil
 
     /**
      * @return array<string,mixed>
+     * @psalm-return ConnectionParams
      */
     private static function getPrivilegedConnectionParameters(): array
     {
@@ -136,6 +162,7 @@ class TestUtil
 
     /**
      * @return array<string,mixed>
+     * @psalm-return ConnectionParams
      */
     public static function getTestConnectionParameters(): array
     {
@@ -152,6 +179,7 @@ class TestUtil
      * @param array<string,mixed> $configuration
      *
      * @return array<string,mixed>
+     * @psalm-return ConnectionParams
      */
     private static function mapConnectionParameters(array $configuration, string $prefix): array
     {

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -27,6 +27,8 @@ use const STDOUT;
 
 /**
  * TestUtil is a class with static utility methods used during tests.
+ *
+ * @psalm-import-type Params from DriverManager
  */
 class TestUtil
 {
@@ -57,7 +59,6 @@ class TestUtil
             self::$initialized = true;
         }
 
-        /** @psalm-suppress ArgumentTypeCoercion */
         $conn = DriverManager::getConnection(self::getTestConnectionParameters());
 
         self::addDbEventSubscribers($conn);
@@ -67,7 +68,6 @@ class TestUtil
 
     public static function getPrivilegedConnection(): Connection
     {
-        /** @psalm-suppress ArgumentTypeCoercion */
         return DriverManager::getConnection(self::getPrivilegedConnectionParameters());
     }
 
@@ -76,7 +76,6 @@ class TestUtil
         $testConnParams = self::getTestConnectionParameters();
         $privConnParams = self::getPrivilegedConnectionParameters();
 
-        /** @psalm-suppress ArgumentTypeCoercion */
         $testConn = DriverManager::getConnection($testConnParams);
 
         // Note, writes direct to STDOUT to prevent phpunit detecting output - otherwise this would cause either an
@@ -84,7 +83,6 @@ class TestUtil
         fwrite(STDOUT, sprintf("\nUsing DB driver %s\n", get_class($testConn->getDriver())));
 
         // Connect as a privileged user to create and drop the test database.
-        /** @psalm-suppress ArgumentTypeCoercion */
         $privConn = DriverManager::getConnection($privConnParams);
 
         $platform = $privConn->getDatabasePlatform();
@@ -125,6 +123,8 @@ class TestUtil
 
     /**
      * @return array<string,mixed>
+     *
+     * @psalm-return Params
      */
     private static function getPrivilegedConnectionParameters(): array
     {
@@ -140,6 +140,8 @@ class TestUtil
 
     /**
      * @return array<string,mixed>
+     *
+     * @psalm-return Params
      */
     public static function getTestConnectionParameters(): array
     {
@@ -156,6 +158,8 @@ class TestUtil
      * @param array<string,mixed> $configuration
      *
      * @return array<string,mixed>
+     *
+     * @psalm-return Params
      */
     private static function mapConnectionParameters(array $configuration, string $prefix): array
     {

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -101,9 +101,9 @@ class TestUtil
 
         $testConn = DriverManager::getConnection($testConnParams);
 
-        // Note, writes direct to STDERR to prevent phpunit detecting output - otherwise this would cause either an
+        // Note, writes direct to STDOUT to prevent phpunit detecting output - otherwise this would cause either an
         // "unexpected output" warning or a failure on the first test case to call this method.
-        fwrite(STDERR, sprintf("\nUsing DB driver %s\n", get_class($testConn->getDriver())));
+        fwrite(STDOUT, sprintf("\nUsing DB driver %s\n", get_class($testConn->getDriver())));
 
         // Connect as a privileged user to create and drop the test database.
         $privConn = DriverManager::getConnection($privConnParams);

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -23,7 +23,7 @@ use function strlen;
 use function strpos;
 use function substr;
 
-use const STDERR;
+use const STDOUT;
 
 /**
  * TestUtil is a class with static utility methods used during tests.
@@ -161,6 +161,7 @@ class TestUtil
 
     /**
      * @return array<string,mixed>
+     *
      * @psalm-return ConnectionParams
      */
     private static function getPrivilegedConnectionParameters(): array
@@ -177,6 +178,7 @@ class TestUtil
 
     /**
      * @return array<string,mixed>
+     *
      * @psalm-return ConnectionParams
      */
     public static function getTestConnectionParameters(): array
@@ -194,6 +196,7 @@ class TestUtil
      * @param array<string,mixed> $configuration
      *
      * @return array<string,mixed>
+     *
      * @psalm-return ConnectionParams
      */
     private static function mapConnectionParameters(array $configuration, string $prefix): array


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement (to unit testing)
| BC Break     | not in the public API - method renamed in internal test helper and may require changes to contributors' local phpunit.xml config.
| Fixed issues | N/A

#### Summary

As discussed with @greg0ire this brings the naming / behaviour of the TestUtil class and the database config parameters up to date with the changes in doctrine/orm#8532 for consistency between projects. See commit message for full details.