### PR TITLE
Deprecate the Constraint interface

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -68,6 +68,10 @@
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\SQLServer2012Keywords"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL94Platform"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\SQLServer2012Platform"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedClass name="Doctrine\DBAL\Schema\Constraint"/>
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedInterface>
@@ -77,6 +81,10 @@
                 -->
                 <referencedClass name="Doctrine\DBAL\Driver\ServerInfoAwareConnection"/>
                 <referencedClass name="Doctrine\DBAL\VersionAwarePlatformDriver"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedClass name="Doctrine\DBAL\Schema\Constraint"/>
             </errorLevel>
         </DeprecatedInterface>
         <DeprecatedMethod>
@@ -169,6 +177,11 @@
                     See https://github.com/doctrine/dbal/pull/4821
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractSchemaManager::getSchemaSearchPaths"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getCreateConstraintSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Schema\ForeignKeyConstraint::getColumns"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1659,6 +1659,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to drop a constraint.
      *
+     * @internal The method should be only used from within the {@link AbstractPlatform} class hierarchy.
+     *
      * @param Constraint|string $constraint
      * @param Table|string      $table
      *
@@ -1702,6 +1704,14 @@ abstract class AbstractPlatform
         $table      = $table->getQuotedName($this);
 
         return 'ALTER TABLE ' . $table . ' DROP FOREIGN KEY ' . $foreignKey;
