### PR TITLE
Narrow down driver return types

### DIFF
--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -6,11 +6,9 @@ namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\API\IBMDB2\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
 
@@ -21,19 +19,19 @@ use function assert;
  */
 abstract class AbstractDB2Driver implements Driver
 {
-    public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform
+    public function getDatabasePlatform(ServerVersionProvider $versionProvider): DB2Platform
     {
         return new DB2Platform();
     }
 
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): DB2SchemaManager
     {
         assert($platform instanceof DB2Platform);
 
         return new DB2SchemaManager($conn, $platform);
     }
 
-    public function getExceptionConverter(): ExceptionConverterInterface
+    public function getExceptionConverter(): ExceptionConverter
     {
         return new ExceptionConverter();
     }

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -6,8 +6,7 @@ namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\API\ExceptionConverter;
-use Doctrine\DBAL\Driver\API\MySQL;
+use Doctrine\DBAL\Driver\API\MySQL\ExceptionConverter;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Exception\InvalidPlatformVersion;
@@ -15,7 +14,6 @@ use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
 
@@ -32,11 +30,9 @@ abstract class AbstractMySQLDriver implements Driver
     /**
      * {@inheritdoc}
      *
-     * @return MySQLPlatform
-     *
      * @throws Exception
      */
-    public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform
+    public function getDatabasePlatform(ServerVersionProvider $versionProvider): MySQLPlatform
     {
         $version = $versionProvider->getServerVersion();
         $mariadb = stripos($version, 'mariadb') !== false;
@@ -118,12 +114,7 @@ abstract class AbstractMySQLDriver implements Driver
         return $versionParts['major'] . '.' . $versionParts['minor'] . '.' . $versionParts['patch'];
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @return MySQLSchemaManager
-     */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): MySQLSchemaManager
     {
         assert($platform instanceof MySQLPlatform);
 
@@ -132,6 +123,6 @@ abstract class AbstractMySQLDriver implements Driver
 
     public function getExceptionConverter(): ExceptionConverter
     {
-        return new MySQL\ExceptionConverter();
+        return new ExceptionConverter();
     }
 }

--- a/src/Driver/AbstractOracleDriver.php
+++ b/src/Driver/AbstractOracleDriver.php
@@ -7,11 +7,9 @@ namespace Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\AbstractOracleDriver\EasyConnectString;
-use Doctrine\DBAL\Driver\API\ExceptionConverter;
-use Doctrine\DBAL\Driver\API\OCI;
+use Doctrine\DBAL\Driver\API\OCI\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\OracleSchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
 
@@ -22,12 +20,12 @@ use function assert;
  */
 abstract class AbstractOracleDriver implements Driver
 {
-    public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform
+    public function getDatabasePlatform(ServerVersionProvider $versionProvider): OraclePlatform
     {
         return new OraclePlatform();
     }
 
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): OracleSchemaManager
     {
         assert($platform instanceof OraclePlatform);
 
@@ -36,7 +34,7 @@ abstract class AbstractOracleDriver implements Driver
 
     public function getExceptionConverter(): ExceptionConverter
     {
-        return new OCI\ExceptionConverter();
+        return new ExceptionConverter();
     }
 
     /**

--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -6,13 +6,11 @@ namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\API\ExceptionConverter;
-use Doctrine\DBAL\Driver\API\PostgreSQL;
+use Doctrine\DBAL\Driver\API\PostgreSQL\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Exception\InvalidPlatformVersion;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
 
@@ -25,7 +23,7 @@ use function version_compare;
  */
 abstract class AbstractPostgreSQLDriver implements Driver
 {
-    public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform
+    public function getDatabasePlatform(ServerVersionProvider $versionProvider): PostgreSQLPlatform
     {
         $version = $versionProvider->getServerVersion();
 
@@ -48,7 +46,7 @@ abstract class AbstractPostgreSQLDriver implements Driver
         return new PostgreSQLPlatform();
     }
 
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): PostgreSQLSchemaManager
     {
         assert($platform instanceof PostgreSQLPlatform);
 
@@ -57,6 +55,6 @@ abstract class AbstractPostgreSQLDriver implements Driver
 
     public function getExceptionConverter(): ExceptionConverter
     {
-        return new PostgreSQL\ExceptionConverter();
+        return new ExceptionConverter();
     }
 }

--- a/src/Driver/AbstractSQLServerDriver.php
+++ b/src/Driver/AbstractSQLServerDriver.php
@@ -6,11 +6,9 @@ namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\API\SQLSrv\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
 
@@ -21,19 +19,19 @@ use function assert;
  */
 abstract class AbstractSQLServerDriver implements Driver
 {
-    public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform
+    public function getDatabasePlatform(ServerVersionProvider $versionProvider): SQLServerPlatform
     {
         return new SQLServerPlatform();
     }
 
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): SQLServerSchemaManager
     {
         assert($platform instanceof SQLServerPlatform);
 
         return new SQLServerSchemaManager($conn, $platform);
     }
 
-    public function getExceptionConverter(): ExceptionConverterInterface
+    public function getExceptionConverter(): ExceptionConverter
     {
         return new ExceptionConverter();
     }

--- a/src/Driver/AbstractSQLiteDriver.php
+++ b/src/Driver/AbstractSQLiteDriver.php
@@ -6,11 +6,9 @@ namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\API\ExceptionConverter;
-use Doctrine\DBAL\Driver\API\SQLite;
+use Doctrine\DBAL\Driver\API\SQLite\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
 
@@ -21,12 +19,12 @@ use function assert;
  */
 abstract class AbstractSQLiteDriver implements Driver
 {
-    public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform
+    public function getDatabasePlatform(ServerVersionProvider $versionProvider): SqlitePlatform
     {
         return new SqlitePlatform();
     }
 
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): SqliteSchemaManager
     {
         assert($platform instanceof SqlitePlatform);
 
@@ -35,6 +33,6 @@ abstract class AbstractSQLiteDriver implements Driver
 
     public function getExceptionConverter(): ExceptionConverter
     {
-        return new SQLite\ExceptionConverter();
+        return new ExceptionConverter();
     }
 }

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -9,8 +9,6 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionError;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionFailed;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\PrepareFailed;
-use Doctrine\DBAL\Driver\Result as ResultInterface;
-use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use stdClass;
 
 use function assert;
@@ -70,7 +68,7 @@ final class Connection implements ConnectionInterface
         return $serverInfo->DBMS_VER;
     }
 
