### PR TITLE
Evaluate TypeRegistry as a runtime instance

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1596,6 +1596,8 @@ class Connection
      */
     public function convertToDatabaseValue($value, $type)
     {
+        // Either we deprecate this method, or we add the type registry as a
+        // dependency
         return Type::getType($type)->convertToDatabaseValue($value, $this->getDatabasePlatform());
     }
 
@@ -1612,6 +1614,7 @@ class Connection
      */
     public function convertToPHPValue($value, $type)
     {
+        // same as above
         return Type::getType($type)->convertToPHPValue($value, $this->getDatabasePlatform());
     }
 
@@ -1669,6 +1672,7 @@ class Connection
     private function getBindingInfo($value, $type): array
     {
         if (is_string($type)) {
+            // same as above
             $type = Type::getType($type);
         }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -174,6 +174,7 @@ abstract class AbstractPlatform
     {
         $this->initializeDoctrineTypeMappings();
 
+        // this method has been deprecated and will be removed, no longer a blocker
         foreach (Type::getTypesMap() as $typeName => $className) {
             foreach (Type::getType($typeName)->getMappedDatabaseTypes($this) as $dbType) {
                 $this->doctrineTypeMapping[$dbType] = $typeName;
@@ -364,6 +365,7 @@ abstract class AbstractPlatform
         $dbType                             = strtolower($dbType);
         $this->doctrineTypeMapping[$dbType] = $doctrineType;
 
+        // deprecated method, so not a big deal either
         $doctrineType = Type::getType($doctrineType);
 
         if (! $doctrineType->requiresSQLCommentHint($this)) {
@@ -427,6 +429,7 @@ abstract class AbstractPlatform
         $this->doctrineTypeComments = [];
 
         foreach (Type::getTypesMap() as $typeName => $className) {
+            // again, deprecated method
             $type = Type::getType($typeName);
 
             if (! $type->requiresSQLCommentHint($this)) {

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -120,6 +120,8 @@ class DB2SchemaManager extends AbstractSchemaManager
             $options['precision'] = $precision;
         }
 
+        // most schema managers perform that kind of call. They know about both
+        // the connection and the platform
         return new Column($tableColumn['colname'], Type::getType($type), $options);
     }
 

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -348,6 +348,8 @@ class Table extends AbstractAsset
      */
     public function addColumn($name, $typeName, array $options = [])
     {
+        // either the signature of addColumn should require a Type instance, or
+        // we should pass a string to Column::__construct and resolve the type later on
         $column = new Column($name, Type::getType($typeName), $options);
 
         $this->_addColumn($column);

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -100,6 +100,7 @@ class Statement
 
         if ($type !== null) {
             if (is_string($type)) {
+                // The type registry could be obtained from the connection
                 $type = Type::getType($type);
             }
 

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -153,7 +153,7 @@ abstract class Type
      *
      * @throws Exception
      */
-    public static function addType($name, $className)
+    public static function addType($name, $className) // this method is only ever used in tests
     {
         self::getTypeRegistry()->register($name, new $className());
     }
@@ -165,7 +165,7 @@ abstract class Type
      *
      * @return bool TRUE if type is supported; FALSE otherwise.
      */
-    public static function hasType($name)
+    public static function hasType($name) // used once in AbstractPlatform
     {
         return self::getTypeRegistry()->has($name);
     }
@@ -180,7 +180,7 @@ abstract class Type
      *
      * @throws Exception
      */
-    public static function overrideType($name, $className)
+    public static function overrideType($name, $className) // used exclusively in tests
     {
         self::getTypeRegistry()->override($name, new $className());
     }
@@ -204,7 +204,7 @@ abstract class Type
      *
      * @return string[]
      */
-    public static function getTypesMap()
+    public static function getTypesMap() // used in AbstractPlatform
     {
         return array_map(
             static function (Type $type): string {


### PR DESCRIPTION
This is not an actual pull request, it's more like a way to annotate code to better discuss #2841 , more precisely what it would take to have the `TypeRegistry` no longer be a singleton.

3 big changes seem to be required here:
- injecting the type registry in the Connection
- injecting the type registry in the Platform
- Dealing with Table::addColumn

Possible steps for the 2 first items:
- have a type registry in the configuration
- use it when instantiating the driver in DriverManager
- the driver can then instantiate the platform with the type registry
- the driver can provide the type registry to Connection
