### PR TITLE
Deprecate `doctrine/cache` in favor of `psr/cache`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,8 +11,9 @@ awareness about deprecated code.
 ## Introduction of PSR-6 for result caching
 
 Instead of relying on the deprecated `doctrine/cache` library, a PSR-6 cache
-can now be used for result caching. Please use the following new methods for
-this purpose:
+can now be used for result caching. The usage of Doctrine Cache is deprecated
+in favor of PSR-6. The following methods related to Doctrine Cache have been
+replaced with PSR-6 counterparts:
 
 | class               | old method               | new method         |
 | ------------------- | ------------------------ | ------------------ |

--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 use Psr\Cache\CacheItemPoolInterface;
 use TypeError;
 
@@ -43,6 +44,15 @@ class QueryCacheProfile
         if ($resultCache instanceof CacheItemPoolInterface) {
             $this->resultCache = $resultCache;
         } elseif ($resultCache instanceof Cache) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/4620',
+                'Passing an instance of %s to %s as $resultCache is deprecated. Pass an instance of %s instead.',
+                Cache::class,
+                __METHOD__,
+                CacheItemPoolInterface::class
+            );
+
             $this->resultCache = CacheAdapter::wrap($resultCache);
         } elseif ($resultCache !== null) {
             throw new TypeError(sprintf(
@@ -66,6 +76,13 @@ class QueryCacheProfile
      */
     public function getResultCacheDriver()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4620',
+            '%s is deprecated, call getResultCache() instead.',
+            __METHOD__
+        );
+
         return $this->resultCache !== null ? DoctrineProvider::wrap($this->resultCache) : null;
     }
 
@@ -130,6 +147,13 @@ class QueryCacheProfile
      */
     public function setResultCacheDriver(Cache $cache)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4620',
+            '%s is deprecated, call setResultCache() instead.',
+            __METHOD__
+        );
+
         return new QueryCacheProfile($this->lifetime, $this->cacheKey, CacheAdapter::wrap($cache));
     }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Logging\SQLLogger;
+use Doctrine\Deprecations\Deprecation;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -85,6 +86,13 @@ class Configuration
      */
     public function getResultCacheImpl(): ?Cache
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4620',
+            '%s is deprecated, call getResultCache() instead.',
+            __METHOD__
+        );
+
         return $this->resultCacheImpl;
     }
 
@@ -104,6 +112,13 @@ class Configuration
      */
     public function setResultCacheImpl(Cache $cacheImpl): void
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4620',
+            '%s is deprecated, call setResultCache() instead.',
+            __METHOD__
+        );
+
         $this->resultCacheImpl = $cacheImpl;
         $this->resultCache     = CacheAdapter::wrap($cacheImpl);
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

Follows #4620 by adding triggers for deprecation warnings for the old Doctrine Cache related methods.
