### PR TITLE
Moved `array_merge` calls out of loops

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1768,14 +1768,13 @@ abstract class AbstractPlatform
             }
         }
 
-        $columnSql = [];
-        $columns   = [];
+        $columnSql                          = [];
+        $columns                            = [];
+        $hasSchemaCreateTableColumnListener = $this->_eventManager !== null
+            && $this->_eventManager->hasListeners(Events::onSchemaCreateTableColumn);
 
         foreach ($table->getColumns() as $column) {
-            if (
-                $this->_eventManager !== null
-                && $this->_eventManager->hasListeners(Events::onSchemaCreateTableColumn)
-            ) {
+            if ($hasSchemaCreateTableColumnListener) {
                 $eventArgs = new SchemaCreateTableColumnEventArgs($column, $table, $this);
 
                 $this->_eventManager->dispatchEvent(Events::onSchemaCreateTableColumn, $eventArgs);

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1780,7 +1780,7 @@ abstract class AbstractPlatform
 
                 $this->_eventManager->dispatchEvent(Events::onSchemaCreateTableColumn, $eventArgs);
 
-                $columnSql = array_merge($columnSql, $eventArgs->getSql());
+                $columnSql[] = $eventArgs->getSql();
 
                 if ($eventArgs->isDefaultPrevented()) {
                     continue;
@@ -1802,7 +1802,7 @@ abstract class AbstractPlatform
             $this->_eventManager->dispatchEvent(Events::onSchemaCreateTable, $eventArgs);
 
             if ($eventArgs->isDefaultPrevented()) {
-                return array_merge($eventArgs->getSql(), $columnSql);
+                return array_merge($eventArgs->getSql(), ...$columnSql);
             }
         }
 
@@ -1824,7 +1824,7 @@ abstract class AbstractPlatform
             }
         }
 
-        return array_merge($sql, $columnSql);
+        return array_merge($sql, ...$columnSql);
     }
 
     protected function getCommentOnTableSQL(string $tableName, ?string $comment): string
@@ -2384,15 +2384,13 @@ abstract class AbstractPlatform
             $sql[] = $this->getCreateIndexSQL($index, $tableName);
         }
 
+        $renamedIndexSql = [];
         foreach ($diff->renamedIndexes as $oldIndexName => $index) {
-            $oldIndexName = new Identifier($oldIndexName);
-            $sql          = array_merge(
-                $sql,
-                $this->getRenameIndexSQL($oldIndexName->getQuotedName($this), $index, $tableName)
-            );
+            $oldIndexName      = new Identifier($oldIndexName);
+            $renamedIndexSql[] = $this->getRenameIndexSQL($oldIndexName->getQuotedName($this), $index, $tableName);
         }
 
