### PR TITLE
Remove deprecated Comparator::compare()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## Removed static keyword from `Comparator::compareSchemas()` signature
+
+The method `Comparator::compareSchemas()` cannot be called statically anymore.
+
+## Removed `Comparator::compare()`
+
+The method `Comparator::compare()` has been removed, use `Comparator::compareSchemas()` instead.
+
 ## Removed `TableGenerator` component
 
 The `TableGenerator` component has been removed.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -143,14 +143,6 @@ parameters:
             paths:
                 - %currentWorkingDirectory%/src/Driver/OCI8/Statement.php
 
-        # See https://github.com/doctrine/dbal/pull/4707
-        # TODO: remove in 4.0.0
-        -
-            message: '~^Dynamic call to static method Doctrine\\DBAL\\Schema\\Comparator::compareSchemas\(\)\.$~'
-            paths:
-                - %currentWorkingDirectory%/src/Schema/AbstractSchemaManager.php
-                - %currentWorkingDirectory%/src/Schema/Comparator.php
-                - %currentWorkingDirectory%/src/Schema/Schema.php
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -60,13 +60,6 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::execute"/>
                 <referencedMethod name="Doctrine\DBAL\Statement::execute"/>
-                <!--
-                    See https://github.com/doctrine/dbal/pull/4707
-                    TODO: remove in 4.0.0
-                -->
-                <file name="src/Schema/Comparator.php" />
-                <file name="tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php" />
-                <file name="tests/Schema/ComparatorTest.php" />
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -49,7 +49,7 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
         $newTable->dropPrimaryKey();
         $newTable->setPrimaryKey(['new_id']);
 
-        $diff = (new Comparator())->compare($schema, $newSchema);
+        $diff = (new Comparator())->compareSchemas($schema, $newSchema);
 
         foreach ($diff->toSql($this->getPlatform()) as $sql) {
             $this->connection->executeStatement($sql);

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -23,6 +23,14 @@ use function get_class;
 
 class ComparatorTest extends TestCase
 {
+    /** @var Comparator */
+    private $comparator;
+
+    protected function setUp(): void
+    {
+        $this->comparator = new Comparator();
+    }
+
     public function testCompareSame1(): void
     {
         $schema1 = new Schema([
@@ -44,7 +52,7 @@ class ComparatorTest extends TestCase
 
         $expected             = new SchemaDiff();
         $expected->fromSchema = $schema1;
-        self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareSame2(): void
@@ -70,7 +78,7 @@ class ComparatorTest extends TestCase
 
         $expected             = new SchemaDiff();
         $expected->fromSchema = $schema1;
-        self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareMissingTable(): void
@@ -85,7 +93,7 @@ class ComparatorTest extends TestCase
 
         $expected = new SchemaDiff([], [], ['bugdb' => $table], $schema1);
 
-        self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareNewTable(): void
@@ -100,7 +108,7 @@ class ComparatorTest extends TestCase
 
         $expected = new SchemaDiff(['bugdb' => $table], [], [], $schema1);
 
-        self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareOnlyAutoincrementChanged(): void
@@ -108,8 +116,7 @@ class ComparatorTest extends TestCase
         $column1 = new Column('foo', Type::getType('integer'), ['autoincrement' => true]);
         $column2 = new Column('foo', Type::getType('integer'), ['autoincrement' => false]);
 
-        $comparator        = new Comparator();
-        $changedProperties = $comparator->diffColumn($column1, $column2);
+        $changedProperties = $this->comparator->diffColumn($column1, $column2);
 
         self::assertEquals(['autoincrement'], $changedProperties);
     }
@@ -149,7 +156,7 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareNewField(): void
@@ -186,7 +193,7 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareChangedColumnsChangeType(): void
@@ -194,9 +201,8 @@ class ComparatorTest extends TestCase
         $column1 = new Column('charcolumn1', Type::getType('string'));
         $column2 = new Column('charcolumn1', Type::getType('integer'));
 
-        $c = new Comparator();
-        self::assertEquals(['type'], $c->diffColumn($column1, $column2));
-        self::assertEquals([], $c->diffColumn($column1, $column1));
+        self::assertEquals(['type'], $this->comparator->diffColumn($column1, $column2));
+        self::assertEquals([], $this->comparator->diffColumn($column1, $column1));
     }
 
     public function testCompareColumnsMultipleTypeInstances(): void
@@ -208,8 +214,7 @@ class ComparatorTest extends TestCase
         $column1 = new Column('integercolumn1', $integerType1);
         $column2 = new Column('integercolumn1', $integerType2);
 
-        $c = new Comparator();
-        self::assertEquals([], $c->diffColumn($column1, $column2));
+        self::assertEquals([], $this->comparator->diffColumn($column1, $column2));
     }
 
     public function testCompareColumnsOverriddenType(): void
@@ -225,8 +230,7 @@ class ComparatorTest extends TestCase
         $column1 = new Column('integercolumn1', $integerType);
         $column2 = new Column('integercolumn1', $overriddenStringType);
 
-        $c = new Comparator();
-        self::assertEquals([], $c->diffColumn($column1, $column2));
+        self::assertEquals([], $this->comparator->diffColumn($column1, $column2));
     }
 
     public function testCompareChangedColumnsChangeCustomSchemaOption(): void
@@ -240,9 +244,8 @@ class ComparatorTest extends TestCase
         $column1->setCustomSchemaOption('foo1', 'bar1');
         $column2->setCustomSchemaOption('foo2', 'bar2');
 
-        $c = new Comparator();
-        self::assertEquals(['foo1', 'foo2'], $c->diffColumn($column1, $column2));
-        self::assertEquals([], $c->diffColumn($column1, $column1));
+        self::assertEquals(['foo1', 'foo2'], $this->comparator->diffColumn($column1, $column2));
+        self::assertEquals([], $this->comparator->diffColumn($column1, $column1));
     }
 
     public function testCompareChangeColumnsMultipleNewColumnsRename(): void
