### PR TITLE
Properly catch lowlevel MySQLi connection errors again

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -80,7 +80,7 @@ class MysqliConnection implements ConnectionInterface, PingableConnection, Serve
         $this->setDriverOptions($driverOptions);
 
         set_error_handler(static function (): bool {
-            return false;
+            return true;
         });
         try {
             if (! $this->conn->real_connect($params['host'], $username, $password, $dbname, $port, $socket, $flags)) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4645

#### Summary

<!-- Provide a summary of your change. -->
Restore the original error handling for MySQLi connections.

If a `set_error_handler()` callback returns `false`, the PHP error handler will be involved. This is a regression since the previous version implicitly returned `null` and thus skipped the PHP error handler.

See https://github.com/doctrine/dbal/commit/26c7adc7f09f408fb2138153c0031e462d33a973
And https://github.com/doctrine/dbal/commit/4a5be97953940a94a3cbe472e8eae450e1dcb1a3