### PR TITLE
Changed handling options of the `Column` Schema

### DIFF
--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -4,10 +4,11 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function is_numeric;
-use function method_exists;
+use function strtolower;
 
 /**
  * Object representation of a database column.
@@ -65,10 +66,12 @@ class Column extends AbstractAsset
     {
         $this->_setName($name);
         $this->setType($type);
-        $this->setOptions($options);
+        $this->_setOptions($options);
     }
 
     /**
+     * @deprecated Use the setter methods directly.
+     *
      * @param mixed[] $options
      *
      * @return Column
@@ -77,17 +80,158 @@ class Column extends AbstractAsset
      */
     public function setOptions(array $options)
     {
-        foreach ($options as $name => $value) {
-            $method = 'set' . $name;
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/',
+            '%s is deprecated, use the setter methods directly.',
+            __METHOD__
+        );
 
-            if (! method_exists($this, $method)) {
-                throw UnknownColumnOption::new($name);
-            }
-
-            $this->$method($value);
-        }
+        $this->_setOptions($options);
 
         return $this;
+    }
+
+    /**
+     * @param mixed[] $options
+     *
+     * @throws UnknownColumnOption
+     */
+    private function _setOptions(array $options): void
+    {
+        foreach ($options as $name => $value) {
+            switch (strtolower($name)) {
+                case 'type':
+                    $this->setType($value);
+                    break;
+                case 'length':
+                    $this->setLength($value);
+                    break;
+                case 'precision':
+                    $this->setPrecision($value);
+                    break;
+                case 'scale':
+                    $this->setScale($value);
+                    break;
+                case 'unsigned':
+                    $this->setUnsigned($value);
+                    break;
+                case 'fixed':
+                    $this->setFixed($value);
+                    break;
+                case 'notnull':
+                    $this->setNotnull($value);
+                    break;
+                case 'default':
+                    $this->setDefault($value);
+                    break;
+                case 'columndefinition':
+                    $this->setColumnDefinition($value);
+                    break;
+                case 'autoincrement':
+                    $this->setAutoincrement($value);
+                    break;
+                case 'comment':
+                    $this->setComment($value);
+                    break;
+                case 'platformoptions':
+                    $this->setPlatformOptions($value);
+                    break;
+                case 'customschemaoptions':
+                    $this->setCustomSchemaOptions($value);
+                    break;
+                default:
+                    throw UnknownColumnOption::new($name);
+            }
+        }
+    }
+
+    /**
+     * @return Type
+     */
+    public function getType()
+    {
+        return $this->_type;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getLength()
+    {
+        return $this->_length;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPrecision()
+    {
+        return $this->_precision;
+    }
+
+    /**
+     * @return int
+     */
+    public function getScale()
+    {
+        return $this->_scale;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getUnsigned()
+    {
+        return $this->_unsigned;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getFixed()
+    {
+        return $this->_fixed;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getNotnull()
+    {
+        return $this->_notnull;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDefault()
+    {
+        return $this->_default;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getColumnDefinition()
+    {
+        return $this->_columnDefinition;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAutoincrement()
+    {
+        return $this->_autoincrement;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getComment()
+    {
+        return $this->_comment;
     }
 
     /**
@@ -197,31 +341,6 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @param mixed[] $platformOptions
-     *
-     * @return Column
-     */
-    public function setPlatformOptions(array $platformOptions)
-    {
-        $this->_platformOptions = $platformOptions;
-
-        return $this;
-    }
-
-    /**
-     * @param string $name
-     * @param mixed  $value
-     *
-     * @return Column
-     */
-    public function setPlatformOption($name, $value)
-    {
-        $this->_platformOptions[$name] = $value;
-
-        return $this;
-    }
-
-    /**
      * @param string $value
      *
      * @return Column
@@ -231,114 +350,6 @@ class Column extends AbstractAsset
         $this->_columnDefinition = $value;
 
         return $this;
-    }
-
-    /**
-     * @return Type
-     */
-    public function getType()
-    {
-        return $this->_type;
-    }
-
-    /**
-     * @return int|null
-     */
-    public function getLength()
-    {
-        return $this->_length;
-    }
-
-    /**
-     * @return int
-     */
-    public function getPrecision()
-    {
-        return $this->_precision;
-    }
-
-    /**
-     * @return int
-     */
-    public function getScale()
-    {
-        return $this->_scale;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getUnsigned()
-    {
-        return $this->_unsigned;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getFixed()
-    {
-        return $this->_fixed;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getNotnull()
-    {
-        return $this->_notnull;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getDefault()
-    {
-        return $this->_default;
-    }
-
-    /**
-     * @return mixed[]
-     */
-    public function getPlatformOptions()
-    {
-        return $this->_platformOptions;
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return bool
-     */
-    public function hasPlatformOption($name)
-    {
-        return isset($this->_platformOptions[$name]);
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return mixed
-     */
-    public function getPlatformOption($name)
-    {
-        return $this->_platformOptions[$name];
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getColumnDefinition()
-    {
-        return $this->_columnDefinition;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getAutoincrement()
-    {
-        return $this->_autoincrement;
     }
 
     /**
@@ -366,11 +377,31 @@ class Column extends AbstractAsset
     }
 
     /**
-     * @return string|null
+     * @param string $name
+     *
+     * @return bool
      */
-    public function getComment()
+    public function hasPlatformOption($name)
     {
-        return $this->_comment;
+        return isset($this->_platformOptions[$name]);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function getPlatformOption($name)
+    {
+        return $this->_platformOptions[$name];
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getPlatformOptions()
+    {
+        return $this->_platformOptions;
     }
 
     /**
@@ -379,9 +410,21 @@ class Column extends AbstractAsset
      *
      * @return Column
      */
-    public function setCustomSchemaOption($name, $value)
+    public function setPlatformOption($name, $value)
     {
-        $this->_customSchemaOptions[$name] = $value;
+        $this->_platformOptions[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed[] $platformOptions
+     *
+     * @return Column
+     */
+    public function setPlatformOptions(array $platformOptions)
+    {
+        $this->_platformOptions = $platformOptions;
 
         return $this;
     }
@@ -407,6 +450,27 @@ class Column extends AbstractAsset
     }
 
     /**
+     * @return mixed[]
+     */
+    public function getCustomSchemaOptions()
+    {
+        return $this->_customSchemaOptions;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @return Column
+     */
+    public function setCustomSchemaOption($name, $value)
+    {
+        $this->_customSchemaOptions[$name] = $value;
+
+        return $this;
+    }
+
+    /**
      * @param mixed[] $customSchemaOptions
      *
      * @return Column
@@ -421,29 +485,29 @@ class Column extends AbstractAsset
     /**
      * @return mixed[]
      */
-    public function getCustomSchemaOptions()
-    {
-        return $this->_customSchemaOptions;
-    }
-
-    /**
-     * @return mixed[]
-     */
     public function toArray()
     {
         return array_merge([
-            'name'          => $this->_name,
-            'type'          => $this->_type,
-            'default'       => $this->_default,
-            'notnull'       => $this->_notnull,
-            'length'        => $this->_length,
-            'precision'     => $this->_precision,
-            'scale'         => $this->_scale,
-            'fixed'         => $this->_fixed,
-            'unsigned'      => $this->_unsigned,
-            'autoincrement' => $this->_autoincrement,
+            'name'             => $this->_name,
+            'type'             => $this->_type,
+            'default'          => $this->_default,
+            'notnull'          => $this->_notnull,
+            'length'           => $this->_length,
+            'precision'        => $this->_precision,
+            'scale'            => $this->_scale,
+            'fixed'            => $this->_fixed,
+            'unsigned'         => $this->_unsigned,
+            'autoincrement'    => $this->_autoincrement,
             'columnDefinition' => $this->_columnDefinition,
-            'comment' => $this->_comment,
+            'comment'          => $this->_comment,
         ], $this->_platformOptions, $this->_customSchemaOptions);
+    }
+
+    public function createCopy(string $name): Column
+    {
+        $column = clone $this;
+        $column->_setName($name);
+
+        return $column;
     }
 }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
 use function array_keys;
@@ -340,16 +341,26 @@ class Table extends AbstractAsset
     }
 
     /**
+     * @deprecated Use {@see addColumns()} instead.
+     *
      * @param string  $name
      * @param string  $typeName
      * @param mixed[] $options
      *
      * @return Column
      *
+     * @throws Exception
      * @throws SchemaException
      */
     public function addColumn($name, $typeName, array $options = [])
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/',
+            '%s is deprecated, use addColumns() instead.',
+            __METHOD__
+        );
+
         $column = new Column($name, Type::getType($typeName), $options);
 
         $this->_addColumn($column);
@@ -358,6 +369,24 @@ class Table extends AbstractAsset
     }
 
     /**
+     * @param Column[] $columns
+     *
+     * @return $this
+     *
+     * @throws SchemaException
+     */
+    public function addColumns(array $columns): self
+    {
+        foreach ($columns as $column) {
+            $this->_addColumn($column);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @deprecated Use {@see getColumn()} instead and change the column directly.
+     *
      * Change Column Details.
      *
      * @param string  $name
@@ -369,6 +398,13 @@ class Table extends AbstractAsset
      */
     public function changeColumn($name, array $options)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/',
+            '%s is deprecated, use getColumn() instead and change the column directly.',
+            __METHOD__
+        );
+
         $column = $this->getColumn($name);
         $column->setOptions($options);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation, feature
| BC Break     | no

## Todos

- [ ] Wait for feedback
- [ ] Change/Add tests
- [ ] Add changelog/upgrade entries

This PR makes some changes to the `Table` and `Column` Schema classes.

**Three methods** creating or changing a column with mixed array-options had been **deprecated**:
- `Table::addColumn`
  - There should be no reason for `Table` to act as a factory class for `Column` 
- `Table::changeColumn`
  -  `Table` should not handle or pass the options of `Column`
- `Column::setOptions`
  - Setting multiple options after the initial creation should be rare. I expect not too many being forced to do bigger changes
  - The method was error prone and unclear as it could try to call setter functions with more than one parameter 

To compensate the deprecations, **two methods** have been **added**:
- `Table::addColumns`
  - Adds column-instances directly. Replacement of the removed `addColumn` method
- `Column::createCopy`
  - It is not possible to change the name of a column to still be able to duplicate a column in a table or copy it to another table this method has been added.

Let me know what you think of the changes.
I hope it forces not too many changes or at least gives more flexibility than it takes away.