### PR TITLE
Test AbstractPlatform::getLengthExpression()

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -369,18 +369,18 @@ jobs:
           - "sqlsrv"
           - "pdo_sqlsrv"
         collation:
-          - "Latin1_General_100_CI_AS"
+          - "Latin1_General_100_CI_AS_SC_UTF8"
         include:
-          - collation: "Latin1_General_100_CS_AS"
+          - collation: "Latin1_General_100_CS_AS_SC_UTF8"
             php-version: "7.4"
             extension: "sqlsrv"
-          - collation: "Latin1_General_100_CS_AS"
+          - collation: "Latin1_General_100_CS_AS_SC_UTF8"
             php-version: "7.4"
             extension: "pdo_sqlsrv"
 
     services:
       mssql:
-        image: "mcr.microsoft.com/mssql/server:2017-latest"
+        image: "mcr.microsoft.com/mssql/server:2019-latest"
         env:
           ACCEPT_EULA: "Y"
           SA_PASSWORD: "Doctrine2018"

--- a/ci/github/phpunit/ibm_db2.xml
+++ b/ci/github/phpunit/ibm_db2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/ci/github/phpunit/mysqli-tls.xml
+++ b/ci/github/phpunit/mysqli-tls.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/ci/github/phpunit/mysqli-tls.xml
+++ b/ci/github/phpunit/mysqli-tls.xml
@@ -14,6 +14,7 @@
         <var name="db_ssl_ca" value="ca.pem"/>
         <var name="db_ssl_cert" value="client-cert.pem"/>
         <var name="db_ssl_key" value="client-key.pem"/>
+        <var name="db_charset" value="utf8mb4" />
 
         <!-- Use MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT since there's no way to generate a certificate
         with a proper common name (CN) on the CI. This flag must be not used in production settings. -->

--- a/ci/github/phpunit/mysqli.xml
+++ b/ci/github/phpunit/mysqli.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/ci/github/phpunit/mysqli.xml
+++ b/ci/github/phpunit/mysqli.xml
@@ -13,6 +13,7 @@
         <var name="db_port" value="3306"/>
         <var name="db_user" value="root" />
         <var name="db_dbname" value="doctrine_tests" />
+        <var name="db_charset" value="utf8mb4" />
     </php>
 
     <testsuites>

--- a/ci/github/phpunit/oci8.xml
+++ b/ci/github/phpunit/oci8.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/ci/github/phpunit/oci8.xml
+++ b/ci/github/phpunit/oci8.xml
@@ -13,6 +13,7 @@
         <var name="db_user" value="doctrine"/>
         <var name="db_password" value="oracle"/>
         <var name="db_dbname" value="XE"/>
+        <var name="db_charset" value="AL32UTF8" />
         <var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit"/>
 
         <var name="tmpdb_driver" value="oci8"/>

--- a/ci/github/phpunit/pdo_mysql.xml
+++ b/ci/github/phpunit/pdo_mysql.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/ci/github/phpunit/pdo_mysql.xml
+++ b/ci/github/phpunit/pdo_mysql.xml
@@ -13,6 +13,7 @@
         <var name="db_port" value="3306"/>
         <var name="db_user" value="root" />
         <var name="db_dbname" value="doctrine_tests" />
+        <var name="db_charset" value="utf8mb4" />
     </php>
 
     <testsuites>

--- a/ci/github/phpunit/pdo_oci.xml
+++ b/ci/github/phpunit/pdo_oci.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/ci/github/phpunit/pdo_oci.xml
+++ b/ci/github/phpunit/pdo_oci.xml
@@ -13,6 +13,7 @@
         <var name="db_user" value="doctrine"/>
         <var name="db_password" value="oracle"/>
         <var name="db_dbname" value="XE"/>
+        <var name="db_charset" value="AL32UTF8" />
         <var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit"/>
 
         <var name="tmpdb_driver" value="pdo_oci"/>

--- a/ci/github/phpunit/pdo_pgsql.xml
+++ b/ci/github/phpunit/pdo_pgsql.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/ci/github/phpunit/pdo_sqlsrv.xml
+++ b/ci/github/phpunit/pdo_sqlsrv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/ci/github/phpunit/sqlite.xml
+++ b/ci/github/phpunit/sqlite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/ci/github/phpunit/sqlsrv.xml
+++ b/ci/github/phpunit/sqlsrv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -791,7 +791,7 @@ abstract class AbstractPlatform
     }
 
     /**
-     * Returns the SQL snippet to get the length of a text column.
+     * Returns the SQL snippet to get the length of a text column in characters.
      *
      * @param string $column
      *

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -819,6 +819,14 @@ class DB2Platform extends AbstractPlatform
         return 'SUBSTR(' . $string . ', ' . $start . ', ' . $length . ')';
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function getLengthExpression($column)
+    {
+        return 'LENGTH(' . $column . ', CODEUNITS32)';
+    }
+
     public function getCurrentDatabaseExpression(): string
     {
         return 'CURRENT_USER';

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -125,6 +125,14 @@ class MySQLPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getLengthExpression($column)
+    {
+        return 'CHAR_LENGTH(' . $column . ')';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getListDatabasesSQL()
     {
         return 'SHOW DATABASES';

--- a/tests/Functional/Platform/LengthExpressionTest.php
+++ b/tests/Functional/Platform/LengthExpressionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Platform;
+
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+final class LengthExpressionTest extends FunctionalTestCase
+{
+    /**
+     * @link https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support
+     *
+     * @dataProvider expressionProvider
+     */
+    public function testLengthExpression(string $value, int $expected, bool $isMultibyte): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($isMultibyte && $platform instanceof SQLServerPlatform) {
+            $version = $this->connection->fetchOne("SELECT SERVERPROPERTY('ProductMajorVersion')");
+
+            if ($version < 15) {
+                self::markTestSkipped('UTF-8 support is only available as of SQL Server 2019');
+            }
+        }
+
+        $platform = $this->connection->getDatabasePlatform();
+        $query    = $platform->getDummySelectSQL($platform->getLengthExpression('?'));
+
+        self::assertEquals($expected, $this->connection->fetchOne($query, [$value]));
+    }
+
+    /**
+     * @return iterable<string,array{string,int}>
+     */
+    public static function expressionProvider(): iterable
+    {
+        yield '1-byte' => ['Hello, world!', 13, false];
+        yield '2-byte' => ['Привет, мир!', 12, true];
+        yield '3-byte' => ['你好，世界', 5, true];
+        yield '4-byte' => ['💩', 1, true];
+    }
+}

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -199,6 +199,7 @@ class TestUtil
                 'ssl_capath',
                 'ssl_cipher',
                 'unix_socket',
+                'charset',
             ] as $parameter
         ) {
             if (! isset($configuration[$prefix . $parameter])) {


### PR DESCRIPTION
This patch adds an integration test and improves the consistency of the `AbstractPlatform::getLengthExpression()` behavior across supported platforms.

1. Pass the "charset" from the PHPUnit configuration to the driver.
2. Add platform-specific implementations for MySQL and IBM DB2. This makes them return the length in characters instead of length in bytes. It's hardly a BC break since previously the expected behavior wasn't specified detailed enough.
3. Switch from SQL Server 2017 to 2019 on GitHub Actions (see [UTF-8 support](https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15#utf8)).
4. Explicitly configure UTF-8 connection charsets where required (MySQL < 8.0 and MariaDB < 10.5: `utf8mb4`, SQL Server: `*_UTF8`, Oracle: `AL32UTF8`).