### PR TITLE
Fix arithmetic interval not numeric in SqlitePlatform

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -116,6 +116,10 @@ class SqlitePlatform extends AbstractPlatform
      */
     protected function getDateArithmeticIntervalExpression($date, $operator, $interval, $unit)
     {
+        if (! is_numeric($interval)) {
+            $interval = "' || " . $interval . " || '";
+        }
+
         switch ($unit) {
             case DateIntervalUnit::SECOND:
             case DateIntervalUnit::MINUTE:
@@ -133,10 +137,6 @@ class SqlitePlatform extends AbstractPlatform
                 $interval *= 3;
                 $unit      = DateIntervalUnit::MONTH;
                 break;
-        }
-
-        if (! is_numeric($interval)) {
-            $interval = "' || " . $interval . " || '";
         }
 
         return 'DATE(' . $date . ",'" . $operator . $interval . ' ' . $unit . "')";

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -761,6 +761,22 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function testDateAddStaticNumberOfMinutes(): void
+    {
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+12 MINUTE')",
+            $this->platform->getDateAddMinutesExpression('rentalBeginsOn', 12)
+        );
+    }
+
+    public function testDateAddNumberOfMinutesFromColumn(): void
+    {
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+' || duration || ' MINUTE')",
+            $this->platform->getDateAddMinutesExpression('rentalBeginsOn', 'duration')
+        );
+    }
+
     public function testDateAddStaticNumberOfDays(): void
     {
         self::assertSame(


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues |

#### Summary
Curently SqlitePlatform not correctly work with Arithmetic Interval Not Numeric with follow units HOUR, MINUTE and SECONDS.

With this commit SqlitePlatform can concatenate field names in all Arithmetic Intervals
<!-- Provide a summary of your change. -->
