### PR TITLE
Provide abstract middleware classes

### DIFF
--- a/src/Driver/Middleware/AbstractConnectionMiddleware.php
+++ b/src/Driver/Middleware/AbstractConnectionMiddleware.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\Middleware;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
+use LogicException;
+
+abstract class AbstractConnectionMiddleware implements ServerInfoAwareConnection
+{
+    /** @var Connection */
+    private $wrappedConnection;
+
+    public function __construct(Connection $wrappedConnection)
+    {
+        $this->wrappedConnection = $wrappedConnection;
+    }
+
+    public function prepare(string $sql): Statement
+    {
+        return $this->wrappedConnection->prepare($sql);
+    }
+
+    public function query(string $sql): Result
+    {
+        return $this->wrappedConnection->query($sql);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function quote($value, $type = ParameterType::STRING)
+    {
+        return $this->wrappedConnection->quote($value, $type);
+    }
+
+    public function exec(string $sql): int
+    {
+        return $this->wrappedConnection->exec($sql);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lastInsertId($name = null)
+    {
+        if ($name !== null) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4687',
+                'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
+            );
+        }
+
+        return $this->wrappedConnection->lastInsertId($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function beginTransaction()
+    {
+        return $this->wrappedConnection->beginTransaction();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        return $this->wrappedConnection->commit();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rollBack()
+    {
+        return $this->wrappedConnection->rollBack();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getServerVersion()
+    {
+        if (! $this->wrappedConnection instanceof ServerInfoAwareConnection) {
+            throw new LogicException('The underlying connection is not a ServerInfoAwareConnection');
+        }
+
+        return $this->wrappedConnection->getServerVersion();
+    }
+}

--- a/src/Driver/Middleware/AbstractDriverMiddleware.php
+++ b/src/Driver/Middleware/AbstractDriverMiddleware.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\Middleware;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\API\ExceptionConverter;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\VersionAwarePlatformDriver;
+
+abstract class AbstractDriverMiddleware implements VersionAwarePlatformDriver
+{
+    /** @var Driver */
+    private $wrappedDriver;
+
+    public function __construct(Driver $wrappedDriver)
+    {
+        $this->wrappedDriver = $wrappedDriver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function connect(array $params)
+    {
+        return $this->wrappedDriver->connect($params);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDatabasePlatform()
+    {
+        return $this->wrappedDriver->getDatabasePlatform();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
+    {
+        return $this->wrappedDriver->getSchemaManager($conn, $platform);
+    }
+
+    public function getExceptionConverter(): ExceptionConverter
+    {
+        return $this->wrappedDriver->getExceptionConverter();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createDatabasePlatformForVersion($version)
+    {
+        if ($this->wrappedDriver instanceof VersionAwarePlatformDriver) {
+            return $this->wrappedDriver->createDatabasePlatformForVersion($version);
+        }
+
+        return $this->wrappedDriver->getDatabasePlatform();
+    }
+}

--- a/src/Driver/Middleware/AbstractResultMiddleware.php
+++ b/src/Driver/Middleware/AbstractResultMiddleware.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\Middleware;
+
+use Doctrine\DBAL\Driver\Result;
+
+abstract class AbstractResultMiddleware implements Result
+{
+    /** @var Result */
+    private $wrappedResult;
+
+    public function __construct(Result $result)
+    {
+        $this->wrappedResult = $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchNumeric()
+    {
+        return $this->wrappedResult->fetchNumeric();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAssociative()
+    {
+        return $this->wrappedResult->fetchAssociative();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchOne()
+    {
+        return $this->wrappedResult->fetchOne();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAllNumeric(): array
+    {
+        return $this->wrappedResult->fetchAllNumeric();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAllAssociative(): array
+    {
+        return $this->wrappedResult->fetchAllAssociative();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchFirstColumn(): array
+    {
+        return $this->wrappedResult->fetchFirstColumn();
+    }
+
+    public function rowCount(): int
+    {
+        return $this->wrappedResult->rowCount();
+    }
+
+    public function columnCount(): int
+    {
+        return $this->wrappedResult->columnCount();
+    }
+
+    public function free(): void
+    {
+        $this->wrappedResult->free();
+    }
+}

--- a/src/Driver/Middleware/AbstractStatementMiddleware.php
+++ b/src/Driver/Middleware/AbstractStatementMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\Middleware;
+
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+
+abstract class AbstractStatementMiddleware implements Statement
+{
+    /** @var Statement */
+    private $wrappedStatement;
+
+    public function __construct(Statement $wrappedStatement)
+    {
+        $this->wrappedStatement = $wrappedStatement;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindValue($param, $value, $type = ParameterType::STRING)
+    {
+        return $this->wrappedStatement->bindValue($param, $value, $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
+    {
+        return $this->wrappedStatement->bindParam($param, $variable, $type, $length);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($params = null): Result
+    {
+        return $this->wrappedStatement->execute($params);
+    }
+}

--- a/src/Logging/Connection.php
+++ b/src/Logging/Connection.php
@@ -5,19 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Logging;
 
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
 use Doctrine\DBAL\Driver\Result;
-use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
-use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
-use LogicException;
 use Psr\Log\LoggerInterface;
 
-final class Connection implements ServerInfoAwareConnection
+final class Connection extends AbstractConnectionMiddleware
 {
-    /** @var ConnectionInterface */
-    private $connection;
-
     /** @var LoggerInterface */
     private $logger;
 
@@ -26,8 +20,9 @@ final class Connection implements ServerInfoAwareConnection
      */
     public function __construct(ConnectionInterface $connection, LoggerInterface $logger)
     {
-        $this->connection = $connection;
-        $this->logger     = $logger;
+        parent::__construct($connection);
+
+        $this->logger = $logger;
     }
 
     public function __destruct()
@@ -38,7 +33,7 @@ final class Connection implements ServerInfoAwareConnection
     public function prepare(string $sql): DriverStatement
     {
         return new Statement(
-            $this->connection->prepare($sql),
+            parent::prepare($sql),
             $this->logger,
             $sql
         );
@@ -48,38 +43,14 @@ final class Connection implements ServerInfoAwareConnection
     {
         $this->logger->debug('Executing query: {sql}', ['sql' => $sql]);
 
-        return $this->connection->query($sql);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function quote($value, $type = ParameterType::STRING)
-    {
-        return $this->connection->quote($value, $type);
+        return parent::query($sql);
     }
 
     public function exec(string $sql): int
     {
         $this->logger->debug('Executing statement: {sql}', ['sql' => $sql]);
 
-        return $this->connection->exec($sql);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function lastInsertId($name = null)
-    {
-        if ($name !== null) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/issues/4687',
-                'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
-            );
-        }
-
-        return $this->connection->lastInsertId($name);
+        return parent::exec($sql);
     }
 
     /**
@@ -89,7 +60,7 @@ final class Connection implements ServerInfoAwareConnection
     {
         $this->logger->debug('Beginning transaction');
 
-        return $this->connection->beginTransaction();
+        return parent::beginTransaction();
     }
 
     /**
@@ -99,7 +70,7 @@ final class Connection implements ServerInfoAwareConnection
     {
         $this->logger->debug('Committing transaction');
 
-        return $this->connection->commit();
+        return parent::commit();
     }
 
     /**
@@ -109,18 +80,6 @@ final class Connection implements ServerInfoAwareConnection
     {
         $this->logger->debug('Rolling back transaction');
 
-        return $this->connection->rollBack();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getServerVersion()
-    {
-        if (! $this->connection instanceof ServerInfoAwareConnection) {
-            throw new LogicException('The underlying connection is not a ServerInfoAwareConnection');
-        }
-
-        return $this->connection->getServerVersion();
+        return parent::rollBack();
     }
 }

--- a/src/Logging/Statement.php
+++ b/src/Logging/Statement.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Logging;
 
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
@@ -12,11 +13,8 @@ use Psr\Log\LoggerInterface;
 use function array_slice;
 use function func_get_args;
 
-final class Statement implements StatementInterface
+final class Statement extends AbstractStatementMiddleware
 {
-    /** @var StatementInterface */
-    private $statement;
-
     /** @var LoggerInterface */
     private $logger;
 
@@ -34,9 +32,10 @@ final class Statement implements StatementInterface
      */
     public function __construct(StatementInterface $statement, LoggerInterface $logger, string $sql)
     {
-        $this->statement = $statement;
-        $this->logger    = $logger;
-        $this->sql       = $sql;
+        parent::__construct($statement);
+
+        $this->logger = $logger;
+        $this->sql    = $sql;
     }
 
     /**
@@ -47,7 +46,7 @@ final class Statement implements StatementInterface
         $this->params[$param] = &$variable;
         $this->types[$param]  = $type;
 
-        return $this->statement->bindParam($param, $variable, $type, ...array_slice(func_get_args(), 3));
+        return parent::bindParam($param, $variable, $type, ...array_slice(func_get_args(), 3));
     }
 
     /**
@@ -58,7 +57,7 @@ final class Statement implements StatementInterface
         $this->params[$param] = $value;
         $this->types[$param]  = $type;
 
-        return $this->statement->bindValue($param, $value, $type);
+        return parent::bindValue($param, $value, $type);
     }
 
     /**
@@ -72,6 +71,6 @@ final class Statement implements StatementInterface
             'types'  => $this->types,
         ]);
 
-        return $this->statement->execute($params);
+        return parent::execute($params);
     }
 }

--- a/src/Portability/Connection.php
+++ b/src/Portability/Connection.php
@@ -3,17 +3,14 @@
 namespace Doctrine\DBAL\Portability;
 
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
 use Doctrine\DBAL\Driver\Result as DriverResult;
-use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
-use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
-use LogicException;
 
 /**
  * Portability wrapper for a Connection.
  */
-final class Connection implements ServerInfoAwareConnection
+final class Connection extends AbstractConnectionMiddleware
 {
     public const PORTABILITY_ALL           = 255;
     public const PORTABILITY_NONE          = 0;
@@ -21,22 +18,20 @@ final class Connection implements ServerInfoAwareConnection
     public const PORTABILITY_EMPTY_TO_NULL = 4;
     public const PORTABILITY_FIX_CASE      = 8;
 
-    /** @var ConnectionInterface */
-    private $connection;
-
     /** @var Converter */
     private $converter;
 
     public function __construct(ConnectionInterface $connection, Converter $converter)
     {
-        $this->connection = $connection;
-        $this->converter  = $converter;
+        parent::__construct($connection);
+
+        $this->converter = $converter;
     }
 
     public function prepare(string $sql): DriverStatement
     {
         return new Statement(
-            $this->connection->prepare($sql),
+            parent::prepare($sql),
             $this->converter
         );
     }
@@ -44,73 +39,8 @@ final class Connection implements ServerInfoAwareConnection
     public function query(string $sql): DriverResult
     {
         return new Result(
-            $this->connection->query($sql),
+            parent::query($sql),
             $this->converter
         );
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function quote($value, $type = ParameterType::STRING)
-    {
-        return $this->connection->quote($value, $type);
-    }
-
-    public function exec(string $sql): int
-    {
-        return $this->connection->exec($sql);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function lastInsertId($name = null)
-    {
-        if ($name !== null) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/issues/4687',
-                'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
-            );
-        }
-
-        return $this->connection->lastInsertId($name);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function beginTransaction()
-    {
-        return $this->connection->beginTransaction();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function commit()
-    {
-        return $this->connection->commit();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function rollBack()
-    {
-        return $this->connection->rollBack();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getServerVersion()
-    {
-        if (! $this->connection instanceof ServerInfoAwareConnection) {
-            throw new LogicException('The underlying connection is not a ServerInfoAwareConnection');
-        }
-
-        return $this->connection->getServerVersion();
     }
 }

--- a/src/Portability/Result.php
+++ b/src/Portability/Result.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Portability;
 
+use Doctrine\DBAL\Driver\Middleware\AbstractResultMiddleware;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 
-final class Result implements ResultInterface
+final class Result extends AbstractResultMiddleware
 {
-    /** @var ResultInterface */
-    private $result;
-
     /** @var Converter */
     private $converter;
 
@@ -19,7 +17,8 @@ final class Result implements ResultInterface
      */
     public function __construct(ResultInterface $result, Converter $converter)
     {
-        $this->result    = $result;
+        parent::__construct($result);
+
         $this->converter = $converter;
     }
 
@@ -29,7 +28,7 @@ final class Result implements ResultInterface
     public function fetchNumeric()
     {
         return $this->converter->convertNumeric(
-            $this->result->fetchNumeric()
+            parent::fetchNumeric()
         );
     }
 
@@ -39,7 +38,7 @@ final class Result implements ResultInterface
     public function fetchAssociative()
     {
         return $this->converter->convertAssociative(
-            $this->result->fetchAssociative()
+            parent::fetchAssociative()
         );
     }
 
@@ -49,7 +48,7 @@ final class Result implements ResultInterface
     public function fetchOne()
     {
         return $this->converter->convertOne(
-            $this->result->fetchOne()
+            parent::fetchOne()
         );
     }
 
@@ -59,7 +58,7 @@ final class Result implements ResultInterface
     public function fetchAllNumeric(): array
     {
         return $this->converter->convertAllNumeric(
-            $this->result->fetchAllNumeric()
+            parent::fetchAllNumeric()
         );
     }
 
@@ -69,7 +68,7 @@ final class Result implements ResultInterface
     public function fetchAllAssociative(): array
     {
         return $this->converter->convertAllAssociative(
-            $this->result->fetchAllAssociative()
+            parent::fetchAllAssociative()
         );
     }
 
@@ -79,22 +78,7 @@ final class Result implements ResultInterface
     public function fetchFirstColumn(): array
     {
         return $this->converter->convertFirstColumn(
-            $this->result->fetchFirstColumn()
+            parent::fetchFirstColumn()
         );
-    }
-
-    public function rowCount(): int
-    {
-        return $this->result->rowCount();
-    }
-
-    public function columnCount(): int
-    {
-        return $this->result->columnCount();
-    }
-
-    public function free(): void
-    {
-        $this->result->free();
     }
 }

--- a/src/Portability/Statement.php
+++ b/src/Portability/Statement.php
@@ -2,18 +2,15 @@
 
 namespace Doctrine\DBAL\Portability;
 
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
-use Doctrine\DBAL\ParameterType;
 
 /**
  * Portability wrapper for a Statement.
  */
-final class Statement implements DriverStatement
+final class Statement extends AbstractStatementMiddleware
 {
-    /** @var DriverStatement */
-    private $stmt;
-
     /** @var Converter */
     private $converter;
 
@@ -22,24 +19,9 @@ final class Statement implements DriverStatement
      */
     public function __construct(DriverStatement $stmt, Converter $converter)
     {
-        $this->stmt      = $stmt;
+        parent::__construct($stmt);
+
         $this->converter = $converter;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
-    {
-        return $this->stmt->bindParam($param, $variable, $type, $length);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function bindValue($param, $value, $type = ParameterType::STRING)
-    {
-        return $this->stmt->bindValue($param, $value, $type);
     }
 
     /**
@@ -48,7 +30,7 @@ final class Statement implements DriverStatement
     public function execute($params = null): ResultInterface
     {
         return new Result(
-            $this->stmt->execute($params),
+            parent::execute($params),
             $this->converter
         );
     }

--- a/tests/Driver/Middleware/AbstractConnectionMiddlewareTest.php
+++ b/tests/Driver/Middleware/AbstractConnectionMiddlewareTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Driver\Middleware;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\Driver\Statement;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+final class AbstractConnectionMiddlewareTest extends TestCase
+{
+    public function testPrepare(): void
+    {
+        $statement  = $this->createMock(Statement::class);
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('prepare')
+            ->with('SELECT 1')
+            ->willReturn($statement);
+
+        self::assertSame($statement, $this->createMiddleware($connection)->prepare('SELECT 1'));
+    }
+
+    public function testQuery(): void
+    {
+        $result     = $this->createMock(Result::class);
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('query')
+            ->with('SELECT 1')
+            ->willReturn($result);
+
+        self::assertSame($result, $this->createMiddleware($connection)->query('SELECT 1'));
+    }
+
+    public function testExec(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('exec')
+            ->with('UPDATE foo SET bar=\'baz\' WHERE some_field > 0')
+            ->willReturn(42);
+
+        self::assertSame(
+            42,
+            $this->createMiddleware($connection)->exec('UPDATE foo SET bar=\'baz\' WHERE some_field > 0')
+        );
+    }
+
+    public function testGetServerVersion(): void
+    {
+        $connection = $this->createMock(ServerInfoAwareConnection::class);
+        $connection->expects(self::once())
+            ->method('getServerVersion')
+            ->willReturn('1.2.3');
+
+        self::assertSame('1.2.3', $this->createMiddleware($connection)->getServerVersion());
+    }
+
+    public function testGetServerVersionFailsOnLegacyConnections(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $middleware = $this->createMiddleware($connection);
+
+        $this->expectException(LogicException::class);
+        $middleware->getServerVersion();
+    }
+
+    private function createMiddleware(Connection $connection): AbstractConnectionMiddleware
+    {
+        return new class ($connection) extends AbstractConnectionMiddleware {
+        };
+    }
+}

--- a/tests/Driver/Middleware/AbstractDriverMiddlewareTest.php
+++ b/tests/Driver/Middleware/AbstractDriverMiddlewareTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Driver\Middleware;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\VersionAwarePlatformDriver;
+use PHPUnit\Framework\TestCase;
+
+final class AbstractDriverMiddlewareTest extends TestCase
+{
+    public function testConnect(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $driver     = $this->createMock(Driver::class);
+        $driver->expects(self::once())
+            ->method('connect')
+            ->with(['foo' => 'bar'])
+            ->willReturn($connection);
+
+        self::assertSame($connection, $this->createMiddleware($driver)->connect(['foo' => 'bar']));
+    }
+
+    public function testCreateDatabasePlatformForVersion(): void
+    {
+        $platform = $this->createMock(AbstractPlatform::class);
+        $driver   = $this->createMock(VersionAwarePlatformDriver::class);
+        $driver->expects(self::once())
+            ->method('createDatabasePlatformForVersion')
+            ->with('1.2.3')
+            ->willReturn($platform);
+
+        self::assertSame($platform, $this->createMiddleware($driver)->createDatabasePlatformForVersion('1.2.3'));
+    }
+
+    public function testCreateDatabasePlatformForVersionWithLegacyDriver(): void
+    {
+        $platform = $this->createMock(AbstractPlatform::class);
+        $driver   = $this->createMock(Driver::class);
+        $driver->expects(self::once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        self::assertSame($platform, $this->createMiddleware($driver)->createDatabasePlatformForVersion('1.2.3'));
+    }
+
+    private function createMiddleware(Driver $driver): AbstractDriverMiddleware
+    {
+        return new class ($driver) extends AbstractDriverMiddleware {
+        };
+    }
+}

--- a/tests/Driver/Middleware/AbstractResultMiddlewareTest.php
+++ b/tests/Driver/Middleware/AbstractResultMiddlewareTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Driver\Middleware;
+
+use Doctrine\DBAL\Driver\Middleware\AbstractResultMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use PHPUnit\Framework\TestCase;
+
+final class AbstractResultMiddlewareTest extends TestCase
+{
+    public function testFetchAssociative(): void
+    {
+        $row    = ['field' => 'value', 'another_field' => 42];
+        $result = $this->createMock(Result::class);
+        $result->expects(self::once())
+            ->method('fetchAssociative')
+            ->willReturn($row);
+
+        self::assertSame($row, $this->createMiddleware($result)->fetchAssociative());
+    }
+
+    private function createMiddleware(Result $result): AbstractResultMiddleware
+    {
+        return new class ($result) extends AbstractResultMiddleware {
+        };
+    }
+}

--- a/tests/Driver/Middleware/AbstractStatementMiddlewareTest.php
+++ b/tests/Driver/Middleware/AbstractStatementMiddlewareTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Driver\Middleware;
+
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use PHPUnit\Framework\TestCase;
+
+final class AbstractStatementMiddlewareTest extends TestCase
+{
+    public function testExecute(): void
+    {
+        $result    = $this->createMock(Result::class);
+        $statement = $this->createMock(Statement::class);
+        $statement->expects(self::once())
+            ->method('execute')
+            ->with(['foo' => 'bar'])
+            ->willReturn($result);
+
+        self::assertSame($result, $this->createMiddleware($statement)->execute(['foo' => 'bar']));
+    }
+
+    private function createMiddleware(Statement $statement): AbstractStatementMiddleware
+    {
+        return new class ($statement) extends AbstractStatementMiddleware {
+        };
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

When writing a middleware, I have to start with a lot of delegating boilerplate code. As a DX improvement, I'd like to propose the introduction of abstract wrapper classes for driver, connection, statement and result. This allows a developer to only override the methods they want to hook into, resulting in smaller and focussed middleware classes.

I have already modified the portability and logging middlewares to use those abstract classes, so we can see the effect that those classes have.

Using those abstract classes of course remains optional. The contract is still defined by the interfaces, so a middleware can still be implemented without the abstract classes.

Although the new classes are already covered by the tests of the portability and logging middlewares, I intend to add dedicated tests for them, once we agree that we want to introduce those abstract classes.