### PR TITLE
Add failing test for Schema::getTableNames() when using sqlite 

### DIFF
--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Schema;
 
+use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -31,6 +32,17 @@ class SchemaTest extends TestCase
         self::assertSame($table, $tables[$tableName]);
         self::assertSame($table, $schema->getTable($tableName));
         self::assertTrue($schema->hasTable($tableName));
+    }
+
+    public function testGetTableNames(): void
+    {
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+
+        $schema = new Schema([], [], $conn->createSchemaManager()->createSchemaConfig());
+        $schema->createTable('foo');
+
+        $tableNames = $schema->getTableNames();
+        self::assertEquals(['foo'], $tableNames);
     }
 
     public function testTableMatchingCaseInsensitive(): void

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Visitor\AbstractVisitor;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
+use Doctrine\DBAL\Tests\TestUtil;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -36,7 +37,7 @@ class SchemaTest extends TestCase
 
     public function testGetTableNames(): void
     {
-        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $conn = DriverManager::getConnection(TestUtil::getConnectionParams());
 
         $schema = new Schema([], [], $conn->createSchemaManager()->createSchemaConfig());
         $schema->createTable('foo');


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | (unexpected change from dbal 2.x)
| Fixed issues | -

#### Summary

When using SQLite (or any other connection for which `\Doctrine\DBAL\Connection::getDatabase()` returns an empty string, the table names contains an invalid name.

This issue seems introduced by https://github.com/doctrine/dbal/commit/460f0a1fe2d41b1f03c929d62fc1783fe325755c 


