### PR TITLE
Bump doctrine/coding-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "doctrine/event-manager": "^1.0"
     },
     "require-dev": {
-        "doctrine/coding-standard": "8.2.0",
+        "doctrine/coding-standard": "9.0.0",
         "jetbrains/phpstorm-stubs": "2020.2",
         "phpstan/phpstan": "0.12.81",
         "phpunit/phpunit": "^7.5.20|^8.5|9.5.0",

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -178,11 +178,10 @@ class Connection implements DriverConnection
      * @param Driver              $driver       The driver to use.
      * @param Configuration|null  $config       The configuration, optional.
      * @param EventManager|null   $eventManager The event manager, optional.
+     * @psalm-param Params $params
+     * @phpstan-param array<string,mixed> $params
      *
      * @throws Exception
-     *
-     * @phpstan-param array<string,mixed> $params
-     * @psalm-param Params $params
      */
     public function __construct(
         array $params,
@@ -229,9 +228,8 @@ class Connection implements DriverConnection
      * @internal
      *
      * @return array<string,mixed>
-     *
-     * @phpstan-return array<string,mixed>
      * @psalm-return Params
+     * @phpstan-return array<string,mixed>
      */
     public function getParams()
     {
@@ -2200,9 +2198,9 @@ class Connection implements DriverConnection
      * @param array<int, mixed>|array<string, mixed>                               $params
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
      *
-     * @throws Exception
-     *
      * @psalm-return never-return
+     *
+     * @throws Exception
      */
     public function handleExceptionDuringQuery(Throwable $e, string $sql, array $params = [], array $types = []): void
     {
@@ -2219,9 +2217,9 @@ class Connection implements DriverConnection
     /**
      * @internal
      *
-     * @throws Exception
-     *
      * @psalm-return never-return
+     *
+     * @throws Exception
      */
     public function handleDriverException(Throwable $e): void
     {
@@ -2236,9 +2234,9 @@ class Connection implements DriverConnection
     /**
      * @internal
      *
-     * @throws Exception
-     *
      * @psalm-return never-return
+     *
+     * @throws Exception
      */
     private function throw(Exception $e): void
     {

--- a/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
+++ b/lib/Doctrine/DBAL/Connections/MasterSlaveConnection.php
@@ -5,13 +5,14 @@ namespace Doctrine\DBAL\Connections;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\DriverManager;
 use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 /**
  * @deprecated Use PrimaryReadReplicaConnection instead
  *
- * @psalm-import-type Params from \Doctrine\DBAL\DriverManager
+ * @psalm-import-type Params from DriverManager
  */
 class MasterSlaveConnection extends PrimaryReadReplicaConnection
 {
@@ -21,11 +22,10 @@ class MasterSlaveConnection extends PrimaryReadReplicaConnection
      * @internal The connection can be only instantiated by the driver manager.
      *
      * @param array<string,mixed> $params
+     * @psalm-param Params $params
+     * @phpstan-param array<string,mixed> $params
      *
      * @throws InvalidArgumentException
-     *
-     * @phpstan-param array<string,mixed> $params
-     * @psalm-param Params $params
      */
     public function __construct(
         array $params,

--- a/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
+++ b/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Events;
 use InvalidArgumentException;
@@ -56,7 +57,7 @@ use function func_get_args;
  *
  * Instantiation through the DriverManager looks like:
  *
- * @psalm-import-type Params from \Doctrine\DBAL\DriverManager
+ * @psalm-import-type Params from DriverManager
  * @example
  *
  * $conn = DriverManager::getConnection(array(
@@ -95,11 +96,10 @@ class PrimaryReadReplicaConnection extends Connection
      * @internal The connection can be only instantiated by the driver manager.
      *
      * @param array<string,mixed> $params
+     * @psalm-param Params $params
+     * @phpstan-param array<string,mixed> $params
      *
      * @throws InvalidArgumentException
-     *
-     * @phpstan-param array<string,mixed> $params
-     * @psalm-param Params $params
      */
     public function __construct(
         array $params,

--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -156,10 +156,6 @@ final class DriverManager
      * @param array<string,mixed> $params
      * @param Configuration|null  $config       The configuration to use.
      * @param EventManager|null   $eventManager The event manager to use.
-     *
-     * @throws Exception
-     *
-     * @phpstan-param array<string,mixed> $params
      * @psalm-param array{
      *     charset?: string,
      *     dbname?: string,
@@ -184,7 +180,12 @@ final class DriverManager
      *     user?: string,
      *     wrapperClass?: class-string<T>,
      * } $params
+     * @phpstan-param array<string,mixed> $params
+     *
      * @psalm-return ($params is array{wrapperClass:mixed} ? T : Connection)
+     *
+     * @throws Exception
+     *
      * @template T of Connection
      */
     public static function getConnection(
@@ -281,11 +282,10 @@ final class DriverManager
 
     /**
      * @param array<string,mixed> $params
+     * @psalm-param Params $params
+     * @phpstan-param array<string,mixed> $params
      *
      * @throws Exception
-     *
-     * @phpstan-param array<string,mixed> $params
-     * @psalm-param Params $params
      */
     private static function createDriver(array $params): Driver
     {
@@ -328,16 +328,15 @@ final class DriverManager
      * updated list of parameters.
      *
      * @param mixed[] $params The list of parameters.
+     * @psalm-param Params $params
+     * @phpstan-param array<string,mixed> $params
      *
      * @return mixed[] A modified list of parameters with info from a database
      *                 URL extracted into indidivual parameter parts.
+     * @psalm-return Params
+     * @phpstan-return array<string,mixed>
      *
      * @throws Exception
-     *
-     * @phpstan-param array<string,mixed> $params
-     * @phpstan-return array<string,mixed>
-     * @psalm-param Params $params
-     * @psalm-return Params
      */
     private static function parseDatabaseUrl(array $params): array
     {

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -3658,10 +3658,9 @@ abstract class AbstractPlatform
      * Returns the class name of the reserved keywords list.
      *
      * @return string
+     * @psalm-return class-string<KeywordList>
      *
      * @throws Exception If not supported on this platform.
-     *
-     * @psalm-return class-string<KeywordList>
      */
     protected function getReservedKeywordsClass()
     {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -76,10 +76,6 @@
         <exclude-pattern>lib/Doctrine/DBAL/Events.php</exclude-pattern>
     </rule>
 
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty">
-        <exclude-pattern>tests/Doctrine/Tests/DBAL/Tools/TestAsset/*</exclude-pattern>
-    </rule>
-
     <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/2099 -->
     <rule ref="Squiz.Commenting.FunctionComment.InvalidNoReturn">
         <exclude-pattern>lib/Doctrine/DBAL/Platforms/AbstractPlatform.php</exclude-pattern>
@@ -123,11 +119,6 @@
     <!-- The override opts out the caller from the strict mode for backward compatibility -->
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod.Found">
         <exclude-pattern>lib/Doctrine/DBAL/Driver/PDOConnection.php</exclude-pattern>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod">
-        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOConnection.php</exclude-pattern>
-        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOStatement.php</exclude-pattern>
     </rule>
 
     <!-- See https://github.com/slevomat/coding-standard/issues/770 -->

--- a/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/ExceptionTest.php
@@ -352,10 +352,9 @@ EOT
 
     /**
      * @param array<string, mixed> $params
+     * @psalm-param Params $params
      *
      * @dataProvider getConnectionParams
-     *
-     * @psalm-param Params $params
      */
     public function testConnectionException(array $params): void
     {

--- a/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/MasterSlaveConnectionTest.php
@@ -15,7 +15,7 @@ use function sprintf;
 use const CASE_LOWER;
 
 /**
- * @psalm-import-type Params from \Doctrine\DBAL\DriverManager
+ * @psalm-import-type Params from DriverManager
  */
 class MasterSlaveConnectionTest extends DbalFunctionalTestCase
 {
@@ -55,7 +55,6 @@ class MasterSlaveConnectionTest extends DbalFunctionalTestCase
 
     /**
      * @return mixed[]
-     *
      * @psalm-return Params
      */
     private function createMasterSlaveConnectionParams(bool $keepSlave = false): array

--- a/tests/Doctrine/Tests/DBAL/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/PrimaryReadReplicaConnectionTest.php
@@ -16,7 +16,7 @@ use const CASE_LOWER;
 
 /**
  * @group DBAL-20
- * @psalm-import-type Params from \Doctrine\DBAL\DriverManager
+ * @psalm-import-type Params from DriverManager
  */
 class PrimaryReadReplicaConnectionTest extends DbalFunctionalTestCase
 {
@@ -56,7 +56,6 @@ class PrimaryReadReplicaConnectionTest extends DbalFunctionalTestCase
 
     /**
      * @return mixed[]
-     *
      * @psalm-return Params
      */
     private function createPrimaryReadReplicaConnectionParams(bool $keepReplica = false): array

--- a/tests/Doctrine/Tests/DBAL/Schema/MySqlInheritCharsetTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/MySqlInheritCharsetTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\MySqlSchemaManager;
@@ -18,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 use function array_merge;
 
 /**
- * @psalm-import-type Params from \Doctrine\DBAL\DriverManager
+ * @psalm-import-type Params from DriverManager
  */
 class MySqlInheritCharsetTest extends TestCase
 {
@@ -77,10 +78,9 @@ class MySqlInheritCharsetTest extends TestCase
 
     /**
      * @param array<string,mixed> $params
+     * @psalm-param Params $params
      *
      * @return string[]
-     *
-     * @psalm-param Params $params
      */
     private function getTableOptionsForOverride(array $params = []): array
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

While working on #4662, I've had some issues with false positives coming the `slevomat/coding-standard` PHPCS ruleset. This is why I'm proposing to bump the `doctrine/coding-standard` version used in this repository.
