### PR TITLE
Remove support for passing assets as names

### DIFF
--- a/src/Event/SchemaDropTableEventArgs.php
+++ b/src/Event/SchemaDropTableEventArgs.php
@@ -5,36 +5,25 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Event;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\Table;
-use InvalidArgumentException;
 
 /**
  * Event Arguments used when the SQL query for dropping tables are generated inside {@link AbstractPlatform}.
  */
 class SchemaDropTableEventArgs extends SchemaEventArgs
 {
-    /** @var string|Table */
-    private $table;
+    private string $table;
 
     private AbstractPlatform $platform;
 
     private ?string $sql = null;
 
-    /**
-     * @param string|Table $table
-     *
-     * @throws InvalidArgumentException
-     */
-    public function __construct($table, AbstractPlatform $platform)
+    public function __construct(string $table, AbstractPlatform $platform)
     {
         $this->table    = $table;
         $this->platform = $platform;
     }
 
-    /**
-     * @return string|Table
-     */
-    public function getTable()
+    public function getTable(): string
     {
         return $this->table;
     }

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -619,7 +619,7 @@ class DB2Platform extends AbstractPlatform
                 } elseif ($remIndex->isUnique()) {
                     $sql[] = 'ALTER TABLE ' . $table . ' DROP UNIQUE ' . $remIndex->getQuotedName($this);
                 } else {
-                    $sql[] = $this->getDropIndexSQL($remIndex, $table);
+                    $sql[] = $this->getDropIndexSQL($remIndex->getQuotedName($this), $table);
                 }
 
                 $sql[] = $this->getCreateIndexSQL($addIndex, $table);

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -894,12 +894,6 @@ SQL
             );
         }
 
-        if ($index instanceof Index && $index->isPrimary()) {
-            // MySQL primary keys are always named "PRIMARY",
-            // so we cannot use them in statements because of them being keyword.
-            return $this->getDropPrimaryKeySQL($table);
-        }
-
         return 'DROP INDEX ' . $indexName . ' ON ' . $table;
     }
 

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -15,7 +15,6 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\TextType;
-use InvalidArgumentException;
 
 use function array_diff_key;
 use function array_merge;
@@ -25,7 +24,6 @@ use function count;
 use function implode;
 use function in_array;
 use function is_numeric;
-use function is_string;
 use function sprintf;
 use function str_replace;
 use function strcasecmp;
@@ -692,7 +690,7 @@ SQL
                 continue;
             }
 
-            $sql[] = $this->getDropForeignKeySQL($foreignKey, $tableName);
+            $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableName);
         }
 
         return $sql;
@@ -871,35 +869,9 @@ SQL
         return $query;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropIndexSQL($index, $table = null): string
+    public function getDropIndexSQL(string $name, string $table): string
     {
-        if ($index instanceof Index) {
-            $indexName = $index->getQuotedName($this);
-        } elseif (is_string($index)) {
-            $indexName = $index;
-        } else {
-            throw new InvalidArgumentException(
-                __METHOD__ . '() expects $index parameter to be string or ' . Index::class . '.'
-            );
-        }
-
-        if ($table instanceof Table) {
-            $table = $table->getQuotedName($this);
-        } elseif (! is_string($table)) {
-            throw new InvalidArgumentException(
-                __METHOD__ . '() expects $table parameter to be string or ' . Table::class . '.'
-            );
-        }
-
-        return 'DROP INDEX ' . $indexName . ' ON ' . $table;
-    }
-
-    protected function getDropPrimaryKeySQL(string $table): string
-    {
-        return 'ALTER TABLE ' . $table . ' DROP PRIMARY KEY';
+        return 'DROP INDEX ' . $name . ' ON ' . $table;
     }
 
     public function getSetTransactionIsolationSQL(int $level): string
@@ -959,16 +931,8 @@ SQL
      * MySQL commits a transaction implicitly when DROP TABLE is executed, however not
      * if DROP TEMPORARY TABLE is executed.
      */
-    public function getDropTemporaryTableSQL($table): string
+    public function getDropTemporaryTableSQL(string $table): string
     {
-        if ($table instanceof Table) {
-            $table = $table->getQuotedName($this);
-        } elseif (! is_string($table)) {
-            throw new InvalidArgumentException(
-                __METHOD__ . '() expects $table parameter to be string or ' . Table::class . '.'
-            );
-        }
-
         return 'DROP TEMPORARY TABLE ' . $table;
     }
 

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Sequence;
-use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\BinaryType;
@@ -625,35 +624,14 @@ SQL
         );
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropSequenceSQL($sequence): string
+    public function getDropForeignKeySQL(string $foreignKey, string $table): string
     {
-        if ($sequence instanceof Sequence) {
-            $sequence = $sequence->getQuotedName($this);
-        }
-
-        return 'DROP SEQUENCE ' . $sequence;
+        return $this->getDropConstraintSQL($foreignKey, $table);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropForeignKeySQL($foreignKey, $table): string
+    public function getDropSequenceSQL(string $name): string
     {
-        if (! $foreignKey instanceof ForeignKeyConstraint) {
-            $foreignKey = new Identifier($foreignKey);
-        }
-
-        if (! $table instanceof Table) {
-            $table = new Identifier($table);
-        }
-
-        $foreignKey = $foreignKey->getQuotedName($this);
-        $table      = $table->getQuotedName($this);
-
-        return 'ALTER TABLE ' . $table . ' DROP CONSTRAINT ' . $foreignKey;
+        return 'DROP SEQUENCE ' . $name;
     }
 
     public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -575,16 +575,9 @@ SQL
         return '';
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropSequenceSQL($sequence): string
+    public function getDropSequenceSQL(string $name): string
     {
-        if ($sequence instanceof Sequence) {
-            $sequence = $sequence->getQuotedName($this);
-        }
-
-        return 'DROP SEQUENCE ' . $sequence . ' CASCADE';
+        return 'DROP SEQUENCE ' . $name . ' CASCADE';
     }
 
     public function getCreateSchemaSQL(string $schemaName): string
@@ -592,10 +585,7 @@ SQL
         return 'CREATE SCHEMA ' . $schemaName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropForeignKeySQL($foreignKey, $table): string
+    public function getDropForeignKeySQL(string $foreignKey, string $table): string
     {
         return $this->getDropConstraintSQL($foreignKey, $table);
     }

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -595,7 +595,7 @@ class SqlitePlatform extends AbstractPlatform
                 continue;
             }
 
