### PR TITLE
Enable default values for Text/Blob type in MariaDB 10.2 platform

### DIFF
--- a/src/Platforms/MariaDb1027Platform.php
+++ b/src/Platforms/MariaDb1027Platform.php
@@ -43,4 +43,12 @@ final class MariaDb1027Platform extends MySQLPlatform
 
         $this->doctrineTypeMapping['json'] = Types::JSON;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function supportsDefaultValue(array $column): bool
+    {
+        return true;
+    }
 }

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -453,7 +453,7 @@ SQL
     public function getDefaultValueDeclarationSQL($column)
     {
         // Unset the default value if the given column definition does not allow default values.
-        if (!$this->supportsDefaultValue($column)) {
+        if (! $this->supportsDefaultValue($column)) {
             $column['default'] = null;
         }
 
@@ -462,12 +462,10 @@ SQL
 
     /**
      * @param array<string, mixed> $column
-     *
-     * @return bool
      */
     protected function supportsDefaultValue(array $column): bool
     {
-        return false === ($column['type'] instanceof TextType || $column['type'] instanceof BlobType);
+        return ($column['type'] instanceof TextType || $column['type'] instanceof BlobType) === false;
     }
 
     /**
@@ -583,7 +581,7 @@ SQL
             if (
                 $columnDiff->hasChanged('default') &&
                 count($columnDiff->changedProperties) === 1 &&
-                !$this->supportsDefaultValue($columnArray)
+                ! $this->supportsDefaultValue($columnArray)
             ) {
                 continue;
             }

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -453,11 +453,21 @@ SQL
     public function getDefaultValueDeclarationSQL($column)
     {
         // Unset the default value if the given column definition does not allow default values.
-        if ($column['type'] instanceof TextType || $column['type'] instanceof BlobType) {
+        if (!$this->supportsDefaultValue($column)) {
             $column['default'] = null;
         }
 
         return parent::getDefaultValueDeclarationSQL($column);
+    }
+
+    /**
+     * @param array<string, mixed> $column
+     *
+     * @return bool
+     */
+    protected function supportsDefaultValue(array $column): bool
+    {
+        return false === ($column['type'] instanceof TextType || $column['type'] instanceof BlobType);
     }
 
     /**
@@ -573,7 +583,7 @@ SQL
             if (
                 $columnDiff->hasChanged('default') &&
                 count($columnDiff->changedProperties) === 1 &&
-                ($columnArray['type'] instanceof TextType || $columnArray['type'] instanceof BlobType)
+                !$this->supportsDefaultValue($columnArray)
             ) {
                 continue;
             }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #4747

#### Summary

MariaDB allows default values on Text and Blob fields starting with 10.2.1, see https://mariadb.com/kb/en/text/
