### PR TITLE
Fix Comparator column diff for blob length

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -13,6 +13,7 @@ use function array_unique;
 use function assert;
 use function count;
 use function get_class;
+use function max;
 use function strtolower;
 
 /**
@@ -480,9 +481,9 @@ class Comparator
                 $changedProperties[] = 'fixed';
             }
         } elseif ($properties1['type'] instanceof Types\BlobType || $properties1['type'] instanceof Types\TextType) {
-            // check if value of length is set at all, default value assumed otherwise.
-            $length1 = $properties1['length'] ?: 0;
-            $length2 = $properties2['length'] ?: 0;
+            // check if value of length is set at all, -1 gets normalized to 0.
+            $length1 = max(0, $properties1['length'] ?: 0);
+            $length2 = max(0, $properties2['length'] ?: 0);
             if ($length1 !== $length2) {
                 $changedProperties[] = 'length';
             }

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -480,7 +480,10 @@ class Comparator
                 $changedProperties[] = 'fixed';
             }
         } elseif ($properties1['type'] instanceof Types\BlobType || $properties1['type'] instanceof Types\TextType) {
-            if ($properties1['length'] !== $properties2['length']) {
+            // check if value of length is set at all, default value assumed otherwise.
+            $length1 = $properties1['length'] ?: 0;
+            $length2 = $properties2['length'] ?: 0;
+            if ($length1 !== $length2) {
                 $changedProperties[] = 'length';
             }
         } elseif ($properties1['type'] instanceof Types\DecimalType) {

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -482,8 +482,8 @@ class Comparator
             }
         } elseif ($properties1['type'] instanceof Types\BlobType || $properties1['type'] instanceof Types\TextType) {
             // check if value of length is set at all, -1 gets normalized to 0.
-            $length1 = max(0, $properties1['length'] ?: 0);
-            $length2 = max(0, $properties2['length'] ?: 0);
+            $length1 = max(0, $properties1['length'] ?? 0);
+            $length2 = max(0, $properties2['length'] ?? 0);
             if ($length1 !== $length2) {
                 $changedProperties[] = 'length';
             }

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -479,7 +479,7 @@ class Comparator
             if ($properties1['fixed'] !== $properties2['fixed']) {
                 $changedProperties[] = 'fixed';
             }
-        } elseif ($properties1['type'] instanceof Types\BlobType) {
+        } elseif ($properties1['type'] instanceof Types\BlobType || $properties1['type'] instanceof Types\TextType) {
             if ($properties1['length'] !== $properties2['length']) {
                 $changedProperties[] = 'length';
             }

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -479,6 +479,10 @@ class Comparator
             if ($properties1['fixed'] !== $properties2['fixed']) {
                 $changedProperties[] = 'fixed';
             }
+        } elseif ($properties1['type'] instanceof Types\BlobType) {
+            if ($properties1['length'] !== $properties2['length']) {
+                $changedProperties[] = 'length';
+            }
         } elseif ($properties1['type'] instanceof Types\DecimalType) {
             if (($properties1['precision'] ?? 10) !== ($properties2['precision'] ?? 10)) {
                 $changedProperties[] = 'precision';

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -78,10 +78,6 @@ class DB2SchemaManager extends AbstractSchemaManager
                 $fixed  = true;
                 break;
 
-            case 'clob':
-                $length = $tableColumn['length'];
-                break;
-
             case 'decimal':
             case 'double':
             case 'real':

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -808,6 +808,57 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         ];
     }
 
+    public function testAlterTableChangeBlobColumnLength(): void
+    {
+        $fromTable = new Table('mytable');
+
+        $fromTable->addColumn('blob1', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYBLOB]);
+        $fromTable->addColumn('blob2', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_BLOB]);
+        $fromTable->addColumn('blob3', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
+        $fromTable->addColumn('blob4', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
+        $fromTable->addColumn('blob5', 'blob');
+        $fromTable->addColumn('blob6', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYBLOB]);
+        $fromTable->addColumn('blob7', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_BLOB]);
+        $fromTable->addColumn('blob8', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
+        $fromTable->addColumn('blob9', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
+        $fromTable->addColumn('blob10', 'blob');
+
+        $toTable = new Table('mytable');
+
+        $toTable->addColumn('blob1', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_BLOB]);
+        $toTable->addColumn('blob2', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
+        $toTable->addColumn('blob3', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
+        $toTable->addColumn('blob4', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYBLOB]);
+        $toTable->addColumn('blob5', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_BLOB]);
+        $toTable->addColumn('blob6', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYBLOB]);
+        $toTable->addColumn('blob7', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_BLOB]);
+        $toTable->addColumn('blob8', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
+        $toTable->addColumn('blob9', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
+        $toTable->addColumn('blob10', 'blob');
+
+        $diff = (new Comparator())->diffTable($fromTable, $toTable);
+        self::assertNotFalse($diff);
+
+        self::assertEquals(
+            $this->getAlterTableChangeBlobColumnLength(),
+            $this->platform->getAlterTableSQL($diff)
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getAlterTableChangeBlobColumnLength(): array
+    {
+        return ['ALTER TABLE mytable ' .
+            'CHANGE blob1 blob1 BLOB NOT NULL, ' .
+            'CHANGE blob2 blob2 MEDIUMBLOB NOT NULL, ' .
+            'CHANGE blob3 blob3 LONGBLOB NOT NULL, ' .
+            'CHANGE blob4 blob4 TINYBLOB NOT NULL, ' .
+            'CHANGE blob5 blob5 BLOB NOT NULL',
+        ];
+    }
+
     public function testReturnsGuidTypeDeclarationSQL(): void
     {
         self::assertSame('CHAR(36)', $this->platform->getGuidTypeDeclarationSQL([]));

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -859,6 +859,57 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         ];
     }
 
+    public function testAlterTableChangeTextColumnLength(): void
+    {
+        $fromTable = new Table('mytable');
+
+        $fromTable->addColumn('text1', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYTEXT]);
+        $fromTable->addColumn('text2', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
+        $fromTable->addColumn('text3', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
+        $fromTable->addColumn('text4', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
+        $fromTable->addColumn('text5', 'text');
+        $fromTable->addColumn('text6', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYTEXT]);
+        $fromTable->addColumn('text7', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
+        $fromTable->addColumn('text8', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
+        $fromTable->addColumn('text9', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
+        $fromTable->addColumn('text10', 'text');
+
+        $toTable = new Table('mytable');
+
+        $toTable->addColumn('text1', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
+        $toTable->addColumn('text2', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
+        $toTable->addColumn('text3', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
+        $toTable->addColumn('text4', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYTEXT]);
+        $toTable->addColumn('text5', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
+        $toTable->addColumn('text6', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYTEXT]);
+        $toTable->addColumn('text7', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
+        $toTable->addColumn('text8', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
+        $toTable->addColumn('text9', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
+        $toTable->addColumn('text10', 'text');
+
+        $diff = (new Comparator())->diffTable($fromTable, $toTable);
+        self::assertNotFalse($diff);
+
+        self::assertEquals(
+            $this->getAlterTableChangeTextColumnLength(),
+            $this->platform->getAlterTableSQL($diff)
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getAlterTableChangeTextColumnLength(): array
+    {
+        return ['ALTER TABLE mytable ' .
+            'CHANGE text1 text1 TEXT NOT NULL, ' .
+            'CHANGE text2 text2 MEDIUMTEXT NOT NULL, ' .
+            'CHANGE text3 text3 LONGTEXT NOT NULL, ' .
+            'CHANGE text4 text4 TINYTEXT NOT NULL, ' .
+            'CHANGE text5 text5 TEXT NOT NULL',
+        ];
+    }
+
     public function testReturnsGuidTypeDeclarationSQL(): void
     {
         self::assertSame('CHAR(36)', $this->platform->getGuidTypeDeclarationSQL([]));

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -812,28 +812,28 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         $fromTable = new Table('mytable');
 
-        $fromTable->addColumn('blob1', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYBLOB]);
-        $fromTable->addColumn('blob2', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_BLOB]);
-        $fromTable->addColumn('blob3', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
-        $fromTable->addColumn('blob4', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
+        $fromTable->addColumn('blob1', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_TINYBLOB]);
+        $fromTable->addColumn('blob2', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_BLOB]);
+        $fromTable->addColumn('blob3', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
+        $fromTable->addColumn('blob4', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
         $fromTable->addColumn('blob5', 'blob');
-        $fromTable->addColumn('blob6', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYBLOB]);
-        $fromTable->addColumn('blob7', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_BLOB]);
-        $fromTable->addColumn('blob8', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
-        $fromTable->addColumn('blob9', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
+        $fromTable->addColumn('blob6', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_TINYBLOB]);
+        $fromTable->addColumn('blob7', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_BLOB]);
+        $fromTable->addColumn('blob8', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
+        $fromTable->addColumn('blob9', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
         $fromTable->addColumn('blob10', 'blob');
 
         $toTable = new Table('mytable');
 
-        $toTable->addColumn('blob1', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_BLOB]);
-        $toTable->addColumn('blob2', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
-        $toTable->addColumn('blob3', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
-        $toTable->addColumn('blob4', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYBLOB]);
-        $toTable->addColumn('blob5', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_BLOB]);
-        $toTable->addColumn('blob6', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYBLOB]);
-        $toTable->addColumn('blob7', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_BLOB]);
-        $toTable->addColumn('blob8', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
-        $toTable->addColumn('blob9', 'blob', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
+        $toTable->addColumn('blob1', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_BLOB]);
+        $toTable->addColumn('blob2', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
+        $toTable->addColumn('blob3', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
+        $toTable->addColumn('blob4', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_TINYBLOB]);
+        $toTable->addColumn('blob5', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_BLOB]);
+        $toTable->addColumn('blob6', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_TINYBLOB]);
+        $toTable->addColumn('blob7', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_BLOB]);
+        $toTable->addColumn('blob8', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
+        $toTable->addColumn('blob9', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB * 2]);
         $toTable->addColumn('blob10', 'blob');
 
         $diff = (new Comparator())->diffTable($fromTable, $toTable);
@@ -863,28 +863,28 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         $fromTable = new Table('mytable');
 
-        $fromTable->addColumn('text1', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYTEXT]);
-        $fromTable->addColumn('text2', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
-        $fromTable->addColumn('text3', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
-        $fromTable->addColumn('text4', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
+        $fromTable->addColumn('text1', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TINYTEXT]);
+        $fromTable->addColumn('text2', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TEXT]);
+        $fromTable->addColumn('text3', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
+        $fromTable->addColumn('text4', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
         $fromTable->addColumn('text5', 'text');
-        $fromTable->addColumn('text6', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYTEXT]);
-        $fromTable->addColumn('text7', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
-        $fromTable->addColumn('text8', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
-        $fromTable->addColumn('text9', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
+        $fromTable->addColumn('text6', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TINYTEXT]);
+        $fromTable->addColumn('text7', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TEXT]);
+        $fromTable->addColumn('text8', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
+        $fromTable->addColumn('text9', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
         $fromTable->addColumn('text10', 'text');
 
         $toTable = new Table('mytable');
 
-        $toTable->addColumn('text1', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
-        $toTable->addColumn('text2', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
-        $toTable->addColumn('text3', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
-        $toTable->addColumn('text4', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYTEXT]);
-        $toTable->addColumn('text5', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
-        $toTable->addColumn('text6', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TINYTEXT]);
-        $toTable->addColumn('text7', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
-        $toTable->addColumn('text8', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
-        $toTable->addColumn('text9', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
+        $toTable->addColumn('text1', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TEXT]);
+        $toTable->addColumn('text2', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
+        $toTable->addColumn('text3', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
+        $toTable->addColumn('text4', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TINYTEXT]);
+        $toTable->addColumn('text5', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TEXT]);
+        $toTable->addColumn('text6', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TINYTEXT]);
+        $toTable->addColumn('text7', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_TEXT]);
+        $toTable->addColumn('text8', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
+        $toTable->addColumn('text9', 'text', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT * 2]);
         $toTable->addColumn('text10', 'text');
 
         $diff = (new Comparator())->diffTable($fromTable, $toTable);

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -1126,6 +1126,31 @@ class ComparatorTest extends TestCase
         self::assertEquals($expected, Comparator::compareSchemas($oldSchema, $newSchema));
     }
 
+    public function testCompareChangedTextColumn(): void
+    {
+        $oldSchema = new Schema();
+
+        $tableFoo = $oldSchema->createTable('foo');
+        $tableFoo->addColumn('id', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_TEXT]);
+
+        $newSchema = new Schema();
+        $table     = $newSchema->createTable('foo');
+        $table->addColumn('id', 'text', ['length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
+
+        $expected             = new SchemaDiff();
+        $expected->fromSchema = $oldSchema;
+
+        $tableDiff            = $expected->changedTables['foo'] = new TableDiff('foo');
+        $tableDiff->fromTable = $tableFoo;
+
+        $columnDiff = $tableDiff->changedColumns['id'] = new ColumnDiff('id', $table->getColumn('id'));
+
+        $columnDiff->fromColumn        = $tableFoo->getColumn('id');
+        $columnDiff->changedProperties = ['length'];
+
+        self::assertEquals($expected, Comparator::compareSchemas($oldSchema, $newSchema));
+    }
+
     public function testCompareQuotedAndUnquotedForeignKeyColumns(): void
     {
         $fk1 = new ForeignKeyConstraint(['foo'], 'bar', ['baz'], 'fk1', ['onDelete' => 'NO ACTION']);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2663

#### Summary

In MySQL the `blob` type depends on the `length` to use one of `TINYBLOB`, `BLOB`, `MEDIUMBLOB` or `LONGBLOB`. When diffing two `blob` columns the length is currently ignored which results in missing changes of the underlying database column type.

UPDATE: It is the same with the `text` type which uses one of `TINYTEXT`, `TEXT`, `MEDIUMTEXT` or `LONGTEXT`.