### PR TITLE
Remove $name from AbstractPlatform object declaration methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: Changed signatures of `AbstractPlatform::getIndexDeclarationSQL()` and `::getUniqueConstraintDeclarationSQL()`
+
+The `AbstractPlatform::getIndexDeclarationSQL()` and `::getUniqueConstraintDeclarationSQL()` methods no longer accept
+the name of the object as a separate parameter. The name of the passed index or constraint is used instead.
+
 ## BC BREAK: Removed `AbstractPlatform::canEmulateSchemas()`
 
 The `AbstractPlatform::canEmulateSchemas()` method and the schema emulation implemented in the SQLite platform

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1130,8 +1130,8 @@ abstract class AbstractPlatform
         $columnListSql = $this->getColumnDeclarationListSQL($columns);
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
-            foreach ($options['uniqueConstraints'] as $index => $definition) {
-                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($index, $definition);
+            foreach ($options['uniqueConstraints'] as $definition) {
+                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition);
             }
         }
 
@@ -1141,7 +1141,7 @@ abstract class AbstractPlatform
 
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
             foreach ($options['indexes'] as $index => $definition) {
-                $columnListSql .= ', ' . $this->getIndexDeclarationSQL($index, $definition);
+                $columnListSql .= ', ' . $this->getIndexDeclarationSQL($definition);
             }
         }
 
@@ -1747,14 +1747,13 @@ abstract class AbstractPlatform
      * Obtains DBMS specific SQL code portion needed to set a unique
      * constraint declaration to be used in statements like CREATE TABLE.
      *
-     * @param string           $name       The name of the unique constraint.
      * @param UniqueConstraint $constraint The unique constraint definition.
      *
      * @return string DBMS specific SQL code portion needed to set a constraint.
      *
      * @throws InvalidArgumentException
      */
-    public function getUniqueConstraintDeclarationSQL(string $name, UniqueConstraint $constraint): string
+    public function getUniqueConstraintDeclarationSQL(UniqueConstraint $constraint): string
     {
         $columns = $constraint->getColumns();
 
@@ -1764,8 +1763,8 @@ abstract class AbstractPlatform
 
         $chunks = ['CONSTRAINT'];
 
-        if ($name !== '') {
-            $chunks[] = (new Identifier($name))->getQuotedName($this);
+        if ($constraint->getName() !== '') {
+            $chunks[] = $constraint->getQuotedName($this);
         }
 
         $chunks[] = 'UNIQUE';
@@ -1783,23 +1782,21 @@ abstract class AbstractPlatform
      * Obtains DBMS specific SQL code portion needed to set an index
      * declaration to be used in statements like CREATE TABLE.
      *
-     * @param string $name  The name of the index.
-     * @param Index  $index The index definition.
+     * @param Index $index The index definition.
      *
      * @return string DBMS specific SQL code portion needed to set an index.
      *
      * @throws InvalidArgumentException
      */
-    public function getIndexDeclarationSQL(string $name, Index $index): string
+    public function getIndexDeclarationSQL(Index $index): string
     {
         $columns = $index->getColumns();
-        $name    = new Identifier($name);
 
         if (count($columns) === 0) {
             throw new InvalidArgumentException('Incomplete definition. "columns" required.');
         }
 
-        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $name->getQuotedName($this)
+        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $index->getQuotedName($this)
             . ' (' . $this->getIndexFieldDeclarationListSQL($index) . ')' . $this->getPartialIndexSQL($index);
     }
 

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -375,7 +375,7 @@ class DB2Platform extends AbstractPlatform
         return 'CURRENT TIMESTAMP';
     }
 
-    public function getIndexDeclarationSQL(string $name, Index $index): string
+    public function getIndexDeclarationSQL(Index $index): string
     {
         // Index declaration in statements like CREATE TABLE is not supported.
         throw NotSupported::new(__METHOD__);

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -321,15 +321,15 @@ SQL
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
-            foreach ($options['uniqueConstraints'] as $constraintName => $definition) {
-                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($constraintName, $definition);
+            foreach ($options['uniqueConstraints'] as $definition) {
+                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition);
             }
         }
 
         // add all indexes
         if (isset($options['indexes']) && ! empty($options['indexes'])) {
-            foreach ($options['indexes'] as $indexName => $definition) {
-                $queryFields .= ', ' . $this->getIndexDeclarationSQL($indexName, $definition);
+            foreach ($options['indexes'] as $definition) {
+                $queryFields .= ', ' . $this->getIndexDeclarationSQL($definition);
             }
         }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -252,8 +252,8 @@ class SQLServerPlatform extends AbstractPlatform
         $columnListSql = $this->getColumnDeclarationListSQL($columns);
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
-            foreach ($options['uniqueConstraints'] as $constraintName => $definition) {
-                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($constraintName, $definition);
+            foreach ($options['uniqueConstraints'] as $definition) {
+                $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition);
             }
         }
 

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -291,8 +291,8 @@ class SqlitePlatform extends AbstractPlatform
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
         if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
-            foreach ($options['uniqueConstraints'] as $constraintName => $definition) {
-                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($constraintName, $definition);
+            foreach ($options['uniqueConstraints'] as $definition) {
+                $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition);
             }
         }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -228,10 +228,10 @@ abstract class AbstractPlatformTestCase extends TestCase
         $indexes = [];
 
         if ($this->supportsInlineIndexDeclaration()) {
-            $indexes[] = $this->platform->getIndexDeclarationSQL('name', $indexDef);
+            $indexes[] = $this->platform->getIndexDeclarationSQL($indexDef);
         }
 
-        $uniqueConstraintSQL = $this->platform->getUniqueConstraintDeclarationSQL('name', $uniqueConstraint);
+        $uniqueConstraintSQL = $this->platform->getUniqueConstraintDeclarationSQL($uniqueConstraint);
         self::assertStringEndsNotWith($expected, $uniqueConstraintSQL, 'WHERE clause should NOT be present');
 
         $indexes[] = $this->platform->getCreateIndexSQL($indexDef, 'table');
@@ -722,7 +722,7 @@ abstract class AbstractPlatformTestCase extends TestCase
 
         self::assertSame(
             $this->getQuotesReservedKeywordInUniqueConstraintDeclarationSQL(),
-            $this->platform->getUniqueConstraintDeclarationSQL('select', $constraint)
+            $this->platform->getUniqueConstraintDeclarationSQL($constraint)
         );
     }
 
@@ -748,7 +748,7 @@ abstract class AbstractPlatformTestCase extends TestCase
 
         self::assertSame(
             $this->getQuotesReservedKeywordInIndexDeclarationSQL(),
-            $this->platform->getIndexDeclarationSQL('select', $index)
+            $this->platform->getIndexDeclarationSQL($index)
         );
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

#### Summary

The object name is already available as part of the object, no need to pass/accept it as a separate value.