### PR TITLE
fixed using lower case column names

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -920,7 +920,8 @@ class SqlitePlatform extends AbstractPlatform
                 continue;
             }
 
-            $columns = $this->replaceColumn($diff->name, $columns, $oldColumnName, $column);
+            $oldColumnName = strtolower($oldColumnName);
+            $columns       = $this->replaceColumn($diff->name, $columns, $oldColumnName, $column);
 
             if (! isset($newColumnNames[$oldColumnName])) {
                 continue;
@@ -934,7 +935,8 @@ class SqlitePlatform extends AbstractPlatform
                 continue;
             }
 
-            $columns = $this->replaceColumn($diff->name, $columns, $oldColumnName, $columnDiff->column);
+            $oldColumnName = strtolower($oldColumnName);
+            $columns       = $this->replaceColumn($diff->name, $columns, $oldColumnName, $columnDiff->column);
 
             if (! isset($newColumnNames[$oldColumnName])) {
                 continue;
@@ -1016,7 +1018,7 @@ class SqlitePlatform extends AbstractPlatform
     private function replaceColumn($tableName, array $columns, $columnName, Column $column): array
     {
         $keys  = array_keys($columns);
-        $index = array_search(strtolower($columnName), $keys, true);
+        $index = array_search($columnName, $keys, true);
 
         if ($index === false) {
             throw SchemaException::columnDoesNotExist($columnName, $tableName);

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -13,9 +13,9 @@ class RenameColumnTest extends FunctionalTestCase
     /**
      * @dataProvider columnNameProvider
      */
-    public function testColumnPositionRetainedAfterRenaming(string $columnName): void
+    public function testColumnPositionRetainedAfterRenaming(string $columnName, string $newColumnName): void
     {
-        if ($columnName === 'C1') {
+        if ($columnName === 'C1' || $columnName === 'importantColumn') {
             self::markTestIncomplete('See https://github.com/doctrine/dbal/issues/4816');
         }
 
@@ -27,7 +27,7 @@ class RenameColumnTest extends FunctionalTestCase
         $sm->dropAndCreateTable($table);
 
         $table->dropColumn($columnName)
-            ->addColumn('c1_x', 'string');
+            ->addColumn($newColumnName, 'string');
 
         $comparator = new Comparator();
         $diff       = $comparator->diffTable($sm->listTableDetails('test_rename'), $table);
@@ -36,7 +36,7 @@ class RenameColumnTest extends FunctionalTestCase
         $sm->alterTable($diff);
 
         $table = $sm->listTableDetails('test_rename');
-        self::assertSame(['c1_x', 'c2'], array_keys($table->getColumns()));
+        self::assertSame([$newColumnName, 'c2'], array_keys($table->getColumns()));
     }
 
     /**
@@ -44,7 +44,8 @@ class RenameColumnTest extends FunctionalTestCase
      */
     public static function columnNameProvider(): iterable
     {
-        yield ['c1'];
-        yield ['C1'];
+        yield ['c1', 'c1_x'];
+        yield ['C1', 'c1_x'];
+        yield ['importantColumn', 'veryImportantColumn'];
     }
 }


### PR DESCRIPTION
Columns are not found when camelCase named columns are changed or renamed when using sqlite as database.

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4832

#### Summary

Recovered the behavior of version 3.1.1 to use lower case column names. 