### PR TITLE
SchemaDiff - remove orphan foreign keys before trying to drop related indexes

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -162,6 +162,15 @@ class SchemaDiff
         }
 
         foreach ($this->changedTables as $tableDiff) {
+            // make sure to drop related orphan foreign keys before dropping indexes that are related to FKs
+            if ($saveMode === true && $platform->supportsForeignKeyConstraints() && $tableDiff->fromTable) {
+                foreach ($this->orphanedForeignKeys as $orphanedForeignKey) {
+                    if ($orphanedForeignKey->getLocalTable()->getName() === $tableDiff->fromTable->getName()) {
+                        $sql[] = $platform->getDropForeignKeySQL($orphanedForeignKey, $orphanedForeignKey->getLocalTable());
+                    }
+                }
+            }
+
             $sql = array_merge($sql, $platform->getAlterTableSQL($tableDiff));
         }
 

--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -165,9 +165,11 @@ class SchemaDiff
             // make sure to drop related orphan foreign keys before dropping indexes that are related to FKs
             if ($saveMode === true && $platform->supportsForeignKeyConstraints() && $tableDiff->fromTable) {
                 foreach ($this->orphanedForeignKeys as $orphanedForeignKey) {
-                    if ($orphanedForeignKey->getLocalTable()->getName() === $tableDiff->fromTable->getName()) {
-                        $sql[] = $platform->getDropForeignKeySQL($orphanedForeignKey, $orphanedForeignKey->getLocalTable());
+                    if ($orphanedForeignKey->getLocalTable()->getName() !== $tableDiff->fromTable->getName()) {
+                        continue;
                     }
+
+                    $sql[] = $platform->getDropForeignKeySQL($orphanedForeignKey, $orphanedForeignKey->getLocalTable());
                 }
             }
 

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
@@ -105,7 +105,7 @@ class SchemaDiffTest extends TestCase
         $platform->expects($this->exactly(1))
                 ->method('supportsSequences')
                 ->will($this->returnValue(true));
-        $platform->expects($this->exactly(2))
+        $platform->expects($this->atLeastOnce())
                 ->method('supportsForeignKeyConstraints')
                 ->will($this->returnValue(true));
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Currently when save mode is enabled, SchemaDiff tries to drop indexes that are needed for foreign keys thus results in error.
With this change, SchemaDiff will only drop orphan foreign keys that their related indexes are going to be dropped.
