### PR TITLE
Update JetBrains PhpStorm stubs to 2021.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -407,7 +407,7 @@ jobs:
 
     services:
       mssql:
-        image: "microsoft/mssql-server-linux:2017-latest"
+        image: "mcr.microsoft.com/mssql/server:2017-latest"
         env:
           ACCEPT_EULA: "Y"
           SA_PASSWORD: "Doctrine2018"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
     steps:
       - name: "Checkout code"
@@ -42,20 +42,24 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Psalm
-        uses: docker://vimeo/psalm-github-actions:4.6.4
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
         with:
-          composer_require_dev: true
-          args: --shepherd
+          coverage: none
+          php-version: ${{ matrix.php-version }}
+          tools: cs2pr
 
-      - name: Psalm type inference tests
-        uses: docker://vimeo/psalm-github-actions:4.6.4
-        with:
-          composer_require_dev: true
-          args: --config=psalm-strict.xml
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v1
+
+      - name: Run static analysis with Vimeo Psalm
+        run: vendor/bin/psalm --shepherd
+
+      - name: Run type inference tests with Vimeo Psalm
+        run: vendor/bin/psalm --config=psalm-strict.xml --shepherd

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "9.0.0",
-        "jetbrains/phpstorm-stubs": "2020.2",
+        "jetbrains/phpstorm-stubs": "2021.1",
         "phpstan/phpstan": "0.12.81",
         "phpunit/phpunit": "^7.5.20|^8.5|9.5.5",
         "squizlabs/php_codesniffer": "3.6.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -37,6 +37,7 @@ parameters:
 
         # weird class name, represented in stubs as OCI_(Lob|Collection)
         - '~unknown class OCI-(Lob|Collection)~'
+        - '~^Call to method writeTemporary\(\) on an unknown class OCILob\.~'
 
         # The ReflectionException in the case when the class does not exist is acceptable and does not need to be handled
         - '~^Parameter #1 \$argument of class ReflectionClass constructor expects class-string<T of object>\|T of object, string given\.$~'

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -323,14 +323,6 @@
         <RedundantConditionGivenDocblockType>
             <errorLevel type="suppress">
                 <!--
-                    Requires a release of https://github.com/JetBrains/phpstorm-stubs/pull/1055
-                -->
-                <file name="lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php"/>
-                <!--
-                    Requires a release of https://github.com/JetBrains/phpstorm-stubs/pull/1053
-                -->
-                <file name="lib/Doctrine/DBAL/Driver/PDOStatement.php"/>
-                <!--
                     Fixing these issues requires support of union types at the language level
                     or breaking API changes.
                 -->
@@ -341,11 +333,6 @@
                 -->
                 <file name="lib/Doctrine/DBAL/Tools/Console/ConsoleRunner.php"/>
                 <file name="tests/Doctrine/Tests/DBAL/Functional/PortabilityTest.php"/>
-                <!--
-                    Requires a release of
-                    https://github.com/JetBrains/phpstorm-stubs/commit/43ce0bb13e927b9eb69cc06c16ab22f548c4735b
-                -->
-                <file name="lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php"/>
             </errorLevel>
         </RedundantConditionGivenDocblockType>
         <ReferenceConstraintViolation>
@@ -457,6 +444,9 @@
 
                 <!-- See https://github.com/doctrine/dbal/issues/4318 -->
                 <file name="lib/Doctrine/DBAL/Types/ConversionException.php"/>
+
+                <!-- See https://bugs.php.net/bug.php?id=77591 -->
+                <referencedFunction name="db2_autocommit"/>
             </errorLevel>
         </InvalidScalarArgument>
         <InvalidReturnStatement>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. Replace `microsoft/mssql-server-linux:2017-latest` in CI configuration with `mcr.microsoft.com/mssql/server:2017-latest`. Unrelated but necessary for the build to pass. Otherwise, it fails as:
   ```shell
   $ docker pull microsoft/mssql-server-linux:2019-latest
   Error response from daemon: manifest for microsoft/mssql-server-linux:2019-latest not found: manifest unknown: manifest unknown
   ```
2. Use PHP 8 for static analysis. The new version of stubs uses multi-line annotations which PHP 7.4 cannot parse. This may be by design (https://github.com/JetBrains/phpstorm-stubs/pull/1160).
3. Switch from the Psalm GitHub action to a generic implementation since there's no Psalm image built on top of PHP 8 (https://github.com/psalm/psalm-github-actions/issues/31).