### PR TITLE
Platform-aware schema comparison 

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## Deprecated schema comparison APIs that don't account for the current database connection and the database platform
+
+1. Instantiation of the `Comparator` class outside the DBAL is deprecated. Use `SchemaManager::createComparator()`
+   to create the comparator specific to the current database connection and the database platform.
+2. The `Schema::getMigrateFromSql()` and `::getMigrateToSql()` methods are deprecated. Compare the schemas using the
+   connection-aware comparator and produce the SQL by passing the resulting diff to the target platform.
+
 ## Deprecated driver-level APIs that don't take the server version into account.
 
 The `ServerInfoAwareConnection` and `VersionAwarePlatformDriver` interfaces are deprecated. In the next major version,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -129,4 +129,9 @@
     <rule ref="Squiz.PHP.LowercasePHPFunctions">
         <exclude-pattern>src/Driver/SQLSrv/Statement.php</exclude-pattern>
     </rule>
+
+    <!-- See https://github.com/squizlabs/PHP_CodeSniffer/issues/3035 -->
+    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod.Found">
+        <exclude-pattern>src/Platforms/*/Comparator.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -139,6 +139,10 @@
                 <referencedMethod name="Doctrine\DBAL\Schema\ForeignKeyConstraint::getLocalTable"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\ForeignKeyConstraint::getLocalTableName"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\ForeignKeyConstraint::setLocalTable"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\Schema::getMigrateToSql"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>
@@ -331,6 +335,8 @@
                 <!-- See https://github.com/doctrine/dbal/pull/3562 -->
                 <file name="src/Schema/AbstractSchemaManager.php"/>
                 <file name="src/Schema/SqliteSchemaManager.php"/>
+                <!-- See https://github.com/doctrine/dbal/pull/3498 -->
+                <file name="tests/Platforms/AbstractMySQLPlatformTestCase.php"/>
             </errorLevel>
         </TooManyArguments>
         <TypeDoesNotContainType>

--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
 
+use function assert;
+
 /**
  * Abstract base implementation of the {@link Driver} interface for IBM DB2 based drivers.
  */
@@ -28,6 +30,8 @@ abstract class AbstractDB2Driver implements Driver
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        assert($platform instanceof DB2Platform);
+
         return new DB2SchemaManager($conn, $platform);
     }
 

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 
+use function assert;
 use function preg_match;
 use function stripos;
 use function version_compare;
@@ -126,6 +127,8 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        assert($platform instanceof MySQLPlatform);
+
         return new MySQLSchemaManager($conn, $platform);
     }
 

--- a/src/Driver/AbstractOracleDriver.php
+++ b/src/Driver/AbstractOracleDriver.php
@@ -11,6 +11,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\OracleSchemaManager;
 
+use function assert;
+
 /**
  * Abstract base implementation of the {@link Driver} interface for Oracle based drivers.
  */
@@ -29,6 +31,8 @@ abstract class AbstractOracleDriver implements Driver
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        assert($platform instanceof OraclePlatform);
+
         return new OracleSchemaManager($conn, $platform);
     }
 

--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 
+use function assert;
 use function preg_match;
 use function version_compare;
 
@@ -57,6 +58,8 @@ abstract class AbstractPostgreSQLDriver implements VersionAwarePlatformDriver
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        assert($platform instanceof PostgreSQL94Platform);
+
         return new PostgreSQLSchemaManager($conn, $platform);
     }
 

--- a/src/Driver/AbstractSQLServerDriver.php
+++ b/src/Driver/AbstractSQLServerDriver.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 
+use function assert;
+
 /**
  * Abstract base implementation of the {@link Driver} interface for Microsoft SQL Server based drivers.
  */
@@ -28,6 +30,8 @@ abstract class AbstractSQLServerDriver implements Driver
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        assert($platform instanceof SQLServer2012Platform);
+
         return new SQLServerSchemaManager($conn, $platform);
     }
 

--- a/src/Driver/AbstractSQLiteDriver.php
+++ b/src/Driver/AbstractSQLiteDriver.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\SqliteSchemaManager;
 
+use function assert;
+
 /**
  * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for SQLite based drivers.
  */
@@ -28,6 +30,8 @@ abstract class AbstractSQLiteDriver implements Driver
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        assert($platform instanceof SqlitePlatform);
+
         return new SqliteSchemaManager($conn, $platform);
     }
 