-        return $sql;
+        return array_merge($sql, ...$renamedIndexSql);
     }
 
     /**

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -623,11 +623,11 @@ SQL
         $table = $diff->getName($this)->getQuotedName($this);
 
         foreach ($diff->changedIndexes as $changedIndex) {
-            $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $changedIndex));
+            $sql[] = $this->getPreAlterTableAlterPrimaryKeySQL($diff, $changedIndex);
         }
 
         foreach ($diff->removedIndexes as $remKey => $remIndex) {
-            $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $remIndex));
+            $sql[] = $this->getPreAlterTableAlterPrimaryKeySQL($diff, $remIndex);
 
             foreach ($diff->addedIndexes as $addKey => $addIndex) {
                 if ($remIndex->getColumns() !== $addIndex->getColumns()) {
@@ -646,7 +646,7 @@ SQL
                 $query .= 'ADD ' . $indexClause;
                 $query .= ' (' . $this->getIndexFieldDeclarationListSQL($addIndex) . ')';
 
-                $sql[] = $query;
+                $sql[] = [$query];
 
                 unset($diff->removedIndexes[$remKey], $diff->addedIndexes[$addKey]);
 
@@ -654,6 +654,7 @@ SQL
             }
         }
 
+        $sql    = array_merge([], ...$sql);
         $engine = 'INNODB';
 
         if ($diff->fromTable instanceof Table && $diff->fromTable->hasOption('engine')) {
@@ -667,14 +668,12 @@ SQL
             $diff->removedForeignKeys = [];
         }
 
-        $sql = array_merge(
+        return array_merge(
             $sql,
             $this->getPreAlterTableAlterIndexForeignKeySQL($diff),
             parent::getPreAlterTableIndexForeignKeySQL($diff),
             $this->getPreAlterTableRenameIndexForeignKeySQL($diff)
         );
-
-        return $sql;
     }
 
     /**

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -407,28 +407,28 @@ class OraclePlatform extends AbstractPlatform
     {
         $indexes            = $options['indexes'] ?? [];
         $options['indexes'] = [];
-        $sql                = parent::_getCreateTableSQL($name, $columns, $options);
+        $sql                = [];
 
         foreach ($columns as $columnName => $column) {
             if (isset($column['sequence'])) {
-                $sql[] = $this->getCreateSequenceSQL($column['sequence']);
+                $sql[] = [$this->getCreateSequenceSQL($column['sequence'])];
             }
 
             if (
-                ! isset($column['autoincrement']) || ! $column['autoincrement'] &&
+                (! isset($column['autoincrement']) || ! $column['autoincrement']) &&
                 (! isset($column['autoinc']) || ! $column['autoinc'])
             ) {
                 continue;
             }
 
-            $sql = array_merge($sql, $this->getCreateAutoincrementSql($columnName, $name));
+            $sql[] = $this->getCreateAutoincrementSql($columnName, $name);
         }
 
         foreach ($indexes as $index) {
-            $sql[] = $this->getCreateIndexSQL($index, $name);
+            $sql[] = [$this->getCreateIndexSQL($index, $name)];
         }
 
-        return $sql;
+        return array_merge(parent::_getCreateTableSQL($name, $columns, $options), ...$sql);
     }
 
     /**

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -115,12 +115,13 @@ class Comparator
             }
         }
 
+        $addOrphanedForeignKeys = [];
         foreach ($diff->removedTables as $tableName => $table) {
             if (! isset($foreignKeysToTable[$tableName])) {
                 continue;
             }
 
-            $diff->orphanedForeignKeys = array_merge($diff->orphanedForeignKeys, $foreignKeysToTable[$tableName]);
+            $addOrphanedForeignKeys[] = $foreignKeysToTable[$tableName];
 
             // deleting duplicated foreign keys present on both on the orphanedForeignKey
             // and the removedForeignKeys from changedTables
@@ -143,6 +144,8 @@ class Comparator
                 }
             }
         }
+
+        $diff->orphanedForeignKeys = array_merge($diff->orphanedForeignKeys, ...$addOrphanedForeignKeys);
 
         foreach ($toSchema->getSequences() as $sequence) {
             $sequenceName = $sequence->getShortestName($toSchema->getName());

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -141,11 +141,9 @@ class SchemaDiff
         }
 
         $foreignKeySql = [];
+        $addSql        = [];
         foreach ($this->newTables as $table) {
-            $sql = array_merge(
-                $sql,
-                $platform->getCreateTableSQL($table, AbstractPlatform::CREATE_INDEXES)
-            );
+            $addSql[] = $platform->getCreateTableSQL($table, AbstractPlatform::CREATE_INDEXES);
 
             if (! $platform->supportsForeignKeyConstraints()) {
                 continue;
@@ -156,7 +154,7 @@ class SchemaDiff
             }
         }
 
-        $sql = array_merge($sql, $foreignKeySql);
+        $sql = array_merge(array_merge($sql, ...$addSql), $foreignKeySql);
 
         if ($saveMode === false) {
             foreach ($this->removedTables as $table) {
@@ -164,10 +162,11 @@ class SchemaDiff
             }
         }
 
+        $addSql = [];
         foreach ($this->changedTables as $tableDiff) {
-            $sql = array_merge($sql, $platform->getAlterTableSQL($tableDiff));
+            $addSql[] = $platform->getAlterTableSQL($tableDiff);
         }
 
-        return $sql;
+        return array_merge($sql, ...$addSql);
     }
 }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -720,10 +720,10 @@ class Table extends AbstractAsset
         $foreignKeyColumns = [];
 
         foreach ($this->getForeignKeys() as $foreignKey) {
-            $foreignKeyColumns = array_merge($foreignKeyColumns, $foreignKey->getLocalColumns());
+            $foreignKeyColumns[] = $foreignKey->getLocalColumns();
         }
 
-        return $this->filterColumns($foreignKeyColumns);
+        return $this->filterColumns(array_merge([], ...$foreignKeyColumns));
     }
 
     /**

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -324,16 +324,19 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         self::assertEquals('SELECT a.* FROM (SELECT * FROM user ORDER BY username DESC) a WHERE ROWNUM <= 10', $sql);
     }
 
-    public function testGenerateTableWithAutoincrement(): void
+    public function testGenerateTableWithAutoincrementAndSequence(): void
     {
-        $columnName = strtoupper('id' . uniqid());
-        $tableName  = strtoupper('table' . uniqid());
-        $table      = new Table($tableName);
-        $column     = $table->addColumn($columnName, 'integer');
+        $columnName   = strtoupper('id' . uniqid());
+        $tableName    = strtoupper('table' . uniqid());
+        $sequenceName = strtoupper('seq' . uniqid());
+        $table        = new Table($tableName);
+        $column       = $table->addColumn($columnName, 'integer');
         $column->setAutoincrement(true);
+        $column->setPlatformOptions(['sequence' => new Sequence($sequenceName)]);
 
         self::assertSame([
             sprintf('CREATE TABLE %s (%s NUMBER(10) NOT NULL)', $tableName, $columnName),
+            sprintf('CREATE SEQUENCE %s START WITH 1 MINVALUE 1 INCREMENT BY 1', $sequenceName),
             sprintf(
                 <<<'SQL'
 DECLARE


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

`array_merge` calls in loops can potentially result in very slow performance and high memory usage

Here is a big loop example showing the possible big difference. The code I changed should not have such a big impact but it is a small improvement.

```php
<?php
$arr = [];

$startTime = microtime(true);
for ($i = 0; $i < 20000; ++$i) {
    $arr = array_merge($arr, ['a'.$i, 'b'.$i]);
}
$endTime = microtime(true);

echo "array_merge in loop took: " . number_format($endTime - $startTime, 3) . " Seconds \n";

$arr = [];

$startTime = microtime(true);
for ($i = 0; $i < 20000; ++$i) {
    $arr[] = ['a'.$i, 'b'.$i];
}
$arr = array_merge([], ...$arr);
$endTime = microtime(true);

echo "array_merge out of loop took: " . number_format($endTime - $startTime, 3) . "Seconds \n";
```

```
array_merge in loop took: 3.017 Seconds 
array_merge out of loop took: 0.008 Seconds 
```