### PR TITLE
Fix version displayed in `ConsoleRunner`

### DIFF
--- a/src/Tools/Console/ConsoleRunner.php
+++ b/src/Tools/Console/ConsoleRunner.php
@@ -25,9 +25,7 @@ class ConsoleRunner
      */
     public static function run(ConnectionProvider $connectionProvider, $commands = [])
     {
-        $cli = new Application('Doctrine Command Line Interface', Versions::getVersion(
-            Versions::rootPackageName()
-        ));
+        $cli = new Application('Doctrine Command Line Interface', Versions::getVersion('doctrine/dbal'));
 
         $cli->setCatchExceptions(true);
         self::addCommands($cli, $connectionProvider);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/A

#### Summary

When calling the `vendor/bin/doctrine-dbal` tool, it displays the version of the root package. The root package is usually the application that uses DBAL as a dependency. For instance, if I call this script from the `symfony/symfony` repository, it displays the Symfony version. I doubt that this is intended and assume that the DBAL version should be displayed instead. At least, this is the behavior on the 2.13.x branch where we still had a `Version` class for that purpose.

This PR fixes this problem by hardcoding the package name.