### PR TITLE
Update PHPStan to 0.12.96

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "require-dev": {
         "doctrine/coding-standard": "9.0.0",
         "jetbrains/phpstorm-stubs": "2021.1",
-        "phpstan/phpstan": "0.12.81",
+        "phpstan/phpstan": "0.12.96",
         "phpunit/phpunit": "^7.5.20|^8.5|9.5.5",
         "squizlabs/php_codesniffer": "3.6.0",
         "symfony/cache": "^4.4",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -124,3 +124,9 @@ parameters:
 
         # The class was added in PHP 8.1
         - '~^Attribute class ReturnTypeWillChange does not exist.$~'
+
+        # https://github.com/phpstan/phpstan/issues/5608
+        -
+            message: '~^Circular definition detected in type alias (Override)?Params\.$~'
+            paths:
+                - %currentWorkingDirectory%/lib/Doctrine/DBAL/DriverManager.php


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The versions of PHPStan extensions currently used in the newer branches are incompatible with PHP 8.1.