### PR TITLE
Address class rename in the docs

### DIFF
--- a/docs/en/reference/caching.rst
+++ b/docs/en/reference/caching.rst
@@ -45,4 +45,4 @@ result set is read (the easiest way to ensure this is to use one of the ``fetchA
 
 .. warning::
 
-    When using the cache layer not all fetch modes are supported. See the code of the ``Doctrine\DBAL\Cache\ResultCacheStatement`` for details.
+    When using the cache layer not all fetch modes are supported. See the code of the ``Doctrine\DBAL\Cache\CachingResult`` for details.


### PR DESCRIPTION


<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | docs
| BC Break     | no
| Fixed issues | n/a

#### Summary

This class has been renamed in 48625f1bc761f1f8f70fe6630a0f3a3204d9a6ff

Found while trying to figure out "how this plays out with dbal 3.x" (see https://github.com/doctrine/dbal/issues/4634)