### PR TITLE
Generalize platform SQL

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1581,18 +1581,6 @@ abstract class AbstractPlatform
     }
 
     /**
-     * Returns the SQL snippet to drop an existing database.
-     *
-     * @param string $name The name of the database that should be dropped.
-     *
-     * @return string
-     */
-    public function getDropDatabaseSQL($name)
-    {
-        return 'DROP DATABASE ' . $name;
-    }
-
-    /**
      * Returns the SQL snippet to drop a schema.
      */
     public function getDropSchemaSQL(string $schemaName): string
@@ -3182,7 +3170,27 @@ abstract class AbstractPlatform
      */
     public function getCreateDatabaseSQL($name)
     {
-        throw Exception::notSupported(__METHOD__);
+        if (! $this->supportsCreateDropDatabase()) {
+            throw Exception::notSupported(__METHOD__);
+        }
+
+        return 'CREATE DATABASE ' . $name;
+    }
+
+    /**
+     * Returns the SQL snippet to drop an existing database.
+     *
+     * @param string $name The name of the database that should be dropped.
+     *
+     * @return string
+     */
+    public function getDropDatabaseSQL($name)
+    {
+        if (! $this->supportsCreateDropDatabase()) {
+            throw Exception::notSupported(__METHOD__);
+        }
+
+        return 'DROP DATABASE ' . $name;
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3123,24 +3123,20 @@ abstract class AbstractPlatform
      * @param string $sql
      *
      * @return string
-     *
-     * @throws Exception If not supported on this platform.
      */
     public function getCreateViewSQL($name, $sql)
     {
-        throw Exception::notSupported(__METHOD__);
+        return 'CREATE VIEW ' . $name . ' AS ' . $sql;
     }
 
     /**
      * @param string $name
      *
      * @return string
-     *
-     * @throws Exception If not supported on this platform.
      */
     public function getDropViewSQL($name)
     {
-        throw Exception::notSupported(__METHOD__);
+        return 'DROP VIEW ' . $name;
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1581,14 +1581,6 @@ abstract class AbstractPlatform
     }
 
     /**
-     * Returns the SQL snippet to drop a schema.
-     */
-    public function getDropSchemaSQL(string $schemaName): string
-    {
-        return 'DROP SCHEMA ' . $schemaName;
-    }
-
-    /**
      * Returns the SQL snippet to drop an existing table.
      *
      * @param Table|string $table
@@ -2082,7 +2074,25 @@ abstract class AbstractPlatform
      */
     public function getCreateSchemaSQL($schemaName)
     {
-        throw Exception::notSupported(__METHOD__);
+        if (! $this->supportsSchemas()) {
+            throw Exception::notSupported(__METHOD__);
+        }
+
+        return 'CREATE SCHEMA ' . $schemaName;
+    }
+
+    /**
+     * Returns the SQL snippet to drop a schema.
+     *
+     * @throws Exception If not supported on this platform.
+     */
+    public function getDropSchemaSQL(string $schemaName): string
+    {
+        if (! $this->supportsSchemas()) {
+            throw Exception::notSupported(__METHOD__);
+        }
+
+        return 'DROP SCHEMA ' . $schemaName;
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1948,6 +1948,28 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Returns the SQL snippet to drop an existing sequence.
+     *
+     * @param Sequence|string $sequence
+     *
+     * @return string
+     *
+     * @throws Exception If not supported on this platform.
+     */
+    public function getDropSequenceSQL($sequence)
+    {
+        if (! $this->supportsSequences()) {
+            throw Exception::notSupported(__METHOD__);
+        }
+
+        if ($sequence instanceof Sequence) {
+            $sequence = $sequence->getQuotedName($this);
+        }
+
+        return 'DROP SEQUENCE ' . $sequence;
+    }
+
+    /**
      * Returns the SQL to create a constraint on a table on this platform.
      *
      * @param Table|string $table
@@ -3137,20 +3159,6 @@ abstract class AbstractPlatform
     public function getDropViewSQL($name)
     {
         return 'DROP VIEW ' . $name;
-    }
-
-    /**
-     * Returns the SQL snippet to drop an existing sequence.
-     *
-     * @param Sequence|string $sequence
-     *
-     * @return string
-     *
-     * @throws Exception If not supported on this platform.
-     */
-    public function getDropSequenceSQL($sequence)
-    {
-        throw Exception::notSupported(__METHOD__);
     }
 
     /**

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -421,22 +421,6 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateDatabaseSQL($name)
-    {
-        return 'CREATE DATABASE ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropDatabaseSQL($name)
-    {
-        return 'DROP DATABASE ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function supportsCreateDropDatabase()
     {
         return false;

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -405,22 +405,6 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateViewSQL($name, $sql)
-    {
-        return 'CREATE VIEW ' . $name . ' AS ' . $sql;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropViewSQL($name)
-    {
-        return 'DROP VIEW ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function supportsCreateDropDatabase()
     {
         return false;

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -201,22 +201,6 @@ class MySQLPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateViewSQL($name, $sql)
-    {
-        return 'CREATE VIEW ' . $name . ' AS ' . $sql;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropViewSQL($name)
-    {
-        return 'DROP VIEW ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
         return $fixed ? ($length > 0 ? 'CHAR(' . $length . ')' : 'CHAR(255)')

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -388,22 +388,6 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreateDatabaseSQL($name)
-    {
-        return 'CREATE DATABASE ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropDatabaseSQL($name)
-    {
-        return 'DROP DATABASE ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     protected function _getCreateTableSQL($name, array $columns, array $options = [])
     {
         $queryFields = $this->getColumnDeclarationListSQL($columns);

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -800,6 +800,14 @@ SQL
     /**
      * {@inheritDoc}
      */
+    public function getCreateDatabaseSQL($name)
+    {
+        return 'CREATE USER ' . $name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDropDatabaseSQL($name)
     {
         return 'DROP USER ' . $name . ' CASCADE';

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -476,22 +476,6 @@ class OraclePlatform extends AbstractPlatform
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function getCreateViewSQL($name, $sql)
-    {
-        return 'CREATE VIEW ' . $name . ' AS ' . $sql;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropViewSQL($name)
-    {
-        return 'DROP VIEW ' . $name;
-    }
-
-    /**
      * @internal The method should be only used from within the OraclePlatform class hierarchy.
      *
      * @param string $name

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -711,18 +711,6 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getDropSequenceSQL($sequence)
-    {
-        if ($sequence instanceof Sequence) {
-            $sequence = $sequence->getQuotedName($this);
-        }
-
-        return 'DROP SEQUENCE ' . $sequence;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getDropForeignKeySQL($foreignKey, $table)
     {
         if (! $foreignKey instanceof ForeignKeyConstraint) {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -315,22 +315,6 @@ class PostgreSQLPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateViewSQL($name, $sql)
-    {
-        return 'CREATE VIEW ' . $name . ' AS ' . $sql;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropViewSQL($name)
-    {
-        return 'DROP VIEW ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getListTableConstraintsSQL($table)
     {
         $table = new Identifier($table);

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -444,14 +444,6 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreateDatabaseSQL($name)
-    {
-        return 'CREATE DATABASE ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
     {
         $query = '';

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -750,14 +750,6 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getCreateSchemaSQL($schemaName)
-    {
-        return 'CREATE SCHEMA ' . $schemaName;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getDropForeignKeySQL($foreignKey, $table)
     {
         return $this->getDropConstraintSQL($foreignKey, $table);

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -724,11 +724,7 @@ SQL
      */
     public function getDropSequenceSQL($sequence)
     {
-        if ($sequence instanceof Sequence) {
-            $sequence = $sequence->getQuotedName($this);
-        }
-
-        return 'DROP SEQUENCE ' . $sequence . ' CASCADE';
+        return parent::getDropSequenceSQL($sequence) . ' CASCADE';
     }
 
     /**

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -213,30 +213,6 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateDatabaseSQL($name)
-    {
-        return 'CREATE DATABASE ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropDatabaseSQL($name)
-    {
-        return 'DROP DATABASE ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function supportsCreateDropDatabase()
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getCreateSchemaSQL($schemaName)
     {
         return 'CREATE SCHEMA ' . $schemaName;

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1003,14 +1003,6 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateViewSQL($name, $sql)
-    {
-        return 'CREATE VIEW ' . $name . ' AS ' . $sql;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getListViewsSQL($database)
     {
         return "SELECT name FROM sysobjects WHERE type = 'V' ORDER BY name";
@@ -1037,14 +1029,6 @@ class SQLServerPlatform extends AbstractPlatform
         }
 
         return sprintf('(%s = %s AND %s = %s)', $tableColumn, $table, $schemaColumn, $schema);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropViewSQL($name)
-    {
-        return 'DROP VIEW ' . $name;
     }
 
     /**

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -170,18 +170,6 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getDropSequenceSQL($sequence): string
-    {
-        if ($sequence instanceof Sequence) {
-            $sequence = $sequence->getQuotedName($this);
-        }
-
-        return 'DROP SEQUENCE ' . $sequence;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getListSequencesSQL($database)
     {
         return 'SELECT seq.name,

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -213,14 +213,6 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateSchemaSQL($schemaName)
-    {
-        return 'CREATE SCHEMA ' . $schemaName;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getDropForeignKeySQL($foreignKey, $table)
     {
         if (! $foreignKey instanceof ForeignKeyConstraint) {

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -506,22 +506,6 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getCreateViewSQL($name, $sql)
-    {
-        return 'CREATE VIEW ' . $name . ' AS ' . $sql;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDropViewSQL($name)
-    {
-        return 'DROP VIEW ' . $name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
     {
         $query = parent::getAdvancedForeignKeyOptionsSQL($foreignKey);

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -258,7 +258,7 @@ class OracleSchemaManager extends AbstractSchemaManager
      */
     public function createDatabase($database)
     {
-        $statement = 'CREATE USER ' . $database;
+        $statement = $this->_platform->getCreateDatabaseSQL($database);
 
         $params = $this->_conn->getParams();
 

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -347,8 +347,6 @@ class DB2PlatformTest extends AbstractPlatformTestCase
 
     public function testGeneratesDDLSnippets(): void
     {
-        self::assertEquals('CREATE DATABASE foobar', $this->platform->getCreateDatabaseSQL('foobar'));
-        self::assertEquals('DROP DATABASE foobar', $this->platform->getDropDatabaseSQL('foobar'));
         self::assertEquals('DECLARE GLOBAL TEMPORARY TABLE', $this->platform->getCreateTemporaryTableSnippetSQL());
         self::assertEquals('TRUNCATE foobar IMMEDIATE', $this->platform->getTruncateTableSQL('foobar'));
         self::assertEquals('TRUNCATE foobar IMMEDIATE', $this->platform->getTruncateTableSQL('foobar'), true);

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -149,14 +149,12 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         );
     }
 
-    public function testCreateDatabaseThrowsException(): void
+    public function testCreateDatabaseSQL(): void
     {
-        $this->expectException(Exception::class);
-
-        self::assertEquals('CREATE DATABASE foobar', $this->platform->getCreateDatabaseSQL('foobar'));
+        self::assertEquals('CREATE USER foobar', $this->platform->getCreateDatabaseSQL('foobar'));
     }
 
-    public function testDropDatabaseThrowsException(): void
+    public function testDropDatabaseSQL(): void
     {
         self::assertEquals('DROP USER foobar CASCADE', $this->platform->getDropDatabaseSQL('foobar'));
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. The `CREATE DATABASE` and `DROP DATABASE` statements are identical on all platforms that support databases.
2. The DBAL uses users on Oracle to emulate databases, so it should implement the "Create database" operation as `CREATE USER`. It already does the same with regards to dropping a database.
3. The IBM DB2 platform declares that it doesn't support databases: https://github.com/doctrine/dbal/blob/525eda78658b99b3118905b1058d272147c5d312/src/Platforms/DB2Platform.php#L440-L443  but its test attempt to cover the generation of the `CREATE DATABASE` and `DROP DATABASE` statements: https://github.com/doctrine/dbal/blob/11f0f94c474c7aa41b38b1defe1ab4c28ae0289d/tests/Platforms/DB2PlatformTest.php#L350-L351
4. The `CREATE SCHEMA` and `DROP SCHEMA` statements are identical on all platforms that support schemas.
5. The `CREATE VIEW` and `DROP VIEW` statements are identical on all platforms.
6. The is a common implementation of `DROP SEQUENCE` statements for all platforms that support sequences.
