### PR TITLE
Introduce platform family abstraction

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -337,7 +337,7 @@ abstract class AbstractPlatform
     /**
      * Gets the name of the platform.
      *
-     * @return string
+     * @return Family::*
      */
     abstract public function getName();
 

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -135,7 +135,7 @@ class DB2Platform extends AbstractPlatform
      */
     public function getName()
     {
-        return 'db2';
+        return Family::DB2;
     }
 
     /**

--- a/src/Platforms/Family.php
+++ b/src/Platforms/Family.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms;
+
+interface Family
+{
+    public const DB2        = 'db2';
+    public const MSSQL      = 'mssql';
+    public const MYSQL      = 'mysql';
+    public const ORACLE     = 'oracle';
+    public const POSTGRESQL = 'postgresql';
+    public const SQLITE     = 'sqlite';
+}

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -1038,7 +1038,7 @@ SQL
      */
     public function getName()
     {
-        return 'mysql';
+        return Family::MYSQL;
     }
 
     /**

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -1006,7 +1006,7 @@ SQL
      */
     public function getName()
     {
-        return 'oracle';
+        return Family::ORACLE;
     }
 
     /**

--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -1064,7 +1064,7 @@ SQL
      */
     public function getName()
     {
-        return 'postgresql';
+        return Family::POSTGRESQL;
     }
 
     /**

--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -1450,7 +1450,7 @@ class SQLServer2012Platform extends AbstractPlatform
      */
     public function getName()
     {
-        return 'mssql';
+        return Family::MSSQL;
     }
 
     /**

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -558,7 +558,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getName()
     {
-        return 'sqlite';
+        return Family::SQLITE;
     }
 
     /**

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\Family;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\Table;
@@ -93,7 +94,7 @@ class ConnectionTest extends FunctionalTestCase
 
     public function testTransactionNestingLevelIsResetOnReconnect(): void
     {
-        if ($this->connection->getDatabasePlatform()->getName() === 'sqlite') {
+        if ($this->connection->getDatabasePlatform()->getName() === Family::SQLITE) {
             $params           = $this->connection->getParams();
             $params['memory'] = false;
             $params['path']   = '/tmp/test_nesting.sqlite';
@@ -322,7 +323,13 @@ class ConnectionTest extends FunctionalTestCase
 
     public function testConnectWithoutExplicitDatabaseName(): void
     {
-        if (in_array($this->connection->getDatabasePlatform()->getName(), ['oracle', 'db2'], true)) {
+        if (
+            in_array(
+                $this->connection->getDatabasePlatform()->getName(),
+                [Family::DB2, Family::ORACLE],
+                true
+            )
+        ) {
             self::markTestSkipped('Platform does not support connecting without database name.');
         }
 
@@ -342,7 +349,13 @@ class ConnectionTest extends FunctionalTestCase
 
     public function testDeterminesDatabasePlatformWhenConnectingToNonExistentDatabase(): void
     {
-        if (in_array($this->connection->getDatabasePlatform()->getName(), ['oracle', 'db2'], true)) {
+        if (
+            in_array(
+                $this->connection->getDatabasePlatform()->getName(),
+                [Family::DB2, Family::ORACLE],
+                true
+            )
+        ) {
             self::markTestSkipped('Platform does not support connecting without database name.');
         }
 

--- a/tests/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Functional/PrimaryReadReplicaConnectionTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\DBAL\Functional;
 
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Platforms\Family;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Throwable;
@@ -25,7 +26,7 @@ class PrimaryReadReplicaConnectionTest extends FunctionalTestCase
         $platformName = $this->connection->getDatabasePlatform()->getName();
 
         // This is a MySQL specific test, skip other vendors.
-        if ($platformName !== 'mysql') {
+        if ($platformName !== Family::MYSQL) {
             self::markTestSkipped(sprintf('Test does not work on %s.', $platformName));
         }
 

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -6,6 +6,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Events;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\Family;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
@@ -361,7 +362,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testDiffListTableColumns(): void
     {
-        if ($this->schemaManager->getDatabasePlatform()->getName() === 'oracle') {
+        if ($this->schemaManager->getDatabasePlatform()->getName() === Family::ORACLE) {
             self::markTestSkipped(
                 'Does not work with Oracle, since it cannot detect DateTime, Date and Time differenecs (at the moment).'
             );
@@ -784,7 +785,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         if (
             ! $this->connection->getDatabasePlatform()->supportsInlineColumnComments() &&
              ! $this->connection->getDatabasePlatform()->supportsCommentOnStatement() &&
-            $this->connection->getDatabasePlatform()->getName() !== 'mssql'
+            $this->connection->getDatabasePlatform()->getName() !== Family::MSSQL
         ) {
             self::markTestSkipped('Database does not support column comments.');
         }
@@ -827,7 +828,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         if (
             ! $this->connection->getDatabasePlatform()->supportsInlineColumnComments() &&
              ! $this->connection->getDatabasePlatform()->supportsCommentOnStatement() &&
-            $this->connection->getDatabasePlatform()->getName() !== 'mssql'
+            $this->connection->getDatabasePlatform()->getName() !== Family::MSSQL
         ) {
             self::markTestSkipped('Database does not support column comments.');
         }
@@ -854,7 +855,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         if (
             ! $this->connection->getDatabasePlatform()->supportsInlineColumnComments() &&
             ! $this->connection->getDatabasePlatform()->supportsCommentOnStatement() &&
-            $this->connection->getDatabasePlatform()->getName() !== 'mssql'
+            $this->connection->getDatabasePlatform()->getName() !== Family::MSSQL
         ) {
             self::markTestSkipped('Database does not support column comments.');
         }
@@ -1130,7 +1131,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         if (
             ! $this->connection->getDatabasePlatform()->supportsInlineColumnComments() &&
             ! $this->connection->getDatabasePlatform()->supportsCommentOnStatement() &&
-            $this->connection->getDatabasePlatform()->getName() !== 'mssql'
+            $this->connection->getDatabasePlatform()->getName() !== Family::MSSQL
         ) {
             self::markTestSkipped('Database does not support column comments.');
         }
@@ -1187,7 +1188,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         if (
             ! $this->connection->getDatabasePlatform()->supportsInlineColumnComments() &&
             ! $this->connection->getDatabasePlatform()->supportsCommentOnStatement() &&
-            $this->connection->getDatabasePlatform()->getName() !== 'mssql'
+            $this->connection->getDatabasePlatform()->getName() !== Family::MSSQL
         ) {
             self::markTestSkipped('Database does not support column comments.');
         }

--- a/tests/Functional/TableGeneratorTest.php
+++ b/tests/Functional/TableGeneratorTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tests\Functional;
 
 use Doctrine\DBAL\Id\TableGenerator;
 use Doctrine\DBAL\Id\TableGeneratorSchemaVisitor;
+use Doctrine\DBAL\Platforms\Family;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
@@ -17,7 +18,7 @@ class TableGeneratorTest extends FunctionalTestCase
         parent::setUp();
 
         $platform = $this->connection->getDatabasePlatform();
-        if ($platform->getName() === 'sqlite') {
+        if ($platform->getName() === Family::SQLITE) {
             self::markTestSkipped('TableGenerator does not work with SQLite');
         }
 

--- a/tests/Functional/TemporaryTableTest.php
+++ b/tests/Functional/TemporaryTableTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Tests\Functional;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\Family;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
@@ -12,7 +13,7 @@ class TemporaryTableTest extends FunctionalTestCase
 {
     public function testDropTemporaryTableNotAutoCommitTransaction(): void
     {
-        if ($this->connection->getDatabasePlatform()->getName() === 'oracle') {
+        if ($this->connection->getDatabasePlatform()->getName() === Family::ORACLE) {
             self::markTestSkipped('Test does not work on Oracle.');
         }
 
@@ -43,7 +44,7 @@ class TemporaryTableTest extends FunctionalTestCase
 
     public function testCreateTemporaryTableNotAutoCommitTransaction(): void
     {
-        if ($this->connection->getDatabasePlatform()->getName() === 'oracle') {
+        if ($this->connection->getDatabasePlatform()->getName() === Family::ORACLE) {
             self::markTestSkipped('Test does not work on Oracle.');
         }
 

--- a/tests/Functional/Ticket/DBAL168Test.php
+++ b/tests/Functional/Ticket/DBAL168Test.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
+use Doctrine\DBAL\Platforms\Family;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
@@ -9,7 +10,7 @@ class DBAL168Test extends FunctionalTestCase
 {
     public function testDomainsTable(): void
     {
-        if ($this->connection->getDatabasePlatform()->getName() !== 'postgresql') {
+        if ($this->connection->getDatabasePlatform()->getName() !== Family::POSTGRESQL) {
             self::markTestSkipped('PostgreSQL only test');
         }
 

--- a/tests/Functional/Ticket/DBAL202Test.php
+++ b/tests/Functional/Ticket/DBAL202Test.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
+use Doctrine\DBAL\Platforms\Family;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
@@ -11,7 +12,7 @@ class DBAL202Test extends FunctionalTestCase
     {
         parent::setUp();
 
-        if ($this->connection->getDatabasePlatform()->getName() !== 'oracle') {
+        if ($this->connection->getDatabasePlatform()->getName() !== Family::ORACLE) {
             self::markTestSkipped('OCI8 only test');
         }
 

--- a/tests/Functional/Ticket/DBAL510Test.php
+++ b/tests/Functional/Ticket/DBAL510Test.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
+use Doctrine\DBAL\Platforms\Family;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -12,7 +13,7 @@ class DBAL510Test extends FunctionalTestCase
     {
         parent::setUp();
 
-        if ($this->connection->getDatabasePlatform()->getName() === 'postgresql') {
+        if ($this->connection->getDatabasePlatform()->getName() === Family::POSTGRESQL) {
             return;
         }
 


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #4749 

#### Summary

The possible return values of `AbstractPlatform::getName()` need to stay
very stable because consumers are relying on those in a lot of
scenarios, probably even more than they rely on `instanceof`, since
doing so for e.g. `PostgreSQLPlatform` no longer works with DBAL 3.
Introducing the possible values as constants of a new type will:
- make these strings explicitly part of our public API;
- help consumers understand better where these strings are defined, and
  hopefully make them add a dependency to doctrine/dbal when they need
  to;
- avoid bugs thanks to IDE auto-completion (less risk of typing
  posgresql instead of postgresql);
- avoid more bugs thanks to static analysis provided by the phpdoc.


Closes #4749 
