### PR TITLE
Use sprintf('%d') like in DB2, SQLServer and Oracle to harden against wrong limit and offset

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3724,11 +3724,11 @@ abstract class AbstractPlatform
     protected function doModifyLimitQuery($query, $limit, $offset)
     {
         if ($limit !== null) {
-            $query .= ' LIMIT ' . $limit;
+            $query .= sprintf(' LIMIT %d', $limit);
         }
 
         if ($offset > 0) {
-            $query .= ' OFFSET ' . $offset;
+            $query .= sprintf(' OFFSET %d', $offset);
         }
 
         return $query;

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -50,14 +50,14 @@ class MySQLPlatform extends AbstractPlatform
     protected function doModifyLimitQuery($query, $limit, $offset)
     {
         if ($limit !== null) {
-            $query .= ' LIMIT ' . $limit;
+            $query .= sprintf(' LIMIT %d', $limit);
 
             if ($offset > 0) {
-                $query .= ' OFFSET ' . $offset;
+                $query .= sprintf(' OFFSET %d', $offset);
             }
         } elseif ($offset > 0) {
             // 2^64-1 is the maximum of unsigned BIGINT, the biggest limit possible
-            $query .= ' LIMIT 18446744073709551615 OFFSET ' . $offset;
+            $query .= sprintf(' LIMIT 18446744073709551615 OFFSET %d', $offset);
         }
 
         return $query;

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -765,7 +765,7 @@ class SqlitePlatform extends AbstractPlatform
     protected function doModifyLimitQuery($query, $limit, $offset)
     {
         if ($limit === null && $offset > 0) {
-            return $query . ' LIMIT -1 OFFSET ' . $offset;
+            return sprintf('%s LIMIT -1 OFFSET %d', $query, $offset);
         }
 
         return parent::doModifyLimitQuery($query, $limit, $offset);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Follow up to #4984

#### Summary

In Oracle, SQLServer and DB2 the limit and offset are handled via a `%d` in a sprintf() call already, adding this to the other platforms here should prevent further issues in case #4984 is ever reverted by accident again.