@@ -254,7 +257,7 @@ class ComparatorTest extends TestCase
         $tableB->addColumn('new_datecolumn1', 'datetime');
         $tableB->addColumn('new_datecolumn2', 'datetime');
 
-        $tableDiff = (new Comparator())->diffTable($tableA, $tableB);
+        $tableDiff = $this->comparator->diffTable($tableA, $tableB);
         self::assertNotNull($tableDiff);
 
         self::assertCount(1, $tableDiff->renamedColumns);
@@ -316,7 +319,7 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareNewIndex(): void
@@ -368,7 +371,7 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareChangedIndex(): void
@@ -431,7 +434,7 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareChangedIndexFieldPositions(): void
@@ -479,7 +482,7 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, Comparator::compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareSequences(): void
@@ -488,10 +491,8 @@ class ComparatorTest extends TestCase
         $seq2 = new Sequence('foo', 1, 2);
         $seq3 = new Sequence('foo', 2, 1);
 
-        $c = new Comparator();
-
-        self::assertTrue($c->diffSequence($seq1, $seq2));
-        self::assertTrue($c->diffSequence($seq1, $seq3));
+        self::assertTrue($this->comparator->diffSequence($seq1, $seq2));
+        self::assertTrue($this->comparator->diffSequence($seq1, $seq3));
     }
 
     public function testRemovedSequence(): void
@@ -501,8 +502,7 @@ class ComparatorTest extends TestCase
 
         $schema2 = new Schema();
 
-        $c          = new Comparator();
-        $diffSchema = $c->compare($schema1, $schema2);
+        $diffSchema = $this->comparator->compareSchemas($schema1, $schema2);
 
         self::assertCount(1, $diffSchema->removedSequences);
         self::assertSame($seq, $diffSchema->removedSequences[0]);
@@ -515,8 +515,7 @@ class ComparatorTest extends TestCase
         $schema2 = new Schema();
         $seq     = $schema2->createSequence('foo');
 
-        $c          = new Comparator();
-        $diffSchema = $c->compare($schema1, $schema2);
+        $diffSchema = $this->comparator->compareSchemas($schema1, $schema2);
 
         self::assertCount(1, $diffSchema->newSequences);
         self::assertSame($seq, $diffSchema->newSequences[0]);
@@ -534,8 +533,7 @@ class ComparatorTest extends TestCase
         $table2->addColumn('fk', 'integer');
         $table2->addForeignKeyConstraint($tableForeign, ['fk'], ['id']);
 
-        $c         = new Comparator();
-        $tableDiff = $c->diffTable($table1, $table2);
+        $tableDiff = $this->comparator->diffTable($table1, $table2);
 
         self::assertInstanceOf(TableDiff::class, $tableDiff);
         self::assertCount(1, $tableDiff->addedForeignKeys);
