### PR TITLE
Ignore errors about missing ReturnTypeWillChange class

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -120,3 +120,6 @@ parameters:
             message: '~^Property Doctrine\\DBAL\\Connection::\$_conn \(Doctrine\\DBAL\\Driver\\Connection\|null\) does not accept PDO\.$~'
             paths:
                 - %currentWorkingDirectory%/lib/Doctrine/DBAL/Connection.php
+
+        # The class was added in PHP 8.1
+        - '~^Attribute class ReturnTypeWillChange does not exist.$~'

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -374,6 +374,12 @@
                 <file name="lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php"/>
             </errorLevel>
         </TooManyArguments>
+        <UndefinedAttributeClass>
+            <errorLevel type="suppress">
+                <!-- The class was added in PHP 8.1 -->
+                <referencedClass name="ReturnTypeWillChange"/>
+            </errorLevel>
+        </UndefinedAttributeClass>
         <UndefinedConstant>
             <errorLevel type="suppress">
                 <directory name="lib/Doctrine/DBAL/Driver/SQLAnywhere"/>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | https://github.com/doctrine/dbal/pull/4662#issuecomment-869401009

#### Summary

PHPStan and Psalm should not complain about `ReturnTypeWillChange` not being defined.