### PR TITLE
Add bind() and binds() methods for more terse user code

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -29,7 +29,8 @@ and are therefore subject to the possibility of SQL injection.
 To safely work with the QueryBuilder you should **NEVER** pass user
 input to any of the methods of the QueryBuilder and use the placeholder
 ``?`` or ``:name`` syntax in combination with
-``$queryBuilder->setParameter($placeholder, $value)`` instead:
+``$queryBuilder->setParameter($placeholder, $value)`` or
+``$queryBuilder->bind($placeholder, $value)`` instead:
 
 .. code-block:: php
 
@@ -40,6 +41,17 @@ input to any of the methods of the QueryBuilder and use the placeholder
         ->from('users')
         ->where('email = ?')
         ->setParameter(0, $userInputEmail)
+    ;
+
+.. code-block:: php
+
+    <?php
+
+    $queryBuilder
+        ->select('id', 'name')
+        ->from('users')
+        ->where('email = ?')
+        ->bind(0, $userInputEmail)
     ;
 
 .. note::
@@ -238,8 +250,8 @@ done with the ``values()`` method on the query builder:
                 'password' => '?'
             )
         )
-        ->setParameter(0, $username)
-        ->setParameter(1, $password)
+        ->bind(0, $username)
+        ->bind(1, $password)
     ;
     // INSERT INTO users (name, password) VALUES (?, ?)
 
@@ -255,8 +267,8 @@ Setting single values instead of all at once is also possible with the
         ->insert('users')
         ->setValue('name', '?')
         ->setValue('password', '?')
-        ->setParameter(0, $username)
-        ->setParameter(1, $password)
+        ->bind(0, $username)
+        ->bind(1, $password)
     ;
     // INSERT INTO users (name, password) VALUES (?, ?)
 
@@ -273,14 +285,14 @@ Of course you can also use both methods in combination:
                 'name' => '?'
             )
         )
-        ->setParameter(0, $username)
+        ->bind(0, $username)
     ;
     // INSERT INTO users (name) VALUES (?)
 
     if ($password) {
         $queryBuilder
             ->setValue('password', '?')
-            ->setParameter(1, $password)
+            ->bind(1, $password)
         ;
         // INSERT INTO users (name, password) VALUES (?, ?)
     }
@@ -312,7 +324,7 @@ user-input:
         ->update('users', 'u')
         ->set('u.logins', 'u.logins + 1')
         ->set('u.last_login', '?')
-        ->setParameter(0, $userInputLastLogin)
+        ->bind(0, $userInputLastLogin)
     ;
 
 Building Expressions

--- a/docs/en/reference/security.rst
+++ b/docs/en/reference/security.rst
@@ -116,13 +116,13 @@ Following are examples of using prepared statements with SQL and DQL:
     // DQL Prepared Statements: Positional
     $dql = "SELECT u FROM User u WHERE u.username = ?1";
     $query = $em->createQuery($dql);
-    $query->setParameter(1, $_GET['username']);
+    $query->bind(1, $_GET['username']);
     $data = $query->getResult();
 
     // DQL Prepared Statements: Named
     $dql = "SELECT u FROM User u WHERE u.username = :name";
     $query = $em->createQuery($dql);
-    $query->setParameter("name", $_GET['username']);
+    $query->bind("name", $_GET['username']);
     $data = $query->getResult();
 
 You can see this is a bit more tedious to write, but this is the only way to write secure queries. If you

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -405,6 +405,28 @@ class QueryBuilder
      *         ->select('u')
      *         ->from('users', 'u')
      *         ->where('u.id = :user_id')
