### PR TITLE
Fix user provided pdo connection

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\Mysqli;
 use Doctrine\DBAL\Driver\OCI8;
 use Doctrine\DBAL\Driver\PDO;
+use Doctrine\DBAL\Driver\PDO\Statement as PDODriverStatement;
 use Doctrine\DBAL\Driver\SQLAnywhere;
 use Doctrine\DBAL\Driver\SQLSrv;
 use Doctrine\Deprecations\Deprecation;
@@ -143,6 +144,7 @@ final class DriverManager
      * <b>pdo</b>:
      * You can pass an existing PDO instance through this parameter. The PDO
      * instance will be wrapped in a Doctrine\DBAL\Connection.
+     * This feature is deprecated and no longer supported in 3.0.x version.
      *
      * <b>wrapperClass</b>:
      * You may specify a custom wrapper class through the 'wrapperClass'
@@ -225,6 +227,7 @@ final class DriverManager
             );
 
             $params['pdo']->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+            $params['pdo']->setAttribute(\PDO::ATTR_STATEMENT_CLASS, [PDODriverStatement::class, []]);
             $params['driver'] = 'pdo_' . $params['pdo']->getAttribute(\PDO::ATTR_DRIVER_NAME);
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -5,9 +5,11 @@ namespace Doctrine\Tests\DBAL\Functional;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use Error;
@@ -348,10 +350,13 @@ class ConnectionTest extends DbalFunctionalTestCase
      */
     public function testUserProvidedPDOConnection(): void
     {
-        self::assertTrue(
-            DriverManager::getConnection([
-                'pdo' => new PDO('sqlite::memory:'),
-            ])->ping()
-        );
+        $connection = DriverManager::getConnection([
+            'pdo' => new PDO('sqlite::memory:'),
+        ]);
+
+        $result = $connection->executeQuery('SELECT 1');
+
+        self::assertInstanceOf(ResultStatement::class, $result);
+        self::assertInstanceOf(Result::class, $result);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4564 

#### Summary

When user provide a PDO connection, we get the following fatal error :

```text
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Doctrine\DBAL\Connection::ensureForwardCompatibilityStatement() must be an instance of Doctrine\DBAL\Driver\ResultStatement, instance of PDOStatement given, called in vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php on line 1313 and defined in vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1370
Stack trace:
#0 vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(1313): Doctrine\DBAL\Connection->ensureForwardCompatibilityStatement(Object(PDOStatement))
#1 t.php(6): Doctrine\DBAL\Connection->executeQuery('SELECT 1;')
#2 {main}
  thrown in vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php on line 1370
```

It happen because the PDO connection is not wrapped with Driver/Connection Interface in that case. The proposed solution, wrap the PDOStatement with Driver\PDO\Statement.

#### How to reproduce

```php
<?php                                                                                                                   
require_once('vendor/autoload.php');                                                                                    
                                                                                                                        
$conn = Doctrine\DBAL\DriverManager::getConnection(['pdo' => new PDO('sqlite::memory:'), 'driver' => 'pdo_sqlite']);    
$conn->executeQuery('SELECT 1;');
```