@@ -553,8 +551,7 @@ class ComparatorTest extends TestCase
         $table2->addColumn('fk', 'integer');
         $table2->addForeignKeyConstraint($tableForeign, ['fk'], ['id']);
 
-        $c         = new Comparator();
-        $tableDiff = $c->diffTable($table2, $table1);
+        $tableDiff = $this->comparator->diffTable($table2, $table1);
 
         self::assertInstanceOf(TableDiff::class, $tableDiff);
         self::assertCount(1, $tableDiff->removedForeignKeys);
@@ -573,8 +570,7 @@ class ComparatorTest extends TestCase
         $table2->addColumn('fk', 'integer');
         $table2->addForeignKeyConstraint($tableForeign, ['fk'], ['id'], ['onUpdate' => 'CASCADE']);
 
-        $c         = new Comparator();
-        $tableDiff = $c->diffTable($table1, $table2);
+        $tableDiff = $this->comparator->diffTable($table1, $table2);
 
         self::assertInstanceOf(TableDiff::class, $tableDiff);
         self::assertCount(1, $tableDiff->changedForeignKeys);
@@ -596,8 +592,7 @@ class ComparatorTest extends TestCase
         $table2->addColumn('fk', 'integer');
         $table2->addForeignKeyConstraint($tableForeign2, ['fk'], ['id']);
 
-        $c         = new Comparator();
-        $tableDiff = $c->diffTable($table1, $table2);
+        $tableDiff = $this->comparator->diffTable($table1, $table2);
 
         self::assertInstanceOf(TableDiff::class, $tableDiff);
         self::assertCount(1, $tableDiff->changedForeignKeys);
@@ -617,8 +612,7 @@ class ComparatorTest extends TestCase
         $schemaB->createTable('Baz');
         $schemaB->createTable('old');
 
-        $c    = new Comparator();
-        $diff = $c->compare($schemaA, $schemaB);
+        $diff = $this->comparator->compareSchemas($schemaA, $schemaB);
 
         $this->assertSchemaTableChangeCount($diff, 1, 0, 1);
     }
@@ -637,8 +631,7 @@ class ComparatorTest extends TestCase
         $schemaB->createSequence('baz');
         $schemaB->createSequence('old');
 
-        $c    = new Comparator();
-        $diff = $c->compare($schemaA, $schemaB);
+        $diff = $this->comparator->compareSchemas($schemaA, $schemaB);
 
         $this->assertSchemaSequenceChangeCount($diff, 1, 0, 1);
     }
@@ -651,8 +644,7 @@ class ComparatorTest extends TestCase
         $tableB = new Table('foo');
         $tableB->addColumn('ID', 'integer');
 
-        $c         = new Comparator();
-        $tableDiff = $c->diffTable($tableA, $tableB);
+        $tableDiff = $this->comparator->diffTable($tableA, $tableB);
 
         self::assertNull($tableDiff);
     }
@@ -667,14 +659,13 @@ class ComparatorTest extends TestCase
         $tableB->addColumn('ID', 'integer');
         $tableB->addIndex(['id'], 'bar_foo_idx');
 
-        $c                                        = new Comparator();
         $tableDiff                                = new TableDiff('foo');
         $tableDiff->fromTable                     = $tableA;
         $tableDiff->renamedIndexes['foo_bar_idx'] = new Index('bar_foo_idx', ['id']);
 
         self::assertEquals(
             $tableDiff,
-            $c->diffTable($tableA, $tableB)
+            $this->comparator->diffTable($tableA, $tableB)
         );
     }
 
@@ -688,8 +679,7 @@ class ComparatorTest extends TestCase
         $tableB->addColumn('ID', 'integer');
         $tableB->addForeignKeyConstraint('bar', ['id'], ['id'], [], 'bar_constraint');
 
-        $c         = new Comparator();
-        $tableDiff = $c->diffTable($tableA, $tableB);
+        $tableDiff = $this->comparator->diffTable($tableA, $tableB);
 
         self::assertNull($tableDiff);
     }
@@ -699,8 +689,7 @@ class ComparatorTest extends TestCase
         $fk1 = new ForeignKeyConstraint(['foo'], 'bar', ['baz'], 'fk1', ['onDelete' => 'NO ACTION']);
         $fk2 = new ForeignKeyConstraint(['foo'], 'bar', ['baz'], 'fk1', ['onDelete' => 'RESTRICT']);
 
