### PR TITLE
Remove reference from foreign key to its referencing table

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,17 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: Deprecated reference from `ForeignKeyConstraint` to its local (referencing) `Table`.
+
+Reference from `ForeignKeyConstraint` to its local (referencing) `Table` is removed as well as the following methods:
+
+- `setLocalTable()`,
+- `getLocalTable()`,
+- `getLocalTableName()`.
+
+The type of `SchemaDiff::$orphanedForeignKeys` has changed from list of foreign keys (list<ForeignKeyConstraint>)
+to map of referencing tables to their list of foreign keys (array<string,list<ForeignKeyConstraint>>).
+
 ## BC BREAK: Removed redundant `AbstractPlatform` methods.
 
 The following redundant `AbstractPlatform` methods have been removed:

--- a/docs/en/reference/schema-manager.rst
+++ b/docs/en/reference/schema-manager.rst
@@ -119,7 +119,7 @@ object:
 
     <?php
     foreach ($foreignKeys as $foreignKey) {
-        echo $foreignKey->getName() . ': ' . $foreignKey->getLocalTableName() ."\n";
+        echo $foreignKey->getName() ."\n";
     }
 
 listTableIndexes()

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -106,6 +106,7 @@
 
     <!-- See https://github.com/squizlabs/PHP_CodeSniffer/issues/2837 -->
     <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
+        <exclude-pattern>src/Schema/Comparator.php</exclude-pattern>
         <exclude-pattern>src/SQLParserUtils.php</exclude-pattern>
     </rule>
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -171,8 +171,6 @@
                 <!-- See https://github.com/psalm/psalm-plugin-phpunit/issues/107 -->
                 <!-- See https://github.com/sebastianbergmann/phpunit/pull/4610 -->
                 <directory name="tests"/>
