### PR TITLE
MariaDb1027Platform class should be non-final

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/MariaDb1027Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/MariaDb1027Platform.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Types\Types;
  *
  * Note: Should not be used with versions prior to 10.2.7.
  */
-final class MariaDb1027Platform extends MySqlPlatform
+class MariaDb1027Platform extends MySqlPlatform
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | no

#### Summary

All other platform classes are non-final, `MariaDb1027Platform` should be non-final too.