### PR TITLE
Basic exception handling for IBM DB2

### DIFF
--- a/src/Driver/API/IBMDB2/ExceptionConverter.php
+++ b/src/Driver/API/IBMDB2/ExceptionConverter.php
@@ -6,16 +6,60 @@ namespace Doctrine\DBAL\Driver\API\IBMDB2;
 
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\Exception;
+use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
+use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
+use Doctrine\DBAL\Exception\SyntaxErrorException;
+use Doctrine\DBAL\Exception\TableExistsException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Query;
 
 /**
  * @internal
+ *
+ * @link https://www.ibm.com/docs/en/db2/11.5?topic=messages-sql
  */
 final class ExceptionConverter implements ExceptionConverterInterface
 {
     public function convert(Exception $exception, ?Query $query): DriverException
     {
+        switch ($exception->getCode()) {
+            case -104:
+                return new SyntaxErrorException($exception, $query);
+
+            case -203:
+                return new NonUniqueFieldNameException($exception, $query);
+
+            case -204:
+                return new TableNotFoundException($exception, $query);
+
+            case -206:
+                return new InvalidFieldNameException($exception, $query);
+
+            case -407:
+                return new NotNullConstraintViolationException($exception, $query);
+
+            case -530:
+            case -531:
+            case -532:
+            case -20356:
+                return new ForeignKeyConstraintViolationException($exception, $query);
+
+            case -601:
+                return new TableExistsException($exception, $query);
+
+            case -803:
+                return new UniqueConstraintViolationException($exception, $query);
+
+            case -1336:
+            case -30082:
+                return new ConnectionException($exception, $query);
+        }
+
         return new DriverException($exception, $query);
     }
 }

--- a/src/Driver/API/MySQL/ExceptionConverter.php
+++ b/src/Driver/API/MySQL/ExceptionConverter.php
@@ -95,6 +95,7 @@ final class ExceptionConverter implements ExceptionConverterInterface
             case 1429:
             case 2002:
             case 2005:
+            case 2054:
                 return new ConnectionException($exception, $query);
 
             case 2006:

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionError;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionFailed;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\PrepareFailed;
+use Doctrine\DBAL\Driver\IBMDB2\Exception\StatementError;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
@@ -109,7 +110,7 @@ final class Connection implements ServerInfoAwareConnection
         $stmt = @db2_exec($this->conn, $sql);
 
         if ($stmt === false) {
-            throw ConnectionError::new($this->conn);
+            throw StatementError::new();
         }
 
         return db2_num_rows($stmt);

--- a/src/Driver/IBMDB2/Exception/ConnectionError.php
+++ b/src/Driver/IBMDB2/Exception/ConnectionError.php
@@ -21,6 +21,11 @@ final class ConnectionError extends AbstractException
      */
     public static function new($connection): self
     {
-        return new self(db2_conn_errormsg($connection), db2_conn_error($connection));
+        $message  = db2_conn_errormsg($connection);
+        $sqlState = db2_conn_error($connection);
+
+        return Factory::create($message, static function (int $code) use ($message, $sqlState): self {
+            return new self($message, $sqlState, $code);
+        });
     }
 }

--- a/src/Driver/IBMDB2/Exception/ConnectionFailed.php
+++ b/src/Driver/IBMDB2/Exception/ConnectionFailed.php
@@ -18,6 +18,11 @@ final class ConnectionFailed extends AbstractException
 {
     public static function new(): self
     {
-        return new self(db2_conn_errormsg(), db2_conn_error());
+        $message  = db2_conn_errormsg();
+        $sqlState = db2_conn_error();
+
+        return Factory::create($message, static function (int $code) use ($message, $sqlState): self {
+            return new self($message, $sqlState, $code);
+        });
     }
 }

--- a/src/Driver/IBMDB2/Exception/Factory.php
+++ b/src/Driver/IBMDB2/Exception/Factory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\IBMDB2\Exception;
+
+use Doctrine\DBAL\Driver\AbstractException;
+
+use function preg_match;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class Factory
+{
+    /**
+     * @param callable(int): T $constructor
+     *
+     * @return T
+     *
+     * @template T of AbstractException
+     */
+    public static function create(string $message, callable $constructor): AbstractException
+    {
+        $code = 0;
+
+        if (preg_match('/ SQL(\d+)N /', $message, $matches) === 1) {
+            $code = -(int) $matches[1];
+        }
+
+        return $constructor($code);
+    }
+}

