### PR TITLE
Fixed generated SQL for UniqueConstraint objects

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1776,6 +1776,8 @@ abstract class AbstractPlatform
                     'Can only create primary or unique constraints, no common indexes with getCreateConstraintSQL().'
                 );
             }
+        } elseif ($constraint instanceof UniqueConstraint) {
+            $query .= ' UNIQUE';
         } elseif ($constraint instanceof ForeignKeyConstraint) {
             $query .= ' FOREIGN KEY';
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -258,6 +258,10 @@ abstract class AbstractPlatformTestCase extends TestCase
         $sql = $this->platform->getCreateConstraintSQL($pk, 'test');
         self::assertEquals($this->getGenerateConstraintPrimaryIndexSql(), $sql);
 
+        $uc  = new UniqueConstraint('constraint_name', ['test']);
+        $sql = $this->platform->getCreateConstraintSQL($uc, 'test');
+        self::assertEquals($this->getGenerateConstraintUniqueIndexSql(), $sql);
+
         $fk  = new ForeignKeyConstraint(['fk_name'], 'foreign', ['id'], 'constraint_fk');
         $sql = $this->platform->getCreateConstraintSQL($fk, 'test');
         self::assertEquals($this->getGenerateConstraintForeignKeySql($fk), $sql);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

<!-- Provide a summary of your change. -->
getCreateConstraintSQL() generated incorrect SQL when passed a UniqueConstraint object.
