### PR TITLE
Allow names with more than two dots in the name

### DIFF
--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -51,7 +51,7 @@ abstract class AbstractAsset
         }
 
         if (strpos($name, '.') !== false) {
-            $parts            = explode('.', $name);
+            $parts            = explode('.', $name, 2);
             $this->_namespace = $parts[0];
             $name             = $parts[1];
         }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes

#### Summary

I stumbled upon an issue using the database of `shopware/platform` with `$connection->getSchemaManager()->listTables()`. This throws an exception stating that a duplicate index has been added to the table class. That should not be the case as this is straight from the database which would've complained first about it. Debugging into it reveiled the issue. Shopware names their indices with multiple dots:

**table order**
* fk.language_id
* fk.order.created_by_id
* fk.order.currency_id
* fk.order.sales_channel_id
* fk.order.updated_by_id
* idx.state_index
* uniq.auto_increment
* uniq.deep_link_code

When the index objects set themselves their names they have the following names:

* fk.language_id
* fk.order
* fk.order
* fk.order
* fk.order
* idx.state_index
* uniq.auto_increment
* uniq.deep_link_code

One can already spot the duplicates which cause the error.

---

I have no idea how to test properly within your framework yet. This is a breaking change which does not just affect indices as this is the base class for basically everything. Guidance needed here.