### PR TITLE
Deprecate AbstractSchemaManager::dropAndCreate() and ::tryMethod() methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,29 @@ awareness about deprecated code.
 
 # Upgrade to 3.2
 
+## Deprecated `AbstractSchemaManager::dropAndCreate*()` and `::tryMethod()` methods.
+
+The following `AbstractSchemaManager::dropAndCreate*()` methods have been deprecated:
+
+1. `AbstractSchemaManager::dropAndCreateConstraint()`. Use `AbstractSchemaManager::dropIndex()`
+   and `AbstractSchemaManager::createIndex()`, `AbstractSchemaManager::dropForeignKey()`
+   and `AbstractSchemaManager::createForeignKey()` or `AbstractSchemaManager::dropUniqueConstraint()`
+   and `AbstractSchemaManager::createUniqueConstraint()` instead.
+2. `AbstractSchemaManager::dropAndCreateIndex()`. Use `AbstractSchemaManager::dropIndex()`
+   and `AbstractSchemaManager::createIndex()` instead.
+3. `AbstractSchemaManager::dropAndCreateForeignKey()`.
+    Use AbstractSchemaManager::dropForeignKey() and AbstractSchemaManager::createForeignKey() instead.
+4. `AbstractSchemaManager::dropAndCreateSequence()`. Use `AbstractSchemaManager::dropSequence()`
+   and `AbstractSchemaManager::createSequence()` instead.
+5. `AbstractSchemaManager::dropAndCreateTable()`. Use `AbstractSchemaManager::dropTable()`
+   and `AbstractSchemaManager::createTable()` instead.
+6. `AbstractSchemaManager::dropAndCreateDatabase()`. Use `AbstractSchemaManager::dropDatabase()`
+   and `AbstractSchemaManager::createDatabase()` instead.
+7. `AbstractSchemaManager::dropAndCreateView()`. Use `AbstractSchemaManager::dropView()`
+   and `AbstractSchemaManager::createView()` instead.
+
+The `AbstractSchemaManager::tryMethod()` method has been also deprecated.
+
 ## Deprecated `AbstractSchemaManager::getSchemaSearchPaths()`.
 
 1. The `AbstractSchemaManager::getSchemaSearchPaths()` method has been deprecated.

--- a/docs/en/reference/testing.rst
+++ b/docs/en/reference/testing.rst
@@ -81,8 +81,8 @@ Data Fixtures in Integration Tests
 ++++++++++++++++++++++++++++++++++
 
 To test selecting and fetching data from the database, the test may create the necessary schema and populate it
-with the test data. To create database tables, instead of checking if the table exists, it is recommended
-to use ``AbstractSchemaManager::dropAndCreateTable()``. This way, the table will be dropped and created every time
+with the test data. To create database tables, instead of checking if the table exists and reusing it,
+it is recommended to use ``FunctionalTestCase::dropAndCreateTable()``. This way, the table will be dropped and created every time
 providing better isolation between the test runs.
 
 Testing Different Database Platforms

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -182,6 +182,11 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getCreateConstraintSQL"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\ForeignKeyConstraint::getColumns"/>
+                <!--
+                    TODO: remove in 4.0.0
+                    See https://github.com/doctrine/dbal/pull/4897
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractSchemaManager::tryMethod"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>
@@ -234,6 +239,8 @@
                 <file name="tests/Driver/OCI8/ExecutionModeTest.php"/>
                 <!-- See https://github.com/vimeo/psalm/issues/5472 -->
                 <file name="src/Portability/Converter.php"/>
+                <!-- See https://github.com/psalm/psalm-plugin-phpunit/issues/107 -->
+                <file name="tests/Functional/Schema/SchemaManagerFunctionalTestCase.php"/>
             </errorLevel>
         </DocblockTypeContradiction>
         <FalsableReturnStatement>

--- a/src/Driver/API/MySQL/ExceptionConverter.php
+++ b/src/Driver/API/MySQL/ExceptionConverter.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\ConnectionLost;
+use Doctrine\DBAL\Exception\DatabaseDoesNotExist;
 use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
