### PR TITLE
Add MariaDb1070Platform with native GUID support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -212,6 +212,7 @@ jobs:
           - "10.0"
           - "10.2"
           - "10.5"
+          - "10.7"
         extension:
           - "mysqli"
           - "pdo_mysql"

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -36,7 +36,7 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
             if (version_compare($this->getMariaDbMysqlVersionNumber($version), '10.7', '>=')) {
                 return new MariaDb1070Platform();
             }
-            
+
             if (version_compare($this->getMariaDbMysqlVersionNumber($version), '10.2.7', '>=')) {
                 return new MariaDb1027Platform();
             }

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\API\MySQL;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Platforms\MariaDb1070Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -31,8 +32,14 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
     public function createDatabasePlatformForVersion($version)
     {
         $mariadb = stripos($version, 'mariadb') !== false;
-        if ($mariadb && version_compare($this->getMariaDbMysqlVersionNumber($version), '10.2.7', '>=')) {
-            return new MariaDb1027Platform();
+        if ($mariadb) {
+            if (version_compare($this->getMariaDbMysqlVersionNumber($version), '10.7', '>=')) {
+                return new MariaDb1070Platform();
+            }
+            
+            if (version_compare($this->getMariaDbMysqlVersionNumber($version), '10.2.7', '>=')) {
+                return new MariaDb1027Platform();
+            }
         }
 
         if (! $mariadb) {

--- a/src/Platforms/MariaDb1070Platform.php
+++ b/src/Platforms/MariaDb1070Platform.php
@@ -5,20 +5,17 @@ namespace Doctrine\DBAL\Platforms;
 use Doctrine\DBAL\Types\Types;
 
 /**
- * Provides the behavior, features and SQL dialect of the MariaDB 10.2 (10.2.7 GA) database platform.
+ * Provides the native GUID type from MariaDB 10.7 database platform.
  *
- * Note: Should not be used with versions prior to 10.2.7.
+ * Note: Should not be used with versions prior to 10.7.
  */
 class MariaDb1070Platform extends MariaDb1027Platform
 {
-    /**
-     * {@inheritDoc}
-     */
     public function hasNativeGuidType(): bool
     {
         return true;
     }
-    
+
     /**
      * {@inheritDoc}
      */

--- a/src/Platforms/MariaDb1070Platform.php
+++ b/src/Platforms/MariaDb1070Platform.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MariaDB 10.2 (10.2.7 GA) database platform.
+ *
+ * Note: Should not be used with versions prior to 10.2.7.
+ */
+class MariaDb1070Platform extends MariaDb1027Platform
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function hasNativeGuidType(): bool
+    {
+        return true;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function getGuidTypeDeclarationSQL(array $column): string
+    {
+        return 'UUID';
+    }
+
+    protected function initializeDoctrineTypeMappings(): void
+    {
+        parent::initializeDoctrineTypeMappings();
+
+        $this->doctrineTypeMapping['uuid'] = Types::GUID;
+    }
+}

--- a/tests/Platforms/MariaDb1070PlatformTest.php
+++ b/tests/Platforms/MariaDb1070PlatformTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Types\Types;
+
+class MariaDb1070PlatformTest extends AbstractMySQLPlatformTestCase
+{
+    public function createPlatform(): AbstractPlatform
+    {
+        return new MariaDb1027Platform();
+    }
+
+    public function testHasNativeJsonType(): void
+    {
+        self::assertTrue($this->platform->hasNativeGuidType());
+    }
+
+    public function testReturnsGuidTypeDeclarationSQL(): void
+    {
+        self::assertSame('UUID', $this->platform->getGuidTypeDeclarationSQL([]));
+    }
+
+    public function testInitializesUuidTypeMapping(): void
+    {
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('uuid'));
+        self::assertSame(Types::GUID, $this->platform->getDoctrineTypeMapping('uuid'));
+    }
+}

--- a/tests/Platforms/MariaDb1070PlatformTest.php
+++ b/tests/Platforms/MariaDb1070PlatformTest.php
@@ -3,17 +3,17 @@
 namespace Doctrine\DBAL\Tests\Platforms;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Platforms\MariaDb1070Platform;
 use Doctrine\DBAL\Types\Types;
 
 class MariaDb1070PlatformTest extends AbstractMySQLPlatformTestCase
 {
     public function createPlatform(): AbstractPlatform
     {
-        return new MariaDb1027Platform();
+        return new MariaDb1070Platform();
     }
 
-    public function testHasNativeJsonType(): void
+    public function testHasNativeGuidType(): void
     {
         self::assertTrue($this->platform->hasNativeGuidType());
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no

#### Summary

Mariadb 10.7 has new type for storing GUID (UUID), https://mariadb.org/10-7-preview-feature-uuid-data-type/