### PR TITLE
Oracle: Keep quoted index names during renameing

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2122,8 +2122,8 @@ abstract class AbstractPlatform
             $sql[] = $this->getCreateIndexSQL($index, $tableName);
         }
 
-        foreach ($diff->renamedIndexes as $oldIndexName => $index) {
-            $oldIndexName = new Identifier($index->oldName ?: $oldIndexName);
+        foreach ($diff->renamedIndexes as $index) {
+            $oldIndexName = new Identifier($index->getPreviousName());
             $sql          = array_merge(
                 $sql,
                 $this->getRenameIndexSQL($oldIndexName->getQuotedName($this), $index, $tableName)

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2123,7 +2123,7 @@ abstract class AbstractPlatform
         }
 
         foreach ($diff->renamedIndexes as $oldIndexName => $index) {
-            $oldIndexName = new Identifier($oldIndexName);
+            $oldIndexName = new Identifier($index->oldName ?: $oldIndexName);
             $sql          = array_merge(
                 $sql,
                 $this->getRenameIndexSQL($oldIndexName->getQuotedName($this), $index, $tableName)

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -16,6 +16,13 @@ use function strtolower;
 class Index extends AbstractAsset implements Constraint
 {
     /**
+     * Old (quoted) index name if index is renamed.
+     *
+     * @var string|false
+     */
+    public $oldName = false;
+
+    /**
      * Asset identifier instances of the column names the index is associated with.
      * array($columnName => Identifier)
      *

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -16,13 +16,6 @@ use function strtolower;
 class Index extends AbstractAsset implements Constraint
 {
     /**
-     * Old (quoted) index name if index is renamed.
-     *
-     * @var string|false
-     */
-    public $oldName = false;
-
-    /**
      * Asset identifier instances of the column names the index is associated with.
      * array($columnName => Identifier)
      *
@@ -45,6 +38,13 @@ class Index extends AbstractAsset implements Constraint
     protected $_flags = [];
 
     /**
+     * Original (quoted) index name if index is renamed.
+     *
+     * @var string
+     */
+    private $prevName;
+
+    /**
      * Platform specific options
      *
      * @todo $_flags should eventually be refactored into options
@@ -59,6 +59,7 @@ class Index extends AbstractAsset implements Constraint
      * @param bool     $isPrimary
      * @param string[] $flags
      * @param mixed[]  $options
+     * @param string|null $prevName
      */
     public function __construct(
         $name,
@@ -66,7 +67,8 @@ class Index extends AbstractAsset implements Constraint
         $isUnique = false,
         $isPrimary = false,
         array $flags = [],
-        array $options = []
+        array $options = [],
+        $prevName = null
     ) {
         $isUnique = $isUnique || $isPrimary;
 
@@ -74,6 +76,7 @@ class Index extends AbstractAsset implements Constraint
         $this->_isUnique  = $isUnique;
         $this->_isPrimary = $isPrimary;
         $this->options    = $options;
+        $this->prevName = $prevName ?? $name;
 
         foreach ($columns as $column) {
             $this->_addColumn($column);
@@ -339,6 +342,16 @@ class Index extends AbstractAsset implements Constraint
     public function getOptions()
     {
         return $this->options;
+    }
+
+    /**
+     * Returns the previous (quoted) index name or the current one if unchanged
+     *
+     * @return string Previous index name or current index name
+     */
+    public function getPreviousName()
+    {
+        $this->prevName;
     }
 
     /**

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -66,11 +66,11 @@ class OracleSchemaManager extends AbstractSchemaManager
         foreach ($tableIndexes as $tableIndex) {
             $tableIndex = array_change_key_case($tableIndex, CASE_LOWER);
 
-            $keyName = strtolower($tableIndex['name']);
+            $keyName = $tableIndex['name'];
             $buffer  = [];
 
             if ($tableIndex['is_primary'] === 'P') {
-                $keyName              = 'primary';
+                $keyName              = 'PRIMARY';
                 $buffer['primary']    = true;
                 $buffer['non_unique'] = false;
             } else {
@@ -78,7 +78,7 @@ class OracleSchemaManager extends AbstractSchemaManager
                 $buffer['non_unique'] = ! $tableIndex['is_unique'];
             }
 
-            $buffer['key_name']    = $keyName;
+            $buffer['key_name']    = $this->getQuotedIdentifierName($keyName);
             $buffer['column_name'] = $this->getQuotedIdentifierName($tableIndex['column_name']);
             $indexBuffer[]         = $buffer;
         }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -272,11 +272,12 @@ class Table extends AbstractAsset
         }
 
         $oldIndex = $this->_indexes[$normalizedOldName];
+        $cols = $oldIndex->getColumns();
 
         if ($oldIndex->isPrimary()) {
             $this->dropPrimaryKey();
 
-            return $this->setPrimaryKey($oldIndex->getColumns(), $newName ?? false);
+            return $this->setPrimaryKey($cols, $newName ?? false);
         }
 
         unset($this->_indexes[$normalizedOldName]);
@@ -284,8 +285,7 @@ class Table extends AbstractAsset
         $opts = $oldIndex->getOptions();
         $flags = !$oldIndex->isUnique() ? $oldIndex->getFlags() : [];
 
-        $newIndex = $this->_createIndex($oldIndex->getColumns(), $newName, $oldIndex->isUnique(), false, $flags, $opts);
-        $newIndex->oldName = $oldName;
+        $newIndex = $this->_createIndex($cols, $newName, $oldIndex->isUnique(), false, $flags, $opts, $oldName);
 
         return $this->_addIndex($newIndex);
     }
@@ -315,6 +315,7 @@ class Table extends AbstractAsset
      * @param bool     $isPrimary
      * @param string[] $flags
      * @param mixed[]  $options
+     * @param string|null $prevName
      *
      * @return Index
      *
@@ -326,7 +327,8 @@ class Table extends AbstractAsset
         $isUnique,
         $isPrimary,
         array $flags = [],
-        array $options = []
+        array $options = [],
+        $prevName = null
     ) {
         if (preg_match('(([^a-zA-Z0-9_]+))', $this->normalizeIdentifier($indexName)) === 1) {
             throw SchemaException::indexNameInvalid($indexName);
@@ -338,7 +340,7 @@ class Table extends AbstractAsset
             }
         }
 
-        return new Index($indexName, $columnNames, $isUnique, $isPrimary, $flags, $options);
+        return new Index($indexName, $columnNames, $isUnique, $isPrimary, $flags, $options, $prevName);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/A

## Summary

Renaming indexes using Oracle database fails if the indexes are quoted. The indexes are not found in the database because the quoting lost during renaming via TableDiff. This is fixed by storing the old quoted index name in the new index object.