### PR TITLE
Test exception handling in wrapper Result

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -506,11 +506,7 @@ class Connection
      */
     public function fetchAssociative(string $query, array $params = [], array $types = [])
     {
-        try {
-            return $this->executeQuery($query, $params, $types)->fetchAssociative();
-        } catch (Driver\Exception $e) {
-            throw $this->convertExceptionDuringQuery($e, $query, $params, $types);
-        }
+        return $this->executeQuery($query, $params, $types)->fetchAssociative();
     }
 
     /**
@@ -527,11 +523,7 @@ class Connection
      */
     public function fetchNumeric(string $query, array $params = [], array $types = [])
     {
-        try {
-            return $this->executeQuery($query, $params, $types)->fetchNumeric();
-        } catch (Driver\Exception $e) {
-            throw $this->convertExceptionDuringQuery($e, $query, $params, $types);
-        }
+        return $this->executeQuery($query, $params, $types)->fetchNumeric();
     }
 
     /**
@@ -548,11 +540,7 @@ class Connection
      */
     public function fetchOne(string $query, array $params = [], array $types = [])
     {
-        try {
-            return $this->executeQuery($query, $params, $types)->fetchOne();
-        } catch (Driver\Exception $e) {
-            throw $this->convertExceptionDuringQuery($e, $query, $params, $types);
-        }
+        return $this->executeQuery($query, $params, $types)->fetchOne();
     }
 
     /**
@@ -817,11 +805,7 @@ class Connection
      */
     public function fetchAllNumeric(string $query, array $params = [], array $types = []): array
     {
-        try {
-            return $this->executeQuery($query, $params, $types)->fetchAllNumeric();
-        } catch (Driver\Exception $e) {
-            throw $this->convertExceptionDuringQuery($e, $query, $params, $types);
-        }
+        return $this->executeQuery($query, $params, $types)->fetchAllNumeric();
     }
 
     /**
@@ -837,11 +821,7 @@ class Connection
      */
     public function fetchAllAssociative(string $query, array $params = [], array $types = []): array
     {
-        try {
-            return $this->executeQuery($query, $params, $types)->fetchAllAssociative();
-        } catch (Driver\Exception $e) {
-            throw $this->convertExceptionDuringQuery($e, $query, $params, $types);
-        }
+        return $this->executeQuery($query, $params, $types)->fetchAllAssociative();
     }
 
     /**
@@ -892,11 +872,7 @@ class Connection
      */
     public function fetchFirstColumn(string $query, array $params = [], array $types = []): array
     {
-        try {
-            return $this->executeQuery($query, $params, $types)->fetchFirstColumn();
-        } catch (Driver\Exception $e) {
-            throw $this->convertExceptionDuringQuery($e, $query, $params, $types);
-        }
+        return $this->executeQuery($query, $params, $types)->fetchFirstColumn();
     }
 
     /**
@@ -912,15 +888,7 @@ class Connection
      */
     public function iterateNumeric(string $query, array $params = [], array $types = []): Traversable
     {
-        try {
-            $result = $this->executeQuery($query, $params, $types);
-
-            while (($row = $result->fetchNumeric()) !== false) {
-                yield $row;
-            }
-        } catch (Driver\Exception $e) {
-            throw $this->convertExceptionDuringQuery($e, $query, $params, $types);
-        }
+        return $this->executeQuery($query, $params, $types)->iterateNumeric();
     }
 
     /**
@@ -937,15 +905,7 @@ class Connection
      */
     public function iterateAssociative(string $query, array $params = [], array $types = []): Traversable
     {
-        try {
-            $result = $this->executeQuery($query, $params, $types);
-
-            while (($row = $result->fetchAssociative()) !== false) {
-                yield $row;
-            }
-        } catch (Driver\Exception $e) {
-            throw $this->convertExceptionDuringQuery($e, $query, $params, $types);
-        }
+        return $this->executeQuery($query, $params, $types)->iterateAssociative();
     }
 
     /**
@@ -996,15 +956,7 @@ class Connection
      */
     public function iterateColumn(string $query, array $params = [], array $types = []): Traversable
     {
-        try {
-            $result = $this->executeQuery($query, $params, $types);
-
-            while (($value = $result->fetchOne()) !== false) {
-                yield $value;
-            }
-        } catch (Driver\Exception $e) {
-            throw $this->convertExceptionDuringQuery($e, $query, $params, $types);
-        }
+        return $this->executeQuery($query, $params, $types)->iterateColumn();
     }
 
     /**

--- a/src/Result.php
+++ b/src/Result.php
@@ -170,12 +170,8 @@ class Result
      */
     public function iterateNumeric(): Traversable
     {
-        try {
-            while (($row = $this->result->fetchNumeric()) !== false) {
-                yield $row;
-            }
-        } catch (DriverException $e) {
-            throw $this->connection->convertException($e);
+        while (($row = $this->fetchNumeric()) !== false) {
+            yield $row;
         }
     }
 
@@ -186,12 +182,8 @@ class Result
      */
     public function iterateAssociative(): Traversable
     {
-        try {
-            while (($row = $this->result->fetchAssociative()) !== false) {
-                yield $row;
-            }
-        } catch (DriverException $e) {
-            throw $this->connection->convertException($e);
+        while (($row = $this->fetchAssociative()) !== false) {
+            yield $row;
         }
     }
 
@@ -231,12 +223,8 @@ class Result
      */
     public function iterateColumn(): Traversable
     {
-        try {
-            while (($value = $this->result->fetchOne()) !== false) {
-                yield $value;
-            }
-        } catch (DriverException $e) {
-            throw $this->connection->convertException($e);
+        while (($value = $this->fetchOne()) !== false) {
+            yield $value;
         }
     }
 
@@ -287,6 +275,8 @@ class Result
      * @deprecated This API is deprecated and will be removed after 2022
      *
      * @return mixed
+     *
+     * @throws Exception
      */
     public function fetch(int $mode = FetchMode::ASSOCIATIVE)
     {
@@ -315,6 +305,8 @@ class Result
      * @deprecated This API is deprecated and will be removed after 2022
      *
      * @return list<mixed>
+     *
+     * @throws Exception
      */
     public function fetchAll(int $mode = FetchMode::ASSOCIATIVE): array
     {

--- a/tests/Functional/ResultTest.php
+++ b/tests/Functional/ResultTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\Driver\IBMDB2;
+use Doctrine\DBAL\Driver\Mysqli;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+class ResultTest extends FunctionalTestCase
+{
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testExceptionHandling(callable $method): void
+    {
+        $driver = $this->connection->getDriver();
+
+        if (! $driver instanceof Mysqli\Driver && ! $driver instanceof IBMDB2\Driver) {
+            self::markTestSkipped('This test works only with the mysqli and ibm_db2 drivers.');
+        }
+
+        $result = $this->connection->executeQuery(
+            $this->connection->getDatabasePlatform()
+                ->getDummySelectSQL()
+        );
+        $result->free();
+
+        $this->expectException(Exception::class);
+        $method($result);
+    }
+
+    /**
+     * @return iterable<string,array{callable(Result):void}>
+     */
+    public static function methodProvider(): iterable
+    {
+        yield 'fetchNumeric' => [
+            static function (Result $result): void {
+                $result->fetchNumeric();
+            },
+        ];
+
+        yield 'fetchAssociative' => [
+            static function (Result $result): void {
+                $result->fetchAssociative();
+            },
+        ];
+
+        yield 'fetchOne' => [
+            static function (Result $result): void {
+                $result->fetchOne();
+            },
+        ];
+
+        yield 'fetchAllNumeric' => [
+            static function (Result $result): void {
+                $result->fetchAllNumeric();
+            },
+        ];
+
+        yield 'fetchAllAssociative' => [
+            static function (Result $result): void {
+                $result->fetchAllAssociative();
+            },
+        ];
+
+        yield 'fetchFirstColumn' => [
+            static function (Result $result): void {
+                $result->fetchFirstColumn();
+            },
+        ];
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. Add testing for exception handling in the wrapper Result. Still cannot find a way to trigger an exception by `rowCount()` or `columnCount()`, maybe the new DBAL API is too fool-proof.
2. Remove some code duplication and redundant error handling in the wrapper Result and Connection.