### PR TITLE
Basic exception handling for SQL Server

### DIFF
--- a/src/Driver/API/SQLSrv/ExceptionConverter.php
+++ b/src/Driver/API/SQLSrv/ExceptionConverter.php
@@ -6,16 +6,59 @@ namespace Doctrine\DBAL\Driver\API\SQLSrv;
 
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\Exception;
+use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
+use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
+use Doctrine\DBAL\Exception\SyntaxErrorException;
+use Doctrine\DBAL\Exception\TableExistsException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Query;
 
 /**
  * @internal
+ *
+ * @link https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors
  */
 final class ExceptionConverter implements ExceptionConverterInterface
 {
     public function convert(Exception $exception, ?Query $query): DriverException
     {
+        switch ($exception->getCode()) {
+            case 102:
+                return new SyntaxErrorException($exception, $query);
+
+            case 207:
+                return new InvalidFieldNameException($exception, $query);
+
+            case 208:
+                return new TableNotFoundException($exception, $query);
+
+            case 209:
+                return new NonUniqueFieldNameException($exception, $query);
+
+            case 515:
+                return new NotNullConstraintViolationException($exception, $query);
+
+            case 547:
+            case 4712:
+                return new ForeignKeyConstraintViolationException($exception, $query);
+
+            case 2601:
+            case 2627:
+                return new UniqueConstraintViolationException($exception, $query);
+
+            case 2714:
+                return new TableExistsException($exception, $query);
+
+            case 11001:
+            case 18456:
+                return new ConnectionException($exception, $query);
+        }
+
         return new DriverException($exception, $query);
     }
 }

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -4,10 +4,8 @@ namespace Doctrine\DBAL\Tests\Functional;
 
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\IBMDB2;
-use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
@@ -15,7 +13,6 @@ use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Throwable;
 
 use function array_merge;
-use function assert;
 use function chmod;
 use function exec;
 use function file_exists;
@@ -25,7 +22,6 @@ use function sprintf;
 use function sys_get_temp_dir;
 use function touch;
 use function unlink;
-use function version_compare;
 
 use const PHP_OS_FAMILY;
 
@@ -361,15 +357,6 @@ class ExceptionTest extends FunctionalTestCase
 
         if ($platform instanceof SqlitePlatform) {
             self::markTestSkipped('Only skipped if platform is not sqlite');
-        }
-
-        if ($platform instanceof MySQLPlatform && isset($params['user'])) {
-            $wrappedConnection = $this->connection->getWrappedConnection();
-            assert($wrappedConnection instanceof ServerInfoAwareConnection);
-
-            if (version_compare($wrappedConnection->getServerVersion(), '8', '>=')) {
-                self::markTestIncomplete('PHP currently does not completely support MySQL 8');
-            }
         }
 
         $defaultParams = $this->connection->getParams();

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
 use Throwable;
 
 use function array_merge;
@@ -356,23 +357,14 @@ class ExceptionTest extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform();
 
         if ($platform instanceof SqlitePlatform) {
-            self::markTestSkipped('Only skipped if platform is not sqlite');
+            self::markTestSkipped('The SQLite driver does not use a network connection');
         }
 
-        $defaultParams = $this->connection->getParams();
-        $params        = array_merge($defaultParams, $params);
-
-        $conn = DriverManager::getConnection($params);
-
-        $schema = new Schema();
-        $table  = $schema->createTable('no_connection');
-        $table->addColumn('id', 'integer');
+        $params = array_merge(TestUtil::getConnectionParams(), $params);
+        $conn   = DriverManager::getConnection($params);
 
         $this->expectException(Exception\ConnectionException::class);
-
-        foreach ($schema->toSql($conn->getDatabasePlatform()) as $sql) {
-            $conn->executeStatement($sql);
-        }
+        $conn->connect();
     }
 
     /**

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -35,15 +35,11 @@ class ExceptionTest extends FunctionalTestCase
     {
         $driver = $this->connection->getDriver();
 
-        if ($driver instanceof IBMDB2\Driver) {
-            self::markTestSkipped("The IBM DB2 driver currently doesn't instantiate specialized exceptions");
-        }
-
-        if (! $driver instanceof AbstractSQLServerDriver) {
+        if (! $driver instanceof IBMDB2\Driver) {
             return;
         }
 
-        self::markTestSkipped("The SQL Server drivers currently don't instantiate specialized exceptions");
+        self::markTestSkipped("The IBM DB2 driver currently doesn't instantiate specialized exceptions");
     }
 
     public function testPrimaryConstraintViolationException(): void
@@ -346,13 +342,34 @@ class ExceptionTest extends FunctionalTestCase
         }
     }
 
+    public function testInvalidUserName(): void
+    {
+        $this->testConnectionException(['user' => 'not_existing']);
+    }
+
+    public function testInvalidPassword(): void
+    {
+        $this->testConnectionException(['password' => 'really_not']);
+    }
+
+    public function testInvalidHost(): void
+    {
+        if ($this->connection->getDriver() instanceof AbstractSQLServerDriver) {
+            self::markTestSkipped(
+                'Some sqlsrv and pdo_sqlsrv versions do not provide the exception code or SQLSTATE for login timeout'
+            );
+        }
+
+        $this->testConnectionException(['host' => 'localnope']);
+    }
+
     /**
      * @param array<string, mixed> $params
      * @psalm-param Params $params
      *
      * @dataProvider getConnectionParams
      */
-    public function testConnectionException(array $params): void
+    private function testConnectionException(array $params): void
     {
         $platform = $this->connection->getDatabasePlatform();
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

1. Do not skip the connection error test on MySQL 8.
2. There's no need to create a schema in order to just reproduce a connection failure.
3. In order to create a new connection, the test should use `TestUtil::getConnectionParams()` instead of `$this->connection->getParams()`. See https://github.com/doctrine/dbal/issues/3593.
3. The `testConnectionException()` test has been refactored into three since one of the scenarios is not fully supported by the SQL Server drivers. Once this test is enabled, we'll need to use `LoginTimeout=1` in the connection parameters. Otherwise, the connection may take 20-30 seconds to fail.