### PR TITLE
Oracle: Fixed removing NOT NULL from columns with sequence

### DIFF
--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -846,11 +846,12 @@ SQL
             }
 
             $columnHasChangedComment = $columnDiff->hasChanged('comment');
+            $columnHasChangedAutoinc = $columnDiff->hasChanged('autoincrement');
 
             /**
              * Do not add query part if only comment has changed
              */
-            if (! ($columnHasChangedComment && count($columnDiff->changedProperties) === 1)) {
+            if (! (($columnHasChangedComment || $columnHasChangedAutoinc) && count($columnDiff->changedProperties) === 1)) {
                 $columnInfo = $column->toArray();
 
                 if (! $columnDiff->hasChanged('notnull')) {
@@ -860,7 +861,7 @@ SQL
                 $fields[] = $column->getQuotedName($this) . $this->getColumnDeclarationSQL('', $columnInfo);
             }
 
-            if (! $columnHasChangedComment) {
+            if (! ($columnHasChangedComment || $columnHasChangedAutoinc)) {
                 continue;
             }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/A

## Summary

Oracle platform class falsly removes `NOT NULL` from columns with sequences.

First run:
```
CREATE TABLE "test" ("id" NUMBER(20) NOT NULL)
```
Second run with existing table:
```
ALTER TABLE "test" MODIFY ("id" NUMBER(20) DEFAUL NULL)
```

The falsy code seems to be a wrong workaround because the `autoincrement` flag is missing when retrieving an existing table schema. Oracle does use sequences instead but they are not bound to tables so the `getListTablesSQL()` method returns no hint that the column has has a sequence to set the `autoincrement` flag in the schema definition:
https://github.com/doctrine/dbal/blob/3.1.x/src/Platforms/OraclePlatform.php#L672-L711

The underlaying problem can be fixed only after https://github.com/doctrine/dbal/pull/5001 is merged because before it's not possible to find out to which column the sequence belongs to due to the column name isn't part of the sequence name.