### PR TITLE
PHPStan check fails on PHP 8

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
     steps:
       - name: "Checkout code"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -29,7 +29,7 @@ parameters:
 
         # weird class name, represented in stubs as OCI_(Lob|Collection)
         - '~unknown class OCI-(Lob|Collection)~'
-        - '~^Call to method writeTemporary\(\) on an unknown class OCILob\.~'
+        - '~^Call to method writetemporary\(\) on an unknown class OCILob\.~'
 
         # Requires a release of https://github.com/JetBrains/phpstorm-stubs/pull/553
         -
@@ -107,5 +107,23 @@ parameters:
             message: '~^Instanceof between Doctrine\\DBAL\\Platforms\\Keywords\\KeywordList and Doctrine\\DBAL\\Platforms\\Keywords\\KeywordList will always evaluate to true\.~'
             paths:
                 - %currentWorkingDirectory%/src/Platforms/AbstractPlatform.php
+
+        # TODO: remove this once the support for PHP 7 is dropped
+        -
+            message: '~^Strict comparison using !== between int and false will always evaluate to true\.$~'
+            paths:
+                - %currentWorkingDirectory%/src/Driver/OCI8/Result.php
+        -
+            message: '~^Unreachable statement - code above always terminates\.$~'
+            paths:
+                - %currentWorkingDirectory%/src/Driver/OCI8/Result.php
+        -
+            message: '~^Call to function assert\(\) with true will always evaluate to true\.$~'
+            paths:
+                - %currentWorkingDirectory%/src/Driver/OCI8/Statement.php
+        -
+            message: '~^Strict comparison using !== between OCILob\|null and false will always evaluate to true\.$~'
+            paths:
+                - %currentWorkingDirectory%/src/Driver/OCI8/Statement.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -131,10 +131,7 @@ final class Result implements ResultInterface
             return false;
         }
 
-        $row = array_combine($this->columnNames, $values);
-        assert(is_array($row));
-
-        return $row;
+        return array_combine($this->columnNames, $values);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Fixes #4538:
1. Remove the assertion after `array_combine()` since none of the static analysis tools flag it as unsafe any longer.
2. Suppress OCI8-related errors until the PHP 7 support is dropped (see https://github.com/phpstan/phpstan/issues/4679#issuecomment-793473948).

Once the PHP 7 support is dropped, we'll need to adjust some OCI8-related assertions. Not worth doing it right now since it would require suppressing more false positives for Psalm.