### PR TITLE
Avoid crash when getting details of table and they exist in different schemas

### DIFF
--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -380,7 +380,7 @@ SQL
             [$schema, $table] = explode('.', $table);
             $schema           = $this->quoteStringLiteral($schema);
         } else {
-            $schema = "CURRENT_SCHEMA";
+            $schema = 'CURRENT_SCHEMA';
         }
 
         $table = new Identifier($table);

--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -380,7 +380,7 @@ SQL
             [$schema, $table] = explode('.', $table);
             $schema           = $this->quoteStringLiteral($schema);
         } else {
-            $schema = 'ANY(current_schemas(false))';
+            $schema = "ANY(CASE WHEN CURRENT_SCHEMA <> 'public' THEN string_to_array(CURRENT_SCHEMA, ',') ELSE current_schemas(false) END)";
         }
 
         $table = new Identifier($table);

--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -380,7 +380,7 @@ SQL
             [$schema, $table] = explode('.', $table);
             $schema           = $this->quoteStringLiteral($schema);
         } else {
-            $schema = "ANY(string_to_array(CURRENT_SCHEMA, ','))";
+            $schema = "CURRENT_SCHEMA";
         }
 
         $table = new Identifier($table);

--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -380,7 +380,7 @@ SQL
             [$schema, $table] = explode('.', $table);
             $schema           = $this->quoteStringLiteral($schema);
         } else {
-            $schema = "ANY(CASE WHEN CURRENT_SCHEMA <> 'public' THEN string_to_array(CURRENT_SCHEMA, ',') ELSE current_schemas(false) END)";
+            $schema = "ANY(string_to_array(CURRENT_SCHEMA, ','))";
         }
 
         $table = new Identifier($table);

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -494,12 +494,12 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($tableFinal->getColumn('id')->getAutoincrement());
     }
 
-    public function testGetDetailsWithTwoSameTablesOnDifferentSchemas(): void
+    public function testListTableDetailsWithTwoSameTablesOnDifferentSchemas(): void
     {
-        $createTableSQL = 'CREATE TABLE migrations(a text);';
-        $this->connection->executeStatement($createTableSQL);
-        $createTableSQL = 'CREATE TABLE "001_test".migrations(a text);';
-        $this->connection->executeStatement($createTableSQL);
+        $sql = 'CREATE TABLE migrations(a text);';
+        $this->connection->executeStatement($sql);
+        $sql = 'CREATE TABLE "001_test".migrations(a text);';
+        $this->connection->executeStatement($sql);
         $this->connection->executeStatement('SET search_path TO "001_test",public');
 
         $databaseTable = $this->schemaManager->listTableDetails('migrations');
@@ -507,12 +507,12 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertNotNull($databaseTable);
     }
 
-    public function testGetDetailsStillWorkingWithOneTable(): void
+    public function testListTableDetailsWithTwoSameTablesOnDifferentSchemasUsingNonPublicSchema(): void
     {
-        $createTableSQL = 'DROP TABLE IF EXISTS migrations;';
-        $this->connection->executeStatement($createTableSQL);
-        $createTableSQL = 'CREATE TABLE IF NOT EXISTS "001_test".migrations(a text);';
-        $this->connection->executeStatement($createTableSQL);
+        $sql = 'CREATE TABLE IF NOT EXISTS migrations(a text);';
+        $this->connection->executeStatement($sql);
+        $sql = 'CREATE TABLE IF NOT EXISTS "001_test".migrations(a text);';
+        $this->connection->executeStatement($sql);
         $this->connection->executeStatement('SET search_path TO "001_test",public');
 
         $databaseTable = $this->schemaManager->listTableDetails('"001_test".migrations');
@@ -520,12 +520,25 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertNotNull($databaseTable);
     }
 
-    public function testGetDetailsStillWorkingWithOneTable2(): void
+    public function testListTableDetailsWithOneTableOnNonPublicDifferentSchema(): void
     {
-        $createTableSQL = 'DROP TABLE IF EXISTS migrations;';
-        $this->connection->executeStatement($createTableSQL);
-        $createTableSQL = 'CREATE TABLE IF NOT EXISTS "001_test".migrations(a text);';
-        $this->connection->executeStatement($createTableSQL);
+        $sql = 'DROP TABLE IF EXISTS migrations;';
+        $this->connection->executeStatement($sql);
+        $sql = 'CREATE TABLE IF NOT EXISTS "001_test".migrations(a text);';
+        $this->connection->executeStatement($sql);
+        $this->connection->executeStatement('SET search_path TO "001_test",public');
+
+        $databaseTable = $this->schemaManager->listTableDetails('"001_test".migrations');
+
+        self::assertNotNull($databaseTable);
+    }
+
+    public function testListTableDetailsWithOneTableOnNonPublicSchemaCanStillBeFound(): void
+    {
+        $sql = 'DROP TABLE IF EXISTS migrations;';
+        $this->connection->executeStatement($sql);
+        $sql = 'CREATE TABLE IF NOT EXISTS "001_test".migrations(a text);';
+        $this->connection->executeStatement($sql);
         $this->connection->executeStatement('SET search_path TO "001_test",public');
 
         $databaseTable = $this->schemaManager->listTableDetails('migrations');
@@ -533,12 +546,29 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertNotNull($databaseTable);
     }
 
