### PR TITLE
BUGFIX: sqlite has no knowledge about longblob

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -567,6 +567,7 @@ class SqlitePlatform extends AbstractPlatform
             'image'            => 'string',
             'int'              => 'integer',
             'integer'          => 'integer',
+            'longblob'         => 'blob',
             'longtext'         => 'text',
             'longvarchar'      => 'string',
             'mediumint'        => 'integer',

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -308,6 +308,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $diff = new TableDiff('user');
 
         $diff->addedColumns['foo']   = new Column('foo', Type::getType('string'));
+        $diff->addedColumns['bar']   = new Column('bar', Type::getType('blob'));
         $diff->addedColumns['count'] = new Column('count', Type::getType('integer'), [
             'notnull' => false,
             'default' => 1,
@@ -315,6 +316,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
 
         $expected = [
             'ALTER TABLE user ADD COLUMN foo VARCHAR(255) NOT NULL',
+            'ALTER TABLE user ADD COLUMN bar BLOB NOT NULL',
             'ALTER TABLE user ADD COLUMN count INTEGER DEFAULT 1',
         ];
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | **bug**
| BC Break     | **no**
| Fixed issues | (none)

#### Summary

<!-- Provide a summary of your change. -->

This fixes a bug where webapps, who are trying to create a longblob field in sqlite, are going wrong. The bugfix is based in the comment by @Neziak on a similar issue with MySQL in the Nextcloud server repository (https://github.com/nextcloud/server/issues/25748#issuecomment-784736577).
The bugfix has successfully been tested on my personal nextcloud instance.
I decided to not create a issue on github as why bother people if typing this message takes 10x more time than fixing the actual bug?