### PR TITLE
Do not normalize current version during comparison

### DIFF
--- a/lib/Doctrine/DBAL/Version.php
+++ b/lib/Doctrine/DBAL/Version.php
@@ -3,7 +3,7 @@
 namespace Doctrine\DBAL;
 
 use function str_replace;
-use function strtolower;
+use function strtoupper;
 use function version_compare;
 
 /**
@@ -28,9 +28,8 @@ class Version
      */
     public static function compare($version)
     {
-        $currentVersion = str_replace(' ', '', strtolower(self::VERSION));
-        $version        = str_replace(' ', '', $version);
+        $version = str_replace(' ', '', strtoupper($version));
 
-        return version_compare($version, $currentVersion);
+        return version_compare($version, self::VERSION);
     }
 }

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -311,15 +311,6 @@
                 <directory name="lib"/>
             </errorLevel>
         </RedundantCastGivenDocblockType>
-        <RedundantCondition>
-            <errorLevel type="suppress">
-                <!--
-                    This suppression should be removed in 3.0.x
-                    See https://github.com/doctrine/dbal/pull/3860
-                -->
-                <file name="lib/Doctrine/DBAL/Version.php"/>
-            </errorLevel>
-        </RedundantCondition>
         <RedundantConditionGivenDocblockType>
             <errorLevel type="suppress">
                 <!--


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #4367

Instead of normalizing the current version, which may be pointless from the static analysis standpoint, normalize the version passed for comparison.