### PR TITLE
 Rework connect/disconnect routines in functional tests

### DIFF
--- a/tests/Driver/API/ExceptionConverterTest.php
+++ b/tests/Driver/API/ExceptionConverterTest.php
@@ -19,8 +19,6 @@ abstract class ExceptionConverterTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->converter = $this->createConverter();
     }
 

--- a/tests/Driver/AbstractDriverTest.php
+++ b/tests/Driver/AbstractDriverTest.php
@@ -27,8 +27,6 @@ abstract class AbstractDriverTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->driver = $this->createDriver();
     }
 

--- a/tests/Driver/PDO/ExceptionTest.php
+++ b/tests/Driver/PDO/ExceptionTest.php
@@ -33,8 +33,6 @@ class ExceptionTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->wrappedException = new PDOException(self::MESSAGE);
 
         $this->wrappedException->errorInfo = [self::SQLSTATE, self::ERROR_CODE];

--- a/tests/Functional/AutoIncrementColumnTest.php
+++ b/tests/Functional/AutoIncrementColumnTest.php
@@ -13,8 +13,6 @@ class AutoIncrementColumnTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $table = new Table('auto_increment_table');
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
@@ -25,11 +23,11 @@ class AutoIncrementColumnTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        if ($this->shouldDisableIdentityInsert) {
-            $this->connection->executeStatement('SET IDENTITY_INSERT auto_increment_table OFF');
+        if (! $this->shouldDisableIdentityInsert) {
+            return;
         }
 
-        parent::tearDown();
+        $this->connection->executeStatement('SET IDENTITY_INSERT auto_increment_table OFF');
     }
 
     public function testInsertIdentityValue(): void

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -17,8 +17,6 @@ class BlobTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDriver() instanceof PDO\OCI\Driver) {
             // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
             // see http://php.net/manual/en/pdo.lobs.php#example-1035

--- a/tests/Functional/Connection/ConnectionLostTest.php
+++ b/tests/Functional/Connection/ConnectionLostTest.php
@@ -12,8 +12,6 @@ class ConnectionLostTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
             return;
         }

--- a/tests/Functional/Connection/FetchTest.php
+++ b/tests/Functional/Connection/FetchTest.php
@@ -16,8 +16,6 @@ class FetchTest extends FunctionalTestCase
 
     public function setUp(): void
     {
-        parent::setUp();
-
         $this->query = TestUtil::generateResultSetQuery([
             [
                 'a' => 'foo',

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -33,8 +33,6 @@ class ConnectionTest extends FunctionalTestCase
         }
 
         $this->markConnectionNotReusable();
-
-        parent::tearDown();
     }
 
     public function testGetWrappedConnection(): void

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -22,15 +22,8 @@ use const CASE_LOWER;
 
 class DataAccessTest extends FunctionalTestCase
 {
-    /** @var bool */
-    private static $generated = false;
-
     protected function setUp(): void
     {
-        if (self::$generated !== false) {
-            return;
-        }
-
         $table = new Table('fetch_table');
         $table->addColumn('test_int', 'integer');
         $table->addColumn('test_string', 'string');
@@ -38,15 +31,13 @@ class DataAccessTest extends FunctionalTestCase
         $table->setPrimaryKey(['test_int']);
 
         $sm = $this->connection->getSchemaManager();
-        $sm->createTable($table);
+        $sm->dropAndCreateTable($table);
 
         $this->connection->insert('fetch_table', [
             'test_int' => 1,
             'test_string' => 'foo',
             'test_datetime' => '2010-01-01 10:10:10',
         ]);
-
-        self::$generated = true;
     }
 
     public function testPrepareWithBindValue(): void

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -27,8 +27,6 @@ class DataAccessTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (self::$generated !== false) {
             return;
         }

--- a/tests/Functional/Driver/AbstractDriverTest.php
+++ b/tests/Functional/Driver/AbstractDriverTest.php
@@ -18,8 +18,6 @@ abstract class AbstractDriverTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->driver = $this->createDriver();
     }
 

--- a/tests/Functional/Driver/IBMDB2/ConnectionTest.php
+++ b/tests/Functional/Driver/IBMDB2/ConnectionTest.php
@@ -18,8 +18,6 @@ class ConnectionTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDriver() instanceof Driver) {
             return;
         }
@@ -30,8 +28,6 @@ class ConnectionTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         $this->markConnectionNotReusable();
-
-        parent::tearDown();
     }
 
     public function testConnectionFailure(): void

