### PR TITLE
Add `getOptions` function to `Column`

### DIFF
--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -91,6 +91,26 @@ class Column extends AbstractAsset
     }
 
     /**
+     * @return mixed[]
+     */
+    public function getOptions(): array
+    {
+        return [
+            'type'          => $this->_type,
+            'default'       => $this->_default,
+            'notnull'       => $this->_notnull,
+            'length'        => $this->_length,
+            'precision'     => $this->_precision,
+            'scale'         => $this->_scale,
+            'fixed'         => $this->_fixed,
+            'unsigned'      => $this->_unsigned,
+            'autoincrement' => $this->_autoincrement,
+            'columnDefinition' => $this->_columnDefinition,
+            'comment' => $this->_comment,
+        ];
+    }
+
+    /**
      * @return Column
      */
     public function setType(Type $type)
@@ -431,19 +451,11 @@ class Column extends AbstractAsset
      */
     public function toArray()
     {
-        return array_merge([
-            'name'          => $this->_name,
-            'type'          => $this->_type,
-            'default'       => $this->_default,
-            'notnull'       => $this->_notnull,
-            'length'        => $this->_length,
-            'precision'     => $this->_precision,
-            'scale'         => $this->_scale,
-            'fixed'         => $this->_fixed,
-            'unsigned'      => $this->_unsigned,
-            'autoincrement' => $this->_autoincrement,
-            'columnDefinition' => $this->_columnDefinition,
-            'comment' => $this->_comment,
-        ], $this->_platformOptions, $this->_customSchemaOptions);
+        return array_merge(
+            ['name' => $this->_name],
+            $this->getOptions(),
+            $this->_platformOptions,
+            $this->_customSchemaOptions
+        );
     }
 }

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -39,6 +39,35 @@ class ColumnTest extends TestCase
         self::assertFalse($column->hasCustomSchemaOption('foo'));
     }
 
+    public function testGetOptions(): void
+    {
+        $expected = [
+            'type' => Type::getType('string'),
+            'default' => 'baz',
+            'notnull' => false,
+            'length' => 200,
+            'precision' => 5,
+            'scale' => 2,
+            'fixed' => true,
+            'unsigned' => true,
+            'autoincrement' => false,
+            'columnDefinition' => null,
+            'comment' => null,
+        ];
+
+        self::assertEquals($expected, $this->createColumn()->getOptions());
+    }
+
+    public function testGetPlatformOptions(): void
+    {
+        self::assertEquals(['foo' => 'bar'], $this->createColumn()->getPlatformOptions());
+    }
+
+    public function testGetCustomSchemaOptions(): void
+    {
+        self::assertEquals(['bar' => 'baz'], $this->createColumn()->getCustomSchemaOptions());
+    }
+
     public function testToArray(): void
     {
         $expected = [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no

While working on this PR https://github.com/sonata-project/EntityAuditBundle/pull/446 it was hard for me to extract the options/properties of a Column-Schema. 
There might be a better way achieving what is done there (copying a column from one table to another) but in the `Column` class we are generally able to create a new one passing its fixed options but cannot extract them again without knowing all the options the class supports.

The use of the new `getOptions` function makes also the composition of `toArray` a bit more clear imho.

Having it in 3.1 would not help for the mentioned PR tho. I fear it would be hard to argument this to be a bugfix, but I would try.  😄 