### PR TITLE
Move fix for user provided pdo connection

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Cache\CacheException;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Cache\ResultCacheStatement;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\PDO\Statement as PDODriverStatement;
 use Doctrine\DBAL\Driver\PingableConnection;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
@@ -21,6 +22,7 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
+use PDO;
 use Throwable;
 use Traversable;
 
@@ -193,7 +195,18 @@ class Connection implements DriverConnection
         $this->params  = $params;
 
         if (isset($params['pdo'])) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/3554',
+                'Passing a user provided PDO instance directly to Doctrine is deprecated.'
+            );
+
+            if (! $params['pdo'] instanceof PDO) {
+                throw Exception::invalidPdoInstance();
+            }
+
             $this->_conn = $params['pdo'];
+            $this->_conn->setAttribute(PDO::ATTR_STATEMENT_CLASS, [PDODriverStatement::class, []]);
             unset($this->params['pdo']);
         }
 

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -8,10 +8,8 @@ use Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\Mysqli;
 use Doctrine\DBAL\Driver\OCI8;
 use Doctrine\DBAL\Driver\PDO;
-use Doctrine\DBAL\Driver\PDO\Statement as PDODriverStatement;
 use Doctrine\DBAL\Driver\SQLAnywhere;
 use Doctrine\DBAL\Driver\SQLSrv;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_keys;
 use function array_merge;
@@ -244,14 +242,7 @@ final class DriverManager
         }
 
         if (isset($params['pdo'])) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/3554',
-                'Passing a user provided PDO instance directly to Doctrine is deprecated.'
-            );
-
             $params['pdo']->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-            $params['pdo']->setAttribute(\PDO::ATTR_STATEMENT_CLASS, [PDODriverStatement::class, []]);
             $params['driver'] = 'pdo_' . $params['pdo']->getAttribute(\PDO::ATTR_DRIVER_NAME);
         }
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -114,3 +114,9 @@ parameters:
             message: '~^Parameter #1 \$scheme of static method Doctrine\\DBAL\\DriverManager::parseDatabaseUrlScheme\(\) expects string\|null, int\|string\|null given\.$~'
             paths:
                 - %currentWorkingDirectory%/lib/Doctrine/DBAL/DriverManager.php
+
+        # Until 3.x, $_conn does accept PDO
+        -
+            message: '~^Property Doctrine\\DBAL\\Connection::\$_conn \(Doctrine\\DBAL\\Driver\\Connection\|null\) does not accept PDO\.$~'
+            paths:
+                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Connection.php

--- a/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ConnectionTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\PDOSqlite\Driver as PDODriver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\ForwardCompatibility;
 use Doctrine\DBAL\ParameterType;
@@ -363,7 +364,22 @@ class ConnectionTest extends DbalFunctionalTestCase
 
         $result = $connection->executeQuery('SELECT 1');
 
-        self::assertInstanceOf(ForwardCompatibility\Result::class, $result);
+        self::assertInstanceOf(ForwardCompatibility\DriverResultStatement::class, $result);
+    }
+
+    /**
+     * @requires extension pdo_sqlite
+     */
+    public function testUserProvidedPDOConnectionWithoutDriverManager(): void
+    {
+        $connection = new Connection(
+            ['pdo' => new PDO('sqlite::memory:')],
+            new PDODriver()
+        );
+
+        $result = $connection->executeQuery('SELECT 1');
+
+        self::assertInstanceOf(ForwardCompatibility\DriverResultStatement::class, $result);
     }
 
     public function testResultCompatibilityWhenExecutingQueryWithoutParam(): void


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #4619

#### Summary

Commit 4297f5027011027529fdccfa3b1fbbb3090a7d25 broke `Connection` when passing in `$params['pdo']`

https://github.com/doctrine/dbal/pull/4590 says it should have fixed the issue, but I'm using 2.13.1 and it still seems to be broken.

I took the fix that was already applied in #4590 and moved it to the `Connection` class. This way it gets applied to all connections, not just connections built using the DriverManager.

If it's a good idea to keep the fix applied inside DriverManager, too, please let me know and I can add that back.

#### How to reproduce

```php

use Doctrine\DBAL\Connection;
use Doctrine\DBAL\Driver\PDO\MySQL\Driver;

$params = [
    'pdo' => new \PDO('mysql:<whatever>'),
];
$driver = new Driver();

$connection = new Connection($params, $driver);
// This is a query that Doctrine Migrations tool does:
$connection->executeQuery("SHOW FULL TABLES WHERE Table_type = 'BASE TABLE'");
```


-----

Also, I love Doctrine. You all are doing awesome work!