### PR TITLE
Allow Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
         "phpunit/phpunit": "9.5.0",
         "psalm/plugin-phpunit": "0.13.0",
         "squizlabs/php_codesniffer": "3.6.0",
-        "symfony/cache": "^5.2",
-        "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
+        "symfony/cache": "^5.2|^6.0",
+        "symfony/console": "^2.0.5|^3.0|^4.0|^5.0|^6.0",
         "vimeo/psalm": "4.6.4"
     },
     "suggest": {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

Same as #3563
Still not strictly required as it doesn't block the Symfony 6 CI. Yet will help ensure Symfony 6 is compatible

Yes @greg0ire one more pipe