-    public function prepare(string $sql): DriverStatement
+    public function prepare(string $sql): Statement
     {
         $stmt = @db2_prepare($this->conn, $sql);
 
@@ -81,7 +79,7 @@ final class Connection implements ConnectionInterface
         return new Statement($stmt);
     }
 
-    public function query(string $sql): ResultInterface
+    public function query(string $sql): Result
     {
         return $this->prepare($sql)->execute();
     }

--- a/src/Driver/IBMDB2/Driver.php
+++ b/src/Driver/IBMDB2/Driver.php
@@ -5,16 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\IBMDB2;
 
 use Doctrine\DBAL\Driver\AbstractDB2Driver;
-use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 
 final class Driver extends AbstractDB2Driver
 {
     /**
      * {@inheritdoc}
-     *
-     * @return Connection
      */
-    public function connect(array $params): ConnectionInterface
+    public function connect(array $params): Connection
     {
         return new Connection(
             DataSourceName::fromConnectionParameters($params)->toString(),

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Driver\IBMDB2\Exception\CannotCopyStreamToStream;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\CannotCreateTemporaryFile;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\CannotWriteToTemporaryFile;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\StatementError;
-use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
 
@@ -115,7 +114,7 @@ final class Statement implements StatementInterface
         }
     }
 
-    public function execute(?array $params = null): ResultInterface
+    public function execute(?array $params = null): Result
     {
         if ($params === null) {
             ksort($this->bindParam);

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -8,8 +8,6 @@ use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\Mysqli\Exception\ConnectionError;
 use Doctrine\DBAL\Driver\Mysqli\Exception\ConnectionFailed;
-use Doctrine\DBAL\Driver\Result as ResultInterface;
-use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use mysqli;
 use mysqli_sql_exception;
 
@@ -102,7 +100,7 @@ final class Connection implements ConnectionInterface
         return $majorVersion . '.' . $minorVersion . '.' . $patchVersion;
     }
 
-    public function prepare(string $sql): DriverStatement
+    public function prepare(string $sql): Statement
     {
         try {
             $stmt = $this->conn->prepare($sql);
@@ -117,7 +115,7 @@ final class Connection implements ConnectionInterface
         return new Statement($stmt);
     }
 
-    public function query(string $sql): ResultInterface
+    public function query(string $sql): Result
     {
         return $this->prepare($sql)->execute();
     }

--- a/src/Driver/Mysqli/Driver.php
+++ b/src/Driver/Mysqli/Driver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
-use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Mysqli\Exception\HostRequired;
 use Doctrine\DBAL\Driver\Mysqli\Initializer\Charset;
 use Doctrine\DBAL\Driver\Mysqli\Initializer\Options;
@@ -17,10 +16,8 @@ final class Driver extends AbstractMySQLDriver
 {
     /**
      * {@inheritdoc}
-     *
-     * @return Connection
      */
-    public function connect(array $params): ConnectionInterface
+    public function connect(array $params): Connection
     {
         if (! empty($params['persistent'])) {
             if (! isset($params['host'])) {

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Driver\Exception\UnknownParameterType;
 use Doctrine\DBAL\Driver\Mysqli\Exception\FailedReadingStreamOffset;
 use Doctrine\DBAL\Driver\Mysqli\Exception\NonStreamResourceUsedAsLargeObject;
 use Doctrine\DBAL\Driver\Mysqli\Exception\StatementError;
-use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
 use mysqli_sql_exception;
@@ -96,7 +95,7 @@ final class Statement implements StatementInterface
         $this->types[$param - 1]   = self::$paramTypeMap[$type];
     }
 
-    public function execute(?array $params = null): ResultInterface
+    public function execute(?array $params = null): Result
     {
         if ($params !== null && count($params) > 0) {
             $this->bindUntypedValues($params);

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -9,8 +9,6 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\Exception\IdentityColumnsNotSupported;
 use Doctrine\DBAL\Driver\OCI8\Exception\ConnectionFailed;
 use Doctrine\DBAL\Driver\OCI8\Exception\Error;
-use Doctrine\DBAL\Driver\Result as ResultInterface;
-use Doctrine\DBAL\Driver\Statement as DriverStatement;
 
 use function addcslashes;
 use function assert;
@@ -74,12 +72,12 @@ final class Connection implements ConnectionInterface
         return $matches[1];
     }
 
-    public function prepare(string $sql): DriverStatement
+    public function prepare(string $sql): Statement
     {
         return new Statement($this->connection, $sql, $this->executionMode);
     }
 
-    public function query(string $sql): ResultInterface
+    public function query(string $sql): Result
     {
         return $this->prepare($sql)->execute();
     }

--- a/src/Driver/OCI8/Driver.php
+++ b/src/Driver/OCI8/Driver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\OCI8;
 
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
-use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 
 use const OCI_NO_AUTO_COMMIT;
 
@@ -16,10 +15,8 @@ final class Driver extends AbstractOracleDriver
 {
     /**
      * {@inheritdoc}
-     *
-     * @return Connection
      */
-    public function connect(array $params): ConnectionInterface
+    public function connect(array $params): Connection
     {
         return new Connection(
             $params['user'] ?? '',

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Driver\OCI8;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\OCI8\Exception\Error;
 use Doctrine\DBAL\Driver\OCI8\Exception\UnknownParameterIndex;
-use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\SQL\Parser;
@@ -137,7 +136,7 @@ final class Statement implements StatementInterface
         }
     }
 
-    public function execute(?array $params = null): ResultInterface
+    public function execute(?array $params = null): Result
     {
         if ($params !== null) {
             foreach ($params as $key => $val) {

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -8,8 +8,6 @@ use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Exception as ExceptionInterface;
 use Doctrine\DBAL\Driver\Exception\IdentityColumnsNotSupported;
 use Doctrine\DBAL\Driver\Exception\NoIdentityValue;
-use Doctrine\DBAL\Driver\Result as ResultInterface;
-use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -55,12 +53,7 @@ final class Connection implements ConnectionInterface
         return $this->connection->getAttribute(PDO::ATTR_SERVER_VERSION);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return Statement
-     */
-    public function prepare(string $sql): StatementInterface
+    public function prepare(string $sql): Statement
     {
         try {
             $stmt = $this->connection->prepare($sql);
@@ -72,7 +65,7 @@ final class Connection implements ConnectionInterface
         }
     }
 
-    public function query(string $sql): ResultInterface
+    public function query(string $sql): Result
     {
         try {
             $stmt = $this->connection->query($sql);

--- a/src/Driver/PDO/MySQL/Driver.php
+++ b/src/Driver/PDO/MySQL/Driver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\PDO\MySQL;
 
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
-use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\PDO\Connection;
 use PDO;
 
@@ -13,10 +12,8 @@ final class Driver extends AbstractMySQLDriver
 {
     /**
      * {@inheritdoc}
-     *
-     * @return Connection
      */
-    public function connect(array $params): ConnectionInterface
+    public function connect(array $params): Connection
     {
         $driverOptions = $params['driverOptions'] ?? [];
 

--- a/src/Driver/PDO/OCI/Driver.php
+++ b/src/Driver/PDO/OCI/Driver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\PDO\OCI;
 
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
-use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\PDO\Connection;
 use PDO;
 
@@ -13,10 +12,8 @@ final class Driver extends AbstractOracleDriver
 {
     /**
      * {@inheritdoc}
-     *
-     * @return Connection
      */
-    public function connect(array $params): ConnectionInterface
+    public function connect(array $params): Connection
     {
         $driverOptions = $params['driverOptions'] ?? [];
 

--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\PDO\PgSQL;
 
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
-use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\PDO\Connection;
 use PDO;
 
@@ -15,10 +14,8 @@ final class Driver extends AbstractPostgreSQLDriver
 {
     /**
      * {@inheritdoc}
-     *
-     * @return Connection
      */
-    public function connect(array $params): ConnectionInterface
+    public function connect(array $params): Connection
     {
         $driverOptions = $params['driverOptions'] ?? [];
 

--- a/src/Driver/PDO/SQLSrv/Connection.php
+++ b/src/Driver/PDO/SQLSrv/Connection.php
@@ -6,8 +6,7 @@ namespace Doctrine\DBAL\Driver\PDO\SQLSrv;
 
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
-use Doctrine\DBAL\Driver\Result;
-use Doctrine\DBAL\Driver\Statement as StatementInterface;
+use Doctrine\DBAL\Driver\PDO\Result;
 use PDO;
 
 final class Connection implements ConnectionInterface
@@ -19,7 +18,7 @@ final class Connection implements ConnectionInterface
         $this->connection = $connection;
     }
 
-    public function prepare(string $sql): StatementInterface
+    public function prepare(string $sql): Statement
     {
         return new Statement(
             $this->connection->prepare($sql)

--- a/src/Driver/PDO/SQLSrv/Driver.php
+++ b/src/Driver/PDO/SQLSrv/Driver.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Driver\PDO\SQLSrv;
 
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
-use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
 use PDO;
@@ -18,10 +17,8 @@ final class Driver extends AbstractSQLServerDriver
 {
     /**
      * {@inheritdoc}
-     *
-     * @return Connection
      */
-    public function connect(array $params): DriverConnection
+    public function connect(array $params): Connection
     {
         $pdoOptions = $dsnOptions = [];
 

--- a/src/Driver/PDO/SQLite/Driver.php
+++ b/src/Driver/PDO/SQLite/Driver.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Driver\PDO\SQLite;
 
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use Doctrine\DBAL\Driver\API\SQLite\UserDefinedFunctions;
-use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\PDO\Connection;
 
 use function array_merge;
@@ -31,10 +30,8 @@ final class Driver extends AbstractSQLiteDriver
 
     /**
      * {@inheritdoc}
-     *
-     * @return Connection
      */
-    public function connect(array $params): ConnectionInterface
+    public function connect(array $params): Connection
     {
         $driverOptions = $params['driverOptions'] ?? [];
 

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Driver\PDO;
 
 use Doctrine\DBAL\Driver\Exception as ExceptionInterface;
 use Doctrine\DBAL\Driver\Exception\UnknownParameterType;
-use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
 use PDO;
@@ -83,7 +82,7 @@ final class Statement implements StatementInterface
         }
     }
 
-    public function execute(?array $params = null): ResultInterface
+    public function execute(?array $params = null): Result
     {
         try {
             $this->stmt->execute($params);

--- a/src/Driver/SQLSrv/Connection.php
+++ b/src/Driver/SQLSrv/Connection.php
@@ -7,9 +7,7 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\Exception\NoIdentityValue;
-use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
-use Doctrine\DBAL\Driver\Statement as DriverStatement;
 
 use function sqlsrv_begin_transaction;
 use function sqlsrv_commit;
@@ -55,12 +53,12 @@ final class Connection implements ConnectionInterface
         return $serverInfo['SQLServerVersion'];
     }
 
-    public function prepare(string $sql): DriverStatement
+    public function prepare(string $sql): Statement
     {
         return new Statement($this->conn, $sql);
     }
 
-    public function query(string $sql): ResultInterface
+    public function query(string $sql): Result
     {
         return $this->prepare($sql)->execute();
     }

--- a/src/Driver/SQLSrv/Driver.php
+++ b/src/Driver/SQLSrv/Driver.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
-use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 
 /**
  * Driver for ext/sqlsrv.
@@ -15,10 +14,8 @@ final class Driver extends AbstractSQLServerDriver
 {
     /**
      * {@inheritdoc}
-     *
-     * @return Connection
      */
-    public function connect(array $params): ConnectionInterface
+    public function connect(array $params): Connection
     {
         $serverName = '';
 

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\SQLSrv;
 
 use Doctrine\DBAL\Driver\Exception;
-use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
@@ -105,7 +104,7 @@ final class Statement implements StatementInterface
         $this->stmt = null;
     }
 
-    public function execute(?array $params = null): ResultInterface
+    public function execute(?array $params = null): Result
     {
         if ($params !== null) {
             foreach ($params as $key => $val) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

On PHP 7.4, we can make use of covariance to be more specific about the return types of `Driver`, `Connection` and `Statement` classes.
