### PR TITLE
Mark Statement::execute() private, remove QueryBuilder::execute()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: `Statement::execute()` marked private.
+
+The `Statement::execute()` method has been marked private.
+
+## BC BREAK: Removed `QueryBuilder::execute()`.
+
+The `QueryBuilder::execute()` method has been removed.
+
 ## BC BREAK: Removed the `Constraint` interface.
 
 The `Constraint` interface has been removed. The `ForeignKeyConstraint`, `Index` and `UniqueConstraint` classes

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -60,10 +60,6 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::execute"/>
                 <referencedMethod name="Doctrine\DBAL\Statement::execute"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\Schema::getMigrateToSql"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -55,11 +55,6 @@
                     See https://github.com/doctrine/dbal/pull/4317
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
-                <!--
-                    These suppressions should be removed in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::execute"/>
-                <referencedMethod name="Doctrine\DBAL\Statement::execute"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -355,36 +355,6 @@ class QueryBuilder
     }
 
     /**
-     * Executes this query using the bound parameters and their types.
-     *
-     * @deprecated Use {@link executeQuery()} or {@link executeStatement()} instead.
-     *
-     * @return Result|int
-     *
-     * @throws Exception
-     */
-    public function execute()
-    {
-        if ($this->type === self::SELECT) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/4578',
-                'QueryBuilder::execute() is deprecated, use QueryBuilder::executeQuery() for SQL queries instead.'
-            );
-
-            return $this->connection->executeQuery($this->getSQL(), $this->params, $this->paramTypes);
-        }
-
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/4578',
-            'QueryBuilder::execute() is deprecated, use QueryBuilder::executeStatement() for SQL statements instead.'
-        );
-
-        return $this->connection->executeStatement($this->getSQL(), $this->params, $this->paramTypes);
-    }
-
-    /**
      * Gets the complete SQL string formed by the current specifications of this QueryBuilder.
      *
      * <code>

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
 use function func_num_args;
 use function is_string;
@@ -152,21 +151,13 @@ class Statement
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @deprecated Statement::execute() is deprecated, use Statement::executeQuery() or executeStatement() instead
+     * @param mixed[] $params
      *
      * @throws Exception
      */
-    public function execute(?array $params = null): Result
+    private function execute(array $params): Result
     {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/4580',
-            'Statement::execute() is deprecated, use Statement::executeQuery() or Statement::executeStatement() instead'
-        );
-
-        if ($params !== null) {
+        if ($params !== []) {
             $this->params = $params;
         }
 
@@ -175,7 +166,7 @@ class Statement
 
         try {
             return new Result(
-                $this->stmt->execute($params),
+                $this->stmt->execute($params === [] ? null : $params),
                 $this->conn
             );
         } catch (Exception $ex) {
@@ -194,10 +185,6 @@ class Statement
      */
     public function executeQuery(array $params = []): Result
     {
-        if ($params === []) {
-            $params = null; // Workaround as long execute() exists and used internally.
-        }
-
         return $this->execute($params);
     }
 
@@ -210,10 +197,6 @@ class Statement
      */
     public function executeStatement(array $params = []): int
     {
-        if ($params === []) {
-            $params = null; // Workaround as long execute() exists and used internally.
-        }
-
         return $this->execute($params)->rowCount();
     }
 

--- a/tests/Connection/LoggingTest.php
+++ b/tests/Connection/LoggingTest.php
@@ -39,7 +39,7 @@ final class LoggingTest extends TestCase
 
         $this->createConnection($driverConnection, 'UPDATE table SET foo = ?')
             ->prepare('UPDATE table SET foo = ?')
-            ->execute();
+            ->executeStatement();
     }
 
     private function createConnection(DriverConnection $driverConnection, string $expectedSQL): Connection

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -151,7 +151,7 @@ class BlobTest extends FunctionalTestCase
         // Bind param does late binding (bind by reference), so create the stream only now:
         $stream = fopen('data://text/plain,test', 'r');
 
-        $stmt->execute();
+        $stmt->executeStatement();
 
         $this->assertBlobContains('test');
     }

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -53,7 +53,7 @@ class DataAccessTest extends FunctionalTestCase
         $stmt->bindValue(1, 1);
         $stmt->bindValue(2, 'foo');
 
-        $row = $stmt->execute()->fetchAssociative();
+        $row = $stmt->executeQuery()->fetchAssociative();
 
         self::assertIsArray($row);
         $row = array_change_key_case($row, CASE_LOWER);
@@ -71,7 +71,7 @@ class DataAccessTest extends FunctionalTestCase
         $stmt->bindParam(1, $paramInt);
         $stmt->bindParam(2, $paramStr);
 
-        $row = $stmt->execute()->fetchAssociative();
+        $row = $stmt->executeQuery()->fetchAssociative();
 
         self::assertIsArray($row);
         $row = array_change_key_case($row, CASE_LOWER);