--- a/tests/Functional/Driver/IBMDB2/StatementTest.php
+++ b/tests/Functional/Driver/IBMDB2/StatementTest.php
@@ -19,8 +19,6 @@ class StatementTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDriver() instanceof Driver) {
             return;
         }

--- a/tests/Functional/Driver/Mysqli/ConnectionTest.php
+++ b/tests/Functional/Driver/Mysqli/ConnectionTest.php
@@ -19,8 +19,6 @@ class ConnectionTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDriver() instanceof Driver) {
             return;
         }

--- a/tests/Functional/Driver/OCI8/ConnectionTest.php
+++ b/tests/Functional/Driver/OCI8/ConnectionTest.php
@@ -13,8 +13,6 @@ class ConnectionTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDriver() instanceof Driver) {
             return;
         }

--- a/tests/Functional/Driver/OCI8/ResultTest.php
+++ b/tests/Functional/Driver/OCI8/ResultTest.php
@@ -30,7 +30,6 @@ class ResultTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->connectionParams = TestUtil::getConnectionParams();
 
         if ($this->connection->getDriver() instanceof Driver) {
@@ -50,8 +49,6 @@ class ResultTest extends FunctionalTestCase
             'DROP TYPE return_numbers',
             $this->connectionParams['user']
         ));
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/Functional/Driver/OCI8/StatementTest.php
+++ b/tests/Functional/Driver/OCI8/StatementTest.php
@@ -12,8 +12,6 @@ class StatementTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDriver() instanceof Driver) {
             return;
         }

--- a/tests/Functional/Driver/PDO/ConnectionTest.php
+++ b/tests/Functional/Driver/PDO/ConnectionTest.php
@@ -24,8 +24,6 @@ class ConnectionTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $driverConnection = $this->connection->getWrappedConnection();
 
         if (! $driverConnection instanceof Connection) {
@@ -38,8 +36,6 @@ class ConnectionTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         $this->markConnectionNotReusable();
-
-        parent::tearDown();
     }
 
     public function testThrowsWrappedExceptionOnConstruct(): void

--- a/tests/Functional/Driver/PDO/PgSQL/ConnectionTest.php
+++ b/tests/Functional/Driver/PDO/PgSQL/ConnectionTest.php
@@ -13,8 +13,6 @@ class ConnectionTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDriver() instanceof Driver) {
             return;
         }

--- a/tests/Functional/Driver/SQLSrv/StatementTest.php
+++ b/tests/Functional/Driver/SQLSrv/StatementTest.php
@@ -13,8 +13,6 @@ class StatementTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDriver() instanceof Driver) {
             return;
         }

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -36,8 +36,6 @@ class ExceptionTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $driver = $this->connection->getDriver();
 
         if ($driver instanceof IBMDB2\Driver) {

--- a/tests/Functional/LegacyAPITest.php
+++ b/tests/Functional/LegacyAPITest.php
@@ -16,8 +16,6 @@ class LegacyAPITest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $table = new Table('legacy_table');
         $table->addColumn('test_int', 'integer');
         $table->addColumn('test_string', 'string');
@@ -32,7 +30,7 @@ class LegacyAPITest extends FunctionalTestCase
         ]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->connection->executeStatement('DELETE FROM legacy_table WHERE test_int > 1');
     }

--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -59,14 +59,14 @@ class NoneTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        if ($this->connection2->isTransactionActive()) {
-            $this->connection2->rollBack();
-        }
-
         $this->connection2->close();
 
         if (! $this->connection->getDatabasePlatform() instanceof SQLServer2012Platform) {
             return;
+        }
+
+        if ($this->connection->isTransactionActive()) {
+            $this->connection->rollBack();
         }
 
         $db = $this->connection->getDatabase();