-    public function testGetDetailsStillWorkingWithOneTable3(): void
+    public function testListTableDetailsWithOneTableOnPublicSchema(): void
     {
-        $createTableSQL = 'CREATE TABLE IF NOT EXISTS migrations(a text);';
-        $this->connection->executeStatement($createTableSQL);
-        $createTableSQL = 'DROP TABLE IF EXISTS "001_test".migrations;';
-        $this->connection->executeStatement($createTableSQL);
+        $sql = 'CREATE TABLE IF NOT EXISTS migrations(a text);';
+        $this->connection->executeStatement($sql);
+        $sql = 'DROP TABLE IF EXISTS "001_test".migrations;';
+        $this->connection->executeStatement($sql);
+        $this->connection->executeStatement('SET search_path TO "001_test",public');
+
+        $databaseTable = $this->schemaManager->listTableDetails('migrations');
+
+        self::assertNotNull($databaseTable);
+    }
+
+    public function testListTableDetailsWithTwoSameTablesWithoutColumns(): void
+    {
+        $sql = 'DROP TABLE IF EXISTS migrations;';
+        $this->connection->executeStatement($sql);
+        $sql = 'DROP TABLE IF EXISTS "001_test".migrations;';
+        $this->connection->executeStatement($sql);
+        $sql = 'CREATE TABLE IF NOT EXISTS migrations();';
+        $this->connection->executeStatement($sql);
+        $sql = 'CREATE TABLE IF NOT EXISTS "001_test".migrations();';
+        $this->connection->executeStatement($sql);
         $this->connection->executeStatement('SET search_path TO "001_test",public');
 
         $databaseTable = $this->schemaManager->listTableDetails('migrations');

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -515,12 +515,25 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->connection->executeStatement($createTableSQL);
         $this->connection->executeStatement('SET search_path TO "001_test",public');
 
-        $databaseTable = $this->schemaManager->listTableDetails('migrations');
+        $databaseTable = $this->schemaManager->listTableDetails('"001_test".migrations');
 
         self::assertNotNull($databaseTable);
     }
 
     public function testGetDetailsStillWorkingWithOneTable2(): void
+    {
+        $createTableSQL = 'DROP TABLE IF EXISTS migrations;';
+        $this->connection->executeStatement($createTableSQL);
+        $createTableSQL = 'CREATE TABLE IF NOT EXISTS "001_test".migrations(a text);';
+        $this->connection->executeStatement($createTableSQL);
+        $this->connection->executeStatement('SET search_path TO "001_test",public');
+
+        $databaseTable = $this->schemaManager->listTableDetails('migrations');
+
+        self::assertNotNull($databaseTable);
+    }
+
+    public function testGetDetailsStillWorkingWithOneTable3(): void
     {
         $createTableSQL = 'CREATE TABLE IF NOT EXISTS migrations(a text);';
         $this->connection->executeStatement($createTableSQL);

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -502,12 +502,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->connection->executeStatement($createTableSQL);
         $this->connection->executeStatement('SET search_path TO "001_test",public');
 
-        try
-        {
-            $databaseTable = $this->schemaManager->listTableDetails('migrations');
-        } catch (\Exception $e) {
-            $databaseTable = null;
-        }
+        $databaseTable = $this->schemaManager->listTableDetails('migrations');
 
         self::assertNotNull($databaseTable);
     }
@@ -520,12 +515,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->connection->executeStatement($createTableSQL);
         $this->connection->executeStatement('SET search_path TO "001_test",public');
 
-        try
-        {
-            $databaseTable = $this->schemaManager->listTableDetails('migrations');
-        } catch (\Exception $e) {
-            $databaseTable = null;
-        }
+        $databaseTable = $this->schemaManager->listTableDetails('migrations');
 
         self::assertNotNull($databaseTable);
     }
@@ -538,12 +528,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->connection->executeStatement($createTableSQL);
         $this->connection->executeStatement('SET search_path TO "001_test",public');
 
-        try
-        {
-            $databaseTable = $this->schemaManager->listTableDetails('migrations');
-        } catch (\Exception $e) {
-            $databaseTable = null;
-        }
+        $databaseTable = $this->schemaManager->listTableDetails('migrations');
 
         self::assertNotNull($databaseTable);
     }

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -519,6 +519,26 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertNotFalse($diff);
     }
 
+    public function testGetDetailsWithTwoSameTablesOnDifferentSchemas2(): void
+    {
+        $this->connection->executeStatement('SET search_path TO public,"001_test"');
+
+        $table = new Table('migrations');
+        $table->addColumn('a', 'text');
+
+        try
+        {
+            $databaseTable = $this->schemaManager->listTableDetails('migrations');
+        } catch (\Exception $e) {
+            $databaseTable = null;
+        }
+
+        $c    = new Comparator();
+        $diff = $c->diffTable($table, $databaseTable);
+
+        self::assertNotFalse($diff);
+    }
+
     /**
      * @return mixed[][]
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #950 

#### Summary

Previous [PR](https://github.com/doctrine/dbal/pull/4494) got lost due to wrong merges, so here's a new one:

This fix will use only the current schema when getting details of a table that has the same name in two or more schemas. Previously it would get the details of all the tables thus producing the exception.
