### PR TITLE
Discourage the usage of Connection::quote()

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -530,35 +530,3 @@ given data.
     <?php
     $conn->update('user', array('username' => 'jwage'), array('id' => 1));
     // UPDATE user (username) VALUES (?) WHERE id = ? (jwage, 1)
-
-By default the Doctrine DBAL does no escaping. Escaping is a very
-tricky business to do automatically, therefore there is none by
-default. The ORM internally escapes all your values, because it has
-lots of metadata available about the current context. When you use
-the Doctrine DBAL as standalone, you have to take care of this
-yourself. The following methods help you with it:
-
-quote()
-~~~~~~~~~
-
-Quote a value:
-
-.. code-block:: php
-
-    <?php
-
-    use Doctrine\DBAL\ParameterType;
-
-    $quoted = $conn->quote('value');
-    $quoted = $conn->quote('1234', ParameterType::INTEGER);
-
-quoteIdentifier()
-~~~~~~~~~~~~~~~~~
-
-Quote an identifier according to the platform details.
-
-.. code-block:: php
-
-    <?php
-    $quoted = $conn->quoteIdentifier('id');
-

--- a/docs/en/reference/security.rst
+++ b/docs/en/reference/security.rst
@@ -43,7 +43,7 @@ Consider **ALL** other APIs to be not safe for user-input:
 - The QueryBuilder API
 - The Platforms and SchemaManager APIs to generate and execute DML/DDL SQL statements
 
-To escape user input in those scenarios use the ``Connection#quote()`` method.
+To use values from the user input in those scenarios use prepared statements.
 
 User input in your queries
 --------------------------
@@ -141,10 +141,10 @@ Besides binding parameters you can also pass the type of the variable. This allo
 vendor to not only escape but also cast the value to the correct type. See the docs on querying and DQL in the
 respective chapters for more information.
 
-Right: Quoting/Escaping values
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Discouraged: Quoting/Escaping values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Although previously we said string concatenation is wrong, there is a way to do it correctly using
+Previously we said string concatenation is wrong. There is a way to do it technically correctly using
 the ``Connection#quote`` method:
 
 .. code-block:: php
@@ -154,4 +154,5 @@ the ``Connection#quote`` method:
     $sql = "SELECT * FROM users WHERE name = " . $connection->quote($_GET['username']);
 
 This method is only available for SQL, not for DQL. For DQL you are always encouraged to use prepared
-statements not only for security, but also for caching reasons.
+statements not only for security, but also for caching reasons. To insert a string literal into DDL,
+use ``AbstractPlatform::quoteStringLiteral()``.

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -784,6 +784,9 @@ class Connection
     }
 
     /**
+     * The usage of this method is discouraged. Use prepared statements
+     * or {@link AbstractPlatform::quoteStringLiteral()} instead.
+     *
      * @param mixed                $value
      * @param int|string|Type|null $type
      *

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -27,6 +27,9 @@ interface Connection
     /**
      * Quotes a string for use in a query.
      *
+     * The usage of this method is discouraged. Use prepared statements
+     * or {@link AbstractPlatform::quoteStringLiteral()} instead.
+     *
      * @param mixed $value
      * @param int   $type
      *

--- a/src/Query/Expression/ExpressionBuilder.php
+++ b/src/Query/Expression/ExpressionBuilder.php
@@ -308,7 +308,10 @@ class ExpressionBuilder
     }
 
     /**
-     * Quotes a given input parameter.
+     * Builds an SQL literal from a given input parameter.
+     *
+     * The usage of this method is discouraged. Use prepared statements
+     * or {@link AbstractPlatform::quoteStringLiteral()} instead.
      *
      * @param mixed    $input The parameter to be quoted.
      * @param int|null $type  The type of the parameter.

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -23,7 +23,6 @@ use function preg_match_all;
 use function preg_quote;
 use function preg_replace;
 use function rtrim;
-use function sprintf;
 use function str_replace;
 use function strpos;
 use function strtolower;
@@ -206,10 +205,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $indexBuffer = [];
 
         // fetch primary
-        $indexArray = $this->_conn->fetchAllAssociative(sprintf(
-            'PRAGMA TABLE_INFO (%s)',
-            $this->_conn->quote($tableName)
-        ));
+        $indexArray = $this->_conn->fetchAllAssociative('SELECT * FROM PRAGMA_TABLE_INFO (?)', [$tableName]);
 
         usort(
             $indexArray,
@@ -252,10 +248,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
             $idx['primary']    = false;
             $idx['non_unique'] = ! $tableIndex['unique'];
 
-            $indexArray = $this->_conn->fetchAllAssociative(sprintf(
-                'PRAGMA INDEX_INFO (%s)',
-                $this->_conn->quote($keyName)
-            ));
+            $indexArray = $this->_conn->fetchAllAssociative('SELECT * FROM PRAGMA_INDEX_INFO (?)', [$keyName]);
 
             foreach ($indexArray as $indexColumnRow) {
                 $idx['column_name'] = $indexColumnRow['name'];


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

This also applies to `ExpressionBuilder::literal()`. From https://github.com/doctrine/dbal/pull/4913#discussion_r734976929:
> 1. If you need to put a value into the statement when the connection is available, you should use a parameter.
> 2. If you do not have a connection, you won't be able to use those methods.
> 3. If you have a connection but you want to generate an SQL literal for future use with a different connection, you're likely asking for trouble because the other connection may interpret your literal differently.

For instance, JDBC doesn't have a way to quote a literal.

There are only two usages of `Connection::quote()` in the DBAL right now:

1. In `SQLServerManager`, for no real reason. The method has been reworked the return the actual data, not the SQL.
2. In `SQLiteSchemaManager`, because `PRAGMA XYZ()` doesn't accept parameters. It is an SQLite syntax limitation that can be overcome by using an alternative syntax.

While as of this patch, the DBAL itself doesn't use `Connection::quote()` anywhere except for the tests, I believe it's premature to deprecate `Connection::quote()` entirely for the following reasons:

1. There might be valid use cases when it has to be used, e.g. inserting literals into DDL which may not accept parameters.
2. Legacy code that was originally written w/o prepared statements and has been migrated towards them partially.

Additionally, the query in the SQL Server schema manager has been reworked in the following way:

1. Use `sys.*` views consistently instead of mixing them with the `sysobjects` which only exists for backward compatibility ([source](https://docs.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-sysobjects-transact-sql?view=sql-server-ver15)).
2. Replace the unnecessary sub-query with a proper `ON` clause in the `JOIN`.
3. Remove the unnecessary `ORDER BY`. Even if it matters in which order the constraints are dropped, it's not the alphabetical order.