### PR TITLE
Refactor MySQLi statement to make it unaware of the connection

### DIFF
--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -107,7 +107,17 @@ final class Connection implements ServerInfoAwareConnection
 
     public function prepare(string $sql): DriverStatement
     {
-        return new Statement($this->conn, $sql);
+        try {
+            $stmt = $this->conn->prepare($sql);
+        } catch (mysqli_sql_exception $e) {
+            throw ConnectionError::upcast($e);
+        }
+
+        if ($stmt === false) {
+            throw ConnectionError::new($this->conn);
+        }
+
+        return new Statement($stmt);
     }
 
     public function query(string $sql): ResultInterface


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

This PR addresses some issues I saw while working on the `Statement` class of the MySQLi driver. The class itself is final, has no ancestors and its constructor is flagged as `@internal`. Under these circumstances, I assume that none of my changes count as a BC break.

All protected properties have been made `private` because `protected` visibility in a `final` class is pretty much useless. Moreover, I've removed their `_` prefix according to our CS rules. I realize that both changes have been applied to the 4.0.x branch already, but I see no reason not to deliver them with 3.2.0 already. That should also ease future merges from 3.x to 4.x.

The constructor requires a `mysqli_stmt` instance now. This way, the statement becomes fully unaware of the connection which is also consistent with the design of the corresponding class of the PDO driver.