--- a/src/Platforms/MySQL/Comparator.php
+++ b/src/Platforms/MySQL/Comparator.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\MySQL;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Comparator as BaseComparator;
+use Doctrine\DBAL\Schema\Table;
+
+use function array_diff_assoc;
+use function array_intersect_key;
+
+/**
+ * Compares schemas in the context of MySQL platform.
+ *
+ * In MySQL, unless specified explicitly, the column's character set and collation are inherited from its containing
+ * table. So during comparison, an omitted value and the value that matches the default value of table in the
+ * desired schema must be considered equal.
+ */
+class Comparator extends BaseComparator
+{
+    /**
+     * @internal The comparator can be only instantiated by a schema manager.
+     */
+    public function __construct(MySQLPlatform $platform)
+    {
+        parent::__construct($platform);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function diffTable(Table $fromTable, Table $toTable)
+    {
+        $defaults = array_intersect_key($fromTable->getOptions(), [
+            'charset'   => null,
+            'collation' => null,
+        ]);
+
+        if ($defaults !== []) {
+            $fromTable = clone $fromTable;
+            $toTable   = clone $toTable;
+
+            $this->normalizeColumns($fromTable, $defaults);
+            $this->normalizeColumns($toTable, $defaults);
+        }
+
+        return parent::diffTable($fromTable, $toTable);
+    }
+
+    /**
+     * @param array<string,mixed> $defaults
+     */
+    private function normalizeColumns(Table $table, array $defaults): void
+    {
+        foreach ($table->getColumns() as $column) {
+            $options = $column->getPlatformOptions();
+            $diff    = array_diff_assoc($options, $defaults);
+
+            if ($diff === $options) {
+                continue;
+            }
+
+            $column->setPlatformOptions($diff);
+        }
+    }
+}

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -370,8 +370,15 @@ class MySQLPlatform extends AbstractPlatform
     {
         return sprintf(
             <<<'SQL'
-SELECT ENGINE, AUTO_INCREMENT, TABLE_COLLATION, TABLE_COMMENT, CREATE_OPTIONS
-FROM information_schema.TABLES
+SELECT t.ENGINE,
+       t.AUTO_INCREMENT,
+       t.TABLE_COMMENT,
+       t.CREATE_OPTIONS,
+       t.TABLE_COLLATION,
+       ccsa.CHARACTER_SET_NAME
+FROM information_schema.TABLES t
+    INNER JOIN information_schema.`COLLATION_CHARACTER_SET_APPLICABILITY` ccsa
+        ON ccsa.COLLATION_NAME = t.TABLE_COLLATION
 WHERE TABLE_TYPE = 'BASE TABLE' AND TABLE_SCHEMA = %s AND TABLE_NAME = %s
 SQL
             ,

--- a/src/Platforms/SQLServer/Comparator.php
+++ b/src/Platforms/SQLServer/Comparator.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\SQLServer;
+
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Doctrine\DBAL\Schema\Comparator as BaseComparator;
+use Doctrine\DBAL\Schema\Table;
+
+/**
+ * Compares schemas in the context of SQL Server platform.
+ *
+ * @link https://docs.microsoft.com/en-us/sql/t-sql/statements/collations?view=sql-server-ver15
+ */
+class Comparator extends BaseComparator
+{
+    /** @var string */
+    private $databaseCollation;
+
+    /**
+     * @internal The comparator can be only instantiated by a schema manager.
+     */
+    public function __construct(SQLServer2012Platform $platform, string $databaseCollation)
+    {
+        parent::__construct($platform);
+
+        $this->databaseCollation = $databaseCollation;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function diffTable(Table $fromTable, Table $toTable)
+    {
+        $fromTable = clone $fromTable;
+        $toTable   = clone $toTable;
+
+        $this->normalizeColumns($fromTable);
+        $this->normalizeColumns($toTable);
+
+        return parent::diffTable($fromTable, $toTable);
+    }
+
+    private function normalizeColumns(Table $table): void
+    {
+        foreach ($table->getColumns() as $column) {
+            $options = $column->getPlatformOptions();
+
+            if (! isset($options['collation']) || $options['collation'] !== $this->databaseCollation) {
+                continue;
+            }
+
+            unset($options['collation']);
+            $column->setPlatformOptions($options);
+        }
+    }
+}

--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -1625,6 +1625,16 @@ class SQLServer2012Platform extends AbstractPlatform
         return $name . ' ' . $columnDef;
     }
 
+    public function columnsEqual(Column $column1, Column $column2): bool
+    {
+        if (! parent::columnsEqual($column1, $column2)) {
+            return false;
+        }
+
+        return $this->getDefaultValueDeclarationSQL($column1->toArray())
+            === $this->getDefaultValueDeclarationSQL($column2->toArray());
+    }
+
     protected function getLikeWildcardCharacters(): string
     {
         return parent::getLikeWildcardCharacters() . '[]^';

--- a/src/Platforms/SQLite/Comparator.php
+++ b/src/Platforms/SQLite/Comparator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\SQLite;
+
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Schema\Comparator as BaseComparator;
+use Doctrine\DBAL\Schema\Table;
+
+use function strcasecmp;
+
+/**
+ * Compares schemas in the context of SQLite platform.
+ *
+ * BINARY is the default column collation and should be ignored if specified explicitly.
+ */
+class Comparator extends BaseComparator
+{
+    /**
+     * @internal The comparator can be only instantiated by a schema manager.
+     */
+    public function __construct(SqlitePlatform $platform)
+    {
+        parent::__construct($platform);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function diffTable(Table $fromTable, Table $toTable)
+    {
+        $fromTable = clone $fromTable;
+        $toTable   = clone $toTable;
+
+        $this->normalizeColumns($fromTable);
+        $this->normalizeColumns($toTable);
+
+        return parent::diffTable($fromTable, $toTable);
+    }
+
+    private function normalizeColumns(Table $table): void
+    {
+        foreach ($table->getColumns() as $column) {
+            $options = $column->getPlatformOptions();
+
+            if (! isset($options['collation']) || strcasecmp($options['collation'], 'binary') !== 0) {
+                continue;
+            }
+
+            unset($options['collation']);
+            $column->setPlatformOptions($options);
+        }
+    }
+}

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -699,7 +699,8 @@ abstract class AbstractSchemaManager
      */
     public function migrateSchema(Schema $toSchema): void
     {
-        $schemaDiff = (new Comparator())->compareSchemas($this->createSchema(), $toSchema);
+        $schemaDiff = $this->createComparator()
+            ->compareSchemas($this->createSchema(), $toSchema);
 
         $this->alterSchema($schemaDiff);
     }
@@ -1217,5 +1218,10 @@ abstract class AbstractSchemaManager
         }
 
         return str_replace('(DC2Type:' . $type . ')', '', $comment);
+    }
+
+    public function createComparator(): Comparator
+    {
+        return new Comparator($this->getDatabasePlatform());
     }
 }

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -28,6 +28,8 @@ use function strtolower;
 /**
  * Base class for schema managers. Schema managers are used to inspect and/or
  * modify the database schema/structure.
+ *
+ * @template T of AbstractPlatform
  */
 abstract class AbstractSchemaManager
 {
@@ -41,10 +43,13 @@ abstract class AbstractSchemaManager
     /**
      * Holds instance of the database platform used for this schema manager.
      *
-     * @var AbstractPlatform
+     * @var T
      */
     protected $_platform;
 
+    /**
+     * @param T $platform
+     */
     public function __construct(Connection $connection, AbstractPlatform $platform)
     {
         $this->_conn     = $connection;
@@ -54,7 +59,7 @@ abstract class AbstractSchemaManager
     /**
      * Returns the associated platform.
      *
-     * @return AbstractPlatform
+     * @return T
      */
     public function getDatabasePlatform()
     {

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
-use function assert;
 use function preg_match;
 use function str_replace;
 use function strpos;
@@ -18,6 +17,8 @@ use const CASE_LOWER;
 
 /**
  * IBM Db2 Schema Manager.
+ *
+ * @extends AbstractSchemaManager<DB2Platform>
  */
 class DB2SchemaManager extends AbstractSchemaManager
 {
@@ -226,9 +227,7 @@ class DB2SchemaManager extends AbstractSchemaManager
     {
         $table = parent::listTableDetails($name);
 
-        $platform = $this->_platform;
-        assert($platform instanceof DB2Platform);
-        $sql = $platform->getListTableCommentsSQL($name);
+        $sql = $this->_platform->getListTableCommentsSQL($name);
 
         $tableOptions = $this->_conn->fetchAssociative($sql);
 

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Platforms\MySQL;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Types\Type;
 
@@ -349,6 +350,8 @@ class MySQLSchemaManager extends AbstractSchemaManager
             $table->addOption('collation', $tableOptions['TABLE_COLLATION']);
         }
 
+        $table->addOption('charset', $tableOptions['CHARACTER_SET_NAME']);
+
         if ($tableOptions['AUTO_INCREMENT'] !== null) {
             $table->addOption('autoincrement', $tableOptions['AUTO_INCREMENT']);
         }
@@ -357,6 +360,11 @@ class MySQLSchemaManager extends AbstractSchemaManager
         $table->addOption('create_options', $this->parseCreateOptions($tableOptions['CREATE_OPTIONS']));
 
         return $table;
+    }
+
+    public function createComparator(): Comparator
+    {
+        return new MySQL\Comparator($this->getDatabasePlatform());
     }
 
     /**

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -22,6 +22,8 @@ use const CASE_LOWER;
 
 /**
  * Schema manager for the MySQL RDBMS.
+ *
+ * @extends AbstractSchemaManager<MySQLPlatform>
  */
 class MySQLSchemaManager extends AbstractSchemaManager
 {
@@ -333,9 +335,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
     {
         $table = parent::listTableDetails($name);
 
-        $platform = $this->_platform;
-        assert($platform instanceof MySQLPlatform);
-        $sql = $platform->getListTableMetadataSQL($name);
+        $sql = $this->_platform->getListTableMetadataSQL($name);
 
         $tableOptions = $this->_conn->fetchAssociative($sql);
 

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
 use function array_values;
-use function assert;
 use function is_string;
 use function preg_match;
 use function str_replace;
@@ -20,6 +19,8 @@ use const CASE_LOWER;
 
 /**
  * Oracle Schema Manager.
+ *
+ * @extends AbstractSchemaManager<OraclePlatform>
  */
 class OracleSchemaManager extends AbstractSchemaManager
 {
@@ -277,8 +278,6 @@ class OracleSchemaManager extends AbstractSchemaManager
      */
     public function dropAutoincrement($table)
     {
-        assert($this->_platform instanceof OraclePlatform);
-
         $sql = $this->_platform->getDropAutoincrementSql($table);
         foreach ($sql as $query) {
             $this->_conn->executeStatement($query);
@@ -323,9 +322,7 @@ class OracleSchemaManager extends AbstractSchemaManager
     {
         $table = parent::listTableDetails($name);
 
-        $platform = $this->_platform;
-        assert($platform instanceof OraclePlatform);
-        $sql = $platform->getListTableCommentsSQL($name);
+        $sql = $this->_platform->getListTableCommentsSQL($name);
 
         $tableOptions = $this->_conn->fetchAssociative($sql);
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -30,6 +30,8 @@ use const CASE_LOWER;
 
 /**
  * PostgreSQL Schema Manager.
+ *
+ * @extends AbstractSchemaManager<PostgreSQL94Platform>
  */
 class PostgreSQLSchemaManager extends AbstractSchemaManager
 {
@@ -536,9 +538,7 @@ SQL
     {
         $table = parent::listTableDetails($name);
 
-        $platform = $this->_platform;
-        assert($platform instanceof PostgreSQL94Platform);
-        $sql = $platform->getListTableMetadataSQL($name);
+        $sql = $this->_platform->getListTableMetadataSQL($name);
 
         $tableOptions = $this->_conn->fetchAssociative($sql);
 

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -19,6 +19,8 @@ use function strtok;
 
 /**
  * SQL Server Schema Manager.
+ *
+ * @extends AbstractSchemaManager<SQLServer2012Platform>
  */
 class SQLServerSchemaManager extends AbstractSchemaManager
 {
@@ -315,9 +317,7 @@ SQL
     {
         $table = parent::listTableDetails($name);
 
-        $platform = $this->_platform;
-        assert($platform instanceof SQLServer2012Platform);
-        $sql = $platform->getListTableMetadataSQL($name);
+        $sql = $this->_platform->getListTableMetadataSQL($name);
 
         $tableOptions = $this->_conn->fetchAssociative($sql);
 

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\SQLServer;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
@@ -24,6 +25,9 @@ use function strtok;
  */
 class SQLServerSchemaManager extends AbstractSchemaManager
 {
+    /** @var string|null */
+    private $databaseCollation;
+
     /**
      * {@inheritDoc}
      */
@@ -326,5 +330,33 @@ SQL
         }
 
         return $table;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function createComparator(): Comparator
+    {
+        return new SQLServer\Comparator($this->getDatabasePlatform(), $this->getDatabaseCollation());
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function getDatabaseCollation(): string
+    {
+        if ($this->databaseCollation === null) {
+            $databaseCollation = $this->_conn->fetchOne(
+                'SELECT collation_name FROM sys.databases WHERE name = '
+                . $this->_platform->getCurrentDatabaseExpression(),
+            );
+
+            // a database is always selected, even if omitted in the connection parameters
+            assert(is_string($databaseCollation));
+
+            $this->databaseCollation = $databaseCollation;
+        }
+
+        return $this->databaseCollation;
     }
 }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -431,6 +431,8 @@ class Schema extends AbstractAsset
     }
 
     /**
+     * @deprecated
+     *
      * @return string[]
      *
      * @throws SchemaException
@@ -443,6 +445,8 @@ class Schema extends AbstractAsset
     }
 
     /**
+     * @deprecated
+     *
      * @return string[]
      *
      * @throws SchemaException

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\SQLite;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
@@ -570,5 +571,10 @@ SQL
         }
 
         return $table;
+    }
+
+    public function createComparator(): Comparator
+    {
+        return new SQLite\Comparator($this->getDatabasePlatform());
     }
 }

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
@@ -32,6 +33,8 @@ use const CASE_LOWER;
 
 /**
  * Sqlite SchemaManager.
+ *
+ * @extends AbstractSchemaManager<SqlitePlatform>
  */
 class SqliteSchemaManager extends AbstractSchemaManager
 {

--- a/tests/Driver/AbstractDB2DriverTest.php
+++ b/tests/Driver/AbstractDB2DriverTest.php
@@ -12,6 +12,9 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
 
+/**
+ * @extends AbstractDriverTest<DB2Platform>
+ */
 class AbstractDB2DriverTest extends AbstractDriverTest
 {
     protected function createDriver(): Driver

--- a/tests/Driver/AbstractDriverTest.php
+++ b/tests/Driver/AbstractDriverTest.php
@@ -16,6 +16,9 @@ use ReflectionProperty;
 use function get_class;
 use function sprintf;
 
+/**
+ * @template P of AbstractPlatform
+ */
 abstract class AbstractDriverTest extends TestCase
 {
     /**
@@ -111,6 +114,8 @@ abstract class AbstractDriverTest extends TestCase
      *
      * The platform instance returned by this method must be the same as returned by
      * the driver's getDatabasePlatform() method.
+     *
+     * @return P
      */
     abstract protected function createPlatform(): AbstractPlatform;
 

--- a/tests/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Driver/AbstractMySQLDriverTest.php
@@ -15,6 +15,9 @@ use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 
+/**
+ * @extends AbstractDriverTest<MySQLPlatform>
+ */
 class AbstractMySQLDriverTest extends AbstractDriverTest
 {
     protected function createDriver(): Driver

--- a/tests/Driver/AbstractOracleDriverTest.php
+++ b/tests/Driver/AbstractOracleDriverTest.php
@@ -12,6 +12,9 @@ use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\OracleSchemaManager;
 
+/**
+ * @extends AbstractDriverTest<OraclePlatform>
+ */
 class AbstractOracleDriverTest extends AbstractDriverTest
 {
     protected function createDriver(): Driver

--- a/tests/Driver/AbstractPostgreSQLDriverTest.php
+++ b/tests/Driver/AbstractPostgreSQLDriverTest.php
@@ -13,6 +13,9 @@ use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 
+/**
+ * @extends AbstractDriverTest<PostgreSQL94Platform>
+ */
 class AbstractPostgreSQLDriverTest extends AbstractDriverTest
 {
     protected function createDriver(): Driver

--- a/tests/Driver/AbstractSQLServerDriverTest.php
+++ b/tests/Driver/AbstractSQLServerDriverTest.php
@@ -11,6 +11,9 @@ use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 
+/**
+ * @extends AbstractDriverTest<SQLServer2012Platform>
+ */
 abstract class AbstractSQLServerDriverTest extends AbstractDriverTest
 {
     protected function createPlatform(): AbstractPlatform

--- a/tests/Driver/AbstractSQLiteDriverTest.php
+++ b/tests/Driver/AbstractSQLiteDriverTest.php
@@ -12,6 +12,9 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\SqliteSchemaManager;
 
+/**
+ * @extends AbstractDriverTest<SqlitePlatform>
+ */
 class AbstractSQLiteDriverTest extends AbstractDriverTest
 {
     protected function createDriver(): Driver

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -33,7 +33,9 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
     public function testAlterPrimaryKeyToAutoIncrementColumn(): void
     {
         $schemaManager = $this->connection->getSchemaManager();
-        $schema        = $schemaManager->createSchema();
+        $schemaManager->tryMethod('dropTable', 'dbal2807');
+
+        $schema = $schemaManager->createSchema();
 
         $table = $schema->createTable('dbal2807');
         $table->addColumn('initial_id', 'integer');

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tests\Functional\Platform;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
@@ -29,8 +30,12 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
      * Before the fix for this problem this resulted in a database error: (at least on mysql)
      * SQLSTATE[42000]: Syntax error or access violation: 1075 Incorrect table definition; there can be only one auto
      * column and it must be defined as a key
+     *
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
      */
-    public function testAlterPrimaryKeyToAutoIncrementColumn(): void
+    public function testAlterPrimaryKeyToAutoIncrementColumn(callable $comparatorFactory): void
     {
         $schemaManager = $this->connection->getSchemaManager();
         $schemaManager->tryMethod('dropTable', 'dbal2807');
@@ -49,11 +54,10 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
         $newTable->dropPrimaryKey();
         $newTable->setPrimaryKey(['new_id']);
 
-        $diff = (new Comparator())->compare($schema, $newSchema);
+        $diff = $comparatorFactory($schemaManager)
+            ->compare($schema, $newSchema);
 
-        foreach ($diff->toSql($this->getPlatform()) as $sql) {
-            $this->connection->executeStatement($sql);
-        }
+        $schemaManager->alterSchema($diff);
 
         $validationSchema = $schemaManager->createSchema();
         $validationTable  = $validationSchema->getTable($table->getName());

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -9,28 +9,27 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
+use function array_merge;
+
 class ComparatorTest extends FunctionalTestCase
 {
     /** @var AbstractSchemaManager */
     private $schemaManager;
-
-    /** @var Comparator */
-    private $comparator;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->schemaManager = $this->connection->getSchemaManager();
-        $this->comparator    = new Comparator();
     }
 
     /**
-     * @param mixed $value
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     * @param mixed                                      $value
      *
      * @dataProvider defaultValueProvider
      */
-    public function testDefaultValueComparison(string $type, $value): void
+    public function testDefaultValueComparison(callable $comparatorFactory, string $type, $value): void
     {
         $table = new Table('default_value');
         $table->addColumn('test', $type, ['default' => $value]);
@@ -39,17 +38,23 @@ class ComparatorTest extends FunctionalTestCase
 
         $onlineTable = $this->schemaManager->listTableDetails('default_value');
 
-        self::assertFalse($this->comparator->diffTable($table, $onlineTable));
+        self::assertFalse($comparatorFactory($this->schemaManager)->diffTable($table, $onlineTable));
     }
 
     /**
-     * @return mixed[][]
+     * @return iterable<mixed[]>
      */
     public static function defaultValueProvider(): iterable
     {
-        return [
-            ['integer', 1],
-            ['boolean', false],
-        ];
+        foreach (ComparatorTestUtils::comparatorProvider() as $comparatorArguments) {
+            foreach (
+                [
+                    ['integer', 1],
+                    ['boolean', false],
+                ] as $testArguments
+            ) {
+                yield array_merge($comparatorArguments, $testArguments);
+            }
+        }
     }
 }

--- a/tests/Functional/Schema/ComparatorTestUtils.php
+++ b/tests/Functional/Schema/ComparatorTestUtils.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Schema;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
+use PHPUnit\Framework\TestCase;
+
+final class ComparatorTestUtils
+{
+    /**
+     * @return TableDiff|false
+     *
+     * @throws Exception
+     */
+    public static function diffOnlineAndOfflineTable(
+        AbstractSchemaManager $schemaManager,
+        Comparator $comparator,
+        Table $table
+    ) {
+        return $comparator->diffTable(
+            $schemaManager->listTableDetails($table->getName()),
+            $table
+        );
+    }
+
+    public static function assertDiffNotEmpty(Connection $connection, Comparator $comparator, Table $table): void
+    {
+        $schemaManager = $connection->createSchemaManager();
+
+        $diff = self::diffOnlineAndOfflineTable($schemaManager, $comparator, $table);
+
+        TestCase::assertNotFalse($diff);
+
+        $schemaManager->alterTable($diff);
+
+        TestCase::assertFalse(self::diffOnlineAndOfflineTable($schemaManager, $comparator, $table));
+    }
+
+    /**
+     * @return iterable<string,array<callable(AbstractSchemaManager):Comparator>>
+     */
+    public static function comparatorProvider(): iterable
+    {
+        yield 'Generic comparator' => [
+            static function (): Comparator {
+                return new Comparator();
+            },
+        ];
+
+        yield 'Platform-specific comparator' => [
+            static function (AbstractSchemaManager $schemaManager): Comparator {
+                return $schemaManager->createComparator();
+            },
+        ];
+    }
+}

--- a/tests/Functional/Schema/MySQL/ComparatorTest.php
+++ b/tests/Functional/Schema/MySQL/ComparatorTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Schema\MySQL;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+
+final class ComparatorTest extends FunctionalTestCase
+{
+    /** @var AbstractPlatform */
+    private $platform;
+
+    /** @var AbstractSchemaManager */
+    private $schemaManager;
+
+    /** @var Comparator */
+    private $comparator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->platform = $this->connection->getDatabasePlatform();
+
+        if (! $this->platform instanceof MySQLPlatform) {
+            self::markTestSkipped();
+        }
+
+        $this->schemaManager = $this->connection->createSchemaManager();
+        $this->comparator    = $this->schemaManager->createComparator();
+    }
+
+    /**
+     * @dataProvider lobColumnProvider
+     */
+    public function testLobLengthIncrementWithinLimit(string $type, int $length): void
+    {
+        $table = $this->createLobTable($type, $length - 1);
+        $this->increaseLobLength($table);
+
+        self::assertFalse(ComparatorTestUtils::diffOnlineAndOfflineTable(
+            $this->schemaManager,
+            $this->comparator,
+            $table
+        ));
+    }
+
+    /**
+     * @dataProvider lobColumnProvider
+     */
+    public function testLobLengthIncrementOverLimit(string $type, int $length): void
+    {
+        $table = $this->createLobTable($type, $length);
+        $this->increaseLobLength($table);
+        ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
+    }
+
+    /**
+     * @return iterable<array{string,int}>
+     */
+    public static function lobColumnProvider(): iterable
+    {
+        yield [Types::BLOB, MySQLPlatform::LENGTH_LIMIT_TINYBLOB];
+        yield [Types::BLOB, MySQLPlatform::LENGTH_LIMIT_BLOB];
+        yield [Types::BLOB, MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB];
+
+        yield [Types::TEXT, MySQLPlatform::LENGTH_LIMIT_TINYTEXT];
+        yield [Types::TEXT, MySQLPlatform::LENGTH_LIMIT_TEXT];
+        yield [Types::TEXT, MySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT];
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function createLobTable(string $type, int $length): Table
+    {
+        $table = new Table('comparator_test');
+        $table->addColumn('lob', $type)->setLength($length);
+
+        $this->schemaManager->dropAndCreateTable($table);
+
+        return $table;
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function increaseLobLength(Table $table): void
+    {
+        $column = $table->getColumn('lob');
+        $column->setLength($column->getLength() + 1);
+    }
+
+    public function testExplicitDefaultCollation(): void
+    {
+        [$table, $column] = $this->createCollationTable();
+        $column->setPlatformOption('collation', 'utf8mb4_general_ci');
+
+        self::assertFalse(ComparatorTestUtils::diffOnlineAndOfflineTable(
+            $this->schemaManager,
+            $this->comparator,
+            $table
+        ));
+    }
+
+    public function testChangeColumnCharsetAndCollation(): void
+    {
+        [$table, $column] = $this->createCollationTable();
+        $column->setPlatformOption('charset', 'utf8');
+        $column->setPlatformOption('collation', 'utf8_bin');
+
+        ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
+    }
+
+    public function testChangeColumnCollation(): void
+    {
+        [$table, $column] = $this->createCollationTable();
+        $column->setPlatformOption('collation', 'utf8mb4_bin');
+
+        ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
+    }
+
+    /**
+     * @return array{Table,Column}
+     *
+     * @throws Exception
+     */
+    private function createCollationTable(): array
+    {
+        $table = new Table('comparator_test');
+        $table->addOption('charset', 'utf8mb4');
+        $table->addOption('collate', 'utf8mb4_general_ci');
+        $column = $table->addColumn('id', Types::STRING);
+        $this->schemaManager->dropAndCreateTable($table);
+
+        return [$table, $column];
+    }
+}

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -6,7 +6,6 @@ use DateTime;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
-use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Functional\Schema\MySQL\PointType;
@@ -44,7 +43,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableNew     = clone $tableFetched;
         $tableNew->setPrimaryKey(['bar_id', 'foo_id']);
 
-        $diff = (new Comparator())->diffTable($tableFetched, $tableNew);
+        $diff = $this->schemaManager->createComparator()
+            ->diffTable($tableFetched, $tableNew);
         self::assertNotFalse($diff);
 
         $this->schemaManager->alterTable($diff);
@@ -74,7 +74,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->schemaManager->createTable($table);
         $tableFetched = $this->schemaManager->listTableDetails('diffbug_routing_translations');
 
-        $diff = (new Comparator())->diffTable($tableFetched, $table);
+        $diff = $this->schemaManager->createComparator()
+            ->diffTable($tableFetched, $table);
 
         self::assertFalse($diff, 'no changes expected.');
     }
@@ -141,7 +142,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $diffTable->dropIndex('idx_id');
         $diffTable->setPrimaryKey(['id']);
 
-        $diff = (new Comparator())->diffTable($table, $diffTable);
+        $diff = $this->schemaManager->createComparator()
+            ->diffTable($table, $diffTable);
         self::assertNotFalse($diff);
 
         $this->schemaManager->alterTable($diff);
@@ -165,7 +167,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $diffTable->dropPrimaryKey();
 
-        $diff = (new Comparator())->diffTable($table, $diffTable);
+        $diff = $this->schemaManager->createComparator()
+            ->diffTable($table, $diffTable);
         self::assertNotFalse($diff);
 
         $this->schemaManager->alterTable($diff);
@@ -201,7 +204,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertNull($onlineTable->getColumn('def_blob_null')->getDefault());
         self::assertFalse($onlineTable->getColumn('def_blob_null')->getNotnull());
 
-        $diff = (new Comparator())->diffTable($table, $onlineTable);
+        $diff = $this->schemaManager->createComparator()
+            ->diffTable($table, $onlineTable);
         self::assertNotFalse($diff);
 
         $this->schemaManager->alterTable($diff);
@@ -245,7 +249,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $diffTable = clone $table;
         $diffTable->getColumn('col_text')->setPlatformOption('charset', 'ascii');
 
-        $diff = (new Comparator())->diffTable($table, $diffTable);
+        $diff = $this->schemaManager->createComparator()
+            ->diffTable($table, $diffTable);
         self::assertNotFalse($diff);
 
         $this->schemaManager->alterTable($diff);
@@ -363,10 +368,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $onlineTable = $this->schemaManager->listTableDetails('list_guid_table_column');
 
-        $comparator = new Comparator();
-
         self::assertFalse(
-            $comparator->diffTable($offlineTable, $onlineTable),
+            $this->schemaManager->createComparator()->diffTable($onlineTable, $offlineTable),
             'No differences should be detected with the offline vs online schema.'
         );
     }
@@ -435,9 +438,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertSame($currentTimeStampSql, $onlineTable->getColumn('col_datetime')->getDefault());
         self::assertSame($currentTimeStampSql, $onlineTable->getColumn('col_datetime_nullable')->getDefault());
 
-        $comparator = new Comparator();
-
-        $diff = $comparator->diffTable($table, $onlineTable);
+        $diff = $this->schemaManager->createComparator()->diffTable($table, $onlineTable);
         self::assertFalse($diff, 'Tables should be identical with column defaults.');
     }
 
@@ -511,9 +512,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertSame($currentDateSql, $onlineTable->getColumn('col_date')->getDefault());
         self::assertSame($currentTimeSql, $onlineTable->getColumn('col_time')->getDefault());
 
-        $comparator = new Comparator();
-
-        $diff = $comparator->diffTable($table, $onlineTable);
+        $diff = $this->schemaManager->createComparator()->diffTable($table, $onlineTable);
         self::assertFalse($diff, 'Tables should be identical with column defauts time and date.');
     }
 

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -83,9 +83,12 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testAlterTableAutoIncrementAdd(): void
     {
+        // see https://github.com/doctrine/dbal/issues/4745
+        $this->schemaManager->tryMethod('dropSequence', 'autoinc_table_add_id_seq');
+
         $tableFrom = new Table('autoinc_table_add');
         $tableFrom->addColumn('id', 'integer');
-        $this->schemaManager->createTable($tableFrom);
+        $this->schemaManager->dropAndCreateTable($tableFrom);
         $tableFrom = $this->schemaManager->listTableDetails('autoinc_table_add');
         self::assertFalse($tableFrom->getColumn('id')->getAutoincrement());
 
@@ -113,7 +116,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableFrom = new Table('autoinc_table_drop');
         $column    = $tableFrom->addColumn('id', 'integer');
         $column->setAutoincrement(true);
-        $this->schemaManager->createTable($tableFrom);
+        $this->schemaManager->dropAndCreateTable($tableFrom);
         $tableFrom = $this->schemaManager->listTableDetails('autoinc_table_drop');
         self::assertTrue($tableFrom->getColumn('id')->getAutoincrement());
 
@@ -273,7 +276,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('id', 'integer');
         $table->addColumn('checked', 'boolean', ['default' => false]);
 
-        $this->schemaManager->createTable($table);
+        $this->schemaManager->dropAndCreateTable($table);
 
         $databaseTable = $this->schemaManager->listTableDetails($table->getName());
 

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -4,18 +4,20 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
-use Doctrine\DBAL\Schema;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Schema\View;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\DecimalType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_map;
+use function array_merge;
 use function array_pop;
 use function array_unshift;
 use function assert;
@@ -81,7 +83,12 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($autoincTable->getColumn('id')->getAutoincrement());
     }
 
-    public function testAlterTableAutoIncrementAdd(): void
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
+     */
+    public function testAlterTableAutoIncrementAdd(callable $comparatorFactory): void
     {
         // see https://github.com/doctrine/dbal/issues/4745
         $this->schemaManager->tryMethod('dropSequence', 'autoinc_table_add_id_seq');
@@ -96,10 +103,11 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $column  = $tableTo->addColumn('id', 'integer');
         $column->setAutoincrement(true);
 
-        $diff = (new Comparator())->diffTable($tableFrom, $tableTo);
+        $platform = $this->schemaManager->getDatabasePlatform();
+        $diff     = $comparatorFactory($this->schemaManager)->diffTable($tableFrom, $tableTo);
         self::assertNotFalse($diff);
 
-        $sql = $this->connection->getDatabasePlatform()->getAlterTableSQL($diff);
+        $sql = $platform->getAlterTableSQL($diff);
         self::assertEquals([
             'CREATE SEQUENCE autoinc_table_add_id_seq',
             "SELECT setval('autoinc_table_add_id_seq', (SELECT MAX(id) FROM autoinc_table_add))",
@@ -111,7 +119,12 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($tableFinal->getColumn('id')->getAutoincrement());
     }
 
-    public function testAlterTableAutoIncrementDrop(): void
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
+     */
+    public function testAlterTableAutoIncrementDrop(callable $comparatorFactory): void
     {
         $tableFrom = new Table('autoinc_table_drop');
         $column    = $tableFrom->addColumn('id', 'integer');
@@ -123,12 +136,13 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableTo = new Table('autoinc_table_drop');
         $tableTo->addColumn('id', 'integer');
 
-        $diff = (new Comparator())->diffTable($tableFrom, $tableTo);
+        $platform = $this->schemaManager->getDatabasePlatform();
+        $diff     = $comparatorFactory($this->schemaManager)->diffTable($tableFrom, $tableTo);
         self::assertNotFalse($diff);
 
         self::assertEquals(
             ['ALTER TABLE autoinc_table_drop ALTER id DROP DEFAULT'],
-            $this->connection->getDatabasePlatform()->getAlterTableSQL($diff)
+            $platform->getAlterTableSQL($diff)
         );
 
         $this->schemaManager->alterTable($diff);
@@ -270,7 +284,12 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('foo', $databaseTable->getColumn('def')->getDefault());
     }
 
-    public function testBooleanDefault(): void
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
+     */
+    public function testBooleanDefault(callable $comparatorFactory): void
     {
         $table = new Table('ddc2843_bools');
         $table->addColumn('id', 'integer');
@@ -280,8 +299,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $databaseTable = $this->schemaManager->listTableDetails($table->getName());
 
-        $c    = new Comparator();
-        $diff = $c->diffTable($table, $databaseTable);
+        $diff = $comparatorFactory($this->schemaManager)->diffTable($table, $databaseTable);
 
         self::assertFalse($diff);
     }
@@ -309,7 +327,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testListQuotedTable(): void
     {
-        $offlineTable = new Schema\Table('user');
+        $offlineTable = new Table('user');
         $offlineTable->addColumn('id', 'integer');
         $offlineTable->addColumn('username', 'string');
         $offlineTable->addColumn('fk', 'integer');
@@ -320,7 +338,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $onlineTable = $this->schemaManager->listTableDetails('"user"');
 
-        $comparator = new Schema\Comparator();
+        $comparator = new Comparator();
 
         self::assertFalse($comparator->diffTable($offlineTable, $onlineTable));
     }
@@ -344,7 +362,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $name = 'list_tables_excludes_views_test_view';
         $sql  = 'SELECT * from list_tables_excludes_views';
 
-        $view = new Schema\View($name, $sql);
+        $view = new View($name, $sql);
 
         $this->schemaManager->dropAndCreateView($view);
 
@@ -365,7 +383,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testPartialIndexes(): void
     {
-        $offlineTable = new Schema\Table('person');
+        $offlineTable = new Table('person');
         $offlineTable->addColumn('id', 'integer');
         $offlineTable->addColumn('name', 'string');
         $offlineTable->addColumn('email', 'string');
@@ -375,7 +393,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $onlineTable = $this->schemaManager->listTableDetails('person');
 
-        $comparator = new Schema\Comparator();
+        $comparator = new Comparator();
 
         self::assertFalse($comparator->diffTable($offlineTable, $onlineTable));
         self::assertTrue($onlineTable->hasIndex('simple_partial_index'));
@@ -391,7 +409,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
             return;
         }
 
-        $table = new Schema\Table('test_jsonb');
+        $table = new Table('test_jsonb');
         $table->addColumn('foo', Types::JSON)->setPlatformOption('jsonb', true);
         $this->schemaManager->dropAndCreateTable($table);
 
@@ -403,7 +421,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testListNegativeColumnDefaultValue(): void
     {
-        $table = new Schema\Table('test_default_negative');
+        $table = new Table('test_default_negative');
         $table->addColumn('col_smallint', 'smallint', ['default' => -1]);
         $table->addColumn('col_integer', 'integer', ['default' => -1]);
         $table->addColumn('col_bigint', 'bigint', ['default' => -1]);
@@ -441,7 +459,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $tableName = 'test_serial_type_' . $type;
 
-        $table = new Schema\Table($tableName);
+        $table = new Table($tableName);
         $table->addColumn('id', $type, ['autoincrement' => true, 'notnull' => false]);
 
         $this->schemaManager->dropAndCreateTable($table);
@@ -458,7 +476,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $tableName = 'test_serial_type_with_default_' . $type;
 
-        $table = new Schema\Table($tableName);
+        $table = new Table($tableName);
         $table->addColumn('id', $type, ['autoincrement' => true, 'notnull' => false, 'default' => 1]);
 
         $this->schemaManager->dropAndCreateTable($table);
@@ -469,10 +487,16 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     }
 
     /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
      * @dataProvider autoIncrementTypeMigrations
      */
-    public function testAlterTableAutoIncrementIntToBigInt(string $from, string $to, string $expected): void
-    {
+    public function testAlterTableAutoIncrementIntToBigInt(
+        callable $comparatorFactory,
+        string $from,
+        string $to,
+        string $expected
+    ): void {
         $tableFrom = new Table('autoinc_type_modification');
         $column    = $tableFrom->addColumn('id', $from);
         $column->setAutoincrement(true);
@@ -484,8 +508,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $column  = $tableTo->addColumn('id', $to);
         $column->setAutoincrement(true);
 
-        $c    = new Comparator();
-        $diff = $c->diffTable($tableFrom, $tableTo);
+        $diff = $comparatorFactory($this->schemaManager)->diffTable($tableFrom, $tableTo);
         self::assertInstanceOf(TableDiff::class, $diff);
         self::assertSame(
             ['ALTER TABLE autoinc_type_modification ALTER id TYPE ' . $expected],
@@ -498,14 +521,20 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     }
 
     /**
-     * @return mixed[][]
+     * @return iterable<mixed[]>
      */
     public static function autoIncrementTypeMigrations(): iterable
     {
-        return [
-            'int->bigint' => ['integer', 'bigint', 'BIGINT'],
-            'bigint->int' => ['bigint', 'integer', 'INT'],
-        ];
+        foreach (ComparatorTestUtils::comparatorProvider() as $comparatorArguments) {
+            foreach (
+                [
+                    'int -> bigint' => ['integer', 'bigint', 'BIGINT'],
+                    'bigint -> int' => ['bigint', 'integer', 'INT'],
+                ] as $testArguments
+            ) {
+                yield array_merge($comparatorArguments, $testArguments);
+            }
+        }
     }
 }
 

--- a/tests/Functional/Schema/SQLite/ComparatorTest.php
+++ b/tests/Functional/Schema/SQLite/ComparatorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Schema\SQLite;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+
+final class ComparatorTest extends FunctionalTestCase
+{
+    /** @var AbstractPlatform */
+    private $platform;
+
+    /** @var AbstractSchemaManager */
+    private $schemaManager;
+
+    /** @var Comparator */
+    private $comparator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->platform = $this->connection->getDatabasePlatform();
+
+        if (! $this->platform instanceof SqlitePlatform) {
+            self::markTestSkipped();
+        }
+
+        $this->schemaManager = $this->connection->createSchemaManager();
+        $this->comparator    = $this->schemaManager->createComparator();
+    }
+
+    public function testChangeTableCollation(): void
+    {
+        $table  = new Table('comparator_test');
+        $column = $table->addColumn('id', Types::STRING);
+        $this->schemaManager->dropAndCreateTable($table);
+
+        $column->setPlatformOption('collation', 'NOCASE');
+        ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
+    }
+}

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -716,6 +716,9 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $tableFK->addIndex(['fk_id'], 'fk_idx');
         $tableFK->addForeignKeyConstraint('test_fk_base', ['fk_id'], ['id']);
 
+        $this->schemaManager->tryMethod('dropTable', $tableFK);
+        $this->schemaManager->tryMethod('dropTable', $table);
+
         $this->schemaManager->createTable($table);
         $this->schemaManager->createTable($tableFK);
 
@@ -761,8 +764,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             'fk_constraint'
         );
 
-        $this->schemaManager->dropAndCreateTable($primaryTable);
-        $this->schemaManager->dropAndCreateTable($foreignTable);
+        $this->schemaManager->tryMethod('dropTable', $foreignTable);
+        $this->schemaManager->tryMethod('dropTable', $primaryTable);
+
+        $this->schemaManager->createTable($primaryTable);
+        $this->schemaManager->createTable($foreignTable);
 
         $foreignTable2 = clone $foreignTable;
         $foreignTable2->renameIndex('rename_index_fk_idx', 'renamed_index_fk_idx');
@@ -1281,6 +1287,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             self::markTestSkipped('This test is only supported on platforms that have native JSON type.');
         }
 
+        $this->schemaManager->tryMethod('dropTable', 'json_test');
         $this->connection->executeQuery('CREATE TABLE json_test (parameters JSON NOT NULL)');
 
         $table = new Table('json_test');

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -33,6 +33,7 @@ use Doctrine\DBAL\Types\Type;
 use function array_filter;
 use function array_keys;
 use function array_map;
+use function array_merge;
 use function array_search;
 use function array_values;
 use function count;
@@ -359,11 +360,16 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->schemaManager->listTableIndexes('list_table_indexes_test');
     }
 
-    public function testDiffListTableColumns(): void
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
+     */
+    public function testDiffListTableColumns(callable $comparatorFactory): void
     {
         if ($this->schemaManager->getDatabasePlatform()->getName() === 'oracle') {
             self::markTestSkipped(
-                'Does not work with Oracle, since it cannot detect DateTime, Date and Time differenecs (at the moment).'
+                'Does not work with Oracle, since it cannot detect DateTime, Date and Time differences (at the moment).'
             );
         }
 
@@ -371,8 +377,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->schemaManager->dropAndCreateTable($offlineTable);
         $onlineTable = $this->schemaManager->listTableDetails('list_table_columns');
 
-        $comparator = new Comparator();
-        $diff       = $comparator->diffTable($offlineTable, $onlineTable);
+        $diff = $comparatorFactory($this->schemaManager)->diffTable($onlineTable, $offlineTable);
 
         self::assertFalse($diff, 'No differences should be detected with the offline vs online schema.');
     }
@@ -698,9 +703,16 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertFalse($inferredTable->getColumn('id')->getAutoincrement());
     }
 
-    public function testUpdateSchemaWithForeignKeyRenaming(): void
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
+     */
+    public function testUpdateSchemaWithForeignKeyRenaming(callable $comparatorFactory): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+        $platform = $this->schemaManager->getDatabasePlatform();
+
+        if (! $platform->supportsForeignKeyConstraints()) {
             self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
         }
 
@@ -730,7 +742,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $tableFKNew->addIndex(['rename_fk_id'], 'fk_idx');
         $tableFKNew->addForeignKeyConstraint('test_fk_base', ['rename_fk_id'], ['id']);
 
-        $diff = (new Comparator())->diffTable($tableFK, $tableFKNew);
+        $diff = $comparatorFactory($this->schemaManager)->diffTable($tableFK, $tableFKNew);
         self::assertNotFalse($diff);
 
         $this->schemaManager->alterTable($diff);
@@ -743,9 +755,16 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertSame(['rename_fk_id'], array_map('strtolower', current($foreignKeys)->getColumns()));
     }
 
-    public function testRenameIndexUsedInForeignKeyConstraint(): void
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
+     */
+    public function testRenameIndexUsedInForeignKeyConstraint(callable $comparatorFactory): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+        $platform = $this->schemaManager->getDatabasePlatform();
+
+        if (! $platform->supportsForeignKeyConstraints()) {
             self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
         }
 
@@ -773,7 +792,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $foreignTable2 = clone $foreignTable;
         $foreignTable2->renameIndex('rename_index_fk_idx', 'renamed_index_fk_idx');
 
-        $diff = (new Comparator())->diffTable($foreignTable, $foreignTable2);
+        $diff = $comparatorFactory($this->schemaManager)->diffTable($foreignTable, $foreignTable2);
         self::assertNotFalse($diff);
 
         $this->schemaManager->alterTable($diff);
@@ -1018,7 +1037,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals(['id', 'other_id'], array_map('strtolower', $fkeys[0]->getForeignColumns()));
     }
 
-    public function testColumnDefaultLifecycle(): void
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
+     */
+    public function testColumnDefaultLifecycle(callable $comparatorFactory): void
     {
         $table = new Table('col_def_lifecycle');
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
@@ -1054,7 +1078,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $diffTable->changeColumn('column6', ['default' => 666]);
         $diffTable->changeColumn('column7', ['default' => null]);
 
-        $diff = (new Comparator())->diffTable($table, $diffTable);
+        $diff = $comparatorFactory($this->schemaManager)->diffTable($table, $diffTable);
         self::assertNotFalse($diff);
 
         $this->schemaManager->alterTable($diff);
@@ -1182,18 +1206,23 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     }
 
     /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
      * @dataProvider getAlterColumnComment
      */
     public function testAlterColumnComment(
+        callable $comparatorFactory,
         ?string $comment1,
         ?string $expectedComment1,
         ?string $comment2,
         ?string $expectedComment2
     ): void {
+        $platform = $this->schemaManager->getDatabasePlatform();
+
         if (
-            ! $this->connection->getDatabasePlatform()->supportsInlineColumnComments() &&
-            ! $this->connection->getDatabasePlatform()->supportsCommentOnStatement() &&
-            $this->connection->getDatabasePlatform()->getName() !== 'mssql'
+            ! $platform->supportsInlineColumnComments() &&
+            ! $platform->supportsCommentOnStatement() &&
+            $platform->getName() !== 'mssql'
         ) {
             self::markTestSkipped('Database does not support column comments.');
         }
@@ -1217,9 +1246,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $onlineTable->changeColumn('no_comment1', ['comment' => $comment1]);
         $onlineTable->changeColumn('no_comment2', ['comment' => $comment2]);
 
-        $comparator = new Comparator();
-
-        $tableDiff = $comparator->diffTable($offlineTable, $onlineTable);
+        $tableDiff = $comparatorFactory($this->schemaManager)->diffTable($offlineTable, $onlineTable);
 
         self::assertInstanceOf(TableDiff::class, $tableDiff);
 
@@ -1234,24 +1261,30 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     }
 
     /**
-     * @return mixed[][]
+     * @return iterable<mixed[]>
      */
     public static function getAlterColumnComment(): iterable
     {
-        return [
-            [null, null, ' ', ' '],
-            [null, null, '0', '0'],
-            [null, null, 'foo', 'foo'],
+        foreach (ComparatorTestUtils::comparatorProvider() as $comparatorArguments) {
+            foreach (
+                [
+                    [null, null, ' ', ' '],
+                    [null, null, '0', '0'],
+                    [null, null, 'foo', 'foo'],
 
-            ['', null, ' ', ' '],
-            ['', null, '0', '0'],
-            ['', null, 'foo', 'foo'],
+                    ['', null, ' ', ' '],
+                    ['', null, '0', '0'],
+                    ['', null, 'foo', 'foo'],
 
-            [' ', ' ', '0', '0'],
-            [' ', ' ', 'foo', 'foo'],
+                    [' ', ' ', '0', '0'],
+                    [' ', ' ', 'foo', 'foo'],
 
-            ['0', '0', 'foo', 'foo'],
-        ];
+                    ['0', '0', 'foo', 'foo'],
+                ] as $testArguments
+            ) {
+                yield array_merge($comparatorArguments, $testArguments);
+            }
+        }
     }
 
     public function testDoesNotListIndexesImplicitlyCreatedByForeignKeys(): void
@@ -1281,9 +1314,16 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertArrayHasKey('idx_3d6c147fdc58d6c', $indexes);
     }
 
-    public function testComparatorShouldNotAddCommentToJsonTypeSinceItIsTheDefaultNow(): void
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
+     */
+    public function testComparatorShouldNotAddCommentToJsonTypeSinceItIsTheDefaultNow(callable $comparatorFactory): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->hasNativeJsonType()) {
+        $platform = $this->schemaManager->getDatabasePlatform();
+
+        if (! $platform->hasNativeJsonType()) {
             self::markTestSkipped('This test is only supported on platforms that have native JSON type.');
         }
 
@@ -1293,8 +1333,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table = new Table('json_test');
         $table->addColumn('parameters', 'json');
 
-        $comparator = new Comparator();
-        $tableDiff  = $comparator->diffTable($this->schemaManager->listTableDetails('json_test'), $table);
+        $tableDiff = $comparatorFactory($this->schemaManager)
+            ->diffTable($this->schemaManager->listTableDetails('json_test'), $table);
 
         self::assertFalse($tableDiff);
     }
@@ -1362,9 +1402,16 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals($sequence2InitialValue, $actualSequence2->getInitialValue());
     }
 
-    public function testComparisonWithAutoDetectedSequenceDefinition(): void
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
+     */
+    public function testComparisonWithAutoDetectedSequenceDefinition(callable $comparatorFactory): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsSequences()) {
+        $platform = $this->schemaManager->getDatabasePlatform();
+
+        if (! $platform->supportsSequences()) {
             self::markTestSkipped('This test is only supported on platforms that support sequences.');
         }
 
@@ -1386,8 +1433,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         self::assertNotNull($createdSequence);
 
-        $comparator = new Comparator();
-        $tableDiff  = $comparator->diffSequence($createdSequence, $sequence);
+        $tableDiff = $comparatorFactory($this->schemaManager)->diffSequence($createdSequence, $sequence);
 
         self::assertFalse($tableDiff);
     }

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -5,8 +5,7 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\DBAL\Schema;
-use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Type;
@@ -73,21 +72,21 @@ EOS
         );
 
         $expected = [
-            new Schema\ForeignKeyConstraint(
+            new ForeignKeyConstraint(
                 ['log'],
                 'log',
                 [],
                 'FK_3',
                 ['onUpdate' => 'SET NULL', 'onDelete' => 'NO ACTION', 'deferrable' => false, 'deferred' => false]
             ),
-            new Schema\ForeignKeyConstraint(
+            new ForeignKeyConstraint(
                 ['parent'],
                 'user',
                 ['id'],
                 '1',
                 ['onUpdate' => 'NO ACTION', 'onDelete' => 'CASCADE', 'deferrable' => false, 'deferred' => false]
             ),
-            new Schema\ForeignKeyConstraint(
+            new ForeignKeyConstraint(
                 ['page'],
                 'page',
                 ['key'],
@@ -101,7 +100,7 @@ EOS
 
     public function testColumnCollation(): void
     {
-        $table = new Schema\Table('test_collation');
+        $table = new Table('test_collation');
         $table->addColumn('id', 'integer');
         $table->addColumn('text', 'text');
         $table->addColumn('foo', 'text')->setPlatformOption('collation', 'BINARY');
@@ -162,52 +161,9 @@ SQL;
         self::assertSame(100, $columns['bar']->getLength());
     }
 
-    /**
-     * @dataProvider getDiffListIntegerAutoincrementTableColumnsData
-     */
-    public function testDiffListIntegerAutoincrementTableColumns(
-        string $integerType,
-        bool $unsigned,
-        bool $expectedComparatorDiff
-    ): void {
-        $tableName = 'test_int_autoincrement_table';
-
-        $offlineTable = new Table($tableName);
-        $offlineTable->addColumn('id', $integerType, ['autoincrement' => true, 'unsigned' => $unsigned]);
-        $offlineTable->setPrimaryKey(['id']);
-
-        $this->schemaManager->dropAndCreateTable($offlineTable);
-
-        $onlineTable = $this->schemaManager->listTableDetails($tableName);
-
-        $diff = (new Comparator())->diffTable($offlineTable, $onlineTable);
-
-        if ($expectedComparatorDiff) {
-            self::assertNotFalse($diff);
-            self::assertEmpty($this->schemaManager->getDatabasePlatform()->getAlterTableSQL($diff));
-        } else {
-            self::assertFalse($diff);
-        }
-    }
-
-    /**
-     * @return mixed[][]
-     */
-    public static function getDiffListIntegerAutoincrementTableColumnsData(): iterable
-    {
-        return [
-            ['smallint', false, true],
-            ['smallint', true, true],
-            ['integer', false, false],
-            ['integer', true, true],
-            ['bigint', false, true],
-            ['bigint', true, true],
-        ];
-    }
-
     public function testPrimaryKeyNoAutoIncrement(): void
     {
-        $table = new Schema\Table('test_pk_auto_increment');
+        $table = new Table('test_pk_auto_increment');
         $table->addColumn('id', 'integer');
         $table->addColumn('text', 'text');
         $table->setPrimaryKey(['id']);

--- a/tests/Functional/Ticket/DBAL461Test.php
+++ b/tests/Functional/Ticket/DBAL461Test.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\DBAL\Types\DecimalType;
 use PHPUnit\Framework\TestCase;
@@ -14,7 +14,7 @@ class DBAL461Test extends TestCase
     public function testIssue(): void
     {
         $conn     = $this->createMock(Connection::class);
-        $platform = $this->getMockForAbstractClass(AbstractPlatform::class);
+        $platform = $this->getMockForAbstractClass(SQLServer2012Platform::class);
         $platform->registerDoctrineTypeMapping('numeric', 'decimal');
 
         $schemaManager = new SQLServerSchemaManager($conn, $platform);

--- a/tests/Functional/Ticket/DBAL510Test.php
+++ b/tests/Functional/Ticket/DBAL510Test.php
@@ -25,7 +25,7 @@ class DBAL510Test extends FunctionalTestCase
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
 
-        $this->connection->getSchemaManager()->createTable($table);
+        $this->connection->getSchemaManager()->dropAndCreateTable($table);
 
         $onlineTable = $this->connection->getSchemaManager()->listTableDetails('dbal510tbl');
 

--- a/tests/Functional/Ticket/DBAL510Test.php
+++ b/tests/Functional/Ticket/DBAL510Test.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -19,17 +20,23 @@ class DBAL510Test extends FunctionalTestCase
         self::markTestSkipped('PostgreSQL Only test');
     }
 
-    public function testSearchPathSchemaChanges(): void
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
+     */
+    public function testSearchPathSchemaChanges(callable $comparatorFactory): void
     {
         $table = new Table('dbal510tbl');
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
 
-        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $schemaManager = $this->connection->getSchemaManager();
+        $schemaManager->dropAndCreateTable($table);
 
-        $onlineTable = $this->connection->getSchemaManager()->listTableDetails('dbal510tbl');
+        $onlineTable = $schemaManager->listTableDetails('dbal510tbl');
 
-        $comparator = new Comparator();
+        $comparator = $comparatorFactory($schemaManager);
         $diff       = $comparator->diffTable($onlineTable, $table);
 
         self::assertFalse($diff);

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Tests\Platforms;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySQL;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -172,7 +173,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         return 'ALTER TABLE test ADD FOREIGN KEY (fk_name_id) REFERENCES other_table (id)';
     }
 
-    public function testUniquePrimaryKey(): void
+    /**
+     * @dataProvider comparatorProvider
+     */
+    public function testUniquePrimaryKey(Comparator $comparator): void
     {
         $keyTable = new Table('foo');
         $keyTable->addColumn('bar', 'integer');
@@ -184,7 +188,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $oldTable->addColumn('bar', 'integer');
         $oldTable->addColumn('baz', 'string');
 
-        $diff = (new Comparator())->diffTable($oldTable, $keyTable);
+        $diff = $comparator->diffTable($oldTable, $keyTable);
         self::assertNotFalse($diff);
 
         $sql = $this->platform->getAlterTableSQL($diff);
@@ -377,7 +381,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertEquals('LONGBLOB', $this->platform->getBlobTypeDeclarationSQL([]));
     }
 
-    public function testAlterTableAddPrimaryKey(): void
+    /**
+     * @dataProvider comparatorProvider
+     */
+    public function testAlterTableAddPrimaryKey(Comparator $comparator): void
     {
         $table = new Table('alter_table_add_pk');
         $table->addColumn('id', 'integer');
@@ -389,7 +396,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $diffTable->dropIndex('idx_id');
         $diffTable->setPrimaryKey(['id']);
 
-        $diff = (new Comparator())->diffTable($table, $diffTable);
+        $diff = $comparator->diffTable($table, $diffTable);
         self::assertNotFalse($diff);
 
         self::assertEquals(
@@ -398,7 +405,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         );
     }
 
-    public function testAlterPrimaryKeyWithAutoincrementColumn(): void
+    /**
+     * @dataProvider comparatorProvider
+     */
+    public function testAlterPrimaryKeyWithAutoincrementColumn(Comparator $comparator): void
     {
         $table = new Table('alter_primary_key');
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
@@ -410,7 +420,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $diffTable->dropPrimaryKey();
         $diffTable->setPrimaryKey(['foo']);
 
-        $diff = (new Comparator())->diffTable($table, $diffTable);
+        $diff = $comparator->diffTable($table, $diffTable);
         self::assertNotFalse($diff);
 
         self::assertEquals(
@@ -423,7 +433,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         );
     }
 
-    public function testDropPrimaryKeyWithAutoincrementColumn(): void
+    /**
+     * @dataProvider comparatorProvider
+     */
+    public function testDropPrimaryKeyWithAutoincrementColumn(Comparator $comparator): void
     {
         $table = new Table('drop_primary_key');
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
@@ -435,7 +448,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
         $diffTable->dropPrimaryKey();
 
-        $diff = (new Comparator())->diffTable($table, $diffTable);
+        $diff = $comparator->diffTable($table, $diffTable);
         self::assertNotFalse($diff);
 
         self::assertEquals(
@@ -447,8 +460,12 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         );
     }
 
-    public function testDropNonAutoincrementColumnFromCompositePrimaryKeyWithAutoincrementColumn(): void
-    {
+    /**
+     * @dataProvider comparatorProvider
+     */
+    public function testDropNonAutoincrementColumnFromCompositePrimaryKeyWithAutoincrementColumn(
+        Comparator $comparator
+    ): void {
         $table = new Table('tbl');
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
         $table->addColumn('foo', 'integer');
@@ -460,7 +477,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $diffTable->dropPrimaryKey();
         $diffTable->setPrimaryKey(['id']);
 
-        $diff = (new Comparator())->diffTable($table, $diffTable);
+        $diff = $comparator->diffTable($table, $diffTable);
         self::assertNotFalse($diff);
 
         self::assertSame(
@@ -473,7 +490,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         );
     }
 
-    public function testAddNonAutoincrementColumnToPrimaryKeyWithAutoincrementColumn(): void
+    /**
+     * @dataProvider comparatorProvider
+     */
+    public function testAddNonAutoincrementColumnToPrimaryKeyWithAutoincrementColumn(Comparator $comparator): void
     {
         $table = new Table('tbl');
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
@@ -486,7 +506,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $diffTable->dropPrimaryKey();
         $diffTable->setPrimaryKey(['id', 'foo']);
 
-        $diff = (new Comparator())->diffTable($table, $diffTable);
+        $diff = $comparator->diffTable($table, $diffTable);
         self::assertNotFalse($diff);
 
         self::assertSame(
@@ -499,7 +519,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         );
     }
 
-    public function testAddAutoIncrementPrimaryKey(): void
+    /**
+     * @dataProvider comparatorProvider
+     */
+    public function testAddAutoIncrementPrimaryKey(Comparator $comparator): void
     {
         $keyTable = new Table('foo');
         $keyTable->addColumn('id', 'integer', ['autoincrement' => true]);
@@ -509,7 +532,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $oldTable = new Table('foo');
         $oldTable->addColumn('baz', 'string');
 
-        $diff = (new Comparator())->diffTable($oldTable, $keyTable);
+        $diff = $comparator->diffTable($oldTable, $keyTable);
         self::assertNotFalse($diff);
 
         $sql = $this->platform->getAlterTableSQL($diff);
@@ -530,7 +553,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         ], $sql);
     }
 
-    public function testAlterPrimaryKeyWithNewColumn(): void
+    /**
+     * @dataProvider comparatorProvider
+     */
+    public function testAlterPrimaryKeyWithNewColumn(Comparator $comparator): void
     {
         $table = new Table('yolo');
         $table->addColumn('pkc1', 'integer');
@@ -543,7 +569,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $diffTable->dropPrimaryKey();
         $diffTable->setPrimaryKey(['pkc1', 'pkc2']);
 
-        $diff = (new Comparator())->diffTable($table, $diffTable);
+        $diff = $comparator->diffTable($table, $diffTable);
         self::assertNotFalse($diff);
 
         self::assertSame(
@@ -744,7 +770,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         return 'ALTER TABLE `table` DROP CONSTRAINT `select`';
     }
 
-    public function testDoesNotPropagateDefaultValuesForUnsupportedColumnTypes(): void
+    public function testIgnoresDifferenceInDefaultValuesForUnsupportedColumnTypes(): void
     {
         $table = new Table('text_blob_default_value');
         $table->addColumn('def_text', 'text', ['default' => 'def']);
@@ -769,10 +795,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $diffTable->changeColumn('def_blob', ['default' => null]);
         $diffTable->changeColumn('def_blob_null', ['default' => null]);
 
-        $diff = (new Comparator())->diffTable($table, $diffTable);
-        self::assertNotFalse($diff);
-
-        self::assertEmpty($this->platform->getAlterTableSQL($diff));
+        self::assertFalse((new MySQL\Comparator($this->platform))->diffTable($table, $diffTable));
     }
 
     /**
@@ -1017,5 +1040,19 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             ],
             $this->platform->getCreateTableSQL($table)
         );
+    }
+
+    /**
+     * @return iterable<string,array{Comparator}>
+     */
+    public static function comparatorProvider(): iterable
+    {
+        yield 'Generic comparator' => [
+            new Comparator(),
+        ];
+
+        yield 'MySQL comparator' => [
+            new MySQL\Comparator(new MySQLPlatform()),
+        ];
     }
 }

--- a/tests/Platforms/MariaDb1027PlatformTest.php
+++ b/tests/Platforms/MariaDb1027PlatformTest.php
@@ -34,14 +34,8 @@ class MariaDb1027PlatformTest extends AbstractMySQLPlatformTestCase
         self::assertSame(Types::JSON, $this->platform->getDoctrineTypeMapping('json'));
     }
 
-    /**
-     * Overrides and skips AbstractMySQLPlatformTestCase test regarding propagation
-     * of unsupported default values for Blob and Text columns.
-     *
-     * @see AbstractMySQLPlatformTestCase::testDoesNotPropagateDefaultValuesForUnsupportedColumnTypes()
-     */
-    public function testDoesNotPropagateDefaultValuesForUnsupportedColumnTypes(): void
+    public function testIgnoresDifferenceInDefaultValuesForUnsupportedColumnTypes(): void
     {
-        self::markTestSkipped('MariaDB102Platform support propagation of default values for BLOB and TEXT columns');
+        self::markTestSkipped('MariaDb1027Platform supports default values for BLOB and TEXT columns');
     }
 }

--- a/tests/Platforms/MySQL/ComparatorTest.php
+++ b/tests/Platforms/MySQL/ComparatorTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Platforms\MySQL;
+
+use Doctrine\DBAL\Platforms\MySQL\Comparator;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Tests\Schema\ComparatorTest as BaseComparatorTest;
+
+class ComparatorTest extends BaseComparatorTest
+{
+    protected function setUp(): void
+    {
+        $this->comparator = new Comparator(new MySQLPlatform());
+    }
+}

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -575,11 +575,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         $table2->addColumn('column_varbinary', 'binary', ['fixed' => true]);
         $table2->addColumn('column_binary', 'binary');
 
-        // VARBINARY -> BINARY
-        // BINARY    -> VARBINARY
-        $diff = (new Comparator())->diffTable($table1, $table2);
-        self::assertNotFalse($diff);
-        self::assertEmpty($this->platform->getAlterTableSQL($diff));
+        self::assertFalse((new Comparator($this->platform))->diffTable($table1, $table2));
     }
 
     public function testUsesSequenceEmulatedIdentityColumns(): void

--- a/tests/Platforms/SQLServer/ComparatorTest.php
+++ b/tests/Platforms/SQLServer/ComparatorTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Platforms\SQLServer;
+
+use Doctrine\DBAL\Platforms\SQLServer\Comparator;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Doctrine\DBAL\Tests\Schema\ComparatorTest as BaseComparatorTest;
+
+class ComparatorTest extends BaseComparatorTest
+{
+    protected function setUp(): void
+    {
+        $this->comparator = new Comparator(new SQLServer2012Platform(), '');
+    }
+}

--- a/tests/Platforms/SQLite/ComparatorTest.php
+++ b/tests/Platforms/SQLite/ComparatorTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Platforms\SQLite;
+
+use Doctrine\DBAL\Platforms\SQLite\Comparator;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Tests\Schema\ComparatorTest as BaseComparatorTest;
+
+class ComparatorTest extends BaseComparatorTest
+{
+    protected function setUp(): void
+    {
+        $this->comparator = new Comparator(new SqlitePlatform());
+    }
+}


### PR DESCRIPTION
## State
The existing property-based column definition comparison has quite some flaws (see all the associated issues):
1. Certain properties, even if different, may yield the same column definition (e.g. the length of a blob column within the type limits).
2. The above is platform-specific, so if a certain type's property is ignored on one platform, it can cause a false-positive match on another platform.

## Proposal
The idea is to replace property-based comparison with the comparison of the SQL that the given column definition generates on the target platform. This way, the diff will be only generated if the column SQL representations on a given platform are different.

### API changes

This is quite an invasive change but it's meant to be safe for a minor release. The changes in the test logic identify the existing bugs rather than breaking changes. 

1. The `Comparator` class now takes an optional `AbstractPlatform` argument. If it's passed, column comparison will be performed in the context of the platform. Not passing a platform is now deprecated.
2. `AbstractPlatform::columnsEqual()` and `Comparator::columnsEqual()` have been added to compare column definitions in the context of the given platform. Depending on the platform, the comparison logic may be more complex than comparing the immediate column SQL. E.g. the default value on SQL Server is represented as a separate constraint.
3. `AbstractSchemaManager::createComparator()` has been added to create the comparator. Besides the schemas being compared and the target platform, the comparison logic may depend on the data available only at runtime (current database collation on SQL Server).
4. Constructors of the `Comparator` class and the subclasses are marked as internal to their schema managers. This will allow potentially improving the comparison logic without introducing breaking changes. The same is already implemented in driver-level connections and statements.

Platform-specific comparators clone the tables, if necessary, and normalize them before passing them to the base implementation. This implementation is far from perfect but it allows to avoid the introduction of a which may be not extensible enough and require a breaking change in the future.

### Testing

Most of the changes in the tests are temporary and are needed to guarantee the parity between the old and the new implementation. The data providers will be removed in the next major release when the dependency of `Comparator` on `AbstractPlatform` becomes mandatory.

1. All functional tests have been reworked to cover the default comparator and the one returned by `$schemaManager->createSchemaManager()`.
2. The unit tests that cover schema comparison in the context of a platform have been reworked to cover the default comparator and the one for the given platform (if it's different from the default).
3. The unit tests covering the `Comparator` outside of the context of a platform have been extended to cover all sub-classes.

## Future scope
1. Array representation of column definitions. Burn with fire. Some of the existing APIs expect `Column $column`, others expect `array<string,mixed> $column`. The latter is an archaism, relies on some magic defaults (see `AbstractPlatfrom::columnToArray()`) and requires unnecessary type conversion back and forth.
2. Deprecate and get rid of `Comparator::diffColumn()` and `ColumnDiff::$changedProperties`. In light of the above changes, the meaning and the purpose of the changed properties become ambiguous. If a property has changed but it doesn't result in a diff in the context of the current platform, should it be included in the changed properties?
3. Mark `SQLServer2012Platform::getDefaultConstraintDeclarationSQL()` and other similar methods internal and then protected. See #4503 for reference.
4. Use parametrized classes instead of the temporarily added assertions.