### PR TITLE
Add events for Transaction begin/commit/rollBack.

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -334,3 +334,84 @@ for event listeners.
 
 It allows you to access the table index definitions of the current database, table name, Platform and
 ``Doctrine\DBAL\Connection`` instance. Indexes, that are about to be added, are not listed.
+
+OnTransactionBegin Event
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``Doctrine\DBAL\Events::onTransactionBegin`` is triggered when ``Doctrine\DBAL\Connection::beginTransaction()``
+is called. An instance of ``Doctrine\DBAL\Event\TransactionBeginEventArgs`` is injected as argument for event listeners.
+
+.. code-block:: php
+
+    <?php
+    class MyEventListener
+    {
+        public function onTransactionBegin(TransactionBeginEventArgs $event)
+        {
+            // Your EventListener code
+        }
+    }
+
+    $evm = new EventManager();
+    $evm->addEventListener(Events::onTransactionBegin, new MyEventListener());
+
+    $conn = DriverManager::getConnection($connectionParams, null, $evm);
+
+It allows you to access the ``Doctrine\DBAL\Connection`` instance.
+Please note that this event can be called multiple times, since transactions can be nested.
+
+OnTransactionCommit Event
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``Doctrine\DBAL\Events::onTransactionCommit`` is triggered when ``Doctrine\DBAL\Connection::commit()`` is called.
+An instance of ``Doctrine\DBAL\Event\TransactionCommitEventArgs`` is injected as argument for event listeners.
+
+.. code-block:: php
+
+    <?php
+    class MyEventListener
+    {
+        public function onTransactionCommit(TransactionCommitEventArgs $event)
+        {
+            // Your EventListener code
+        }
+    }
+
+    $evm = new EventManager();
+    $evm->addEventListener(Events::onTransactionCommit, new MyEventListener());
+
+    $conn = DriverManager::getConnection($connectionParams, null, $evm);
+
+It allows you to access the ``Doctrine\DBAL\Connection`` instance.
+Please note that this event can be called multiple times, since transactions can be nested.
+If you want to know if a transaction is actually committed, you should rely on
+``TransactionCommitEventArgs::getConnection()->getTransactionNestingLevel() === 0`` or
+``TransactionCommitEventArgs::getConnection()->isTransactionActive()``
+
+OnTransactionRollBack Event
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``Doctrine\DBAL\Events::onTransactionRollBack`` is triggered when ``Doctrine\DBAL\Connection::rollBack()`` is called.
+An instance of ``Doctrine\DBAL\Event\TransactionRollBackEventArgs`` is injected as argument for event listeners.
+
+.. code-block:: php
+
+    <?php
+    class MyEventListener
+    {
+        public function onTransactionRollBack(TransactionRollBackEventArgs $event)
+        {
+            // Your EventListener code
+        }
+    }
+
+    $evm = new EventManager();
+    $evm->addEventListener(Events::onTransactionRollBack, new MyEventListener());
+
+    $conn = DriverManager::getConnection($connectionParams, null, $evm);
+
+It allows you to access the ``Doctrine\DBAL\Connection`` instance.
+Please note that this event can be called multiple times, since transactions can be nested.
+If you want to know if a transaction is actually rolled back, you should rely on
+``TransactionCommitRollBackArgs::getConnection()->getTransactionNestingLevel() === 0`` or
+``TransactionCommitRollBackArgs::getConnection()->isTransactionActive()``

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -12,6 +12,9 @@ use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
+use Doctrine\DBAL\Event\TransactionBeginEventArgs;
+use Doctrine\DBAL\Event\TransactionCommitEventArgs;
+use Doctrine\DBAL\Event\TransactionRollBackEventArgs;
 use Doctrine\DBAL\Exception\ConnectionLost;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
@@ -1321,6 +1324,8 @@ class Connection
             }
         }
 
+        $this->getEventManager()->dispatchEvent(Events::onTransactionBegin, new TransactionBeginEventArgs($this));
+
         return true;
     }
 
@@ -1367,6 +1372,8 @@ class Connection
         }
 
         --$this->transactionNestingLevel;
+
+        $this->getEventManager()->dispatchEvent(Events::onTransactionCommit, new TransactionCommitEventArgs($this));
 
         if ($this->autoCommit !== false || $this->transactionNestingLevel !== 0) {
             return $result;
@@ -1443,6 +1450,8 @@ class Connection
             $this->isRollbackOnly = true;
             --$this->transactionNestingLevel;
         }
+
+        $this->getEventManager()->dispatchEvent(Events::onTransactionRollBack, new TransactionRollBackEventArgs($this));
 
         return true;
     }

--- a/src/Event/TransactionBeginEventArgs.php
+++ b/src/Event/TransactionBeginEventArgs.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Event;
+
+class TransactionBeginEventArgs extends TransactionEventArgs
+{
+}

--- a/src/Event/TransactionCommitEventArgs.php
+++ b/src/Event/TransactionCommitEventArgs.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Event;
+
+class TransactionCommitEventArgs extends TransactionEventArgs
+{
+}

--- a/src/Event/TransactionEventArgs.php
+++ b/src/Event/TransactionEventArgs.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Event;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\DBAL\Connection;
+
+abstract class TransactionEventArgs extends EventArgs
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function getConnection(): Connection
+    {
+        return $this->connection;
+    }
+}

--- a/src/Event/TransactionRollBackEventArgs.php
+++ b/src/Event/TransactionRollBackEventArgs.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Event;
+
+class TransactionRollBackEventArgs extends TransactionEventArgs
+{
+}

--- a/src/Events.php
+++ b/src/Events.php
@@ -30,4 +30,7 @@ final class Events
     public const onSchemaAlterTableRenameColumn = 'onSchemaAlterTableRenameColumn';
     public const onSchemaColumnDefinition       = 'onSchemaColumnDefinition';
     public const onSchemaIndexDefinition        = 'onSchemaIndexDefinition';
+    public const onTransactionBegin             = 'onTransactionBegin';
+    public const onTransactionCommit            = 'onTransactionCommit';
+    public const onTransactionRollBack          = 'onTransactionRollBack';
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #3996

#### Summary

The use-case is the following: Got Entity which represents file. Got listener https://github.com/Warxcell/files/blob/master/src/EventListener/DoctrineORMListener.php#L49-L53 which deletes the actual file in case Entity is deleted. All good until it's all wrapped in transaction:

```php
$em->beginTransaction();
try {
  $em->delete($file);

  $em->flush();

  // do other stuffs
  
  $em->flush();

  $em->commit();
} catch(\Exception $ex) {
   $em->rollBack();
}
```

if exception is thrown after 1st flush - file will be deleted but Entity will stays.


