### PR TITLE
Remove pinned platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,6 @@
     },
     "bin": ["bin/doctrine-dbal"],
     "config": {
-        "platform": {
-            "php": "7.3.0"
-        },
         "sort-packages": true
     },
     "autoload": {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

I'd like to remove the `platform.php` setting from our composer.json file.

Without a lock file under version control, all that setting does is preventing the installation of newer packages on PHP 7.4 and higher (e.g. psr/log 2). I would argue that testing with different sets of dependencies for different PHP versions is somewhat desirable. 