### PR TITLE
Create tables with unique constraints on PostgreSQL

### DIFF
--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -785,6 +785,12 @@ SQL
             }
         }
 
+        if (isset($options['uniqueConstraints'])) {
+            foreach ($options['uniqueConstraints'] as $uniqueConstraint) {
+                $sql[] = $this->getCreateConstraintSQL($uniqueConstraint, $name);
+            }
+        }
+
         if (isset($options['foreignKeys'])) {
             foreach ((array) $options['foreignKeys'] as $definition) {
                 $sql[] = $this->getCreateForeignKeySQL($definition, $name);

--- a/tests/Platforms/PostgreSQL94PlatformTest.php
+++ b/tests/Platforms/PostgreSQL94PlatformTest.php
@@ -19,6 +19,21 @@ class PostgreSQL94PlatformTest extends AbstractPostgreSQLPlatformTestCase
         self::assertTrue($this->platform->supportsPartialIndexes());
     }
 
+    public function testGetCreateTableSQLWithUniqueConstraints(): void
+    {
+        $table = new Table('foo');
+        $table->addColumn('id', 'string');
+        $table->addUniqueConstraint(['id'], 'test_unique_constraint');
+        self::assertSame(
+            [
+                'CREATE TABLE foo (id VARCHAR(255) NOT NULL)',
+                'ALTER TABLE foo ADD CONSTRAINT test_unique_constraint UNIQUE (id)',
+            ],
+            $this->platform->getCreateTableSQL($table),
+            'Unique constraints are added to table.'
+        );
+    }
+
     public function testGetCreateTableSQLWithColumnCollation(): void
     {
         $table = new Table('foo');


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
PostgreSQL94Platform::_getCreateTableSQL() ignored unique constraints.
Implementations for other platforms are OK.