--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -22,8 +22,6 @@ class NoneTest extends FunctionalTestCase
 
     public function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDriver() instanceof OCI8\Driver) {
             // https://github.com/doctrine/dbal/issues/4417
             self::markTestSkipped('This test fails on OCI8 for a currently unknown reason');
@@ -59,17 +57,13 @@ class NoneTest extends FunctionalTestCase
         self::fail('Separate connections do not seem to talk to the same database');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
-        parent::tearDown();
-
         if ($this->connection2->isTransactionActive()) {
             $this->connection2->rollBack();
         }
 
         $this->connection2->close();
-
-        $this->connection->getSchemaManager()->dropTable('users');
 
         if (! $this->connection->getDatabasePlatform() instanceof SQLServer2012Platform) {
             return;

--- a/tests/Functional/ModifyLimitQueryTest.php
+++ b/tests/Functional/ModifyLimitQueryTest.php
@@ -20,8 +20,6 @@ class ModifyLimitQueryTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (! self::$tableCreated) {
             $table = new Table('modify_limit_table');
             $table->addColumn('test_int', 'integer');

--- a/tests/Functional/ModifyLimitQueryTest.php
+++ b/tests/Functional/ModifyLimitQueryTest.php
@@ -15,36 +15,20 @@ use const CASE_LOWER;
 
 class ModifyLimitQueryTest extends FunctionalTestCase
 {
-    /** @var bool */
-    private static $tableCreated = false;
-
     protected function setUp(): void
     {
-        if (! self::$tableCreated) {
-            $table = new Table('modify_limit_table');
-            $table->addColumn('test_int', 'integer');
-            $table->setPrimaryKey(['test_int']);
+        $table = new Table('modify_limit_table');
+        $table->addColumn('test_int', 'integer');
+        $table->setPrimaryKey(['test_int']);
 
-            $table2 = new Table('modify_limit_table2');
-            $table2->addColumn('id', 'integer', ['autoincrement' => true]);
-            $table2->addColumn('test_int', 'integer');
-            $table2->setPrimaryKey(['id']);
+        $table2 = new Table('modify_limit_table2');
+        $table2->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table2->addColumn('test_int', 'integer');
+        $table2->setPrimaryKey(['id']);
 
-            $sm = $this->connection->getSchemaManager();
-            $sm->createTable($table);
-            $sm->createTable($table2);
-            self::$tableCreated = true;
-        }
-
-        $platform = $this->connection->getDatabasePlatform();
-
-        $this->connection->executeStatement(
-            $platform->getTruncateTableSQL('modify_limit_table')
-        );
-
-        $this->connection->executeStatement(
-            $platform->getTruncateTableSQL('modify_limit_table2')
-        );
+        $sm = $this->connection->getSchemaManager();
+        $sm->dropAndCreateTable($table);
+        $sm->dropAndCreateTable($table2);
     }
 
     public function testModifyLimitQuerySimpleQuery(): void

--- a/tests/Functional/NamedParametersTest.php
+++ b/tests/Functional/NamedParametersTest.php
@@ -150,8 +150,6 @@ class NamedParametersTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getSchemaManager()->tablesExist('ddc1372_foobar')) {
             return;
         }

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -13,8 +13,6 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->getPlatform() instanceof MySQLPlatform) {
             return;
         }

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -16,8 +16,6 @@ class PortabilityTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->connection = DriverManager::getConnection(
             $this->connection->getParams(),
             $this->connection->getConfiguration()
@@ -49,11 +47,9 @@ class PortabilityTest extends FunctionalTestCase
         }
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->markConnectionNotReusable();
-
-        parent::tearDown();
     }
 
     public function testFullFetchMode(): void

--- a/tests/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Functional/PrimaryReadReplicaConnectionTest.php
@@ -20,8 +20,6 @@ class PrimaryReadReplicaConnectionTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $platformName = $this->connection->getDatabasePlatform()->getName();
 
         // This is a MySQL specific test, skip other vendors.

--- a/tests/Functional/ResultCacheTest.php
+++ b/tests/Functional/ResultCacheTest.php
@@ -34,8 +34,6 @@ class ResultCacheTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $table = new Table('caching');
         $table->addColumn('test_int', 'integer');
         $table->addColumn('test_string', 'string', ['notnull' => false]);
@@ -58,8 +56,6 @@ class ResultCacheTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         $this->connection->getSchemaManager()->dropTable('caching');
-
-        parent::tearDown();
     }
 
     public function testCacheFetchAssociative(): void

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -19,8 +19,6 @@ class ComparatorTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->schemaManager = $this->connection->getSchemaManager();
         $this->comparator    = new Comparator();
     }

