### PR TITLE
CI: Bump MariaDB to 10.7

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -264,16 +264,16 @@ jobs:
         mariadb-version:
           - "10.0"
           - "10.2"
-          - "10.5"
+          - "10.7"
         extension:
           - "mysqli"
           - "pdo_mysql"
         include:
           - php-version: "8.1"
-            mariadb-version: "10.5"
+            mariadb-version: "10.7"
             extension: "mysqli"
           - php-version: "8.1"
-            mariadb-version: "10.5"
+            mariadb-version: "10.7"
             extension: "pdo_mysql"
 
     services:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

MariaDB 10.7 is about to be released as a stable version, so let's update our CI.