### PR TITLE
Update PHPUnit to 9.5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "doctrine/coding-standard": "9.0.0",
         "jetbrains/phpstorm-stubs": "2020.2",
         "phpstan/phpstan": "0.12.81",
-        "phpunit/phpunit": "^7.5.20|^8.5|9.5.0",
+        "phpunit/phpunit": "^7.5.20|^8.5|9.5.5",
         "squizlabs/php_codesniffer": "3.6.0",
         "symfony/cache": "^4.4",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

PHPUnit 9.5.5 improves compatibility with PHP 8.1. Specifically, in https://github.com/sebastianbergmann/phpunit/commit/3e3aecdeb1160de5500fa7715436e73689cc11a3 by addressing the [`Serializable` deprecation](https://wiki.php.net/rfc/phase_out_serializable).

Currently, if run on PHP 8.1, the test suite produces the following errors:
```
$ phpunit
PHP Deprecated:  The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in vendor/phpunit/phpunit/src/Runner/DefaultTestResultCache.php on line 34

Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in vendor/phpunit/phpunit/src/Runner/DefaultTestResultCache.php on line 34
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.
```
Note, I don't believe DBAL 2.x will support PHP 8.1 but as long this release is supported, we should update dependencies starting the oldest supported release.