### PR TITLE
Fix BC break on QueryBuilder::execute()

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -18,7 +18,6 @@ use Doctrine\DBAL\Exception\NoKeyValue;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\DBAL\Result as BaseResult;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
@@ -1264,7 +1263,9 @@ class Connection implements DriverConnection
      * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
-     * @return ResultStatement&BaseResult The executed statement.
+     * @return ForwardCompatibility\DriverStatement|ForwardCompatibility\DriverResultStatement
+     *
+     * The executed statement or the cached result statement if a query cache profile is used
      *
      * @throws Exception
      */
@@ -1320,7 +1321,7 @@ class Connection implements DriverConnection
      * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
-     * @return ResultStatement&BaseResult
+     * @return ForwardCompatibility\DriverResultStatement
      *
      * @throws CacheException
      */
@@ -1365,15 +1366,11 @@ class Connection implements DriverConnection
     }
 
     /**
-     * @return ResultStatement&BaseResult
+     * @return ForwardCompatibility\Result
      */
     private function ensureForwardCompatibilityStatement(ResultStatement $stmt)
     {
-        if ($stmt instanceof BaseResult) {
-            return $stmt;
-        }
-
-        return new ForwardCompatibility\Result($stmt);
+        return ForwardCompatibility\Result::ensure($stmt);
     }
 
     /**

--- a/lib/Doctrine/DBAL/ForwardCompatibility/DriverResultStatement.php
+++ b/lib/Doctrine/DBAL/ForwardCompatibility/DriverResultStatement.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Doctrine\DBAL\ForwardCompatibility;
+
+use Doctrine\DBAL;
+
+interface DriverResultStatement extends DBAL\Driver\ResultStatement, DBAL\Result
+{
+}

--- a/lib/Doctrine/DBAL/ForwardCompatibility/DriverStatement.php
+++ b/lib/Doctrine/DBAL/ForwardCompatibility/DriverStatement.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Doctrine\DBAL\ForwardCompatibility;
+
+use Doctrine\DBAL;
+
+interface DriverStatement extends DBAL\Driver\Statement, DBAL\Result
+{
+}

--- a/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
+++ b/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
@@ -2,10 +2,10 @@
 
 namespace Doctrine\DBAL\ForwardCompatibility;
 
-use Doctrine\DBAL\Driver\ResultStatement as DriverResultStatement;
+use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\NoKeyValue;
-use Doctrine\DBAL\Result as BaseResult;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
 use IteratorAggregate;
 use PDO;
@@ -18,18 +18,27 @@ use function method_exists;
  * A wrapper around a Doctrine\DBAL\Driver\ResultStatement that adds 3.0 features
  * defined in Result interface
  */
-class Result implements IteratorAggregate, DriverResultStatement, BaseResult
+class Result implements IteratorAggregate, DriverStatement, DriverResultStatement
 {
-    /** @var DriverResultStatement */
+    /** @var Driver\ResultStatement */
     private $stmt;
 
-    public function __construct(DriverResultStatement $stmt)
+    public static function ensure(Driver\ResultStatement $stmt): Result
+    {
+        if ($stmt instanceof Result) {
+            return $stmt;
+        }
+
+        return new Result($stmt);
+    }
+
+    public function __construct(Driver\ResultStatement $stmt)
     {
         $this->stmt = $stmt;
     }
 
     /**
-     * @return DriverResultStatement
+     * @return Driver\ResultStatement
      */
     public function getIterator()
     {
@@ -300,5 +309,105 @@ class Result implements IteratorAggregate, DriverResultStatement, BaseResult
         if ($columnCount < 2) {
             throw NoKeyValue::fromColumnCount($columnCount);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated This feature will no longer be available on Result object in 3.0.x version.
+     */
+    public function bindValue($param, $value, $type = ParameterType::STRING)
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Result::bindValue() is deprecated, no replacement.'
+        );
+
+        if ($this->stmt instanceof Driver\Statement) {
+            return $this->stmt->bindValue($param, $value, $type);
+        }
+
+        throw Exception::notSupported('bindValue');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated This feature will no longer be available on Result object in 3.0.x version.
+     */
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Result::bindParam() is deprecated, no replacement.'
+        );
+
+        if ($this->stmt instanceof Driver\Statement) {
+            return $this->stmt->bindParam($param, $variable, $type, $length);
+        }
+
+        throw Exception::notSupported('bindParam');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated The error information is available via exceptions.
+     */
+    public function errorCode()
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Result::errorCode() is deprecated, the error information is available via exceptions.'
+        );
+
+        if ($this->stmt instanceof Driver\Statement) {
+            return $this->stmt->errorCode();
+        }
+
+        throw Exception::notSupported('errorCode');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated The error information is available via exceptions.
+     */
+    public function errorInfo()
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Result::errorInfo() is deprecated, the error information is available via exceptions.'
+        );
+
+        if ($this->stmt instanceof Driver\Statement) {
+            return $this->stmt->errorInfo();
+        }
+
+        throw Exception::notSupported('errorInfo');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated This feature will no longer be available on Result object in 3.0.x version.
+     */
+    public function execute($params = null)
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4019',
+            'Result::execute() is deprecated, no replacement.'
+        );
+
+        if ($this->stmt instanceof Driver\Statement) {
+            return $this->stmt->execute($params);
+        }
+
+        throw Exception::notSupported('execute');
     }
 }

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -3,8 +3,8 @@
 namespace Doctrine\DBAL\Query;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\ForwardCompatibility;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
