### PR TITLE
Clarify ExpressionBuilder arguments

### DIFF
--- a/src/Query/Expression/ExpressionBuilder.php
+++ b/src/Query/Expression/ExpressionBuilder.php
@@ -256,8 +256,8 @@ class ExpressionBuilder
     /**
      * Creates a LIKE() comparison expression with the given arguments.
      *
-     * @param string $x Field in string format to be inspected by LIKE() comparison.
-     * @param mixed  $y Argument to be used in LIKE() comparison.
+     * @param string $x The expression to be inspected by the LIKE comparison
+     * @param mixed  $y The pattern to compare against
      *
      * @return string
      */
@@ -270,8 +270,8 @@ class ExpressionBuilder
     /**
      * Creates a NOT LIKE() comparison expression with the given arguments.
      *
-     * @param string $x Field in string format to be inspected by NOT LIKE() comparison.
-     * @param mixed  $y Argument to be used in NOT LIKE() comparison.
+     * @param string $x The expression to be inspected by the NOT LIKE comparison
+     * @param mixed  $y The pattern to compare against
      *
      * @return string
      */
@@ -282,10 +282,10 @@ class ExpressionBuilder
     }
 
     /**
-     * Creates a IN () comparison expression with the given arguments.
+     * Creates an IN () comparison expression with the given arguments.
      *
-     * @param string          $x The field in string format to be inspected by IN() comparison.
-     * @param string|string[] $y The placeholder or the array of values to be used by IN() comparison.
+     * @param string          $x The SQL expression to be matched against the set.
+     * @param string|string[] $y The SQL expression or an array of SQL expressions representing the set.
      *
      * @return string
      */
@@ -297,8 +297,8 @@ class ExpressionBuilder
     /**
      * Creates a NOT IN () comparison expression with the given arguments.
      *
-     * @param string          $x The expression to be inspected by NOT IN() comparison.
-     * @param string|string[] $y The placeholder or the array of values to be used by NOT IN() comparison.
+     * @param string          $x The SQL expression to be matched against the set.
+     * @param string|string[] $y The SQL expression or an array of SQL expressions representing the set.
      *
      * @return string
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

The current API documentation isn't clear enough. Specifically for the `in()` and `notIn()` methods, it says that the second argument is an array of _values_ while it's a list of arbitrary SQL expressions. See https://github.com/doctrine/dbal/pull/2711#issuecomment-876850494.