### PR TITLE
Add ReturnTypeWillChange to PDO implementations

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOConnection.php
+++ b/lib/Doctrine/DBAL/Driver/PDOConnection.php
@@ -10,6 +10,7 @@ use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
 use PDOStatement;
+use ReturnTypeWillChange;
 
 use function assert;
 
@@ -47,6 +48,7 @@ class PDOConnection extends PDO implements ConnectionInterface, ServerInfoAwareC
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function exec($sql)
     {
         try {
@@ -73,6 +75,7 @@ class PDOConnection extends PDO implements ConnectionInterface, ServerInfoAwareC
      *
      * @return PDOStatement
      */
+    #[ReturnTypeWillChange]
     public function prepare($sql, $driverOptions = [])
     {
         try {
@@ -88,6 +91,7 @@ class PDOConnection extends PDO implements ConnectionInterface, ServerInfoAwareC
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function quote($value, $type = ParameterType::STRING)
     {
         return parent::quote($value, $type);
@@ -96,6 +100,7 @@ class PDOConnection extends PDO implements ConnectionInterface, ServerInfoAwareC
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function lastInsertId($name = null)
     {
         try {

--- a/lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php
+++ b/lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Driver;
 
 use PDOStatement;
+use ReturnTypeWillChange;
 
 use function func_get_args;
 
@@ -17,6 +18,7 @@ if (PHP_VERSION_ID >= 80000) {
         /**
          * @return PDOStatement
          */
+        #[ReturnTypeWillChange]
         public function query(?string $query = null, ?int $fetchMode = null, mixed ...$fetchModeArgs)
         {
             return $this->doQuery($query, $fetchMode, ...$fetchModeArgs);

--- a/lib/Doctrine/DBAL/Driver/PDOStatement.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatement.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
+use ReturnTypeWillChange;
 
 use function array_slice;
 use function assert;
@@ -56,6 +57,7 @@ class PDOStatement extends \PDOStatement implements StatementInterface, Result
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function bindValue($param, $value, $type = ParameterType::STRING)
     {
         $type = $this->convertParamType($type);
@@ -76,6 +78,7 @@ class PDOStatement extends \PDOStatement implements StatementInterface, Result
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null, $driverOptions = null)
     {
         $type = $this->convertParamType($type);
@@ -92,6 +95,7 @@ class PDOStatement extends \PDOStatement implements StatementInterface, Result
      *
      * @deprecated Use free() instead.
      */
+    #[ReturnTypeWillChange]
     public function closeCursor()
     {
         try {
@@ -106,6 +110,7 @@ class PDOStatement extends \PDOStatement implements StatementInterface, Result
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function execute($params = null)
     {
         try {
@@ -120,6 +125,7 @@ class PDOStatement extends \PDOStatement implements StatementInterface, Result
      *
      * @deprecated Use fetchNumeric(), fetchAssociative() or fetchOne() instead.
      */
+    #[ReturnTypeWillChange]
     public function fetch($fetchMode = null, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         $args = func_get_args();
@@ -140,6 +146,7 @@ class PDOStatement extends \PDOStatement implements StatementInterface, Result
      *
      * @deprecated Use fetchOne() instead.
      */
+    #[ReturnTypeWillChange]
     public function fetchColumn($columnIndex = 0)
     {
         try {

--- a/lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php
+++ b/lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Driver;
 
+use ReturnTypeWillChange;
+
 use function func_get_args;
 
 use const PHP_VERSION_ID;
@@ -20,6 +22,7 @@ if (PHP_VERSION_ID >= 80000) {
          *
          * @return bool
          */
+        #[ReturnTypeWillChange]
         public function setFetchMode($mode, ...$args)
         {
             return $this->doSetFetchMode($mode, ...$args);
@@ -33,6 +36,7 @@ if (PHP_VERSION_ID >= 80000) {
          *
          * @return mixed[]
          */
+        #[ReturnTypeWillChange]
         public function fetchAll($mode = null, ...$args)
         {
             return $this->doFetchAll($mode, ...$args);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/A

#### Summary

PHP 8.1 will introduce a process to add return types to internal methods, see https://wiki.php.net/rfc/internal_method_return_types

This library extends various PDO classes and overrides public methods that are affected by this change. PHP 8.1 triggers deprecation warnings unless we declare that a future version of this library will add these return types as well. We can do so by adding the `ReturnTypeWillChange` attribute to those methods.

This PR suggests to do just that because adding the actual return types would break code that extends our classes. IIRC, the affected classes have been removed in 3.0 anyway, so let's just get rid of the warnings. 🙂 
