### PR TITLE
sqlite expression based index

### DIFF
--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -236,4 +236,23 @@ SQL;
             ->getColumn('col1')
             ->getComment());
     }
+    
+    public function testListTableIndexesWithIndexExpression(): void
+    {
+        $sql = <<<SQL
+CREATE TABLE company (
+    com_id int(4),
+    com_name text(15)
+);
+CREATE INDEX com_id_index ON company (com_id);
+CREATE INDEX com_name_5_index ON company (substr(com_name, 0, 5))
+SQL;
+
+        $this->connection->executeStatement($sql);
+
+        $indexes = $this->schemaManager->listTableIndexes('company');
+
+        self::assertArrayHasKey('com_id_index', $indexes);
+        self::assertEquals('substr(com_name, 0, 5)', $indexes['com_name_5_index']->getColumns()[0]);
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

when use expression based index, index column name would be null, must parse column name from sqlite_master
