### PR TITLE
Run tests on PHP 8.1 with different database drivers

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -96,7 +96,7 @@ jobs:
       matrix:
         php-version:
           - "7.4"
-          - "8.0"
+          - "8.1"
 
     services:
       oracle:
@@ -139,7 +139,7 @@ jobs:
       matrix:
         php-version:
           - "7.4"
-          - "8.0"
+          - "8.1"
 
     services:
       oracle:
@@ -188,7 +188,7 @@ jobs:
           - "13"
           - "14"
         include:
-          - php-version: "8.0"
+          - php-version: "8.1"
             postgres-version: "14"
 
     services:
@@ -245,10 +245,10 @@ jobs:
           - "mysqli"
           - "pdo_mysql"
         include:
-          - php-version: "8.0"
+          - php-version: "8.1"
             mariadb-version: "10.5"
             extension: "mysqli"
-          - php-version: "8.0"
+          - php-version: "8.1"
             mariadb-version: "10.5"
             extension: "pdo_mysql"
 
@@ -291,7 +291,6 @@ jobs:
           name: "${{ github.job }}-${{ matrix.mariadb-version }}-${{ matrix.extension }}-${{ matrix.php-version }}.coverage"
           path: "coverage.xml"
 
-
   phpunit-mysql:
     name: "PHPUnit with MySQL"
     runs-on: "ubuntu-20.04"
@@ -329,12 +328,12 @@ jobs:
             php-version: "7.4"
             mysql-version: "8.0"
             extension: "mysqli"
-          - php-version: "8.0"
+          - php-version: "8.1"
             mysql-version: "8.0"
             extension: "mysqli"
             custom-entrypoint: >-
               --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
-          - php-version: "8.0"
+          - php-version: "8.1"
             mysql-version: "8.0"
             extension: "pdo_mysql"
             custom-entrypoint: >-
@@ -393,7 +392,7 @@ jobs:
         php-version:
           - "7.3"
           - "7.4"
-          - "8.0"
+          - "8.1"
         extension:
           - "sqlsrv"
           - "pdo_sqlsrv"
@@ -434,7 +433,7 @@ jobs:
           coverage: "pcov"
           ini-values: "zend.assertions=1"
           tools: "pecl"
-          extensions: "${{ matrix.extension }}-5.9.0preview1"
+          extensions: "${{ matrix.extension }}-5.10.0beta1"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
@@ -505,7 +504,6 @@ jobs:
         with:
           name: "${{ github.job }}-${{ matrix.php-version }}.coverage"
           path: "coverage.xml"
-
 
   development-deps:
     name: "PHPUnit with SQLite and development dependencies"

--- a/lib/Doctrine/DBAL/Driver/AbstractException.php
+++ b/lib/Doctrine/DBAL/Driver/AbstractException.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Driver;
 
 use Doctrine\Deprecations\Deprecation;
 use Exception as BaseException;
+use Throwable;
 
 /**
  * Base implementation of the {@link Exception} interface.
@@ -35,9 +36,9 @@ abstract class AbstractException extends BaseException implements DriverExceptio
      * @param string|null     $sqlState  The SQLSTATE the driver is in at the time the error occurred, if any.
      * @param int|string|null $errorCode The driver specific error code if any.
      */
-    public function __construct($message, $sqlState = null, $errorCode = null)
+    public function __construct($message, $sqlState = null, $errorCode = null, ?Throwable $previous = null)
     {
-        parent::__construct($message);
+        parent::__construct($message, 0, $previous);
 
         $this->errorCode = $errorCode;
         $this->sqlState  = $sqlState;

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionError.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionError.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Driver\Mysqli\Exception;
 
 use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use mysqli;
+use mysqli_sql_exception;
+use ReflectionProperty;
 
 /**
  * @internal
@@ -17,5 +19,13 @@ final class ConnectionError extends MysqliException
     public static function new(mysqli $connection): self
     {
         return new self($connection->error, $connection->sqlstate, $connection->errno);
+    }
+
+    public static function upcast(mysqli_sql_exception $exception): self
+    {
+        $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
+        $p->setAccessible(true);
+
+        return new self($exception->getMessage(), $p->getValue($exception), $exception->getCode(), $exception);
     }
 }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionFailed.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionFailed.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Driver\Mysqli\Exception;
 
 use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use mysqli;
+use mysqli_sql_exception;
+use ReflectionProperty;
 
 /**
  * @internal
@@ -17,5 +19,13 @@ final class ConnectionFailed extends MysqliException
     public static function new(mysqli $connection): self
     {
         return new self($connection->connect_error, 'HY000', $connection->connect_errno);
+    }
+
+    public static function upcast(mysqli_sql_exception $exception): self
+    {
+        $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
+        $p->setAccessible(true);
+
+        return new self($exception->getMessage(), $p->getValue($exception), $exception->getCode(), $exception);
     }
 }

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Exception/StatementError.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Exception/StatementError.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\Mysqli\Exception;
 
 use Doctrine\DBAL\Driver\Mysqli\MysqliException;
+use mysqli_sql_exception;
 use mysqli_stmt;
+use ReflectionProperty;
 
 /**
  * @internal
@@ -17,5 +19,13 @@ final class StatementError extends MysqliException
     public static function new(mysqli_stmt $statement): self
     {
         return new self($statement->error, $statement->sqlstate, $statement->errno);
+    }
+
+    public static function upcast(mysqli_sql_exception $exception): self
+    {
+        $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
+        $p->setAccessible(true);
+
+        return new self($exception->getMessage(), $p->getValue($exception), $exception->getCode(), $exception);
     }
 }

--- a/tests/Doctrine/Tests/DBAL/Functional/Connection/ConnectionLostTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Connection/ConnectionLostTest.php
@@ -23,7 +23,7 @@ class ConnectionLostTest extends DbalFunctionalTestCase
 
     public function testConnectionLost(): void
     {
-        $this->connection->query('SET SESSION wait_timeout=1');
+        $this->connection->executeStatement('SET SESSION wait_timeout=1');
 
         sleep(2);
 


### PR DESCRIPTION
I've bumped all PHP 8.0 jobs for individual database drivers to PHP 8.1 to uncover issue that we might have there. If you think that testing on PHP 8.0 additionally provides extra value, I can re-add those jobs again. But for now, I did not want to bloat the test matrix further.

Fixes #4870 