### PR TITLE
fix mysql identifier quoting fail

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/Keywords/MySQLKeywords.php
+++ b/lib/Doctrine/DBAL/Platforms/Keywords/MySQLKeywords.php
@@ -18,6 +18,15 @@ class MySQLKeywords extends KeywordList
     /**
      * {@inheritdoc}
      */
+    public function isKeyword($word)
+    {
+        return parent::isKeyword($word) ||  preg_match('/^\d+$/', $word) ||
+            preg_match('/[^\w$\x{0080}-\x{FFFF}]+/u', $word);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getKeywords()
     {
         return [


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | ?
| Fixed issues | #4357

#### Summary

<!-- Provide a summary of your change. -->

\Doctrine\DBAL\Schema\AbstractAsset::getQuotedName()

does this:

        $keywords = $platform->getReservedKeywordsList();
        $parts    = explode('.', $this->getName());
        foreach ($parts as $k => $v) {
            $parts[$k] = $this->_quoted || $keywords->isKeyword($v) ? $platform->quoteIdentifier($v) : $v;
        }

as mentioned in #4357 there is no api available if an identifier needs to be quoted or not. I just added this to the Keywords implementation. Not saying it should be done like that, but its a working workaround for me, and it should be added as an platform abstraction properly.

this definitely needs fixing! see also https://dev.mysql.com/doc/refman/5.6/en/identifiers.html for MySQL