### PR TITLE
Fixed Oracle quoted identifier handling

### DIFF
--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -669,6 +669,26 @@ END;';
     /**
      * {@inheritDoc}
      */
+    public function getDropIndexSQL($index, $table = null)
+    {
+        if ($index instanceof Index) {
+            $index = $index->getQuotedName($this);
+        } elseif (! is_string($index)) {
+            throw new InvalidArgumentException(
+                __METHOD__ . '() expects $index parameter to be string or ' . Index::class . '.'
+            );
+        }
+
+        if( strtoupper($index) !== $index) {
+            $index = $this->quoteIdentifier($index);
+        }
+
+        return 'DROP INDEX ' . $index;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getListTableColumnsSQL($table, $database = null)
     {
         $table = $this->normalizeIdentifier($table);
@@ -960,6 +980,10 @@ SQL
      */
     protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
     {
+        if(strtoupper($oldIndexName) !== $oldIndexName) {
+            $oldIndexName = $this->quoteIdentifier($oldIndexName);
+        }
+
         if (strpos($tableName, '.') !== false) {
             [$schema]     = explode('.', $tableName);
             $oldIndexName = $schema . '.' . $oldIndexName;

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -1008,7 +1008,7 @@ SQL
         $table = new Identifier($tableName);
 
         // No usage of column name to preserve BC compatibility with <2.5
-        $identitySequenceName = $this->addSuffix($table->getName(), '_seq');
+        $identitySequenceName = $this->addSuffix($table->getName() . '_' . $columnName, '_seq');
 
         if ($table->isQuoted()) {
             $identitySequenceName = '"' . $identitySequenceName . '"';

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -1008,7 +1008,7 @@ SQL
         $table = new Identifier($tableName);
 
         // No usage of column name to preserve BC compatibility with <2.5
-        $identitySequenceName = $this->addSuffix($table->getName(), '_SEQ');
+        $identitySequenceName = $this->addSuffix($table->getName(), '_seq');
 
         if ($table->isQuoted()) {
             $identitySequenceName = '"' . $identitySequenceName . '"';

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -829,6 +829,30 @@ EOD;
         self::assertEquals($createTriggerStatement, $sql[3]);
     }
 
+    public function testDropIndexWithoutQuotedIndexName(): void
+    {
+        $sql = $this->platform->getDropIndexSQL('IDX_NAME');
+        self::assertEquals('DROP INDEX IDX_NAME', $sql[0]);
+    }
+
+    public function testDropIndexWithInitiallyQuotedIndexName(): void
+    {
+        $sql = $this->platform->getDropIndexSQL('idx_name');
+        self::assertEquals('DROP INDEX "idx_name"', $sql[0]);
+    }
+
+    public function testRenameIndexWithoutQuotedIndexName(): void
+    {
+        $sql = $this->platform->getRenameIndexSQL('OLDNAME', new Index('newname', []), 'TEST.testtable');
+        self::assertEquals('ALTER INDEX TEST.OLDNAME RENAME TO newname', $sql[0]);
+    }
+
+    public function testRenameIndexWithInitiallyQuotedIndexName(): void
+    {
+        $sql = $this->platform->getRenameIndexSQL('oldname', new Index('"newname"', []), 'TEST.testtable');
+        self::assertEquals('ALTER INDEX TEST."oldname" RENAME TO "newname"', $sql[0]);
+    }
+
     /**
      * @dataProvider getReturnsGetListTableColumnsSQL
      */

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -591,10 +591,10 @@ SQL
 
     public function testReturnsIdentitySequenceName(): void
     {
-        self::assertSame('MYTABLE_SEQ', $this->platform->getIdentitySequenceName('mytable', 'mycolumn'));
-        self::assertSame('"mytable_SEQ"', $this->platform->getIdentitySequenceName('"mytable"', 'mycolumn'));
-        self::assertSame('MYTABLE_SEQ', $this->platform->getIdentitySequenceName('mytable', '"mycolumn"'));
-        self::assertSame('"mytable_SEQ"', $this->platform->getIdentitySequenceName('"mytable"', '"mycolumn"'));
+        self::assertSame('MYTABLE_MYCOLUMN_SEQ', $this->platform->getIdentitySequenceName('mytable', 'mycolumn'));
+        self::assertSame('"mytable_mycolumn_seq"', $this->platform->getIdentitySequenceName('"mytable"', 'mycolumn'));
+        self::assertSame('MYTABLE_MYCOLUMN_SEQ', $this->platform->getIdentitySequenceName('mytable', '"mycolumn"'));
+        self::assertSame('"mytable_mycolumn_seq"', $this->platform->getIdentitySequenceName('"mytable"', '"mycolumn"'));
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues |

## Summary

### Fixed dropping/renaming initially quoted indexes:

Oracle turns all unquoted identifiers to upper case, e.g. idx_name to IDX_NAME
and returns the upper case names in listTableIndexes() but not if they have
been quoted initially, i.e. using "idx_name".

When using a schema diff, DBAL doesn't know any more that the index names
have been quoted initially and creates a SQL statement with unquoted
identifiers which causes an "index not available" error.

### Streamlines identity sequence name with PostgreSQL

Using "autoincrement" option creates a sequence with the table name
(e.g. test) and _SEQ as suffix, i.e. test_SEQ. If unquoted, Oracle platform
class turns this to TEST_SEQ but if the table name is quoted, it will be "test_SEQ".

This change adds lower case "_seq" as suffix so test_seq will be still
turned to TEST_SEQ by platform driver but quoted "test_seq" stays as is. Quoted
table names will now create the same sequence names as PostgreSQL does so
no special handling of "test_SEQ" in Oracle and "test_seq" in PostgreSQL
is necessary any more.

Furthermore this creates the same sequence names as PostgreSQL now, so

$conn->lastInsertId('table_col_seq')

will work for PostgreSQL and Oracle