### PR TITLE
Deprecate not passing $fromColumn to ColumnDiff

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## Deprecated not passing the `$fromColumn` argument to the `ColumnDiff` constructor.
+
+Not passing the `$fromColumn` argument to the `ColumnDiff` constructor is deprecated.
+
 ## Deprecated `AbstractPlatform::getName()`
 
 Relying on the name of the platform is discouraged. To identify the platform, use its class name.

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\Deprecations\Deprecation;
+
 use function in_array;
 
 /**
@@ -31,6 +33,15 @@ class ColumnDiff
         array $changedProperties = [],
         ?Column $fromColumn = null
     ) {
+        if ($fromColumn === null) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/4785',
+                'Not passing the $fromColumn to %s is deprecated.',
+                __METHOD__
+            );
+        }
+
         $this->oldColumnName     = $oldColumnName;
         $this->column            = $column;
         $this->changedProperties = $changedProperties;

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -271,10 +271,13 @@ class Comparator
                 continue;
             }
 
-            $columnDiff = new ColumnDiff($column->getName(), $toColumn, $changedProperties);
+            $tableDifferences->changedColumns[$column->getName()] = new ColumnDiff(
+                $column->getName(),
+                $toColumn,
+                $changedProperties,
+                $column
+            );
 
-            $columnDiff->fromColumn                               = $column;
-            $tableDifferences->changedColumns[$column->getName()] = $columnDiff;
             $changes++;
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

The `$fromColumn` parameter is optional since its introduction in https://github.com/doctrine/dbal/pull/220. It had to be declared as optional to avoid a BC break. The fact that not passing it wasn't immediately deprecated, requires the code that interprets the diff to interpret it in two modes: with and without the `$fromColumn`.

Given that the property-based comparison is deprecated (https://github.com/doctrine/dbal/pull/4746), the next step is to stop using `$changedProperties` and only rely on the actual column definitions. For that, we need to require `$fromColumn` to be always set.

Once we stop using `$changedProperties` in `4.0.x`, we can deprecate it.