### PR TITLE
Use willReturn() in mocks instead of will(returnValue())

### DIFF
--- a/tests/Doctrine/Tests/DBAL/ConnectionTest.php
+++ b/tests/Doctrine/Tests/DBAL/ConnectionTest.php
@@ -58,9 +58,9 @@ class ConnectionTest extends DbalTestCase
 
         $driverMock->expects($this->any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->willReturn(
                 $this->createMock(DriverConnection::class)
-            ));
+            );
 
         $platform = $this->getMockForAbstractClass(AbstractPlatform::class);
 
@@ -247,9 +247,9 @@ EOF
         $driverMock = $this->createMock(Driver::class);
         $driverMock->expects($this->any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->willReturn(
                 $this->createMock(DriverConnection::class)
-            ));
+            );
         $conn = new Connection([], $driverMock);
 
         $conn->setAutoCommit(false);
@@ -266,9 +266,9 @@ EOF
         $driverMock = $this->createMock(Driver::class);
         $driverMock->expects($this->any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->willReturn(
                 $this->createMock(DriverConnection::class)
-            ));
+            );
         $conn = new Connection([], $driverMock);
 
         $conn->setAutoCommit(false);
@@ -290,7 +290,7 @@ EOF
         $driverMock = $this->createMock(Driver::class);
         $driverMock->expects($this->any())
             ->method('connect')
-            ->will($this->returnValue($driverConnection));
+            ->willReturn($driverConnection);
 
         $conn = new Connection([], $driverMock);
 
@@ -313,9 +313,9 @@ EOF
         $driverMock = $this->createMock(Driver::class);
         $driverMock->expects($this->any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->willReturn(
                 $this->createMock(DriverConnection::class)
-            ));
+            );
         $conn = new Connection([], $driverMock);
 
         $conn->setAutoCommit(false);
@@ -330,9 +330,9 @@ EOF
         $driverMock = $this->createMock(Driver::class);
         $driverMock->expects($this->any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->willReturn(
                 $this->createMock(DriverConnection::class)
-            ));
+            );
         $conn = new Connection([], $driverMock);
 
         $conn->connect();
@@ -516,16 +516,16 @@ EOF
 
         $driverMock->expects($this->any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->willReturn(
                 $this->createMock(DriverConnection::class)
-            ));
+            );
 
         $driverStatementMock = $this->createMock(Statement::class);
 
         $driverStatementMock->expects($this->once())
             ->method('fetch')
             ->with(FetchMode::ASSOCIATIVE)
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $conn = (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['executeQuery'])
@@ -535,7 +535,7 @@ EOF
         $conn->expects($this->once())
             ->method('executeQuery')
             ->with($statement, $params, $types)
-            ->will($this->returnValue($driverStatementMock));
+            ->willReturn($driverStatementMock);
 
         self::assertSame($result, $conn->fetchAssoc($statement, $params, $types));
     }
@@ -551,16 +551,16 @@ EOF
 
         $driverMock->expects($this->any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->willReturn(
                 $this->createMock(DriverConnection::class)
-            ));
+            );
 
         $driverStatementMock = $this->createMock(Statement::class);
 
         $driverStatementMock->expects($this->once())
             ->method('fetch')
             ->with(FetchMode::NUMERIC)
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $conn = (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['executeQuery'])
@@ -570,7 +570,7 @@ EOF
         $conn->expects($this->once())
             ->method('executeQuery')
             ->with($statement, $params, $types)
-            ->will($this->returnValue($driverStatementMock));
+            ->willReturn($driverStatementMock);
 
         self::assertSame($result, $conn->fetchArray($statement, $params, $types));
     }
@@ -587,16 +587,16 @@ EOF
 
         $driverMock->expects($this->any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->willReturn(
                 $this->createMock(DriverConnection::class)
-            ));
+            );
 
         $driverStatementMock = $this->createMock(Statement::class);
 
         $driverStatementMock->expects($this->once())
             ->method('fetchColumn')
             ->with($column)
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $conn = (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['executeQuery'])
@@ -606,7 +606,7 @@ EOF
         $conn->expects($this->once())
             ->method('executeQuery')
             ->with($statement, $params, $types)
