### PR TITLE
Fix auto_increment implementation for Oracle

### DIFF
--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -529,7 +529,6 @@ DECLARE
    last_Sequence NUMBER;
    last_InsertID NUMBER;
 BEGIN
-   SELECT ' . $sequenceName . '.NEXTVAL INTO :NEW.' . $quotedName . ' FROM DUAL;
    IF (:NEW.' . $quotedName . ' IS NULL OR :NEW.' . $quotedName . ' = 0) THEN
       SELECT ' . $sequenceName . '.NEXTVAL INTO :NEW.' . $quotedName . ' FROM DUAL;
    ELSE
@@ -540,6 +539,7 @@ BEGIN
       WHILE (last_InsertID > last_Sequence) LOOP
          SELECT ' . $sequenceName . '.NEXTVAL INTO last_Sequence FROM DUAL;
       END LOOP;
+      SELECT ' . $sequenceName . '.NEXTVAL INTO last_Sequence FROM DUAL;
    END IF;
 END;';
 

--- a/tests/Functional/AutoIncrementColumnTest.php
+++ b/tests/Functional/AutoIncrementColumnTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+class AutoIncrementColumnTest extends FunctionalTestCase
+{
+    /** @var bool */
+    private $shouldDisableIdentityInsert = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $table = new Table('auto_increment_table');
+        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->setPrimaryKey(['id']);
+
+        $this->connection->createSchemaManager()
+            ->dropAndCreateTable($table);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->shouldDisableIdentityInsert) {
+            $this->connection->executeStatement('SET IDENTITY_INSERT auto_increment_table OFF');
+        }
+
+        parent::tearDown();
+    }
+
+    public function testInsertIdentityValue(): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof SQLServer2012Platform) {
+            $this->connection->executeStatement('SET IDENTITY_INSERT auto_increment_table ON');
+            $this->shouldDisableIdentityInsert = true;
+        }
+
+        $this->connection->insert('auto_increment_table', ['id' => 2]);
+        self::assertEquals(2, $this->connection->fetchOne('SELECT id FROM auto_increment_table'));
+    }
+}

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -358,8 +358,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
             sprintf(
                 'CREATE TRIGGER %s_AI_PK BEFORE INSERT ON %s FOR EACH ROW DECLARE last_Sequence NUMBER;'
                 . ' last_InsertID NUMBER;'
-                . ' BEGIN SELECT %s_SEQ.NEXTVAL'
-                . ' INTO :NEW.%s FROM DUAL;'
+                . ' BEGIN'
                 . ' IF (:NEW.%s IS NULL OR :NEW.%s = 0)'
                 . ' THEN SELECT %s_SEQ.NEXTVAL INTO :NEW.%s FROM DUAL;'
                 . ' ELSE SELECT NVL(Last_Number, 0) INTO last_Sequence'
@@ -368,18 +367,18 @@ class OraclePlatformTest extends AbstractPlatformTestCase
                 . ' WHILE (last_InsertID > last_Sequence) LOOP'
                 . ' SELECT %s_SEQ.NEXTVAL INTO last_Sequence FROM DUAL;'
                 . ' END LOOP;'
+                . ' SELECT %s_SEQ.NEXTVAL INTO last_Sequence FROM DUAL;'
                 . ' END IF;'
                 . ' END;',
                 $tableName,
                 $tableName,
-                $tableName,
                 $columnName,
-                $columnName,
-                $columnName,
-                $tableName,
                 $columnName,
                 $tableName,
                 $columnName,
+                $tableName,
+                $columnName,
+                $tableName,
                 $tableName
             ),
         ];
@@ -811,7 +810,6 @@ DECLARE
    last_Sequence NUMBER;
    last_InsertID NUMBER;
 BEGIN
-   SELECT "test_SEQ".NEXTVAL INTO :NEW."id" FROM DUAL;
    IF (:NEW."id" IS NULL OR :NEW."id" = 0) THEN
       SELECT "test_SEQ".NEXTVAL INTO :NEW."id" FROM DUAL;
    ELSE
@@ -822,6 +820,7 @@ BEGIN
       WHILE (last_InsertID > last_Sequence) LOOP
          SELECT "test_SEQ".NEXTVAL INTO last_Sequence FROM DUAL;
       END LOOP;
+      SELECT "test_SEQ".NEXTVAL INTO last_Sequence FROM DUAL;
    END IF;
 END;
 EOD;


### PR DESCRIPTION
Fixes #4725.

Obviously, different behavior per platform is not something very attractive, but at least with this MR we make Oracle behave like MySql and SQLite, and add tests for all the platforms (except MS Sql that does not allow arbitrary values in INSERT for identity columns).