### PR TITLE
Remove redundant reference assignment

### DIFF
--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -205,8 +205,6 @@ final class Statement implements StatementInterface
      */
     private function bindUntypedValues(array $values): bool
     {
-        $types = str_repeat('s', count($values));
-
-        return $this->stmt->bind_param($types, ...$values);
+        return $this->stmt->bind_param(str_repeat('s', count($values)), ...$values);
     }
 }

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -205,13 +205,8 @@ final class Statement implements StatementInterface
      */
     private function bindUntypedValues(array $values): bool
     {
-        $params = [];
-        $types  = str_repeat('s', count($values));
+        $types = str_repeat('s', count($values));
 
-        foreach ($values as &$v) {
-            $params[] =& $v;
-        }
-
-        return $this->stmt->bind_param($types, ...$params);
+        return $this->stmt->bind_param($types, ...$values);
     }
 }


### PR DESCRIPTION
Signed-off-by: Kamil Tekiela <tekiela246@gmail.com>

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | Improved performance. 

#### Summary

There is no need for the strange loop that does reference assignments. The splat operator unfolds all ZVALs from the array, which doesn't require the weird gimmicks that `call_user_func()` required. 
