### PR TITLE
Oracle fix duplicate identifier for 3.2.x

### DIFF
--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -32,6 +32,8 @@ use function substr;
  */
 class OraclePlatform extends AbstractPlatform
 {
+    private const HASH_LENGTH = 4;
+
     /**
      * Assertion for Oracle identifiers.
      *
@@ -603,7 +605,7 @@ END;';
     {
         $maxPossibleLengthWithoutSuffix = $this->getMaxIdentifierLength() - strlen($suffix);
         if (strlen($identifier) > $maxPossibleLengthWithoutSuffix) {
-            $identifier = substr($identifier, 0, $maxPossibleLengthWithoutSuffix);
+            $identifier = substr($identifier, 0, $maxPossibleLengthWithoutSuffix - self::HASH_LENGTH - 1) . '_' . substr(hash('sha256', $identifier), -self::HASH_LENGTH);
         }
 
         return $identifier . $suffix;

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -589,6 +589,8 @@ SQL
         self::assertSame('"mytable_SEQ"', $this->platform->getIdentitySequenceName('"mytable"', 'mycolumn'));
         self::assertSame('MYTABLE_SEQ', $this->platform->getIdentitySequenceName('mytable', '"mycolumn"'));
         self::assertSame('"mytable_SEQ"', $this->platform->getIdentitySequenceName('"mytable"', '"mycolumn"'));
+        self::assertSame('MY_REALLY_LENGTHY_TAB_F134_SEQ', $this->platform->getIdentitySequenceName('my_really_lengthy_table_name', 'mycolumn'));
+        self::assertSame('"my_really_lengthy_tab_f134_SEQ"', $this->platform->getIdentitySequenceName('"my_really_lengthy_table_name"', '"mycolumn"'));
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/A

Rebased https://github.com/doctrine/dbal/pull/5000 to 3.2.x

## Summary

The Oracle platform class creates duplicate identifier if the passed name is longer then 24 characters because the original code simply truncates everything beyond that limit. For example:

```
my_really_lengthy_table_name -> MY_REALLY_LENGTHY_TABLE_N_AI_PK
my_really_lengthy_table_name2 -> MY_REALLY_LENGTHY_TABLE_N_AI_PK
```

The database reports an already existing identifier and fails to proceed. This PR adds a three character random part if the identifier would be longer then allowed:

```
my_really_lengthy_table_name -> MY_REALLY_LENGTHY_TABL_EAD_SEQ
my_really_lengthy_table_name2 -> MY_REALLY_LENGTHY_TABL_085_SEQ
```
