### PR TITLE
Make Table::removeUniqueConstraint() actually work

### DIFF
--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -686,7 +686,7 @@ class Table extends AbstractAsset
     {
         $name = $this->normalizeIdentifier($name);
 
-        if (! $this->hasForeignKey($name)) {
+        if (! $this->hasUniqueConstraint($name)) {
             throw SchemaException::uniqueConstraintDoesNotExist($name, $this->_name);
         }
 

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -831,4 +831,25 @@ class TableTest extends TestCase
         $table->setComment('foo');
         self::assertEquals('foo', $table->getComment());
     }
+
+    public function testRemoveUniqueConstraint(): void
+    {
+        $table = new Table('foo');
+        $table->addColumn('bar', 'integer');
+        $table->addUniqueConstraint(['bar'], 'unique_constraint');
+
+        $table->removeUniqueConstraint('unique_constraint');
+
+        self::assertFalse($table->hasUniqueConstraint('unique_constraint'));
+    }
+
+    public function testRemoveUniqueConstraintUnknownNameThrowsException(): void
+    {
+        $this->expectException(SchemaException::class);
+
+        $table = new Table('foo');
+        $table->addColumn('bar', 'integer');
+
+        $table->removeUniqueConstraint('unique_constraint');
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Table::removeUniqueConstraint() used the wrong method (hasForeignKey()) instead of hasUniqueConstraint() to check for existing unique constraint, causing removeUniqueConstraint() to fail unconditionally.

Also adding tests for removeUniqueConstraint().
