### PR TITLE
Temporarily remove PHP 8.1 jobs from CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,6 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
-          - "8.1"
         dependencies:
           - "highest"
         include:
@@ -69,7 +68,6 @@ jobs:
         php-version:
           - "7.4"
           - "8.0"
-          - "8.1"
 
     services:
       oracle:
@@ -113,7 +111,6 @@ jobs:
         php-version:
           - "7.4"
           - "8.0"
-          - "8.1"
 
     services:
       oracle:
@@ -161,8 +158,6 @@ jobs:
           - "13"
         include:
           - php-version: "8.0"
-            postgres-version: "13"
-          - php-version: "8.1"
             postgres-version: "13"
 
     services:
@@ -223,12 +218,6 @@ jobs:
             mariadb-version: "10.5"
             extension: "mysqli"
           - php-version: "8.0"
-            mariadb-version: "10.5"
-            extension: "pdo_mysql"
-          - php-version: "8.1"
-            mariadb-version: "10.5"
-            extension: "mysqli"
-          - php-version: "8.1"
             mariadb-version: "10.5"
             extension: "pdo_mysql"
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

From https://github.com/actions/runner/issues/2347: the `continue-on-error` is scoped to a step and allows to proceed to the next step in the job. What we're looking for is allowing a job to fail which is different.

Specifying `job.continue-on-error
` as documented [here](https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/#expressions-in-jobcontinue-on-error) doesn't work either.