### PR TITLE
Deprecate TableGenerator

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -51,6 +51,11 @@
                     is no longer supported.
                 -->
                 <file name="tests/Functional/ResultCacheTest.php"/>
+                <!--
+                    This suppression should be removed in 4.0.0.
+                -->
+                <referencedClass name="Doctrine\DBAL\Id\TableGenerator"/>
+                <referencedClass name="Doctrine\DBAL\Id\TableGeneratorSchemaVisitor"/>
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedMethod>

--- a/src/Id/TableGenerator.php
+++ b/src/Id/TableGenerator.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\LockMode;
+use Doctrine\Deprecations\Deprecation;
 use Throwable;
 
 use function array_change_key_case;
@@ -51,6 +52,8 @@ use const CASE_LOWER;
  *
  * If no row is present for a given sequence a new one will be created with the
  * default values 'value' = 1 and 'increment_by' = 1
+ *
+ * @deprecated
  */
 class TableGenerator
 {
@@ -70,6 +73,12 @@ class TableGenerator
      */
     public function __construct(Connection $conn, $generatorTableName = 'sequences')
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4681',
+            'The TableGenerator class is is deprecated.',
+        );
+
         if ($conn->getDriver() instanceof Driver\PDO\SQLite\Driver) {
             throw new Exception('Cannot use TableGenerator with SQLite.');
         }

--- a/src/Id/TableGeneratorSchemaVisitor.php
+++ b/src/Id/TableGeneratorSchemaVisitor.php
@@ -9,7 +9,11 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
+use Doctrine\Deprecations\Deprecation;
 
+/**
+ * @deprecated
+ */
 class TableGeneratorSchemaVisitor implements Visitor
 {
     /** @var string */
@@ -20,6 +24,12 @@ class TableGeneratorSchemaVisitor implements Visitor
      */
     public function __construct($generatorTableName = 'sequences')
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4681',
+            'The TableGeneratorSchemaVisitor class is is deprecated.',
+        );
+
         $this->generatorTableName = $generatorTableName;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

I propose to deprecate and later remove the `TableGenerator` component for the following reasons:
1. It doesn't seem to be used by open-source projects.
2. It's one of the components that use `Connection::getParams()` which I'd like to get rid of eventually (https://github.com/doctrine/dbal/issues/3593).
3. This code hasn't received any significant changes since its introduction in 2012 (https://github.com/doctrine/dbal/commit/468af759a58c88ee28fcf588fcbbd1bcae26f20e). This is either because it's perfect or because nobody uses it.