### PR TITLE
Code cleanup

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -110,11 +110,6 @@ class Exception extends \Exception
         return new self('No columns specified for table ' . $tableName);
     }
 
-    public static function limitOffsetInvalid(): self
-    {
-        return new self('Invalid Offset in Limit Query, it has to be larger than or equal to 0.');
-    }
-
     public static function typeExists(string $name): self
     {
         return new self('Type ' . $name . ' already exists.');

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -812,37 +812,6 @@ abstract class AbstractSchemaManager
     }
 
     /**
-     * @param mixed[][] $triggers
-     *
-     * @return mixed[][]
-     */
-    protected function _getPortableTriggersList($triggers)
-    {
-        $list = [];
-        foreach ($triggers as $value) {
-            $value = $this->_getPortableTriggerDefinition($value);
-
-            if (! $value) {
-                continue;
-            }
-
-            $list[] = $value;
-        }
-
-        return $list;
-    }
-
-    /**
-     * @param mixed[] $trigger
-     *
-     * @return mixed
-     */
-    protected function _getPortableTriggerDefinition($trigger)
-    {
-        return $trigger;
-    }
-
-    /**
      * @param mixed[][] $sequences
      *
      * @return Sequence[]

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -180,14 +180,6 @@ SQL
     /**
      * {@inheritdoc}
      */
-    protected function _getPortableTriggerDefinition($trigger)
-    {
-        return $trigger['trigger_name'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function _getPortableViewDefinition($view)
     {
         return new View($view['schemaname'] . '.' . $view['viewname'], $view['definition']);

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -445,7 +445,7 @@ SQL
 
                 if (
                     preg_match(
-                        '([A-Za-z]+\(([0-9]+)\,([0-9]+)\))',
+                        '([A-Za-z]+\(([0-9]+),([0-9]+)\))',
                         $tableColumn['complete_type'],
                         $match
                     ) === 1

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -126,7 +126,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
                     '#
                     (?:CONSTRAINT\s+([^\s]+)\s+)?
                     (?:FOREIGN\s+KEY[^\)]+\)\s*)?
-                    REFERENCES\s+[^\s]+\s+(?:\([^\)]+\))?
+                    REFERENCES\s+[^\s]+\s+(?:\([^)]+\))?
                     (?:
                         [^,]*?
                         (NOT\s+DEFERRABLE|DEFERRABLE)


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. `Exception::limitOffsetInvalid()` is unused as of f580f0a27960df0424ce5645b2e4e1b151b5b69c (`2.0.0-BETA2`).
2. The trigger-related methods are unused as of 5b43f72e273a06dbf729c619eda8ca4ab536c6a9 (`2.0.0-BETA1`).
3. Some escaping in regular expressions is unnecessary.