### PR TITLE
[GH-4643] Fix SQLServerPlatform::quoteIdentifier()

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1610,7 +1610,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function quoteSingleIdentifier($str)
     {
-        return '[' . str_replace(']', '][', $str) . ']';
+        return '[' . str_replace(']', ']]', $str) . ']';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/QuotingTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/QuotingTest.php
@@ -2,7 +2,10 @@
 
 namespace Doctrine\Tests\DBAL\Functional\Platform;
 
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\Tests\DbalFunctionalTestCase;
+
+use function key;
 
 class QuotingTest extends DbalFunctionalTestCase
 {
@@ -27,6 +30,43 @@ class QuotingTest extends DbalFunctionalTestCase
         return [
             'backslash' => ['\\'],
             'single-quote' => ["'"],
+        ];
+    }
+
+    /**
+     * @dataProvider identifierProvider
+     */
+    public function testQuoteIdentifier(string $identifier): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        /**
+         * @link https://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements008.htm
+         */
+        if ($platform instanceof OraclePlatform && $identifier === '"') {
+            self::markTestSkipped('Oracle does not support double quotes in identifiers');
+        }
+
+        $query = $platform->getDummySelectSQL(
+            'NULL AS ' . $platform->quoteIdentifier($identifier)
+        );
+
+        $row = $this->connection->fetchAssociative($query);
+
+        self::assertNotFalse($row);
+        self::assertSame($identifier, key($row));
+    }
+
+    /**
+     * @return iterable<string,array{0:string}>
+     */
+    public static function identifierProvider(): iterable
+    {
+        return [
+            '[' => ['['],
+            ']' => [']'],
+            '"' => ['"'],
+            '`' => ['`'],
         ];
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -545,14 +545,14 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
 
     public function testQuoteIdentifier(): void
     {
-        self::assertEquals('[fo][o]', $this->platform->quoteIdentifier('fo]o'));
+        self::assertEquals('[fo]]o]', $this->platform->quoteIdentifier('fo]o'));
         self::assertEquals('[test]', $this->platform->quoteIdentifier('test'));
         self::assertEquals('[test].[test]', $this->platform->quoteIdentifier('test.test'));
     }
 
     public function testQuoteSingleIdentifier(): void
     {
-        self::assertEquals('[fo][o]', $this->platform->quoteSingleIdentifier('fo]o'));
+        self::assertEquals('[fo]]o]', $this->platform->quoteSingleIdentifier('fo]o'));
         self::assertEquals('[test]', $this->platform->quoteSingleIdentifier('test'));
         self::assertEquals('[test.test]', $this->platform->quoteSingleIdentifier('test.test'));
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Closes #4643.

From the Oracle [documentation](https://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements008.htm):

> Quoted identifiers can contain any characters and punctuations marks as well as spaces. However, neither quoted nor nonquoted identifiers can contain double quotation marks or the null character (`\0`).