### PR TITLE
[3.x] Allow support for CONCAT() in SQL Server 2012

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,12 +4,12 @@
     Procedure:
         1) Save a copy of this file with a name of your choosing. It doesn't matter
            where you place it as long as you know where it is.
-           i.e. "mysqlconf.xml" (It needs the ending .xml).
+           i.e. "mysqlconf.phpunit.xml" (It needs the ending .xml).
         2) Edit the file and fill in your settings (database name, type, username, etc.)
            Just change the "value"s, not the names of the var elements.
         3) To run the tests against the database type the following from within the
            tests/ folder: phpunit -c <filename> ...
-           Example: phpunit -c mysqlconf.xml
+           Example: phpunit -c mysqlconf.phpunit.xml
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"

--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -1146,9 +1146,7 @@ class SQLServer2012Platform extends AbstractPlatform
      */
     public function getConcatExpression()
     {
-        $args = func_get_args();
-
-        return 'CONCAT(' . implode(', ', $args) . ')';
+        return sprintf('CONCAT(%s)', implode(', ', func_get_args()));
     }
 
     /**

--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -1148,7 +1148,7 @@ class SQLServer2012Platform extends AbstractPlatform
     {
         $args = func_get_args();
 
-        return '(' . implode(' + ', $args) . ')';
+        return 'CONCAT(' . implode(', ', $args) . ')';
     }
 
     /**

--- a/tests/Functional/Platform/ConcatTest.php
+++ b/tests/Functional/Platform/ConcatTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Platform;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+class ConcatTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+            return;
+        }
+
+        if ($this->connection->getDatabasePlatform() instanceof SQLServer2012Platform) {
+            return;
+        }
+
+        self::markTestSkipped('Restricted to MySQL and SQL Server.');
+    }
+
+    public function testConcat(): void
+    {
+        $table = new Table('concat_test');
+        $table->addColumn('name', 'string');
+        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $this->connection->insert('concat_test', ['name' => 'A long string']);
+        $this->connection->insert('concat_test', ['name' => 'A short string']);
+
+        $platform = $this->connection->getDatabasePlatform();
+        $query    = $this->connection->fetchOne(
+            \sprintf(
+                'SELECT name FROM concat_test WHERE name LIKE %s',
+                $platform->getConcatExpression("'%'", "'long'", "'%'")
+            )
+        );
+
+        self::assertEquals('A long string', $query);
+    }
+}

--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -404,4 +404,11 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('colB', $columns[0]);
         self::assertEquals('colA', $columns[1]);
     }
+
+    public function testConcat(): void
+    {
+        $result = $this->connection->fetchOne('SELECT CONCAT(1, 2, 3)');
+
+        self::assertEquals('123', $result);
+    }
 }

--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -404,11 +404,4 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('colB', $columns[0]);
         self::assertEquals('colA', $columns[1]);
     }
-
-    public function testConcat(): void
-    {
-        $result = $this->connection->fetchOne('SELECT CONCAT(1, 2, 3)');
-
-        self::assertEquals('123', $result);
-    }
 }

--- a/tests/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -73,7 +73,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         self::assertEquals('"', $this->platform->getIdentifierQuoteCharacter());
 
         self::assertEquals(
-            '(column1 + column2 + column3)',
+            'CONCAT(column1, column2, column3)',
             $this->platform->getConcatExpression('column1', 'column2', 'column3')
         );
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #3346

#### Summary

As per [SQL Server 2012](https://docs.microsoft.com/en-us/previous-versions/sql/sql-server-2012/hh231515(v=sql.110)) ([and onwards](https://docs.microsoft.com/en-us/sql/t-sql/functions/concat-transact-sql?view=sql-server-2016)), the `CONCAT()` function is available for use to generate valid T-SQL. 