### PR TITLE
Deprecate AbstractPlatform::canEmulateSchemas()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## Deprecated `AbstractPlatform::canEmulateSchemas()`.
+
+The `AbstractPlatform::canEmulateSchemas()` method and the schema emulation implemented in the SQLite platform
+have been deprecated.
+
 ## Deprecated `udf*` methods of the `SQLitePlatform` methods.
 
 The following `SQLServerPlatform` methods have been deprecated in favor of their implementations

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3467,6 +3467,8 @@ abstract class AbstractPlatform
     /**
      * Whether this platform can emulate schemas.
      *
+     * @deprecated
+     *
      * Platforms that either support or emulate schemas don't automatically
      * filter a schema for the namespaced elements in {@link AbstractManager::createSchema()}.
      *
@@ -3474,6 +3476,12 @@ abstract class AbstractPlatform
      */
     public function canEmulateSchemas()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4805',
+            'AbstractPlatform::canEmulateSchemas() is deprecated.'
+        );
+
         return false;
     }
 

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -800,6 +800,8 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      *
+     * @deprecated
+     *
      * Sqlite Platform emulates schema by underscoring each dot and generating tables
      * into the default database.
      *
@@ -808,6 +810,12 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function canEmulateSchemas()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4805',
+            'SqlitePlatform::canEmulateSchemas() is deprecated.'
+        );
+
         return true;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

The "schema emulation" feature as it's currently implemented in the DBAL doesn't belong to the DBAL. The emulation is effectively replacing the dot in the table names with a double underscore, assuming the dot is a fully qualified name separator (see https://github.com/doctrine/dbal/pull/4804), which isn't always true (see https://github.com/doctrine/dbal/pull/4708).

It is used by the ORM but since the ORM owns the table names, it can do the same replacement itself and emulate the schema on any platform. As such, this feature is really questionable. I wouldn't trust the results of such tests.

There isn't a single test in the DBAL that would cover this feature.