-            ->will($this->returnValue($driverStatementMock));
+            ->willReturn($driverStatementMock);
 
         self::assertSame($result, $conn->fetchColumn($statement, $params, $column, $types));
     }
@@ -622,15 +622,15 @@ EOF
 
         $driverMock->expects($this->any())
             ->method('connect')
-            ->will($this->returnValue(
+            ->willReturn(
                 $this->createMock(DriverConnection::class)
-            ));
+            );
 
         $driverStatementMock = $this->createMock(Statement::class);
 
         $driverStatementMock->expects($this->once())
             ->method('fetchAll')
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $conn = (new MockBuilderProxy($this->getMockBuilder(Connection::class)))
             ->onlyMethods(['executeQuery'])
@@ -640,7 +640,7 @@ EOF
         $conn->expects($this->once())
             ->method('executeQuery')
             ->with($statement, $params, $types)
-            ->will($this->returnValue($driverStatementMock));
+            ->willReturn($driverStatementMock);
 
         self::assertSame($result, $conn->fetchAll($statement, $params, $types));
     }
@@ -714,7 +714,7 @@ EOF
 
         $wrappedConnection
             ->method('prepare')
-            ->will($this->returnValue($stmt));
+            ->willReturn($stmt);
 
         $platform = $this->createMock(AbstractPlatform::class);
 
@@ -735,20 +735,20 @@ EOF
 
         $driverMock->expects($this->once())
             ->method('connect')
-            ->will($this->returnValue($driverConnectionMock));
+            ->willReturn($driverConnectionMock);
 
         $driverConnectionMock->expects($this->once())
             ->method('requiresQueryForServerVersion')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $driverConnectionMock->expects($this->once())
             ->method('getServerVersion')
-            ->will($this->returnValue('6.6.6'));
+            ->willReturn('6.6.6');
 
         $driverMock->expects($this->once())
             ->method('createDatabasePlatformForVersion')
             ->with('6.6.6')
-            ->will($this->returnValue($platformMock));
+            ->willReturn($platformMock);
 
         self::assertSame($platformMock, $connection->getDatabasePlatform());
     }
@@ -761,7 +761,7 @@ EOF
             ->expects($this->atLeastOnce())
             ->method('fetch')
             ->with('cacheKey')
-            ->will($this->returnValue(['realKey' => []]));
+            ->willReturn(['realKey' => []]);
 
         $query  = 'SELECT * FROM foo WHERE bar = ?';
         $params = [666];
@@ -772,14 +772,14 @@ EOF
         $queryCacheProfileMock
             ->expects($this->any())
             ->method('getResultCacheDriver')
-            ->will($this->returnValue($resultCacheDriverMock));
+            ->willReturn($resultCacheDriverMock);
 
         // This is our main expectation
         $queryCacheProfileMock
             ->expects($this->once())
             ->method('generateCacheKeys')
             ->with($query, $params, $types, $this->params)
-            ->will($this->returnValue(['cacheKey', 'realKey']));
+            ->willReturn(['cacheKey', 'realKey']);
 
         $driver = $this->createMock(Driver::class);
         $result = (new Connection($this->params, $driver))
@@ -797,14 +797,14 @@ EOF
             ->expects($this->atLeastOnce())
             ->method('fetch')
             ->with('cacheKey')
-            ->will($this->returnValue(['realKey' => []]));
+            ->willReturn(['realKey' => []]);
 
         $queryCacheProfileMock = $this->createMock(QueryCacheProfile::class);
 
         $queryCacheProfileMock
             ->expects($this->any())
             ->method('getResultCacheDriver')
-            ->will($this->returnValue($resultCacheDriverMock));
+            ->willReturn($resultCacheDriverMock);
 
         $query = 'SELECT 1';
 
@@ -814,7 +814,7 @@ EOF
             ->expects($this->once())
             ->method('generateCacheKeys')
             ->with($query, [], [], $connectionParams)
