### PR TITLE
Add alterSchema() methods in AbstractSchemaManager

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -677,6 +677,26 @@ abstract class AbstractSchemaManager
         $this->createView($view);
     }
 
+    /**
+     * Alters an existing schema.
+     *
+     * @throws Exception
+     */
+    public function alterSchema(SchemaDiff $schemaDiff): void
+    {
+        $this->_execSql($schemaDiff->toSql($this->_platform));
+    }
+
+    /**
+     * Migrates an existing schema to a new schema.
+     *
+     * @throws Exception
+     */
+    public function migrateSchema(Schema $toSchema): void
+    {
+        $this->alterSchema(Comparator::compareSchemas($this->createSchema(), $toSchema));
+    }
+
     /* alterTable() Methods */
 
     /**

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -496,6 +496,34 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertTrue($schema->hasTable('test_table'));
     }
 
+    public function testMigrateSchema(): void
+    {
+        $this->createTestTable('table_to_alter');
+        $this->createTestTable('table_to_drop');
+
+        $schema = $this->schemaManager->createSchema();
+
+        $tableToAlter = $schema->getTable('table_to_alter');
+        $tableToAlter->dropColumn('foreign_key_test');
+        $tableToAlter->addColumn('number', 'integer');
+
+        $schema->dropTable('table_to_drop');
+
+        $tableToCreate = $schema->createTable('table_to_create');
+        $tableToCreate->addColumn('id', 'integer', ['notnull' => true]);
+        $tableToCreate->setPrimaryKey(['id']);
+
+        $this->schemaManager->migrateSchema($schema);
+
+        $schema = $this->schemaManager->createSchema();
+
+        self::assertTrue($schema->hasTable('table_to_alter'));
+        self::assertFalse($schema->getTable('table_to_alter')->hasColumn('foreign_key_test'));
+        self::assertTrue($schema->getTable('table_to_alter')->hasColumn('number'));
+        self::assertFalse($schema->hasTable('table_to_drop'));
+        self::assertTrue($schema->hasTable('table_to_create'));
+    }
+
     public function testAlterTableScenario(): void
     {
         if (! $this->schemaManager->getDatabasePlatform()->supportsAlterTable()) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

This is my first contribution to Doctrine DBAL! :tada: 

This PR introduces new convenient methods to apply a schema diff in one go.

I tried to follow the same template used in `alterTable()` methods.

The methods introduced in this PR would help me implement a [new feature on a small library](https://github.com/trompette/php-feature-toggles/issues/13) based on Doctrine DBAL I am maintaining.

What do you think? :thinking: 