### PR TITLE
Get rid of current working directory variable

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 parameters:
     level: 8
     paths:
-        - %currentWorkingDirectory%/lib
+        - lib
     reportUnmatchedIgnoredErrors: false
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
@@ -50,77 +50,77 @@ parameters:
         -
             message: '~^Return type \(Doctrine\\DBAL\\Platforms\\DrizzlePlatform\) of method Doctrine\\DBAL\\Driver\\DrizzlePDOMySql\\Driver::getDatabasePlatform\(\) should be compatible with return type \(Doctrine\\DBAL\\Platforms\\MySqlPlatform\) of method Doctrine\\DBAL\\Driver\\AbstractMySQLDriver::getDatabasePlatform\(\)$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Driver.php
+                - lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Driver.php
 
         # This is deprecated code. Fixing the issue may cause a BC break.
         # TODO: remove in 3.0.0
         -
             message: '~^Return type \(Doctrine\\DBAL\\Schema\\DrizzleSchemaManager\) of method Doctrine\\DBAL\\Driver\\DrizzlePDOMySql\\Driver::getSchemaManager\(\) should be compatible with return type \(Doctrine\\DBAL\\Schema\\MySqlSchemaManager\) of method Doctrine\\DBAL\\Driver\\AbstractMySQLDriver::getSchemaManager\(\)$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Driver.php
+                - lib/Doctrine/DBAL/Driver/DrizzlePDOMySql/Driver.php
 
         # This is deprecated code. Fixing the issue may cause a BC break.
         # TODO: remove in 3.0.0
         -
             message: '~^Return type \(int\) of method Doctrine\\DBAL\\Driver\\Mysqli\\MysqliConnection::errorCode\(\) should be compatible with return type \(string\|null\) of method Doctrine\\DBAL\\Driver\\Connection::errorCode\(\)$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+                - lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
 
         # This is deprecated code. Fixing the issue may cause a BC break.
         # TODO: remove in 3.0.0
         -
             message: '~^Return type \(string\) of method Doctrine\\DBAL\\Driver\\Mysqli\\MysqliConnection::errorInfo\(\) should be compatible with return type \(array\) of method Doctrine\\DBAL\\Driver\\Connection::errorInfo\(\)$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+                - lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
 
         # Fixing the issue may cause a BC break.
         -
             message: '~^Method Doctrine\\DBAL\\Driver\\Mysqli\\MysqliConnection::lastInsertId\(\) should return string but returns int\|string\.$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+                - lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
 
         # Fixing the issue may cause a BC break.
         # TODO: fix in 3.0.0
         -
             message: '~^Parameter \#2 \$sqlState of class Doctrine\\DBAL\\Driver\\Mysqli\\MysqliException constructor expects string\|null, int given\.$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+                - lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
 
         # This is deprecated code. Fixing the issue may cause a BC break.
         # TODO: remove in 3.0.0
         -
             message: '~^Return type \(string\) of method Doctrine\\DBAL\\Driver\\Mysqli\\MysqliStatement::errorInfo\(\) should be compatible with return type \(array\) of method Doctrine\\DBAL\\Driver\\Statement::errorInfo\(\)$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
+                - lib/Doctrine/DBAL/Driver/Mysqli/MysqliStatement.php
 
         # This is poorly typed deprecated code. The issue doesn't have practical implication and can be suppressed.
         # TODO: remove in 3.0.0
         -
             message: '~^Parameter \#1 \$how of method PDOStatement\:\:fetchAll\(\) expects int, array\|int\|null given\.$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/PDOStatement.php
+                - lib/Doctrine/DBAL/Driver/PDOStatement.php
 
         -
             message: '~Method Doctrine\\DBAL\\Driver\\PDOSqlsrv\\Connection\:\:lastInsertId\(\) should return string but returns int\|string\|false\|null\.~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
+                - lib/Doctrine/DBAL/Driver/PDOSqlsrv/Connection.php
 
         -
             message: '~Return type \(Doctrine\\DBAL\\Portability\\Statement\) of method Doctrine\\DBAL\\Portability\\Connection::prepare\(\) should be compatible with return type \(Doctrine\\DBAL\\Statement\) of method Doctrine\\DBAL\\Connection::prepare\(\)~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Portability/Connection.php
+                - lib/Doctrine/DBAL/Portability/Connection.php
 
         # Unlike Psalm, PHPStan doesn't understand the shape of the parse_str() return value
         -
             message: '~^Parameter #1 \$scheme of static method Doctrine\\DBAL\\DriverManager::parseDatabaseUrlScheme\(\) expects string\|null, int\|string\|null given\.$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/DriverManager.php
+                - lib/Doctrine/DBAL/DriverManager.php
 
         # Until 3.x, $_conn does accept PDO
         -
             message: '~^Property Doctrine\\DBAL\\Connection::\$_conn \(Doctrine\\DBAL\\Driver\\Connection\|null\) does not accept PDO\.$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Connection.php
+                - lib/Doctrine/DBAL/Connection.php
 
         # The class was added in PHP 8.1
         - '~^Attribute class ReturnTypeWillChange does not exist.$~'
@@ -129,22 +129,22 @@ parameters:
         -
             message: '~^Circular definition detected in type alias (Override)?Params\.$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/DriverManager.php
+                - lib/Doctrine/DBAL/DriverManager.php
 
         # TODO: remove in 4.0.0
         -
             message: '~^Parameter #2 \$table of class Doctrine\\DBAL\\Event\\SchemaIndexDefinitionEventArgs constructor expects string, string\|null given\.$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
+                - lib/Doctrine/DBAL/Schema/AbstractSchemaManager.php
 
         # https://github.com/phpstan/phpstan/issues/1901
         -
             message: '~^Method Doctrine\\DBAL\\Platforms\\AbstractPlatform::escapeStringForLike\(\) should return string but returns string\|null\.$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
+                - lib/Doctrine/DBAL/Platforms/AbstractPlatform.php
 
         # https://github.com/phpstan/phpstan/issues/4679
         -
             message: '~^Cannot call method writeTemporary\(\) on OCILob\|null\.$~'
             paths:
-                - %currentWorkingDirectory%/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php
+                - lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php


### PR DESCRIPTION

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

They are useless because there is only one directory from which this
configuration makes sense.