@@ -33,6 +34,9 @@ final class ExceptionConverter implements ExceptionConverterInterface
     public function convert(Exception $exception, ?Query $query): DriverException
     {
         switch ($exception->getCode()) {
+            case 1008:
+                return new DatabaseDoesNotExist($exception, $query);
+
             case 1213:
                 return new DeadlockException($exception, $query);
 

--- a/src/Driver/API/OCI/ExceptionConverter.php
+++ b/src/Driver/API/OCI/ExceptionConverter.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Driver\API\OCI;
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Exception\DatabaseDoesNotExist;
+use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\InvalidFieldNameException;
@@ -56,6 +58,14 @@ final class ExceptionConverter implements ExceptionConverterInterface
 
             case 1400:
                 return new NotNullConstraintViolationException($exception, $query);
+
+            case 1918:
+                return new DatabaseDoesNotExist($exception, $query);
+
+            case 2289:
+            case 2443:
+            case 4080:
+                return new DatabaseObjectNotFoundException($exception, $query);
 
             case 2266:
             case 2291:

--- a/src/Driver/API/PostgreSQL/ExceptionConverter.php
+++ b/src/Driver/API/PostgreSQL/ExceptionConverter.php
@@ -7,12 +7,14 @@ namespace Doctrine\DBAL\Driver\API\PostgreSQL;
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Exception\DatabaseDoesNotExist;
 use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\InvalidFieldNameException;
 use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
 use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
+use Doctrine\DBAL\Exception\SchemaDoesNotExist;
 use Doctrine\DBAL\Exception\SyntaxErrorException;
 use Doctrine\DBAL\Exception\TableExistsException;
 use Doctrine\DBAL\Exception\TableNotFoundException;
@@ -53,6 +55,12 @@ final class ExceptionConverter implements ExceptionConverterInterface
 
             case '23505':
                 return new UniqueConstraintViolationException($exception, $query);
+
+            case '3D000':
+                return new DatabaseDoesNotExist($exception, $query);
+
+            case '3F000':
+                return new SchemaDoesNotExist($exception, $query);
 
             case '42601':
                 return new SyntaxErrorException($exception, $query);

--- a/src/Driver/API/SQLSrv/ExceptionConverter.php
+++ b/src/Driver/API/SQLSrv/ExceptionConverter.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Driver\API\SQLSrv;
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\InvalidFieldNameException;
@@ -53,6 +54,10 @@ final class ExceptionConverter implements ExceptionConverterInterface
 
             case 2714:
                 return new TableExistsException($exception, $query);
+
+            case 3701:
+            case 15151:
+                return new DatabaseObjectNotFoundException($exception, $query);
 
             case 11001:
             case 18456:

--- a/src/Exception/DatabaseDoesNotExist.php
+++ b/src/Exception/DatabaseDoesNotExist.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\DBAL\Exception;
+
+/**
+ * @psalm-immutable
+ */
+class DatabaseDoesNotExist extends DatabaseObjectNotFoundException
+{
+}

--- a/src/Exception/SchemaDoesNotExist.php
+++ b/src/Exception/SchemaDoesNotExist.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\DBAL\Exception;
+
+/**
+ * @psalm-immutable
+ */
+class SchemaDoesNotExist extends DatabaseObjectNotFoundException
+{
+}

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -76,10 +76,18 @@ abstract class AbstractSchemaManager
      * $result = $sm->tryMethod('dropView', 'view_name');
      * </code>
      *
+     * @deprecated
+     *
      * @return mixed
      */
     public function tryMethod()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4897',
+            'AbstractSchemaManager::tryMethod() is deprecated.'
+        );
+
         $args   = func_get_args();
         $method = $args[0];
         unset($args[0]);
@@ -605,7 +613,8 @@ abstract class AbstractSchemaManager
     /**
      * Drops and creates a constraint.
      *
-     * @deprecated Use {@link dropAndCreateIndex()}, {@link dropAndCreateForeignKey()}
+     * @deprecated Use {@link dropIndex()} and {@link createIndex()},
+     *             {@link dropForeignKey()} and {@link createForeignKey()}
      *             or {@link dropUniqueConstraint()} and {@link createUniqueConstraint()} instead.
      *
      * @see dropConstraint()
@@ -619,12 +628,24 @@ abstract class AbstractSchemaManager
      */
     public function dropAndCreateConstraint(Constraint $constraint, $table)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4897',
+            'AbstractSchemaManager::dropAndCreateConstraint() is deprecated.'
+                . ' Use AbstractSchemaManager::dropIndex() and AbstractSchemaManager::createIndex(),'
+                . ' AbstractSchemaManager::dropForeignKey() and AbstractSchemaManager::createForeignKey()'
+                . ' or AbstractSchemaManager::dropUniqueConstraint()'
+                . ' and AbstractSchemaManager::createUniqueConstraint() instead.'
+        );
+
         $this->tryMethod('dropConstraint', $constraint, $table);
         $this->createConstraint($constraint, $table);
     }
 
     /**
      * Drops and creates a new index on a table.
+     *
+     * @deprecated Use {@link dropIndex()} and {@link createIndex()} instead.
      *
      * @param Table|string $table The name of the table on which the index is to be created.
      *
@@ -634,12 +655,21 @@ abstract class AbstractSchemaManager
      */
     public function dropAndCreateIndex(Index $index, $table)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4897',
+            'AbstractSchemaManager::dropAndCreateIndex() is deprecated.'
+            . ' Use AbstractSchemaManager::dropIndex() and AbstractSchemaManager::createIndex() instead.'
+        );
+
         $this->tryMethod('dropIndex', $index->getQuotedName($this->_platform), $table);
         $this->createIndex($index, $table);
     }
 
     /**
      * Drops and creates a new foreign key.
+     *
+     * @deprecated Use {@link dropForeignKey()} and {@link createForeignKey()} instead.
      *
      * @param ForeignKeyConstraint $foreignKey An associative array that defines properties
      *                                         of the foreign key to be created.
@@ -651,6 +681,13 @@ abstract class AbstractSchemaManager
      */
     public function dropAndCreateForeignKey(ForeignKeyConstraint $foreignKey, $table)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4897',
+            'AbstractSchemaManager::dropAndCreateForeignKey() is deprecated.'
+            . ' Use AbstractSchemaManager::dropForeignKey() and AbstractSchemaManager::createForeignKey() instead.'
+        );
+
         $this->tryMethod('dropForeignKey', $foreignKey, $table);
         $this->createForeignKey($foreignKey, $table);
     }
@@ -658,12 +695,21 @@ abstract class AbstractSchemaManager
     /**
      * Drops and create a new sequence.
      *
+     * @deprecated Use {@link dropSequence()} and {@link createSequence()} instead.
+     *
      * @return void
      *
      * @throws Exception
      */
     public function dropAndCreateSequence(Sequence $sequence)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4897',
+            'AbstractSchemaManager::dropAndCreateSequence() is deprecated.'
+            . ' Use AbstractSchemaManager::dropSequence() and AbstractSchemaManager::createSequence() instead.'
+        );
+
         $this->tryMethod('dropSequence', $sequence->getQuotedName($this->_platform));
         $this->createSequence($sequence);
     }
@@ -671,18 +717,29 @@ abstract class AbstractSchemaManager
     /**
      * Drops and creates a new table.
      *
+     * @deprecated Use {@link dropTable()} and {@link createTable()} instead.
+     *
      * @return void
      *
      * @throws Exception
      */
     public function dropAndCreateTable(Table $table)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4897',
+            'AbstractSchemaManager::dropAndCreateTable() is deprecated.'
+            . ' Use AbstractSchemaManager::dropTable() and AbstractSchemaManager::createTable() instead.'
+        );
+
         $this->tryMethod('dropTable', $table->getQuotedName($this->_platform));
         $this->createTable($table);
     }
 
     /**
      * Drops and creates a new database.
+     *
+     * @deprecated Use {@link dropDatabase()} and {@link createDatabase()} instead.
      *
      * @param string $database The name of the database to create.
      *
@@ -692,6 +749,13 @@ abstract class AbstractSchemaManager
      */
     public function dropAndCreateDatabase($database)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4897',
