### PR TITLE
Get view definition for SQL Server

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -993,7 +993,9 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getListViewsSQL($database)
     {
-        return "SELECT name FROM sysobjects WHERE type = 'V' ORDER BY name";
+        return "SELECT name, definition FROM sysobjects
+                    INNER JOIN sys.sql_modules ON sysobjects.id = sys.sql_modules.object_id
+                WHERE type = 'V' ORDER BY name";
     }
 
     /**

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -248,7 +248,7 @@ SQL
     protected function _getPortableViewDefinition($view)
     {
         // @todo
-        return new View($view['name'], '');
+        return new View($view['name'], $view['definition']);
     }
 
     /**

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -106,14 +106,24 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     private function hasElementWithName(array $items, string $name): bool
     {
-        $filteredList = array_filter(
+        $filteredList = $this->filterElementsByName($items, $name);
+
+        return count($filteredList) === 1;
+    }
+
+    /**
+     * @param AbstractAsset[] $items
+     *
+     * @return AbstractAsset[]
+     */
+    private function filterElementsByName(array $items, string $name): array
+    {
+        return array_filter(
             $items,
             static function (AbstractAsset $item) use ($name): bool {
                 return $item->getShortestName($item->getNamespaceName()) === $name;
             }
         );
-
-        return count($filteredList) === 1;
     }
 
     public function testListSequences(): void
@@ -688,7 +698,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->dropAndCreateView($view);
 
-        self::assertTrue($this->hasElementWithName($this->schemaManager->listViews(), $name));
+        $views = $this->schemaManager->listViews();
+
+        $filtered = array_values($this->filterElementsByName($views, $name));
+        self::assertCount(1, $filtered);
+
+        $viewKey = strtolower($filtered[0]->getName());
+        self::assertStringContainsString('view_test_table', $views[$viewKey]->getSql());
     }
 
     public function testAutoincrementDetection(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Currently, `SQLServer2012Platform::getListViewsSQL` does not export view definition.
This PR updated the SQL so that `Doctrine\DBAL\Schema\View::getSql()` will return view definition instead of empty string.
