### PR TITLE
Platform API cleanup

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## Deprecated `OraclePlatform::assertValidIdentifier()`
+
+The `OraclePlatform::assertValidIdentifier()` method has been deprecated.
+
 ## Deprecated features of `Table::getColumns()`
 
 1. Using the returned array keys as column names is deprecated. Retrieve the name from the column

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## `SQLServerPlatform` methods marked internal.
+
+The following `SQLServerPlatform` methods have been marked internal:
+- `getDefaultConstraintDeclarationSQL()`,
+- `getAddExtendedPropertySQL()`,
+- `getDropExtendedPropertySQL()`,
+- `getUpdateExtendedPropertySQL()`.
+
 ## `OraclePlatform` methods marked internal.
 
 The `OraclePlatform::getCreateAutoincrementSql()` and `::getDropAutoincrementSql()` have been marked internal.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## Deprecated `udf*` methods of the `SQLitePlatform` methods.
+
+The following `SQLServerPlatform` methods have been deprecated in favor of their implementations
+in the `UserDefinedFunctions` class:
+- `udfSqrt()`,
+- `udfMod()`,
+- `udfLocate()`.
+
 ## `SQLServerPlatform` methods marked internal.
 
 The following `SQLServerPlatform` methods have been marked internal:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## `OraclePlatform` methods marked internal.
+
+The `OraclePlatform::getCreateAutoincrementSql()` and `::getDropAutoincrementSql()` have been marked internal.
+
 ## Deprecated `OraclePlatform::assertValidIdentifier()`
 
 The `OraclePlatform::assertValidIdentifier()` method has been deprecated.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -150,6 +150,10 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\Schema::getMigrateToSql"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\OraclePlatform::assertValidIdentifier"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Driver/API/SQLite/UserDefinedFunctions.php
+++ b/src/Driver/API/SQLite/UserDefinedFunctions.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\API\SQLite;
+
+use function strpos;
+
+/**
+ * User-defined SQLite functions.
+ *
+ * @internal
+ */
+final class UserDefinedFunctions
+{
+    /**
+     * User-defined function that implements MOD().
+     *
+     * @param int $a
+     * @param int $b
+     *
+     * @return int
+     */
+    public static function mod($a, $b)
+    {
+        return $a % $b;
+    }
+
+    /**
+     * User-defined function that implements LOCATE().
+     *
+     * @param string $str
+     * @param string $substr
+     * @param int    $offset
+     *
+     * @return int
+     */
+    public static function locate($str, $substr, $offset = 0)
+    {
+        // SQL's LOCATE function works on 1-based positions, while PHP's strpos works on 0-based positions.
+        // So we have to make them compatible if an offset is given.
+        if ($offset > 0) {
+            $offset -= 1;
+        }
+
+        $pos = strpos($str, $substr, $offset);
+
+        if ($pos !== false) {
+            return $pos + 1;
+        }
+
+        return 0;
+    }
+}

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -35,6 +35,8 @@ class OraclePlatform extends AbstractPlatform
     /**
      * Assertion for Oracle identifiers.
      *
+     * @deprecated
+     *
      * @link http://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements008.htm
      *
      * @param string $identifier

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -492,6 +492,8 @@ class OraclePlatform extends AbstractPlatform
     }
 
     /**
+     * @internal The method should be only used from within the OraclePlatform class hierarchy.
+     *
      * @param string $name
      * @param string $table
      * @param int    $start
@@ -559,6 +561,8 @@ END;';
     }
 
     /**
+     * @internal The method should be only used from within the OracleSchemaManager class hierarchy.
+     *
      * Returns the SQL statements to drop the autoincrement for the given table name.
      *
      * @param string $table The table name to drop the autoincrement for.

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -438,6 +438,8 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * Returns the SQL snippet for declaring a default constraint.
      *
+     * @internal The method should be only used from within the SQLServerPlatform class hierarchy.
+     *
      * @param string  $table  Name of the table to return the default constraint declaration for.
      * @param mixed[] $column Column definition.
      *
@@ -843,6 +845,8 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * Returns the SQL statement for adding an extended property to a database object.
      *
+     * @internal The method should be only used from within the SQLServerPlatform class hierarchy.
+     *
      * @link http://msdn.microsoft.com/en-us/library/ms180047%28v=sql.90%29.aspx
      *
      * @param string      $name       The name of the property to add.
@@ -876,6 +880,8 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * Returns the SQL statement for dropping an extended property from a database object.
      *
+     * @internal The method should be only used from within the SQLServerPlatform class hierarchy.
+     *
      * @link http://technet.microsoft.com/en-gb/library/ms178595%28v=sql.90%29.aspx
      *
      * @param string      $name       The name of the property to drop.
@@ -906,6 +912,8 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * Returns the SQL statement for updating an extended property of a database object.
+     *
+     * @internal The method should be only used from within the SQLServerPlatform class hierarchy.
      *
      * @link http://msdn.microsoft.com/en-us/library/ms186885%28v=sql.90%29.aspx
      *

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Driver\API\SQLite\UserDefinedFunctions;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Constraint;
@@ -27,7 +28,6 @@ use function sprintf;
 use function sqrt;
 use function str_replace;
 use function strlen;
-use function strpos;
 use function strtolower;
 use function trim;
 
@@ -594,6 +594,8 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * User-defined function for Sqlite that is used with PDO::sqliteCreateFunction().
      *
+     * @deprecated The driver will use {@link sqrt()} in the next major release.
+     *
      * @param int|float $value
      *
      * @return float
@@ -606,6 +608,8 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * User-defined function for Sqlite that implements MOD(a, b).
      *
+     * @deprecated The driver will use {@link UserDefinedFunctions::mod()} in the next major release.
+     *
      * @param int $a
      * @param int $b
      *
@@ -613,10 +617,12 @@ class SqlitePlatform extends AbstractPlatform
      */
     public static function udfMod($a, $b)
     {
-        return $a % $b;
+        return UserDefinedFunctions::mod($a, $b);
     }
 
     /**
+     * @deprecated The driver will use {@link UserDefinedFunctions::locate()} in the next major release.
+     *
      * @param string $str
      * @param string $substr
      * @param int    $offset
@@ -625,19 +631,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public static function udfLocate($str, $substr, $offset = 0)
     {
-        // SQL's LOCATE function works on 1-based positions, while PHP's strpos works on 0-based positions.
-        // So we have to make them compatible if an offset is given.
-        if ($offset > 0) {
-            $offset -= 1;
-        }
-
-        $pos = strpos($str, $substr, $offset);
-
-        if ($pos !== false) {
-            return $pos + 1;
-        }
-
-        return 0;
+        return UserDefinedFunctions::locate($str, $substr, $offset);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement, deprecation
| BC Break     | no

The methods being reworked are defined in the `AbstractPlatform` sub-classes but do not belong to the Platform API:
1. `OraclePlatform::assertValidIdentifier()` is not used anywhere. The DBAL is not the source of truth about the validity of a given identifier.
2. `OraclePlatform::getCreateAutoincrementSql()` is only called from within the class and should be made protected.
3. `OraclePlatform::getDropAutoincrementSql()` is only called from within the schema manager. There's definitely some asymmetry with the above method. We can decide on how to improve this API later. For instance, get rid of the triggers in favor of identity columns.
4. The `SQLServerPlatform` methods in question are only called from within the class and should be made protected.
5. The SQLite user-defined functions don't need to be defined within the platform class.