### PR TITLE
Deprecate Schema::getTableNames()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,16 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## Deprecated `Schema::getTableNames()`.
+
+The `Schema::getTableNames()` method has been deprecated. In order to obtain schema table names,
+use `Schema::getTables()` and call `Table::getName()` on the elements of the returned array.
+
+## Deprecated features of `Schema::getTables()`
+
+Using the returned array keys as table names is deprecated. Retrieve the name from the table
+via `Table::getName()` instead. In order to retrieve a table by name, use `Schema::getTable()`.
+
 ## Deprecated `AbstractPlatform::canEmulateSchemas()`.
 
 The `AbstractPlatform::canEmulateSchemas()` method and the schema emulation implemented in the SQLite platform

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\Visitor\CreateSchemaSqlCollector;
 use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
 use Doctrine\DBAL\Schema\Visitor\NamespaceVisitor;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_keys;
 use function strpos;
@@ -246,10 +247,20 @@ class Schema extends AbstractAsset
     /**
      * Gets all table names, prefixed with a schema name, even the default one if present.
      *
+     * @deprecated Use {@link getTables()} and {@link Table::getName()} instead.
+     *
      * @return string[]
      */
     public function getTableNames()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4800',
+            'Schema::getTableNames() is deprecated.'
+            . ' Use Schema::getTables() and Table::getName() instead.',
+            __METHOD__
+        );
+
         return array_keys($this->_tables);
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

The behavior of the method as it's documented is quite questionable:
> Gets all table names, prefixed with a schema name, even the default one if present.

The DBAL doesn't implement schemas for most of the supported platforms but the table names are still prefixed with the PostgreSQL-specific "public" schema. There is already a getter for tables, so all the additional information can be obtained from there.

Additionally, using array keys of `Schema::getTables()` is being deprecated for the reasons described in https://github.com/doctrine/dbal/pull/4777.