### PR TITLE
Fix introspection of BINARY columns

### DIFF
--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -291,6 +291,7 @@ class DB2Platform extends AbstractPlatform
                  c.colname,
                  c.colno,
                  c.typename,
+                 c.codepage,
                  c.nulls,
                  c.length,
                  c.scale,

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 use function array_change_key_case;
 use function assert;
@@ -69,11 +70,19 @@ class DB2SchemaManager extends AbstractSchemaManager
 
         switch (strtolower($tableColumn['typename'])) {
             case 'varchar':
+                if ($tableColumn['codepage'] === 0) {
+                    $type = Types::BINARY;
+                }
+
                 $length = $tableColumn['length'];
                 $fixed  = false;
                 break;
 
             case 'character':
+                if ($tableColumn['codepage'] === 0) {
+                    $type = Types::BINARY;
+                }
+
                 $length = $tableColumn['length'];
                 $fixed  = true;
                 break;

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -154,6 +154,11 @@ class OracleSchemaManager extends AbstractSchemaManager
                 $fixed  = false;
                 break;
 
+            case 'raw':
+                $length = $tableColumn['data_length'];
+                $fixed  = true;
+                break;
+
             case 'char':
             case 'nchar':
                 $length = $tableColumn['char_length'];

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -100,7 +100,7 @@ SQL
             'comment'       => $tableColumn['comment'] !== '' ? $tableColumn['comment'] : null,
         ];
 
-        if ($length !== 0 && ($type === 'text' || $type === 'string')) {
+        if ($length !== 0 && ($type === 'text' || $type === 'string' || $type === 'binary')) {
             $options['length'] = $length;
         }
 

--- a/tests/Functional/Schema/Db2SchemaManagerTest.php
+++ b/tests/Functional/Schema/Db2SchemaManagerTest.php
@@ -30,9 +30,4 @@ class Db2SchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertNull($columns['bool']->getComment());
         self::assertSame("That's a comment", $columns['bool_commented']->getComment());
     }
-
-    public function testListTableWithBinary(): void
-    {
-        self::markTestSkipped('Binary data type is currently not supported on DB2 LUW');
-    }
 }

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -54,25 +54,14 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertHasTable($tables);
     }
 
-    public function testListTableWithBinary(): void
+    /**
+     * Oracle currently stores VARBINARY columns as RAW (fixed-size)
+     */
+    protected function assertVarBinaryColumnIsValid(Table $table, string $columnName, int $expectedLength): void
     {
-        $tableName = 'test_binary_table';
-
-        $table = new Table($tableName);
-        $table->addColumn('id', 'integer');
-        $table->addColumn('column_varbinary', 'binary', []);
-        $table->addColumn('column_binary', 'binary', ['fixed' => true]);
-        $table->setPrimaryKey(['id']);
-
-        $this->schemaManager->createTable($table);
-
-        $table = $this->schemaManager->listTableDetails($tableName);
-
-        self::assertInstanceOf(BinaryType::class, $table->getColumn('column_varbinary')->getType());
-        self::assertFalse($table->getColumn('column_varbinary')->getFixed());
-
-        self::assertInstanceOf(BinaryType::class, $table->getColumn('column_binary')->getType());
-        self::assertFalse($table->getColumn('column_binary')->getFixed());
+        $column = $table->getColumn($columnName);
+        self::assertInstanceOf(BinaryType::class, $column->getType());
+        self::assertSame($expectedLength, $column->getLength());
     }
 
     public function testAlterTableColumnNotNull(): void

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -283,25 +283,20 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertFalse($diff);
     }
 
-    public function testListTableWithBinary(): void
+    /**
+     * PostgreSQL stores BINARY columns as BLOB
+     */
+    protected function assertBinaryColumnIsValid(Table $table, string $columnName, int $expectedLength): void
     {
-        $tableName = 'test_binary_table';
+        self::assertInstanceOf(BlobType::class, $table->getColumn($columnName)->getType());
+    }
 
