### PR TITLE
Deprecate AbstractAsset::getFullQualifiedName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## Deprecated `AbstractAsset::getFullQualifiedName()`.
+
+The `AbstractAsset::getFullQualifiedName()` method has been deprecated. Use `::getNamespaceName()`
+and `::getName()` instead.
+
 ## Deprecated schema methods related to explicit foreign key indexes.
 
 The following methods have been deprecated:

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -159,6 +159,11 @@
                     See https://github.com/doctrine/dbal/pull/4822
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\SchemaConfig::hasExplicitForeignKeyIndexes"/>
+                <!--
+                    TODO: remove in 4.0.0
+                    See https://github.com/doctrine/dbal/pull/4814
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getFullQualifiedName"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
 use function crc32;
@@ -102,7 +103,7 @@ abstract class AbstractAsset
     }
 
     /**
-     * The normalized name is full-qualified and lowerspaced. Lowerspacing is
+     * The normalized name is full-qualified and lower-cased. Lower-casing is
      * actually wrong, but we have to do it to keep our sanity. If you are
      * using database objects that only differentiate in the casing (FOO vs
      * Foo) then you will NOT be able to use Doctrine Schema abstraction.
@@ -110,12 +111,21 @@ abstract class AbstractAsset
      * Every non-namespaced element is prefixed with the default namespace
      * name which is passed as argument to this method.
      *
+     * @deprecated Use {@link getNamespaceName()} and {@link getName()} instead.
+     *
      * @param string $defaultNamespaceName
      *
      * @return string
      */
     public function getFullQualifiedName($defaultNamespaceName)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4814',
+            'AbstractAsset::getFullQualifiedName() is deprecated.'
+            . ' Use AbstractAsset::getNamespaceName() and ::getName() instead.'
+        );
+
         $name = $this->getName();
         if ($this->_namespace === null) {
             $name = $defaultNamespaceName . '.' . $name;

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -112,7 +112,7 @@ class Schema extends AbstractAsset
     protected function _addTable(Table $table)
     {
         $namespaceName = $table->getNamespaceName();
-        $tableName     = $table->getFullQualifiedName($this->getName());
+        $tableName     = $this->normalizeName($table);
 
         if (isset($this->_tables[$tableName])) {
             throw SchemaException::tableAlreadyExists($tableName);
@@ -138,7 +138,7 @@ class Schema extends AbstractAsset
     protected function _addSequence(Sequence $sequence)
     {
         $namespaceName = $sequence->getNamespaceName();
-        $seqName       = $sequence->getFullQualifiedName($this->getName());
+        $seqName       = $this->normalizeName($sequence);
 
         if (isset($this->_sequences[$seqName])) {
             throw SchemaException::sequenceAlreadyExists($seqName);
@@ -206,6 +206,11 @@ class Schema extends AbstractAsset
         }
 
         return strtolower($name);
+    }
+
+    private function normalizeName(AbstractAsset $asset): string
+    {
+        return $asset->getFullQualifiedName($this->getName());
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

By definition, a fully qualified name is absolute and shouldn't depend on any input. The fully-qualified name of the assets is only used by `Schema` to index schema objects.