-            ->will($this->returnValue(['cacheKey', 'realKey']));
+            ->willReturn(['cacheKey', 'realKey']);
 
         $connectionParams['platform'] = $this->createMock(AbstractPlatform::class);
 
@@ -867,13 +867,13 @@ EOF
         $queryCacheProfile
             ->expects($this->any())
             ->method('getResultCacheDriver')
-            ->will($this->returnValue($resultCacheDriver));
+            ->willReturn($resultCacheDriver);
 
         $resultCacheDriver
             ->expects($this->atLeastOnce())
             ->method('fetch')
             ->with('cacheKey')
-            ->will($this->returnValue(['realKey' => []]));
+            ->willReturn(['realKey' => []]);
 
         $query = 'SELECT 1';
 
@@ -889,7 +889,7 @@ EOF
             ->expects($this->once())
             ->method('generateCacheKeys')
             ->with($query, [], [], $paramsWithoutPlatform)
-            ->will($this->returnValue(['cacheKey', 'realKey']));
+            ->willReturn(['cacheKey', 'realKey']);
 
         $connection = new Connection($params, $driver);
 

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractDriverTest.php
@@ -155,7 +155,7 @@ abstract class AbstractDriverTest extends DbalTestCase
 
         $connection->expects($this->once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         self::assertSame($params['dbname'], $this->driver->getDatabase($connection));
     }

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractMySQLDriverTest.php
@@ -30,17 +30,17 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
 
         $statement->expects($this->once())
             ->method('fetchColumn')
-            ->will($this->returnValue($database));
+            ->willReturn($database);
 
         $connection = $this->getConnectionMock();
 
         $connection->expects($this->once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $connection->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($statement));
+            ->willReturn($statement);
 
         self::assertSame($database, $this->driver->getDatabase($connection));
     }

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractOracleDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractOracleDriverTest.php
@@ -24,7 +24,7 @@ class AbstractOracleDriverTest extends AbstractDriverTest
 
         $connection->expects($this->once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         self::assertSame($params['user'], $this->driver->getDatabase($connection));
     }
@@ -43,7 +43,7 @@ class AbstractOracleDriverTest extends AbstractDriverTest
 
         $connection->expects($this->once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         self::assertSame($params['user'], $this->driver->getDatabase($connection));
     }

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractPostgreSQLDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractPostgreSQLDriverTest.php
@@ -31,17 +31,17 @@ class AbstractPostgreSQLDriverTest extends AbstractDriverTest
 
         $statement->expects($this->once())
             ->method('fetchColumn')
-            ->will($this->returnValue($database));
+            ->willReturn($database);
 
         $connection = $this->getConnectionMock();
 
         $connection->expects($this->once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $connection->expects($this->once())
             ->method('query')
-            ->will($this->returnValue($statement));
+            ->willReturn($statement);
 
         self::assertSame($database, $this->driver->getDatabase($connection));
     }

--- a/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLiteDriverTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/AbstractSQLiteDriverTest.php
@@ -25,7 +25,7 @@ class AbstractSQLiteDriverTest extends AbstractDriverTest
 
         $connection->expects($this->once())
             ->method('getParams')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         self::assertSame($params['path'], $this->driver->getDatabase($connection));
     }

--- a/tests/Doctrine/Tests/DBAL/Portability/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Portability/StatementTest.php
@@ -41,7 +41,7 @@ class StatementTest extends DbalTestCase
         $this->wrappedStmt->expects($this->once())
             ->method('bindParam')
             ->with($column, $variable, $type, $length)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         self::assertTrue($this->stmt->bindParam($column, $variable, $type, $length));
     }
@@ -55,7 +55,7 @@ class StatementTest extends DbalTestCase
         $this->wrappedStmt->expects($this->once())
             ->method('bindValue')
             ->with($param, $value, $type)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         self::assertTrue($this->stmt->bindValue($param, $value, $type));
     }
