### PR TITLE
[GH-4687] Deprecate Connection::lastInsertId($name)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## Deprecated `Connection::lastInsertId($name)`
+
+The usage of `Connection::lastInsertId()` with a sequence name is deprecated as unsafe in scenarios with multiple
+concurrent connections. If a newly inserted row needs to be referenced, it is recommended to generate its identifier
+explicitly prior to insertion.
+
 ## Introduction of PSR-6 for result caching
 
 Instead of relying on the deprecated `doctrine/cache` library, a PSR-6 cache

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1209,6 +1209,14 @@ class Connection
      */
     public function lastInsertId($name = null)
     {
+        if ($name !== null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4687',
+                'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
+            );
+        }
+
         try {
             return $this->getWrappedConnection()->lastInsertId($name);
         } catch (Driver\Exception $e) {

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use stdClass;
 
 use function assert;
@@ -119,6 +120,14 @@ final class Connection implements ServerInfoAwareConnection
      */
     public function lastInsertId($name = null)
     {
+        if ($name !== null) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4687',
+                'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
+            );
+        }
+
         return db2_last_insert_id($this->conn);
     }
 

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use mysqli;
 
 use function assert;
@@ -134,6 +135,14 @@ final class Connection implements ServerInfoAwareConnection
      */
     public function lastInsertId($name = null)
     {
+        if ($name !== null) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4687',
+                'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
+            );
+        }
+
         return $this->conn->insert_id;
     }
 

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 
 use function addcslashes;
 use function assert;
@@ -124,6 +125,12 @@ final class Connection implements ServerInfoAwareConnection
         if ($name === null) {
             return false;
         }
+
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/4687',
+            'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
+        );
 
         $result = $this->query('SELECT ' . $name . '.CURRVAL FROM DUAL')->fetchOne();
 

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -105,6 +106,12 @@ final class Connection implements ServerInfoAwareConnection
             if ($name === null) {
                 return $this->connection->lastInsertId();
             }
+
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4687',
+                'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
+            );
 
             return $this->connection->lastInsertId($name);
         } catch (PDOException $exception) {

--- a/src/Driver/PDO/SQLSrv/Connection.php
+++ b/src/Driver/PDO/SQLSrv/Connection.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use PDO;
 
 final class Connection implements ServerInfoAwareConnection
@@ -52,6 +53,12 @@ final class Connection implements ServerInfoAwareConnection
         if ($name === null) {
             return $this->connection->lastInsertId($name);
         }
+
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/4687',
+            'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
+        );
 
         return $this->prepare('SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?')
             ->execute([$name])

--- a/src/Driver/SQLSrv/Connection.php
+++ b/src/Driver/SQLSrv/Connection.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 
 use function is_float;
 use function is_int;
@@ -109,6 +110,12 @@ final class Connection implements ServerInfoAwareConnection
     public function lastInsertId($name = null)
     {
         if ($name !== null) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4687',
+                'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
+            );
+
             $result = $this->prepare('SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?')
                 ->execute([$name]);
         } else {

--- a/src/Portability/Connection.php
+++ b/src/Portability/Connection.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Result as DriverResult;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Portability wrapper for a Connection.
@@ -64,6 +65,14 @@ final class Connection implements ConnectionInterface
      */
     public function lastInsertId($name = null)
     {
+        if ($name !== null) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4687',
+                'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
+            );
+        }
+
         return $this->connection->lastInsertId($name);
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Fixes #4687.

Apart from the issue in question, this change will reduce the scope and the number of breaking changes introduced in https://github.com/doctrine/dbal/pull/4324.