### PR TITLE
Returning file *path* as `->getDatabase()` for SQLite

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -165,7 +165,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getCurrentDatabaseExpression(): string
     {
-        return "''";
+        return "file from pragma_database_list where name='main'";
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | ?
| Fixed issues | none

#### Summary

I'm suggesting to return the file path as "database name" for SQLite (instead of nothing)

Right now, when loading fixtures, the CLI prompt reads:
> Careful, database "" will be purged. Do you want to continue? (yes/no)

This is due to `LoadDataFixturesDoctrineCommand::execute()` at https://github.com/doctrine/DoctrineFixturesBundle/blob/3.4.x/Command/LoadDataFixturesDoctrineCommand.php#L106

I don't know where else `Connection::getDatabase()` gets called, but I'm figuring that returning the path is always a good idea :-)

The query syntax is taken from https://stackoverflow.com/a/44279467/1668200
