### PR TITLE
Deprecate SQLAnywhere driver

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,12 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 2.13
+
+## Deprecated SQLAnywhere drivers
+
+The `SQLAnywhere` driver has been deprecated and will be removed from DBAL. 
+
 # Upgrade to 2.12
 
 ## Deprecated non-zero based positional parameter keys

--- a/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractSQLAnywhereDriver.php
@@ -31,6 +31,8 @@ use function version_compare;
 
 /**
  * Abstract base implementation of the {@link Driver} interface for SAP Sybase SQL Anywhere based drivers.
+ *
+ * @deprecated Support for SQLAnywhere will be removed in 3.0.
  */
 abstract class AbstractSQLAnywhereDriver implements Driver, ExceptionConverterDriver, VersionAwarePlatformDriver
 {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/Driver.php
@@ -12,6 +12,8 @@ use function implode;
 
 /**
  * A Doctrine DBAL driver for the SAP Sybase SQL Anywhere PHP extension.
+ *
+ * @deprecated Support for SQLAnywhere will be removed in 3.0.
  */
 class Driver extends AbstractSQLAnywhereDriver
 {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereConnection.php
@@ -28,6 +28,8 @@ use function sasql_set_option;
 
 /**
  * SAP Sybase SQL Anywhere implementation of the Connection interface.
+ *
+ * @deprecated Support for SQLAnywhere will be removed in 3.0.
  */
 class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
 {
@@ -46,6 +48,12 @@ class SQLAnywhereConnection implements Connection, ServerInfoAwareConnection
      */
     public function __construct($dsn, $persistent = false)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4077',
+            'The SQLAnywhere driver is deprecated'
+        );
+
         $this->connection = $persistent ? @sasql_pconnect($dsn) : @sasql_connect($dsn);
 
         if (! is_resource($this->connection)) {

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereException.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereException.php
@@ -14,6 +14,8 @@ use function sasql_stmt_error;
 /**
  * SAP Sybase SQL Anywhere driver exception.
  *
+ * @deprecated Support for SQLAnywhere will be removed in 3.0.
+ *
  * @psalm-immutable
  */
 class SQLAnywhereException extends AbstractDriverException

--- a/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
+++ b/lib/Doctrine/DBAL/Driver/SQLAnywhere/SQLAnywhereStatement.php
@@ -45,6 +45,8 @@ use const SASQL_BOTH;
 
 /**
  * SAP SQL Anywhere implementation of the Statement interface.
+ *
+ * @deprecated Support for SQLAnywhere will be removed in 3.0.
  */
 class SQLAnywhereStatement implements IteratorAggregate, Statement, Result
 {

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywhere11Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywhere11Platform.php
@@ -6,7 +6,7 @@ namespace Doctrine\DBAL\Platforms;
  * The SQLAnywhere11Platform provides the behavior, features and SQL dialect of the
  * SAP Sybase SQL Anywhere 11 database platform.
  *
- * @deprecated Use SQLAnywhere 16 or newer
+ * @deprecated Support for SQLAnywhere will be removed in 3.0.
  */
 class SQLAnywhere11Platform extends SQLAnywherePlatform
 {

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywhere12Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywhere12Platform.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Schema\Sequence;
  * The SQLAnywhere12Platform provides the behavior, features and SQL dialect of the
  * SAP Sybase SQL Anywhere 12 database platform.
  *
- * @deprecated Use SQLAnywhere 16 or newer
+ * @deprecated Support for SQLAnywhere will be removed in 3.0.
  */
 class SQLAnywhere12Platform extends SQLAnywhere11Platform
 {

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywhere16Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywhere16Platform.php
@@ -8,6 +8,8 @@ use UnexpectedValueException;
 /**
  * The SQLAnywhere16Platform provides the behavior, features and SQL dialect of the
  * SAP Sybase SQL Anywhere 16 database platform.
+ *
+ * @deprecated Support for SQLAnywhere will be removed in 3.0.
  */
 class SQLAnywhere16Platform extends SQLAnywhere12Platform
 {

--- a/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLAnywherePlatform.php
@@ -37,7 +37,7 @@ use function substr;
  * The SQLAnywherePlatform provides the behavior, features and SQL dialect of the
  * SAP Sybase SQL Anywhere 10 database platform.
  *
- * @deprecated Use SQLAnywhere 16 or newer
+ * @deprecated Support for SQLAnywhere will be removed in 3.0.
  */
 class SQLAnywherePlatform extends AbstractPlatform
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/A

#### Summary

Support for SQLAnywhere has been removed in 3.0, see #4077. Unfortunately, the corresponding classes on DBAL 2 are not flagged as deprecated. This PR attempts to solve that issue.
