### PR TITLE
[Tools] Add some return type information in a command method

### DIFF
--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -59,7 +59,7 @@ EOT
     /**
      * {@inheritdoc}
      *
-     * @returns int
+     * @return int
      * @throws Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -59,6 +59,7 @@ EOT
     /**
      * {@inheritdoc}
      *
+     * @returns int
      * @throws Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

This is needed to fix the following deprecation:

```
  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Doctrine\DBAL\Tools\Console\Command\RunSqlCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AddUserCommandTest::testCreateUserNonInteractive from App\Tests\Command
```