### PR TITLE
Don't fake the PHP version anymore

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,10 +45,6 @@ jobs:
           coverage: "pcov"
           ini-values: "zend.assertions=1"
 
-      - name: "Adjust dependencies"
-        if: "${{ matrix.php-version == '8.1' }}"
-        run: composer config platform.php 8.0.99
-
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
         with:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

All of our dependencies should provide a stable package for PHP 8.1 now. Because of that, we don't need to fake the PHP version anymore for Composer.
