### PR TITLE
allow setting operator classes for indexes in postgresql

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3118,6 +3118,14 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Whether the platform supports operator classes for indexes.
+     */
+    public function supportsIndexOperatorClasses(): bool
+    {
+        return false;
+    }
+
+    /**
      * Whether the platform supports altering tables.
      *
      * @return bool

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -936,6 +936,10 @@ abstract class AbstractSchemaManager
                     $options['where'] = $tableIndex['where'];
                 }
 
+                if (isset($tableIndex['operator_classes'])) {
+                    $options['operator_classes'] = $tableIndex['operator_classes'];
+                }
+
                 $result[$keyName] = [
                     'name' => $indexName,
                     'columns' => [],

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -98,18 +98,25 @@ class Index extends AbstractAsset implements Constraint
      */
     public function getQuotedColumns(AbstractPlatform $platform)
     {
-        $subParts = $platform->supportsColumnLengthIndexes() && $this->hasOption('lengths')
+        $lengthParts  = $platform->supportsColumnLengthIndexes() && $this->hasOption('lengths')
             ? $this->getOption('lengths') : [];
+        $opClassParts = $platform->supportsIndexOperatorClasses() && $this->hasOption('operator_classes')
+            ? $this->getOption('operator_classes') : [];
 
         $columns = [];
 
         foreach ($this->_columns as $column) {
-            $length = array_shift($subParts);
+            $length  = array_shift($lengthParts);
+            $opClass = array_shift($opClassParts);
 
             $quotedColumn = $column->getQuotedName($platform);
 
             if ($length !== null) {
                 $quotedColumn .= '(' . $length . ')';
+            }
+
+            if ($opClass !== null) {
+                $quotedColumn .= ' ' . $opClass;
             }
 
             $columns[] = $quotedColumn;

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -24,6 +24,7 @@ use function str_replace;
 use function strlen;
 use function strpos;
 use function strtolower;
+use function substr;
 use function trim;
 
 use const CASE_LOWER;
@@ -241,12 +242,19 @@ SQL
                         continue;
                     }
 
+                    $operatorClasses = [];
+                    if ($row['op_class'] !== null) {
+                        // result is in the form of '{foo_ops,bar_ops}'
+                        $operatorClasses = explode(',', substr($row['op_class'], 1, -1));
+                    }
+
                     $buffer[] = [
                         'key_name' => $row['relname'],
                         'column_name' => trim($colRow['attname']),
                         'non_unique' => ! $row['indisunique'],
                         'primary' => $row['indisprimary'],
                         'where' => $row['where'],
+                        'operator_classes' => $operatorClasses,
                     ];
                 }
             }

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -504,6 +504,19 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
             'bigint->int' => ['bigint', 'integer', 'INT'],
         ];
     }
+
+    public function testIndexWithOpClass(): void
+    {
+        $table = new Table('index_op_class');
+        $table->addColumn('text', 'string');
+        $table->addIndex(['text'], 'text_index', [], ['operator_classes' => ['text_pattern_ops']]);
+
+        $this->schemaManager->dropAndCreateTable($table);
+
+        $indexes = $this->schemaManager->listTableIndexes('index_op_class');
+        self::assertArrayHasKey('text_index', $indexes);
+        self::assertSame(['text_pattern_ops'], $indexes['text_index']->getOption('operator_classes'));
+    }
 }
 
 class MoneyType extends Type


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

This allows setting [operator classes](https://www.postgresql.org/docs/current/indexes-opclass.html) on postgresql indexes, which is required for making the query usable in `LIKE` expressions when using a non `C` locale.
