### PR TITLE
Reuse centralized coding standard workflow

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,27 +11,4 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    runs-on: "ubuntu-20.04"
-
-    strategy:
-      matrix:
-        php-version:
-          - "8.0"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v2"
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          coverage: "none"
-          php-version: "${{ matrix.php-version }}"
-          tools: "cs2pr"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
-
-      # https://github.com/doctrine/.github/issues/3
-      - name: "Run PHP_CodeSniffer"
-        run: "vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.1.1"


### PR DESCRIPTION
Other workflows have divergences that make this impossible:
- continuous integration has special jobs because we support many RDBMS;
- static analysis has an extra command to test files under a special
  directory;
- release has a lot fewer steps than its centralized counterpart.

Settings will have to be tweaked to account for the new name for the job.