### PR TITLE
QueryCacheProfiler::generateCacheKey: Param password should be ignore in connection hash

### DIFF
--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -78,7 +78,7 @@ class QueryCacheProfile
      */
     public function generateCacheKeys($sql, $params, $types, array $connectionParams = [])
     {
-        if (count($connectionParams) > 1 && array_key_exists('password', $connectionParams)) {
+        if (isset($connectionParams['password'])) {
             unset($connectionParams['password']);
         }
         $realCacheKey = 'query=' . $sql .

--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -81,6 +81,7 @@ class QueryCacheProfile
         if (isset($connectionParams['password'])) {
             unset($connectionParams['password']);
         }
+
         $realCacheKey = 'query=' . $sql .
             '&params=' . serialize($params) .
             '&types=' . serialize($types) .

--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -78,6 +78,9 @@ class QueryCacheProfile
      */
     public function generateCacheKeys($sql, $params, $types, array $connectionParams = [])
     {
+        if (count($connectionParams) > 1 && array_key_exists('password', $connectionParams)) {
+            unset($connectionParams['password']);
+        }
         $realCacheKey = 'query=' . $sql .
             '&params=' . serialize($params) .
             '&types=' . serialize($types) .

--- a/tests/Cache/QueryCacheProfileTest.php
+++ b/tests/Cache/QueryCacheProfileTest.php
@@ -158,6 +158,10 @@ class QueryCacheProfileTest extends TestCase
             ]
         );
 
-        self::assertEquals($firstRealCacheKey, $secondRealCacheKey, 'Cache keys for different password should be the same');
+        self::assertEquals(
+            $firstRealCacheKey,
+            $secondRealCacheKey,
+            'Cache keys for different password should be the same'
+        );
     }
 }

--- a/tests/Cache/QueryCacheProfileTest.php
+++ b/tests/Cache/QueryCacheProfileTest.php
@@ -135,4 +135,29 @@ class QueryCacheProfileTest extends TestCase
 
         self::assertEquals($firstCacheKey, $secondCacheKey, 'Cache keys should be the same');
     }
+
+    public function testShouldGenerateDifferentPasswordInTheParams(): void
+    {
+        [, $firstRealCacheKey] = $this->queryCacheProfile->generateCacheKeys(
+            $this->query,
+            $this->params,
+            $this->types,
+            [
+                'user'     => 'database_user',
+                'password' => 'first-password',
+            ]
+        );
+
+        [, $secondRealCacheKey] = $this->queryCacheProfile->generateCacheKeys(
+            $this->query,
+            $this->params,
+            $this->types,
+            [
+                'user'     => 'database_user',
+                'password' => 'second-password',
+            ]
+        );
+
+        self::assertEquals($firstRealCacheKey, $secondRealCacheKey, 'Cache keys for different password should be the same');
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes

#### Summary

We use Doctrine in many containers for production and we change passwords every 3 days for better security.

When the password is changed, the old original cache is ignored and we have to re-generate everything very expensively. I think the password should not be part of the hash.

![Snímek obrazovky 2021-10-08 v 15 39 39](https://user-images.githubusercontent.com/4738758/136568202-736c6b23-5cab-4b6b-9240-c42f973ee90c.png)