@@ -89,7 +89,7 @@ class DataAccessTest extends FunctionalTestCase
         $stmt->bindParam(1, $paramInt);
         $stmt->bindParam(2, $paramStr);
 
-        $rows    = $stmt->execute()->fetchAllAssociative();
+        $rows    = $stmt->executeQuery()->fetchAllAssociative();
         $rows[0] = array_change_key_case($rows[0], CASE_LOWER);
         self::assertEquals(['test_int' => 1, 'test_string' => 'foo'], $rows[0]);
     }
@@ -105,7 +105,7 @@ class DataAccessTest extends FunctionalTestCase
         $stmt->bindParam(1, $paramInt);
         $stmt->bindParam(2, $paramStr);
 
-        $column = $stmt->execute()->fetchOne();
+        $column = $stmt->executeQuery()->fetchOne();
         self::assertEquals(1, $column);
     }
 
@@ -116,7 +116,7 @@ class DataAccessTest extends FunctionalTestCase
 
         $sql    = 'SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?';
         $stmt   = $this->connection->prepare($sql);
-        $result = $stmt->execute([$paramInt, $paramStr]);
+        $result = $stmt->executeQuery([$paramInt, $paramStr]);
 
         $row = $result->fetchAssociative();
         self::assertNotFalse($row);
@@ -294,7 +294,7 @@ class DataAccessTest extends FunctionalTestCase
         $stmt = $this->connection->prepare($sql);
 
         $stmt->bindValue(1, new DateTime('2010-01-01 10:10:10'), Types::DATETIME_MUTABLE);
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
 
         self::assertEquals(1, $result->fetchOne());
     }
@@ -674,7 +674,7 @@ class DataAccessTest extends FunctionalTestCase
         $stmt  = $connection->prepare($query);
         $bindParams($stmt, $interval);
 
-        $date = $stmt->execute()->fetchOne();
+        $date = $stmt->executeQuery()->fetchOne();
         self::assertNotFalse($date);
 
         self::assertEquals($expected, date('Y-m-d H:i:s', strtotime($date)));

--- a/tests/Functional/Driver/OCI8/ResultTest.php
+++ b/tests/Functional/Driver/OCI8/ResultTest.php
@@ -84,7 +84,7 @@ class ResultTest extends FunctionalTestCase
             'SELECT * FROM TABLE(%s.test_oracle_fetch_failure())',
             $this->connectionParams['user']
         ));
-        $result    = $statement->execute();
+        $result    = $statement->executeQuery();
 
         // Access the first result to cause the first X rows to be prefetched
         // as defined by oci8.default_prefetch (often 100 rows)

--- a/tests/Functional/Driver/OCI8/StatementTest.php
+++ b/tests/Functional/Driver/OCI8/StatementTest.php
@@ -50,7 +50,7 @@ class StatementTest extends FunctionalTestCase
         self::assertEquals(
             $expected,
             $this->connection->prepare($query)
-                ->execute($params)
+                ->executeQuery($params)
                 ->fetchAssociative()
         );
     }

--- a/tests/Functional/LikeWildcardsEscapingTest.php
+++ b/tests/Functional/LikeWildcardsEscapingTest.php
@@ -25,7 +25,7 @@ final class LikeWildcardsEscapingTest extends FunctionalTestCase
                     $escapeChar
                 )
             )
-        )->execute();
+        )->executeQuery();
 
         self::assertTrue((bool) $result->fetchOne());
     }

--- a/tests/Functional/ParameterTypes/AsciiTest.php
+++ b/tests/Functional/ParameterTypes/AsciiTest.php
@@ -19,7 +19,7 @@ class AsciiTest extends FunctionalTestCase
         $statement = $this->connection->prepare('SELECT sql_variant_property(?, \'BaseType\')');
 
         $statement->bindValue(1, 'test', ParameterType::ASCII);
-        $results = $statement->execute()->fetchOne();
+        $results = $statement->executeQuery()->fetchOne();
 
         self::assertEquals('varchar', $results);
     }

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -77,7 +77,7 @@ class PortabilityTest extends FunctionalTestCase
 
         $result = $this->connection
             ->prepare('SELECT * FROM portability_table')
-            ->execute();
+            ->executeQuery();
 
         while (($row = $result->fetchAssociative())) {
             $this->assertFetchResultRow($row);
@@ -95,7 +95,7 @@ class PortabilityTest extends FunctionalTestCase
         }
 
         $result = $this->connection->prepare('SELECT * FROM portability_table')
