### PR TITLE
Remove references to Doctrine 2

### DIFF
--- a/docs/en/reference/known-vendor-issues.rst
+++ b/docs/en/reference/known-vendor-issues.rst
@@ -140,7 +140,7 @@ Rethans explains it very well
 OCI-LOB instances
 ~~~~~~~~~~~~~~~~~
 
-Doctrine 2 always requests CLOB columns as strings, so that you as
+Doctrine DBAL always requests CLOB columns as strings, so that you as
 a developer never get access to the ``OCI-LOB`` instance. Since we
 are using prepared statements for all write operations inside the
 ORM, using strings instead of the ``OCI-LOB`` does not cause any

--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -92,6 +92,6 @@ functions.
 Platforms are also responsible to know which database type
 translates to which PHP Type. This is a very tricky issue across
 all the different database vendors, for example MySQL BIGINT and
-Oracle NUMBER should be handled as integer. Doctrine 2 offers a
+Oracle NUMBER should be handled as integer. Doctrine DBAL offers a
 powerful way to abstract the database to php and back conversion,
 which is described in the next section.

--- a/docs/en/reference/portability.rst
+++ b/docs/en/reference/portability.rst
@@ -36,7 +36,7 @@ can use to write a portable application.
 Connection Wrapper
 ------------------
 
-This functionality is only implemented with Doctrine 2.1 upwards.
+This functionality is only implemented with Doctrine DBAL 2.1 upwards.
 
 To handle all the points 1-3 you have to use a special wrapper around the database
 connection. The handling and differences to tackle are all taken from the great
@@ -79,7 +79,7 @@ at all the different methods that the platforms allow you to access.
 Keyword Lists
 -------------
 
-This functionality is only implemented with Doctrine 2.1 upwards.
+This functionality is only implemented with Doctrine DBAL 2.1 upwards.
 
 Doctrine ships with lists of keywords for every supported vendor. You
 can access a keyword list through the schema manager of the vendor you

--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -67,7 +67,7 @@ Schema Assets
 
 A schema asset is considered any abstract atomic unit in a database such as schemas,
 tables, indexes, but also sequences, columns and even identifiers.
-The following chapter gives an overview of all available Doctrine 2
+The following chapter gives an overview of all available Doctrine DBAL
 schema assets with short explanations on their context and usage.
 All schema assets reside in the ``Doctrine\DBAL\Schema`` namespace.
 

--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -3,14 +3,14 @@ Types
 
 Besides abstraction of SQL one needs a translation between database
 and PHP data-types to implement database independent applications.
-Doctrine 2 has a type translation system baked in that supports the
+Doctrine DBAL has a type translation system baked in that supports the
 conversion from and to PHP values from any database platform,
 as well as platform independent SQL generation for any Doctrine
 Type.
 
 Using the ORM you generally don't need to know about the Type
 system. This is unless you want to make use of database vendor
-specific database types not included in Doctrine 2.
+specific database types not included in Doctrine DBAL.
 
 Types are flyweights. This means there is only ever one instance of
 a type and it is not allowed to contain any state. Creation of type
@@ -23,7 +23,7 @@ vendors.
 Reference
 ---------
 
-The following chapter gives an overview of all available Doctrine 2
+The following chapter gives an overview of all available Doctrine DBAL
 types with short explanations on their context and usage.
 The type names listed here equal those that can be passed to the
 ``Doctrine\DBAL\Types\Type::getType()``  factory method in order to retrieve


### PR DESCRIPTION
Doctrine 2 designates more than just the DBAL, and no longer makes a lot
of sense to refer to it like that. Let's instead reference the current
project.