--- a/tests/Functional/Schema/DefaultValueTest.php
+++ b/tests/Functional/Schema/DefaultValueTest.php
@@ -16,8 +16,6 @@ class DefaultValueTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (self::$initialized) {
             return;
         }

--- a/tests/Functional/Schema/DefaultValueTest.php
+++ b/tests/Functional/Schema/DefaultValueTest.php
@@ -11,17 +11,8 @@ use function sprintf;
 
 class DefaultValueTest extends FunctionalTestCase
 {
-    /** @var bool */
-    private static $initialized = false;
-
     protected function setUp(): void
     {
-        if (self::$initialized) {
-            return;
-        }
-
-        self::$initialized = true;
-
         $table = new Table('default_value');
         $table->addColumn('id', 'integer');
 

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -24,8 +24,6 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     protected function tearDown(): void
     {
         $this->markConnectionNotReusable();
-
-        parent::tearDown();
     }
 
     protected function supportsPlatform(AbstractPlatform $platform): bool

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -15,9 +15,6 @@ use function array_map;
 
 class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
-    /** @var bool */
-    private static $privilegesGranted = false;
-
     protected function supportsPlatform(AbstractPlatform $platform): bool
     {
         return $platform instanceof OraclePlatform;
@@ -27,18 +24,12 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         parent::setUp();
 
-        if (self::$privilegesGranted) {
-            return;
-        }
-
         if (! isset($GLOBALS['db_user'])) {
             self::markTestSkipped('Username must be explicitly specified in connection parameters for this test');
         }
 
         TestUtil::getPrivilegedConnection()
             ->executeStatement('GRANT ALL PRIVILEGES TO ' . $GLOBALS['db_user']);
-
-        self::$privilegesGranted = true;
     }
 
     public function testRenameTable(): void

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -54,8 +54,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $platform = $this->connection->getDatabasePlatform();
 
         if (! $this->supportsPlatform($platform)) {
@@ -81,8 +79,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         }
 
         $this->markConnectionNotReusable();
-
-        parent::tearDown();
     }
 
     public function testDropAndCreateSequence(): void

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -17,8 +17,6 @@ class StatementTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $table = new Table('stmt_test');
         $table->addColumn('id', 'integer');
         $table->addColumn('name', 'text', ['notnull' => false]);

--- a/tests/Functional/TableGeneratorTest.php
+++ b/tests/Functional/TableGeneratorTest.php
@@ -15,8 +15,6 @@ class TableGeneratorTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $platform = $this->connection->getDatabasePlatform();
         if ($platform->getName() === 'sqlite') {
             self::markTestSkipped('TableGenerator does not work with SQLite');

--- a/tests/Functional/Ticket/DBAL202Test.php
+++ b/tests/Functional/Ticket/DBAL202Test.php
@@ -9,8 +9,6 @@ class DBAL202Test extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDatabasePlatform()->getName() !== 'oracle') {
             self::markTestSkipped('OCI8 only test');
         }

--- a/tests/Functional/Ticket/DBAL510Test.php
+++ b/tests/Functional/Ticket/DBAL510Test.php
@@ -10,8 +10,6 @@ class DBAL510Test extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDatabasePlatform()->getName() === 'postgresql') {
             return;
         }

--- a/tests/Functional/Ticket/DBAL630Test.php
+++ b/tests/Functional/Ticket/DBAL630Test.php
@@ -16,8 +16,6 @@ class DBAL630Test extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (! $this->connection->getDatabasePlatform() instanceof PostgreSQL94Platform) {
             self::markTestSkipped('Currently restricted to PostgreSQL');
         }
