### PR TITLE
Use original case to index renamed columns

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -373,7 +373,7 @@ class Comparator
             }
 
             [$removedColumn, $addedColumn] = $candidateColumns[0];
-            $removedColumnName             = strtolower($removedColumn->getName());
+            $removedColumnName             = $removedColumn->getName();
             $addedColumnName               = strtolower($addedColumn->getName());
 
             if (isset($tableDifferences->renamedColumns[$removedColumnName])) {
@@ -383,7 +383,7 @@ class Comparator
             $tableDifferences->renamedColumns[$removedColumnName] = $addedColumn;
             unset(
                 $tableDifferences->addedColumns[$addedColumnName],
-                $tableDifferences->removedColumns[$removedColumnName]
+                $tableDifferences->removedColumns[strtolower($removedColumnName)]
             );
         }
     }

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
 use function array_keys;
+use function strtolower;
 
 class RenameColumnTest extends FunctionalTestCase
 {
@@ -15,10 +16,6 @@ class RenameColumnTest extends FunctionalTestCase
      */
     public function testColumnPositionRetainedAfterRenaming(string $columnName, string $newColumnName): void
     {
-        if ($columnName === 'C1' || $columnName === 'importantColumn') {
-            self::markTestIncomplete('See https://github.com/doctrine/dbal/issues/4816');
-        }
-
         $table = new Table('test_rename');
         $table->addColumn($columnName, 'string');
         $table->addColumn('c2', 'integer');
@@ -36,7 +33,7 @@ class RenameColumnTest extends FunctionalTestCase
         $sm->alterTable($diff);
 
         $table = $sm->listTableDetails('test_rename');
-        self::assertSame([$newColumnName, 'c2'], array_keys($table->getColumns()));
+        self::assertSame([strtolower($newColumnName), 'c2'], array_keys($table->getColumns()));
     }
 
     /**

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -823,7 +823,7 @@ class ComparatorTest extends TestCase
         $tableDiff = $this->comparator->diffTable($table, $newtable);
 
         self::assertInstanceOf(TableDiff::class, $tableDiff);
-        self::assertEquals(['twitterid', 'displayname'], array_keys($tableDiff->renamedColumns));
+        self::assertEquals(['twitterId', 'displayName'], array_keys($tableDiff->renamedColumns));
         self::assertEquals(['logged_in_at'], array_keys($tableDiff->addedColumns));
         self::assertCount(0, $tableDiff->removedColumns);
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | unclear

Fixes #4816.

Depending on what's considered the API, this change may constitute a minor BC break: instead of containing lower-cased names, `renamedColumns` will contain the original names while the table definition still uses lower-cased column names for indexing columns.