### PR TITLE
Add ReturnTypeWillChange to core interface implementations

### DIFF
--- a/lib/Doctrine/DBAL/Cache/ArrayStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ArrayStatement.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\FetchMode;
 use InvalidArgumentException;
 use IteratorAggregate;
 use PDO;
+use ReturnTypeWillChange;
 
 use function array_merge;
 use function array_values;
@@ -95,6 +96,7 @@ class ArrayStatement implements IteratorAggregate, ResultStatement, Result
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         $data = $this->fetchAll();

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\FetchMode;
 use InvalidArgumentException;
 use IteratorAggregate;
 use PDO;
+use ReturnTypeWillChange;
 
 use function array_map;
 use function array_merge;
@@ -109,6 +110,7 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement, Result
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         $data = $this->fetchAll();

--- a/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
+++ b/lib/Doctrine/DBAL/Driver/IBMDB2/DB2Statement.php
@@ -17,6 +17,7 @@ use PDO;
 use ReflectionClass;
 use ReflectionObject;
 use ReflectionProperty;
+use ReturnTypeWillChange;
 use stdClass;
 
 use function array_change_key_case;
@@ -270,6 +271,7 @@ class DB2Statement implements IteratorAggregate, StatementInterface, Result
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new StatementIterator($this);

--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
@@ -17,6 +17,7 @@ use IteratorAggregate;
 use mysqli;
 use mysqli_stmt;
 use PDO;
+use ReturnTypeWillChange;
 
 use function array_combine;
 use function array_fill;
@@ -563,6 +564,7 @@ class MysqliStatement implements IteratorAggregate, StatementInterface, Result
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new StatementIterator($this);

--- a/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+++ b/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\ParameterType;
 use InvalidArgumentException;
 use IteratorAggregate;
 use PDO;
+use ReturnTypeWillChange;
 
 use function array_key_exists;
 use function assert;
@@ -431,6 +432,7 @@ class OCI8Statement implements IteratorAggregate, StatementInterface, Result
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new StatementIterator($this);

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -13,6 +13,7 @@ use IteratorAggregate;
 use PDO;
 use ReflectionClass;
 use ReflectionObject;
+use ReturnTypeWillChange;
 use stdClass;
 
 use function array_key_exists;
@@ -320,6 +321,7 @@ class SQLAnywhereStatement implements IteratorAggregate, Statement, Result
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new StatementIterator($this);

--- a/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLSrv/SQLSrvStatement.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use IteratorAggregate;
 use PDO;
+use ReturnTypeWillChange;
 
 use function array_key_exists;
 use function count;
@@ -349,6 +350,7 @@ class SQLSrvStatement implements IteratorAggregate, StatementInterface, Result
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new StatementIterator($this);

--- a/lib/Doctrine/DBAL/Driver/StatementIterator.php
+++ b/lib/Doctrine/DBAL/Driver/StatementIterator.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Driver;
 
 use IteratorAggregate;
+use ReturnTypeWillChange;
 
 /**
  * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn().
@@ -20,6 +21,7 @@ class StatementIterator implements IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         while (($result = $this->statement->fetch()) !== false) {

--- a/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
+++ b/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
 use IteratorAggregate;
 use PDO;
+use ReturnTypeWillChange;
 use Traversable;
 
 use function array_shift;
@@ -40,6 +41,7 @@ class Result implements IteratorAggregate, DriverStatement, DriverResultStatemen
     /**
      * @return Driver\ResultStatement
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->stmt;

--- a/lib/Doctrine/DBAL/Portability/Statement.php
+++ b/lib/Doctrine/DBAL/Portability/Statement.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use IteratorAggregate;
 use PDO;
+use ReturnTypeWillChange;
 
 use function array_change_key_case;
 use function assert;
@@ -134,6 +135,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new StatementIterator($this);

--- a/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
+++ b/lib/Doctrine/DBAL/Query/Expression/CompositeExpression.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Query\Expression;
 
 use Countable;
 use Doctrine\Deprecations\Deprecation;
+use ReturnTypeWillChange;
 
 use function array_merge;
 use function count;
@@ -153,6 +154,7 @@ class CompositeExpression implements Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->parts);

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -13,6 +13,7 @@ use Doctrine\Deprecations\Deprecation;
 use IteratorAggregate;
 use PDO;
 use PDOStatement;
+use ReturnTypeWillChange;
 use Throwable;
 use Traversable;
 
@@ -319,6 +320,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
      *
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         Deprecation::trigger(

--- a/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/Statement.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Connection/BackwardCompatibility/Statement.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\StatementIterator;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Statement as BaseStatement;
 use PDO;
+use Traversable;
 
 use function assert;
 
@@ -112,7 +113,7 @@ class Statement extends BaseStatement
      *
      * @deprecated Use iterateNumeric(), iterateAssociative() or iterateColumn() instead.
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new StatementIterator($this);
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/A

#### Summary

PHP 8.1 triggers a deprecation, if we implement `Countable` or `IteratorAggregate` without return types. This PR proposes to suppress that warning because we cannot fix this without breaking BC.