@@ -64,7 +64,7 @@ class StatementTest extends DbalTestCase
     {
         $this->wrappedStmt->expects($this->once())
             ->method('closeCursor')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         self::assertTrue($this->stmt->closeCursor());
     }
@@ -75,7 +75,7 @@ class StatementTest extends DbalTestCase
 
         $this->wrappedStmt->expects($this->once())
             ->method('columnCount')
-            ->will($this->returnValue($columnCount));
+            ->willReturn($columnCount);
 
         self::assertSame($columnCount, $this->stmt->columnCount());
     }
@@ -86,7 +86,7 @@ class StatementTest extends DbalTestCase
 
         $this->wrappedStmt->expects($this->once())
             ->method('errorCode')
-            ->will($this->returnValue($errorCode));
+            ->willReturn($errorCode);
 
         self::assertSame($errorCode, $this->stmt->errorCode());
     }
@@ -97,7 +97,7 @@ class StatementTest extends DbalTestCase
 
         $this->wrappedStmt->expects($this->once())
             ->method('errorInfo')
-            ->will($this->returnValue($errorInfo));
+            ->willReturn($errorInfo);
 
         self::assertSame($errorInfo, $this->stmt->errorInfo());
     }
@@ -112,7 +112,7 @@ class StatementTest extends DbalTestCase
         $this->wrappedStmt->expects($this->once())
             ->method('execute')
             ->with($params)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         self::assertTrue($this->stmt->execute($params));
     }
@@ -126,7 +126,7 @@ class StatementTest extends DbalTestCase
         $this->wrappedStmt->expects($this->once())
             ->method('setFetchMode')
             ->with($fetchMode, $arg1, $arg2)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $re = new ReflectionProperty($this->stmt, 'defaultFetchMode');
         $re->setAccessible(true);
@@ -151,7 +151,7 @@ class StatementTest extends DbalTestCase
 
         $this->wrappedStmt->expects($this->once())
             ->method('rowCount')
-            ->will($this->returnValue($rowCount));
+            ->willReturn($rowCount);
 
         self::assertSame($rowCount, $this->stmt->rowCount());
     }

--- a/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/Expression/ExpressionBuilderTest.php
@@ -20,7 +20,7 @@ class ExpressionBuilderTest extends DbalTestCase
 
         $conn->expects($this->any())
              ->method('getExpressionBuilder')
-             ->will($this->returnValue($this->expr));
+             ->willReturn($this->expr);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/DBAL/Query/QueryBuilderTest.php
@@ -25,7 +25,7 @@ class QueryBuilderTest extends DbalTestCase
 
         $this->conn->expects($this->any())
                    ->method('getExpressionBuilder')
-                   ->will($this->returnValue($expressionBuilder));
+                   ->willReturn($expressionBuilder);
     }
 
     public function testSimpleSelectWithoutFrom(): void

--- a/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ComparatorTest.php
@@ -1173,7 +1173,7 @@ class ComparatorTest extends TestCase
 
         $fromSchema->expects($this->once())
             ->method('getNamespaces')
-            ->will($this->returnValue(['foo', 'bar']));
+            ->willReturn(['foo', 'bar']);
 
         $fromSchema->method('hasNamespace')
             ->withConsecutive(['bar'], ['baz'])
@@ -1181,7 +1181,7 @@ class ComparatorTest extends TestCase
 
         $toSchema->expects($this->once())
             ->method('getNamespaces')
-            ->will($this->returnValue(['bar', 'baz']));
+            ->willReturn(['bar', 'baz']);
 
         $toSchema->method('hasNamespace')
             ->withConsecutive(['foo'], ['bar'])

