### PR TITLE
Update Psalm to 4.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "squizlabs/php_codesniffer": "3.6.0",
         "symfony/cache": "^4.4",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-        "vimeo/psalm": "4.6.4"
+        "vimeo/psalm": "4.8.1"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."

--- a/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
+++ b/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php
@@ -367,11 +367,11 @@ class PrimaryReadReplicaConnection extends Connection
     /**
      * {@inheritDoc}
      */
-    public function exec($statement)
+    public function exec($sql)
     {
         $this->ensureConnectedToPrimary();
 
-        return parent::exec($statement);
+        return parent::exec($sql);
     }
 
     /**
@@ -433,10 +433,10 @@ class PrimaryReadReplicaConnection extends Connection
     /**
      * {@inheritDoc}
      */
-    public function prepare($statement)
+    public function prepare($sql)
     {
         $this->ensureConnectedToPrimary();
 
-        return parent::prepare($statement);
+        return parent::prepare($sql);
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
@@ -1411,13 +1411,13 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL snippet to drop an existing database.
      *
-     * @param string $database The name of the database that should be dropped.
+     * @param string $name The name of the database that should be dropped.
      *
      * @return string
      */
-    public function getDropDatabaseSQL($database)
+    public function getDropDatabaseSQL($name)
     {
-        return 'DROP DATABASE ' . $database;
+        return 'DROP DATABASE ' . $name;
     }
 
     /**
@@ -2990,13 +2990,13 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to create a new database.
      *
-     * @param string $database The name of the database that should be created.
+     * @param string $name The name of the database that should be created.
      *
      * @return string
      *
      * @throws Exception If not supported on this platform.
      */
-    public function getCreateDatabaseSQL($database)
+    public function getCreateDatabaseSQL($name)
     {
         throw Exception::notSupported(__METHOD__);
     }

--- a/lib/Doctrine/DBAL/Platforms/DB2Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/DB2Platform.php
@@ -414,17 +414,17 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateDatabaseSQL($database)
+    public function getCreateDatabaseSQL($name)
     {
-        return 'CREATE DATABASE ' . $database;
+        return 'CREATE DATABASE ' . $name;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getDropDatabaseSQL($database)
+    public function getDropDatabaseSQL($name)
     {
-        return 'DROP DATABASE ' . $database;
+        return 'DROP DATABASE ' . $name;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -785,9 +785,9 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDropDatabaseSQL($database)
+    public function getDropDatabaseSQL($name)
     {
-        return 'DROP USER ' . $database . ' CASCADE';
+        return 'DROP USER ' . $name . ' CASCADE';
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -406,11 +406,11 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getCreateDatabaseSQL($database)
+    public function getCreateDatabaseSQL($name)
     {
-        $database = new Identifier($database);
+        $name = new Identifier($name);
 
-        return "CREATE DATABASE '" . $database->getName() . "'";
+        return "CREATE DATABASE '" . $name->getName() . "'";
     }
 
     /**
@@ -540,11 +540,11 @@ class SQLAnywherePlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDropDatabaseSQL($database)
+    public function getDropDatabaseSQL($name)
     {
-        $database = new Identifier($database);
+        $name = new Identifier($name);
 
-        return "DROP DATABASE '" . $database->getName() . "'";
+        return "DROP DATABASE '" . $name->getName() . "'";
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/Connection.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/Connection.php
@@ -26,9 +26,9 @@ class Connection extends BaseConnection
     /**
      * {@inheritdoc}
      */
-    public function prepare($statement)
+    public function prepare($sql)
     {
-        return new Statement(parent::prepare($statement));
+        return new Statement(parent::prepare($sql));
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | mostly no

#### Summary

While we did most of the argument names cleanup in https://github.com/doctrine/dbal/pull/4172, the updated Psalm flagged some more cases. Since we already support PHP 8, changing argument names could be technically called out as a BC break, I believe this change is acceptable:

1. The argument names are inconsistent across implementations, so the current state cannot be considered correct.
2. All changes are made in the methods that accept a single argument, so it's very unlikely that the calling side passes the argument by name.