### PR TITLE
Revert GUID type deprecation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -67,11 +67,6 @@ The following `AbstractPlatform` methods and their implementations in specific p
 
 If required by the target platform(s), the column length should be specified based on the application logic.
 
-## Deprecated `AbstractPlatform::hasNativeGuidType()`
-
-The `AbstractPlatform::hasNativeGuidType()` method and its implementations in specific platforms have been deprecated
-since it was only needed to support the Guid data type the support for which was dropped in 3.0.0.
-
 ## Deprecated static calls to `Comparator::compareSchemas($fromSchema, $toSchema)`
 
 The usage of `Comparator::compareSchemas($fromSchema, $toSchema)` statically is

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -56,10 +56,6 @@
                 -->
                 <referencedClass name="Doctrine\DBAL\Id\TableGenerator"/>
                 <referencedClass name="Doctrine\DBAL\Id\TableGeneratorSchemaVisitor"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedClass name="Doctrine\DBAL\Types\GuidType" />
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedMethod>
@@ -116,7 +112,6 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
-                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::hasNativeGuidType" />
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getBinaryDefaultLength"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getBinaryMaxLength"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getIsNullExpression"/>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3542,18 +3542,10 @@ abstract class AbstractPlatform
     /**
      * Does this platform have native guid type.
      *
-     * @deprecated
-     *
      * @return bool
      */
     public function hasNativeGuidType()
     {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/issues/3167',
-            'AbstractPlatform::hasNativeGuidType() is deprecated.'
-        );
-
         return false;
     }
 

--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -212,17 +212,9 @@ class PostgreSQL94Platform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
-     *
-     * @deprecated
      */
     public function hasNativeGuidType()
     {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/issues/3167',
-            'PostgreSQL94Platform::hasNativeGuidType() is deprecated.'
-        );
-
         return true;
     }
 

--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -203,17 +203,9 @@ class SQLServer2012Platform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
-     *
-     * @deprecated
      */
     public function hasNativeGuidType()
     {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/issues/3167',
-            'SQLServer2012::hasNativeGuidType() is deprecated.'
-        );
-
         return true;
     }
 

--- a/src/Types/GuidType.php
+++ b/src/Types/GuidType.php
@@ -6,8 +6,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * Represents a GUID/UUID datatype (both are actually synonyms) in the database.
- *
- * @deprecated Generate UUIDs on the application side.
  */
 class GuidType extends StringType
 {

--- a/tests/Functional/Types/GuidTest.php
+++ b/tests/Functional/Types/GuidTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+class GuidTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $table = new Table('guid_table');
+        $table->addColumn('guid', 'guid');
+
+        $this->connection->createSchemaManager()->dropAndCreateTable($table);
+    }
+
+    public function testInsertAndSelect(): void
+    {
+        $guid = '7c620eda-ea79-11eb-9a03-0242ac130003';
+
+        $result = $this->connection->insert('guid_table', ['guid' => $guid]);
+        self::assertSame(1, $result);
+
+        $value = $this->connection->fetchOne('SELECT guid FROM guid_table');
+
+        // the platforms with native UUID support inconsistently format the binary value
+        // as a string using the lower or the upper case; this is acceptable since
+        // regardless of the case they encode the same binary value
+        self::assertEqualsIgnoringCase($guid, $value);
+    }
+}


### PR DESCRIPTION
The APIs related to the GUID column type were mistakenly deprecated in #4724. There are two features in the DBAL related to the GUID type:

1. Generation of UUID values on the DB side (deprecated in https://github.com/doctrine/dbal/pull/3212).
2. Storing UUID values in the database (mistakenly deprecated).

The purpose of the GUID column type in the DBAL is:

1. Provide a way to store UUID values efficiently on the platforms that support it natively (PostgreSQL, SQL Server). These platforms will store the value in a binary format (effectively, `BINARY(16)`) and provide automatic parsing and formatting for a better developer experience.
2. Enable the rest of the platforms to store the UUID value as `CHAR(36)`. This is way less efficient from the storage and lookup perspective than the above but still works.

Without this type in place, the users would have to use either `BINARY(16)` or `CHAR(36)` to write portable code which will result in a worse developer experience on the platforms that support the type natively.

Additionally, a functional test is added that covers the type across all supported platforms and identifies a minor inconsistency in their behavior.