### PR TITLE
Rework negation of the special characters in SQL parser

### DIFF
--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\SQL;
 
+use Doctrine\DBAL\SQL\Parser\Exception;
+use Doctrine\DBAL\SQL\Parser\Exception\RegularExpressionError;
 use Doctrine\DBAL\SQL\Parser\Visitor;
 
 use function array_merge;
@@ -10,10 +12,13 @@ use function current;
 use function implode;
 use function key;
 use function next;
+use function preg_last_error;
 use function preg_match;
 use function reset;
 use function sprintf;
 use function strlen;
+
+use const PREG_NO_ERROR;
 
 /**
  * The SQL parser that focuses on identifying prepared statement parameters. It implements parsing other tokens like
@@ -70,6 +75,8 @@ final class Parser
 
     /**
      * Parses the given SQL statement
+     *
+     * @throws Exception
      */
     public function parse(string $sql, Visitor $visitor): void
     {
@@ -97,6 +104,10 @@ final class Parser
                 reset($patterns);
 
                 $offset += strlen($matches[0]);
+            } elseif (preg_last_error() !== PREG_NO_ERROR) {
+                // @codeCoverageIgnoreStart
+                throw RegularExpressionError::new();
+                // @codeCoverageIgnoreEnd
             } else {
                 next($patterns);
             }

--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -27,8 +27,7 @@ use function strlen;
  */
 final class Parser
 {
-    private const ANY     = '.';
-    private const SPECIAL = '[:\?\'"`\\[\\-\\/]';
+    private const SPECIAL_CHARS = ':\?\'"`\\[\\-\\/';
 
     private const BACKTICK_IDENTIFIER  = '`[^`]*`';
     private const BRACKET_IDENTIFIER   = '(?<!\b(?i:ARRAY))\[(?:[^\]])*\]';
@@ -37,7 +36,8 @@ final class Parser
     private const POSITIONAL_PARAMETER = '(?<!\\?)\\?(?!\\?)';
     private const ONE_LINE_COMMENT     = '--[^\r\n]*';
     private const MULTI_LINE_COMMENT   = '/\*([^*]+|\*+[^/*])*\**\*/';
-    private const OTHER                = '((?!' . self::SPECIAL . ')' . self::ANY . ')+';
+    private const SPECIAL              = '[' . self::SPECIAL_CHARS . ']';
+    private const OTHER                = '[^' . self::SPECIAL_CHARS . ']+';
 
     /** @var string */
     private $sqlPattern;
@@ -65,7 +65,7 @@ final class Parser
             self::OTHER,
         ]);
 
-        $this->sqlPattern = sprintf('(%s)', implode('|', $patterns));
+        $this->sqlPattern = sprintf('(%s)+', implode('|', $patterns));
     }
 
     /**
@@ -107,7 +107,7 @@ final class Parser
 
     private function getMySQLStringLiteralPattern(string $delimiter): string
     {
-        return $delimiter . '((\\\\' . self::ANY . ')|(?![' . $delimiter . '\\\\])' . self::ANY . ')*' . $delimiter;
+        return $delimiter . '((\\\\.)|(?![' . $delimiter . '\\\\]).)*' . $delimiter;
     }
 
     private function getAnsiSQLStringLiteralPattern(string $delimiter): string

--- a/src/SQL/Parser/Exception.php
+++ b/src/SQL/Parser/Exception.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\SQL\Parser;
+
+use Throwable;
+
+interface Exception extends Throwable
+{
+}

--- a/src/SQL/Parser/Exception/RegularExpressionError.php
+++ b/src/SQL/Parser/Exception/RegularExpressionError.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\SQL\Parser\Exception;
+
+use Doctrine\DBAL\SQL\Parser\Exception;
+use RuntimeException;
+
+use function preg_last_error;
+use function preg_last_error_msg;
+
+class RegularExpressionError extends RuntimeException implements Exception
+{
+    public static function new(): self
+    {
+        return new self(preg_last_error_msg(), preg_last_error());
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | regression
| BC Break     | no

Fixes #4907.

This is another attempt at optimizing the regular expression patterns in the parser. It looks like the problem is not that multiple "SQL" patterns get concatenated but the "OTHERS" pattern.

According to `regex101`, this is the ``~\G((?![:\?'"`\[\-\/]).)+~s`` pattern that alone takes ~52K steps to match against the 9KB SQL query mentioned in the issue ([ref](https://regex101.com/r/1dYusm/1)).

The reason why it was originally implemented like this is that in the original re2c-based parser, it's [coded](https://github.com/php/php-src/blob/php-7.4.12/ext/pdo/pdo_sql_parser.re#L68) as `ANYNOEOF\SPECIALS` where `\` means "except for". Since our parser uses `.` for `ANYNOEOF` instead of `[\001-\377]`, we can replace `((?!u).` (where `u` is the pattern that we want to exclude) with a more performant `[^u]`.

The new implementation takes 3 steps ([ref](https://regex101.com/r/0SgYuS/1)). The original greediness of the SQL pattern is restored since it's not a problem and takes only 82 steps ([ref](https://regex101.com/r/2ElsR0/1)).