@@ -201,14 +201,16 @@ class QueryBuilder
     /**
      * Executes this query using the bound parameters and their types.
      *
-     * @return ResultStatement|int
+     * @return ForwardCompatibility\DriverStatement|int
      *
      * @throws Exception
      */
     public function execute()
     {
         if ($this->type === self::SELECT) {
-            return $this->connection->executeQuery($this->getSQL(), $this->params, $this->paramTypes);
+            return ForwardCompatibility\Result::ensure(
+                $this->connection->executeQuery($this->getSQL(), $this->params, $this->paramTypes)
+            );
         }
 
         return $this->connection->executeStatement($this->getSQL(), $this->params, $this->paramTypes);

--- a/tests/Doctrine/Tests/DBAL/ForwardCompatibility/ResultTest.php
+++ b/tests/Doctrine/Tests/DBAL/ForwardCompatibility/ResultTest.php
@@ -3,9 +3,10 @@
 namespace Doctrine\Tests\DBAL\ForwardCompatibility;
 
 use Doctrine\DBAL\Cache\ArrayStatement;
-use Doctrine\DBAL\Driver\ResultStatement as DriverResultStatement;
+use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ForwardCompatibility\Result;
+use Doctrine\DBAL\ParameterType;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use Traversable;
@@ -38,6 +39,24 @@ class ResultTest extends TestCase
                 ],
             ])
         );
+    }
+
+    public function testEnsureWithResult(): void
+    {
+        $instance = Result::ensure($this->instance);
+        $this->assertSame($this->instance, $instance, 'Result is not wrapped twice');
+    }
+
+    public function testEnsureWithResultStatement(): void
+    {
+        $instance = Result::ensure($this->createMock(Driver\ResultStatement::class));
+        $this->assertInstanceOf(Result::class, $instance);
+    }
+
+    public function testEnsureWithStatement(): void
+    {
+        $instance = Result::ensure($this->createMock(Driver\Statement::class));
+        $this->assertInstanceOf(Result::class, $instance);
     }
 
     public function testIsTraversable(): void
@@ -335,7 +354,7 @@ class ResultTest extends TestCase
         );
     }
 
-    public function testRowCountIsSupportedByWrappedStatement(): void
+    public function testRowCountIsSupportedByWrappedArrayStatement(): void
     {
         $this->assertSame(3, $this->instance->rowCount());
     }
