### PR TITLE
Normalize identifiers before filtering; fix getPrimaryKeyColumns not returning uppercased primary key

### DIFF
--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -735,6 +735,8 @@ class Table extends AbstractAsset
      */
     private function filterColumns(array $columnNames, bool $reverse = false): array
     {
+        $columnNames = array_map([$this, 'normalizeIdentifier'], $columnNames);
+
         return array_filter($this->_columns, static function (string $columnName) use ($columnNames, $reverse): bool {
             return in_array($columnName, $columnNames, true) !== $reverse;
         }, ARRAY_FILTER_USE_KEY);

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -852,4 +852,18 @@ class TableTest extends TestCase
 
         $table->removeUniqueConstraint('unique_constraint');
     }
+
+    public function testPrimaryKeyWithCaptialization(): void
+    {
+        $table = new Table('foo');
+        $table->addColumn('fooID', 'integer');
+        $table->addColumn('bar_id', 'integer');
+        $table->setPrimaryKey(['bar_id', 'fooID']);
+
+        $primaryKey = $table->getPrimaryKeyColumns();
+
+        self::assertCount(2, $primaryKey);
+        self::assertArrayHasKey('fooid', $primaryKey);
+        self::assertArrayHasKey('bar_id', $primaryKey);
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | compatible with v2
| Fixed issues | None

I found out that my primary column "fooId" was not returned by Table::getPrimaryKeyColumns. After some investigation, it seems that the columnnames are normalized early on, translating the columname to lowercase. However in the filtering, the original name with upper-case characters is used. Since uppercase is not the same as lowercase, it wil not return the key, "loosing" the primary key.

This worked fine in the 2.x branch, but broke when we upgraded to version 3.x.

I've written a test to illustrate the problem, and applied normalization just before filtering. This will at least ensure that the column can be found; hoewever, I think it is still "wrong" to return the normalized version; changing that would probably mean a whole lot more work.