### PR TITLE
Let `json_encode()` and `json_decode()` throw on error

### DIFF
--- a/src/Types/ConversionException.php
+++ b/src/Types/ConversionException.php
@@ -5,6 +5,8 @@ namespace Doctrine\DBAL\Types;
 use Doctrine\DBAL\Exception;
 use Throwable;
 
+use function func_get_arg;
+use function func_num_args;
 use function get_class;
 use function gettype;
 use function implode;
@@ -98,7 +100,7 @@ class ConversionException extends Exception
      *
      * @return ConversionException
      */
-    public static function conversionFailedSerialization($value, $format, $error)
+    public static function conversionFailedSerialization($value, $format, $error /*, ?Throwable $previous = null */)
     {
         $actualType = is_object($value) ? get_class($value) : gettype($value);
 
@@ -107,7 +109,7 @@ class ConversionException extends Exception
             $actualType,
             $format,
             $error
-        ));
+        ), 0, func_num_args() >= 4 ? func_get_arg(3) : null);
     }
 
     public static function conversionFailedUnserialization(string $format, string $error): self

--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -3,15 +3,14 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use JsonException;
 
 use function is_resource;
 use function json_decode;
 use function json_encode;
-use function json_last_error;
-use function json_last_error_msg;
 use function stream_get_contents;
 
-use const JSON_ERROR_NONE;
+use const JSON_THROW_ON_ERROR;
 
 /**
  * Type generating json objects values
@@ -35,13 +34,11 @@ class JsonType extends Type
             return null;
         }
 
-        $encoded = json_encode($value);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw ConversionException::conversionFailedSerialization($value, 'json', json_last_error_msg());
+        try {
+            return json_encode($value, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw ConversionException::conversionFailedSerialization($value, 'json', $e->getMessage(), $e);
         }
-
-        return $encoded;
     }
 
     /**
@@ -57,13 +54,11 @@ class JsonType extends Type
             $value = stream_get_contents($value);
         }
 
-        $val = json_decode($value, true);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw ConversionException::conversionFailed($value, $this->getName());
+        try {
+            return json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw ConversionException::conversionFailed($value, $this->getName(), $e);
         }
-
-        return $val;
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

This PR proposes to harden the calls to `json_encode()` and `json_decode()` by allowing the functions to throw exceptions in case of an error.