### PR TITLE
Add direct dependency on PHP_CodeSniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "jetbrains/phpstorm-stubs": "2020.2",
         "phpstan/phpstan": "0.12.81",
         "phpunit/phpunit": "^7.5.20|^8.5|9.5.0",
+        "squizlabs/php_codesniffer": "3.6.0",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
         "vimeo/psalm": "4.6.4"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -97,8 +97,7 @@
         <exclude-pattern>tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php</exclude-pattern>
     </rule>
 
-    <!-- https://github.com/squizlabs/PHP_CodeSniffer/issues/2837 -->
-    <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
+    <rule ref="Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps">
         <!--
             This file uses the return value db2_server_info(), which does not follow conventions
             phpcs wrongly complains about it, and that has been reported here:
@@ -106,11 +105,14 @@
         -->
         <exclude-pattern>lib/Doctrine/DBAL/Driver/IBMDB2/DB2Connection.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionFailed.php</exclude-pattern>
-        <!-- See https://github.com/squizlabs/PHP_CodeSniffer/issues/2837 -->
-        <exclude-pattern>lib/Doctrine/DBAL/SQLParserUtils.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/DBAL/Tools/Dumper.php</exclude-pattern>
-        <exclude-pattern>tests/Doctrine/Tests/DBAL/Driver/StatementIteratorTest.php</exclude-pattern>
         <exclude-pattern>tests/Doctrine/Tests/DBAL/Tools/DumperTest.php</exclude-pattern>
+    </rule>
+
+    <!-- See https://github.com/squizlabs/PHP_CodeSniffer/issues/2837 -->
+    <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
+        <exclude-pattern>lib/Doctrine/DBAL/SQLParserUtils.php</exclude-pattern>
+        <exclude-pattern>tests/Doctrine/Tests/DBAL/Driver/StatementIteratorTest.php</exclude-pattern>
     </rule>
 
     <!-- some statement classes close cursor using an empty while-loop -->


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

See the build failure of https://github.com/doctrine/dbal/pull/4592.

PHP_CodeSniffer 3.6.0 introduces changes of some error codes suppressed in the codebase (e.g. https://github.com/squizlabs/PHP_CodeSniffer/commit/0aeb095248f307cc7bac7b0268ae4d5d3440f300).

Since it's an indirect dependency currently restricted to `^3.5.6` by `slevomat/coding-standard`, without restricting it directly, the repository would have to maintain compatibility with both 3.5 and 3.6. The solution is to restrict it temporarily until it's restricted by a direct dependency.