@@ -343,7 +362,120 @@ class ResultTest extends TestCase
     public function testRowCountIsNotSupportedByWrappedStatement(): void
     {
         $this->expectExceptionObject(Exception::notSupported('rowCount'));
-        $instance = new Result($this->createMock(DriverResultStatement::class));
+        $instance = new Result($this->createMock(Driver\ResultStatement::class));
         $instance->rowCount();
+    }
+
+    public function testBindValueIsSupportedByWrappedStatement(): void
+    {
+        $param = ':key';
+        $value = 'value';
+
+        $statement = $this->createMock(Driver\Statement::class);
+        $statement
+            ->expects($this->once())
+            ->method('bindValue')
+            ->with($param, $value, ParameterType::STRING)
+            ->willReturn(true);
+
+        $instance = new Result($statement);
+
+        $this->assertTrue($instance->bindValue($param, $value));
+    }
+
+    public function testBindValueIsNotSupportedByWrappedResultStatement(): void
+    {
+        $this->expectExceptionObject(Exception::notSupported('bindValue'));
+        $this->instance->bindValue(':key', 'value');
+    }
+
+    public function testBindParamIsSupportedByWrappedStatement(): void
+    {
+        $param = ':key';
+        $value = 'value';
+
+        $statement = $this->createMock(Driver\Statement::class);
+        $statement
+            ->expects($this->once())
+            ->method('bindParam')
+            ->with($param, $value, ParameterType::STRING)
+            ->willReturn(true);
+
+        $instance = new Result($statement);
+
+        $this->assertTrue($instance->bindParam($param, $value));
+    }
+
+    public function testBindParamIsNotSupportedByWrappedResultStatement(): void
+    {
+        $param = ':key';
+        $value = 'value';
+
+        $this->expectExceptionObject(Exception::notSupported('bindParam'));
+        $this->instance->bindParam($param, $value);
+    }
+
+    public function testErrorCodeIsSupportedByWrappedStatement(): void
+    {
+        $errorCode = 32;
+
+        $statement = $this->createMock(Driver\Statement::class);
+        $statement
+            ->expects($this->once())
+            ->method('errorCode')
+            ->willReturn($errorCode);
+
+        $instance = new Result($statement);
+
+        $this->assertSame($errorCode, $instance->errorCode());
+    }
+
+    public function testErrorCodeIsNotSupportedByWrappedResultStatement(): void
+    {
+        $this->expectExceptionObject(Exception::notSupported('errorCode'));
+        $this->instance->errorCode();
+    }
+
+    public function testErrorInfoIsSupportedByWrappedStatement(): void
+    {
+        $errorInfo = ['Some info'];
+
+        $statement = $this->createMock(Driver\Statement::class);
+        $statement
+            ->expects($this->once())
+            ->method('errorInfo')
+            ->willReturn($errorInfo);
+
+        $instance = new Result($statement);
+
+        $this->assertSame($errorInfo, $instance->errorInfo());
+    }
+
+    public function testErrorInfoIsNotSupportedByWrappedResultStatement(): void
+    {
+        $this->expectExceptionObject(Exception::notSupported('errorInfo'));
+        $this->instance->errorInfo();
+    }
+
+    public function testExecuteIsSupportedByWrappedStatement(): void
+    {
+        $params = [':key' => 'value'];
+
+        $statement = $this->createMock(Driver\Statement::class);
+        $statement
+            ->expects($this->once())
+            ->method('execute')
+            ->with($params)
+            ->willReturn(true);
+
+        $instance = new Result($statement);
+
+        $this->assertTrue($instance->execute($params));
+    }
+
+    public function testExecuteIsNotSupportedByWrappedResultStatement(): void
+    {
+        $this->expectExceptionObject(Exception::notSupported('execute'));
+        $this->instance->execute([':key' => 'value']);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -3,15 +3,18 @@
 namespace Doctrine\Tests\DBAL\Query;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Query\QueryException;
+use Doctrine\DBAL\Result;
 use Doctrine\Tests\DbalTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class QueryBuilderTest extends DbalTestCase
 {
-    /** @var Connection */
+    /** @var Connection&MockObject */
     protected $conn;
 
     protected function setUp(): void
@@ -1074,5 +1077,23 @@ class QueryBuilderTest extends DbalTestCase
         $qb->orHaving('', 'c = d');
 
         self::assertSame('SELECT id FROM foo HAVING (a = b) OR (c = d)', $qb->getSQL());
+    }
+
+    public function testExecuteSelect(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $this->conn
+            ->expects($this->any())
+            ->method('executeQuery')
+            ->willReturn($this->createMock(Driver\Statement::class));
+
+        $result = $qb
+            ->select('id')
+            ->from('foo')
+            ->execute();
+
+        self::assertInstanceOf(Driver\Statement::class, $result);
+        self::assertInstanceOf(Result::class, $result);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4591

### Summary

This PR fix a BC break on return type for :
- Doctrine\DBAL\Connection::execute()
- Doctrine\DBAL\Query\QueryBuilder::execute()

Previously, this methods expected to return a Doctrine\DBAL\Driver\Statement object as result.

### Contents description

#### Situation in 2.12.x
- Connection::executeCacheQuery() return a Driver\ResultStatement
- Connection::executeQuery() return either a Driver\ResultStatement if cache is used, or a Driver\Statement if query is executed
- QueryBuilder::execute() return either a Driver\Statement when the query is a select, or an integer for any other statement

#### Situation in 2.13.0 :
- Connection::executeCacheQuery() return a Driver\ResultStatement & DBAL\Result 
- Connection::executeQuery() return a Driver\ResultStatement & DBAL\Result 
- QueryBuilder::execute() return a Driver\ResultStatement & DBAL\Result

#### Situation in this PR

Create 2 new interfaces ensuring forward compatibility :
- ForwardCompatibility\DriverResultStatement extends Driver\ResultStatement and DBAL\ResultStatement
- ForwardCompatibility\DriverStatement extends Driver\Statement and DBAL\Statement

Query execution result :
- Connection::executeCacheQuery() return a ForwardCompatibility\Result wrapping Driver\ResultStatement
- Connection::executeQuery() return a ForwardCompatibility\Result wrapping Driver\ResultStatement if cache is used, or a ForwardCompatibility\Result wrapping Driver\Statement if query is executed
- QueryBuilder::execute() return either a a ForwardCompatibility\Result wrapping Driver\Statement when the query is a select, or an integer for any other statement

ForwardCompatibility/Result now implements Driver\Statement interface. If a Driver\Statement object is provided to constructor, Driver\Statement features will be availables, if a Driver\ResultStatement object is provided an exception will be thrown when trying to use Driver\Statement features.
