### PR TITLE
Deprecate Statement::execute in favor of Statement::executeStatement/executeQuery

### DIFF
--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\Exception\NoKeyValue;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Result as BaseResult;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use IteratorAggregate;
@@ -179,6 +180,34 @@ class Statement implements IteratorAggregate, DriverStatement, Result
         }
 
         return $stmt;
+    }
+
+    /**
+     * Executes the statement with the currently bound parameters and return result.
+     *
+     * @param mixed[]|null $params
+
+     * @throws Exception
+     */
+    public function executeQuery(?array $params = null): BaseResult
+    {
+        $this->execute($params);
+
+        return new ForwardCompatibility\Result($this);
+    }
+
+    /**
+     * Executes the statement with the currently bound parameters and return affected rows.
+     *
+     * @param mixed[]|null $params
+
+     * @throws Exception
+     */
+    public function executeStatement(?array $params = null): int
+    {
+        $this->execute($params);
+
+        return $this->rowCount();
     }
 
     /**

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -148,6 +148,8 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /**
      * Executes the statement with the currently bound parameters.
      *
+     * @deprecated Statement::execute() is deprecated, use Statement::executeQuery() or executeStatement() instead
+     *
      * @param mixed[]|null $params
      *
      * @return bool TRUE on success, FALSE on failure.
@@ -156,6 +158,12 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      */
     public function execute($params = null)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4580',
+            'Statement::execute() is deprecated, use Statement::executeQuery() or Statement::executeStatement() instead'
+        );
+
         if (is_array($params)) {
             $this->params = $params;
         }

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -193,12 +193,16 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /**
      * Executes the statement with the currently bound parameters and return result.
      *
-     * @param mixed[]|null $params
-
+     * @param mixed[] $params
+     *
      * @throws Exception
      */
-    public function executeQuery(?array $params = null): BaseResult
+    public function executeQuery(array $params = []): BaseResult
     {
+        if ($params === []) {
+            $params = null; // Workaround as long execute() exists and used internally.
+        }
+
         $this->execute($params);
 
         return new ForwardCompatibility\Result($this);
@@ -207,12 +211,16 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /**
      * Executes the statement with the currently bound parameters and return affected rows.
      *
-     * @param mixed[]|null $params
-
+     * @param mixed[] $params
+     *
      * @throws Exception
      */
-    public function executeStatement(?array $params = null): int
+    public function executeStatement(array $params = []): int
     {
+        if ($params === []) {
+            $params = null; // Workaround as long execute() exists and used internally.
+        }
+
         $this->execute($params);
 
         return $this->rowCount();

--- a/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/StatementTest.php
@@ -326,4 +326,42 @@ EOF
 
         self::assertEquals(1, $result);
     }
+
+    public function testExecuteQuery(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $query    = $platform->getDummySelectSQL();
+        $result   = $this->connection->prepare($query)->executeQuery()->fetchOne();
+
+        self::assertEquals(1, $result);
+    }
+
+    public function testExecuteQueryWithParams(): void
+    {
+        $this->connection->insert('stmt_test', ['id' => 1]);
+
+        $query  = 'SELECT id FROM stmt_test WHERE id = ?';
+        $result = $this->connection->prepare($query)->executeQuery([1])->fetchOne();
+
+        self::assertEquals(1, $result);
+    }
+
+    public function testExecuteStatement(): void
+    {
+        $this->connection->insert('stmt_test', ['id' => 1]);
+
+        $query = 'UPDATE stmt_test SET name = ? WHERE id = 1';
+        $stmt  = $this->connection->prepare($query);
+
+        $stmt->bindValue(1, 'bar');
+
+        $result = $stmt->executeStatement();
+
+        $this->assertEquals(1, $result);
+
+        $query  = 'UPDATE stmt_test SET name = ? WHERE id = ?';
+        $result = $this->connection->prepare($query)->executeStatement(['foo', 1]);
+
+        $this->assertEquals(1, $result);
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixes        | https://github.com/doctrine/dbal/issues/4569

#### Summary

Adopt the `Connection` API with differentation of `executeQuery` and `executeStatement` also for `Statement`.

This would allow to return `Result` or `int` respectively instead of `Statement::execute` returning a boolean.

Old code:

```php
$sql = 'SELECT * FROM test WHERE id = ?';
$stmt = $connection->prepare($sql);
$stmt->bindValue(1, $id);

$stmt->execute();
$row = $stmt->fetch();
```

New Code:

```php
$sql = 'SELECT * FROM test WHERE id = ?';
$stmt = $connection->prepare($sql);
$stmt->bindValue(1, $id);

$row = $stmt->executeQuery()->fetchAssociative();
```

This deprecation is going to be spread out across mre versions, as DBAL 3.x is already released with Statement::execute as well, we can only remove it earliest in DBAL 4.