### PR TITLE
Remove redundant code in mysqli Result

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -126,5 +126,10 @@ parameters:
             message: '~Only numeric types are allowed in \-, float\|null given on the right side\.~'
             path: src/Logging/DebugStack.php
 
+        # https://github.com/phpstan/phpstan-src/pull/731
+        -
+            message: '~Parameter #1 \$array of function array_column expects array, array\|false given\.~'
+            path: src/Driver/Mysqli/Result.php
+
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | Performance improvement

#### Summary

There was a mistake in the PHPStorm stubs. The `fetch_fields` method always returns an array of objects. This PR aims to remove redundant code from `Result` constructor. 

First, we remove the redundant `foreach` loop that did needless reference assignments. The splat operator doesn't need it. It was a remnant of `call_user_func` from before PHP 5.6. 

Second, we remove `assert` and refactor `array_map` into a `array_column`. We can do that as we know that we will always get an array. This reduces complexity and improves performance. 

The PHPStorm stubs need to be fixed and the [PHP manual needs to be improved](https://github.com/php/doc-en/pull/1043) to remove invalid information. 
