### PR TITLE
Suppress deprecation notices for ArrayCache

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -45,6 +45,11 @@
                     is no longer supported.
                 -->
                 <file name="src/Tools/Console/ConsoleRunner.php"/>
+                <!--
+                    This suppression should be removed in 4.0.0.
+                    See https://github.com/doctrine/dbal/pull/4626
+                -->
+                <referencedClass name="Doctrine\Common\Cache\ArrayCache"/>
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedMethod>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

CI builds fail since the release of https://github.com/doctrine/cache/pull/355. The issue isn't reproducible on `2.13.x` because it suppresses all deprecation notices.