### PR TITLE
[GH-4510] Deprecate ReservedWordsCommand::setKeywordListClass()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -25,6 +25,11 @@ Use `AbstractSchemaManager::listSchemaNames()` instead.
 Instead of implementing `getReservedKeywordsClass()`, `AbstractPlatform` subclasses should implement
 `createReservedKeywordsList()`.
 
+## Deprecated `ReservedWordsCommand::setKeywordListClass()`
+
+The usage of `ReservedWordsCommand::setKeywordListClass()` has been deprecated. To add or replace a keyword list,
+use `setKeywordList()` instead.
+
 ## Deprecated `$driverOptions` argument of `PDO\Statement::bindParam()` and `PDO\SQLSrv\Statement::bindParam()`
 
 The usage of the `$driverOptions` argument of `PDO\Statement::bindParam()` and `PDO\SQLSrv\Statement::bindParam()` is deprecated.


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

See #4510.

The usage of `ReservedWordsCommand::setKeywordListClass()` is being deprecated in favor of `setKeywordList()`. This way, the DBAL will be no longer responsible for unsafe instantiation of classes with unknown constructor signature.

Additionally, the list of keyword lists has been sorted alphabetically and the command help message has been corrected: all keyword lists are used by default including the IBM DB2 list.