-            $sql[] = $this->getDropIndexSQL($index, $diff->name);
+            $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $diff->name);
         }
 
         return $sql;
@@ -675,34 +675,22 @@ class SqlitePlatform extends AbstractPlatform
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getCreatePrimaryKeySQL(Index $index, $table): string
+    public function getCreatePrimaryKeySQL(Index $index, string $table): string
     {
         throw new Exception('Sqlite platform does not support alter primary key.');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, $table): string
+    public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, string $table): string
     {
         throw new Exception('Sqlite platform does not support alter foreign key.');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getDropForeignKeySQL($foreignKey, $table): string
+    public function getDropForeignKeySQL(string $foreignKey, string $table): string
     {
         throw new Exception('Sqlite platform does not support alter foreign key.');
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getCreateConstraintSQL(Constraint $constraint, $table): string
+    public function getCreateConstraintSQL(Constraint $constraint, string $table): string
     {
         throw new Exception('Sqlite platform does not support alter constraint.');
     }
@@ -832,7 +820,7 @@ class SqlitePlatform extends AbstractPlatform
                 implode(', ', $oldColumnNames),
                 $table->getQuotedName($this)
             );
-            $sql[] = $this->getDropTableSQL($fromTable);
+            $sql[] = $this->getDropTableSQL($fromTable->getQuotedName($this));
 
             $sql   = array_merge($sql, $this->getCreateTableSQL($newTable));
             $sql[] = sprintf(
@@ -842,7 +830,7 @@ class SqlitePlatform extends AbstractPlatform
                 implode(', ', $oldColumnNames),
                 $dataTable->getQuotedName($this)
             );
-            $sql[] = $this->getDropTableSQL($dataTable);
+            $sql[] = $this->getDropTableSQL($dataTable->getQuotedName($this));
 
             $newName = $diff->getNewName();
 

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -347,43 +347,31 @@ abstract class AbstractSchemaManager
     /**
      * Drops the index from the given table.
      *
-     * @param Index|string $index The name of the index.
-     * @param Table|string $table The name of the table.
-     *
      * @throws Exception
      */
-    public function dropIndex($index, $table): void
+    public function dropIndex(string $index, string $table): void
     {
-        if ($index instanceof Index) {
-            $index = $index->getQuotedName($this->_platform);
-        }
-
         $this->_execSql($this->_platform->getDropIndexSQL($index, $table));
     }
 
     /**
      * Drops the constraint from the given table.
      *
-     * @param Table|string $table The name of the table.
-     *
      * @throws Exception
      */
-    public function dropConstraint(Constraint $constraint, $table): void
+    public function dropConstraint(string $name, string $table): void
     {
-        $this->_execSql($this->_platform->getDropConstraintSQL($constraint, $table));
+        $this->_execSql($this->_platform->getDropConstraintSQL($name, $table));
     }
 
     /**
      * Drops a foreign key from a table.
      *
-     * @param ForeignKeyConstraint|string $foreignKey The name of the foreign key.
-     * @param Table|string                $table      The name of the table with the foreign key.
-     *
      * @throws Exception
      */
-    public function dropForeignKey($foreignKey, $table): void
+    public function dropForeignKey(string $name, string $table): void
     {
-        $this->_execSql($this->_platform->getDropForeignKeySQL($foreignKey, $table));
+        $this->_execSql($this->_platform->getDropForeignKeySQL($name, $table));
     }
 
     /**
@@ -442,11 +430,9 @@ abstract class AbstractSchemaManager
     /**
      * Creates a constraint on a table.
      *
-     * @param Table|string $table
-     *
      * @throws Exception
      */
-    public function createConstraint(Constraint $constraint, $table): void
+    public function createConstraint(Constraint $constraint, string $table): void
     {
         $this->_execSql($this->_platform->getCreateConstraintSQL($constraint, $table));
     }
@@ -454,11 +440,11 @@ abstract class AbstractSchemaManager
     /**
      * Creates a new index on a table.
      *
-     * @param Table|string $table The name of the table on which the index is to be created.
+     * @param string $table The name of the table on which the index is to be created.
      *
      * @throws Exception
      */
-    public function createIndex(Index $index, $table): void
+    public function createIndex(Index $index, string $table): void
     {
         $this->_execSql($this->_platform->getCreateIndexSQL($index, $table));
     }
@@ -467,11 +453,11 @@ abstract class AbstractSchemaManager
      * Creates a new foreign key.
      *
      * @param ForeignKeyConstraint $foreignKey The ForeignKey instance.
-     * @param Table|string         $table      The name of the table on which the foreign key is to be created.
+     * @param string               $table      The name of the table on which the foreign key is to be created.
      *
      * @throws Exception
      */
-    public function createForeignKey(ForeignKeyConstraint $foreignKey, $table): void
+    public function createForeignKey(ForeignKeyConstraint $foreignKey, string $table): void
     {
         $this->_execSql($this->_platform->getCreateForeignKeySQL($foreignKey, $table));
     }
@@ -494,11 +480,9 @@ abstract class AbstractSchemaManager
      * @see dropConstraint()
      * @see createConstraint()
      *
-     * @param Table|string $table
-     *
      * @throws Exception
      */
-    public function dropAndCreateConstraint(Constraint $constraint, $table): void
+    public function dropAndCreateConstraint(Constraint $constraint, string $table): void
     {
         $this->tryMethod('dropConstraint', $constraint, $table);
         $this->createConstraint($constraint, $table);
@@ -507,11 +491,11 @@ abstract class AbstractSchemaManager
     /**
      * Drops and creates a new index on a table.
      *
-     * @param Table|string $table The name of the table on which the index is to be created.
+     * @param string $table The name of the table on which the index is to be created.
      *
      * @throws Exception
      */
-    public function dropAndCreateIndex(Index $index, $table): void
+    public function dropAndCreateIndex(Index $index, string $table): void
     {
         $this->tryMethod('dropIndex', $index->getQuotedName($this->_platform), $table);
         $this->createIndex($index, $table);
@@ -522,11 +506,11 @@ abstract class AbstractSchemaManager
      *
      * @param ForeignKeyConstraint $foreignKey An associative array that defines properties
      *                                         of the foreign key to be created.
-     * @param Table|string         $table      The name of the table on which the foreign key is to be created.
+     * @param string               $table      The name of the table on which the foreign key is to be created.
      *
      * @throws Exception
      */
-    public function dropAndCreateForeignKey(ForeignKeyConstraint $foreignKey, $table): void
+    public function dropAndCreateForeignKey(ForeignKeyConstraint $foreignKey, string $table): void
     {
         $this->tryMethod('dropForeignKey', $foreignKey, $table);
         $this->createForeignKey($foreignKey, $table);

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -27,10 +27,8 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
 
     /**
      * Table or asset identifier instance of the referenced table name the foreign key constraint is associated with.
-     *
-     * @var Table|Identifier
      */
-    protected $_foreignTableName;
+    protected Identifier $_foreignTableName;
 
     /**
      * Asset identifier instances of the referenced table column names the foreign key constraint is associated with.
@@ -50,14 +48,14 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * Initializes the foreign key constraint.
      *
      * @param array<int, string>   $localColumnNames   Names of the referencing table columns.
-     * @param Table|string         $foreignTableName   Referenced table.
+     * @param string               $foreignTableName   Referenced table.
      * @param array<int, string>   $foreignColumnNames Names of the referenced table columns.
      * @param string               $name               Name of the foreign key constraint.
      * @param array<string, mixed> $options            Options associated with the foreign key constraint.
      */
     public function __construct(
         array $localColumnNames,
-        $foreignTableName,
+        string $foreignTableName,
         array $foreignColumnNames,
         string $name = '',
         array $options = []
@@ -65,12 +63,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
         $this->_setName($name);
 
         $this->_localColumnNames = $this->createIdentifierMap($localColumnNames);
-
-        if ($foreignTableName instanceof Table) {
-            $this->_foreignTableName = $foreignTableName;
-        } else {
-            $this->_foreignTableName = new Identifier($foreignTableName);
-        }
+        $this->_foreignTableName = new Identifier($foreignTableName);
 
         $this->_foreignColumnNames = $this->createIdentifierMap($foreignColumnNames);
         $this->_options            = $options;

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -128,7 +128,10 @@ class SchemaDiff
         if ($platform->supportsForeignKeyConstraints() && $saveMode === false) {
             foreach ($this->orphanedForeignKeys as $localTableName => $tableOrphanedForeignKey) {
                 foreach ($tableOrphanedForeignKey as $orphanedForeignKey) {
-                    $sql[] = $platform->getDropForeignKeySQL($orphanedForeignKey, $localTableName);
+                    $sql[] = $platform->getDropForeignKeySQL(
+                        $orphanedForeignKey->getQuotedName($platform),
+                        $localTableName
+                    );
                 }
             }
         }
@@ -140,7 +143,7 @@ class SchemaDiff
 
             if ($saveMode === false) {
                 foreach ($this->removedSequences as $sequence) {
-                    $sql[] = $platform->getDropSequenceSQL($sequence);
+                    $sql[] = $platform->getDropSequenceSQL($sequence->getQuotedName($platform));
                 }
             }
 
@@ -161,7 +164,7 @@ class SchemaDiff
             }
 
             foreach ($table->getForeignKeys() as $foreignKey) {
-                $foreignKeySql[] = $platform->getCreateForeignKeySQL($foreignKey, $table);
+                $foreignKeySql[] = $platform->getCreateForeignKeySQL($foreignKey, $table->getQuotedName($platform));
             }
         }
 
@@ -169,7 +172,7 @@ class SchemaDiff
 
         if ($saveMode === false) {
             foreach ($this->removedTables as $table) {
-                $sql[] = $platform->getDropTableSQL($table);
+                $sql[] = $platform->getDropTableSQL($table->getQuotedName($platform));
             }
         }
 

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -71,10 +71,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $this->alterTable($tableDiff);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function createForeignKey(ForeignKeyConstraint $foreignKey, $table): void
+    public function createForeignKey(ForeignKeyConstraint $foreignKey, string $table): void
     {
         $table = $this->ensureTable($table);
 
@@ -85,10 +82,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $this->alterTable($tableDiff);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dropAndCreateForeignKey(ForeignKeyConstraint $foreignKey, $table): void
+    public function dropAndCreateForeignKey(ForeignKeyConstraint $foreignKey, string $table): void
     {
         $table = $this->ensureTable($table);
 
@@ -99,20 +93,12 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $this->alterTable($tableDiff);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dropForeignKey($foreignKey, $table): void
+    public function dropForeignKey(string $name, string $table): void
     {
         $table = $this->ensureTable($table);
 
-        $tableDiff = $this->getTableDiffForAlterForeignKey($table);
-
-        if (is_string($foreignKey)) {
-            $tableDiff->removedForeignKeys[] = $table->getForeignKey($foreignKey);
-        } else {
-            $tableDiff->removedForeignKeys[] = $foreignKey;
-        }
+        $tableDiff                       = $this->getTableDiffForAlterForeignKey($table);
+        $tableDiff->removedForeignKeys[] = $table->getForeignKey($name);
 
         $this->alterTable($tableDiff);
     }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -329,7 +329,6 @@ class Table extends AbstractAsset
      *
      * Name is inferred from the local columns.
      *
-     * @param Table|string         $foreignTable       Table schema instance or table name
      * @param array<int, string>   $localColumnNames
      * @param array<int, string>   $foreignColumnNames
      * @param array<string, mixed> $options
@@ -337,7 +336,7 @@ class Table extends AbstractAsset
      * @throws SchemaException
      */
     public function addForeignKeyConstraint(
-        $foreignTable,
+        string $foreignTableName,
         array $localColumnNames,
         array $foreignColumnNames,
         array $options = [],
@@ -351,14 +350,6 @@ class Table extends AbstractAsset
             );
         }
 
-        if ($foreignTable instanceof Table) {
-            foreach ($foreignColumnNames as $columnName) {
-                if (! $foreignTable->hasColumn($columnName)) {
-                    throw ColumnDoesNotExist::new($columnName, $foreignTable->getName());
-                }
-            }
-        }
-
         foreach ($localColumnNames as $columnName) {
             if (! $this->hasColumn($columnName)) {
                 throw ColumnDoesNotExist::new($columnName, $this->_name);
@@ -367,7 +358,7 @@ class Table extends AbstractAsset
 
         $constraint = new ForeignKeyConstraint(
             $localColumnNames,
-            $foreignTable,
+            $foreignTableName,
             $foreignColumnNames,
             $name,
             $options

--- a/src/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/src/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -52,7 +52,10 @@ class CreateSchemaSqlCollector extends AbstractVisitor
             return;
         }
 
-        $this->createFkConstraintQueries[] = $this->platform->getCreateForeignKeySQL($fkConstraint, $localTable);
+        $this->createFkConstraintQueries[] = $this->platform->getCreateForeignKeySQL(
+            $fkConstraint,
+            $localTable->getQuotedName($this->platform)
+        );
     }
 
     public function acceptSequence(Sequence $sequence): void

--- a/src/Schema/Visitor/DropSchemaSqlCollector.php
+++ b/src/Schema/Visitor/DropSchemaSqlCollector.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use SplObjectStorage;
 
-use function assert;
 use function strlen;
 
 /**
@@ -19,10 +18,13 @@ use function strlen;
  */
 class DropSchemaSqlCollector extends AbstractVisitor
 {
+    /** @var SplObjectStorage<ForeignKeyConstraint,Table> */
     private SplObjectStorage $constraints;
 
+    /** @var SplObjectStorage<Sequence,null> */
     private SplObjectStorage $sequences;
 
+    /** @var SplObjectStorage<Table,null> */
     private SplObjectStorage $tables;
 
     private AbstractPlatform $platform;
@@ -65,19 +67,19 @@ class DropSchemaSqlCollector extends AbstractVisitor
         $sql = [];
 
         foreach ($this->constraints as $fkConstraint) {
-            assert($fkConstraint instanceof ForeignKeyConstraint);
             $localTable = $this->constraints[$fkConstraint];
-            $sql[]      = $this->platform->getDropForeignKeySQL($fkConstraint, $localTable);
+            $sql[]      = $this->platform->getDropForeignKeySQL(
+                $fkConstraint->getQuotedName($this->platform),
+                $localTable->getQuotedName($this->platform)
+            );
         }
 
         foreach ($this->sequences as $sequence) {
-            assert($sequence instanceof Sequence);
-            $sql[] = $this->platform->getDropSequenceSQL($sequence);
+            $sql[] = $this->platform->getDropSequenceSQL($sequence->getQuotedName($this->platform));
         }
 
         foreach ($this->tables as $table) {
-            assert($table instanceof Table);
-            $sql[] = $this->platform->getDropTableSQL($table);
+            $sql[] = $this->platform->getDropTableSQL($table->getQuotedName($this->platform));
         }
 
         return $sql;

--- a/tests/Functional/ForeignKeyExceptionTest.php
+++ b/tests/Functional/ForeignKeyExceptionTest.php
@@ -33,7 +33,7 @@ class ForeignKeyExceptionTest extends FunctionalTestCase
         $owningTable->addColumn('id', 'integer', []);
         $owningTable->addColumn('constraint_id', 'integer', []);
         $owningTable->setPrimaryKey(['id']);
-        $owningTable->addForeignKeyConstraint($table, ['constraint_id'], ['id']);
+        $owningTable->addForeignKeyConstraint($table->getName(), ['constraint_id'], ['id']);
 
         $schemaManager->createTable($table);
         $schemaManager->createTable($owningTable);

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -149,7 +149,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $column            = $nestedSchemaTable->addColumn('id', 'integer');
         $column->setAutoincrement(true);
         $nestedSchemaTable->setPrimaryKey(['id']);
-        $nestedSchemaTable->addForeignKeyConstraint($nestedRelatedTable, ['id'], ['id']);
+        $nestedSchemaTable->addForeignKeyConstraint($nestedRelatedTable->getName(), ['id'], ['id']);
 
         $this->schemaManager->createTable($nestedRelatedTable);
         $this->schemaManager->createTable($nestedSchemaTable);
@@ -309,7 +309,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $offlineTable->addColumn('username', 'string');
         $offlineTable->addColumn('fk', 'integer');
         $offlineTable->setPrimaryKey(['id']);
-        $offlineTable->addForeignKeyConstraint($offlineTable, ['fk'], ['id']);
+        $offlineTable->addForeignKeyConstraint($offlineTable->getName(), ['fk'], ['id']);
 
         $this->schemaManager->dropAndCreateTable($offlineTable);
 

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -374,7 +374,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table->addUniqueIndex(['test'], 'test');
         $this->schemaManager->dropAndCreateTable($table);
 
-        $this->schemaManager->dropAndCreateIndex($table->getIndex('test'), $table);
+        $platform = $this->schemaManager->getDatabasePlatform();
+        $this->schemaManager->dropAndCreateIndex($table->getIndex('test'), $table->getQuotedName($platform));
         $tableIndexes = $this->schemaManager->listTableIndexes('test_create_index');
 
         self::assertEquals('test', strtolower($tableIndexes['test']->getName()));

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -684,16 +684,6 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         ];
     }
 
-    protected function getQuotesDropForeignKeySQL(): string
-    {
-        return 'ALTER TABLE `table` DROP FOREIGN KEY `select`';
-    }
-
-    protected function getQuotesDropConstraintSQL(): string
-    {
-        return 'ALTER TABLE `table` DROP CONSTRAINT `select`';
-    }
-
     public function testIgnoresDifferenceInDefaultValuesForUnsupportedColumnTypes(): void
     {
         $table = new Table('text_blob_default_value');

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -402,7 +402,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertEquals(
             [
                 'ALTER TABLE alter_primary_key MODIFY id INT NOT NULL',
-                'ALTER TABLE alter_primary_key DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON alter_primary_key',
                 'ALTER TABLE alter_primary_key ADD PRIMARY KEY (foo)',
             ],
             $this->platform->getAlterTableSQL($diff)
@@ -428,7 +428,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertEquals(
             [
                 'ALTER TABLE drop_primary_key MODIFY id INT NOT NULL',
-                'ALTER TABLE drop_primary_key DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON drop_primary_key',
             ],
             $this->platform->getAlterTableSQL($diff)
         );
@@ -454,7 +454,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertSame(
             [
                 'ALTER TABLE tbl MODIFY id INT NOT NULL',
-                'ALTER TABLE tbl DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON tbl',
                 'ALTER TABLE tbl ADD PRIMARY KEY (id)',
             ],
             $this->platform->getAlterTableSQL($diff)
@@ -481,7 +481,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertSame(
             [
                 'ALTER TABLE tbl MODIFY id INT NOT NULL',
-                'ALTER TABLE tbl DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON tbl',
                 'ALTER TABLE tbl ADD PRIMARY KEY (id, foo)',
             ],
             $this->platform->getAlterTableSQL($diff)
@@ -507,19 +507,6 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertEquals(['ALTER TABLE foo ADD id INT AUTO_INCREMENT NOT NULL, ADD PRIMARY KEY (id)'], $sql);
     }
 
-    public function testNamedPrimaryKey(): void
-    {
-        $diff                              = new TableDiff('mytable');
-        $diff->changedIndexes['foo_index'] = new Index('foo_index', ['foo'], true, true);
-
-        $sql = $this->platform->getAlterTableSQL($diff);
-
-        self::assertEquals([
-            'ALTER TABLE mytable DROP PRIMARY KEY',
-            'ALTER TABLE mytable ADD PRIMARY KEY (foo)',
-        ], $sql);
-    }
-
     public function testAlterPrimaryKeyWithNewColumn(): void
     {
         $table = new Table('yolo');
@@ -539,7 +526,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
         self::assertSame(
             [
-                'ALTER TABLE yolo DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON yolo',
                 'ALTER TABLE yolo ADD pkc2 INT NOT NULL',
                 'ALTER TABLE yolo ADD PRIMARY KEY (pkc1, pkc2)',
             ],

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -1159,46 +1159,6 @@ abstract class AbstractPlatformTestCase extends TestCase
         ];
     }
 
-    public function testQuotesDropForeignKeySQL(): void
-    {
-        if (! $this->platform->supportsForeignKeyConstraints()) {
-            self::markTestSkipped(
-                sprintf('%s does not support foreign key constraints.', get_class($this->platform))
-            );
-        }
-
-        $tableName      = 'table';
-        $table          = new Table($tableName);
-        $foreignKeyName = 'select';
-        $foreignKey     = new ForeignKeyConstraint([], 'foo', [], 'select');
-        $expectedSql    = $this->getQuotesDropForeignKeySQL();
-
-        self::assertSame($expectedSql, $this->platform->getDropForeignKeySQL($foreignKeyName, $tableName));
-        self::assertSame($expectedSql, $this->platform->getDropForeignKeySQL($foreignKey, $table));
-    }
-
-    protected function getQuotesDropForeignKeySQL(): string
-    {
-        return 'ALTER TABLE "table" DROP FOREIGN KEY "select"';
-    }
-
-    public function testQuotesDropConstraintSQL(): void
-    {
-        $tableName      = 'table';
-        $table          = new Table($tableName);
-        $constraintName = 'select';
-        $constraint     = new ForeignKeyConstraint([], 'foo', [], 'select');
-        $expectedSql    = $this->getQuotesDropConstraintSQL();
-
-        self::assertSame($expectedSql, $this->platform->getDropConstraintSQL($constraintName, $tableName));
-        self::assertSame($expectedSql, $this->platform->getDropConstraintSQL($constraint, $table));
-    }
-
-    protected function getQuotesDropConstraintSQL(): string
-    {
-        return 'ALTER TABLE "table" DROP CONSTRAINT "select"';
-    }
-
     protected function getStringLiteralQuoteCharacter(): string
     {
         return "'";

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -665,7 +665,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         $foreignTable->addColumn('`foo-bar`', 'string');
 
         $table->addForeignKeyConstraint(
-            $foreignTable,
+            $foreignTable->getQuotedName($this->platform),
             ['create', 'foo', '`bar`'],
             ['create', 'bar', '`foo-bar`'],
             [],
@@ -685,7 +685,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         $foreignTable->addColumn('`foo-bar`', 'string');
 
         $table->addForeignKeyConstraint(
-            $foreignTable,
+            $foreignTable->getQuotedName($this->platform),
             ['create', 'foo', '`bar`'],
             ['create', 'bar', '`foo-bar`'],
             [],
@@ -705,7 +705,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         $foreignTable->addColumn('`foo-bar`', 'string');
 
         $table->addForeignKeyConstraint(
-            $foreignTable,
+            $foreignTable->getQuotedName($this->platform),
             ['create', 'foo', '`bar`'],
             ['create', 'bar', '`foo-bar`'],
             [],
@@ -1468,8 +1468,8 @@ abstract class AbstractPlatformTestCase extends TestCase
         $primaryTable->addColumn('baz', 'integer');
         $primaryTable->addIndex(['foo'], 'idx_foo');
         $primaryTable->addIndex(['bar'], 'idx_bar');
-        $primaryTable->addForeignKeyConstraint($foreignTable, ['foo'], ['id'], [], 'fk_foo');
-        $primaryTable->addForeignKeyConstraint($foreignTable, ['bar'], ['id'], [], 'fk_bar');
+        $primaryTable->addForeignKeyConstraint($foreignTable->getName(), ['foo'], ['id'], [], 'fk_foo');
+        $primaryTable->addForeignKeyConstraint($foreignTable->getName(), ['bar'], ['id'], [], 'fk_bar');
 
         $tableDiff                            = new TableDiff('mytable');
         $tableDiff->fromTable                 = $primaryTable;

--- a/tests/Platforms/AbstractPostgreSQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractPostgreSQLPlatformTestCase.php
@@ -770,11 +770,6 @@ abstract class AbstractPostgreSQLPlatformTestCase extends AbstractPlatformTestCa
         ];
     }
 
-    protected function getQuotesDropForeignKeySQL(): string
-    {
-        return 'ALTER TABLE "table" DROP CONSTRAINT "select"';
-    }
-
     public function testReturnsGuidTypeDeclarationSQL(): void
     {
         self::assertSame('UUID', $this->platform->getGuidTypeDeclarationSQL([]));

--- a/tests/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -1218,16 +1218,6 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
         ];
     }
 
-    protected function getQuotesDropForeignKeySQL(): string
-    {
-        return 'ALTER TABLE [table] DROP CONSTRAINT [select]';
-    }
-
-    protected function getQuotesDropConstraintSQL(): string
-    {
-        return 'ALTER TABLE [table] DROP CONSTRAINT [select]';
-    }
-
     /**
      * @param mixed[] $column
      *

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -705,11 +705,6 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         ];
     }
 
-    protected function getQuotesDropForeignKeySQL(): string
-    {
-        return 'ALTER TABLE "table" DROP CONSTRAINT "select"';
-    }
-
     public function testReturnsGuidTypeDeclarationSQL(): void
     {
         self::assertSame('CHAR(36)', $this->platform->getGuidTypeDeclarationSQL([]));

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -526,7 +526,7 @@ abstract class ComparatorTest extends TestCase
 
         $table2 = new Table('foo');
         $table2->addColumn('fk', 'integer');
-        $table2->addForeignKeyConstraint($tableForeign, ['fk'], ['id']);
+        $table2->addForeignKeyConstraint($tableForeign->getName(), ['fk'], ['id']);
 
         $tableDiff = $this->comparator->diffTable($table1, $table2);
 
@@ -544,7 +544,7 @@ abstract class ComparatorTest extends TestCase
 
         $table2 = new Table('foo');
         $table2->addColumn('fk', 'integer');
-        $table2->addForeignKeyConstraint($tableForeign, ['fk'], ['id']);
+        $table2->addForeignKeyConstraint($tableForeign->getName(), ['fk'], ['id']);
 
         $tableDiff = $this->comparator->diffTable($table2, $table1);
 
@@ -559,11 +559,11 @@ abstract class ComparatorTest extends TestCase
 
         $table1 = new Table('foo');
         $table1->addColumn('fk', 'integer');
-        $table1->addForeignKeyConstraint($tableForeign, ['fk'], ['id']);
+        $table1->addForeignKeyConstraint($tableForeign->getName(), ['fk'], ['id']);
 
         $table2 = new Table('foo');
         $table2->addColumn('fk', 'integer');
-        $table2->addForeignKeyConstraint($tableForeign, ['fk'], ['id'], ['onUpdate' => 'CASCADE']);
+        $table2->addForeignKeyConstraint($tableForeign->getName(), ['fk'], ['id'], ['onUpdate' => 'CASCADE']);
 
         $tableDiff = $this->comparator->diffTable($table1, $table2);
 
@@ -581,11 +581,11 @@ abstract class ComparatorTest extends TestCase
 
         $table1 = new Table('foo');
         $table1->addColumn('fk', 'integer');
-        $table1->addForeignKeyConstraint($tableForeign, ['fk'], ['id']);
+        $table1->addForeignKeyConstraint($tableForeign->getName(), ['fk'], ['id']);
 
         $table2 = new Table('foo');
         $table2->addColumn('fk', 'integer');
-        $table2->addForeignKeyConstraint($tableForeign2, ['fk'], ['id']);
+        $table2->addForeignKeyConstraint($tableForeign2->getName(), ['fk'], ['id']);
 
         $tableDiff = $this->comparator->diffTable($table1, $table2);
 
@@ -982,8 +982,8 @@ abstract class ComparatorTest extends TestCase
         $tableC->addColumn('table_a_id', 'integer');
         $tableC->addColumn('table_b_id', 'integer');
 
-        $tableC->addForeignKeyConstraint($tableA, ['table_a_id'], ['id']);
-        $tableC->addForeignKeyConstraint($tableB, ['table_b_id'], ['id']);
+        $tableC->addForeignKeyConstraint($tableA->getName(), ['table_a_id'], ['id']);
+        $tableC->addForeignKeyConstraint($tableB->getName(), ['table_b_id'], ['id']);
 
         $newSchema = new Schema();
 

--- a/tests/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Schema/ForeignKeyConstraintTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Table;
 use PHPUnit\Framework\TestCase;
 
 class ForeignKeyConstraintTest extends TestCase
@@ -60,12 +59,12 @@ class ForeignKeyConstraintTest extends TestCase
     }
 
     /**
-     * @param string|Table $foreignTableName
-     *
      * @dataProvider getUnqualifiedForeignTableNameData
      */
-    public function testGetUnqualifiedForeignTableName($foreignTableName, string $expectedUnqualifiedTableName): void
-    {
+    public function testGetUnqualifiedForeignTableName(
+        string $foreignTableName,
+        string $expectedUnqualifiedTableName
+    ): void {
         $foreignKey = new ForeignKeyConstraint(['foo', 'bar'], $foreignTableName, ['fk_foo', 'fk_bar']);
 
         self::assertSame($expectedUnqualifiedTableName, $foreignKey->getUnqualifiedForeignTableName());
@@ -79,8 +78,6 @@ class ForeignKeyConstraintTest extends TestCase
         return [
             ['schema.foreign_table', 'foreign_table'],
             ['foreign_table', 'foreign_table'],
-            [new Table('schema.foreign_table'), 'foreign_table'],
-            [new Table('foreign_table'), 'foreign_table'],
         ];
     }
 }

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -53,7 +53,7 @@ class MySQLSchemaTest extends TestCase
 
         $sqls = [];
         foreach ($tableOld->getForeignKeys() as $fk) {
-            $sqls[] = $this->platform->getCreateForeignKeySQL($fk, $tableOld);
+            $sqls[] = $this->platform->getCreateForeignKeySQL($fk, $tableOld->getQuotedName($this->platform));
         }
 
         self::assertEquals(

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -38,7 +38,7 @@ class MySQLSchemaTest extends TestCase
 
         self::assertEquals(
             [
-                'ALTER TABLE test DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON test',
                 'ALTER TABLE test ADD PRIMARY KEY (bar_id, foo_id)',
             ],
             $sql

--- a/tests/Schema/SchemaDiffTest.php
+++ b/tests/Schema/SchemaDiffTest.php
@@ -60,7 +60,7 @@ class SchemaDiffTest extends TestCase
         if ($unsafe) {
             $platform->expects(self::exactly(1))
                  ->method('getDropSequenceSql')
-                 ->with(self::isInstanceOf(Sequence::class))
+                 ->with('baz_seq')
                  ->will(self::returnValue('drop_seq'));
         }
 
@@ -75,7 +75,7 @@ class SchemaDiffTest extends TestCase
         if ($unsafe) {
             $platform->expects(self::exactly(1))
                      ->method('getDropTableSql')
-                     ->with(self::isInstanceOf(Table::class))
+                     ->with('bar_table')
                      ->will(self::returnValue('drop_table'));
         }
 

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -202,7 +202,7 @@ class SchemaTest extends TestCase
         $tableB = $schema->createTable('bar');
         $tableB->addColumn('id', 'integer');
         $tableB->addColumn('foo_id', 'integer');
-        $tableB->addForeignKeyConstraint($tableA, ['foo_id'], ['id']);
+        $tableB->addForeignKeyConstraint($tableA->getName(), ['foo_id'], ['id']);
 
         $schemaNew = clone $schema;
 

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -296,20 +296,7 @@ class TableTest extends TestCase
         $foreignTable = new Table('bar');
         $foreignTable->addColumn('id', 'integer');
 
-        $table->addForeignKeyConstraint($foreignTable, ['foo'], ['id']);
-    }
-
-    public function testAddForeignKeyConstraintUnknownForeignColumnThrowsException(): void
-    {
-        $this->expectException(SchemaException::class);
-
-        $table = new Table('foo');
-        $table->addColumn('id', 'integer');
-
-        $foreignTable = new Table('bar');
-        $foreignTable->addColumn('id', 'integer');
-
-        $table->addForeignKeyConstraint($foreignTable, ['id'], ['foo']);
+        $table->addForeignKeyConstraint($foreignTable->getName(), ['foo'], ['id']);
     }
 
     public function testAddForeignKeyConstraint(): void
@@ -320,7 +307,7 @@ class TableTest extends TestCase
         $foreignTable = new Table('bar');
         $foreignTable->addColumn('id', 'integer');
 
-        $table->addForeignKeyConstraint($foreignTable, ['id'], ['id'], ['foo' => 'bar']);
+        $table->addForeignKeyConstraint($foreignTable->getName(), ['id'], ['id'], ['foo' => 'bar']);
 
         $constraints = $table->getForeignKeys();
         self::assertCount(1, $constraints);
@@ -373,7 +360,7 @@ class TableTest extends TestCase
         $foreignTable = new Table('bar');
         $foreignTable->addColumn('id', 'integer');
 
-        $table->addForeignKeyConstraint($foreignTable, ['id'], ['id'], ['foo' => 'bar']);
+        $table->addForeignKeyConstraint($foreignTable->getName(), ['id'], ['id'], ['foo' => 'bar']);
 
         $indexes = $table->getIndexes();
         self::assertCount(1, $indexes);
@@ -392,7 +379,7 @@ class TableTest extends TestCase
         $foreignTable = new Table('bar');
         $foreignTable->addColumn('foo', 'integer');
 
-        $table->addForeignKeyConstraint($foreignTable, ['bar'], ['foo']);
+        $table->addForeignKeyConstraint($foreignTable->getName(), ['bar'], ['foo']);
 
         self::assertCount(1, $table->getIndexes());
         self::assertTrue($table->hasIndex('bar_idx'));
@@ -412,7 +399,7 @@ class TableTest extends TestCase
         $foreignTable->addColumn('foo', 'integer');
         $foreignTable->addColumn('baz', 'string');
 
-        $table->addForeignKeyConstraint($foreignTable, ['bar', 'baz'], ['foo', 'baz']);
+        $table->addForeignKeyConstraint($foreignTable->getName(), ['bar', 'baz'], ['foo', 'baz']);
 
         self::assertCount(3, $table->getIndexes());
         self::assertTrue($table->hasIndex('composite_idx'));
@@ -491,7 +478,7 @@ class TableTest extends TestCase
 
         $localTable = new Table('local');
         $localTable->addColumn('id', 'integer');
-        $localTable->addForeignKeyConstraint($foreignTable, ['id'], ['id']);
+        $localTable->addForeignKeyConstraint($foreignTable->getName(), ['id'], ['id']);
 
         self::assertCount(1, $localTable->getIndexes());
 
@@ -508,7 +495,7 @@ class TableTest extends TestCase
 
         $localTable = new Table('local');
         $localTable->addColumn('id', 'integer');
-        $localTable->addForeignKeyConstraint($foreignTable, ['id'], ['id']);
+        $localTable->addForeignKeyConstraint($foreignTable->getName(), ['id'], ['id']);
 
         self::assertCount(1, $localTable->getIndexes());
 
@@ -525,7 +512,7 @@ class TableTest extends TestCase
 
         $localTable = new Table('local');
         $localTable->addColumn('id', 'integer');
-        $localTable->addForeignKeyConstraint($foreignTable, ['id'], ['id']);
+        $localTable->addForeignKeyConstraint($foreignTable->getName(), ['id'], ['id']);
 
         self::assertCount(1, $localTable->getIndexes());
 
@@ -542,7 +529,7 @@ class TableTest extends TestCase
 
         $localTable = new Table('local');
         $localTable->addColumn('id', 'integer');
-        $localTable->addForeignKeyConstraint($foreignTable, ['id'], ['id']);
+        $localTable->addForeignKeyConstraint($foreignTable->getName(), ['id'], ['id']);
 
         self::assertCount(1, $localTable->getIndexes());
         self::assertTrue($localTable->hasIndex('IDX_8BD688E8BF396750'));

--- a/tests/Schema/Visitor/DropSchemaSqlCollectorTest.php
+++ b/tests/Schema/Visitor/DropSchemaSqlCollectorTest.php
@@ -33,8 +33,8 @@ class DropSchemaSqlCollectorTest extends TestCase
         $platform->expects(self::exactly(2))
             ->method('getDropForeignKeySQL')
             ->withConsecutive(
-                [$keyConstraintOne, $tableOne],
-                [$keyConstraintTwo, $tableTwo]
+                [$keyConstraintOne->getQuotedName($platform), $tableOne->getQuotedName($platform)],
+                [$keyConstraintTwo->getQuotedName($platform), $tableTwo->getQuotedName($platform)]
             );
 
         $collector->acceptForeignKey($tableOne, $keyConstraintOne);

--- a/tests/Schema/Visitor/SchemaSqlCollectorTest.php
+++ b/tests/Schema/Visitor/SchemaSqlCollectorTest.php
@@ -68,7 +68,7 @@ class SchemaSqlCollectorTest extends TestCase
         $tableB->addColumn('id', 'integer');
         $tableB->setPrimaryKey(['id']);
 
-        $tableA->addForeignKeyConstraint($tableB, ['bar'], ['id']);
+        $tableA->addForeignKeyConstraint($tableB->getName(), ['bar'], ['id']);
 
         return $schema;
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

#### Summary

The current Platform and Schema APIs allow passing object names as strings or as objects themselves (sub-classes of `Asset`). For instance, in order to drop a table, the caller can pass the table name or the `Table` object.

While it may look handly from the API consumer perspective, it violates the Interface Segregation Principle. In the example above, the `getDropTableSQL()` method has to support accepting an object although it only needs the name of the object.

Another problem is that this API is prone to being implemented inconsistently depending on the type of the actually passed argument. For instance:
1. MySQL will drop the PK using `ALTER TABLE tbl DROP PRIMARY KEY` only if the index is passed as an object since the information about whether the given index is the PK or not isn't encoded in the index name: https://github.com/doctrine/dbal/blob/27c26d2ccad78384534fd2db797b76c3c0e8d9af/src/Platforms/MySQLPlatform.php#L897-L901
2. The `Table` class will validate the columns of the foreign key against the referenced table only if the referenced table name is passed as an asset: https://github.com/doctrine/dbal/blob/f83121fa971abe481a5f3129821a28232f6bacd9/src/Schema/Table.php#L354-L360

Another practical problem is that it cripples the Events API: https://github.com/doctrine/dbal/blob/dc4ad2a0d7f72e9e55dd1f9e2a341c068fd2b89f/src/Event/SchemaDropTableEventArgs.php#L34-L37

The consumer of the `SchemaDropTableEventArgs` class has to support receiving the table name expressed as _either_ of the `string` and `Table`.

As part of prototyping https://github.com/doctrine/dbal/issues/4772, I'd like to convert all `string $name` arguments into `Name $name`. This is where the need to drop the support for `Asset|string` arguments arose.

**TODO**:
- [x] Deprecate the previous API (#4798).
   The deprecation should happen after the `Name`-based API is implemented or before 4.0.x is released (whatever happens first).