### PR TITLE
Remove `ReturnTypeWillChange` attribute

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -201,12 +201,6 @@
                 <file name="src/Schema/Index.php"/>
             </errorLevel>
         </TypeDoesNotContainType>
-        <UndefinedAttributeClass>
-            <errorLevel type="suppress">
-                <!-- This class has been added in PHP 8.1 -->
-                <referencedClass name="ReturnTypeWillChange"/>
-            </errorLevel>
-        </UndefinedAttributeClass>
         <UndefinedConstant>
             <errorLevel type="suppress">
                 <!--

--- a/src/Query/Expression/CompositeExpression.php
+++ b/src/Query/Expression/CompositeExpression.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Query\Expression;
 
 use Countable;
-use ReturnTypeWillChange;
 
 use function array_merge;
 use function array_values;
@@ -89,7 +88,6 @@ class CompositeExpression implements Countable
     /**
      * Retrieves the amount of expressions on composite expression.
      */
-    #[ReturnTypeWillChange]
     public function count(): int
     {
         return count($this->parts);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

The method received the correct return type on the 4.0.x branch, so we don't need the attribute anymore.
