### PR TITLE
Deprecate Connection::getWrappedConnection(), mark Connection::connect() internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 3.3
 
+## Deprecated `Connection::getWrappedConnection()`, `Connection::connect()` made `@internal`.
+
+The wrapper-level `Connection::getWrappedConnection()` method has been deprecated.
+Use `Connection::getNativeConnection()` to access the native connection.
+
+The `Connection::connect()` method has been marked internal. It will be marked `protected` in DBAL 4.0.
+
 ## Add `Connection::getNativeConnection()`
 
 Driver and middleware connections need to implement a new method `getNativeConnection()` that gives access to the

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -197,6 +197,11 @@
 
                 <!-- TODO: remove in 4.0.0 -->
                 <referencedMethod name="Doctrine\DBAL\Driver\PDO\Connection::getWrappedConnection"/>
+                <!--
+                    TODO: remove in 4.0.0
+                    See https://github.com/doctrine/dbal/pull/4966
+                -->
+                <referencedMethod name="Doctrine\DBAL\Connection::getWrappedConnection"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -313,6 +313,8 @@ class Connection
     /**
      * Establishes the connection with the database.
      *
+     * @internal This method will be made protected in DBAL 4.0.
+     *
      * @return bool TRUE if the connection was successfully established, FALSE if
      *              the connection is already open.
      *
@@ -320,6 +322,12 @@ class Connection
      */
     public function connect()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/4966',
+            'Public access to Connection::connect() is deprecated.'
+        );
+
         if ($this->_conn !== null) {
             return false;
         }
@@ -1501,12 +1509,21 @@ class Connection
     /**
      * Gets the wrapped driver connection.
      *
+     * @deprecated Use {@link getNativeConnection()} to access the native connection.
+     *
      * @return DriverConnection
      *
      * @throws Exception
      */
     public function getWrappedConnection()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/4966',
+            'Connection::getWrappedConnection() is deprecated.'
+                . ' Use Connection::getNativeConnection() to access the native connection.'
+        );
+
         $this->connect();
 
         assert($this->_conn !== null);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

Currently, `Connection::getWrappedConnection()` is only used by the connection class itself and the tests. This method will return the object that is immediately wrapped into the wrapper connection. If there's a middleware between the wrapper and the actual driver, it is not guaranteed that there is a way to get to the actual driver.

If it is necessary to get the underlying driver connection, e.g. for integration with another database layer, it's possible to implement a custom driver:
```php
use Doctrine\DBAL\Driver as DriverInterface;

class Driver implements DriverInterface
{
    /** @var DriverInterface */
    private $driver;

    /** @var Connection */
    private $connection;

    public function __construct(DriverInterface $driver)
    {
        $this->driver = $driver;
    }

    public function connect(array $params)
    {
        $this->connection = $this->driver->connect($params);

        return $this->connection;
    }

    public function getWrappedConnection()
    {
        return $this->connection;
    }
}
```

See a complete [example](https://gist.github.com/morozov/aef49beb45ff998c37d9598c6db6d9c5) of a driver middleware for more details.

In DBAL 4.0, the `Connection::connect()` method will return the underlying driver connection and will be made `protected`.