### PR TITLE
Remove redundant PHPUnit mocks

### DIFF
--- a/tests/Connection/LoggingTest.php
+++ b/tests/Connection/LoggingTest.php
@@ -7,9 +7,7 @@ namespace Doctrine\DBAL\Tests\Connection;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
-use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Logging\SQLLogger;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use PHPUnit\Framework\TestCase;
 
 final class LoggingTest extends TestCase
@@ -34,8 +32,6 @@ final class LoggingTest extends TestCase
     public function testLogPrepareExecute(): void
     {
         $driverConnection = $this->createStub(DriverConnection::class);
-        $driverConnection->method('prepare')
-            ->willReturn($this->createStub(Statement::class));
 
         $this->createConnection($driverConnection, 'UPDATE table SET foo = ?')
             ->prepare('UPDATE table SET foo = ?')
@@ -47,8 +43,6 @@ final class LoggingTest extends TestCase
         $driver = $this->createStub(Driver::class);
         $driver->method('connect')
             ->willReturn($driverConnection);
-        $driver->method('getDatabasePlatform')
-            ->willReturn($this->createMock(AbstractPlatform::class));
 
         $logger = $this->createMock(SQLLogger::class);
         $logger->expects(self::once())

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -62,12 +62,6 @@ class ConnectionTest extends TestCase
     {
         $driverMock = $this->createMock(Driver::class);
 
-        $driverMock->expects(self::any())
-            ->method('connect')
-            ->willReturn(
-                $this->createMock(DriverConnection::class)
-            );
-
         $platform = $this->getMockForAbstractClass(AbstractPlatform::class);
 
         return $this->getMockBuilder(Connection::class)
@@ -135,11 +129,6 @@ class ConnectionTest extends TestCase
     {
         $eventManager = new EventManager();
         $driverMock   = $this->createMock(Driver::class);
-        $driverMock->expects(self::any())
-            ->method('connect')
-            ->willReturn(
-                $this->createMock(DriverConnection::class)
-            );
         $conn         = new Connection([], $driverMock, new Configuration(), $eventManager);
         $listenerMock = $this->createMock(TransactionBeginDispatchEventListener::class);
         $listenerMock
@@ -161,11 +150,6 @@ class ConnectionTest extends TestCase
     {
         $eventManager = new EventManager();
         $driverMock   = $this->createMock(Driver::class);
-        $driverMock->expects(self::any())
-            ->method('connect')
-            ->willReturn(
-                $this->createMock(DriverConnection::class)
-            );
         $conn         = new Connection([], $driverMock, new Configuration(), $eventManager);
         $listenerMock = $this->createMock(TransactionCommitDispatchEventListener::class);
         $listenerMock
@@ -188,12 +172,8 @@ class ConnectionTest extends TestCase
     {
         $eventManager = new EventManager();
         $driverMock   = $this->createMock(Driver::class);
-        $driverMock->expects(self::any())
-            ->method('connect')
-            ->willReturn(
-                $this->createMock(DriverConnection::class)
-            );
-        $conn                 = new Connection([], $driverMock, new Configuration(), $eventManager);
+        $conn         = new Connection([], $driverMock, new Configuration(), $eventManager);
+
         $rollBackListenerMock = $this->createMock(TransactionRollBackDispatchEventListener::class);
         $rollBackListenerMock
             ->expects(self::exactly(1))
@@ -224,11 +204,6 @@ class ConnectionTest extends TestCase
     {
         $eventManager = new EventManager();
         $driverMock   = $this->createMock(Driver::class);
-        $driverMock->expects(self::any())
-            ->method('connect')
-            ->willReturn(
-                $this->createMock(DriverConnection::class)
-            );
         $conn         = new Connection([], $driverMock, new Configuration(), $eventManager);
         $listenerMock = $this->createMock(TransactionRollBackDispatchEventListener::class);
         $listenerMock
@@ -333,11 +308,7 @@ class ConnectionTest extends TestCase
     public function testConnectStartsTransactionInNoAutoCommitMode(): void
     {
         $driverMock = $this->createMock(Driver::class);
-        $driverMock->expects(self::any())
-            ->method('connect')
-            ->willReturn(
-                $this->createMock(DriverConnection::class)
-            );
+
         $conn = new Connection([], $driverMock);
 
         $conn->setAutoCommit(false);
@@ -352,11 +323,7 @@ class ConnectionTest extends TestCase
     public function testCommitStartsTransactionInNoAutoCommitMode(): void
     {
         $driverMock = $this->createMock(Driver::class);
-        $driverMock->expects(self::any())
-            ->method('connect')
-            ->willReturn(
-                $this->createMock(DriverConnection::class)
-            );
+
         $conn = new Connection([], $driverMock);
 
         $conn->setAutoCommit(false);
@@ -377,11 +344,7 @@ class ConnectionTest extends TestCase
     public function testRollBackStartsTransactionInNoAutoCommitMode(): void
     {
         $driverMock = $this->createMock(Driver::class);
-        $driverMock->expects(self::any())
-            ->method('connect')
-            ->willReturn(
-                $this->createMock(DriverConnection::class)
-            );
+
         $conn = new Connection([], $driverMock);
 
         $conn->setAutoCommit(false);
@@ -394,11 +357,7 @@ class ConnectionTest extends TestCase
     public function testSwitchingAutoCommitModeCommitsAllCurrentTransactions(): void
     {
         $driverMock = $this->createMock(Driver::class);
-        $driverMock->expects(self::any())
-            ->method('connect')
-            ->willReturn(
-                $this->createMock(DriverConnection::class)
-            );
+
         $conn = new Connection([], $driverMock);
 
         $conn->connect();
@@ -680,10 +639,7 @@ class ConnectionTest extends TestCase
     {
         $driver = $this->createMock(Driver::class);
         $driver->expects(self::once())
-            ->method('connect')
-            ->willReturn(
-                $this->createMock(Driver\Connection::class)
-            );
+            ->method('connect');
 
         $platform = $this->createMock(AbstractPlatform::class);
 

--- a/tests/Schema/MySQLInheritCharsetTest.php
+++ b/tests/Schema/MySQLInheritCharsetTest.php
@@ -8,7 +8,6 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Column;
@@ -73,8 +72,6 @@ class MySQLInheritCharsetTest extends TestCase
         $eventManager = new EventManager();
 
         $driverMock = $this->createMock(Driver::class);
-        $driverMock->method('connect')
-            ->willReturn($this->createMock(DriverConnection::class));
 
         $platform = new MySQLPlatform();
         $params   = array_merge(['platform' => $platform], $params);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

PHPUnit is capable of generating mocks for the return values if their type is known.