### PR TITLE
Require $table in SQLServerPlatform::getDropIndexSQL()

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1656,8 +1656,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to drop an index from a table.
      *
-     * @param Index|string $index
-     * @param Table|string $table
+     * @param Index|string      $index
+     * @param Table|string|null $table
      *
      * @return string
      *

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -274,28 +274,15 @@ class SQLServerPlatform extends AbstractPlatform
             );
         }
 
-        if (! isset($table)) {
-            return 'DROP INDEX ' . $index;
-        }
-
         if ($table instanceof Table) {
             $table = $table->getQuotedName($this);
+        } elseif (! is_string($table)) {
+            throw new InvalidArgumentException(
+                __METHOD__ . '() expects $table parameter to be string or ' . Table::class . '.'
+            );
         }
 
-        return sprintf(
-            <<<SQL
-                IF EXISTS (SELECT * FROM sysobjects WHERE name = '%s')
-                    ALTER TABLE %s DROP CONSTRAINT %s
-                ELSE
-                    DROP INDEX %s ON %s
-                SQL
-            ,
-            $index,
-            $table,
-            $index,
-            $index,
-            $table
-        );
+        return 'DROP INDEX ' . $index . ' ON ' . $table;
     }
 
     /**

--- a/tests/Platforms/MySQLPlatformTest.php
+++ b/tests/Platforms/MySQLPlatformTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Platforms;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\TransactionIsolationLevel;
+use InvalidArgumentException;
 
 class MySQLPlatformTest extends AbstractMySQLPlatformTestCase
 {
@@ -19,5 +20,11 @@ class MySQLPlatformTest extends AbstractMySQLPlatformTestCase
             TransactionIsolationLevel::REPEATABLE_READ,
             $this->platform->getDefaultTransactionIsolationLevel()
         );
+    }
+
+    public function testDropIndexSQLRequiresTable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->platform->getDropIndexSQL('foo');
     }
 }

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Platforms;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use InvalidArgumentException;
 
 class SQLServerPlatformTest extends AbstractSQLServerPlatformTestCase
 {
@@ -40,5 +41,11 @@ class SQLServerPlatformTest extends AbstractSQLServerPlatformTestCase
     public function testGeneratesTypeDeclarationForDateTimeTz(): void
     {
         self::assertEquals('DATETIMEOFFSET(6)', $this->platform->getDateTimeTzTypeDeclarationSQL([]));
+    }
+
+    public function testDropIndexSQLRequiresTable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->platform->getDropIndexSQL('foo');
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

Currently, SQLServer platform allows omitting table name when generating the `DROP INDEX` SQL statement and if the table name is omitted, generates an invalid statement:
```php
$connection->executeStatement(
    $connection->getDatabasePlatform()->getDropIndexSQL('foo')
);
// Must specify the table name and index name for the DROP INDEX statement
```

Additionally, the method implementation contains code unrelated to dropping indices not covered by tests. `DROP CONSTRAINT` statements should be generated by the corresponding method.