-        $c = new Comparator();
-        self::assertFalse($c->diffForeignKey($fk1, $fk2));
+        self::assertFalse($this->comparator->diffForeignKey($fk1, $fk2));
     }
 
     public function testCompareForeignKeyNamesUnqualifiedAsNoSchemaInformationIsAvailable(): void
@@ -708,8 +697,7 @@ class ComparatorTest extends TestCase
         $fk1 = new ForeignKeyConstraint(['foo'], 'foo.bar', ['baz'], 'fk1');
         $fk2 = new ForeignKeyConstraint(['foo'], 'baz.bar', ['baz'], 'fk1');
 
-        $c = new Comparator();
-        self::assertFalse($c->diffForeignKey($fk1, $fk2));
+        self::assertFalse($this->comparator->diffForeignKey($fk1, $fk2));
     }
 
     public function testDetectRenameColumn(): void
@@ -720,7 +708,7 @@ class ComparatorTest extends TestCase
         $tableB = new Table('foo');
         $tableB->addColumn('bar', 'integer');
 
-        $tableDiff = (new Comparator())->diffTable($tableA, $tableB);
+        $tableDiff = $this->comparator->diffTable($tableA, $tableB);
         self::assertNotNull($tableDiff);
 
         self::assertCount(0, $tableDiff->addedColumns);
@@ -743,7 +731,7 @@ class ComparatorTest extends TestCase
         $tableB = new Table('foo');
         $tableB->addColumn('baz', 'integer');
 
-        $tableDiff = (new Comparator())->diffTable($tableA, $tableB);
+        $tableDiff = $this->comparator->diffTable($tableA, $tableB);
         self::assertNotNull($tableDiff);
 
         self::assertCount(1, $tableDiff->addedColumns);
@@ -765,7 +753,7 @@ class ComparatorTest extends TestCase
 
         $table2->addIndex(['foo'], 'idx_bar');
 
-        $tableDiff = (new Comparator())->diffTable($table1, $table2);
+        $tableDiff = $this->comparator->diffTable($table1, $table2);
         self::assertNotNull($tableDiff);
 
         self::assertCount(0, $tableDiff->addedIndexes);
@@ -791,7 +779,7 @@ class ComparatorTest extends TestCase
 
         $table2->addIndex(['foo'], 'idx_baz');
 
-        $tableDiff = (new Comparator())->diffTable($table1, $table2);
+        $tableDiff = $this->comparator->diffTable($table1, $table2);
         self::assertNotNull($tableDiff);
 
         self::assertCount(1, $tableDiff->addedIndexes);
@@ -810,8 +798,7 @@ class ComparatorTest extends TestCase
         $tableB = new Table('foo');
         $tableB->addColumn('id', 'integer', ['autoincrement' => true]);
 
-        $c         = new Comparator();
-        $tableDiff = $c->diffTable($tableA, $tableB);
+        $tableDiff = $this->comparator->diffTable($tableA, $tableB);
 
         self::assertInstanceOf(TableDiff::class, $tableDiff);
         self::assertArrayHasKey('id', $tableDiff->changedColumns);
@@ -832,8 +819,7 @@ class ComparatorTest extends TestCase
         $newtable->addColumn('logged_in_at', 'datetime');
         $newtable->setPrimaryKey(['id']);
 
-        $c         = new Comparator();
-        $tableDiff = $c->diffTable($table, $newtable);
+        $tableDiff = $this->comparator->diffTable($table, $newtable);
 
         self::assertInstanceOf(TableDiff::class, $tableDiff);
         self::assertEquals(['twitterid', 'displayname'], array_keys($tableDiff->renamedColumns));
@@ -849,8 +835,7 @@ class ComparatorTest extends TestCase
         $schemaNew = clone $schema;
         $schemaNew->getSequence('baz')->setAllocationSize(20);
 
-        $c    = new Comparator();
-        $diff = $c->compare($schema, $schemaNew);
+        $diff = $this->comparator->compareSchemas($schema, $schemaNew);
 
         self::assertSame($diff->changedSequences[0], $schemaNew->getSequence('baz'));
     }
@@ -865,8 +850,7 @@ class ComparatorTest extends TestCase
 
         $column2 = new Column('foo', Type::getType('decimal'));
 
-        $c = new Comparator();
-        self::assertEquals([], $c->diffColumn($column, $column2));
+        self::assertEquals([], $this->comparator->diffColumn($column, $column2));
     }
 
     public function testFqnSchemaComparison(): void
