### PR TITLE
Deprecate schema methods related to explicit foreign key indexes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## Deprecated schema methods related to explicit foreign key indexes.
+
+The following methods have been deprecated:
+
+- `Schema::hasExplicitForeignKeyIndexes()`,
+- `SchemaConfig::hasExplicitForeignKeyIndexes()`,
+- `SchemaConfig::setExplicitForeignKeyIndexes()`.
+
 ## Deprecated `Schema::getTableNames()`.
 
 The `Schema::getTableNames()` method has been deprecated. In order to obtain schema table names,

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -154,6 +154,11 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\OraclePlatform::assertValidIdentifier"/>
+                <!--
+                    TODO: remove in 4.0.0
+                    See https://github.com/doctrine/dbal/pull/4822
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\SchemaConfig::hasExplicitForeignKeyIndexes"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>
@@ -169,6 +174,11 @@
                     See https://github.com/doctrine/dbal/pull/4620
                 -->
                 <file name="src/Configuration.php"/>
+                <!--
+                    This suppression should be removed in 4.0.x
+                    See https://github.com/doctrine/dbal/pull/4822
+                -->
+                <referencedProperty name="Doctrine\DBAL\Schema\SchemaConfig::$hasExplicitForeignKeyIndexes"/>
             </errorLevel>
         </DeprecatedProperty>
         <DocblockTypeContradiction>

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -89,10 +89,18 @@ class Schema extends AbstractAsset
     }
 
     /**
+     * @deprecated
+     *
      * @return bool
      */
     public function hasExplicitForeignKeyIndexes()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4822',
+            'Schema::hasExplicitForeignKeyIndexes() is deprecated.'
+        );
+
         return $this->_schemaConfig->hasExplicitForeignKeyIndexes();
     }
 

--- a/src/Schema/SchemaConfig.php
+++ b/src/Schema/SchemaConfig.php
@@ -2,12 +2,18 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * Configuration for a Schema.
  */
 class SchemaConfig
 {
-    /** @var bool */
+    /**
+     * @deprecated
+     *
+     * @var bool
+     */
     protected $hasExplicitForeignKeyIndexes = false;
 
     /** @var int */
@@ -20,20 +26,36 @@ class SchemaConfig
     protected $defaultTableOptions = [];
 
     /**
+     * @deprecated
+     *
      * @return bool
      */
     public function hasExplicitForeignKeyIndexes()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4822',
+            'SchemaConfig::hasExplicitForeignKeyIndexes() is deprecated.'
+        );
+
         return $this->hasExplicitForeignKeyIndexes;
     }
 
     /**
+     * @deprecated
+     *
      * @param bool $flag
      *
      * @return void
      */
     public function setExplicitForeignKeyIndexes($flag)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4822',
+            'SchemaConfig::setExplicitForeignKeyIndexes() is deprecated.'
+        );
+
         $this->hasExplicitForeignKeyIndexes = (bool) $flag;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

This API is undocumented and isn't used by the DBAL. The ORM uses it `ORM\Tools\SchemaTool` but only by calling `setExplicitForeignKeyIndexes(false)` which is the default.