### PR TITLE
[GH-4613] Use utf8mb4 instead of utf8 for testing connection charset

### DIFF
--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -72,7 +72,7 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
     public function testInheritCharsetFromMaster(): void
     {
         $charsets = [
-            'utf8',
+            'utf8mb4',
             'latin1',
         ];
 

--- a/tests/Doctrine/Tests/DBAL/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PrimaryReadReplicaConnectionTest.php
@@ -73,7 +73,7 @@ class PrimaryReadReplicaConnectionTest extends DbalFunctionalTestCase
     public function testInheritCharsetFromPrimary(): void
     {
         $charsets = [
-            'utf8',
+            'utf8mb4',
             'latin1',
         ];
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

This is a backport of #4614.