-                <!-- See https://github.com/doctrine/dbal/issues/4506 -->
-                <file name="src/Schema/ForeignKeyConstraint.php"/>
             </errorLevel>
         </PropertyNotSetInConstructor>
         <RedundantCondition>

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -19,11 +19,6 @@ use function substr;
 class ForeignKeyConstraint extends AbstractAsset implements Constraint
 {
     /**
-     * Instance of the referencing table the foreign key constraint is associated with.
-     */
-    protected Table $_localTable;
-
-    /**
      * Asset identifier instances of the referencing table column names the foreign key constraint is associated with.
      *
      * @var array<string, Identifier>
@@ -95,29 +90,6 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
         }
 
         return $identifiers;
-    }
-
-    /**
-     * Returns the name of the referencing table
-     * the foreign key constraint is associated with.
-     */
-    public function getLocalTableName(): string
-    {
-        return $this->_localTable->getName();
-    }
-
-    /**
-     * Sets the Table instance of the referencing table
-     * the foreign key constraint is associated with.
-     */
-    public function setLocalTable(Table $table): void
-    {
-        $this->_localTable = $table;
-    }
-
-    public function getLocalTable(): Table
-    {
-        return $this->_localTable;
     }
 
     /**

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -62,7 +62,11 @@ class SchemaDiff
     /** @var array<int, Sequence> */
     public array $removedSequences = [];
 
-    /** @var array<string|int, ForeignKeyConstraint> */
+    /**
+     * Map of table names to their list of orphaned foreign keys.
+     *
+     * @var array<string,list<ForeignKeyConstraint>>
+     */
     public array $orphanedForeignKeys = [];
 
     /**
@@ -122,8 +126,10 @@ class SchemaDiff
         }
 
         if ($platform->supportsForeignKeyConstraints() && $saveMode === false) {
-            foreach ($this->orphanedForeignKeys as $orphanedForeignKey) {
-                $sql[] = $platform->getDropForeignKeySQL($orphanedForeignKey, $orphanedForeignKey->getLocalTable());
+            foreach ($this->orphanedForeignKeys as $localTableName => $tableOrphanedForeignKey) {
+                foreach ($tableOrphanedForeignKey as $orphanedForeignKey) {
+                    $sql[] = $platform->getDropForeignKeySQL($orphanedForeignKey, $localTableName);
+                }
             }
         }
 

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -692,7 +692,6 @@ class Table extends AbstractAsset
 
         foreach ($this->_fkConstraints as $k => $fk) {
             $this->_fkConstraints[$k] = clone $fk;
-            $this->_fkConstraints[$k]->setLocalTable($this);
         }
     }
 
@@ -795,8 +794,6 @@ class Table extends AbstractAsset
 
     protected function _addForeignKeyConstraint(ForeignKeyConstraint $constraint): self
     {
-        $constraint->setLocalTable($this);
-
         $name = $constraint->getName() !== ''
             ? $constraint->getName()
             : $this->_generateIdentifierName(

--- a/src/Schema/Visitor/Graphviz.php
+++ b/src/Schema/Visitor/Graphviz.php
@@ -23,7 +23,7 @@ class Graphviz extends AbstractVisitor
     public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint): void
     {
         $this->output .= $this->createNodeRelation(
-            $fkConstraint->getLocalTableName() . ':col' . current($fkConstraint->getLocalColumns()) . ':se',
+            $localTable->getName() . ':col' . current($fkConstraint->getLocalColumns()) . ':se',
             $fkConstraint->getForeignTableName() . ':col' . current($fkConstraint->getForeignColumns()) . ':se',
             [
                 'dir'       => 'back',

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -1266,7 +1266,7 @@ class ComparatorTest extends TestCase
 
         self::assertArrayHasKey('table2', $actual->changedTables);
         self::assertCount(1, $actual->orphanedForeignKeys);
-        self::assertEquals('fk_table2_table1', $actual->orphanedForeignKeys[0]->getName());
+        self::assertEquals('fk_table2_table1', $actual->orphanedForeignKeys['table1'][0]->getName());
         self::assertCount(1, $actual->changedTables['table2']->addedForeignKeys, 'FK to table3 should be added.');
         self::assertEquals('table3', $actual->changedTables['table2']->addedForeignKeys[0]->getForeignTableName());
     }

--- a/tests/Schema/SchemaDiffTest.php
+++ b/tests/Schema/SchemaDiffTest.php
@@ -94,10 +94,6 @@ class SchemaDiffTest extends TestCase
         if ($unsafe) {
             $platform->expects(self::exactly(1))
                      ->method('getDropForeignKeySql')
-                     ->with(
-                         self::isInstanceOf(ForeignKeyConstraint::class),
-                         self::isInstanceOf(Table::class)
-                     )
                      ->will(self::returnValue('drop_orphan_fk'));
         }
 
@@ -127,9 +123,11 @@ class SchemaDiffTest extends TestCase
         $diff->changedTables['baz_table']  = new TableDiff('baz_table');
         $diff->newTables['foo_table']->addColumn('foreign_id', 'integer');
         $diff->newTables['foo_table']->addForeignKeyConstraint('foreign_table', ['foreign_id'], ['id']);
-        $fk = new ForeignKeyConstraint(['id'], 'foreign_table', ['id']);
-        $fk->setLocalTable(new Table('local_table'));
-        $diff->orphanedForeignKeys[] = $fk;
+        $diff->orphanedForeignKeys['local_table'][] = new ForeignKeyConstraint(
+            ['id'],
+            'foreign_table',
+            ['id']
+        );
 
         return $diff;
     }

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Visitor\AbstractVisitor;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
 
 use function array_shift;
 use function strlen;
@@ -214,15 +213,6 @@ class SchemaTest extends TestCase
 
         self::assertNotSame($tableB, $schemaNew->getTable('bar'));
         self::assertNotSame($tableB->getColumn('id'), $schemaNew->getTable('bar')->getColumn('id'));
-
-        $foreignKeys = $schemaNew->getTable('bar')->getForeignKeys();
-        self::assertCount(1, $foreignKeys);
-        $fk = array_shift($foreignKeys);
-
-        $re = new ReflectionProperty($fk, '_localTable');
-        $re->setAccessible(true);
-
-        self::assertSame($schemaNew->getTable('bar'), $re->getValue($fk));
     }
 
     public function testHasTableForQuotedAsset(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes

Deprecated in #4743. Fixes #4506.

The original idea was to make the local table name part of the constructor signature like all other properties. While it's technically possible, it has the following downsides:
1. This reference is redundant since the table references the foreign keys that use it as a referencing table: https://github.com/doctrine/dbal/blob/dc4ad2a0d7f72e9e55dd1f9e2a341c068fd2b89f/src/Schema/Table.php#L52-L53
2. The referencing table isn't used to build the foreign key constraint SQL.
3. None of the other table components (e.g. columns, unique constraints, indexes) reference their containing table.
4. This would require significant code and API changes used to implement `AbstractSchemaManager::listTableForeignKeys()`.