### PR TITLE
Add return types to private and final methods

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -755,7 +755,7 @@ class Connection
      *
      * @return array<int, int|string|Type|null>|array<string, int|string|Type|null>
      */
-    private function extractTypeValues(array $columnList, array $types)
+    private function extractTypeValues(array $columnList, array $types): array
     {
         $typeValues = [];
 

--- a/src/Driver/API/SQLite/UserDefinedFunctions.php
+++ b/src/Driver/API/SQLite/UserDefinedFunctions.php
@@ -16,10 +16,8 @@ final class UserDefinedFunctions
      *
      * @param int $a
      * @param int $b
-     *
-     * @return int
      */
-    public static function mod($a, $b)
+    public static function mod($a, $b): int
     {
         return $a % $b;
     }
@@ -30,10 +28,8 @@ final class UserDefinedFunctions
      * @param string $str
      * @param string $substr
      * @param int    $offset
-     *
-     * @return int
      */
-    public static function locate($str, $substr, $offset = 0)
+    public static function locate($str, $substr, $offset = 0): int
     {
         // SQL's LOCATE function works on 1-based positions, while PHP's strpos works on 0-based positions.
         // So we have to make them compatible if an offset is given.

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -111,10 +111,7 @@ final class Connection implements ServerInfoAwareConnection
         return db2_last_insert_id($this->connection);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         $result = db2_autocommit($this->connection, DB2_AUTOCOMMIT_OFF);
         assert(is_bool($result));
@@ -122,10 +119,7 @@ final class Connection implements ServerInfoAwareConnection
         return $result;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function commit()
+    public function commit(): bool
     {
         if (! db2_commit($this->connection)) {
             throw ConnectionError::new($this->connection);
@@ -137,10 +131,7 @@ final class Connection implements ServerInfoAwareConnection
         return $result;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function rollBack()
+    public function rollBack(): bool
     {
         if (! db2_rollback($this->connection)) {
             throw ConnectionError::new($this->connection);

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -59,7 +59,7 @@ final class Statement implements StatementInterface
     /**
      * {@inheritdoc}
      */
-    public function bindValue($param, $value, $type = ParameterType::STRING)
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
         assert(is_int($param));
 
@@ -69,7 +69,7 @@ final class Statement implements StatementInterface
     /**
      * {@inheritdoc}
      */
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
         assert(is_int($param));
 

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -36,10 +36,8 @@ final class Connection implements ServerInfoAwareConnection
      * Retrieves mysqli native resource handle.
      *
      * Could be used if part of your application is not using DBAL.
-     *
-     * @return mysqli
      */
-    public function getWrappedResourceHandle()
+    public function getWrappedResourceHandle(): mysqli
     {
         return $this->connection;
     }
@@ -52,7 +50,7 @@ final class Connection implements ServerInfoAwareConnection
      *
      * @link https://jira.mariadb.org/browse/MDEV-4088
      */
-    public function getServerVersion()
+    public function getServerVersion(): string
     {
         $serverInfos = $this->connection->get_server_info();
         if (stripos($serverInfos, 'mariadb') !== false) {
@@ -125,20 +123,14 @@ final class Connection implements ServerInfoAwareConnection
         return $this->connection->insert_id;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         $this->connection->begin_transaction();
 
         return true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function commit()
+    public function commit(): bool
     {
         try {
             return $this->connection->commit();
@@ -147,10 +139,7 @@ final class Connection implements ServerInfoAwareConnection
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function rollBack()
+    public function rollBack(): bool
     {
         try {
             return $this->connection->rollback();

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -67,7 +67,7 @@ final class Statement implements StatementInterface
     /**
      * {@inheritdoc}
      */
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
         assert(is_int($param));
 
@@ -84,7 +84,7 @@ final class Statement implements StatementInterface
     /**
      * {@inheritdoc}
      */
-    public function bindValue($param, $value, $type = ParameterType::STRING)
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
         assert(is_int($param));
 

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -47,10 +47,7 @@ final class Connection implements ServerInfoAwareConnection
         $this->executionMode = new ExecutionMode();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getServerVersion()
+    public function getServerVersion(): string
     {
         $version = oci_server_version($this->connection);
 
@@ -140,20 +137,14 @@ final class Connection implements ServerInfoAwareConnection
         return (int) $result;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         $this->executionMode->disableAutoCommit();
 
         return true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function commit()
+    public function commit(): bool
     {
         if (! oci_commit($this->connection)) {
             throw Error::new($this->connection);
@@ -164,10 +155,7 @@ final class Connection implements ServerInfoAwareConnection
         return true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function rollBack()
+    public function rollBack(): bool
     {
         if (! oci_rollback($this->connection)) {
             throw Error::new($this->connection);

--- a/src/Driver/OCI8/Driver.php
+++ b/src/Driver/OCI8/Driver.php
@@ -41,16 +41,4 @@ final class Driver extends AbstractOracleDriver
 
         return new Connection($connection);
     }
-
-    /**
-     * Constructs the Oracle DSN.
-     *
-     * @param mixed[] $params
-     *
-     * @return string The DSN.
-     */
-    protected function _constructDsn(array $params)
-    {
-        return $this->getEasyConnectString($params);
-    }
 }

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -53,7 +53,7 @@ final class Statement implements StatementInterface
     /**
      * {@inheritdoc}
      */
-    public function bindValue($param, $value, $type = ParameterType::STRING)
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
         return $this->bindParam($param, $value, $type);
     }
@@ -61,7 +61,7 @@ final class Statement implements StatementInterface
     /**
      * {@inheritdoc}
      */
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
         if (is_int($param)) {
             if (! isset($this->parameterMap[$param])) {

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -108,26 +108,17 @@ final class Connection implements ServerInfoAwareConnection
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         return $this->connection->beginTransaction();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function commit()
+    public function commit(): bool
     {
         return $this->connection->commit();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function rollBack()
+    public function rollBack(): bool
     {
         return $this->connection->rollBack();
     }

--- a/src/Driver/PDO/MySQL/Driver.php
+++ b/src/Driver/PDO/MySQL/Driver.php
@@ -41,10 +41,8 @@ final class Driver extends AbstractMySQLDriver
      * Constructs the MySQL PDO DSN.
      *
      * @param mixed[] $params
-     *
-     * @return string The DSN.
      */
-    private function constructPdoDsn(array $params)
+    private function constructPdoDsn(array $params): string
     {
         $dsn = 'mysql:';
         if (isset($params['host']) && $params['host'] !== '') {

--- a/src/Driver/PDO/OCI/Driver.php
+++ b/src/Driver/PDO/OCI/Driver.php
@@ -41,10 +41,8 @@ final class Driver extends AbstractOracleDriver
      * Constructs the Oracle PDO DSN.
      *
      * @param mixed[] $params
-     *
-     * @return string The DSN.
      */
-    private function constructPdoDsn(array $params)
+    private function constructPdoDsn(array $params): string
     {
         $dsn = 'oci:dbname=' . $this->getEasyConnectString($params);
 

--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -57,10 +57,8 @@ final class Driver extends AbstractPostgreSQLDriver
      * Constructs the Postgres PDO DSN.
      *
      * @param mixed[] $params
-     *
-     * @return string The DSN.
      */
-    private function constructPdoDsn(array $params)
+    private function constructPdoDsn(array $params): string
     {
         $dsn = 'pgsql:';
 

--- a/src/Driver/PDO/SQLSrv/Connection.php
+++ b/src/Driver/PDO/SQLSrv/Connection.php
@@ -65,26 +65,17 @@ final class Connection implements ServerInfoAwareConnection
             ->fetchOne();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         return $this->connection->beginTransaction();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function commit()
+    public function commit(): bool
     {
         return $this->connection->commit();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function rollBack()
+    public function rollBack(): bool
     {
         return $this->connection->rollBack();
     }

--- a/src/Driver/PDO/SQLSrv/Driver.php
+++ b/src/Driver/PDO/SQLSrv/Driver.php
@@ -57,11 +57,9 @@ final class Driver extends AbstractSQLServerDriver
      * @param mixed[]  $params
      * @param string[] $connectionOptions
      *
-     * @return string The DSN.
-     *
      * @throws Exception
      */
-    private function constructDsn(array $params, array $connectionOptions)
+    private function constructDsn(array $params, array $connectionOptions): string
     {
         $dsn = 'sqlsrv:server=';
 

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -33,8 +33,13 @@ final class Statement implements StatementInterface
      * @param int|null   $length
      * @param mixed      $driverOptions The usage of the argument is deprecated.
      */
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null, $driverOptions = null)
-    {
+    public function bindParam(
+        $param,
+        &$variable,
+        $type = ParameterType::STRING,
+        $length = null,
+        $driverOptions = null
+    ): bool {
         if (func_num_args() > 4) {
             Deprecation::triggerIfCalledFromOutside(
                 'doctrine/dbal',
@@ -65,7 +70,7 @@ final class Statement implements StatementInterface
     /**
      * {@inheritdoc}
      */
-    public function bindValue($param, $value, $type = ParameterType::STRING)
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
         return $this->bindParam($param, $value, $type);
     }

--- a/src/Driver/PDO/SQLite/Driver.php
+++ b/src/Driver/PDO/SQLite/Driver.php
@@ -59,10 +59,8 @@ final class Driver extends AbstractSQLiteDriver
      * Constructs the Sqlite PDO DSN.
      *
      * @param mixed[] $params
-     *
-     * @return string The DSN.
      */
-    private function constructPdoDsn(array $params)
+    private function constructPdoDsn(array $params): string
     {
         $dsn = 'sqlite:';
         if (isset($params['path'])) {

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -61,11 +61,14 @@ final class Statement implements StatementInterface
      * @param int      $type
      * @param int|null $length
      * @param mixed    $driverOptions The usage of the argument is deprecated.
-     *
-     * @return bool
      */
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null, $driverOptions = null)
-    {
+    public function bindParam(
+        $param,
+        &$variable,
+        $type = ParameterType::STRING,
+        $length = null,
+        $driverOptions = null
+    ): bool {
         if (func_num_args() > 4) {
             Deprecation::triggerIfCalledFromOutside(
                 'doctrine/dbal',

--- a/src/Driver/SQLSrv/Connection.php
+++ b/src/Driver/SQLSrv/Connection.php
@@ -109,10 +109,7 @@ final class Connection implements ServerInfoAwareConnection
         return $result->fetchOne();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         if (! sqlsrv_begin_transaction($this->connection)) {
             throw Error::new();
@@ -121,10 +118,7 @@ final class Connection implements ServerInfoAwareConnection
         return true;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function commit()
+    public function commit(): bool
     {
         if (! sqlsrv_commit($this->connection)) {
             throw Error::new();
@@ -133,10 +127,7 @@ final class Connection implements ServerInfoAwareConnection
         return true;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function rollBack()
+    public function rollBack(): bool
     {
         if (! sqlsrv_rollback($this->connection)) {
             throw Error::new();

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -84,7 +84,7 @@ final class Statement implements StatementInterface
     /**
      * {@inheritdoc}
      */
-    public function bindValue($param, $value, $type = ParameterType::STRING)
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
         assert(is_int($param));
 
@@ -97,7 +97,7 @@ final class Statement implements StatementInterface
     /**
      * {@inheritdoc}
      */
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
         assert(is_int($param));
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -169,10 +169,8 @@ abstract class AbstractPlatform
     /**
      * Initializes Doctrine Type Mappings with the platform defaults
      * and with all additional type mappings.
-     *
-     * @return void
      */
-    private function initializeAllDoctrineTypeMappings()
+    private function initializeAllDoctrineTypeMappings(): void
     {
         $this->initializeDoctrineTypeMappings();
 
@@ -3689,11 +3687,9 @@ abstract class AbstractPlatform
      * @param int|null $limit
      * @param int      $offset
      *
-     * @return string
-     *
      * @throws Exception
      */
-    final public function modifyLimitQuery($query, $limit, $offset = 0)
+    final public function modifyLimitQuery($query, $limit, $offset = 0): string
     {
         if ($offset < 0) {
             throw new Exception(sprintf(
@@ -3845,11 +3841,9 @@ abstract class AbstractPlatform
     /**
      * Returns the keyword list instance of this platform.
      *
-     * @return KeywordList
-     *
      * @throws Exception If no keyword list is specified.
      */
-    final public function getReservedKeywordsList()
+    final public function getReservedKeywordsList(): KeywordList
     {
         // Check for an existing instantiation of the keywords class.
         if ($this->_keywords === null) {

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -633,11 +633,9 @@ class DB2Platform extends AbstractPlatform
     /**
      * Returns the ALTER COLUMN SQL clauses for altering a column described by the given column diff.
      *
-     * @param ColumnDiff $columnDiff The column diff to evaluate.
-     *
      * @return string[]
      */
-    private function getAlterColumnClausesSQL(ColumnDiff $columnDiff)
+    private function getAlterColumnClausesSQL(ColumnDiff $columnDiff): array
     {
         $column = $columnDiff->column->toArray();
 

--- a/src/Platforms/Keywords/ReservedKeywordsValidator.php
+++ b/src/Platforms/Keywords/ReservedKeywordsValidator.php
@@ -43,7 +43,7 @@ class ReservedKeywordsValidator implements Visitor
      *
      * @return string[]
      */
-    private function isReservedWord($word)
+    private function isReservedWord($word): array
     {
         if ($word[0] === '`') {
             $word = str_replace('`', '', $word);
@@ -64,10 +64,8 @@ class ReservedKeywordsValidator implements Visitor
     /**
      * @param string   $asset
      * @param string[] $violatedPlatforms
-     *
-     * @return void
      */
-    private function addViolation($asset, $violatedPlatforms)
+    private function addViolation($asset, $violatedPlatforms): void
     {
         if (count($violatedPlatforms) === 0) {
             return;

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -447,10 +447,8 @@ SQL
      * Build SQL for table options
      *
      * @param mixed[] $options
-     *
-     * @return string
      */
-    private function buildTableOptions(array $options)
+    private function buildTableOptions(array $options): string
     {
         if (isset($options['table_options'])) {
             return $options['table_options'];
@@ -501,10 +499,8 @@ SQL
      * Build SQL for partition options.
      *
      * @param mixed[] $options
-     *
-     * @return string
      */
-    private function buildPartitionOptions(array $options)
+    private function buildPartitionOptions(array $options): string
     {
         return isset($options['partition_options'])
             ? ' ' . $options['partition_options']
@@ -682,7 +678,7 @@ SQL
      *
      * @throws Exception
      */
-    private function getPreAlterTableAlterPrimaryKeySQL(TableDiff $diff, Index $index)
+    private function getPreAlterTableAlterPrimaryKeySQL(TableDiff $diff, Index $index): array
     {
         $sql = [];
 
@@ -723,7 +719,7 @@ SQL
      *
      * @throws Exception
      */
-    private function getPreAlterTableAlterIndexForeignKeySQL(TableDiff $diff)
+    private function getPreAlterTableAlterIndexForeignKeySQL(TableDiff $diff): array
     {
         $sql   = [];
         $table = $diff->getName($this)->getQuotedName($this);
@@ -787,7 +783,7 @@ SQL
      *
      * @return ForeignKeyConstraint[]
      */
-    private function getRemainingForeignKeyConstraintsRequiringRenamedIndexes(TableDiff $diff)
+    private function getRemainingForeignKeyConstraintsRequiringRenamedIndexes(TableDiff $diff): array
     {
         if (empty($diff->renamedIndexes) || ! $diff->fromTable instanceof Table) {
             return [];
@@ -912,10 +908,8 @@ SQL
      * Get unsigned declaration for a column.
      *
      * @param mixed[] $columnDef
-     *
-     * @return string
      */
-    private function getUnsignedDeclaration(array $columnDef)
+    private function getUnsignedDeclaration(array $columnDef): string
     {
         return ! empty($columnDef['unsigned']) ? ' UNSIGNED' : '';
     }

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -218,10 +218,8 @@ class OraclePlatform extends AbstractPlatform
 
     /**
      * Cache definition for sequences
-     *
-     * @return string
      */
-    private function getSequenceCacheSQL(Sequence $sequence)
+    private function getSequenceCacheSQL(Sequence $sequence): string
     {
         if ($sequence->getCache() === 0) {
             return ' NOCACHE';
@@ -587,10 +585,8 @@ END;';
      * to reflect Oracle's internal auto uppercasing strategy of unquoted identifiers.
      *
      * @param string $name The identifier to normalize.
-     *
-     * @return Identifier The normalized identifier.
      */
-    private function normalizeIdentifier($name)
+    private function normalizeIdentifier($name): Identifier
     {
         $identifier = new Identifier($name);
 
@@ -618,12 +614,8 @@ END;';
      *
      * Quotes the autoincrement primary key identifier name
      * if the given table name is quoted by intention.
-     *
-     * @param Identifier $table The table identifier to return the autoincrement primary key identifier name for.
-     *
-     * @return string
      */
-    private function getAutoincrementIdentifierName(Identifier $table)
+    private function getAutoincrementIdentifierName(Identifier $table): string
     {
         $identifierName = $this->addSuffix($table->getName(), '_AI_PK');
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -362,10 +362,8 @@ SQL
      * @param string $table
      * @param string $classAlias
      * @param string $namespaceAlias
-     *
-     * @return string
      */
-    private function getTableWhereClause($table, $classAlias = 'c', $namespaceAlias = 'n')
+    private function getTableWhereClause($table, $classAlias = 'c', $namespaceAlias = 'n'): string
     {
         $whereClause = $namespaceAlias . ".nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast') AND ";
         if (strpos($table, '.') !== false) {
@@ -621,12 +619,8 @@ SQL
      * as this platform does not have a native VARBINARY/BINARY column type. Therefore the comparator
      * might detect differences for binary type columns which do not have to be propagated
      * to database as there actually is no difference at database level.
-     *
-     * @param ColumnDiff $columnDiff The column diff to check against.
-     *
-     * @return bool True if the given column diff is an unchanged binary type column, false otherwise.
      */
-    private function isUnchangedBinaryColumn(ColumnDiff $columnDiff)
+    private function isUnchangedBinaryColumn(ColumnDiff $columnDiff): bool
     {
         $columnType = $columnDiff->column->getType();
 
@@ -707,10 +701,8 @@ SQL
 
     /**
      * Cache definition for sequences
-     *
-     * @return string
      */
-    private function getSequenceCacheSQL(Sequence $sequence)
+    private function getSequenceCacheSQL(Sequence $sequence): string
     {
         if ($sequence->getCache() > 1) {
             return ' CACHE ' . $sequence->getCache();

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -65,10 +65,8 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * @param string $dataType   The target native data type. Alias data types cannot be used.
      * @param string $expression The SQL expression to convert.
-     *
-     * @return string
      */
-    private function getConvertExpression($dataType, $expression)
+    private function getConvertExpression($dataType, $expression): string
     {
         return sprintf('CONVERT(%s, %s)', $dataType, $expression);
     }
@@ -441,10 +439,8 @@ class SQLServerPlatform extends AbstractPlatform
      * Extend unique key constraint with required filters
      *
      * @param string $sql
-     *
-     * @return string
      */
-    private function _appendUniqueConstraintDefinition($sql, Index $index)
+    private function _appendUniqueConstraintDefinition($sql, Index $index): string
     {
         $fields = [];
 
@@ -632,10 +628,8 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * @param string $tableName The name of the table to generate the clause for.
      * @param Column $column    The column to generate the clause for.
-     *
-     * @return string
      */
-    private function getAlterTableAddDefaultConstraintClause($tableName, Column $column)
+    private function getAlterTableAddDefaultConstraintClause($tableName, Column $column): string
     {
         $columnDef         = $column->toArray();
         $columnDef['name'] = $column->getQuotedName($this);
@@ -648,10 +642,8 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * @param string $tableName  The name of the table to generate the clause for.
      * @param string $columnName The name of the column to generate the clause for.
-     *
-     * @return string
      */
-    private function getAlterTableDropDefaultConstraintClause($tableName, $columnName)
+    private function getAlterTableDropDefaultConstraintClause($tableName, $columnName): string
     {
         return 'DROP CONSTRAINT ' . $this->generateDefaultConstraintName($tableName, $columnName);
     }
@@ -663,12 +655,8 @@ class SQLServerPlatform extends AbstractPlatform
      * as constraints and therefore changes in a column's default value as well as changes
      * in a column's type require dropping the default constraint first before being to
      * alter the particular column to the new definition.
-     *
-     * @param ColumnDiff $columnDiff The column diff to evaluate.
-     *
-     * @return bool True if the column alteration requires dropping its default constraint first, false otherwise.
      */
-    private function alterColumnRequiresDropDefaultConstraint(ColumnDiff $columnDiff)
+    private function alterColumnRequiresDropDefaultConstraint(ColumnDiff $columnDiff): bool
     {
         // We can only decide whether to drop an existing default constraint
         // if we know the original default value.
@@ -1004,10 +992,8 @@ class SQLServerPlatform extends AbstractPlatform
      * @param string $table        The full qualified name of the table.
      * @param string $schemaColumn The name of the column to compare the schema to in the where clause.
      * @param string $tableColumn  The name of the column to compare the table to in the where clause.
-     *
-     * @return string
      */
-    private function getTableWhereClause($table, $schemaColumn, $tableColumn)
+    private function getTableWhereClause($table, $schemaColumn, $tableColumn): string
     {
         if (strpos($table, '.') !== false) {
             [$schema, $table] = explode('.', $table);
@@ -1582,10 +1568,8 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * @param string $table  Name of the table to generate the unique default constraint name for.
      * @param string $column Name of the column in the table to generate the unique default constraint name for.
-     *
-     * @return string
      */
-    private function generateDefaultConstraintName($table, $column)
+    private function generateDefaultConstraintName($table, $column): string
     {
         return 'DF_' . $this->generateIdentifierName($table) . '_' . $this->generateIdentifierName($column);
     }
@@ -1594,10 +1578,8 @@ class SQLServerPlatform extends AbstractPlatform
      * Returns a hash value for a given identifier.
      *
      * @param string $identifier Identifier to generate a hash value for.
-     *
-     * @return string
      */
-    private function generateIdentifierName($identifier)
+    private function generateIdentifierName($identifier): string
     {
         // Always generate name for unquoted identifiers to ensure consistency.
         $identifier = new Identifier($identifier);

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -1140,7 +1140,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * @return string[]
      */
-    private function getColumnNamesInAlteredTable(TableDiff $diff, Table $fromTable)
+    private function getColumnNamesInAlteredTable(TableDiff $diff, Table $fromTable): array
     {
         $columns = [];
 
@@ -1180,7 +1180,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * @return Index[]
      */
-    private function getIndexesInAlteredTable(TableDiff $diff, Table $fromTable)
+    private function getIndexesInAlteredTable(TableDiff $diff, Table $fromTable): array
     {
         $indexes     = $fromTable->getIndexes();
         $columnNames = $this->getColumnNamesInAlteredTable($diff, $fromTable);
@@ -1248,7 +1248,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * @return ForeignKeyConstraint[]
      */
-    private function getForeignKeysInAlteredTable(TableDiff $diff, Table $fromTable)
+    private function getForeignKeysInAlteredTable(TableDiff $diff, Table $fromTable): array
     {
         $foreignKeys = $fromTable->getForeignKeys();
         $columnNames = $this->getColumnNamesInAlteredTable($diff, $fromTable);
@@ -1312,7 +1312,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * @return Index[]
      */
-    private function getPrimaryIndexInAlteredTable(TableDiff $diff, Table $fromTable)
+    private function getPrimaryIndexInAlteredTable(TableDiff $diff, Table $fromTable): array
     {
         $primaryIndex = [];
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -1315,11 +1315,9 @@ class QueryBuilder
     }
 
     /**
-     * @return string
-     *
      * @throws QueryException
      */
-    private function getSQLForSelect()
+    private function getSQLForSelect(): string
     {
         $query = 'SELECT ' . ($this->sqlParts['distinct'] ? 'DISTINCT ' : '') .
                   implode(', ', $this->sqlParts['select']);
@@ -1346,7 +1344,7 @@ class QueryBuilder
      *
      * @throws QueryException
      */
-    private function getFromClauses()
+    private function getFromClauses(): array
     {
         $fromClauses  = [];
         $knownAliases = [];
@@ -1385,20 +1383,15 @@ class QueryBuilder
         }
     }
 
-    /**
-     * @return bool
-     */
-    private function isLimitQuery()
+    private function isLimitQuery(): bool
     {
         return $this->maxResults !== null || $this->firstResult !== 0;
     }
 
     /**
      * Converts this instance into an INSERT string in SQL.
-     *
-     * @return string
      */
-    private function getSQLForInsert()
+    private function getSQLForInsert(): string
     {
         return 'INSERT INTO ' . $this->sqlParts['from']['table'] .
         ' (' . implode(', ', array_keys($this->sqlParts['values'])) . ')' .
@@ -1407,10 +1400,8 @@ class QueryBuilder
 
     /**
      * Converts this instance into an UPDATE string in SQL.
-     *
-     * @return string
      */
-    private function getSQLForUpdate()
+    private function getSQLForUpdate(): string
     {
         $table = $this->sqlParts['from']['table']
             . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
@@ -1422,10 +1413,8 @@ class QueryBuilder
 
     /**
      * Converts this instance into a DELETE string in SQL.
-     *
-     * @return string
      */
-    private function getSQLForDelete()
+    private function getSQLForDelete(): string
     {
         $table = $this->sqlParts['from']['table']
             . ($this->sqlParts['from']['alias'] ? ' ' . $this->sqlParts['from']['alias'] : '');
@@ -1517,11 +1506,9 @@ class QueryBuilder
      * @param string             $fromAlias
      * @param array<string,true> $knownAliases
      *
-     * @return string
-     *
      * @throws QueryException
      */
-    private function getSQLForJoins($fromAlias, array &$knownAliases)
+    private function getSQLForJoins($fromAlias, array &$knownAliases): string
     {
         $sql = '';
 

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -195,10 +195,8 @@ class Comparator
     /**
      * @param Schema   $schema
      * @param Sequence $sequence
-     *
-     * @return bool
      */
-    private function isAutoIncrementSequenceInSchema($schema, $sequence)
+    private function isAutoIncrementSequenceInSchema($schema, $sequence): bool
     {
         foreach ($schema->getTables() as $table) {
             if ($sequence->isAutoIncrementsFor($table)) {
@@ -355,10 +353,8 @@ class Comparator
     /**
      * Try to find columns that only changed their name, rename operations maybe cheaper than add/drop
      * however ambiguities between different possibilities should not lead to renaming at all.
-     *
-     * @return void
      */
-    private function detectColumnRenamings(TableDiff $tableDifferences)
+    private function detectColumnRenamings(TableDiff $tableDifferences): void
     {
         $renameCandidates = [];
         foreach ($tableDifferences->addedColumns as $addedColumnName => $addedColumn) {
@@ -395,10 +391,8 @@ class Comparator
     /**
      * Try to find indexes that only changed their name, rename operations maybe cheaper than add/drop
      * however ambiguities between different possibilities should not lead to renaming at all.
-     *
-     * @return void
      */
-    private function detectIndexRenamings(TableDiff $tableDifferences)
+    private function detectIndexRenamings(TableDiff $tableDifferences): void
     {
         $renameCandidates = [];
 

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -367,10 +367,8 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * on the referenced table the foreign key constraint is associated with.
      *
      * @param string $event Name of the database operation/event to return the referential action for.
-     *
-     * @return string|null
      */
-    private function onEvent($event)
+    private function onEvent($event): ?string
     {
         if (isset($this->_options[$event])) {
             $onEvent = strtoupper($this->_options[$event]);

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -336,10 +336,8 @@ class Index extends AbstractAsset implements Constraint
 
     /**
      * Return whether the two indexes have the same partial index
-     *
-     * @return bool
      */
-    private function samePartialIndex(Index $other)
+    private function samePartialIndex(Index $other): bool
     {
         if (
             $this->hasOption('where')

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -308,10 +308,8 @@ class OracleSchemaManager extends AbstractSchemaManager
      * and thus make references to the particular identifier work.
      *
      * @param string $identifier The identifier to quote.
-     *
-     * @return string The quoted identifier.
      */
-    private function getQuotedIdentifierName($identifier)
+    private function getQuotedIdentifierName($identifier): string
     {
         if (preg_match('/[a-z]/', $identifier) === 1) {
             return $this->_platform->quoteIdentifier($identifier);

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -298,10 +298,8 @@ SQL
      *
      * @param string $table
      * @param string $column
-     *
-     * @return string
      */
-    private function getColumnConstraintSQL($table, $column)
+    private function getColumnConstraintSQL($table, $column): string
     {
         return "SELECT sysobjects.[Name]
             FROM sysobjects INNER JOIN (SELECT [Name],[ID] FROM sysobjects WHERE XType = 'U') AS Tab

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -194,10 +194,8 @@ class Schema extends AbstractAsset
 
     /**
      * @param string $name
-     *
-     * @return string
      */
-    private function getFullQualifiedAssetName($name)
+    private function getFullQualifiedAssetName($name): string
     {
         $name = $this->getUnquotedAssetName($name);
 
@@ -217,10 +215,8 @@ class Schema extends AbstractAsset
      * Returns the unquoted representation of a given asset name.
      *
      * @param string $assetName Quoted or unquoted representation of an asset name.
-     *
-     * @return string
      */
-    private function getUnquotedAssetName($assetName)
+    private function getUnquotedAssetName($assetName): string
     {
         if ($this->isIdentifierQuoted($assetName)) {
             return $this->trimQuotes($assetName);

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -481,11 +481,9 @@ class SqliteSchemaManager extends AbstractSchemaManager
     /**
      * @param Table|string $table
      *
-     * @return TableDiff
-     *
      * @throws Exception
      */
-    private function getTableDiffForAlterForeignKey($table)
+    private function getTableDiffForAlterForeignKey($table): TableDiff
     {
         if (! $table instanceof Table) {
             $table = $this->listTableDetails($table);

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -314,8 +314,6 @@ class Table extends AbstractAsset
      * @param string[] $flags
      * @param mixed[]  $options
      *
-     * @return Index
-     *
      * @throws SchemaException
      */
     private function _createIndex(
@@ -325,7 +323,7 @@ class Table extends AbstractAsset
         $isPrimary,
         array $flags = [],
         array $options = []
-    ) {
+    ): Index {
         if (preg_match('(([^a-zA-Z0-9_]+))', $this->normalizeIdentifier($indexName)) === 1) {
             throw SchemaException::indexNameInvalid($indexName);
         }

--- a/src/Schema/Visitor/Graphviz.php
+++ b/src/Schema/Visitor/Graphviz.php
@@ -62,10 +62,7 @@ class Graphviz extends AbstractVisitor
         );
     }
 
-    /**
-     * @return string
-     */
-    private function createTableLabel(Table $table)
+    private function createTableLabel(Table $table): string
     {
         // Start the table
         $label = '<<TABLE CELLSPACING="0" BORDER="1" ALIGN="LEFT">';
@@ -107,10 +104,8 @@ class Graphviz extends AbstractVisitor
     /**
      * @param string   $name
      * @param string[] $options
-     *
-     * @return string
      */
-    private function createNode($name, $options)
+    private function createNode($name, $options): string
     {
         $node = $name . ' [';
         foreach ($options as $key => $value) {
@@ -126,10 +121,8 @@ class Graphviz extends AbstractVisitor
      * @param string   $node1
      * @param string   $node2
      * @param string[] $options
-     *
-     * @return string
      */
-    private function createNodeRelation($node1, $node2, $options)
+    private function createNodeRelation($node1, $node2, $options): string
     {
         $relation = $node1 . ' -> ' . $node2 . ' [';
         foreach ($options as $key => $value) {

--- a/src/Types/AsciiStringType.php
+++ b/src/Types/AsciiStringType.php
@@ -12,15 +12,12 @@ final class AsciiStringType extends StringType
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $column, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return $platform->getAsciiStringTypeDeclarationSQL($column);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBindingType()
+    public function getBindingType(): int
     {
         return ParameterType::ASCII;
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

Adding a return type to a method is a breaking change for code if we have to assume that downstream code overrides that method without or with a different return type.

In this PR, I'd like to propose to add return types to several methods where I was certain about the previously annotated return type and where we can be sure that downstream code does not override a method because…

* … it is declared `private`
* … it is declared `final`
* … it is a member of a `final` class