@@ -883,7 +867,7 @@ class ComparatorTest extends TestCase
         $expected             = new SchemaDiff();
         $expected->fromSchema = $oldSchema;
 
-        self::assertEquals($expected, Comparator::compareSchemas($oldSchema, $newSchema));
+        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
     }
 
     public function testNamespacesComparison(): void
@@ -904,7 +888,7 @@ class ComparatorTest extends TestCase
         $expected->fromSchema    = $oldSchema;
         $expected->newNamespaces = ['bar' => 'bar', 'baz' => 'baz'];
 
-        $diff = Comparator::compareSchemas($oldSchema, $newSchema);
+        $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 
         self::assertEquals(['bar' => 'bar', 'baz' => 'baz'], $diff->newNamespaces);
         self::assertCount(2, $diff->newTables);
@@ -924,7 +908,7 @@ class ComparatorTest extends TestCase
         $expected             = new SchemaDiff();
         $expected->fromSchema = $oldSchema;
 
-        self::assertEquals($expected, Comparator::compareSchemas($oldSchema, $newSchema));
+        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
     }
 
     public function testFqnSchemaComparisonNoSchemaSame(): void
@@ -940,7 +924,7 @@ class ComparatorTest extends TestCase
         $expected             = new SchemaDiff();
         $expected->fromSchema = $oldSchema;
 
-        self::assertEquals($expected, Comparator::compareSchemas($oldSchema, $newSchema));
+        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
     }
 
     public function testAutoIncrementSequences(): void
@@ -956,8 +940,7 @@ class ComparatorTest extends TestCase
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
 
-        $c    = new Comparator();
-        $diff = $c->compare($oldSchema, $newSchema);
+        $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 
         self::assertCount(0, $diff->removedSequences);
     }
@@ -978,8 +961,7 @@ class ComparatorTest extends TestCase
         $table->setPrimaryKey(['id']);
         $newSchema->createSequence('foo_id_seq');
 
-        $c    = new Comparator();
-        $diff = $c->compare($oldSchema, $newSchema);
+        $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 
         self::assertCount(0, $diff->newSequences);
     }
@@ -1016,8 +998,7 @@ class ComparatorTest extends TestCase
         $tableC = $newSchema->createTable('table_c');
         $tableC->addColumn('id', 'integer');
 
-        $comparator = new Comparator();
-        $schemaDiff = $comparator->compare($oldSchema, $newSchema);
+        $schemaDiff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 
         self::assertCount(1, $schemaDiff->changedTables['table_c']->removedForeignKeys);
         self::assertCount(1, $schemaDiff->orphanedForeignKeys);
@@ -1045,7 +1026,7 @@ class ComparatorTest extends TestCase
         $columnDiff->fromColumn        = $tableFoo->getColumn('id');
         $columnDiff->changedProperties = ['type'];
 
-        self::assertEquals($expected, Comparator::compareSchemas($oldSchema, $newSchema));
+        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
     }
 
     public function testCompareChangedBinaryColumn(): void
@@ -1070,7 +1051,7 @@ class ComparatorTest extends TestCase
         $columnDiff->fromColumn        = $tableFoo->getColumn('id');
         $columnDiff->changedProperties = ['length', 'fixed'];
 
-        self::assertEquals($expected, Comparator::compareSchemas($oldSchema, $newSchema));
+        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
     }
 
     public function testCompareQuotedAndUnquotedForeignKeyColumns(): void
@@ -1078,8 +1059,7 @@ class ComparatorTest extends TestCase
         $fk1 = new ForeignKeyConstraint(['foo'], 'bar', ['baz'], 'fk1', ['onDelete' => 'NO ACTION']);
         $fk2 = new ForeignKeyConstraint(['`foo`'], 'bar', ['`baz`'], 'fk1', ['onDelete' => 'NO ACTION']);
 
-        $comparator = new Comparator();
-        $diff       = $comparator->diffForeignKey($fk1, $fk2);
+        $diff = $this->comparator->diffForeignKey($fk1, $fk2);
 
         self::assertFalse($diff);
     }
@@ -1131,14 +1111,12 @@ class ComparatorTest extends TestCase
 
         $column4 = new Column('foo', Type::getType('string'));
 
