### PR TITLE
Fix hardcoded varchar default length

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -586,7 +586,7 @@ abstract class AbstractPlatform
      */
     public function getVarcharDefaultLength()
     {
-        Deprecation::trigger(
+        Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/issues/3263',
             'Relying on the default varchar column length is deprecated, specify the length explicitly.'
@@ -3957,7 +3957,7 @@ abstract class AbstractPlatform
         ]);
 
         if ($columnData['type'] instanceof Types\StringType && $columnData['length'] === null) {
-            $columnData['length'] = 255;
+            $columnData['length'] = $this->getVarcharDefaultLength();
         }
 
         return $columnData;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no - the hardcoded value is default on all platforms
| Fixed issues | n/a

#### Summary

When AbstractPlatform::getVarcharDefaultLength is overriden, it must be honored AbstractPlatform::getCreateTableSQL.