### PR TITLE
Accept connection object/resource as a driver connection constructor argument

### DIFF
--- a/src/Driver/IBMDB2/Driver.php
+++ b/src/Driver/IBMDB2/Driver.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Driver\IBMDB2;
 
 use Doctrine\DBAL\Driver\AbstractDB2Driver;
+use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionFailed;
 
 final class Driver extends AbstractDB2Driver
 {
@@ -13,12 +14,22 @@ final class Driver extends AbstractDB2Driver
      */
     public function connect(array $params)
     {
-        return new Connection(
-            DataSourceName::fromConnectionParameters($params)->toString(),
-            isset($params['persistent']) && $params['persistent'] === true,
-            $params['user'] ?? '',
-            $params['password'] ?? '',
-            $params['driverOptions'] ?? []
-        );
+        $dataSourceName = DataSourceName::fromConnectionParameters($params)->toString();
+
+        $username      = $params['user'] ?? '';
+        $password      = $params['password'] ?? '';
+        $driverOptions = $params['driverOptions'] ?? [];
+
+        if (! empty($params['persistent'])) {
+            $connection = db2_pconnect($dataSourceName, $username, $password, $driverOptions);
+        } else {
+            $connection = db2_connect($dataSourceName, $username, $password, $driverOptions);
+        }
+
+        if ($connection === false) {
+            throw ConnectionFailed::new();
+        }
+
+        return new Connection($connection);
     }
 }

--- a/src/Driver/Mysqli/Driver.php
+++ b/src/Driver/Mysqli/Driver.php
@@ -3,10 +3,13 @@
 namespace Doctrine\DBAL\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Doctrine\DBAL\Driver\Mysqli\Exception\ConnectionFailed;
 use Doctrine\DBAL\Driver\Mysqli\Exception\HostRequired;
 use Doctrine\DBAL\Driver\Mysqli\Initializer\Charset;
 use Doctrine\DBAL\Driver\Mysqli\Initializer\Options;
 use Doctrine\DBAL\Driver\Mysqli\Initializer\Secure;
+use mysqli;
+use mysqli_sql_exception;
 
 use function count;
 
@@ -47,17 +50,35 @@ final class Driver extends AbstractMySQLDriver
         $preInitializers  = $this->withSecure($preInitializers, $params);
         $postInitializers = $this->withCharset($postInitializers, $params);
 
-        return new Connection(
-            $host,
-            $params['user'] ?? null,
-            $params['password'] ?? null,
-            $params['dbname'] ?? null,
-            $params['port'] ?? null,
-            $params['unix_socket'] ?? null,
-            $flags,
-            $preInitializers,
-            $postInitializers
-        );
+        $connection = new mysqli();
+
+        foreach ($preInitializers as $initializer) {
+            $initializer->initialize($connection);
+        }
+
+        try {
+            $success = @$connection->real_connect(
+                $host,
+                $params['user'] ?? null,
+                $params['password'] ?? null,
+                $params['dbname'] ?? null,
+                $params['port'] ?? null,
+                $params['unix_socket'] ?? null,
+                $flags
+            );
+        } catch (mysqli_sql_exception $e) {
+            throw ConnectionFailed::upcast($e);
+        }
+
+        if (! $success) {
+            throw ConnectionFailed::new($connection);
+        }
+
+        foreach ($postInitializers as $initializer) {
+            $initializer->initialize($connection);
+        }
+
+        return new Connection($connection);
     }
 
     /**

--- a/src/Driver/OCI8/Driver.php
+++ b/src/Driver/OCI8/Driver.php
@@ -3,6 +3,10 @@
 namespace Doctrine\DBAL\Driver\OCI8;
 
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
+use Doctrine\DBAL\Driver\OCI8\Exception\ConnectionFailed;
+
+use function oci_connect;
+use function oci_pconnect;
 
 use const OCI_NO_AUTO_COMMIT;
 
@@ -18,14 +22,24 @@ final class Driver extends AbstractOracleDriver
      */
     public function connect(array $params)
     {
-        return new Connection(
-            $params['user'] ?? '',
-            $params['password'] ?? '',
-            $this->_constructDsn($params),
-            $params['charset'] ?? '',
-            $params['sessionMode'] ?? OCI_NO_AUTO_COMMIT,
-            $params['persistent'] ?? false
-        );
+        $username    = $params['user'] ?? '';
+        $password    = $params['password'] ?? '';
+        $charset     = $params['charset'] ?? '';
+        $sessionMode = $params['sessionMode'] ?? OCI_NO_AUTO_COMMIT;
+
+        $connectionString = $this->getEasyConnectString($params);
+
+        if (! empty($params['persistent'])) {
+            $connection = @oci_pconnect($username, $password, $connectionString, $charset, $sessionMode);
+        } else {
+            $connection = @oci_connect($username, $password, $connectionString, $charset, $sessionMode);
+        }
+
+        if ($connection === false) {
+            throw ConnectionFailed::new();
+        }
+
+        return new Connection($connection);
     }
 
     /**

--- a/src/Driver/SQLSrv/Driver.php
+++ b/src/Driver/SQLSrv/Driver.php
@@ -4,6 +4,10 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
+use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
+
+use function sqlsrv_configure;
+use function sqlsrv_connect;
 
 /**
  * Driver for ext/sqlsrv.
@@ -51,6 +55,16 @@ final class Driver extends AbstractSQLServerDriver
             $driverOptions['ReturnDatesAsStrings'] = 1;
         }
 
-        return new Connection($serverName, $driverOptions);
+        if (! sqlsrv_configure('WarningsReturnAsErrors', 0)) {
+            throw Error::new();
+        }
+
+        $connection = sqlsrv_connect($serverName, $driverOptions);
+
+        if ($connection === false) {
+            throw Error::new();
+        }
+
+        return new Connection($connection);
     }
 }

--- a/tests/Functional/Driver/IBMDB2/ConnectionTest.php
+++ b/tests/Functional/Driver/IBMDB2/ConnectionTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Driver\IBMDB2;
 
-use Doctrine\DBAL\Driver\IBMDB2\Connection;
-use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionFailed;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\PrepareFailed;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -30,17 +28,11 @@ class ConnectionTest extends FunctionalTestCase
         $this->markConnectionNotReusable();
     }
 
-    public function testConnectionFailure(): void
-    {
-        $this->expectException(ConnectionFailed::class);
-        new Connection('garbage', false, '', '');
-    }
-
     public function testPrepareFailure(): void
     {
         $driverConnection = $this->connection->getWrappedConnection();
 
-        $re = new ReflectionProperty($driverConnection, 'conn');
+        $re = new ReflectionProperty($driverConnection, 'connection');
         $re->setAccessible(true);
         $conn = $re->getValue($driverConnection);
         db2_close($conn);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

This patch applies the idea implemented in https://github.com/doctrine/dbal/pull/4948 for the PDO drivers to the rest of the drivers. This way, it will be possible to implement a custom driver that will inject a pre-established connection into any DBAL driver.