### PR TITLE
Disable DebugStack logger in the test suite

### DIFF
--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -3,23 +3,7 @@
 namespace Doctrine\DBAL\Tests;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Logging\DebugStack;
-use Exception;
-use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
-use Throwable;
-
-use function array_map;
-use function array_reverse;
-use function count;
-use function get_class;
-use function implode;
-use function is_object;
-use function is_scalar;
-use function strpos;
-use function var_export;
-
-use const PHP_EOL;
 
 abstract class FunctionalTestCase extends TestCase
 {
@@ -32,9 +16,6 @@ abstract class FunctionalTestCase extends TestCase
 
     /** @var Connection */
     protected $connection;
-
-    /** @var DebugStack|null */
-    protected $sqlLoggerStack;
 
     /**
      * Whether the shared connection could be reused by subsequent tests.
@@ -56,15 +37,11 @@ abstract class FunctionalTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $this->sqlLoggerStack = new DebugStack();
-
         if (self::$sharedConnection === null) {
             self::$sharedConnection = TestUtil::getConnection();
         }
 
         $this->connection = self::$sharedConnection;
-
-        $this->connection->getConfiguration()->setSQLLogger($this->sqlLoggerStack);
     }
 
     protected function tearDown(): void
@@ -90,60 +67,5 @@ abstract class FunctionalTestCase extends TestCase
         unset($this->connection);
 
         $this->isConnectionReusable = true;
-    }
-
-    protected function onNotSuccessfulTest(Throwable $t): void
-    {
-        if ($t instanceof AssertionFailedError) {
-            throw $t;
-        }
-
-        if ($this->sqlLoggerStack !== null && count($this->sqlLoggerStack->queries) > 0) {
-            $queries = '';
-            $i       = count($this->sqlLoggerStack->queries);
-            foreach (array_reverse($this->sqlLoggerStack->queries) as $query) {
-                $params = array_map(
-                    /**
-                     * @param mixed $p
-                     */
-                    static function ($p): string {
-                        if (is_object($p)) {
-                            return get_class($p);
-                        }
-
-                        if (is_scalar($p)) {
-                            return "'" . $p . "'";
-                        }
-
-                        return var_export($p, true);
-                    },
-                    $query['params'] ?? []
-                );
-                $queries .= $i . ". SQL: '" . $query['sql'] . "' Params: " . implode(', ', $params) . PHP_EOL;
-                $i--;
-            }
-
-            $trace    = $t->getTrace();
-            $traceMsg = '';
-            foreach ($trace as $part) {
-                if (! isset($part['file'])) {
-                    continue;
-                }
-
-                if (strpos($part['file'], 'PHPUnit/') !== false) {
-                    // Beginning with PHPUnit files we don't print the trace anymore.
-                    break;
-                }
-
-                $traceMsg .= $part['file'] . ':' . $part['line'] . PHP_EOL;
-            }
-
-            $message = '[' . get_class($t) . '] ' . $t->getMessage() . PHP_EOL . PHP_EOL
-                . 'With queries:' . PHP_EOL . $queries . PHP_EOL . 'Trace:' . PHP_EOL . $traceMsg;
-
-            throw new Exception($message, (int) $t->getCode(), $t);
-        }
-
-        throw $t;
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The logger does not provide any value when it comes to diagnosing test failures. The primary assumption behind logging the stack of SQL statements is that their combination may be the root cause of an issue but in 100% of my experience with the test suite it's not true. Furthermore, when it comes to running tests in some new environment (e.g. against a new PHP version), massive test failures are expected but the details provided by the logger just create additional noise.

We may consider removing this logger entirely or moving to another higher-level library (e.g. DoctrineBundle).