--- a/src/Driver/IBMDB2/Exception/StatementError.php
+++ b/src/Driver/IBMDB2/Exception/StatementError.php
@@ -17,10 +17,20 @@ use function db2_stmt_errormsg;
 final class StatementError extends AbstractException
 {
     /**
-     * @param resource $statement
+     * @param resource|null $statement
      */
-    public static function new($statement): self
+    public static function new($statement = null): self
     {
-        return new self(db2_stmt_errormsg($statement), db2_stmt_error($statement));
+        if ($statement !== null) {
+            $message  = db2_stmt_errormsg($statement);
+            $sqlState = db2_stmt_error($statement);
+        } else {
+            $message  = db2_stmt_errormsg();
+            $sqlState = db2_stmt_error();
+        }
+
+        return Factory::create($message, static function (int $code) use ($message, $sqlState): self {
+            return new self($message, $sqlState, $code);
+        });
     }
 }

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -140,7 +140,7 @@ final class Statement implements StatementInterface
             $this->writeStringToStream($source, $target);
         }
 
-        $result = db2_execute($this->stmt, $params);
+        $result = @db2_execute($this->stmt, $params);
 
         foreach ($this->lobs as [, $handle]) {
             fclose($handle);

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -3,7 +3,6 @@
 namespace Doctrine\DBAL\Tests\Functional;
 
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
-use Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -31,17 +30,6 @@ use const PHP_OS_FAMILY;
  */
 class ExceptionTest extends FunctionalTestCase
 {
-    protected function setUp(): void
-    {
-        $driver = $this->connection->getDriver();
-
-        if (! $driver instanceof IBMDB2\Driver) {
-            return;
-        }
-
-        self::markTestSkipped("The IBM DB2 driver currently doesn't instantiate specialized exceptions");
-    }
-
     public function testPrimaryConstraintViolationException(): void
     {
         $table = new Table('duplicatekey_table');
@@ -220,7 +208,7 @@ class ExceptionTest extends FunctionalTestCase
 
         $table = $schema->createTable('notnull_table');
         $table->addColumn('id', 'integer', []);
-        $table->addColumn('value', 'integer', ['notnull' => true]);
+        $table->addColumn('val', 'integer', ['notnull' => true]);
         $table->setPrimaryKey(['id']);
 
         foreach ($schema->toSql($this->connection->getDatabasePlatform()) as $sql) {
@@ -228,7 +216,7 @@ class ExceptionTest extends FunctionalTestCase
         }
 
         $this->expectException(Exception\NotNullConstraintViolationException::class);
-        $this->connection->insert('notnull_table', ['id' => 1, 'value' => null]);
+        $this->connection->insert('notnull_table', ['id' => 1, 'val' => null]);
     }
 
     public function testInvalidFieldNameException(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

## MySQL

After the changes in https://github.com/doctrine/dbal/pull/4928, the build on PHP 7.3 and MySQL 8 started failing with:
> 1\) Doctrine\DBAL\Tests\Functional\ExceptionTest::testInvalidUserName
> Failed asserting that exception of type "Doctrine\DBAL\Exception\DriverException" matches expected exception "Doctrine\DBAL\Exception\ConnectionException". Message was: "An exception occurred in the driver: SQLSTATE[HY000] [2054] The server requested authentication method unknown to the client" at

I cannot reproduce it locally and it didn't fail previously, but we need to fix it in order to let the build pass on this PR.

## IBM DB2

1. Although there's no statement resource available during `db2_exec()`, if it fails, the error information will be available via `db2_stmt_*()`, not `db2_conn_*()`. The driver will use the latest executed statement which is available to the driver internally.
2. The call to `@db2_execute` needs to be error-suppressed since otherwise, it may trigger a warning.
3. The SQLSTATE exposed via `db2_(conn|stmt)_error()` doesn't uniquely identify a given error type, so it cannot be used for instantiation of error-specific exceptions.
4. The SQLSTATE and SQLCODE that do uniquely identify a given error type are only available as part of the error message, so we have to parse it to get the code.
5. Since each factory method accepts a message and has to instantiate its own class, we need a factory that parses the message and instantiates the exception with the corresponding code.
6. `VALUE` is a reserved keyword in IBM DB2, so we have to use another name in the integration test.
