### PR TITLE
Cast decimals integers to string on SQLite [PHP 8.1]

### DIFF
--- a/lib/Doctrine/DBAL/Types/DecimalType.php
+++ b/lib/Doctrine/DBAL/Types/DecimalType.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Types;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 use function is_float;
+use function is_int;
 
 use const PHP_VERSION_ID;
 
@@ -34,9 +35,9 @@ class DecimalType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        // Some drivers starting from PHP 8.1 can represent decimals as float
+        // Some drivers starting from PHP 8.1 can represent decimals as float/int
         // See also: https://github.com/doctrine/dbal/pull/4818
-        if (PHP_VERSION_ID >= 80100 && is_float($value)) {
+        if (PHP_VERSION_ID >= 80100 && (is_float($value) || is_int($value))) {
             return (string) $value;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Functional/Types/DecimalTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Types/DecimalTest.php
@@ -9,9 +9,25 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\DbalFunctionalTestCase;
 
+use function rtrim;
+
 final class DecimalTest extends DbalFunctionalTestCase
 {
-    public function testInsertAndRetrieveDecimal(): void
+    /**
+     * @return string[][]
+     */
+    public function dataValuesProvider(): array
+    {
+        return [
+            ['13.37'],
+            ['13.0'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataValuesProvider
+     */
+    public function testInsertAndRetrieveDecimal(string $expected): void
     {
         $table = new Table('decimal_table');
         $table->addColumn('val', Types::DECIMAL, ['precision' => 4, 'scale' => 2]);
@@ -21,7 +37,7 @@ final class DecimalTest extends DbalFunctionalTestCase
 
         $this->connection->insert(
             'decimal_table',
-            ['val' => '13.37'],
+            ['val' => $expected],
             ['val' => Types::DECIMAL]
         );
 
@@ -30,6 +46,12 @@ final class DecimalTest extends DbalFunctionalTestCase
             $this->connection->getDatabasePlatform()
         );
 
-        self::assertSame('13.37', $value);
+        self::assertIsString($value);
+        self::assertSame($this->stripTrailingZero($expected), $this->stripTrailingZero($value));
+    }
+
+    private function stripTrailingZero(string $expected): string
+    {
+        return rtrim(rtrim($expected, '0'), '.');
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

This is fix of bugfix https://github.com/doctrine/dbal/pull/4818. When zero-fraction number is stored in decimal column, SQLite returns it as integer, not float. Therefore `is_float` check in mentioned PR fails and int is returned.

