### PR TITLE
Add Postgres 14 to the test matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -186,9 +186,10 @@ jobs:
           - "9.2"
           - "9.4"
           - "13"
+          - "14"
         include:
           - php-version: "8.0"
-            postgres-version: "13"
+            postgres-version: "14"
 
     services:
       postgres:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

Postgres 14 has been released and we should test against it.

https://www.postgresql.org/about/news/postgresql-14-released-2318/

I decided to keep Postgres 13 for now because it's still widely used. But we can probably remove it in a couple of months.
