### PR TITLE
Use less verbose Comparator::compareSchema()

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -27,9 +27,7 @@ class Comparator
      */
     public static function compareSchemas(Schema $fromSchema, Schema $toSchema)
     {
-        $c = new self();
-
-        return $c->compare($fromSchema, $toSchema);
+        return (new self())->compare($fromSchema, $toSchema);
     }
 
     /**

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -437,10 +437,7 @@ class Schema extends AbstractAsset
      */
     public function getMigrateToSql(Schema $toSchema, AbstractPlatform $platform)
     {
-        $comparator = new Comparator();
-        $schemaDiff = $comparator->compare($this, $toSchema);
-
-        return $schemaDiff->toSql($platform);
+        return Comparator::compareSchemas($this, $toSchema)->toSql($platform);
     }
 
     /**
@@ -450,10 +447,7 @@ class Schema extends AbstractAsset
      */
     public function getMigrateFromSql(Schema $fromSchema, AbstractPlatform $platform)
     {
-        $comparator = new Comparator();
-        $schemaDiff = $comparator->compare($fromSchema, $this);
-
-        return $schemaDiff->toSql($platform);
+        return Comparator::compareSchemas($fromSchema, $this)->toSql($platform);
     }
 
     /**

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -47,7 +47,7 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
         $newTable->dropPrimaryKey();
         $newTable->setPrimaryKey(['new_id']);
 
-        $diff = (new Comparator())->compare($schema, $newSchema);
+        $diff = Comparator::compareSchemas($schema, $newSchema);
 
         foreach ($diff->toSql($this->getPlatform()) as $sql) {
             $this->connection->executeStatement($sql);

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -501,8 +501,7 @@ class ComparatorTest extends TestCase
 
         $schema2 = new Schema();
 
-        $c          = new Comparator();
-        $diffSchema = $c->compare($schema1, $schema2);
+        $diffSchema = Comparator::compareSchemas($schema1, $schema2);
 
         self::assertCount(1, $diffSchema->removedSequences);
         self::assertSame($seq, $diffSchema->removedSequences[0]);
@@ -515,8 +514,7 @@ class ComparatorTest extends TestCase
         $schema2 = new Schema();
         $seq     = $schema2->createSequence('foo');
 
-        $c          = new Comparator();
-        $diffSchema = $c->compare($schema1, $schema2);
+        $diffSchema = Comparator::compareSchemas($schema1, $schema2);
 
         self::assertCount(1, $diffSchema->newSequences);
         self::assertSame($seq, $diffSchema->newSequences[0]);
@@ -617,8 +615,7 @@ class ComparatorTest extends TestCase
         $schemaB->createTable('Baz');
         $schemaB->createTable('old');
 
-        $c    = new Comparator();
-        $diff = $c->compare($schemaA, $schemaB);
+        $diff = Comparator::compareSchemas($schemaA, $schemaB);
 
         $this->assertSchemaTableChangeCount($diff, 1, 0, 1);
     }
@@ -637,8 +634,7 @@ class ComparatorTest extends TestCase
         $schemaB->createSequence('baz');
         $schemaB->createSequence('old');
 
-        $c    = new Comparator();
-        $diff = $c->compare($schemaA, $schemaB);
+        $diff = Comparator::compareSchemas($schemaA, $schemaB);
 
         $this->assertSchemaSequenceChangeCount($diff, 1, 0, 1);
     }
@@ -851,8 +847,7 @@ class ComparatorTest extends TestCase
         $schemaNew = clone $schema;
         $schemaNew->getSequence('baz')->setAllocationSize(20);
 
-        $c    = new Comparator();
-        $diff = $c->compare($schema, $schemaNew);
+        $diff = Comparator::compareSchemas($schema, $schemaNew);
 
         self::assertSame($diff->changedSequences[0], $schemaNew->getSequence('baz'));
     }
@@ -958,8 +953,7 @@ class ComparatorTest extends TestCase
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
 
-        $c    = new Comparator();
-        $diff = $c->compare($oldSchema, $newSchema);
+        $diff = Comparator::compareSchemas($oldSchema, $newSchema);
 
         self::assertCount(0, $diff->removedSequences);
     }
@@ -980,8 +974,7 @@ class ComparatorTest extends TestCase
         $table->setPrimaryKey(['id']);
         $newSchema->createSequence('foo_id_seq');
 
-        $c    = new Comparator();
-        $diff = $c->compare($oldSchema, $newSchema);
+        $diff = Comparator::compareSchemas($oldSchema, $newSchema);
 
         self::assertCount(0, $diff->newSequences);
     }
@@ -1018,8 +1011,7 @@ class ComparatorTest extends TestCase
         $tableC = $newSchema->createTable('table_c');
         $tableC->addColumn('id', 'integer');
 
-        $comparator = new Comparator();
-        $schemaDiff = $comparator->compare($oldSchema, $newSchema);
+        $schemaDiff = Comparator::compareSchemas($oldSchema, $newSchema);
 
         self::assertCount(1, $schemaDiff->changedTables['table_c']->removedForeignKeys);
         self::assertCount(1, $schemaDiff->orphanedForeignKeys);
@@ -1162,7 +1154,6 @@ class ComparatorTest extends TestCase
 
     public function testComparesNamespaces(): void
     {
-        $comparator = new Comparator();
         $fromSchema = $this->getMockBuilder(Schema::class)
             ->onlyMethods(['getNamespaces', 'hasNamespace'])
             ->getMock();
@@ -1191,7 +1182,7 @@ class ComparatorTest extends TestCase
         $expected->newNamespaces     = ['baz' => 'baz'];
         $expected->removedNamespaces = ['foo' => 'foo'];
 
-        self::assertEquals($expected, $comparator->compare($fromSchema, $toSchema));
+        self::assertEquals($expected, Comparator::compareSchemas($fromSchema, $toSchema));
     }
 
     public function testCompareGuidColumns(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

<!-- Provide a summary of your change. -->

While working on #4698, I noticed a small inconsistency when comparing schemas with `Comparator`.

This PR uses an existing shortcut everywhere instead of a verbose alternative.