### PR TITLE
Accept PDO as a Connection constructor argument

### DIFF
--- a/src/Driver/PDO/MySQL/Driver.php
+++ b/src/Driver/PDO/MySQL/Driver.php
@@ -4,7 +4,9 @@ namespace Doctrine\DBAL\Driver\PDO\MySQL;
 
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Driver\PDO\Connection;
+use Doctrine\DBAL\Driver\PDO\Exception;
 use PDO;
+use PDOException;
 
 final class Driver extends AbstractMySQLDriver
 {
@@ -21,12 +23,18 @@ final class Driver extends AbstractMySQLDriver
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
-        return new Connection(
-            $this->constructPdoDsn($params),
-            $params['user'] ?? '',
-            $params['password'] ?? '',
-            $driverOptions
-        );
+        try {
+            $pdo = new PDO(
+                $this->constructPdoDsn($params),
+                $params['user'] ?? '',
+                $params['password'] ?? '',
+                $driverOptions
+            );
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
+
+        return new Connection($pdo);
     }
 
     /**
@@ -36,7 +44,7 @@ final class Driver extends AbstractMySQLDriver
      *
      * @return string The DSN.
      */
-    protected function constructPdoDsn(array $params)
+    private function constructPdoDsn(array $params)
     {
         $dsn = 'mysql:';
         if (isset($params['host']) && $params['host'] !== '') {

--- a/src/Driver/PDO/OCI/Driver.php
+++ b/src/Driver/PDO/OCI/Driver.php
@@ -4,7 +4,9 @@ namespace Doctrine\DBAL\Driver\PDO\OCI;
 
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
 use Doctrine\DBAL\Driver\PDO\Connection;
+use Doctrine\DBAL\Driver\PDO\Exception;
 use PDO;
+use PDOException;
 
 final class Driver extends AbstractOracleDriver
 {
@@ -21,12 +23,18 @@ final class Driver extends AbstractOracleDriver
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
-        return new Connection(
-            $this->constructPdoDsn($params),
-            $params['user'] ?? '',
-            $params['password'] ?? '',
-            $driverOptions
-        );
+        try {
+            $pdo = new PDO(
+                $this->constructPdoDsn($params),
+                $params['user'] ?? '',
+                $params['password'] ?? '',
+                $driverOptions
+            );
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
+
+        return new Connection($pdo);
     }
 
     /**

--- a/src/Driver/PDO/SQLSrv/Driver.php
+++ b/src/Driver/PDO/SQLSrv/Driver.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
+use Doctrine\DBAL\Driver\PDO\Exception as PDOException;
 use PDO;
 
 use function is_int;
@@ -20,12 +21,12 @@ final class Driver extends AbstractSQLServerDriver
      */
     public function connect(array $params)
     {
-        $pdoOptions = $dsnOptions = [];
+        $driverOptions = $dsnOptions = [];
 
         if (isset($params['driverOptions'])) {
             foreach ($params['driverOptions'] as $option => $value) {
                 if (is_int($option)) {
-                    $pdoOptions[$option] = $value;
+                    $driverOptions[$option] = $value;
                 } else {
                     $dsnOptions[$option] = $value;
                 }
@@ -33,17 +34,21 @@ final class Driver extends AbstractSQLServerDriver
         }
 
         if (! empty($params['persistent'])) {
-            $pdoOptions[PDO::ATTR_PERSISTENT] = true;
+            $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
-        return new Connection(
-            new PDOConnection(
-                $this->_constructPdoDsn($params, $dsnOptions),
+        try {
+            $pdo = new PDO(
+                $this->constructDsn($params, $dsnOptions),
                 $params['user'] ?? '',
                 $params['password'] ?? '',
-                $pdoOptions
-            )
-        );
+                $driverOptions
+            );
+        } catch (\PDOException $exception) {
+            throw PDOException::new($exception);
+        }
+
+        return new Connection(new PDOConnection($pdo));
     }
 
     /**
@@ -56,7 +61,7 @@ final class Driver extends AbstractSQLServerDriver
      *
      * @throws Exception
      */
-    private function _constructPdoDsn(array $params, array $connectionOptions)
+    private function constructDsn(array $params, array $connectionOptions)
     {
         $dsn = 'sqlsrv:server=';
 

--- a/src/Driver/PDO/SQLite/Driver.php
+++ b/src/Driver/PDO/SQLite/Driver.php
@@ -4,14 +4,17 @@ namespace Doctrine\DBAL\Driver\PDO\SQLite;
 
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use Doctrine\DBAL\Driver\PDO\Connection;
+use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use PDO;
+use PDOException;
 
 use function array_merge;
 
 final class Driver extends AbstractSQLiteDriver
 {
     /** @var mixed[] */
-    protected $_userDefinedFunctions = [
+    private $userDefinedFunctions = [
         'sqrt' => ['callback' => [SqlitePlatform::class, 'udfSqrt'], 'numArgs' => 1],
         'mod'  => ['callback' => [SqlitePlatform::class, 'udfMod'], 'numArgs' => 2],
         'locate'  => ['callback' => [SqlitePlatform::class, 'udfLocate'], 'numArgs' => -1],
@@ -27,27 +30,29 @@ final class Driver extends AbstractSQLiteDriver
         $driverOptions = $params['driverOptions'] ?? [];
 
         if (isset($driverOptions['userDefinedFunctions'])) {
-            $this->_userDefinedFunctions = array_merge(
-                $this->_userDefinedFunctions,
+            $this->userDefinedFunctions = array_merge(
+                $this->userDefinedFunctions,
                 $driverOptions['userDefinedFunctions']
             );
             unset($driverOptions['userDefinedFunctions']);
         }
 
-        $connection = new Connection(
-            $this->_constructPdoDsn($params),
-            $params['user'] ?? '',
-            $params['password'] ?? '',
-            $driverOptions
-        );
+        try {
+            $pdo = new PDO(
+                $this->constructPdoDsn($params),
+                $params['user'] ?? '',
+                $params['password'] ?? '',
+                $driverOptions
+            );
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
 
-        $pdo = $connection->getWrappedConnection();
-
-        foreach ($this->_userDefinedFunctions as $fn => $data) {
+        foreach ($this->userDefinedFunctions as $fn => $data) {
             $pdo->sqliteCreateFunction($fn, $data['callback'], $data['numArgs']);
         }
 
-        return $connection;
+        return new Connection($pdo);
     }
 
     /**
@@ -57,7 +62,7 @@ final class Driver extends AbstractSQLiteDriver
      *
      * @return string The DSN.
      */
-    protected function _constructPdoDsn(array $params)
+    private function constructPdoDsn(array $params)
     {
         $dsn = 'sqlite:';
         if (isset($params['path'])) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

This patch is a step towards sunsetting `Connection::getWrappedConnection()`. This method is not part of the driver API, so wrapping a driver connection into a decorator will make this method inaccessible. This is likely already a problem when the Portability middleware is used (https://github.com/doctrine/dbal/pull/4157) and will become more obvious when the Logging middleware has been introduced (https://github.com/doctrine/dbal/issues/4941).

Instead of instantiating PDO, the driver connection constructor will now accept it as a dependency. It has the following advantages:
1. It becomes possible to implement a driver that uses a custom PDO instance and reuse the rest of the PDO driver components ([example](https://gist.github.com/morozov/aef49beb45ff998c37d9598c6db6d9c5)). This solves the problem of sharing an underlying connection between multiple libraries w/o using a dedicated type-unsafe API.
2. The `pdo_pgsql` and `pdo_sqlite` drivers will no longer break their connection encapsulation by calling `Connection::getWrappedConnection()` in order to access the underlying PDO instance.

The general idea here is that every driver-level component should _accept_ and wrap its lower-level counterpart, not _instantiate_ it. This will allow for a more clear separation of concerns and, eventually, a cleaner internal API. 

A similar change was applied recently in https://github.com/doctrine/dbal/pull/4894.