### PR TITLE
Build ibm_db2 with a public driver

### DIFF
--- a/ci/github/ext/install-ibm_db2.sh
+++ b/ci/github/ext/install-ibm_db2.sh
@@ -4,23 +4,18 @@ set -ex
 
 echo "Installing extension"
 (
-    # updating APT packages as per support recommendation
-    sudo apt-get -y -q update
-    sudo apt-get install ksh php-pear
-
     cd /tmp
 
-    wget http://cdn1.netmake.com.br/download/Conexao/DB2/Linux/x64_v10.5fp8_linuxx64_dsdriver.tar.gz
+    wget https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/linuxx64_odbc_cli.tar.gz
 
-    tar xf x64_v10.5fp8_linuxx64_dsdriver.tar.gz
-    ksh dsdriver/installDSDriver
+    tar xf linuxx64_odbc_cli.tar.gz
 
     pecl download ibm_db2
     tar xf ibm_db2-*
     rm ibm_db2-*.tgz
     cd ibm_db2-*
     phpize
-    ./configure --with-IBM_DB2=/tmp/dsdriver
+    ./configure --with-IBM_DB2=/tmp/clidriver
     make -j "$(nproc)"
     sudo make install
 )


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

See the build failure in https://github.com/doctrine/dbal/pull/4831:
```
wget http://cdn1.netmake.com.br/download/Conexao/DB2/Linux/x64_v10.5fp8_linuxx64_dsdriver.tar.gz
--2021-09-30 16:43:20--  http://cdn1.netmake.com.br/download/Conexao/DB2/Linux/x64_v10.5fp8_linuxx64_dsdriver.tar.gz
Resolving cdn1.netmake.com.br (cdn1.netmake.com.br)... 3.218.74.34
Connecting to cdn1.netmake.com.br (cdn1.netmake.com.br)|3.218.74.34|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2021-09-30 16:43:21 ERROR 404: Not Found.
```