### PR TITLE
Initial support for PHP 8.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,6 +25,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         dependencies:
           - "highest"
         include:

--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -912,7 +912,7 @@ SQL
      */
     public function convertFromBoolean($item)
     {
-        if (in_array(strtolower($item), $this->booleanLiterals['false'], true)) {
+        if ($item !== null && in_array(strtolower($item), $this->booleanLiterals['false'], true)) {
             return false;
         }
 

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -24,7 +24,7 @@ use function substr;
 abstract class AbstractAsset
 {
     /** @var string */
-    protected $_name;
+    protected $_name = '';
 
     /**
      * Namespace of the asset. If none isset the default namespace is assumed.

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -419,7 +419,12 @@ class SqliteSchemaManager extends AbstractSchemaManager
                 ];
             }
 
-            $list[$name]['local'][]   = $value['from'];
+            $list[$name]['local'][] = $value['from'];
+
+            if ($value['to'] === null) {
+                continue;
+            }
+
             $list[$name]['foreign'][] = $value['to'];
         }
 

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -196,7 +196,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         );
 
         foreach ($indexArray as $indexColumnRow) {
-            if ($indexColumnRow['pk'] === '0') {
+            if ($indexColumnRow['pk'] === 0 || $indexColumnRow['pk'] === '0') {
                 continue;
             }
 
@@ -247,7 +247,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $autoincrementCount  = 0;
 
         foreach ($tableColumns as $tableColumn) {
-            if ($tableColumn['pk'] === '0') {
+            if ($tableColumn['pk'] === 0 || $tableColumn['pk'] === '0') {
                 continue;
             }
 

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 
+use function func_num_args;
 use function is_string;
 
 /**
@@ -147,7 +148,11 @@ class Statement
         $this->types[$param]  = $type;
 
         try {
-            return $this->stmt->bindParam($param, $variable, $type, $length);
+            if (func_num_args() > 3) {
+                return $this->stmt->bindParam($param, $variable, $type, $length);
+            }
+
+            return $this->stmt->bindParam($param, $variable, $type);
         } catch (Exception $e) {
             throw $this->conn->convertException($e);
         }

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -144,7 +144,6 @@ class BlobTest extends FunctionalTestCase
             "INSERT INTO blob_table(id, clobcolumn, blobcolumn) VALUES (1, 'ignored', ?)"
         );
 
-        $stream = null;
         $stmt->bindParam(1, $stream, ParameterType::LARGE_OBJECT);
 
         // Bind param does late binding (bind by reference), so create the stream only now:

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -76,7 +76,7 @@ EOS
             new Schema\ForeignKeyConstraint(
                 ['log'],
                 'log',
-                [''],
+                [],
                 'FK_3',
                 ['onUpdate' => 'SET NULL', 'onDelete' => 'NO ACTION', 'deferrable' => false, 'deferred' => false]
             ),

--- a/tests/Functional/TypeConversionTest.php
+++ b/tests/Functional/TypeConversionTest.php
@@ -139,9 +139,7 @@ class TypeConversionTest extends FunctionalTestCase
     {
         return [
             'string' => ['string', 'ABCDEFGabcdefg'],
-            'bigint' => ['bigint', 12345678],
             'text' => ['text', str_repeat('foo ', 1000)],
-            'decimal' => ['decimal', 1.55],
         ];
     }
 

--- a/tests/Tools/DumperTest.php
+++ b/tests/Tools/DumperTest.php
@@ -99,7 +99,7 @@ class DumperTest extends TestCase
         $var = (array) $var;
         unset($var['__CLASS__']);
 
-        self::assertSame($expected, $var);
+        self::assertEquals($expected, $var);
     }
 
     /**

--- a/tests/Types/VarDateTimeTest.php
+++ b/tests/Types/VarDateTimeTest.php
@@ -19,7 +19,7 @@ class VarDateTimeTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = $this->getMockForAbstractClass(AbstractPlatform::class);
         $this->type     = new VarDateTimeType();
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

References:
1. https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg
2. https://github.com/php/php-src/blob/578b67da49af51b2f796a48782e51ceb62860943/UPGRADING#L334-L341
3. https://github.com/php/php-src/blob/578b67da49af51b2f796a48782e51ceb62860943/UPGRADING#L123-L126