-        $table = new Table($tableName);
-        $table->addColumn('id', 'integer');
-        $table->addColumn('column_varbinary', 'binary', []);
-        $table->addColumn('column_binary', 'binary', ['fixed' => true]);
-        $table->setPrimaryKey(['id']);
-
-        $this->schemaManager->createTable($table);
-
-        $table = $this->schemaManager->listTableDetails($tableName);
-
-        self::assertInstanceOf(BlobType::class, $table->getColumn('column_varbinary')->getType());
-        self::assertFalse($table->getColumn('column_varbinary')->getFixed());
-
-        self::assertInstanceOf(BlobType::class, $table->getColumn('column_binary')->getType());
-        self::assertFalse($table->getColumn('column_binary')->getFixed());
+    /**
+     * PostgreSQL stores VARBINARY columns as BLOB
+     */
+    protected function assertVarBinaryColumnIsValid(Table $table, string $columnName, int $expectedLength): void
+    {
+        self::assertInstanceOf(BlobType::class, $table->getColumn($columnName)->getType());
     }
 
     public function testListQuotedTable(): void

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1041,20 +1041,30 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $tableName = 'test_binary_table';
 
         $table = new Table($tableName);
-        $table->addColumn('id', 'integer');
-        $table->addColumn('column_varbinary', 'binary', []);
-        $table->addColumn('column_binary', 'binary', ['fixed' => true]);
-        $table->setPrimaryKey(['id']);
+        $table->addColumn('column_binary', 'binary', ['length' => 16, 'fixed' => true]);
+        $table->addColumn('column_varbinary', 'binary', ['length' => 32]);
 
         $this->schemaManager->createTable($table);
 
         $table = $this->schemaManager->listTableDetails($tableName);
+        $this->assertBinaryColumnIsValid($table, 'column_binary', 16);
+        $this->assertVarBinaryColumnIsValid($table, 'column_varbinary', 32);
+    }
 
-        self::assertInstanceOf(BinaryType::class, $table->getColumn('column_varbinary')->getType());
-        self::assertFalse($table->getColumn('column_varbinary')->getFixed());
+    protected function assertBinaryColumnIsValid(Table $table, string $columnName, int $expectedLength): void
+    {
+        $column = $table->getColumn($columnName);
+        self::assertInstanceOf(BinaryType::class, $column->getType());
+        self::assertSame($expectedLength, $column->getLength());
+        self::assertTrue($column->getFixed());
+    }
 
-        self::assertInstanceOf(BinaryType::class, $table->getColumn('column_binary')->getType());
-        self::assertTrue($table->getColumn('column_binary')->getFixed());
+    protected function assertVarBinaryColumnIsValid(Table $table, string $columnName, int $expectedLength): void
+    {
+        $column = $table->getColumn($columnName);
+        self::assertInstanceOf(BinaryType::class, $column->getType());
+        self::assertSame($expectedLength, $column->getLength());
+        self::assertFalse($column->getFixed());
     }
 
     public function testListTableDetailsWithFullQualifiedTableName(): void

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -116,25 +116,20 @@ EOS
         self::assertEquals('NOCASE', $columns['bar']->getPlatformOption('collation'));
     }
 
-    public function testListTableWithBinary(): void
+    /**
+     * SQLite stores BINARY columns as BLOB
+     */
+    protected function assertBinaryColumnIsValid(Table $table, string $columnName, int $expectedLength): void
     {
-        $tableName = 'test_binary_table';
+        self::assertInstanceOf(BlobType::class, $table->getColumn($columnName)->getType());
+    }
 
-        $table = new Table($tableName);
-        $table->addColumn('id', 'integer');
-        $table->addColumn('column_varbinary', 'binary', []);
-        $table->addColumn('column_binary', 'binary', ['fixed' => true]);
-        $table->setPrimaryKey(['id']);
-
-        $this->schemaManager->createTable($table);
-
-        $table = $this->schemaManager->listTableDetails($tableName);
-
-        self::assertInstanceOf(BlobType::class, $table->getColumn('column_varbinary')->getType());
-        self::assertFalse($table->getColumn('column_varbinary')->getFixed());
-
-        self::assertInstanceOf(BlobType::class, $table->getColumn('column_binary')->getType());
-        self::assertFalse($table->getColumn('column_binary')->getFixed());
+    /**
+     * SQLite stores VARBINARY columns as BLOB
+     */
+    protected function assertVarBinaryColumnIsValid(Table $table, string $columnName, int $expectedLength): void
+    {
+        self::assertInstanceOf(BlobType::class, $table->getColumn($columnName)->getType());
     }
 
     public function testListTableColumnsWithWhitespacesInTypeDeclarations(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #4761.

1. Refactor `SchemaManagerFunctionalTestCase::testListTableWithBinary()` to minimize the discrepancy in the test logic across platforms.
2. Enable the test for IBM DB2.
3. Fix introspection on Oracle, SQL Server and IBM DB2.