### PR TITLE
Add explicit @deprecated in ForwardCompatibility\Result

### DIFF
--- a/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
+++ b/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
@@ -37,6 +37,8 @@ class Result implements IteratorAggregate, DriverResultStatement, BaseResult
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use Result::free() instead.
      */
     public function closeCursor()
     {
@@ -53,6 +55,8 @@ class Result implements IteratorAggregate, DriverResultStatement, BaseResult
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use one of the fetch- or iterate-related methods.
      */
     public function setFetchMode($fetchMode, $arg2 = null, $arg3 = null)
     {
@@ -61,6 +65,8 @@ class Result implements IteratorAggregate, DriverResultStatement, BaseResult
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use fetchNumeric(), fetchAssociative() or fetchOne() instead.
      */
     public function fetch($fetchMode = null, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
@@ -69,6 +75,8 @@ class Result implements IteratorAggregate, DriverResultStatement, BaseResult
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use fetchAllNumeric(), fetchAllAssociative() or fetchFirstColumn() instead.
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
@@ -77,6 +85,8 @@ class Result implements IteratorAggregate, DriverResultStatement, BaseResult
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use fetchOne() instead.
      */
     public function fetchColumn($columnIndex = 0)
     {


### PR DESCRIPTION
PHPStorm will not by able to detect deprecated methods with {@inheritDoc}.
Copy deprecation annotations from \Doctrine\DBAL\Driver\ResultStatement.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | https://github.com/doctrine/dbal/issues/4570

