### PR TITLE
[GH-4613] Use utf8mb4 instead of utf8 for testing connection charset

### DIFF
--- a/tests/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Functional/PrimaryReadReplicaConnectionTest.php
@@ -71,7 +71,7 @@ class PrimaryReadReplicaConnectionTest extends FunctionalTestCase
     public function testInheritCharsetFromPrimary(): void
     {
         $charsets = [
-            'utf8',
+            'utf8mb4',
             'latin1',
         ];
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Closes #4613.