### PR TITLE
Handle lost connection during commit

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1237,6 +1237,8 @@ class Connection
 
             try {
                 $connection->commit();
+            } catch (Driver\Exception $e) {
+                throw $this->convertException($e);
             } finally {
                 $logger->stopQuery();
             }
@@ -1298,6 +1300,8 @@ class Connection
 
             try {
                 $connection->rollBack();
+            } catch (Driver\Exception $e) {
+                throw $this->convertException($e);
             } finally {
                 $this->isRollbackOnly = false;
                 $logger->stopQuery();

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -112,12 +112,20 @@ final class Connection implements ServerInfoAwareConnection
 
     public function commit(): void
     {
-        $this->connection->commit();
+        try {
+            $this->connection->commit();
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
     }
 
     public function rollBack(): void
     {
-        $this->connection->rollBack();
+        try {
+            $this->connection->rollBack();
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
     }
 
     public function getWrappedConnection(): PDO

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDO;
+use Doctrine\DBAL\Exception\ConnectionLost;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+use function sleep;
+
+use const E_ALL;
+use const E_WARNING;
+use const PHP_VERSION_ID;
+
+class TransactionTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+            return;
+        }
+
+        self::markTestSkipped('Restricted to MySQL.');
+    }
+
+    public function testCommitFailure(): void
+    {
+        $this->expectConnectionLoss(static function (Connection $connection): void {
+            $connection->commit();
+        });
+    }
+
+    public function testRollbackFailure(): void
+    {
+        $this->expectConnectionLoss(static function (Connection $connection): void {
+            $connection->rollBack();
+        });
+    }
+
+    private function expectConnectionLoss(callable $scenario): void
+    {
+        if (PHP_VERSION_ID < 70413 && $this->connection->getDriver() instanceof PDO\MySQL\Driver) {
+            self::markTestSkipped('See https://bugs.php.net/bug.php?id=66528.');
+        }
+
+        $this->connection->executeStatement('SET SESSION wait_timeout=1');
+        $this->connection->beginTransaction();
+
+        // during the sleep MySQL will close the connection
+        sleep(2);
+
+        // prevent the PHPUnit error handler from handling the "MySQL server has gone away" warning
+        $this->iniSet('error_reporting', (string) (E_ALL & ~E_WARNING));
+
+        $this->expectException(ConnectionLost::class);
+        $scenario($this->connection);
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Fixes #4522.

The improvement relies on the breaking API changes introduced in https://github.com/doctrine/dbal/pull/3486 (`4.0.x`) and thus cannot be backported to earlier releases as is.

`TransactionTest` being introduced already exists in the older branches but it looks like it was mistakenly dropped during the merge up in https://github.com/doctrine/dbal/pull/3712.