@@ -33,13 +31,13 @@ class DBAL630Test extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        if ($this->running) {
-            $this->getWrappedConnection()
-                ->getWrappedConnection()
-                ->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+        if (! $this->running) {
+            return;
         }
 
-        parent::tearDown();
+        $this->getWrappedConnection()
+            ->getWrappedConnection()
+            ->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
     }
 
     public function testBooleanConversionSqlLiteral(): void

--- a/tests/Functional/Ticket/DBAL752Test.php
+++ b/tests/Functional/Ticket/DBAL752Test.php
@@ -9,8 +9,6 @@ class DBAL752Test extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
             return;
         }

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -12,8 +12,6 @@ class TransactionTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
             return;
         }

--- a/tests/Functional/TypeConversionTest.php
+++ b/tests/Functional/TypeConversionTest.php
@@ -18,8 +18,6 @@ class TypeConversionTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $table = new Table('type_conversion');
         $table->addColumn('id', 'integer', ['notnull' => false]);
         $table->addColumn('test_string', 'string', ['notnull' => false]);

--- a/tests/Functional/Types/AsciiStringTest.php
+++ b/tests/Functional/Types/AsciiStringTest.php
@@ -12,8 +12,6 @@ class AsciiStringTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $table = new Table('ascii_table');
         $table->addColumn('id', 'ascii_string', [
             'length' => 3,

--- a/tests/Functional/Types/BinaryTest.php
+++ b/tests/Functional/Types/BinaryTest.php
@@ -19,8 +19,6 @@ class BinaryTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if ($this->connection->getDriver() instanceof PDO\OCI\Driver) {
             self::markTestSkipped('PDO_OCI doesn\'t support binding binary values');
         }

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -18,8 +18,6 @@ class WriteTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         try {
             $table = new Table('write_table');
             $table->addColumn('id', 'integer', ['autoincrement' => true]);

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -27,7 +27,7 @@ abstract class FunctionalTestCase extends TestCase
     /**
      * Mark shared connection not reusable for subsequent tests.
      *
-     * Should be called by the tests that modify configuration configuration
+     * Should be called by the tests that modify configuration
      * or alter the connection state in another way that may impact other tests.
      */
     protected function markConnectionNotReusable(): void
@@ -35,7 +35,10 @@ abstract class FunctionalTestCase extends TestCase
         $this->isConnectionReusable = false;
     }
 
-    protected function setUp(): void
+    /**
+     * @before
+     */
+    final protected function connect(): void
     {
         if (self::$sharedConnection === null) {
             self::$sharedConnection = TestUtil::getConnection();
@@ -44,7 +47,10 @@ abstract class FunctionalTestCase extends TestCase
         $this->connection = self::$sharedConnection;
     }
 
-    protected function tearDown(): void
+    /**
+     * @after
+     */
+    final protected function disconnect(): void
     {
         while ($this->connection->isTransactionActive()) {
             $this->connection->rollBack();

--- a/tests/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -20,8 +20,6 @@ class CreateSchemaSqlCollectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->platformMock = $this->getMockBuilder(AbstractPlatform::class)
             ->onlyMethods(
                 [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The `FunctionalTestCase::tearDown()` method contains the connection management logic that must work correctly. Otherwise, connection resource leaks are possible (see https://github.com/doctrine/dbal/pull/4521). While some tests override the `tearDown()` method, there's no guarantee that they will call the parent. Having to keep an eye on the implementations is an additional development and maintenance burden.

Instead of implementing connection management in `setUp()` and `tearDown()`, we can use arbitrarily named `@before` and `@after` methods that the extending classes don't have to be aware of. It simplifies the tests by reducing the number of the necessary `parent::` calls.

**Change summary**:
1. Replace `setUp()` and `tearDown()` in `FunctionalTestCase` with `@before` and `@after`.
2. Remove the no longer necessary `parent::` calls.
3. (not directly related) Remove some `private static $xyz` shared state from the tests for better test isolation.