### PR TITLE
Configure PHP version for PHP_CodeSniffer

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
     steps:
       - name: "Checkout"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,6 +12,8 @@
     <!-- Show progress of the run and show sniff names -->
     <arg value="ps"/>
 
+    <config name="php_version" value="70300"/>
+
     <file>bin</file>
     <file>lib</file>
     <file>tests/Doctrine/Tests</file>
@@ -35,13 +37,6 @@
     <rule ref="Generic.Classes.DuplicateClassName.Found">
         <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php</exclude-pattern>
         <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php</exclude-pattern>
-    </rule>
-
-    <!-- Disable the rules that will require PHP 7.4 -->
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
-        <properties>
-            <property name="enableNativeTypeHint" value="false"/>
-        </properties>
     </rule>
 
     <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Currently, `phpcs` fails with a bunch of false-positive errors if run on PHP 8:
```
$ php -v
PHP 8.0.8 (cli) (built: Jun 29 2021 22:25:18) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.8, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.8, Copyright (c), by Zend Technologies
    with Xdebug v3.0.4, Copyright (c) 2002-2021, by Derick Rethans

$ phpcs
.......................EE.E......E..........E.........EEE..E 60 / 76 (79%)
E.EEEE...EEEE...                                             76 / 76 (100%)



FILE: tests/Doctrine/Tests/DBAL/Functional/Driver/PDO/ConnectionTest.php
--------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------------------------------------------------------------------
 86 | ERROR | [x] Class name referenced via call of function get_class().
    |       |     (SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaFunctionCall)
--------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------------------------------------------------------------------
...
And a lot more.
```
Note that `$object::class` is only [available as of PHP 8.0](https://wiki.php.net/rfc/class_name_literal_on_object). All of the errors are trigger with the assumption that the runtime PHP version (8.0) is the minimum supported version (7.3).

We already have some rules specific to PHP 7.4 suppressed: https://github.com/doctrine/dbal/blob/ce7db44c5becbc69db0bc11fd3816294aafc5a11/phpcs.xml.dist#L40-L45

But there's a better way to configure the minimum supported PHP version.