+    }
+
+    /**
+     * Returns the SQL to drop a unique constraint.
+     */
+    public function getDropUniqueConstraintSQL(string $name, string $tableName): string
+    {
+        return $this->getDropConstraintSQL($name, $tableName);
     }
 
     /**
@@ -1972,6 +1982,9 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to create a constraint on a table on this platform.
      *
+     * @deprecated Use {@link getCreateIndexSQL()}, {@link getCreateForeignKeySQL()}
+     *             or {@link getCreateUniqueConstraintSQL()} instead.
+     *
      * @param Table|string $table
      *
      * @return string
@@ -2101,6 +2114,14 @@ abstract class AbstractPlatform
         }
 
         return 'CREATE SCHEMA ' . $schemaName;
+    }
+
+    /**
+     * Returns the SQL to create a unique constraint on a table on this platform.
+     */
+    public function getCreateUniqueConstraintSQL(UniqueConstraint $constraint, string $tableName): string
+    {
+        return $this->getCreateConstraintSQL($constraint, $tableName);
     }
 
     /**

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -999,6 +999,16 @@ SQL
     }
 
     /**
+     * The `ALTER TABLE ... DROP CONSTRAINT` syntax is only available as of MySQL 8.0.19.
+     *
+     * @link https://dev.mysql.com/doc/refman/8.0/en/alter-table.html
+     */
+    public function getDropUniqueConstraintSQL(string $name, string $tableName): string
+    {
+        return $this->getDropIndexSQL($name, $tableName);
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getSetTransactionIsolationSQL($level)

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -179,6 +179,19 @@ class OraclePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     */
+    public function getCreatePrimaryKeySQL(Index $index, $table): string
+    {
+        if ($table instanceof Table) {
+            $table = $table->getQuotedName($this);
+        }
+
+        return 'ALTER TABLE ' . $table . ' ADD CONSTRAINT ' . $index->getQuotedName($this)
+            . ' PRIMARY KEY (' . $this->getIndexFieldDeclarationListSQL($index) . ')';
+    }
+
+    /**
+     * {@inheritDoc}
      *
      * Need to specifiy minvalue, since start with is hidden in the system and MINVALUE <= START WITH.
      * Therefore we can use MINVALUE to be able to get a hint what START WITH was for later introspection
@@ -411,10 +424,8 @@ class OraclePlatform extends AbstractPlatform
             $sql = array_merge($sql, $this->getCreateAutoincrementSql($columnName, $name));
         }
 
-        if (isset($indexes) && ! empty($indexes)) {
-            foreach ($indexes as $index) {
-                $sql[] = $this->getCreateIndexSQL($index, $name);
-            }
+        foreach ($indexes as $index) {
+            $sql[] = $this->getCreateIndexSQL($index, $name);
         }
 
         return $sql;

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -837,6 +837,8 @@ class SqlitePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function getCreateConstraintSQL(Constraint $constraint, $table)
     {

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -424,6 +424,8 @@ abstract class AbstractSchemaManager
     /**
      * Drops the constraint from the given table.
      *
+     * @deprecated Use {@link dropIndex()}, {@link dropForeignKey()} or {@link dropUniqueConstraint()} instead.
+     *
      * @param Table|string $table The name of the table.
      *
      * @return void
@@ -462,6 +464,16 @@ abstract class AbstractSchemaManager
     public function dropSequence($name)
     {
         $this->_execSql($this->_platform->getDropSequenceSQL($name));
+    }
+
+    /**
+     * Drops the unique constraint from the given table.
+     *
+     * @throws Exception
+     */
+    public function dropUniqueConstraint(string $name, string $tableName): void
+    {
+        $this->_execSql($this->_platform->getDropUniqueConstraintSQL($name, $tableName));
     }
 
     /**
@@ -524,6 +536,8 @@ abstract class AbstractSchemaManager
     /**
      * Creates a constraint on a table.
      *
+     * @deprecated Use {@link createIndex()}, {@link createForeignKey()} or {@link createUniqueConstraint()} instead.
+     *
      * @param Table|string $table
      *
      * @return void
@@ -565,6 +579,16 @@ abstract class AbstractSchemaManager
     }
 
     /**
+     * Creates a unique constraint on a table.
+     *
+     * @throws Exception
+     */
+    public function createUniqueConstraint(UniqueConstraint $uniqueConstraint, string $tableName): void
+    {
+        $this->_execSql($this->_platform->getCreateUniqueConstraintSQL($uniqueConstraint, $tableName));
+    }
+
+    /**
      * Creates a new view.
      *
      * @return void
@@ -580,6 +604,9 @@ abstract class AbstractSchemaManager
 
     /**
      * Drops and creates a constraint.
+     *
+     * @deprecated Use {@link dropAndCreateIndex()}, {@link dropAndCreateForeignKey()}
+     *             or {@link dropUniqueConstraint()} and {@link createUniqueConstraint()} instead.
      *
      * @see dropConstraint()
      * @see createConstraint()

--- a/src/Schema/Constraint.php
+++ b/src/Schema/Constraint.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * Marker interface for constraints.
+ *
+ * @deprecated Use {@link ForeignKeyConstraint}, {@link Index} or {@link UniqueConstraint} instead.
  */
 interface Constraint
 {

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -196,6 +196,8 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
     /**
      * {@inheritdoc}
      *
+     * @deprecated Use {@link getLocalColumns()} instead.
+     *
      * @see getLocalColumns
      */
     public function getColumns()
@@ -210,6 +212,8 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * But only if they were defined with one or the referencing table column name
      * is a keyword reserved by the platform.
      * Otherwise the plain unquoted value as inserted is returned.
+     *
+     * @deprecated Use {@link getQuotedLocalColumns()} instead.
      *
      * @see getQuotedLocalColumns
      *

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -254,9 +254,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addUniqueIndex(['id'], 'id_unique_index');
         $this->schemaManager->dropAndCreateTable($table);
 
-        // Adding a primary key on already indexed columns
-        // Oracle will reuse the unique index, which cause a constraint name differing from the index name
-        $this->schemaManager->createConstraint(
+        $this->schemaManager->createIndex(
             new Index('id_pk_id_index', ['id'], true, true),
             'list_table_indexes_pk_id_test'
         );

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Events;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -19,6 +20,7 @@ use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\DBAL\Schema\View;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\ArrayType;
@@ -422,6 +424,34 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals(['test'], array_map('strtolower', $tableIndexes['test']->getColumns()));
         self::assertTrue($tableIndexes['test']->isUnique());
         self::assertFalse($tableIndexes['test']->isPrimary());
+    }
+
+    public function testDropAndCreateUniqueConstraint(): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
+            self::markTestSkipped('SQLite does not support adding constraints to a table');
+        }
+
+        $table = new Table('test_unique_constraint');
+        $table->addColumn('id', 'integer');
+        $this->schemaManager->dropAndCreateTable($table);
+
+        $uniqueConstraint = new UniqueConstraint('uniq_id', ['id']);
+        $this->schemaManager->createUniqueConstraint($uniqueConstraint, $table->getName());
+
+        // there's currently no API for introspecting unique constraints,
+        // so introspect the underlying indexes instead
+        $indexes = $this->schemaManager->listTableIndexes('test_unique_constraint');
+        self::assertCount(1, $indexes);
+
+        $index = current($indexes);
+        self::assertEqualsIgnoringCase('uniq_id', $index->getName());
+        self::assertTrue($index->isUnique());
+
+        $this->schemaManager->dropUniqueConstraint($uniqueConstraint->getName(), $table->getName());
+
+        $indexes = $this->schemaManager->listTableIndexes('test_unique_constraint');
+        self::assertEmpty($indexes);
     }
 
     public function testCreateTableWithForeignKeys(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation, improvement
| BC Break     | no

#### Summary

The interface attempts to unify the API for different constraint classes but does it poorly.

1. Indeed, both indices and unique constraints are defined with a list of columns but the foreign key constraint is defined with _two sets_ of columns: referring (a.k.a. local) and referred (a.k.a. foreign). The `getColumns()` method on a `ForeignKeyConstraint` class doesn't make any sense (implies the only set of columns) but has to be implemented: https://github.com/doctrine/dbal/blob/916c90f43f3acb2bf27882688115395a5ca87915/src/Schema/ForeignKeyConstraint.php#L199-L204
2. There are other constraints in SQL like `CHECK`, `DEFAULT`, `NOT NULL`, etc. that do not use a list of columns in their definition.
3. The `AbstractPlatform::getCreateConstraintSQL()` method accepts a `Constraint` and by its signature is supposed to be capable of creating any constraint. But it only implements handling some specific sub-classes: https://github.com/doctrine/dbal/blob/f6f79552d33508e6d9df2938a84d333823d5feca/src/Platforms/AbstractPlatform.php#L1992-L2009 If a new class implementing the `Constraint` method is added, this method will have to be reworked which violates the Open-closed principle.

#### Additionally
The current implementation of `AbstractPlatform::getDropConstraintSQL()` doesn't work on MySQL older than 8.0.19 and MariaDB (see `SchemaManagerFunctionalTestCase::testDropAndCreateUniqueConstraint()`).

#### Proposed changes
1. Deprecate the `Constraint` interface and the corresponding methods.
2. Mark `AbstractPlatform::getDropConstraintSQL()` as `@internal` and convert to `protected` in the next major release. This method generates valid SQL and could be used by the methods that drop specific constraints.
3. Introduce drop/create methods for unique constraints in `AbstractPlatform` and `AbstractSchemaManager`.
4. Do not introduce `AbstractSchemaManager::dropAndCreateUniqueConstraint()`. It's hard to think of the usefulness of such "drop-and-create" methods outside of integration testing. These methods are primarily untested, do not allow proper static analysis, and suppress all underlying exceptions thrown by the "drop" part. We can deprecate them separately.
5. The proper implementation of `OraclePlatform::getCreatePrimaryKeySQL()` allows using `createIndex()` to create a primary key in the test instead of `createConstraint()`. This is still not the best API but at least it's consistent with the rest of the platforms.