### PR TITLE
Remove suppression for MissingNativeTypeHint errors

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,14 +48,6 @@
         <exclude-pattern>*/src/Tools/Console/Helper/ConnectionHelper.php</exclude-pattern>
     </rule>
 
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
-        <exclude-pattern>*/src/*</exclude-pattern>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
-        <exclude-pattern>*/src/*</exclude-pattern>
-    </rule>
-
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php</exclude-pattern>
         <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php</exclude-pattern>

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -619,7 +619,7 @@ class Connection implements ServerVersionProvider
      *
      * @return array<int, int|string|Type|null>|array<string, int|string|Type|null>
      */
-    private function extractTypeValues(array $columnList, array $types)
+    private function extractTypeValues(array $columnList, array $types): array
     {
         $typeValues = [];
 

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -94,6 +94,9 @@ final class Connection implements ConnectionInterface
         return $this->prepare($sql)->execute()->rowCount();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function lastInsertId()
     {
         throw IdentityColumnsNotSupported::new();

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1473,10 +1473,7 @@ class SQLServerPlatform extends AbstractPlatform
         );
     }
 
-    /**
-     * @param string $query
-     */
-    private function shouldAddOrderBy($query): bool
+    private function shouldAddOrderBy(string $query): bool
     {
         // Find the position of the last instance of ORDER BY and ensure it is not within a parenthetical statement
         // but can be in a newline


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The `MissingNativeTypeHint`PHP_CodeSniffer errors are currently suppressed in `4.0.x` for no real reason. Having them suppressed allows for introducing new APIs without native type hints.