### PR TITLE
Fix a deprecation in console command return types

### DIFF
--- a/lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php
@@ -50,6 +50,8 @@ EOT
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/ReservedWordsCommand.php
@@ -145,6 +145,8 @@ EOT
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
+++ b/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php
@@ -67,6 +67,8 @@ EOT
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

This is needed to fix the following deprecation:

```
  1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Doctrine\DBAL\Tools\Console\Command\RunSqlCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AddUserCommandTest::testCreateUserNonInteractive from App\Tests\Command
```
