### PR TITLE
[GH-4645] Use error suppression instead of an error handler in MySQLi Connection

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -21,8 +21,6 @@ use function mysqli_errno;
 use function mysqli_error;
 use function mysqli_init;
 use function mysqli_options;
-use function restore_error_handler;
-use function set_error_handler;
 use function sprintf;
 use function stripos;
 
@@ -79,15 +77,8 @@ class MysqliConnection implements ConnectionInterface, PingableConnection, Serve
         $this->setSecureConnection($params);
         $this->setDriverOptions($driverOptions);
 
-        set_error_handler(static function (): bool {
-            return false;
-        });
-        try {
-            if (! $this->conn->real_connect($params['host'], $username, $password, $dbname, $port, $socket, $flags)) {
-                throw ConnectionFailed::new($this->conn);
-            }
-        } finally {
-            restore_error_handler();
+        if (! @$this->conn->real_connect($params['host'], $username, $password, $dbname, $port, $socket, $flags)) {
+            throw ConnectionFailed::new($this->conn);
         }
 
         if (! isset($params['charset'])) {

--- a/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php
@@ -3,13 +3,9 @@
 namespace Doctrine\Tests\DBAL\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\Mysqli\MysqliConnection;
-use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\Tests\DbalFunctionalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-
-use function restore_error_handler;
-use function set_error_handler;
 
 /**
  * @requires extension mysqli
@@ -39,25 +35,5 @@ class MysqliConnectionTest extends DbalFunctionalTestCase
     public function testDoesNotRequireQueryForServerVersion(): void
     {
         self::assertFalse($this->connectionMock->requiresQueryForServerVersion());
-    }
-
-    public function testRestoresErrorHandlerOnException(): void
-    {
-        $handler = static function (): bool {
-            self::fail('Never expected this to be called');
-        };
-
-        $defaultHandler = set_error_handler($handler);
-
-        try {
-            new MysqliConnection(['host' => '255.255.255.255'], 'user', 'pass');
-            self::fail('An exception was supposed to be raised');
-        } catch (MysqliException $e) {
-            self::assertSame('Network is unreachable', $e->getMessage());
-        }
-
-        self::assertSame($handler, set_error_handler($defaultHandler), 'Restoring error handler failed.');
-        restore_error_handler();
-        restore_error_handler();
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Closes #4645.

This is a backport of c9ce80acd7fc480c6c4585dc285741722919efe3 (#4081). It will also solve the test failure on non-Linux operating systems:
```
1) Doctrine\Tests\DBAL\Driver\Mysqli\MysqliConnectionTest::testRestoresErrorHandlerOnException
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'Network is unreachable'
+'Permission denied'

tests/Doctrine/Tests/DBAL/Driver/Mysqli/MysqliConnectionTest.php:56
```