### PR TITLE
Move built in type registry instanciation

### DIFF
--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -16,37 +16,6 @@ use function get_class;
  */
 abstract class Type
 {
-    /**
-     * The map of supported doctrine mapping types.
-     */
-    private const BUILTIN_TYPES_MAP = [
-        Types::ARRAY                => ArrayType::class,
-        Types::ASCII_STRING         => AsciiStringType::class,
-        Types::BIGINT               => BigIntType::class,
-        Types::BINARY               => BinaryType::class,
-        Types::BLOB                 => BlobType::class,
-        Types::BOOLEAN              => BooleanType::class,
-        Types::DATE_MUTABLE         => DateType::class,
-        Types::DATE_IMMUTABLE       => DateImmutableType::class,
-        Types::DATEINTERVAL         => DateIntervalType::class,
-        Types::DATETIME_MUTABLE     => DateTimeType::class,
-        Types::DATETIME_IMMUTABLE   => DateTimeImmutableType::class,
-        Types::DATETIMETZ_MUTABLE   => DateTimeTzType::class,
-        Types::DATETIMETZ_IMMUTABLE => DateTimeTzImmutableType::class,
-        Types::DECIMAL              => DecimalType::class,
-        Types::FLOAT                => FloatType::class,
-        Types::GUID                 => GuidType::class,
-        Types::INTEGER              => IntegerType::class,
-        Types::JSON                 => JsonType::class,
-        Types::OBJECT               => ObjectType::class,
-        Types::SIMPLE_ARRAY         => SimpleArrayType::class,
-        Types::SMALLINT             => SmallIntType::class,
-        Types::STRING               => StringType::class,
-        Types::TEXT                 => TextType::class,
-        Types::TIME_MUTABLE         => TimeType::class,
-        Types::TIME_IMMUTABLE       => TimeImmutableType::class,
-    ];
-
     /** @var TypeRegistry|null */
     private static $typeRegistry;
 
@@ -111,21 +80,10 @@ abstract class Type
     final public static function getTypeRegistry(): TypeRegistry
     {
         if (self::$typeRegistry === null) {
-            self::$typeRegistry = self::createTypeRegistry();
+            self::$typeRegistry = TypeRegistry::builtIn();
         }
 
         return self::$typeRegistry;
-    }
-
-    private static function createTypeRegistry(): TypeRegistry
-    {
-        $instances = [];
-
-        foreach (self::BUILTIN_TYPES_MAP as $name => $class) {
-            $instances[$name] = new $class();
-        }
-
-        return new TypeRegistry($instances);
     }
 
     /**

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -26,6 +26,37 @@ final class TypeRegistry
         $this->instances = $instances;
     }
 
+    public static function builtIn(): self
+    {
+        return new self([
+            Types::ARRAY                => new ArrayType(),
+            Types::ASCII_STRING         => new AsciiStringType(),
+            Types::BIGINT               => new BigIntType(),
+            Types::BINARY               => new BinaryType(),
+            Types::BLOB                 => new BlobType(),
+            Types::BOOLEAN              => new BooleanType(),
+            Types::DATE_MUTABLE         => new DateType(),
+            Types::DATE_IMMUTABLE       => new DateImmutableType(),
+            Types::DATEINTERVAL         => new DateIntervalType(),
+            Types::DATETIME_MUTABLE     => new DateTimeType(),
+            Types::DATETIME_IMMUTABLE   => new DateTimeImmutableType(),
+            Types::DATETIMETZ_MUTABLE   => new DateTimeTzType(),
+            Types::DATETIMETZ_IMMUTABLE => new DateTimeTzImmutableType(),
+            Types::DECIMAL              => new DecimalType(),
+            Types::FLOAT                => new FloatType(),
+            Types::GUID                 => new GuidType(),
+            Types::INTEGER              => new IntegerType(),
+            Types::JSON                 => new JsonType(),
+            Types::OBJECT               => new ObjectType(),
+            Types::SIMPLE_ARRAY         => new SimpleArrayType(),
+            Types::SMALLINT             => new SmallIntType(),
+            Types::STRING               => new StringType(),
+            Types::TEXT                 => new TextType(),
+            Types::TIME_MUTABLE         => new TimeType(),
+            Types::TIME_IMMUTABLE       => new TimeImmutableType(),
+        ]);
+    }
+
     /**
      * Finds a type by the given name.
      *


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

Ideally, the `Type` abstract class will be removed in the future. Moving
the built in type map and the instanciation of the built in type
registry to `TypeRegistry` makes it smaller.
