### PR TITLE
Add explanation why we need to cast float to string in decimal type

### DIFF
--- a/lib/Doctrine/DBAL/Types/DecimalType.php
+++ b/lib/Doctrine/DBAL/Types/DecimalType.php
@@ -34,6 +34,8 @@ class DecimalType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
+        // Some drivers starting from PHP 8.1 can represent decimals as float
+        // See also: https://github.com/doctrine/dbal/pull/4818
         if (PHP_VERSION_ID >= 80100 && is_float($value)) {
             return (string) $value;
         }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
Added explanation to code, why we need to cast a float to string only after PHP 8.1

refs: https://github.com/doctrine/dbal/pull/4818#discussion_r717958844
/cc @derrabus 