### PR TITLE
Cast decimals to string on SQLite

### DIFF
--- a/lib/Doctrine/DBAL/Types/DecimalType.php
+++ b/lib/Doctrine/DBAL/Types/DecimalType.php
@@ -4,6 +4,10 @@ namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
+use function is_float;
+
+use const PHP_VERSION_ID;
+
 /**
  * Type that maps an SQL DECIMAL to a PHP string.
  */
@@ -30,6 +34,10 @@ class DecimalType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
+        if (PHP_VERSION_ID >= 80100 && is_float($value)) {
+            return (string) $value;
+        }
+
         return $value;
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Types/DecimalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Types/DecimalTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Functional\Types;
+
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+final class DecimalTest extends DbalFunctionalTestCase
+{
+    public function testInsertAndRetrieveDecimal(): void
+    {
+        $table = new Table('decimal_table');
+        $table->addColumn('val', Types::DECIMAL, ['precision' => 4, 'scale' => 2]);
+
+        $sm = $this->connection->getSchemaManager();
+        $sm->dropAndCreateTable($table);
+
+        $this->connection->insert(
+            'decimal_table',
+            ['val' => '13.37'],
+            ['val' => Types::DECIMAL]
+        );
+
+        $value = Type::getType(Types::DECIMAL)->convertToPHPValue(
+            $this->connection->fetchOne('SELECT val FROM decimal_table'),
+            $this->connection->getDatabasePlatform()
+        );
+
+        self::assertSame('13.37', $value);
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | doctrine/orm#8963

#### Summary

On PHP 8.1, PDO's SQLite driver has "learnt" to convert integers and floats coming from the database to the corresponding native PHP types. Unfortunately, since SQLite is unable to differ between floats and decimals, we now get floats for decimals as well.

See the linked ORM issue for a more detailed discussion.

Since every driver has delivered DECIMALs as strings so far, `DecimalType::convertToPHPValue()` has not performed any type conversion yet. This PR proposes to change that by adding a `(string)` cast if we're on PHP 8.1 or higher and the value is a float. I believe that the caller of `DecimalType::convertToPHPValue()` would expect a string because otherwise they would've omitted the call and directly used the value as the driver returns it.

PHP should be able to optimize both checks, so the added condition should be fairly cheap. A float-to-string cast is unsafe on PHP 7 (because the result depends on the locale) which is another reason why we should have a version check here.