### PR TITLE
Deprecate AbstractSchemaManager::getSchemaSearchPaths()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## Deprecated `AbstractSchemaManager::getSchemaSearchPaths()`.
+
+1. The `AbstractSchemaManager::getSchemaSearchPaths()` method has been deprecated.
+2. Relying on `AbstractSchemaManager::createSchemaConfig()` populating the schema name for those database
+   platforms that don't support schemas (currently, all except for PostgreSQL) is deprecated.
+3. Relying on `Schema` using "public" as the default name is deprecated.
+
 ## Deprecated `AbstractAsset::getFullQualifiedName()`.
 
 The `AbstractAsset::getFullQualifiedName()` method has been deprecated. Use `::getNamespaceName()`

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -164,6 +164,11 @@
                     See https://github.com/doctrine/dbal/pull/4814
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getFullQualifiedName"/>
+                <!--
+                    TODO: remove in 4.0.0
+                    See https://github.com/doctrine/dbal/pull/4821
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractSchemaManager::getSchemaSearchPaths"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -1172,12 +1172,20 @@ abstract class AbstractSchemaManager
      * For databases that don't support subschema/namespaces this method
      * returns the name of the currently connected database.
      *
+     * @deprecated
+     *
      * @return string[]
      *
      * @throws Exception
      */
     public function getSchemaSearchPaths()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4821',
+            'AbstractSchemaManager::getSchemaSearchPaths() is deprecated.'
+        );
+
         $database = $this->_conn->getDatabase();
 
         if ($database !== null) {

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -76,9 +76,17 @@ SQL
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function getSchemaSearchPaths()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4821',
+            'PostgreSQLSchemaManager::getSchemaSearchPaths() is deprecated.'
+        );
+
         $params = $this->_conn->getParams();
 
         $searchPaths = $this->_conn->fetchOne('SHOW search_path');
@@ -101,6 +109,8 @@ SQL
      * @internal The method should be only used from within the PostgreSQLSchemaManager class hierarchy.
      *
      * @return string[]
+     *
+     * @throws Exception
      */
     public function getExistingSchemaSearchPaths()
     {
@@ -112,6 +122,20 @@ SQL
     }
 
     /**
+     * Returns the name of the current schema.
+     *
+     * @return string|null
+     *
+     * @throws Exception
+     */
+    protected function getCurrentSchema()
+    {
+        $schemas = $this->getExistingSchemaSearchPaths();
+
+        return array_shift($schemas);
+    }
+
+    /**
      * Sets or resets the order of the existing schemas in the current search path of the user.
      *
      * This is a PostgreSQL only function.
@@ -119,6 +143,8 @@ SQL
      * @internal The method should be only used from within the PostgreSQLSchemaManager class hierarchy.
      *
      * @return void
+     *
+     * @throws Exception
      */
     public function determineExistingSchemaSearchPaths()
     {
@@ -200,10 +226,9 @@ SQL
      */
     protected function _getPortableTableDefinition($table)
     {
-        $schemas     = $this->getExistingSchemaSearchPaths();
-        $firstSchema = array_shift($schemas);
+        $currentSchema = $this->getCurrentSchema();
 
-        if ($table['schema_name'] === $firstSchema) {
+        if ($table['schema_name'] === $currentSchema) {
             return $table['table_name'];
         }
 

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_change_key_case;
 use function array_map;
@@ -580,9 +581,17 @@ SQL
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function getSchemaSearchPaths()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4821',
+            'SqliteSchemaManager::getSchemaSearchPaths() is deprecated.'
+        );
+
         // SQLite does not support schemas or databases
         return [];
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

The concept of a search path as well as the "public" schema name are specific to PostgreSQL and don't belong to the DBAL: https://github.com/doctrine/dbal/blob/3f45d98b4e750f5bb14c99150d0ec96ba0f0b99e/src/Schema/Schema.php#L76

The APIs around the search path are only used by the PostgreSQL schema manager and only in order to identify the current schema (which is the first element of the search path). The `protected PostgreSQLSchemaManager::getCurrentSchema()` method is being introduced for this purpose.

**TODO**:
- [x] Rebase after merging the changes from #4811 into `3.2.x` (#4820).