### PR TITLE
Update Psalm to 4.10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,10 +43,11 @@
         "jetbrains/phpstorm-stubs": "2021.1",
         "phpstan/phpstan": "0.12.81",
         "phpunit/phpunit": "^7.5.20|^8.5|9.5.5",
+        "psalm/plugin-phpunit": "0.16.1",
         "squizlabs/php_codesniffer": "3.6.0",
         "symfony/cache": "^4.4",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-        "vimeo/psalm": "4.8.1"
+        "vimeo/psalm": "4.10.0"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."

--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -512,8 +512,10 @@ class OraclePlatform extends AbstractPlatform
         $sql[] = "DECLARE
   constraints_Count NUMBER;
 BEGIN
-  SELECT COUNT(CONSTRAINT_NAME) INTO constraints_Count FROM USER_CONSTRAINTS WHERE TABLE_NAME = '" . $unquotedTableName
-            . "' AND CONSTRAINT_TYPE = 'P';
+  SELECT COUNT(CONSTRAINT_NAME) INTO constraints_Count
+    FROM USER_CONSTRAINTS
+   WHERE TABLE_NAME = '" . $unquotedTableName . "'
+     AND CONSTRAINT_TYPE = 'P';
   IF constraints_Count = 0 OR constraints_Count = '' THEN
     EXECUTE IMMEDIATE '" . $this->getCreateConstraintSQL($idx, $quotedTableName) . "';
   END IF;

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -15,8 +15,6 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Type;
 
-use function array_walk;
-use function preg_replace;
 use function sprintf;
 use function strtoupper;
 use function uniqid;
@@ -335,20 +333,24 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         $table      = new Table($tableName);
         $column     = $table->addColumn($columnName, 'integer');
         $column->setAutoincrement(true);
-        $targets    = [
+
+        self::assertSame([
             sprintf('CREATE TABLE %s (%s NUMBER(10) NOT NULL)', $tableName, $columnName),
             sprintf(
-                'DECLARE constraints_Count NUMBER;'
-                    . ' BEGIN'
-                    . ' SELECT COUNT(CONSTRAINT_NAME)'
-                    . ' INTO constraints_Count'
-                    . ' FROM USER_CONSTRAINTS'
-                    . " WHERE TABLE_NAME = '%s' AND CONSTRAINT_TYPE = 'P';"
-                    . " IF constraints_Count = 0 OR constraints_Count = ''"
-                    . ' THEN EXECUTE IMMEDIATE'
-                    . " 'ALTER TABLE %s ADD CONSTRAINT %s_AI_PK PRIMARY KEY (%s)';"
-                    . ' END IF;'
-                    . ' END;',
+                <<<'SQL'
+DECLARE
+  constraints_Count NUMBER;
+BEGIN
+  SELECT COUNT(CONSTRAINT_NAME) INTO constraints_Count
+    FROM USER_CONSTRAINTS
+   WHERE TABLE_NAME = '%s'
+     AND CONSTRAINT_TYPE = 'P';
+  IF constraints_Count = 0 OR constraints_Count = '' THEN
+    EXECUTE IMMEDIATE 'ALTER TABLE %s ADD CONSTRAINT %s_AI_PK PRIMARY KEY (%s)';
+  END IF;
+END;
+SQL
+                ,
                 $tableName,
                 $tableName,
                 $tableName,
@@ -356,20 +358,30 @@ class OraclePlatformTest extends AbstractPlatformTestCase
             ),
             sprintf('CREATE SEQUENCE %s_SEQ START WITH 1 MINVALUE 1 INCREMENT BY 1', $tableName),
             sprintf(
-                'CREATE TRIGGER %s_AI_PK BEFORE INSERT ON %s FOR EACH ROW DECLARE last_Sequence NUMBER;'
-                . ' last_InsertID NUMBER;'
-                . ' BEGIN SELECT %s_SEQ.NEXTVAL'
-                . ' INTO :NEW.%s FROM DUAL;'
-                . ' IF (:NEW.%s IS NULL OR :NEW.%s = 0)'
-                . ' THEN SELECT %s_SEQ.NEXTVAL INTO :NEW.%s FROM DUAL;'
-                . ' ELSE SELECT NVL(Last_Number, 0) INTO last_Sequence'
-                . " FROM User_Sequences WHERE Sequence_Name = '%s_SEQ';"
-                . ' SELECT :NEW.%s INTO last_InsertID FROM DUAL;'
-                . ' WHILE (last_InsertID > last_Sequence) LOOP'
-                . ' SELECT %s_SEQ.NEXTVAL INTO last_Sequence FROM DUAL;'
-                . ' END LOOP;'
-                . ' END IF;'
-                . ' END;',
+                <<<SQL
+CREATE TRIGGER %s_AI_PK
+   BEFORE INSERT
+   ON %s
+   FOR EACH ROW
+DECLARE
+   last_Sequence NUMBER;
+   last_InsertID NUMBER;
+BEGIN
+   SELECT %s_SEQ.NEXTVAL INTO :NEW.%s FROM DUAL;
+   IF (:NEW.%s IS NULL OR :NEW.%s = 0) THEN
+      SELECT %s_SEQ.NEXTVAL INTO :NEW.%s FROM DUAL;
+   ELSE
+      SELECT NVL(Last_Number, 0) INTO last_Sequence
+        FROM User_Sequences
+       WHERE Sequence_Name = '%s_SEQ';
+      SELECT :NEW.%s INTO last_InsertID FROM DUAL;
+      WHILE (last_InsertID > last_Sequence) LOOP
+         SELECT %s_SEQ.NEXTVAL INTO last_Sequence FROM DUAL;
+      END LOOP;
+   END IF;
+END;
+SQL
+                ,
                 $tableName,
                 $tableName,
                 $tableName,
@@ -382,16 +394,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
                 $columnName,
                 $tableName
             ),
-        ];
-        $statements = $this->platform->getCreateTableSQL($table);
-        //strip all the whitespace from the statements
-        array_walk($statements, static function (string &$value): void {
-            $value = preg_replace('/\s+/', ' ', $value);
-        });
-        foreach ($targets as $key => $sql) {
-            self::assertArrayHasKey($key, $statements);
-            self::assertEquals($sql, $statements[$key]);
-        }
+        ], $this->platform->getCreateTableSQL($table));
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Just a dependency update. Additionally:
1. `OraclePlatform` and the test cleanup (only whitespace changes) in order to avoid a false-positive caused by the usage of `array_walk()`.
2. Reinstate the dependency on the Psalm plugin for PHPUnit (seems to have been accidentally removed in #4556).