### PR TITLE
Optimize sharing test connection

### DIFF
--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -49,7 +49,9 @@ class PortabilityTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->markConnectionNotReusable();
+        // the connection that overrides the shared one has to be manually closed prior to 4.0.0 to prevent leak
+        // see https://github.com/doctrine/dbal/issues/4515
+        $this->connection->close();
     }
 
     public function testFullFetchMode(): void

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -21,11 +21,6 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         Type::addType('point', PointType::class);
     }
 
-    protected function tearDown(): void
-    {
-        $this->markConnectionNotReusable();
-    }
-
     protected function supportsPlatform(AbstractPlatform $platform): bool
     {
         return $platform instanceof MySQLPlatform;
@@ -105,6 +100,9 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $index->addFlag('spatial');
 
         $this->schemaManager->dropAndCreateTable($table);
+
+        // see https://github.com/doctrine/dbal/issues/4983
+        $this->markConnectionNotReusable();
 
         $indexes = $this->schemaManager->listTableIndexes('spatial_index');
         self::assertArrayHasKey('s_index', $indexes);

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -198,6 +198,8 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $testTable->addColumn('id', 'integer');
         $this->schemaManager->createTable($testTable);
 
+        $this->markConnectionNotReusable();
+
         $this->connection->getConfiguration()->setSchemaAssetsFilter(static function (string $name): bool {
             return preg_match('#^dbal204_#', $name) === 1;
         });

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -78,8 +78,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             $this->connection->executeStatement('DROP SCHEMA testschema');
         } catch (Exception $e) {
         }
-
-        $this->markConnectionNotReusable();
     }
 
     public function testDropAndCreateSequence(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The https://github.com/doctrine/dbal/pull/4967 tests have been failing with Oracle-based drivers with the following error messages:
> ORA-12519: TNS:no appropriate service handler found

While the root cause isn't exactly clear, it is clear that the test suite attempts to establish an abnormally large number of connections which the containerized database server starts rejecting at some point in time.

The large number of connections is caused by the fact that the schema manager tests mark the connection as non-reusable during the teardown. This is necessary to avoid the side effects produced by the following tests:
1. `MySQLSchemaManagerTest::testSpatialIndex()` creates a table with a column of type `POINT`. Due to https://github.com/doctrine/dbal/issues/4983, the pre-existing shared connection won't be able to use this type during table introspection. Because of that, any subsequent test that tries to introspect the schema will fail.
2. `PostgreSQLSchemaManagerTest::testFilterSchemaExpression()` modifies the asset filtering configuration on the shared connection. If this connection is used by subsequent tests, they will fail to introspect the assets that don't match the filter.

Each of the schema manager tests establishes a connection in order to identify the current platforms and skips if it doesn't support the platform. Combined with marking the connection non-reusable, all schema manager tests combined establish ~400 connections per test suite, most of which get immediately closed because all schema manager tests except one don't support the currently configured database platform.

The solution is to have each individual test mark the connection as non-reusable (2 out of ~400).