+            'AbstractSchemaManager::dropAndCreateDatabase() is deprecated.'
+            . ' Use AbstractSchemaManager::dropDatabase() and AbstractSchemaManager::createDatabase() instead.'
+        );
+
         $this->tryMethod('dropDatabase', $database);
         $this->createDatabase($database);
     }
@@ -699,12 +763,21 @@ abstract class AbstractSchemaManager
     /**
      * Drops and creates a new view.
      *
+     * @deprecated Use {@link dropView()} and {@link createView()} instead.
+     *
      * @return void
      *
      * @throws Exception
      */
     public function dropAndCreateView(View $view)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4897',
+            'AbstractSchemaManager::dropAndCreateView() is deprecated.'
+            . ' Use AbstractSchemaManager::dropView() and AbstractSchemaManager::createView() instead.'
+        );
+
         $this->tryMethod('dropView', $view->getQuotedName($this->_platform));
         $this->createView($view);
     }

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -91,9 +91,18 @@ class SqliteSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@link dropForeignKey()} and {@link createForeignKey()} instead.
      */
     public function dropAndCreateForeignKey(ForeignKeyConstraint $foreignKey, $table)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4897',
+            'SqliteSchemaManager::dropAndCreateForeignKey() is deprecated.'
+                . ' Use SqliteSchemaManager::dropForeignKey() and SqliteSchemaManager::createForeignKey() instead.'
+        );
+
         $tableDiff                       = $this->getTableDiffForAlterForeignKey($table);
         $tableDiff->changedForeignKeys[] = $foreignKey;
 

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -462,15 +462,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     private function getTableDiffForAlterForeignKey($table)
     {
         if (! $table instanceof Table) {
-            $tableDetails = $this->tryMethod('listTableDetails', $table);
-
-            if ($tableDetails === false) {
-                throw new Exception(
-                    sprintf('Sqlite schema manager requires to modify foreign keys table definition "%s".', $table)
-                );
-            }
-
-            $table = $tableDetails;
+            $table = $this->listTableDetails($table);
         }
 
         $tableDiff            = new TableDiff($table->getName());

--- a/tests/Functional/AutoIncrementColumnTest.php
+++ b/tests/Functional/AutoIncrementColumnTest.php
@@ -17,8 +17,7 @@ class AutoIncrementColumnTest extends FunctionalTestCase
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
 
-        $this->connection->createSchemaManager()
-            ->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
     }
 
     protected function tearDown(): void

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -29,8 +29,7 @@ class BlobTest extends FunctionalTestCase
         $table->addColumn('blobcolumn', 'blob');
         $table->setPrimaryKey(['id']);
 
-        $sm = $this->connection->getSchemaManager();
-        $sm->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
     }
 
     public function testInsert(): void

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -106,6 +106,7 @@ class ConnectionTest extends FunctionalTestCase
             $connection = $this->connection;
         }
 
+        $this->dropTableIfExists('test_nesting');
         $connection->executeQuery('CREATE TABLE test_nesting(test int not null)');
 
         $this->connection->beginTransaction();
@@ -398,7 +399,7 @@ class ConnectionTest extends FunctionalTestCase
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
 
-        $this->connection->createSchemaManager()->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->insert(self::TABLE, ['id' => 1]);
     }

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -27,8 +27,7 @@ class DataAccessTest extends FunctionalTestCase
         $table->addColumn('test_datetime', 'datetime', ['notnull' => false]);
         $table->setPrimaryKey(['test_int']);
 
