### PR TITLE
Workflow for closing stale pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: 'Close stale pull requests'
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-pr-message: >
+            There hasn't been any activity on this pull request in the past year, so
+            it has been marked as stale and it will be closed automatically if no
+            further activity occurs in the next 7 days.
+
+            If you want to continue working on it, please leave a comment.
+
+          close-pr-message: >
+            This pull request was closed due to a year of no activity.
+
+          days-before-pr-stale: 365
+          days-before-pr-close: 7


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Yesterday, I closed a bunch of pull requests opened before 2020. The ones that I closed individually, all had merge conflicts and didn't have any activity.

Issues with no activity deserve more delicate handling since even if an issue has been inactive for a long time, it may still be relevant. Although, if a pull request is inactive, it means that there's no mutual interest between the maintainers and the contributor to continuing the work. Such pull requests most often will have merge conflicts and be targeted at a no longer maintained branch.

The reminder that a pull request is stale may trigger another round of discussion and prevent the pull request from being closed. If the discussion doesn't happen, there's no reason for keeping the pull request open.