### PR TITLE
Server version param replication fix

### DIFF
--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -41,6 +41,7 @@ use function substr;
  *     port?: int,
  *     user?: string,
  *     unix_socket?: string,
+ *     serverVersion?: string,
  * }
  * @psalm-type Params = array{
  *     charset?: string,
@@ -66,6 +67,7 @@ use function substr;
  *     user?: string,
  *     wrapperClass?: class-string<Connection>,
  *     unix_socket?: string,
+ *     serverVersion?: string,
  * }
  */
 final class DriverManager
@@ -169,6 +171,7 @@ final class DriverManager
      *     slaves?: array<OverrideParams>,
      *     user?: string,
      *     wrapperClass?: class-string<T>,
+     *     serverVersion?: string,
      * } $params
      * @phpstan-param array<string,mixed> $params
      *
@@ -197,6 +200,9 @@ final class DriverManager
         // URL support for PrimaryReplicaConnection
         if (isset($params['primary'])) {
             $params['primary'] = self::parseDatabaseUrl($params['primary']);
+            if (isset($params['primary']['serverVersion'])) {
+                $params['serverVersion'] = $params['primary']['serverVersion'];
+            }
         }
 
         if (isset($params['replica'])) {

--- a/tests/DriverManagerTest.php
+++ b/tests/DriverManagerTest.php
@@ -149,6 +149,28 @@ class DriverManagerTest extends TestCase
         );
     }
 
+    public function testDatabaseUrlPrimaryReplicaWithServerVersionInUrl(): void
+    {
+        $serverVersion = 11.2;
+
+        $options = [
+            'driver' => 'pdo_mysql',
+            'primary' => ['url' => 'mysql://foo:bar@localhost:11211/baz?serverVersion=' . $serverVersion],
+            'replica' => [
+                'replica1' => ['url' => 'mysql://foo:bar@localhost:11211/baz_replica?serverVersion=' . $serverVersion],
+            ],
+            'wrapperClass' => PrimaryReadReplicaConnection::class,
+        ];
+
+        $conn = DriverManager::getConnection($options);
+
+        $params = $conn->getParams();
+        self::assertInstanceOf(PDO\MySQL\Driver::class, $conn->getDriver());
+
+        self::assertArrayHasKey('serverVersion', $params);
+        self::assertEquals($serverVersion, $params['serverVersion'] ?? null);
+    }
+
     /**
      * @param mixed $url
      * @param mixed $expected


### PR DESCRIPTION
|      Q           |   A
|------------- | -----------
| Type            | bug
| BC Break     | no
| Fixed issues | -

#### Summary
Sets serverVersion from database url to params when using replication scheme. Prevents unnecessary connections to database with every request, even when getting data from cache.
