### PR TITLE
Use correct column order for composite foreign keys

### DIFF
--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -185,7 +185,7 @@ class MySQLPlatform extends AbstractPlatform
         }
 
         $sql = 'SELECT DISTINCT k.`CONSTRAINT_NAME`, k.`COLUMN_NAME`, k.`REFERENCED_TABLE_NAME`, ' .
-               'k.`REFERENCED_COLUMN_NAME` /*!50116 , c.update_rule, c.delete_rule */ ' .
+               'k.`REFERENCED_COLUMN_NAME`, k.`ORDINAL_POSITION` /*!50116 , c.update_rule, c.delete_rule */ ' .
                'FROM information_schema.key_column_usage k /*!50116 ' .
                'INNER JOIN information_schema.referential_constraints c ON ' .
                '  c.constraint_name = k.constraint_name AND ' .
@@ -195,7 +195,8 @@ class MySQLPlatform extends AbstractPlatform
 
         return $sql . ' AND k.table_schema = ' . $databaseNameSql
             . ' /*!50116 AND c.constraint_schema = ' . $databaseNameSql . ' */'
-            . ' AND k.`REFERENCED_COLUMN_NAME` is not NULL';
+            . ' AND k.`REFERENCED_COLUMN_NAME` is not NULL'
+            . ' ORDER BY k.`ORDINAL_POSITION`';
     }
 
     /**

--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -1010,7 +1010,8 @@ class SQLServer2012Platform extends AbstractPlatform
                 INNER JOIN sys.objects AS o ON o.OBJECT_ID = fc.referenced_object_id
                 ON f.OBJECT_ID = fc.constraint_object_id
                 WHERE ' .
-                $this->getTableWhereClause($table, 'SCHEMA_NAME (f.schema_id)', 'OBJECT_NAME (f.parent_object_id)');
+                $this->getTableWhereClause($table, 'SCHEMA_NAME (f.schema_id)', 'OBJECT_NAME (f.parent_object_id)') .
+                ' ORDER BY fc.constraint_column_id';
     }
 
     /**


### PR DESCRIPTION
Fixes wrong foreign key order. For now just an integration test.

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4971
