### PR TITLE
Fixes spelling error discovered via textlint

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -226,12 +226,12 @@ pdo_pgsql
    the server's certificate will be verified to be signed by one of these
    authorities.
    See https://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT
--  ``sslcert`` (string): specifies the file name of the client SSL certificate.
+-  ``sslcert`` (string): specifies the filename of the client SSL certificate.
    See `https://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNECT-SSLCERT`
 -  ``sslkey`` (string): specifies the location for the secret key used for the
    client certificate.
    See `https://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNECT-SSLKEY`
--  ``sslcrl`` (string): specifies the file name of the SSL certificate
+-  ``sslcrl`` (string): specifies the filename of the SSL certificate
    revocation list (CRL).
    See `https://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNECT-SSLCRL`
 -  ``application_name`` (string): Name of the application that is


### PR DESCRIPTION
Fixes spelling error discovered via [textlint](https://textlint.github.io/).
