### PR TITLE
Fix getServerVersion for OCI8 when assertions are disabled

### DIFF
--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -78,7 +78,8 @@ final class Connection implements ServerInfoAwareConnection
             throw Error::new($this->dbh);
         }
 
-        assert(preg_match('/\s+(\d+\.\d+\.\d+\.\d+\.\d+)\s+/', $version, $matches) === 1);
+        $result = preg_match('/\s+(\d+\.\d+\.\d+\.\d+\.\d+)\s+/', $version, $matches);
+        assert($result === 1);
 
         return $matches[1];
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #4994