### PR TITLE
Code cleanup

### DIFF
--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -20,7 +20,7 @@ class QueryCacheProfile
     private $resultCacheDriver;
 
     /** @var int */
-    private $lifetime = 0;
+    private $lifetime;
 
     /** @var string|null */
     private $cacheKey;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -760,7 +760,7 @@ class Connection
     {
         $typeValues = [];
 
-        foreach ($columnList as $columnIndex => $columnName) {
+        foreach ($columnList as $columnName) {
             $typeValues[] = $types[$columnName] ?? ParameterType::STRING;
         }
 

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -125,7 +125,7 @@ final class Statement implements StatementInterface
 
             $params = [];
 
-            foreach ($this->bindParam as $column => $value) {
+            foreach ($this->bindParam as $value) {
                 $params[] = $value;
             }
         }

--- a/src/Logging/LoggerChain.php
+++ b/src/Logging/LoggerChain.php
@@ -8,7 +8,7 @@ namespace Doctrine\DBAL\Logging;
 class LoggerChain implements SQLLogger
 {
     /** @var iterable<SQLLogger> */
-    private $loggers = [];
+    private $loggers;
 
     /**
      * @param iterable<SQLLogger> $loggers

--- a/src/Platforms/Keywords/ReservedKeywordsValidator.php
+++ b/src/Platforms/Keywords/ReservedKeywordsValidator.php
@@ -17,7 +17,7 @@ use function str_replace;
 class ReservedKeywordsValidator implements Visitor
 {
     /** @var KeywordList[] */
-    private $keywordLists = [];
+    private $keywordLists;
 
     /** @var string[] */
     private $violations = [];

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -43,7 +43,7 @@ class Index extends AbstractAsset implements Constraint
      * @todo $_flags should eventually be refactored into options
      * @var mixed[]
      */
-    private $options = [];
+    private $options;
 
     /**
      * @param string   $name

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -133,11 +133,8 @@ SQL
      */
     protected function _getPortableTableForeignKeyDefinition($tableForeignKey)
     {
-        $onUpdate       = null;
-        $onDelete       = null;
-        $localColumns   = [];
-        $foreignColumns = [];
-        $foreignTable   = null;
+        $onUpdate = null;
+        $onDelete = null;
 
         if (
             preg_match(

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -34,7 +34,7 @@ class UniqueConstraint extends AbstractAsset implements Constraint
      *
      * @var mixed[]
      */
-    private $options = [];
+    private $options;
 
     /**
      * @param string[] $columns

--- a/src/Tools/Dumper.php
+++ b/src/Tools/Dumper.php
@@ -86,8 +86,7 @@ final class Dumper
      */
     public static function export($var, int $maxDepth)
     {
-        $return = null;
-        $isObj  = is_object($var);
+        $isObj = is_object($var);
 
         if ($var instanceof Collection) {
             $var = $var->toArray();

--- a/tests/Cache/QueryCacheProfileTest.php
+++ b/tests/Cache/QueryCacheProfileTest.php
@@ -98,7 +98,7 @@ class QueryCacheProfileTest extends TestCase
     {
         $this->queryCacheProfile = $this->queryCacheProfile->setCacheKey(null);
 
-        [$cacheKey, $queryString] = $this->queryCacheProfile->generateCacheKeys(
+        [, $queryString] = $this->queryCacheProfile->generateCacheKeys(
             $this->query,
             $this->params,
             $this->types,

--- a/tests/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Functional/PrimaryReadReplicaConnectionTest.php
@@ -140,7 +140,7 @@ class PrimaryReadReplicaConnectionTest extends FunctionalTestCase
 
     public function testKeepReplicaBeginTransactionStaysOnPrimary(): void
     {
-        $conn = $this->createPrimaryReadReplicaConnection($keepReplica = true);
+        $conn = $this->createPrimaryReadReplicaConnection(true);
         $conn->ensureConnectedToReplica();
 
         $conn->beginTransaction();
@@ -158,7 +158,7 @@ class PrimaryReadReplicaConnectionTest extends FunctionalTestCase
 
     public function testKeepReplicaInsertStaysOnPrimary(): void
     {
-        $conn = $this->createPrimaryReadReplicaConnection($keepReplica = true);
+        $conn = $this->createPrimaryReadReplicaConnection(true);
         $conn->ensureConnectedToReplica();
 
         $conn->insert('primary_replica_table', ['test_int' => 30]);

--- a/tests/Functional/ResultCacheTest.php
+++ b/tests/Functional/ResultCacheTest.php
@@ -171,8 +171,7 @@ class ResultCacheTest extends FunctionalTestCase
             new QueryCacheProfile(0, 'testcachekey')
         );
 
-        while (($row = $result->fetchAssociative()) !== false) {
-        }
+        $result->fetchAllAssociative();
 
         $result = $this->connection->executeQuery(
             'SELECT * FROM caching ORDER BY test_int ASC',
@@ -181,8 +180,7 @@ class ResultCacheTest extends FunctionalTestCase
             new QueryCacheProfile(0, 'testcachekey')
         );
 
-        while (($row = $result->fetchNumeric()) !== false) {
-        }
+        $result->fetchAllNumeric();
 
         self::assertCount(1, $this->sqlLogger->queries);
     }

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -280,7 +280,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testColumnCollation(): void
     {
         $table = new Table('test_collation');
-        $table->addOption('collate', $collation = 'latin1_swedish_ci');
+        $table->addOption('collate', 'latin1_swedish_ci');
         $table->addOption('charset', 'latin1');
         $table->addColumn('id', 'integer');
         $table->addColumn('text', 'text');

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -84,7 +84,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testAlterTableAutoIncrementAdd(): void
     {
         $tableFrom = new Table('autoinc_table_add');
-        $column    = $tableFrom->addColumn('id', 'integer');
+        $tableFrom->addColumn('id', 'integer');
         $this->schemaManager->createTable($tableFrom);
         $tableFrom = $this->schemaManager->listTableDetails('autoinc_table_add');
         self::assertFalse($tableFrom->getColumn('id')->getAutoincrement());
@@ -192,10 +192,10 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testFilterSchemaExpression(): void
     {
         $testTable = new Table('dbal204_test_prefix');
-        $column    = $testTable->addColumn('id', 'integer');
+        $testTable->addColumn('id', 'integer');
         $this->schemaManager->createTable($testTable);
         $testTable = new Table('dbal204_without_prefix');
-        $column    = $testTable->addColumn('id', 'integer');
+        $testTable->addColumn('id', 'integer');
         $this->schemaManager->createTable($testTable);
 
         $this->connection->getConfiguration()->setSchemaAssetsFilter(static function (string $name): bool {

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -156,7 +156,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         $table = new Table('test');
 
         $this->expectException(Exception::class);
-        $sql = $this->platform->getCreateTableSQL($table);
+        $this->platform->getCreateTableSQL($table);
     }
 
     public function testGeneratesTableCreationSql(): void
@@ -218,22 +218,22 @@ abstract class AbstractPlatformTestCase extends TestCase
 
         $expected = ' WHERE ' . $where;
 
-        $actuals = [];
+        $indexes = [];
 
         if ($this->supportsInlineIndexDeclaration()) {
-            $actuals[] = $this->platform->getIndexDeclarationSQL('name', $indexDef);
+            $indexes[] = $this->platform->getIndexDeclarationSQL('name', $indexDef);
         }
 
         $uniqueConstraintSQL = $this->platform->getUniqueConstraintDeclarationSQL('name', $uniqueConstraint);
-        $indexSQL            = $this->platform->getCreateIndexSQL($indexDef, 'table');
-
         $this->assertStringEndsNotWith($expected, $uniqueConstraintSQL, 'WHERE clause should NOT be present');
 
-        foreach ($actuals as $actual) {
+        $indexes[] = $this->platform->getCreateIndexSQL($indexDef, 'table');
+
+        foreach ($indexes as $index) {
             if ($this->platform->supportsPartialIndexes()) {
-                self::assertStringEndsWith($expected, $indexSQL, 'WHERE clause should be present');
+                self::assertStringEndsWith($expected, $index, 'WHERE clause should be present');
             } else {
-                self::assertStringEndsNotWith($expected, $indexSQL, 'WHERE clause should NOT be present');
+                self::assertStringEndsNotWith($expected, $index, 'WHERE clause should NOT be present');
             }
         }
     }

--- a/tests/Platforms/AbstractPostgreSQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractPostgreSQLPlatformTestCase.php
@@ -442,9 +442,7 @@ abstract class AbstractPostgreSQLPlatformTestCase extends AbstractPlatformTestCa
      */
     public function testConvertBooleanAsLiteralStrings(
         $databaseValue,
-        string $preparedStatementValue,
-        ?int $integerValue,
-        ?bool $booleanValue
+        string $preparedStatementValue
     ): void {
         $platform = $this->createPlatform();
 

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -575,8 +575,6 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         $table2->addColumn('column_varbinary', 'binary', ['fixed' => true]);
         $table2->addColumn('column_binary', 'binary');
 
-        $comparator = new Comparator();
-
         // VARBINARY -> BINARY
         // BINARY    -> VARBINARY
         $diff = (new Comparator())->diffTable($table1, $table2);

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -132,8 +132,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectWithAndWhereConditions(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -145,8 +144,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectWithOrWhereConditions(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -158,8 +156,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectWithOrOrWhereConditions(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -171,8 +168,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectWithAndOrWhereConditions(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -190,8 +186,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectGroupBy(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -202,8 +197,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectEmptyGroupBy(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->groupBy([])
@@ -214,8 +208,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectEmptyAddGroupBy(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->addGroupBy([])
@@ -226,8 +219,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectAddGroupBy(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -239,8 +231,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectAddGroupBys(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -252,8 +243,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectHaving(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -265,8 +255,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectAndHaving(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -278,8 +267,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectHavingAndHaving(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -295,8 +283,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectHavingOrHaving(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -312,8 +299,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectOrHavingOrHaving(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -329,8 +315,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectHavingAndOrHaving(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -347,8 +332,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectOrderBy(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -359,8 +343,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectAddOrderBy(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -372,8 +355,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectAddAddOrderBy(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*', 'p.*')
            ->from('users', 'u')
@@ -394,8 +376,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectAddSelect(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*')
            ->addSelect('p.*')
@@ -415,8 +396,7 @@ class QueryBuilderTest extends TestCase
 
     public function testSelectMultipleFrom(): void
     {
-        $qb   = new QueryBuilder($this->conn);
-        $expr = $qb->expr();
+        $qb = new QueryBuilder($this->conn);
 
         $qb->select('u.*')
            ->addSelect('p.*')

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -845,8 +845,8 @@ class ComparatorTest extends TestCase
 
     public function testChangedSequence(): void
     {
-        $schema   = new Schema();
-        $sequence = $schema->createSequence('baz');
+        $schema = new Schema();
+        $schema->createSequence('baz');
 
         $schemaNew = clone $schema;
         $schemaNew->getSequence('baz')->setAllocationSize(20);

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -62,7 +62,7 @@ class SchemaTest extends TestCase
         $table     = new Table($tableName);
         $tables    = [$table, $table];
 
-        $schema = new Schema($tables);
+        new Schema($tables);
     }
 
     public function testRenameTable(): void
@@ -171,7 +171,7 @@ class SchemaTest extends TestCase
 
         $sequence = new Sequence('a_seq', 1, 1);
 
-        $schema = new Schema([], [$sequence, $sequence]);
+        new Schema([], [$sequence, $sequence]);
     }
 
     public function testConfigMaxIdentifierLength(): void

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -108,7 +108,7 @@ class TableTest extends TestCase
         $columns   = [];
         $columns[] = new Column('foo', $type);
         $columns[] = new Column('foo', $type);
-        $table     = new Table('foo', $columns, [], []);
+        new Table('foo', $columns, [], []);
     }
 
     public function testCreateIndex(): void
@@ -181,7 +181,7 @@ class TableTest extends TestCase
             new Index('the_primary', ['foo'], true, true),
             new Index('other_primary', ['bar'], true, true),
         ];
-        $table   = new Table('foo', $columns, $indexes, [], []);
+        new Table('foo', $columns, $indexes, [], []);
     }
 
     public function testAddTwoIndexesWithSameNameThrowsException(): void
@@ -194,7 +194,7 @@ class TableTest extends TestCase
             new Index('an_idx', ['foo'], false, false),
             new Index('an_idx', ['bar'], false, false),
         ];
-        $table   = new Table('foo', $columns, $indexes, [], []);
+        new Table('foo', $columns, $indexes, [], []);
     }
 
     public function testConstraints(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. Remove unnecessary property default values
2. Remove unused local variables

The above issues have been identified using PhpStorm code inspection.