### PR TITLE
Use CONCAT() with SQL Server to concatenate strings

### DIFF
--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -1146,9 +1146,7 @@ class SQLServer2012Platform extends AbstractPlatform
      */
     public function getConcatExpression()
     {
-        $args = func_get_args();
-
-        return '(' . implode(' + ', $args) . ')';
+        return sprintf('CONCAT(%s)', implode(', ', func_get_args()));
     }
 
     /**

--- a/tests/Functional/Platform/ConcatExpressionTest.php
+++ b/tests/Functional/Platform/ConcatExpressionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Platform;
+
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+final class ConcatExpressionTest extends FunctionalTestCase
+{
+    /**
+     * @param list<string> $arguments
+     *
+     * @dataProvider expressionProvider
+     */
+    public function testConcatExpression(array $arguments, string $expected): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $query    = $platform->getDummySelectSQL($platform->getConcatExpression(...$arguments));
+
+        self::assertEquals($expected, $this->connection->fetchOne($query));
+    }
+
+    /**
+     * @return iterable<string,array{list<string>,string}>
+     */
+    public static function expressionProvider(): iterable
+    {
+        yield 'strings' => [["'foo'", "'bar'"], 'foobar'];
+        yield 'numbers and a hyphen' => [['2010', "'-'", '2019'], '2010-2019'];
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes https://github.com/doctrine/dbal/issues/3346.