### PR TITLE
Remove redundant implementation of PDO\SQLSrv\Connection::lastInsertId($name)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ on:
     - cron: "42 3 * * *"
 
 env:
-  fail-fast: true
+  fail-fast: false
 
 jobs:
   phpunit-smoke-check:

--- a/src/Driver/PDO/SQLSrv/Connection.php
+++ b/src/Driver/PDO/SQLSrv/Connection.php
@@ -49,13 +49,7 @@ final class Connection implements ServerInfoAwareConnection
      */
     public function lastInsertId($name = null)
     {
-        if ($name === null) {
-            return $this->connection->lastInsertId($name);
-        }
-
-        return $this->prepare('SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?')
-            ->execute([$name])
-            ->fetchOne();
+        return $this->connection->lastInsertId($name);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The implementation is available in `pdo_sqlsrv` since 5.0.0 (https://github.com/microsoft/msphpsql/pull/479). The code is covered by `Functional\WriteTest`.