-            ->execute();
+            ->executeQuery();
 
         while (($row = $result->fetchAssociative())) {
             $this->assertFetchResultRow($row);

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -47,14 +47,14 @@ class StatementTest extends FunctionalTestCase
 
         $stmt = $this->connection->prepare('SELECT id FROM stmt_test ORDER BY id');
 
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
 
         $id = $result->fetchOne();
         self::assertEquals(1, $id);
 
         $result->free();
 
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(1, $result->fetchOne());
         self::assertEquals(2, $result->fetchOne());
     }
@@ -78,7 +78,7 @@ class StatementTest extends FunctionalTestCase
         $this->connection->insert('stmt_longer_results', $row1);
 
         $stmt   = $this->connection->prepare('SELECT param, val FROM stmt_longer_results ORDER BY param');
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals([
             ['param1', 'X'],
         ], $result->fetchAllNumeric());
@@ -89,7 +89,7 @@ class StatementTest extends FunctionalTestCase
         ];
         $this->connection->insert('stmt_longer_results', $row2);
 
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals([
             ['param1', 'X'],
             ['param2', 'A bit longer value'],
@@ -133,7 +133,7 @@ EOF
         $this->connection->insert('stmt_long_blob', ['contents' => $contents], [ParameterType::LARGE_OBJECT]);
 
         $result = $this->connection->prepare('SELECT contents FROM stmt_long_blob')
-            ->execute();
+            ->executeQuery();
 
         $stream = Type::getType('blob')
             ->convertToPHPValue(
@@ -150,15 +150,15 @@ EOF
         $this->connection->insert('stmt_test', ['id' => 2]);
 
         $stmt1  = $this->connection->prepare('SELECT id FROM stmt_test');
-        $result = $stmt1->execute();
+        $result = $stmt1->executeQuery();
         $result->fetchAssociative();
 
-        $result = $stmt1->execute();
+        $result = $stmt1->executeQuery();
         // fetching only one record out of two
         $result->fetchAssociative();
 
         $stmt2  = $this->connection->prepare('SELECT id FROM stmt_test WHERE id = ?');
-        $result = $stmt2->execute([1]);
+        $result = $stmt2->executeQuery([1]);
         self::assertEquals(1, $result->fetchOne());
     }
 
@@ -173,14 +173,14 @@ EOF
 
         $stmt = $this->connection->prepare('SELECT id FROM stmt_test WHERE id = ?');
 
-        $result = $stmt->execute([1]);
+        $result = $stmt->executeQuery([1]);
 
         $id = $result->fetchOne();
         self::assertEquals(1, $id);
 
         $result->free();
 
-        $result = $stmt->execute([2]);
+        $result = $stmt->executeQuery([2]);
 
         $id = $result->fetchOne();
         self::assertEquals(2, $id);
@@ -196,12 +196,12 @@ EOF
 
         $id = 1;
 
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(1, $result->fetchOne());
 
         $id = 2;
 
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(2, $result->fetchOne());
     }
 
@@ -213,11 +213,11 @@ EOF
         $stmt = $this->connection->prepare('SELECT id FROM stmt_test WHERE id = ?');
 
         $stmt->bindValue(1, 1);
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(1, $result->fetchOne());
 
         $stmt->bindValue(1, 2);
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(2, $result->fetchOne());
     }
 
@@ -230,12 +230,12 @@ EOF
 
         $x = 1;
         $stmt->bindParam(1, $x);
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(1, $result->fetchOne());
 
         $y = 2;
         $stmt->bindParam(1, $y);
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(2, $result->fetchOne());
     }
 
@@ -249,7 +249,7 @@ EOF
         $this->connection->insert('stmt_test', ['id' => 1]);
 
         $stmt   = $this->connection->prepare('SELECT id FROM stmt_test');
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         $result->free();
 
         try {
@@ -359,7 +359,7 @@ EOF
             $this->expectException(Exception::class);
         }
 
-        $stmt->execute([null]);
+        $stmt->executeQuery([null]);
     }
 
     public function testExecuteQuery(): void

