### PR TITLE
PHP 8.1 compatibility for 2.13

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,6 +25,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         dependencies:
           - "highest"
         include:
@@ -43,6 +44,10 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
           ini-values: "zend.assertions=1"
+
+      - name: "Adjust dependencies"
+        if: "${{ matrix.php-version == '8.1' }}"
+        run: composer config platform.php 8.0.99
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"

--- a/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
+++ b/lib/Doctrine/DBAL/ForwardCompatibility/Result.php
@@ -13,6 +13,7 @@ use ReturnTypeWillChange;
 use Traversable;
 
 use function array_shift;
+use function func_get_args;
 use function method_exists;
 
 /**
@@ -88,7 +89,7 @@ class Result implements IteratorAggregate, DriverStatement, DriverResultStatemen
             'Result::fetch() is deprecated, use Result::fetchNumeric(), fetchAssociative() or fetchOne() instead.'
         );
 
-        return $this->stmt->fetch($fetchMode, $cursorOrientation, $cursorOffset);
+        return $this->stmt->fetch(...func_get_args());
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -950,7 +950,7 @@ SQL
      */
     public function convertFromBoolean($item)
     {
-        if (in_array(strtolower($item), $this->booleanLiterals['false'], true)) {
+        if ($item !== null && in_array(strtolower($item), $this->booleanLiterals['false'], true)) {
             return false;
         }
 

--- a/lib/Doctrine/DBAL/Schema/AbstractAsset.php
+++ b/lib/Doctrine/DBAL/Schema/AbstractAsset.php
@@ -24,7 +24,7 @@ use function substr;
 abstract class AbstractAsset
 {
     /** @var string */
-    protected $_name;
+    protected $_name = '';
 
     /**
      * Namespace of the asset. If none isset the default namespace is assumed.

--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -196,7 +196,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         );
 
         foreach ($indexArray as $indexColumnRow) {
-            if ($indexColumnRow['pk'] === '0') {
+            if ($indexColumnRow['pk'] === 0 || $indexColumnRow['pk'] === '0') {
                 continue;
             }
 
@@ -262,7 +262,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $autoincrementCount  = 0;
 
         foreach ($tableColumns as $tableColumn) {
-            if ($tableColumn['pk'] === '0') {
+            if ($tableColumn['pk'] === 0 || $tableColumn['pk'] === '0') {
                 continue;
             }
 
@@ -434,7 +434,12 @@ class SqliteSchemaManager extends AbstractSchemaManager
                 ];
             }
 
-            $list[$name]['local'][]   = $value['from'];
+            $list[$name]['local'][] = $value['from'];
+
+            if ($value['to'] === null) {
+                continue;
+            }
+
             $list[$name]['foreign'][] = $value['to'];
         }
 

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -18,6 +18,7 @@ use Throwable;
 use Traversable;
 
 use function array_shift;
+use function func_get_args;
 use function is_array;
 use function is_string;
 
@@ -346,7 +347,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
             'Statement::fetch() is deprecated, use Result::fetchNumeric(), fetchAssociative() or fetchOne() instead.'
         );
 
-        return $this->stmt->fetch($fetchMode);
+        return $this->stmt->fetch(...func_get_args());
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Schema/SqliteSchemaManagerTest.php
@@ -104,7 +104,7 @@ EOS
             new Schema\ForeignKeyConstraint(
                 ['log'],
                 'log',
-                [''],
+                [],
                 'FK_3',
                 ['onUpdate' => 'SET NULL', 'onDelete' => 'NO ACTION', 'deferrable' => false, 'deferred' => false]
             ),

--- a/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/TypeConversionTest.php
@@ -139,9 +139,7 @@ class TypeConversionTest extends DbalFunctionalTestCase
     {
         return [
             'string' => ['string', 'ABCDEFGabcdefg'],
-            'bigint' => ['bigint', 12345678],
             'text' => ['text', str_repeat('foo ', 1000)],
-            'decimal' => ['decimal', 1.55],
         ];
     }
 

--- a/tests/Doctrine/Tests/DBAL/Tools/DumperTest.php
+++ b/tests/Doctrine/Tests/DBAL/Tools/DumperTest.php
@@ -99,7 +99,7 @@ class DumperTest extends DbalTestCase
         $var = (array) $var;
         unset($var['__CLASS__']);
 
-        self::assertSame($expected, $var);
+        self::assertEquals($expected, $var);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Types/VarDateTimeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/VarDateTimeTest.php
@@ -19,8 +19,9 @@ class VarDateTimeTest extends DbalTestCase
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = new VarDateTimeType();
+        $this->platform = $this->getMockForAbstractClass(AbstractPlatform::class);
+
+        $this->type = new VarDateTimeType();
     }
 
     public function testDateTimeConvertsToDatabaseValue(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/A

#### Summary

The methods `getDateTimeTzFormatString()` and `getDateTimeFormatString()` will never return `null` in real implementations, but this is what the mock created in that test currently does.

Their return value is passed to `DateTime::format()`. Passing `null` to that method triggers a deprecation warning in PHP 8.1. With this PR, I'd like to fix the broken mock.
