### PR TITLE
Make the SQL parser regular expression less greedy

### DIFF
--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -34,8 +34,7 @@ final class Parser
     private const BRACKET_IDENTIFIER   = '(?<!\b(?i:ARRAY))\[(?:[^\]])*\]';
     private const MULTICHAR            = ':{2,}';
     private const NAMED_PARAMETER      = ':[a-zA-Z0-9_]+';
-    private const POSITIONAL_PARAMETER = '\\?';
-    private const ESCAPED_QUESTION     = '\\?\\?';
+    private const POSITIONAL_PARAMETER = '(?<!\\?)\\?(?!\\?)';
     private const ONE_LINE_COMMENT     = '--[^\r\n]*';
     private const MULTI_LINE_COMMENT   = '/\*([^*]+|\*+[^/*])*\**\*/';
     private const OTHER                = '((?!' . self::SPECIAL . ')' . self::ANY . ')+';
@@ -61,13 +60,12 @@ final class Parser
             self::BACKTICK_IDENTIFIER,
             self::BRACKET_IDENTIFIER,
             self::MULTICHAR,
-            self::ESCAPED_QUESTION,
             self::ONE_LINE_COMMENT,
             self::MULTI_LINE_COMMENT,
             self::OTHER,
         ]);
 
-        $this->sqlPattern = sprintf('(%s)+', implode('|', $patterns));
+        $this->sqlPattern = sprintf('(%s)', implode('|', $patterns));
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #4907.

The primary solution is to make `$sqlPattern` match one token at a time. This seems to help the regex engine stay within the limits at the cost of calling the visitor more often with smaller chunks of SQL. This is what I was trying to avoid originally by adding a `+` at the end of the set.

Now the parser implementation deviates from the PDOs a little bit: instead of adding `??` to the list of the "SQL" patterns and expecting that it will be captured as part of a larger query fragment, we have to define more specific rules for the positional parameter placeholder (`?`) as "not preceded by a `?` and not followed by a `?`". This is necessary because when a match for the current pattern is found, the parser resets to the first pattern. Without this change, it would find `?` before `??`.

I tested it locally, and it seems to handle the query from the linked issue repeated 1000 times, so the size should be no longer a problem.

I cannot think of a proper way to cover this with a test. It's usually a bad idea to enforce performance- and resource-related requirements with unit tests since the result significantly depends on the environment.