--- a/tests/Functional/Ticket/DBAL202Test.php
+++ b/tests/Functional/Ticket/DBAL202Test.php
@@ -33,7 +33,7 @@ class DBAL202Test extends FunctionalTestCase
     {
         $stmt = $this->connection->prepare('INSERT INTO DBAL202 VALUES (8)');
         $this->connection->beginTransaction();
-        $stmt->execute();
+        $stmt->executeStatement();
         $this->connection->rollBack();
 
         self::assertEquals(0, $this->connection->fetchOne('SELECT COUNT(1) FROM DBAL202'));
@@ -43,7 +43,7 @@ class DBAL202Test extends FunctionalTestCase
     {
         $stmt = $this->connection->prepare('INSERT INTO DBAL202 VALUES (8)');
         $this->connection->beginTransaction();
-        $stmt->execute();
+        $stmt->executeStatement();
         $this->connection->commit();
 
         self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM DBAL202'));

--- a/tests/Functional/Ticket/DBAL630Test.php
+++ b/tests/Functional/Ticket/DBAL630Test.php
@@ -81,7 +81,7 @@ class DBAL630Test extends FunctionalTestCase
 
         $stmt = $this->connection->prepare('INSERT INTO dbal630 (bool_col) VALUES(?)');
         $stmt->bindValue(1, $platform->convertBooleansToDatabaseValue('false'), ParameterType::BOOLEAN);
-        $stmt->execute();
+        $stmt->executeStatement();
 
         $id = $this->connection->lastInsertId();
 
@@ -108,7 +108,7 @@ class DBAL630Test extends FunctionalTestCase
 
         $stmt = $this->connection->prepare('INSERT INTO dbal630_allow_nulls (bool_col) VALUES(?)');
         $stmt->bindValue(1, $platform->convertBooleansToDatabaseValue($statementValue));
-        $stmt->execute();
+        $stmt->executeStatement();
 
         $id = $this->connection->lastInsertId();
 
@@ -139,7 +139,7 @@ class DBAL630Test extends FunctionalTestCase
             $platform->convertBooleansToDatabaseValue($statementValue),
             ParameterType::BOOLEAN
         );
-        $stmt->execute();
+        $stmt->executeStatement();
 
         $id = $this->connection->lastInsertId();
 

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -64,7 +64,7 @@ class WriteTest extends FunctionalTestCase
         $stmt->bindValue(1, 1);
         $stmt->bindValue(2, 'foo');
 
-        self::assertEquals(1, $stmt->execute()->rowCount());
+        self::assertEquals(1, $stmt->executeStatement());
     }
 
     public function testPrepareWithPrimitiveTypes(): void
@@ -75,7 +75,7 @@ class WriteTest extends FunctionalTestCase
         $stmt->bindValue(1, 1, ParameterType::INTEGER);
         $stmt->bindValue(2, 'foo', ParameterType::STRING);
 
-        self::assertEquals(1, $stmt->execute()->rowCount());
+        self::assertEquals(1, $stmt->executeStatement());
     }
 
     public function testPrepareWithDoctrineMappingTypes(): void
@@ -86,7 +86,7 @@ class WriteTest extends FunctionalTestCase
         $stmt->bindValue(1, 1, ParameterType::INTEGER);
         $stmt->bindValue(2, 'foo', ParameterType::STRING);
 
-        self::assertEquals(1, $stmt->execute()->rowCount());
+        self::assertEquals(1, $stmt->executeStatement());
     }
 
     public function testPrepareWithDoctrineMappingTypeNames(): void
@@ -97,7 +97,7 @@ class WriteTest extends FunctionalTestCase
         $stmt->bindValue(1, 1, ParameterType::INTEGER);
         $stmt->bindValue(2, 'foo', ParameterType::STRING);
 
-        self::assertEquals(1, $stmt->execute()->rowCount());
+        self::assertEquals(1, $stmt->executeStatement());
     }
 
     public function insertRows(): void

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -849,23 +849,6 @@ class QueryBuilderTest extends TestCase
         $qb->getSQL();
     }
 
-    public function testExecuteSelect(): void
-    {
-        $qb = new QueryBuilder($this->conn);
-
-        $this->conn
-            ->expects(self::any())
-            ->method('executeQuery')
-            ->willReturn($this->createMock(Result::class));
-
-        $result = $qb
-            ->select('id')
-            ->from('foo')
-            ->execute();
-
-        self::assertInstanceOf(Result::class, $result);
-    }
-
     /**
      * @param list<mixed>|array<string, mixed>                                     $parameters
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -75,7 +75,7 @@ class StatementTest extends TestCase
 
         $statement = new Statement($sql, $this->conn);
         $statement->bindValue($name, $var, $type);
-        $statement->execute();
+        $statement->executeQuery();
     }
 
     public function testExecuteCallsLoggerStartQueryWithParametersWhenParamsPassedToExecute(): void
@@ -96,7 +96,7 @@ class StatementTest extends TestCase
                 ->will(self::returnValue($logger));
 
         $statement = new Statement($sql, $this->conn);
-        $statement->execute($values);
+        $statement->executeQuery($values);
     }
 
     public function testExecuteCallsStartQueryWithTheParametersBoundViaBindParam(): void
@@ -118,7 +118,7 @@ class StatementTest extends TestCase
 
         $statement = new Statement($sql, $this->conn);
         $statement->bindParam($name, $var);
-        $statement->execute();
+        $statement->executeQuery();
     }
 
     public function testExecuteCallsLoggerStopQueryOnException(): void
@@ -145,6 +145,6 @@ class StatementTest extends TestCase
 
         $this->expectException(Exception::class);
 
-        $statement->execute();
+        $statement->executeQuery();
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

See https://github.com/doctrine/dbal/pull/4580.