### PR TITLE
Create `const`s for platform names

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -73,6 +73,8 @@ abstract class AbstractPlatform
 
     public const CREATE_FOREIGNKEYS = 2;
 
+    public const SQLITE = 'sqlite';
+
     /** @var string[]|null */
     protected $doctrineTypeMapping;
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

I'm suggesting to create a `const` for every platform here, and have [`SqlitePlatform::getName()`](https://github.com/doctrine/dbal/blob/3.1.x/src/Platforms/SqlitePlatform.php#L566) return it.

Reason: When creating a [User Defined Function](https://www.doctrine-project.org/projects/doctrine-orm/en/current/cookbook/dql-user-defined-functions.html), you sometimes need to differentiate between platforms:
```php
switch ($sqlWalker->getConnection()->getDatabasePlatform()->getName()) {
    case 'sqlite':
    // ...
```
And using a `const` there just feels nicer :-)

If you agree in principle, I'll add the others :-)
