### PR TITLE
Use the driver API to begin a transaction on mysqli

### DIFF
--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -169,7 +169,7 @@ final class Connection implements ServerInfoAwareConnection
      */
     public function beginTransaction()
     {
-        $this->conn->query('START TRANSACTION');
+        $this->conn->begin_transaction();
 
         return true;
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

In theory, mixing the driver API with SQL for managing transactions may confuse the driver. E.g. it is [recommended](https://www.php.net/manual/en/mysqli.set-charset.php) to use the driver API for setting the charset (`mysqli_set_charset()`) instead of SQL (`SET NAMES`).