-        $comparator = new Comparator();
-
-        self::assertEquals([], $comparator->diffColumn($column1, $column2));
-        self::assertEquals([], $comparator->diffColumn($column2, $column1));
-        self::assertEquals(['bar'], $comparator->diffColumn($column1, $column3));
-        self::assertEquals(['bar'], $comparator->diffColumn($column3, $column1));
-        self::assertEquals([], $comparator->diffColumn($column1, $column4));
-        self::assertEquals([], $comparator->diffColumn($column4, $column1));
+        self::assertEquals([], $this->comparator->diffColumn($column1, $column2));
+        self::assertEquals([], $this->comparator->diffColumn($column2, $column1));
+        self::assertEquals(['bar'], $this->comparator->diffColumn($column1, $column3));
+        self::assertEquals(['bar'], $this->comparator->diffColumn($column3, $column1));
+        self::assertEquals([], $this->comparator->diffColumn($column1, $column4));
+        self::assertEquals([], $this->comparator->diffColumn($column4, $column1));
     }
 
     public function testComplexDiffColumn(): void
@@ -1152,15 +1130,12 @@ class ComparatorTest extends TestCase
             'platformOptions' => ['foo' => 'bar'],
         ]);
 
-        $comparator = new Comparator();
-
-        self::assertEquals([], $comparator->diffColumn($column1, $column2));
-        self::assertEquals([], $comparator->diffColumn($column2, $column1));
+        self::assertEquals([], $this->comparator->diffColumn($column1, $column2));
+        self::assertEquals([], $this->comparator->diffColumn($column2, $column1));
     }
 
     public function testComparesNamespaces(): void
     {
-        $comparator = new Comparator();
         $fromSchema = $this->getMockBuilder(Schema::class)
             ->onlyMethods(['getNamespaces', 'hasNamespace'])
             ->getMock();
@@ -1189,13 +1164,11 @@ class ComparatorTest extends TestCase
         $expected->newNamespaces     = ['baz' => 'baz'];
         $expected->removedNamespaces = ['foo' => 'foo'];
 
-        self::assertEquals($expected, $comparator->compare($fromSchema, $toSchema));
+        self::assertEquals($expected, $this->comparator->compareSchemas($fromSchema, $toSchema));
     }
 
     public function testCompareGuidColumns(): void
     {
-        $comparator = new Comparator();
-
         $column1 = new Column('foo', Type::getType('guid'), ['comment' => 'GUID 1']);
         $column2 = new Column(
             'foo',
@@ -1203,8 +1176,8 @@ class ComparatorTest extends TestCase
             ['notnull' => false, 'length' => 36, 'fixed' => true, 'default' => 'NEWID()', 'comment' => 'GUID 2.']
         );
 
-        self::assertEquals(['notnull', 'default', 'comment'], $comparator->diffColumn($column1, $column2));
-        self::assertEquals(['notnull', 'default', 'comment'], $comparator->diffColumn($column2, $column1));
+        self::assertEquals(['notnull', 'default', 'comment'], $this->comparator->diffColumn($column1, $column2));
+        self::assertEquals(['notnull', 'default', 'comment'], $this->comparator->diffColumn($column2, $column1));
     }
 
     /**
@@ -1215,15 +1188,13 @@ class ComparatorTest extends TestCase
         $column1 = new Column('foo', Type::getType('integer'), ['comment' => $comment1]);
         $column2 = new Column('foo', Type::getType('integer'), ['comment' => $comment2]);
 
-        $comparator = new Comparator();
-
         $expectedDiff = $equals ? [] : ['comment'];
 
-        $actualDiff = $comparator->diffColumn($column1, $column2);
+        $actualDiff = $this->comparator->diffColumn($column1, $column2);
 
         self::assertSame($expectedDiff, $actualDiff);
 
-        $actualDiff = $comparator->diffColumn($column2, $column1);
+        $actualDiff = $this->comparator->diffColumn($column2, $column1);
 
         self::assertSame($expectedDiff, $actualDiff);
     }
@@ -1292,7 +1263,7 @@ class ComparatorTest extends TestCase
                 ]
             ),
         ]);
-        $actual     = Comparator::compareSchemas($fromSchema, $toSchema);
+        $actual     = $this->comparator->compareSchemas($fromSchema, $toSchema);
 
         self::assertArrayHasKey('table2', $actual->changedTables);
         self::assertCount(1, $actual->orphanedForeignKeys);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | none

#### Summary

<!-- Provide a summary of your change. -->

The method has been deprecated and scheduled for removal since https://github.com/doctrine/dbal/pull/4707.