### PR TITLE
Catch MySQLi exceptions on PHP 8.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -216,10 +216,10 @@ jobs:
           - "mysqli"
           - "pdo_mysql"
         include:
-          - php-version: "8.0"
+          - php-version: "8.1"
             mariadb-version: "10.5"
             extension: "mysqli"
-          - php-version: "8.0"
+          - php-version: "8.1"
             mariadb-version: "10.5"
             extension: "pdo_mysql"
 
@@ -262,7 +262,6 @@ jobs:
           name: "${{ github.job }}-${{ matrix.mariadb-version }}-${{ matrix.extension }}-${{ matrix.php-version }}.coverage"
           path: "coverage.xml"
 
-
   phpunit-mysql:
     name: "PHPUnit with MySQL"
     runs-on: "ubuntu-20.04"
@@ -301,12 +300,12 @@ jobs:
             php-version: "7.4"
             mysql-version: "8.0"
             extension: "mysqli"
-          - php-version: "8.0"
+          - php-version: "8.1"
             mysql-version: "8.0"
             extension: "mysqli"
             custom-entrypoint: >-
               --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
-          - php-version: "8.0"
+          - php-version: "8.1"
             mysql-version: "8.0"
             extension: "pdo_mysql"
             custom-entrypoint: >-
@@ -477,7 +476,6 @@ jobs:
         with:
           name: "${{ github.job }}-${{ matrix.php-version }}.coverage"
           path: "coverage.xml"
-
 
   development-deps:
     name: "PHPUnit with SQLite and development dependencies"

--- a/src/Driver/Mysqli/Exception/ConnectionError.php
+++ b/src/Driver/Mysqli/Exception/ConnectionError.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Driver\Mysqli\Exception;
 
 use Doctrine\DBAL\Driver\AbstractException;
 use mysqli;
+use mysqli_sql_exception;
+use ReflectionProperty;
 
 /**
  * @internal
@@ -17,5 +19,13 @@ final class ConnectionError extends AbstractException
     public static function new(mysqli $connection): self
     {
         return new self($connection->error, $connection->sqlstate, $connection->errno);
+    }
+
+    public static function upcast(mysqli_sql_exception $exception): self
+    {
+        $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
+        $p->setAccessible(true);
+
+        return new self($exception->getMessage(), $p->getValue($exception), (int) $exception->getCode(), $exception);
     }
 }

--- a/src/Driver/Mysqli/Exception/ConnectionFailed.php
+++ b/src/Driver/Mysqli/Exception/ConnectionFailed.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Driver\Mysqli\Exception;
 
 use Doctrine\DBAL\Driver\AbstractException;
 use mysqli;
+use mysqli_sql_exception;
+use ReflectionProperty;
 
 /**
  * @internal
@@ -17,5 +19,13 @@ final class ConnectionFailed extends AbstractException
     public static function new(mysqli $connection): self
     {
         return new self($connection->connect_error, 'HY000', $connection->connect_errno);
+    }
+
+    public static function upcast(mysqli_sql_exception $exception): self
+    {
+        $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
+        $p->setAccessible(true);
+
+        return new self($exception->getMessage(), $p->getValue($exception), (int) $exception->getCode(), $exception);
     }
 }

--- a/src/Driver/Mysqli/Exception/InvalidCharset.php
+++ b/src/Driver/Mysqli/Exception/InvalidCharset.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Driver\Mysqli\Exception;
 
 use Doctrine\DBAL\Driver\AbstractException;
 use mysqli;
+use mysqli_sql_exception;
+use ReflectionProperty;
 
 use function sprintf;
 
@@ -22,6 +24,19 @@ final class InvalidCharset extends AbstractException
             sprintf('Failed to set charset "%s": %s', $charset, $connection->error),
             $connection->sqlstate,
             $connection->errno
+        );
+    }
+
+    public static function upcast(mysqli_sql_exception $exception, string $charset): self
+    {
+        $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
+        $p->setAccessible(true);
+
+        return new self(
+            sprintf('Failed to set charset "%s": %s', $charset, $exception->getMessage()),
+            $p->getValue($exception),
+            (int) $exception->getCode(),
+            $exception
         );
     }
 }

--- a/src/Driver/Mysqli/Exception/StatementError.php
+++ b/src/Driver/Mysqli/Exception/StatementError.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\Mysqli\Exception;
 
 use Doctrine\DBAL\Driver\AbstractException;
+use mysqli_sql_exception;
 use mysqli_stmt;
+use ReflectionProperty;
 
 /**
  * @internal
@@ -17,5 +19,13 @@ final class StatementError extends AbstractException
     public static function new(mysqli_stmt $statement): self
     {
         return new self($statement->error, $statement->sqlstate, $statement->errno);
+    }
+
+    public static function upcast(mysqli_sql_exception $exception): self
+    {
+        $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
+        $p->setAccessible(true);
+
+        return new self($exception->getMessage(), $p->getValue($exception), (int) $exception->getCode(), $exception);
     }
 }

--- a/src/Driver/Mysqli/Initializer/Charset.php
+++ b/src/Driver/Mysqli/Initializer/Charset.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Driver\Mysqli\Initializer;
 use Doctrine\DBAL\Driver\Mysqli\Exception\InvalidCharset;
 use Doctrine\DBAL\Driver\Mysqli\Initializer;
 use mysqli;
+use mysqli_sql_exception;
 
 final class Charset implements Initializer
 {
@@ -20,7 +21,13 @@ final class Charset implements Initializer
 
     public function initialize(mysqli $connection): void
     {
-        if ($connection->set_charset($this->charset)) {
+        try {
+            $success = $connection->set_charset($this->charset);
+        } catch (mysqli_sql_exception $e) {
+            throw InvalidCharset::upcast($e, $this->charset);
+        }
+
+        if ($success) {
             return;
         }
 

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\Mysqli\Exception\StatementError;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
+use mysqli_sql_exception;
 use mysqli_stmt;
 use stdClass;
 
@@ -101,7 +102,11 @@ final class Result implements ResultInterface
      */
     public function fetchNumeric()
     {
-        $ret = $this->statement->fetch();
+        try {
+            $ret = $this->statement->fetch();
+        } catch (mysqli_sql_exception $e) {
+            throw StatementError::upcast($e);
+        }
 
         if ($ret === false) {
             throw StatementError::new($this->statement);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4870

#### Summary

This is the MySQLi part of #4875, redone on the 3.1.x branch. The branches diverged in this area of the code so that I preferred to redo the changes to ease the merge-up.
