### PR TITLE
Backport changes from 4.x and 3.x to avoid memory leaks

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -146,13 +146,6 @@ class Connection implements DriverConnection
     private $platform;
 
     /**
-     * The schema manager.
-     *
-     * @var AbstractSchemaManager|null
-     */
-    protected $_schemaManager;
-
-    /**
      * The used DBAL driver.
      *
      * @var Driver
@@ -217,8 +210,6 @@ class Connection implements DriverConnection
 
         $this->_config       = $config;
         $this->_eventManager = $eventManager;
-
-        $this->_expr = new Query\Expression\ExpressionBuilder($this);
 
         $this->autoCommit = $config->getAutoCommit();
     }
@@ -378,7 +369,7 @@ class Connection implements DriverConnection
      */
     public function getExpressionBuilder()
     {
-        return $this->_expr;
+        return new ExpressionBuilder($this);
     }
 
     /**
@@ -1952,11 +1943,7 @@ class Connection implements DriverConnection
      */
     public function getSchemaManager()
     {
-        if ($this->_schemaManager === null) {
-            $this->_schemaManager = $this->_driver->getSchemaManager($this);
-        }
-
-        return $this->_schemaManager;
+        return $this->_driver->getSchemaManager($this);
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues |  #4515

#### Summary

<!-- Provide a summary of your change. -->
Backport changes from 3.x and 4.x.  to 2.13.x.
The main idea to copy the changes down to this version is that the official package for the ORM part does not support 3.x yet.
So this fixes the memory leak in the DBAL part.

I'm not very familiar with the codebase, so if there is something more that have to be done - please, let me know. 
