### PR TITLE
Add missing runtime deprecations related to FC Result API (#4529, #4571)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,11 @@
+Note about upgrading: Doctrine uses static and runtime mechanisms to raise
+awareness about deprecated code.
+
+- Use of `@deprecated` docblock that is detected by IDEs (like PHPStorm) or
+  Static Analysis tools (like Psalm, phpstan)
+- Use of our low-overhead runtime deprecation API, details:
+  https://github.com/doctrine/deprecations/
+
 # Upgrade to 2.12
 
 ## Deprecated non-zero based positional parameter keys

--- a/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
+++ b/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\ResultStatement as DriverResultStatement;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\NoKeyValue;
 use Doctrine\DBAL\Result as BaseResult;
+use Doctrine\Deprecations\Deprecation;
 use IteratorAggregate;
 use PDO;
 use Traversable;
@@ -70,6 +71,12 @@ class Result implements IteratorAggregate, DriverResultStatement, BaseResult
      */
     public function fetch($fetchMode = null, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Result::fetch() is deprecated, use Result::fetchNumeric(), fetchAssociative() or fetchOne() instead.'
+        );
+
         return $this->stmt->fetch($fetchMode, $cursorOrientation, $cursorOffset);
     }
 
@@ -80,6 +87,13 @@ class Result implements IteratorAggregate, DriverResultStatement, BaseResult
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Result::fetchAll() is deprecated, use Result::fetchAllNumeric(), fetchAllAssociative() or ' .
+            'fetchFirstColumn() instead.'
+        );
+
         return $this->stmt->fetchAll($fetchMode, $fetchArgument, $ctorArgs);
     }
 
@@ -90,6 +104,12 @@ class Result implements IteratorAggregate, DriverResultStatement, BaseResult
      */
     public function fetchColumn($columnIndex = 0)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Result::fetchColumn() is deprecated, use Result::fetchOne() instead.'
+        );
+
         return $this->stmt->fetchColumn($columnIndex);
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

Related to #4529 and #4571 this change adds runtime deprecations to `ForwardCompatibility\Result` calls and a small note about our deprecation policy in `UPGRAE.md`