### PR TITLE
Remove obsolete PHPCS config

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -34,11 +34,6 @@
         <exclude name="Squiz.NamingConventions.ValidVariableName.PublicHasUnderscore"/>
     </rule>
 
-    <rule ref="Generic.Classes.DuplicateClassName.Found">
-        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php</exclude-pattern>
-        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php</exclude-pattern>
-    </rule>
-
     <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
         <exclude-pattern>*/src/Configuration.php</exclude-pattern>
         <exclude-pattern>*/src/Connection.php</exclude-pattern>
@@ -58,8 +53,6 @@
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
-        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php</exclude-pattern>
-        <exclude-pattern>*/lib/Doctrine/DBAL/Driver/PDOStatementImplementations.php</exclude-pattern>
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 


### PR DESCRIPTION
This part of the PHPCS config refers to files that were added on 2.13 but not merged up to 3.0/3.1.