### PR TITLE
Document a non-deprecated way to interact with prepared statements

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -309,8 +309,8 @@ Prepare a given SQL statement and return the
 
     <?php
     $statement = $conn->prepare('SELECT * FROM user');
-    $statement->execute();
-    $users = $statement->fetchAllAssociative();
+    $resultSet = $statement->execute();
+    $users = $resultSet->fetchAllAssociative();
 
     /*
     array(

--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -316,7 +316,7 @@ Prepare a given SQL statement and return the
     array(
       0 => array(
         'username' => 'jwage',
-        'password' => 'changeme'
+        'email' => 'j.wage@example.com'
       )
     )
     */
@@ -353,7 +353,7 @@ parameters to the execute method, then returning the statement:
     /*
     array(
       0 => 'jwage',
-      1 => 'changeme'
+      1 => 'j.wage@example.com'
     )
     */
 
@@ -376,7 +376,7 @@ Execute the query and fetch all results into an array:
     array(
       0 => array(
         'username' => 'jwage',
-        'password' => 'changeme'
+        'email' => 'j.wage@example.com'
       )
     )
     */
@@ -389,11 +389,11 @@ Execute the query and fetch the first two columns into an associative array as k
 .. code-block:: php
 
     <?php
-    $users = $conn->fetchAllKeyValue('SELECT username, password FROM user');
+    $users = $conn->fetchAllKeyValue('SELECT username, email FROM user');
 
     /*
     array(
-      'jwage' => 'changeme',
+      'jwage' => 'j.wage@example.com',
     )
     */
 
@@ -409,13 +409,13 @@ an associative array of the rest of the columns and their values:
 .. code-block:: php
 
     <?php
-    $users = $conn->fetchAllAssociativeIndexed('SELECT id, username, password FROM user');
+    $users = $conn->fetchAllAssociativeIndexed('SELECT id, username, email FROM user');
 
     /*
     array(
         1 => array(
           'username' => 'jwage',
-          'password' => 'changeme',
+          'email' => 'j.wage@example.com'
         )
     )
     */
@@ -433,7 +433,7 @@ Numeric index retrieval of first result row of the given query:
     /*
     array(
       0 => 'jwage',
-      1 => 'changeme'
+      1 => 'j.wage@example.com'
     )
     */
 
@@ -460,7 +460,7 @@ Retrieve associative array of the first result row.
     /*
     array(
       'username' => 'jwage',
-      'password' => 'changeme'
+      'email' => 'j.wage@example.com'
     )
     */
 
@@ -474,7 +474,7 @@ Execute the query and iterate over the first two columns as keys and values resp
 .. code-block:: php
 
     <?php
-    foreach ($conn->iterateKeyValue('SELECT username, password FROM user') as $username => $password) {
+    foreach ($conn->iterateKeyValue('SELECT username, email FROM user') as $username => $email) {
         // ...
     }
 
@@ -490,7 +490,7 @@ an associative array of the rest of the columns and their values:
 .. code-block:: php
 
     <?php
-    foreach ($conn->iterateAssociativeIndexed('SELECT id, username, password FROM user') as $id => $data) {
+    foreach ($conn->iterateAssociativeIndexed('SELECT id, username, email FROM user') as $id => $data) {
         // ...
     }
 

--- a/docs/en/reference/security.rst
+++ b/docs/en/reference/security.rst
@@ -105,13 +105,13 @@ Following are examples of using prepared statements with SQL and DQL:
     $sql = "SELECT * FROM users WHERE username = ?";
     $stmt = $connection->prepare($sql);
     $stmt->bindValue(1, $_GET['username']);
-    $stmt->execute();
+    $resultSet = $stmt->executeQuery();
 
     // SQL Prepared Statements: Named
     $sql = "SELECT * FROM users WHERE username = :user";
     $stmt = $connection->prepare($sql);
     $stmt->bindValue("user", $_GET['username']);
-    $stmt->execute();
+    $resultSet = $stmt->executeQuery();
 
     // DQL Prepared Statements: Positional
     $dql = "SELECT u FROM User u WHERE u.username = ?1";
@@ -133,7 +133,7 @@ are using just the DBAL there are also helper methods which simplify the usage q
     <?php
     // bind parameters and execute query at once.
     $sql = "SELECT * FROM users WHERE username = ?";
-    $stmt = $connection->executeQuery($sql, array($_GET['username']));
+    $resultSet = $connection->executeQuery($sql, array($_GET['username']));
 
 There is also ``executeStatement`` which does not return a statement but the number of affected rows.
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

While browsing the documentation I noticed that it still contains code examples with the now-deprecated `Statement::execute()` method.

This PR attempts to fix that by only showing the preferred way to interact with prepared statements. In order to keep merges easy, the PR contains backports of #4505 and #4502 by @xelan and @Sephster.