--- a/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/DB2SchemaManagerTest.php
@@ -44,12 +44,12 @@ final class DB2SchemaManagerTest extends TestCase
     public function testListTableNamesFiltersAssetNamesCorrectly(): void
     {
         $this->conn->getConfiguration()->setFilterSchemaAssetsExpression('/^(?!T_)/');
-        $this->conn->expects($this->once())->method('fetchAllAssociative')->will($this->returnValue([
+        $this->conn->expects($this->once())->method('fetchAllAssociative')->willReturn([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
             ['name' => 'T_BAR'],
-        ]));
+        ]);
 
         self::assertSame(
             [
@@ -64,12 +64,12 @@ final class DB2SchemaManagerTest extends TestCase
     {
         $filterExpression = '/^(?!T_)/';
         $this->conn->getConfiguration()->setFilterSchemaAssetsExpression($filterExpression);
-        $this->conn->expects($this->once())->method('fetchAllAssociative')->will($this->returnValue([
+        $this->conn->expects($this->once())->method('fetchAllAssociative')->willReturn([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
             ['name' => 'T_BAR'],
-        ]));
+        ]);
 
         self::assertSame(
             [
@@ -93,12 +93,12 @@ final class DB2SchemaManagerTest extends TestCase
             return in_array($assetName, $accepted);
         });
         $this->conn->expects($this->any())->method('quote');
-        $this->conn->expects($this->once())->method('fetchAllAssociative')->will($this->returnValue([
+        $this->conn->expects($this->once())->method('fetchAllAssociative')->willReturn([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
             ['name' => 'T_BAR'],
-        ]));
+        ]);
 
         self::assertSame(
             [
@@ -118,12 +118,12 @@ final class DB2SchemaManagerTest extends TestCase
             return in_array($assetName, $accepted);
         });
         $this->conn->expects($this->any())->method('quote');
-        $this->conn->expects($this->atLeastOnce())->method('fetchAllAssociative')->will($this->returnValue([
+        $this->conn->expects($this->atLeastOnce())->method('fetchAllAssociative')->willReturn([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
             ['name' => 'T_BAR'],
-        ]));
+        ]);
 
         self::assertSame(
             [
@@ -153,12 +153,12 @@ final class DB2SchemaManagerTest extends TestCase
         $filterExpression = '/^(?!T_)/';
         $this->conn->getConfiguration()->setFilterSchemaAssetsExpression($filterExpression);
 
-        $this->conn->expects($this->exactly(2))->method('fetchAllAssociative')->will($this->returnValue([
+        $this->conn->expects($this->exactly(2))->method('fetchAllAssociative')->willReturn([
             ['name' => 'FOO'],
             ['name' => 'T_FOO'],
             ['name' => 'BAR'],
             ['name' => 'T_BAR'],
-        ]));
+        ]);
 
         self::assertSame(
             [

--- a/tests/Doctrine/Tests/DBAL/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/ForeignKeyConstraintTest.php
@@ -23,7 +23,7 @@ class ForeignKeyConstraintTest extends TestCase
             ->getMock();
         $index->expects($this->once())
             ->method('getColumns')
-            ->will($this->returnValue($indexColumns));
+            ->willReturn($indexColumns);
 
         self::assertSame($expectedResult, $foreignKey->intersectsIndexColumns($index));
     }

--- a/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/SchemaDiffTest.php
@@ -54,41 +54,41 @@ class SchemaDiffTest extends TestCase
         $platform->expects($this->exactly(1))
             ->method('getCreateSchemaSQL')
             ->with('foo_ns')
-            ->will($this->returnValue('create_schema'));
+            ->willReturn('create_schema');
         if ($unsafe) {
             $platform->expects($this->exactly(1))
                  ->method('getDropSequenceSql')
                  ->with($this->isInstanceOf(Sequence::class))
-                 ->will($this->returnValue('drop_seq'));
+                 ->willReturn('drop_seq');
         }
 
         $platform->expects($this->exactly(1))
                  ->method('getAlterSequenceSql')
                  ->with($this->isInstanceOf(Sequence::class))
-                 ->will($this->returnValue('alter_seq'));
+                 ->willReturn('alter_seq');
         $platform->expects($this->exactly(1))
                  ->method('getCreateSequenceSql')
                  ->with($this->isInstanceOf(Sequence::class))
-                 ->will($this->returnValue('create_seq'));
+                 ->willReturn('create_seq');
         if ($unsafe) {
             $platform->expects($this->exactly(1))
                      ->method('getDropTableSql')
                      ->with($this->isInstanceOf(Table::class))
-                     ->will($this->returnValue('drop_table'));
+                     ->willReturn('drop_table');
         }
 
         $platform->expects($this->exactly(1))
                  ->method('getCreateTableSql')
                  ->with($this->isInstanceOf(Table::class))
-                 ->will($this->returnValue(['create_table']));
+                 ->willReturn(['create_table']);
         $platform->expects($this->exactly(1))
                  ->method('getCreateForeignKeySQL')
                  ->with($this->isInstanceOf(ForeignKeyConstraint::class))
-                 ->will($this->returnValue('create_foreign_key'));
+                 ->willReturn('create_foreign_key');
         $platform->expects($this->exactly(1))
                  ->method('getAlterTableSql')
                  ->with($this->isInstanceOf(TableDiff::class))
-                 ->will($this->returnValue(['alter_table']));
+                 ->willReturn(['alter_table']);
         if ($unsafe) {
             $platform->expects($this->exactly(1))
                      ->method('getDropForeignKeySql')
@@ -96,18 +96,18 @@ class SchemaDiffTest extends TestCase
                          $this->isInstanceOf(ForeignKeyConstraint::class),
                          $this->isInstanceOf(Table::class)
                      )
-                     ->will($this->returnValue('drop_orphan_fk'));
+                     ->willReturn('drop_orphan_fk');
         }
 
         $platform->expects($this->exactly(1))
                 ->method('supportsSchemas')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
         $platform->expects($this->exactly(1))
                 ->method('supportsSequences')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
         $platform->expects($this->exactly(2))
                 ->method('supportsForeignKeyConstraints')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         return $platform;
     }

--- a/tests/Doctrine/Tests/DBAL/Schema/TableDiffTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/TableDiffTest.php
@@ -38,7 +38,7 @@ class TableDiffTest extends TestCase
         $tableMock->expects($this->once())
             ->method('getQuotedName')
             ->with($this->platform)
-            ->will($this->returnValue('foo'));
+            ->willReturn('foo');
 
         self::assertEquals(new Identifier('foo'), $tableDiff->getName($this->platform));
     }

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -115,7 +115,7 @@ class CreateSchemaSqlCollectorTest extends TestCase
         foreach (['supportsSchemas', 'supportsForeignKeyConstraints'] as $method) {
             $this->platformMock->expects($this->any())
                 ->method($method)
-                ->will($this->returnValue(true));
+                ->willReturn(true);
         }
 
         $table      = $this->createTableMock();

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/DropSchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/DropSchemaSqlCollectorTest.php
@@ -48,15 +48,15 @@ class DropSchemaSqlCollectorTest extends TestCase
 
         $constraint->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue($name));
+            ->willReturn($name);
 
         $constraint->expects($this->any())
             ->method('getForeignColumns')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $constraint->expects($this->any())
             ->method('getColumns')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         return $constraint;
     }

--- a/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/Schema/Visitor/SchemaSqlCollectorTest.php
@@ -16,13 +16,13 @@ class SchemaSqlCollectorTest extends TestCase
             ->getMock();
         $platformMock->expects($this->exactly(2))
                      ->method('getCreateTableSql')
-                     ->will($this->returnValue(['foo']));
+                     ->willReturn(['foo']);
         $platformMock->expects($this->exactly(1))
                      ->method('getCreateSequenceSql')
-                     ->will($this->returnValue('bar'));
+                     ->willReturn('bar');
         $platformMock->expects($this->exactly(1))
                      ->method('getCreateForeignKeySql')
-                     ->will($this->returnValue('baz'));
+                     ->willReturn('baz');
 
         $schema = $this->createFixtureSchema();
 
@@ -38,13 +38,13 @@ class SchemaSqlCollectorTest extends TestCase
             ->getMock();
         $platformMock->expects($this->exactly(2))
                      ->method('getDropTableSql')
-                     ->will($this->returnValue('tbl'));
+                     ->willReturn('tbl');
         $platformMock->expects($this->exactly(1))
                      ->method('getDropSequenceSql')
-                     ->will($this->returnValue('seq'));
+                     ->willReturn('seq');
         $platformMock->expects($this->exactly(1))
                      ->method('getDropForeignKeySql')
-                     ->will($this->returnValue('fk'));
+                     ->willReturn('fk');
 
         $schema = $this->createFixtureSchema();
 

--- a/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
+++ b/tests/Doctrine/Tests/DBAL/Sharding/PoolingShardManagerTest.php
@@ -79,10 +79,8 @@ class PoolingShardManagerTest extends TestCase
     public function testGetShards(): void
     {
         $conn = $this->createConnectionMock();
-        $conn->expects($this->any())->method('getParams')->will(
-            $this->returnValue(
-                ['shards' => [['id' => 1], ['id' => 2]], 'shardChoser' => $this->createPassthroughShardChoser()]
-            )
+        $conn->expects($this->any())->method('getParams')->willReturn(
+            ['shards' => [['id' => 1], ['id' => 2]], 'shardChoser' => $this->createPassthroughShardChoser()]
         );
 
         $shardManager = new PoolingShardManager($conn);

--- a/tests/Doctrine/Tests/DBAL/StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/StatementTest.php
@@ -35,7 +35,7 @@ class StatementTest extends DbalTestCase
         $driverConnection = $this->createMock(DriverConnection::class);
         $driverConnection->expects($this->any())
                 ->method('prepare')
-                ->will($this->returnValue($this->pdoStatement));
+                ->willReturn($this->pdoStatement);
 
         $driver = $this->createMock(Driver::class);
 
@@ -44,16 +44,16 @@ class StatementTest extends DbalTestCase
             ->getMock();
         $this->conn->expects($this->atLeastOnce())
                 ->method('getWrappedConnection')
-                ->will($this->returnValue($driverConnection));
+                ->willReturn($driverConnection);
 
         $this->configuration = $this->createMock(Configuration::class);
         $this->conn->expects($this->any())
                 ->method('getConfiguration')
-                ->will($this->returnValue($this->configuration));
+                ->willReturn($this->configuration);
 
         $this->conn->expects($this->any())
             ->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
     }
 
     public function testExecuteCallsLoggerStartQueryWithParametersWhenValuesBound(): void
@@ -72,7 +72,7 @@ class StatementTest extends DbalTestCase
 
         $this->configuration->expects($this->once())
                 ->method('getSQLLogger')
-                ->will($this->returnValue($logger));
+                ->willReturn($logger);
 
         $statement = new Statement($sql, $this->conn);
         $statement->bindValue($name, $var, $type);
@@ -94,7 +94,7 @@ class StatementTest extends DbalTestCase
 
         $this->configuration->expects($this->once())
                 ->method('getSQLLogger')
-                ->will($this->returnValue($logger));
+                ->willReturn($logger);
 
         $statement = new Statement($sql, $this->conn);
         $statement->execute($values);
@@ -128,7 +128,7 @@ class StatementTest extends DbalTestCase
 
         $this->configuration->expects($this->once())
             ->method('getSQLLogger')
-            ->will($this->returnValue($logger));
+            ->willReturn($logger);
 
         $this->conn->expects($this->any())
             ->method('handleExceptionDuringQuery')

--- a/tests/Doctrine/Tests/DBAL/Types/GuidTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Types/GuidTypeTest.php
@@ -38,7 +38,7 @@ class GuidTypeTest extends DbalTestCase
 
         $this->platform->expects($this->any())
              ->method('hasNativeGuidType')
-             ->will($this->returnValue(true));
+             ->willReturn(true);
 
         self::assertFalse($this->type->requiresSQLCommentHint($this->platform));
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The calls like `$mock->will($this->returnValue($value))` are unnecessary verbose and may cause conflicts with `4.0.x` which enforces static calls as `self::returnValue()`.

Using the shortcut consistently will make it simpler to identify the no longer needed mocks in `4.0.x` where PHPUnit will be able to generate them automatically based on the method return type.