### PR TITLE
Remove unwanted colon in code samples

### DIFF
--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -405,7 +405,7 @@ class QueryBuilder
      *         ->select('u')
      *         ->from('users', 'u')
      *         ->where('u.id = :user_id')
-     *         ->setParameter(':user_id', 1);
+     *         ->setParameter('user_id', 1);
      * </code>
      *
      * @param int|string           $key   Parameter position or name
@@ -434,8 +434,8 @@ class QueryBuilder
      *         ->from('users', 'u')
      *         ->where('u.id = :user_id1 OR u.id = :user_id2')
      *         ->setParameters(array(
-     *             ':user_id1' => 1,
-     *             ':user_id2' => 2
+     *             'user_id1' => 1,
+     *             'user_id2' => 2
      *         ));
      * </code>
      *


### PR DESCRIPTION
#### Summary

When `setParameter{s,}` is called, we know we are dealing with parameters.
It makes sense that this colon is unneeded, and since it results in an
error being thrown, let us document the one true way of using that API
instead.
