### PR TITLE
Remove AbstractPlatform::getSequencePrefix()

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2266,21 +2266,6 @@ abstract class AbstractPlatform
     }
 
     /**
-     * Gets the sequence name prefix based on table information.
-     */
-    public function getSequencePrefix(string $tableName, ?string $schemaName = null): string
-    {
-        if ($schemaName === null) {
-            return $tableName;
-        }
-
-        // Prepend the schema name to the table name if there is one
-        return ! $this->supportsSchemas() && $this->canEmulateSchemas()
-            ? $schemaName . '__' . $tableName
-            : $schemaName . '.' . $tableName;
-    }
-
-    /**
      * Returns the name of the sequence for a particular identity column in a particular table.
      *
      * @see usesSequenceEmulatedIdentityColumns


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The method was introduced in https://github.com/doctrine/dbal/commit/0ff4d9bf4553f9155b88d5a754fc79ef01f9272d as part of a larger change (https://github.com/doctrine/dbal/pull/3712). It's not used by the DBAL and, despite the commit message, doesn't seem to be used by the ORM either.