-        $sm = $this->connection->getSchemaManager();
-        $sm->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->insert('fetch_table', [
             'test_int' => 1,

--- a/tests/Functional/Driver/OCI8/ConnectionTest.php
+++ b/tests/Functional/Driver/OCI8/ConnectionTest.php
@@ -22,18 +22,16 @@ class ConnectionTest extends FunctionalTestCase
 
     public function testLastInsertIdAcceptsFqn(): void
     {
-        $platform      = $this->connection->getDatabasePlatform();
-        $schemaManager = $this->connection->getSchemaManager();
-
         $table = new Table('DBAL2595');
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
         $table->addColumn('foo', 'integer');
 
-        $schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->executeStatement('INSERT INTO DBAL2595 (foo) VALUES (1)');
 
         $schema   = $this->connection->getDatabase();
+        $platform = $this->connection->getDatabasePlatform();
         $sequence = $platform->getIdentitySequenceName($schema . '.DBAL2595', 'id');
 
         self::assertSame(1, $this->connection->lastInsertId($sequence));

--- a/tests/Functional/LegacyAPITest.php
+++ b/tests/Functional/LegacyAPITest.php
@@ -21,8 +21,7 @@ class LegacyAPITest extends FunctionalTestCase
         $table->addColumn('test_string', 'string');
         $table->setPrimaryKey(['test_int']);
 
-        $sm = $this->connection->getSchemaManager();
-        $sm->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->insert('legacy_table', [
             'test_int' => 1,

--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -42,7 +42,7 @@ class NoneTest extends FunctionalTestCase
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
 
-        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection2 = TestUtil::getConnection();
 

--- a/tests/Functional/ModifyLimitQueryTest.php
+++ b/tests/Functional/ModifyLimitQueryTest.php
@@ -26,9 +26,8 @@ class ModifyLimitQueryTest extends FunctionalTestCase
         $table2->addColumn('test_int', 'integer');
         $table2->setPrimaryKey(['id']);
 
-        $sm = $this->connection->getSchemaManager();
-        $sm->dropAndCreateTable($table);
-        $sm->dropAndCreateTable($table2);
+        $this->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table2);
     }
 
     public function testModifyLimitQuerySimpleQuery(): void

--- a/tests/Functional/Platform/AddColumnWithDefaultTest.php
+++ b/tests/Functional/Platform/AddColumnWithDefaultTest.php
@@ -20,7 +20,7 @@ class AddColumnWithDefaultTest extends FunctionalTestCase
         $table = new Table('add_default_test');
 
         $table->addColumn('original_field', Types::STRING);
-        $schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->executeStatement("INSERT INTO add_default_test (original_field) VALUES ('one')");
 

--- a/tests/Functional/Platform/AlterColumnTest.php
+++ b/tests/Functional/Platform/AlterColumnTest.php
@@ -18,12 +18,12 @@ class AlterColumnTest extends FunctionalTestCase
         $table->addColumn('c1', 'integer');
         $table->addColumn('c2', 'integer');
 
-        $sm = $this->connection->createSchemaManager();
-        $sm->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $table->getColumn('c1')
             ->setType(Type::getType(Types::STRING));
 
+        $sm         = $this->connection->createSchemaManager();
         $comparator = new Comparator();
         $diff       = $comparator->diffTable($sm->listTableDetails('test_alter'), $table);
 

--- a/tests/Functional/Platform/DateExpressionTest.php
+++ b/tests/Functional/Platform/DateExpressionTest.php
@@ -18,7 +18,7 @@ class DateExpressionTest extends FunctionalTestCase
         $table = new Table('date_expr_test');
         $table->addColumn('date1', 'datetime');
         $table->addColumn('date2', 'datetime');
-        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
         $this->connection->insert('date_expr_test', [
             'date1' => $date1,
             'date2' => $date2,

--- a/tests/Functional/Platform/DefaultExpressionTest.php
+++ b/tests/Functional/Platform/DefaultExpressionTest.php
@@ -60,7 +60,7 @@ class DefaultExpressionTest extends FunctionalTestCase
         $table = new Table('default_expr_test');
         $table->addColumn('actual_value', $type);
         $table->addColumn('default_value', $type, ['default' => $defaultSql]);
-        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->executeStatement(
             sprintf(

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -35,16 +35,16 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
      */
     public function testAlterPrimaryKeyToAutoIncrementColumn(callable $comparatorFactory): void
     {
-        $schemaManager = $this->connection->getSchemaManager();
-        $schemaManager->tryMethod('dropTable', 'dbal2807');
+        $this->dropTableIfExists('dbal2807');
 
-        $schema = $schemaManager->createSchema();
+        $schemaManager = $this->connection->getSchemaManager();
+        $schema        = $schemaManager->createSchema();
 
         $table = $schema->createTable('dbal2807');
         $table->addColumn('initial_id', 'integer');
         $table->setPrimaryKey(['initial_id']);
 
-        $schemaManager->dropAndCreateTable($table);
+        $schemaManager->createTable($table);
 
         $newSchema = clone $schema;
         $newTable  = $newSchema->getTable($table->getName());

--- a/tests/Functional/Platform/PlatformRestrictionsTest.php
+++ b/tests/Functional/Platform/PlatformRestrictionsTest.php
@@ -25,7 +25,7 @@ class PlatformRestrictionsTest extends FunctionalTestCase
         $table      = new Table($tableName);
         $table->addColumn($columnName, 'integer', ['autoincrement' => true]);
         $table->setPrimaryKey([$columnName]);
-        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
         $createdTable = $this->connection->getSchemaManager()->listTableDetails($tableName);
 
         $this->assertTrue($createdTable->hasColumn($columnName));

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -23,12 +23,12 @@ class RenameColumnTest extends FunctionalTestCase
         $table->addColumn($columnName, 'string');
         $table->addColumn('c2', 'integer');
 
-        $sm = $this->connection->createSchemaManager();
-        $sm->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $table->dropColumn($columnName)
             ->addColumn($newColumnName, 'string');
 
+        $sm         =  $this->connection->createSchemaManager();
         $comparator = new Comparator();
         $diff       = $comparator->diffTable($sm->listTableDetails('test_rename'), $table);
 

--- a/tests/Functional/ResultCacheTest.php
+++ b/tests/Functional/ResultCacheTest.php
@@ -38,8 +38,7 @@ class ResultCacheTest extends FunctionalTestCase
         $table->addColumn('test_string', 'string', ['notnull' => false]);
         $table->setPrimaryKey(['test_int']);
 
-        $sm = $this->connection->getSchemaManager();
-        $sm->createTable($table);
+        $this->dropAndCreateTable($table);
 
         foreach ($this->expectedResult as $row) {
             $this->connection->insert('caching', $row);

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -32,7 +32,7 @@ class ComparatorTest extends FunctionalTestCase
         $table = new Table('default_value');
         $table->addColumn('test', $type, ['default' => $value]);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $onlineTable = $this->schemaManager->listTableDetails('default_value');
 

--- a/tests/Functional/Schema/DefaultValueTest.php
+++ b/tests/Functional/Schema/DefaultValueTest.php
@@ -23,8 +23,7 @@ class DefaultValueTest extends FunctionalTestCase
             ]);
         }
 
-        $this->connection->getSchemaManager()
-            ->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->insert('default_value', ['id' => 1]);
     }

--- a/tests/Functional/Schema/MySQL/ComparatorTest.php
+++ b/tests/Functional/Schema/MySQL/ComparatorTest.php
@@ -83,7 +83,7 @@ final class ComparatorTest extends FunctionalTestCase
         $table = new Table('comparator_test');
         $table->addColumn('lob', $type)->setLength($length);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         return $table;
     }
@@ -137,7 +137,7 @@ final class ComparatorTest extends FunctionalTestCase
         $table->addOption('charset', 'utf8mb4');
         $table->addOption('collate', 'utf8mb4_general_ci');
         $column = $table->addColumn('id', Types::STRING);
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         return [$table, $column];
     }

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -88,7 +88,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $index = $table->getIndex('f_index');
         $index->addFlag('fulltext');
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $indexes = $this->schemaManager->listTableIndexes('fulltext_index');
         self::assertArrayHasKey('f_index', $indexes);
@@ -105,7 +105,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $index = $table->getIndex('s_index');
         $index->addFlag('spatial');
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $indexes = $this->schemaManager->listTableIndexes('spatial_index');
         self::assertArrayHasKey('s_index', $indexes);
@@ -119,7 +119,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('text', 'string', ['length' => 255]);
         $table->addIndex(['text'], 'text_index', [], ['lengths' => [128]]);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $indexes = $this->schemaManager->listTableIndexes('index_length');
         self::assertArrayHasKey('text_index', $indexes);
@@ -159,7 +159,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('foo', 'integer');
         $table->setPrimaryKey(['id', 'foo']);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $diffTable = clone $table;
 
@@ -191,7 +191,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('def_blob', 'blob', ['default' => 'def']);
         $table->addColumn('def_blob_null', 'blob', ['notnull' => false, 'default' => 'def']);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $onlineTable = $this->schemaManager->listTableDetails('text_blob_default_value');
 
@@ -225,7 +225,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('no_charset', 'text');
         $table->addColumn('foo', 'text')->setPlatformOption('charset', 'ascii');
         $table->addColumn('bar', 'text')->setPlatformOption('charset', 'latin1');
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('test_column_charset');
 
@@ -242,7 +242,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table = new Table($tableName);
         $table->addColumn('col_text', 'text')->setPlatformOption('charset', 'utf8');
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $diffTable = clone $table;
         $diffTable->getColumn('col_text')->setPlatformOption('charset', 'ascii');
@@ -290,7 +290,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('foo', 'text')->setPlatformOption('collation', 'latin1_swedish_ci');
         $table->addColumn('bar', 'text')->setPlatformOption('collation', 'utf8_general_ci');
         $table->addColumn('baz', 'text')->setPlatformOption('collation', 'binary');
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('test_collation');
 
@@ -316,7 +316,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('col_mediumblob', 'blob', ['length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
         $table->addColumn('col_longblob', 'blob');
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $platform       = $this->schemaManager->getDatabasePlatform();
         $offlineColumns = $table->getColumns();
@@ -362,7 +362,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $offlineTable = new Table('list_guid_table_column');
         $offlineTable->addColumn('col_guid', 'guid');
 
-        $this->schemaManager->dropAndCreateTable($offlineTable);
+        $this->dropAndCreateTable($offlineTable);
 
         $onlineTable = $this->schemaManager->listTableDetails('list_guid_table_column');
 
@@ -380,7 +380,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('col', 'decimal');
         $table->addColumn('col_unsigned', 'decimal', ['unsigned' => true]);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns($tableName);
 
@@ -398,7 +398,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('col', 'float');
         $table->addColumn('col_unsigned', 'float', ['unsigned' => true]);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns($tableName);
 
@@ -412,7 +412,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $table = new Table('test_mysql_json');
         $table->addColumn('col_json', 'json');
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('test_mysql_json');
 
@@ -430,7 +430,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('col_datetime', 'datetime', ['notnull' => true, 'default' => $currentTimeStampSql]);
         $table->addColumn('col_datetime_nullable', 'datetime', ['default' => $currentTimeStampSql]);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $onlineTable = $this->schemaManager->listTableDetails('test_column_defaults_current_timestamp');
         self::assertSame($currentTimeStampSql, $onlineTable->getColumn('col_datetime')->getDefault());
@@ -453,7 +453,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('col_decimal', 'decimal', ['scale' => 3, 'precision' => 6, 'default' => -2.3]);
         $table->addColumn('col_date', 'date', ['default' => '2012-12-12']);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->executeStatement(
             'INSERT INTO test_column_defaults_are_valid () VALUES()'
@@ -502,7 +502,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('col_date', 'date', ['default' => $currentDateSql]);
         $table->addColumn('col_time', 'time', ['default' => $currentTimeSql]);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $onlineTable = $this->schemaManager->listTableDetails('test_column_defaults_current_time_and_date');
 

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
+use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -23,10 +24,8 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testRenameTable(): void
     {
-        $this->schemaManager->tryMethod('DropTable', 'list_tables_test');
-        $this->schemaManager->tryMethod('DropTable', 'list_tables_test_new_name');
-
         $this->createTestTable('list_tables_test');
+        $this->dropTableIfExists('list_tables_test_new_name');
         $this->schemaManager->renameTable('list_tables_test', 'list_tables_test_new_name');
 
         $tables = $this->schemaManager->listTables();
@@ -59,7 +58,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('bar', 'string');
         $table->setPrimaryKey(['id']);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns($tableName);
 
@@ -81,19 +80,6 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($columns['id']->getNotnull());
         self::assertFalse($columns['foo']->getNotnull());
         self::assertTrue($columns['bar']->getNotnull());
-    }
-
-    public function testListDatabases(): void
-    {
-        // We need a privileged connection to create the database.
-        $sm = TestUtil::getPrivilegedConnection()->getSchemaManager();
-
-        $sm->dropAndCreateDatabase('c##test_create_database');
-
-        $databases = $this->schemaManager->listDatabases();
-        $databases = array_map('strtolower', $databases);
-
-        self::assertContains('c##test_create_database', $databases);
     }
 
     public function testListTableDetailsWithDifferentIdentifierQuotingRequirements(): void
@@ -129,8 +115,8 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         );
         $offlineForeignTable->setPrimaryKey(['id']);
 
-        $this->schemaManager->tryMethod('dropTable', $foreignTableName);
-        $this->schemaManager->tryMethod('dropTable', $primaryTableName);
+        $this->dropTableIfExists($foreignTableName);
+        $this->dropTableIfExists($primaryTableName);
 
         $this->schemaManager->createTable($offlinePrimaryTable);
         $this->schemaManager->createTable($offlineForeignTable);
@@ -215,11 +201,20 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testListTableColumnsSameTableNamesInDifferentSchemas(): void
     {
         $table = $this->createListTableColumns();
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $otherTable = new Table($table->getName());
         $otherTable->addColumn('id', Types::STRING);
-        TestUtil::getPrivilegedConnection()->getSchemaManager()->dropAndCreateTable($otherTable);
+
+        $schemaManager = TestUtil::getPrivilegedConnection()
+            ->getSchemaManager();
+
+        try {
+            $schemaManager->dropTable($otherTable->getName());
+        } catch (DatabaseObjectNotFoundException $e) {
+        }
+
+        $schemaManager->createTable($otherTable);
 
         $columns = $this->schemaManager->listTableColumns($table->getName(), $this->connection->getDatabase());
         self::assertCount(7, $columns);
@@ -231,7 +226,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
         $table->addColumn('id', 'integer', ['notnull' => true]);
         $table->addUniqueIndex(['id'], 'id_unique_index');
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->schemaManager->createIndex(
             new Index('id_pk_id_index', ['id'], true, true),
@@ -253,7 +248,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('col_datetime', 'datetime');
         $table->addColumn('col_datetimetz', 'datetimetz');
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('tbl_date');
 

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
+use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -77,7 +78,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $autoincTable = new Table('autoinc_table');
         $column       = $autoincTable->addColumn('id', 'integer');
         $column->setAutoincrement(true);
-        $this->schemaManager->createTable($autoincTable);
+        $this->dropAndCreateTable($autoincTable);
         $autoincTable = $this->schemaManager->listTableDetails('autoinc_table');
 
         self::assertTrue($autoincTable->getColumn('id')->getAutoincrement());
@@ -91,11 +92,14 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testAlterTableAutoIncrementAdd(callable $comparatorFactory): void
     {
         // see https://github.com/doctrine/dbal/issues/4745
-        $this->schemaManager->tryMethod('dropSequence', 'autoinc_table_add_id_seq');
+        try {
+            $this->schemaManager->dropSequence('autoinc_table_add_id_seq');
+        } catch (DatabaseObjectNotFoundException $e) {
+        }
 
         $tableFrom = new Table('autoinc_table_add');
         $tableFrom->addColumn('id', 'integer');
-        $this->schemaManager->dropAndCreateTable($tableFrom);
+        $this->dropAndCreateTable($tableFrom);
         $tableFrom = $this->schemaManager->listTableDetails('autoinc_table_add');
         self::assertFalse($tableFrom->getColumn('id')->getAutoincrement());
 
@@ -129,7 +133,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableFrom = new Table('autoinc_table_drop');
         $column    = $tableFrom->addColumn('id', 'integer');
         $column->setAutoincrement(true);
-        $this->schemaManager->dropAndCreateTable($tableFrom);
+        $this->dropAndCreateTable($tableFrom);
         $tableFrom = $this->schemaManager->listTableDetails('autoinc_table_drop');
         self::assertTrue($tableFrom->getColumn('id')->getAutoincrement());
 
@@ -187,6 +191,8 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testReturnQuotedAssets(): void
     {
+        $this->connection->executeStatement('DROP TABLE IF EXISTS dbal91_something');
+
         $sql = 'create table dbal91_something'
             . ' (id integer CONSTRAINT id_something PRIMARY KEY NOT NULL, "table" integer)';
         $this->connection->executeStatement($sql);
@@ -210,10 +216,11 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $testTable = new Table('dbal204_test_prefix');
         $testTable->addColumn('id', 'integer');
-        $this->schemaManager->createTable($testTable);
+        $this->dropAndCreateTable($testTable);
+
         $testTable = new Table('dbal204_without_prefix');
         $testTable->addColumn('id', 'integer');
-        $this->schemaManager->createTable($testTable);
+        $this->dropAndCreateTable($testTable);
 
         $this->connection->getConfiguration()->setSchemaAssetsFilter(static function (string $name): bool {
             return preg_match('#^dbal204_#', $name) === 1;
@@ -248,7 +255,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
             );
         }
 
-        $this->schemaManager->dropAndCreateTable($fkTable);
+        $this->dropAndCreateTable($fkTable);
         $this->createTestTable('test_create_fk2');
 
         foreach ($foreignKeys as $foreignKey) {
@@ -276,8 +283,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $testTable->addColumn('id', 'integer');
         $testTable->addColumn('def', 'string', ['default' => 'foo']);
         $testTable->setPrimaryKey(['id']);
-
-        $this->schemaManager->createTable($testTable);
+        $this->dropAndCreateTable($testTable);
 
         $databaseTable = $this->schemaManager->listTableDetails($testTable->getName());
 
@@ -295,7 +301,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('id', 'integer');
         $table->addColumn('checked', 'boolean', ['default' => false]);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $databaseTable = $this->schemaManager->listTableDetails($table->getName());
 
@@ -329,7 +335,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $offlineTable->setPrimaryKey(['id']);
         $offlineTable->addForeignKeyConstraint($offlineTable, ['fk'], ['id']);
 
-        $this->schemaManager->dropAndCreateTable($offlineTable);
+        $this->dropAndCreateTable($offlineTable);
 
         $onlineTable = $this->schemaManager->listTableDetails('"user"');
 
@@ -359,7 +365,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $view = new View($name, $sql);
 
-        $this->schemaManager->dropAndCreateView($view);
+        $this->schemaManager->createView($view);
 
         $tables = $this->schemaManager->listTables();
 
@@ -384,7 +390,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $offlineTable->addColumn('email', 'string');
         $offlineTable->addUniqueIndex(['id', 'name'], 'simple_partial_index', ['where' => '(id IS NULL)']);
 
-        $this->schemaManager->dropAndCreateTable($offlineTable);
+        $this->dropAndCreateTable($offlineTable);
 
         $onlineTable = $this->schemaManager->listTableDetails('person');
 
@@ -406,7 +412,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $table = new Table('test_jsonb');
         $table->addColumn('foo', Types::JSON)->setPlatformOption('jsonb', true);
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('test_jsonb');
 
@@ -424,7 +430,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('col_decimal', 'decimal', ['default' => -1.1]);
         $table->addColumn('col_string', 'string', ['default' => '(-1)']);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('test_default_negative');
 
@@ -457,7 +463,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table = new Table($tableName);
         $table->addColumn('id', $type, ['autoincrement' => true, 'notnull' => false]);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns($tableName);
 
@@ -474,7 +480,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table = new Table($tableName);
         $table->addColumn('id', $type, ['autoincrement' => true, 'notnull' => false, 'default' => 1]);
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns($tableName);
 
@@ -495,7 +501,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableFrom = new Table('autoinc_type_modification');
         $column    = $tableFrom->addColumn('id', $from);
         $column->setAutoincrement(true);
-        $this->schemaManager->dropAndCreateTable($tableFrom);
+        $this->dropAndCreateTable($tableFrom);
         $tableFrom = $this->schemaManager->listTableDetails('autoinc_type_modification');
         self::assertTrue($tableFrom->getColumn('id')->getAutoincrement());
 

--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -39,7 +39,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table  = new Table($tableName = 'test_collation');
         $column = $table->addColumn($columnName = 'test', 'string');
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
         $columns = $this->schemaManager->listTableColumns($tableName);
 
         // SQL Server should report a default collation on the column
@@ -47,7 +47,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $column->setPlatformOption('collation', $collation = 'Icelandic_CS_AS');
 
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
         $columns = $this->schemaManager->listTableColumns($tableName);
 
         self::assertEquals($collation, $columns[$columnName]->getPlatformOption('collation'));

--- a/tests/Functional/Schema/SQLite/ComparatorTest.php
+++ b/tests/Functional/Schema/SQLite/ComparatorTest.php
@@ -38,7 +38,7 @@ final class ComparatorTest extends FunctionalTestCase
     {
         $table  = new Table('comparator_test');
         $column = $table->addColumn('id', Types::STRING);
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $column->setPlatformOption('collation', 'NOCASE');
         ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -105,7 +105,7 @@ EOS
         $table->addColumn('text', 'text');
         $table->addColumn('foo', 'text')->setPlatformOption('collation', 'BINARY');
         $table->addColumn('bar', 'text')->setPlatformOption('collation', 'NOCASE');
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('test_collation');
 
@@ -162,7 +162,7 @@ SQL;
         $table->addColumn('id', 'integer');
         $table->addColumn('text', 'text');
         $table->setPrimaryKey(['id']);
-        $this->schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '1']);
 

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -20,7 +20,7 @@ class StatementTest extends FunctionalTestCase
         $table = new Table('stmt_test');
         $table->addColumn('id', 'integer');
         $table->addColumn('name', 'text', ['notnull' => false]);
-        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
     }
 
     public function testStatementIsReusableAfterFreeingResult(): void
@@ -52,11 +52,10 @@ class StatementTest extends FunctionalTestCase
             self::markTestIncomplete('PDO_OCI doesn\'t support fetching blobs via PDOStatement::fetchAll()');
         }
 
-        $sm    = $this->connection->getSchemaManager();
         $table = new Table('stmt_longer_results');
         $table->addColumn('param', 'string');
         $table->addColumn('val', 'text');
-        $sm->createTable($table);
+        $this->dropAndCreateTable($table);
 
         $row1 = [
             'param' => 'param1',
@@ -95,10 +94,9 @@ class StatementTest extends FunctionalTestCase
         // but is still not enough to store a LONGBLOB of the max possible size
         $this->iniSet('memory_limit', '4G');
 
-        $sm    = $this->connection->getSchemaManager();
         $table = new Table('stmt_long_blob');
         $table->addColumn('contents', 'blob', ['length' => 0xFFFFFFFF]);
-        $sm->createTable($table);
+        $this->dropAndCreateTable($table);
 
         $contents = base64_decode(<<<EOF
 H4sICJRACVgCA2RvY3RyaW5lLmljbwDtVNtLFHEU/ia1i9fVzVWxvJSrZmoXS6pd0zK7QhdNc03z

--- a/tests/Functional/TableGeneratorTest.php
+++ b/tests/Functional/TableGeneratorTest.php
@@ -20,8 +20,7 @@ class TableGeneratorTest extends FunctionalTestCase
             self::markTestSkipped('TableGenerator does not work with SQLite');
         }
 
-        $this->connection->createSchemaManager()
-            ->tryMethod('dropTable', 'sequences');
+        $this->dropTableIfExists('sequences');
 
         $schema  = new Schema();
         $visitor = new TableGeneratorSchemaVisitor();

--- a/tests/Functional/TemporaryTableTest.php
+++ b/tests/Functional/TemporaryTableTest.php
@@ -30,7 +30,7 @@ class TemporaryTableTest extends FunctionalTestCase
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
 
-        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->beginTransaction();
         $this->connection->insert('nontemporary', ['id' => 1]);
@@ -61,7 +61,7 @@ class TemporaryTableTest extends FunctionalTestCase
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
 
-        $this->connection->getSchemaManager()->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->beginTransaction();
         $this->connection->insert('nontemporary', ['id' => 1]);

--- a/tests/Functional/Ticket/DBAL510Test.php
+++ b/tests/Functional/Ticket/DBAL510Test.php
@@ -30,10 +30,10 @@ class DBAL510Test extends FunctionalTestCase
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
 
-        $schemaManager = $this->connection->getSchemaManager();
-        $schemaManager->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
-        $onlineTable = $schemaManager->listTableDetails('dbal510tbl');
+        $schemaManager = $this->connection->createSchemaManager();
+        $onlineTable   = $schemaManager->listTableDetails('dbal510tbl');
 
         $comparator = $comparatorFactory($schemaManager);
         $diff       = $comparator->diffTable($onlineTable, $table);

--- a/tests/Functional/TypeConversionTest.php
+++ b/tests/Functional/TypeConversionTest.php
@@ -36,9 +36,7 @@ class TypeConversionTest extends FunctionalTestCase
         $table->addColumn('test_decimal', 'decimal', ['notnull' => false, 'scale' => 2, 'precision' => 10]);
         $table->setPrimaryKey(['id']);
 
-        $this->connection
-            ->getSchemaManager()
-            ->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
     }
 
     /**

--- a/tests/Functional/Types/AsciiStringTest.php
+++ b/tests/Functional/Types/AsciiStringTest.php
@@ -21,8 +21,7 @@ class AsciiStringTest extends FunctionalTestCase
         $table->addColumn('val', 'ascii_string', ['length' => 4]);
         $table->setPrimaryKey(['id']);
 
-        $sm = $this->connection->getSchemaManager();
-        $sm->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
     }
 
     public function testInsertAndSelect(): void

--- a/tests/Functional/Types/BinaryTest.php
+++ b/tests/Functional/Types/BinaryTest.php
@@ -31,8 +31,7 @@ class BinaryTest extends FunctionalTestCase
         $table->addColumn('val', 'binary', ['length' => 64]);
         $table->setPrimaryKey(['id']);
 
-        $sm = $this->connection->getSchemaManager();
-        $sm->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
     }
 
     public function testInsertAndSelect(): void

--- a/tests/Functional/Types/DecimalTest.php
+++ b/tests/Functional/Types/DecimalTest.php
@@ -16,8 +16,7 @@ final class DecimalTest extends FunctionalTestCase
         $table = new Table('decimal_table');
         $table->addColumn('val', Types::DECIMAL, ['precision' => 4, 'scale' => 2]);
 
-        $sm = $this->connection->getSchemaManager();
-        $sm->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
 
         $this->connection->insert(
             'decimal_table',

--- a/tests/Functional/Types/GuidTest.php
+++ b/tests/Functional/Types/GuidTest.php
@@ -14,7 +14,7 @@ class GuidTest extends FunctionalTestCase
         $table = new Table('guid_table');
         $table->addColumn('guid', 'guid');
 
-        $this->connection->createSchemaManager()->dropAndCreateTable($table);
+        $this->dropAndCreateTable($table);
     }
 
     public function testInsertAndSelect(): void

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -18,16 +18,13 @@ class WriteTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        try {
-            $table = new Table('write_table');
-            $table->addColumn('id', 'integer', ['autoincrement' => true]);
-            $table->addColumn('test_int', 'integer');
-            $table->addColumn('test_string', 'string', ['notnull' => false]);
-            $table->setPrimaryKey(['id']);
+        $table = new Table('write_table');
+        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('test_int', 'integer');
+        $table->addColumn('test_string', 'string', ['notnull' => false]);
+        $table->setPrimaryKey(['id']);
 
-            $this->connection->getSchemaManager()->createTable($table);
-        } catch (Throwable $e) {
-        }
+        $this->dropAndCreateTable($table);
 
         $this->connection->executeStatement('DELETE FROM write_table');
     }

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -3,6 +3,9 @@
 namespace Doctrine\DBAL\Tests;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
+use Doctrine\DBAL\Schema\Table;
 use PHPUnit\Framework\TestCase;
 
 abstract class FunctionalTestCase extends TestCase
@@ -73,5 +76,35 @@ abstract class FunctionalTestCase extends TestCase
         unset($this->connection);
 
         $this->isConnectionReusable = true;
+    }
+
+    /**
+     * Drops the table with the specified name, if it exists.
+     *
+     * @throws Exception
+     */
+    public function dropTableIfExists(string $name): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        try {
+            $schemaManager->dropTable($name);
+        } catch (DatabaseObjectNotFoundException $e) {
+        }
+    }
+
+    /**
+     * Drops and creates a new table.
+     *
+     * @throws Exception
+     */
+    public function dropAndCreateTable(Table $table): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $platform      = $schemaManager->getDatabasePlatform();
+        $tableName     = $table->getQuotedName($platform);
+
+        $this->dropTableIfExists($tableName);
+        $schemaManager->createTable($table);
     }
 }

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -84,8 +84,6 @@ class TestUtil
         $testConnParams = self::getTestConnectionParameters();
         $privConnParams = self::getPrivilegedConnectionParameters();
 
-        $testConn = DriverManager::getConnection($testConnParams);
-
         // Connect as a privileged user to create and drop the test database.
         $privConn = DriverManager::getConnection($privConnParams);
 
@@ -98,12 +96,10 @@ class TestUtil
                 $dbname = $testConnParams['user'];
             }
 
-            $testConn->close();
-
             $privConn->getSchemaManager()->dropAndCreateDatabase($dbname);
-
-            $privConn->close();
         } else {
+            $testConn = DriverManager::getConnection($testConnParams);
+
             $sm = $testConn->getSchemaManager();
 
             $schema = $sm->createSchema();
@@ -112,7 +108,11 @@ class TestUtil
             foreach ($stmts as $stmt) {
                 $testConn->executeStatement($stmt);
             }
+
+            $testConn->close();
         }
+
+        $privConn->close();
     }
 
     /**

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use PHPUnit\Framework\Assert;
@@ -96,7 +97,14 @@ class TestUtil
                 $dbname = $testConnParams['user'];
             }
 
-            $privConn->getSchemaManager()->dropAndCreateDatabase($dbname);
+            $sm = $privConn->getSchemaManager();
+
+            try {
+                $sm->dropDatabase($dbname);
+            } catch (DatabaseObjectNotFoundException $e) {
+            }
+
+            $sm->createDatabase($dbname);
         } else {
             $testConn = DriverManager::getConnection($testConnParams);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

1. `AbstractSchemaManager::tryMethod()` is poorly designed: it accepts arbitrary arguments via `func_get_args()` and suppresses any internal `Throwable`. It makes it challenging to analyze it statically and actually use. You can call it with an arbitrary set of arguments and get nothing in return because it will suppress even a `TypeError`.
2. The implementations of the `AbstractSchemaManager::dropAndCreate*()` methods are based on the above error suppression. It makes certain scenarios very confusing. For instance:
   1. An attempt to drop and create a table for which there is a referencing foreign key will result in an exception like "table already exists" because the failure to drop an existing table will be suppressed.
   2. An attempt to drop and create an SQL Server or a PostgreSQL database while there's a session using this database will fail with an exception like "database already exists" because the failure to drop an existing database will be suppressed.

These methods are used primarily by the integration tests (including the ORM) and should be used _only_ for integration testing. Instead of suppressing all exceptions, the test methods should only suppress the "already exists" or "doesn't exist" ones.

## Change summary
1. Introduce `DatabaseDoesNotExist` and `SchemaDoesNotExist` exceptions. Note, some of the platforms produce the same error code for any type of object. Their exception converters will convert the corresponding error codes to a `DatabaseObjectNotFoundException`. The API consumers, depending on the supported platforms, may catch more or less specific exceptions.
2. `FunctionalTestCase::dropTableIfExists()` and `::dropAndCreateTable()` have been introduced to be used to set up fixture tables for integration testing.
3. All integration tests that used the `dropAndCreate*()` methods use the above new methods or `try/catch` in rare cases.