### PR TITLE
Do not mark issues as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,5 +19,6 @@ jobs:
           close-pr-message: >
             This pull request was closed due to a year of no activity.
 
+          days-before-stale:    -1
           days-before-pr-stale: 365
           days-before-pr-close: 7


### PR DESCRIPTION
By default, both issues and PRs are marked as stale after [`days-before-stale`](https://github.com/actions/stale#days-before-stale) (60) of inactivity. So, even though it didn't contain any issue-related configuration, the workflow deployed in https://github.com/doctrine/dbal/pull/4935 started marking issues as stale as well (e.g. https://github.com/doctrine/dbal/issues/4479#event-5543387044).

As a side effect of that, the workflow seems to be [unable to go through all items](https://github.com/doctrine/dbal/runs/4058099684) due to the default limit on [`operations-per-run`](https://github.com/actions/stale#operations-per-run):
```
Processing the batch of issues #1 containing 100 issues...
...
Warning: No more operations left! Exiting...
Warning: If you think that not enough issues were processed you could try to increase the quantity related to the operations-per-run (​https://github.com/actions/stale#operations-per-run​) option which is currently set to 30
Statistics:
Processed items: 54
├── Processed issues: 28
└── Processed PRs   : 26
...
Operations performed: 32
```

Apart from that, the bot doesn't seem to post any comments, probably due to a lack of permissions. We can figure it out separately.