### PR TITLE
Fix incorrect handling of transactions using deferred constraints

### DIFF
--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -95,7 +95,7 @@ final class Connection implements ConnectionInterface
 
     public function commit(): void
     {
-        if (! oci_commit($this->connection)) {
+        if (! @oci_commit($this->connection)) {
             throw Error::new($this->connection);
         }
 

--- a/src/Driver/OCI8/Exception/Error.php
+++ b/src/Driver/OCI8/Exception/Error.php
@@ -7,7 +7,9 @@ namespace Doctrine\DBAL\Driver\OCI8\Exception;
 use Doctrine\DBAL\Driver\AbstractException;
 
 use function assert;
+use function explode;
 use function oci_error;
+use function str_replace;
 
 /**
  * @internal
@@ -16,12 +18,26 @@ use function oci_error;
  */
 final class Error extends AbstractException
 {
+    private const CODE_TRANSACTION_ROLLED_BACK = 2091;
+
     /** @param resource $resource */
     public static function new($resource): self
     {
         $error = oci_error($resource);
         assert($error !== false);
 
-        return new self($error['message'], null, $error['code']);
+        $code    = $error['code'];
+        $message = $error['message'];
+        if ($code === self::CODE_TRANSACTION_ROLLED_BACK) {
+            // There's no way this can be unit-tested as it's impossible to mock $resource
+            //ORA-02091: transaction rolled back
+            //ORA-00001: unique constraint (DOCTRINE.GH3423_UNIQUE) violated
+            [$firstMessage, $secondMessage] = explode("\n", $message, 2);
+
+            [$code, $message] = explode(': ', $secondMessage, 2);
+            $code             = (int) str_replace('ORA-', '', $code);
+        }
+
+        return new self($message, null, $code);
     }
 }

--- a/tests/Driver/PDO/ExceptionTest.php
+++ b/tests/Driver/PDO/ExceptionTest.php
@@ -56,4 +56,25 @@ class ExceptionTest extends TestCase
     {
         self::assertSame($this->wrappedException, $this->exception->getPrevious());
     }
+
+    public function testExposesUnderlyingErrorOnOracle(): void
+    {
+        $pdoException = new PDOException(<<<'TEXT'
+OCITransCommit: ORA-02091: transaction rolled back
+ORA-00001: unique constraint (DOCTRINE.C1_UNIQUE) violated
+ (/private/tmp/php-20211003-35441-1sggrmq/php-8.0.11/ext/pdo_oci/oci_driver.c:410)
+TEXT);
+
+        $pdoException->errorInfo = [self::SQLSTATE, 2091,
+
+        ];
+
+        $exception = Exception::new($pdoException);
+
+        self::assertSame(1, $exception->getCode());
+        self::assertStringContainsString(
+            'unique constraint (DOCTRINE.C1_UNIQUE) violated',
+            $exception->getMessage(),
+        );
+    }
 }

--- a/tests/Functional/UniqueConstraintViolationsTest.php
+++ b/tests/Functional/UniqueConstraintViolationsTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\UniqueConstraint;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Throwable;
+
+use function sprintf;
+
+final class UniqueConstraintViolationsTest extends FunctionalTestCase
+{
+    private string $constraintName = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof OraclePlatform) {
+            $constraintName = 'C1_UNIQUE';
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $constraintName = 'c1_unique';
+        } else {
+            $constraintName = 'c1_unique';
+        }
+
+        $this->constraintName = $constraintName;
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $table = new Table('unique_constraint_violations');
+        $table->addColumn('unique_field', 'integer', ['notnull' => true]);
+        $schemaManager->createTable($table);
+
+        if ($platform instanceof OraclePlatform) {
+            $createConstraint = sprintf(
+                'ALTER TABLE unique_constraint_violations ' .
+                'ADD CONSTRAINT %s UNIQUE (unique_field) DEFERRABLE INITIALLY IMMEDIATE',
+                $constraintName,
+            );
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $createConstraint = sprintf(
+                'ALTER TABLE unique_constraint_violations ' .
+                'ADD CONSTRAINT %s UNIQUE (unique_field) DEFERRABLE INITIALLY IMMEDIATE',
+                $constraintName,
+            );
+        } elseif ($platform instanceof SQLitePlatform) {
+            $createConstraint = sprintf(
+                'CREATE UNIQUE INDEX %s ON unique_constraint_violations(unique_field)',
+                $constraintName,
+            );
+        } else {
+            $createConstraint = new UniqueConstraint($constraintName, ['unique_field']);
+        }
+
+        if ($createConstraint instanceof UniqueConstraint) {
+            $schemaManager->createUniqueConstraint($createConstraint, 'unique_constraint_violations');
+        } else {
+            $this->connection->executeStatement($createConstraint);
+        }
+
+        $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+    }
+
+    public function testTransactionalViolatesDeferredConstraint(): void
+    {
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+
+            $connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+
+            $this->expectUniqueConstraintViolation();
+        });
+    }
+
+    public function testTransactionalViolatesConstraint(): void
+    {
+        $this->connection->transactional(function (Connection $connection): void {
+            $this->expectUniqueConstraintViolation();
+            $connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        });
+    }
+
+    public function testTransactionalViolatesDeferredConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+            $connection->beginTransaction();
+            $connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+            $connection->commit();
+
+            $this->expectUniqueConstraintViolation();
+        });
+    }
+
+    public function testTransactionalViolatesConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->beginTransaction();
+
+            try {
+                $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+            } catch (Throwable $t) {
+                $this->connection->rollBack();
+
+                $this->expectUniqueConstraintViolation();
+
+                throw $t;
+            }
+        });
+    }
+
+    public function testCommitViolatesDeferredConstraint(): void
+    {
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+        $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+
+        $this->expectUniqueConstraintViolation();
+        $this->connection->commit();
+    }
+
+    public function testInsertViolatesConstraint(): void
+    {
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        } catch (Throwable $t) {
+            $this->connection->rollBack();
+
+            $this->expectUniqueConstraintViolation();
+
+            throw $t;
+        }
+    }
+
+    public function testCommitViolatesDeferredConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        $this->connection->commit();
+
+        $this->expectUniqueConstraintViolation();
+
+        $this->connection->commit();
+    }
+
+    public function testCommitViolatesConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->beginTransaction();
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        } catch (Throwable $t) {
+            $this->connection->rollBack();
+
+            $this->expectUniqueConstraintViolation();
+
+            throw $t;
+        }
+    }
+
+    private function supportsDeferrableConstraints(): bool
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        return $platform instanceof OraclePlatform || $platform instanceof PostgreSQLPlatform;
+    }
+
+    private function skipIfDeferrableIsNotSupported(): void
+    {
+        if ($this->supportsDeferrableConstraints()) {
+            return;
+        }
+
+        self::markTestSkipped('Only databases supporting deferrable constraints are eligible for this test.');
+    }
+
+    private function expectUniqueConstraintViolation(): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof SQLServerPlatform) {
+            $this->expectExceptionMessage(sprintf("Violation of UNIQUE KEY constraint '%s'", $this->constraintName));
+
+            return;
+        }
+
+        if ($this->connection->getDatabasePlatform() instanceof DB2Platform) {
+            // No concrete message is provided
+            $this->expectException(DriverException::class);
+
+            return;
+        }
+
+        $this->expectException(UniqueConstraintViolationException::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->dropTable('unique_constraint_violations');
+
+        $this->markConnectionNotReusable();
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
_Closes #3424 as it's very long and outdated so I decided to start again here_

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature
| BC Break     | yes
| Fixed issues | #3423, https://github.com/doctrine/orm/issues/7545

#### Summary

Rollback is being called when outside of a transaction when using e.g. deferred constraints or when using ORM and database throws error like https://www.cockroachlabs.com/docs/v21.1/transaction-retry-error-reference.html#retry_write_too_old which is then effectively hidden after PDO's `There's no active transaction`.
