### PR TITLE
Remove redundant assert

### DIFF
--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -13,9 +13,7 @@ use Doctrine\Deprecations\Deprecation;
 use mysqli;
 use mysqli_sql_exception;
 
-use function assert;
 use function floor;
-use function mysqli_init;
 use function stripos;
 
 final class Connection implements ServerInfoAwareConnection
@@ -47,8 +45,7 @@ final class Connection implements ServerInfoAwareConnection
         iterable $preInitializers = [],
         iterable $postInitializers = []
     ) {
-        $connection = mysqli_init();
-        assert($connection !== false);
+        $connection = new mysqli();
 
         foreach ($preInitializers as $initializer) {
             $initializer->initialize($connection);


### PR DESCRIPTION
Signed-off-by: Kamil Tekiela <tekiela246@gmail.com>

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | Code cleanup

#### Summary

The function `mysqli_init` can only return false when the initialization fails. The initialization can only fail when there's not enough system memory, in which case this function returning false is the least of the problems. There's no reason to assert that this function didn't return false. If we want to avoid FP static analyser warnings then we can use the OO style (which I also think should be used to follow the coding style as I can't see any other mysqli function used in procedural style). This makes the code cleaner and easier to understand. 
