### PR TITLE
[2.x] Allow support for CONCAT() in SQL Server 2012

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2012Platform.php
@@ -92,6 +92,16 @@ class SQLServer2012Platform extends SQLServer2008Platform
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getConcatExpression()
+    {
+        $args = func_get_args();
+
+        return 'CONCAT(' . implode(', ', $args) . ')';
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function doModifyLimitQuery($query, $limit, $offset = null)

--- a/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SQLServer2012PlatformTest.php
@@ -189,6 +189,19 @@ class SQLServer2012PlatformTest extends AbstractSQLServerPlatformTestCase
         );
     }
 
+    public function testGeneratesSqlSnippets(): void
+    {
+        self::assertEquals('CONVERT(date, GETDATE())', $this->platform->getCurrentDateSQL());
+        self::assertEquals('CONVERT(time, GETDATE())', $this->platform->getCurrentTimeSQL());
+        self::assertEquals('CURRENT_TIMESTAMP', $this->platform->getCurrentTimestampSQL());
+        self::assertEquals('"', $this->platform->getIdentifierQuoteCharacter());
+
+        self::assertEquals(
+            'CONCAT(column1, column2, column3)',
+            $this->platform->getConcatExpression('column1', 'column2', 'column3')
+        );
+    }
+
     public function testModifyLimitQueryWithExtraLongQuery(): void
     {
         $expected = 'SELECT table1.column1, table2.column2, table3.column3, table4.column4, '


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3346

#### Summary

As per [SQL Server 2012](https://docs.microsoft.com/en-us/previous-versions/sql/sql-server-2012/hh231515(v=sql.110)) ([and onwards](https://docs.microsoft.com/en-us/sql/t-sql/functions/concat-transact-sql?view=sql-server-2016)), the `CONCAT()` function is available for use to generate valid T-SQL.

Backported this to 2.13.x as I'm still using 2.x in a project but upgrading to 3.x soon™️.