### PR TITLE
Fix MSSQL CLOB column type to support Unicode

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServer2005Platform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServer2005Platform.php
@@ -33,7 +33,7 @@ class SQLServer2005Platform extends SQLServerPlatform
      */
     public function getClobTypeDeclarationSQL(array $column)
     {
-        return 'VARCHAR(MAX)';
+        return 'NVARCHAR(MAX)';
     }
 
     /**

--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use InvalidArgumentException;
 
 use function array_merge;
@@ -1238,7 +1240,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getClobTypeDeclarationSQL(array $column)
     {
-        return 'VARCHAR(MAX)';
+        return 'NVARCHAR(MAX)';
     }
 
     /**
@@ -1530,6 +1532,20 @@ class SQLServerPlatform extends AbstractPlatform
             'image' => 'blob',
             'uniqueidentifier' => 'guid',
         ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCommentedDoctrineType(Type $doctrineType)
+    {
+        if ($doctrineType->getName() === Types::TEXT) {
+            // We require a commented text type in order to distinguish between text and string
+            // as both (have to) map to the same native type.
+            return true;
+        }
+
+        return parent::isCommentedDoctrineType($doctrineType);
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 use function sprintf;
 
@@ -143,9 +144,9 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
             'NVARCHAR(255)',
             $this->platform->getVarcharTypeDeclarationSQL([])
         );
-        self::assertSame('VARCHAR(MAX)', $this->platform->getClobTypeDeclarationSQL([]));
+        self::assertSame('NVARCHAR(MAX)', $this->platform->getClobTypeDeclarationSQL([]));
         self::assertSame(
-            'VARCHAR(MAX)',
+            'NVARCHAR(MAX)',
             $this->platform->getClobTypeDeclarationSQL(['length' => 5, 'fixed' => true])
         );
     }
@@ -741,7 +742,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     public function getCreateTableColumnTypeCommentsSQL(): array
     {
         return [
-            'CREATE TABLE test (id INT NOT NULL, data VARCHAR(MAX) NOT NULL, PRIMARY KEY (id))',
+            'CREATE TABLE test (id INT NOT NULL, data NVARCHAR(MAX) NOT NULL, PRIMARY KEY (id))',
             "EXEC sp_addextendedproperty N'MS_Description', N'(DC2Type:array)', "
                 . "N'SCHEMA', 'dbo', N'TABLE', 'test', N'COLUMN', data",
         ];
@@ -780,8 +781,8 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
                     . 'comment INT NOT NULL, '
                     . '[comment_quoted] INT NOT NULL, '
                     . '[create] INT NOT NULL, '
-                    . 'commented_type VARCHAR(MAX) NOT NULL, '
-                    . 'commented_type_with_comment VARCHAR(MAX) NOT NULL, '
+                    . 'commented_type NVARCHAR(MAX) NOT NULL, '
+                    . 'commented_type_with_comment NVARCHAR(MAX) NOT NULL, '
                     . 'comment_with_string_literal_char NVARCHAR(255) NOT NULL, '
                     . 'PRIMARY KEY (id))',
                 "EXEC sp_addextendedproperty N'MS_Description', "
@@ -988,14 +989,14 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
                 'ALTER TABLE mytable ADD added_comment INT NOT NULL',
                 'ALTER TABLE mytable ADD [added_comment_quoted] INT NOT NULL',
                 'ALTER TABLE mytable ADD [select] INT NOT NULL',
-                'ALTER TABLE mytable ADD added_commented_type VARCHAR(MAX) NOT NULL',
-                'ALTER TABLE mytable ADD added_commented_type_with_comment VARCHAR(MAX) NOT NULL',
+                'ALTER TABLE mytable ADD added_commented_type NVARCHAR(MAX) NOT NULL',
+                'ALTER TABLE mytable ADD added_commented_type_with_comment NVARCHAR(MAX) NOT NULL',
                 'ALTER TABLE mytable ADD added_comment_with_string_literal_char NVARCHAR(255) NOT NULL',
                 'ALTER TABLE mytable DROP COLUMN comment_integer_0',
                 'ALTER TABLE mytable ALTER COLUMN comment_null NVARCHAR(255) NOT NULL',
-                'ALTER TABLE mytable ALTER COLUMN comment_empty_string VARCHAR(MAX) NOT NULL',
-                'ALTER TABLE mytable ALTER COLUMN [comment_quoted] VARCHAR(MAX) NOT NULL',
-                'ALTER TABLE mytable ALTER COLUMN [create] VARCHAR(MAX) NOT NULL',
+                'ALTER TABLE mytable ALTER COLUMN comment_empty_string NVARCHAR(MAX) NOT NULL',
+                'ALTER TABLE mytable ALTER COLUMN [comment_quoted] NVARCHAR(MAX) NOT NULL',
+                'ALTER TABLE mytable ALTER COLUMN [create] NVARCHAR(MAX) NOT NULL',
                 'ALTER TABLE mytable ALTER COLUMN commented_type INT NOT NULL',
 
                 // Added columns.
@@ -1120,6 +1121,18 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
 
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('uniqueidentifier'));
         self::assertSame('guid', $this->platform->getDoctrineTypeMapping('uniqueidentifier'));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIsCommentedDoctrineType(): array
+    {
+        $data = parent::getIsCommentedDoctrineType();
+
+        $data[Types::TEXT] = [Type::getType(Types::TEXT), true];
+
+        return $data;
     }
 
     protected function getBinaryMaxLength(): int


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes

#### Summary

`VARCHAR` MSSQL type does not support Unicode, fix CLOB mapping to `NVARCHAR`. This is also consistent with standard string mapping which uses `NVARCHAR` already.