+     *         ->bind(':user_id', 1);
+     * </code>
+     *
+     * @param int|string           $key   Parameter position or name
+     * @param mixed                $value Parameter value
+     * @param int|string|Type|null $type  Parameter type
+     *
+     * @return $this This QueryBuilder instance.
+     */
+    public function bind($key, $value, $type = null)
+    {
+        $this->setParameter($key, $value, $type);
+    }
+
+    /**
+     * Sets a query parameter for the query being constructed.
+     *
+     * <code>
+     *     $qb = $conn->createQueryBuilder()
+     *         ->select('u')
+     *         ->from('users', 'u')
+     *         ->where('u.id = :user_id')
      *         ->setParameter(':user_id', 1);
      * </code>
      *
@@ -423,6 +445,30 @@ class QueryBuilder
         $this->params[$key] = $value;
 
         return $this;
+    }
+
+    /**
+     * Sets a collection of query parameters for the query being constructed.
+     *
+     * <code>
+     *     $qb = $conn->createQueryBuilder()
+     *         ->select('u')
+     *         ->from('users', 'u')
+     *         ->where('u.id = :user_id1 OR u.id = :user_id2')
+     *         ->binds(array(
+     *             ':user_id1' => 1,
+     *             ':user_id2' => 2
+     *         ));
+     * </code>
+     *
+     * @param list<mixed>|array<string, mixed>                                     $params Parameters to set
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     *
+     * @return $this This QueryBuilder instance.
+     */
+    public function binds(array $params, array $types = [])
+    {
+        return $this->setParameters($params, $types);
     }
 
     /**

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -804,7 +804,7 @@ class QueryBuilderTest extends TestCase
             ->from('users', 'u')
             ->where('u.id = :test');
 
-        $qb->setParameter(':test', (object) 1);
+        $qb->bind(':test', (object) 1);
 
         $qbClone = clone $qb;
 
@@ -905,11 +905,11 @@ class QueryBuilderTest extends TestCase
         self::assertNull($qb->getParameterType('name'));
 
         $qb->where('name = :name');
-        $qb->setParameter('name', 'foo');
+        $qb->bind('name', 'foo');
 
         self::assertNull($qb->getParameterType('name'));
 
-        $qb->setParameter('name', 'foo', ParameterType::STRING);
+        $qb->bind('name', 'foo', ParameterType::STRING);
 
         self::assertSame(ParameterType::STRING, $qb->getParameterType('name'));
     }
@@ -923,14 +923,14 @@ class QueryBuilderTest extends TestCase
         self::assertSame([], $qb->getParameterTypes());
 
         $qb->where('name = :name');
-        $qb->setParameter('name', 'foo');
+        $qb->bind('name', 'foo');
 
         self::assertSame([], $qb->getParameterTypes());
 
-        $qb->setParameter('name', 'foo', ParameterType::STRING);
+        $qb->bind('name', 'foo', ParameterType::STRING);
 
         $qb->where('is_active = :isActive');
-        $qb->setParameter('isActive', true, ParameterType::BOOLEAN);
+        $qb->bind('isActive', true, ParameterType::BOOLEAN);
 
         self::assertSame([
             'name'     => ParameterType::STRING,
@@ -995,7 +995,7 @@ class QueryBuilderTest extends TestCase
         $row = $qb->select($select)
             ->from($from)
             ->where($where)
-            ->setParameters($parameters, $parameterTypes)
+            ->binds($parameters, $parameterTypes)
             ->fetchAssociative();
 
         self::assertEquals(['username' => 'jwage', 'password' => 'changeme'], $row);
@@ -1025,7 +1025,7 @@ class QueryBuilderTest extends TestCase
         $row = $qb->select($select)
             ->from($from)
             ->where($where)
-            ->setParameters($parameters, $parameterTypes)
+            ->binds($parameters, $parameterTypes)
             ->fetchNumeric();
 
         self::assertEquals(['jwage', 'changeme'], $row);
@@ -1055,7 +1055,7 @@ class QueryBuilderTest extends TestCase
         $username = $qb->select($select)
             ->from($from)
             ->where($where)
-            ->setParameters($parameters, $parameterTypes)
+            ->binds($parameters, $parameterTypes)
             ->fetchOne();
 
         self::assertEquals('jwage', $username);
@@ -1090,7 +1090,7 @@ class QueryBuilderTest extends TestCase
         $results = $qb->select($select)
             ->from($from)
             ->where($where)
-            ->setParameters($parameters, $parameterTypes)
+            ->binds($parameters, $parameterTypes)
             ->fetchAllAssociative();
 
         self::assertEquals(
@@ -1131,7 +1131,7 @@ class QueryBuilderTest extends TestCase
         $results = $qb->select($select)
             ->from($from)
             ->where($where)
-            ->setParameters($parameters, $parameterTypes)
+            ->binds($parameters, $parameterTypes)
             ->fetchAllNumeric();
 
         self::assertEquals(
@@ -1172,7 +1172,7 @@ class QueryBuilderTest extends TestCase
         $results = $qb->select($select)
             ->from($from)
             ->where($where)
-            ->setParameters($parameters, $parameterTypes)
+            ->binds($parameters, $parameterTypes)
             ->fetchAllKeyValue();
 
         self::assertEquals(
@@ -1215,7 +1215,7 @@ class QueryBuilderTest extends TestCase
         $results = $qb->select($select)
             ->from($from)
             ->where($where)
-            ->setParameters($parameters, $parameterTypes)
+            ->binds($parameters, $parameterTypes)
             ->fetchAllAssociativeIndexed();
 
         self::assertEquals(
@@ -1258,7 +1258,7 @@ class QueryBuilderTest extends TestCase
         $results = $qb->select($select)
             ->from($from)
             ->where($where)
-            ->setParameters($parameters, $parameterTypes)
+            ->binds($parameters, $parameterTypes)
             ->fetchFirstColumn();
 
         self::assertEquals(
@@ -1346,7 +1346,7 @@ class QueryBuilderTest extends TestCase
         $results = $qb->select($select)
             ->from($from)
             ->where($where)
-            ->setParameters($parameters, $parameterTypes)
+            ->binds($parameters, $parameterTypes)
             ->executeQuery();
 
         self::assertSame(
@@ -1380,7 +1380,7 @@ class QueryBuilderTest extends TestCase
             ->set('foo', '?')
             ->set('bar', '?')
             ->where('bar = 1')
-            ->setParameters($parameters, $parameterTypes)
+            ->binds($parameters, $parameterTypes)
             ->executeStatement();
 
         self::assertSame(


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

Adds bind() and binds() methods to the query builder as alias for setParameter() and setParameters() for shorter user code.
