### PR TITLE
Reset transaction nesting level when closing connection

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -325,8 +325,6 @@ class Connection
             throw $this->convertException($e);
         }
 
-        $this->transactionNestingLevel = 0;
-
         if ($this->autoCommit === false) {
             $this->beginTransaction();
         }
@@ -641,7 +639,8 @@ class Connection
      */
     public function close()
     {
-        $this->_conn = null;
+        $this->_conn                   = null;
+        $this->transactionNestingLevel = 0;
     }
 
     /**

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -164,6 +164,14 @@ class ConnectionTest extends FunctionalTestCase
         $this->connection->setNestTransactionsWithSavepoints(true);
     }
 
+    public function testTransactionIsInactiveAfterConnectionClose(): void
+    {
+        $this->connection->beginTransaction();
+        $this->connection->close();
+
+        self::assertFalse($this->connection->isTransactionActive());
+    }
+
     public function testSetNestedTransactionsThroughSavepointsNotSupportedThrowsException(): void
     {
         if ($this->connection->getDatabasePlatform()->supportsSavepoints()) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #4718.