### PR TITLE
Add `Connection::getNativeConnection()`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,23 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 3.3
+
+## Add `Connection::getNativeConnection()`
+
+Driver and middleware connections need to implement a new method `getNativeConnection()` that gives access to the
+native database connection. Not doing so is deprecated.
+
+## Deprecate accessors for the native connection in favor of `getNativeConnection()`
+
+The following methods have been deprecated:
+
+* `Doctrine\DBAL\Driver\PDO\Connection::getWrappedConnection()`
+* `Doctrine\DBAL\Driver\PDO\SQLSrv\Connection::getWrappedConnection()`
+* `Doctrine\DBAL\Driver\Mysqli\Connection::getWrappedResourceHandle()`
+
+Call `getNativeConnection()` to access the underlying PDO or MySQLi connection.
+
 # Upgrade to 3.2
 
 ## Deprecated `SQLLogger` and its implementations.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -141,5 +141,9 @@ parameters:
             message: '~Method Doctrine\\DBAL\\Driver\\Mysqli\\Result::rowCount\(\) should return int but returns int\|string\.~'
             paths:
                 - src/Driver/Mysqli/Result.php
+
+        # Type check for legacy implementations of the Connection interface
+        # TODO: remove in 4.0.0
+        - "~Call to function method_exists\\(\\) with Doctrine\\\\DBAL\\\\Driver\\\\Connection and 'getNativeConnection' will always evaluate to true\\.~"
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -194,6 +194,9 @@
                     See https://github.com/doctrine/dbal/pull/4897
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractSchemaManager::tryMethod"/>
+
+                <!-- TODO: remove in 4.0.0 -->
+                <referencedMethod name="Doctrine\DBAL\Driver\PDO\Connection::getWrappedConnection"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>
@@ -376,6 +379,7 @@
                     or breaking API changes.
                 -->
                 <file name="src/Platforms/MySQLPlatform.php"/>
+                <file name="tests/Functional/Driver/AbstractDriverTest.php"/>
             </errorLevel>
         </RedundantConditionGivenDocblockType>
         <ReferenceConstraintViolation>

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\SQL\Parser;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
+use LogicException;
 use Throwable;
 use Traversable;
 
@@ -34,6 +35,8 @@ use function implode;
 use function is_int;
 use function is_string;
 use function key;
+use function method_exists;
+use function sprintf;
 
 /**
  * A database abstraction-level connection that implements features like events, transaction isolation levels,
@@ -1509,6 +1512,24 @@ class Connection
         assert($this->_conn !== null);
 
         return $this->_conn;
+    }
+
+    /**
+     * @return resource|object
+     */
+    public function getNativeConnection()
+    {
+        $this->connect();
+
+        assert($this->_conn !== null);
+        if (! method_exists($this->_conn, 'getNativeConnection')) {
+            throw new LogicException(sprintf(
+                'The driver connection %s does not support accessing the native connection.',
+                get_class($this->_conn)
+            ));
+        }
+
+        return $this->_conn->getNativeConnection();
     }
 
     /**

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -7,6 +7,8 @@ use Doctrine\DBAL\ParameterType;
 /**
  * Connection interface.
  * Driver connections must implement this interface.
+ *
+ * @method resource|object getNativeConnection()
  */
 interface Connection
 {

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -142,4 +142,12 @@ final class Connection implements ServerInfoAwareConnection
 
         return $result;
     }
+
+    /**
+     * @return resource
+     */
+    public function getNativeConnection()
+    {
+        return $this->connection;
+    }
 }

--- a/src/Driver/Middleware/AbstractConnectionMiddleware.php
+++ b/src/Driver/Middleware/AbstractConnectionMiddleware.php
@@ -10,6 +10,10 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
 
+use function get_class;
+use function method_exists;
+use function sprintf;
+
 abstract class AbstractConnectionMiddleware implements ServerInfoAwareConnection
 {
     /** @var Connection */
@@ -93,5 +97,20 @@ abstract class AbstractConnectionMiddleware implements ServerInfoAwareConnection
         }
 
         return $this->wrappedConnection->getServerVersion();
+    }
+
+    /**
+     * @return resource|object
+     */
+    public function getNativeConnection()
+    {
+        if (! method_exists($this->wrappedConnection, 'getNativeConnection')) {
+            throw new LogicException(sprintf(
+                'The driver connection %s does not support accessing the native connection.',
+                get_class($this->wrappedConnection)
+            ));
+        }
+
+        return $this->wrappedConnection->getNativeConnection();
     }
 }

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -36,10 +36,19 @@ final class Connection implements ServerInfoAwareConnection
      * Retrieves mysqli native resource handle.
      *
      * Could be used if part of your application is not using DBAL.
+     *
+     * @deprecated Call {@see getNativeConnection()} instead.
      */
     public function getWrappedResourceHandle(): mysqli
     {
-        return $this->connection;
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5037',
+            '%s is deprecated, call getNativeConnection() instead.',
+            __METHOD__
+        );
+
+        return $this->getNativeConnection();
     }
 
     /**
@@ -146,5 +155,10 @@ final class Connection implements ServerInfoAwareConnection
         } catch (mysqli_sql_exception $e) {
             return false;
         }
+    }
+
+    public function getNativeConnection(): mysqli
+    {
+        return $this->connection;
     }
 }

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -166,4 +166,12 @@ final class Connection implements ServerInfoAwareConnection
 
         return true;
     }
+
+    /**
+     * @return resource
+     */
+    public function getNativeConnection()
+    {
+        return $this->connection;
+    }
 }

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -123,8 +123,23 @@ final class Connection implements ServerInfoAwareConnection
         return $this->connection->rollBack();
     }
 
-    public function getWrappedConnection(): PDO
+    public function getNativeConnection(): PDO
     {
         return $this->connection;
+    }
+
+    /**
+     * @deprecated Call {@see getNativeConnection()} instead.
+     */
+    public function getWrappedConnection(): PDO
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5037',
+            '%s is deprecated, call getNativeConnection() instead.',
+            __METHOD__
+        );
+
+        return $this->getNativeConnection();
     }
 }

--- a/src/Driver/PDO/SQLSrv/Connection.php
+++ b/src/Driver/PDO/SQLSrv/Connection.php
@@ -88,8 +88,23 @@ final class Connection implements ServerInfoAwareConnection
         return $this->connection->getServerVersion();
     }
 
+    public function getNativeConnection(): PDO
+    {
+        return $this->connection->getNativeConnection();
+    }
+
+    /**
+     * @deprecated Call {@see getNativeConnection()} instead.
+     */
     public function getWrappedConnection(): PDO
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5037',
+            '%s is deprecated, call getNativeConnection() instead.',
+            __METHOD__
+        );
+
         return $this->connection->getWrappedConnection();
     }
 }

--- a/src/Driver/SQLSrv/Connection.php
+++ b/src/Driver/SQLSrv/Connection.php
@@ -23,7 +23,7 @@ use function str_replace;
 final class Connection implements ServerInfoAwareConnection
 {
     /** @var resource */
-    protected $connection;
+    private $connection;
 
     /**
      * @internal The connection can be only instantiated by its driver.
@@ -134,5 +134,13 @@ final class Connection implements ServerInfoAwareConnection
         }
 
         return true;
+    }
+
+    /**
+     * @return resource
+     */
+    public function getNativeConnection()
+    {
+        return $this->connection;
     }
 }

--- a/tests/Driver/Middleware/AbstractConnectionMiddlewareTest.php
+++ b/tests/Driver/Middleware/AbstractConnectionMiddlewareTest.php
@@ -69,9 +69,38 @@ final class AbstractConnectionMiddlewareTest extends TestCase
         $middleware->getServerVersion();
     }
 
+    public function testGetNativeConnection(): void
+    {
+        $nativeConnection = new class () {
+        };
+
+        $connection = $this->createMock(NativeDriverConnection::class);
+        $connection->method('getNativeConnection')
+            ->willReturn($nativeConnection);
+
+        self::assertSame($nativeConnection, $this->createMiddleware($connection)->getNativeConnection());
+    }
+
+    public function testGetNativeConnectionFailsWithLegacyConnection(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $middleware = $this->createMiddleware($connection);
+
+        $this->expectException(LogicException::class);
+        $middleware->getNativeConnection();
+    }
+
     private function createMiddleware(Connection $connection): AbstractConnectionMiddleware
     {
         return new class ($connection) extends AbstractConnectionMiddleware {
         };
     }
+}
+
+interface NativeDriverConnection extends ServerInfoAwareConnection
+{
+    /**
+     * @return object|resource
+     */
+    public function getNativeConnection();
 }

--- a/tests/Driver/PDO/PgSQL/DriverTest.php
+++ b/tests/Driver/PDO/PgSQL/DriverTest.php
@@ -30,7 +30,7 @@ class DriverTest extends AbstractPostgreSQLDriverTest
 
         self::assertInstanceOf(PDO\Connection::class, $connection);
         self::assertTrue(
-            $connection->getWrappedConnection()->getAttribute(\PDO::PGSQL_ATTR_DISABLE_PREPARES)
+            $connection->getNativeConnection()->getAttribute(\PDO::PGSQL_ATTR_DISABLE_PREPARES)
         );
     }
 
@@ -42,7 +42,7 @@ class DriverTest extends AbstractPostgreSQLDriverTest
 
         self::assertInstanceOf(PDO\Connection::class, $connection);
         self::assertNotTrue(
-            $connection->getWrappedConnection()->getAttribute(\PDO::PGSQL_ATTR_DISABLE_PREPARES)
+            $connection->getNativeConnection()->getAttribute(\PDO::PGSQL_ATTR_DISABLE_PREPARES)
         );
     }
 
@@ -54,7 +54,7 @@ class DriverTest extends AbstractPostgreSQLDriverTest
 
         self::assertInstanceOf(PDO\Connection::class, $connection);
         self::assertTrue(
-            $connection->getWrappedConnection()->getAttribute(\PDO::PGSQL_ATTR_DISABLE_PREPARES)
+            $connection->getNativeConnection()->getAttribute(\PDO::PGSQL_ATTR_DISABLE_PREPARES)
         );
     }
 

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -386,7 +386,7 @@ class ConnectionTest extends FunctionalTestCase
             self::markTestSkipped('Unable to test if the connection is persistent');
         }
 
-        $pdo = $driverConnection->getWrappedConnection();
+        $pdo = $driverConnection->getNativeConnection();
 
         self::assertTrue($pdo->getAttribute(PDO::ATTR_PERSISTENT));
     }

--- a/tests/Functional/Driver/AbstractDriverTest.php
+++ b/tests/Functional/Driver/AbstractDriverTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Constraint\IsType;
 
 abstract class AbstractDriverTest extends FunctionalTestCase
 {
@@ -47,6 +48,16 @@ abstract class AbstractDriverTest extends FunctionalTestCase
             static::getDatabaseNameForConnectionWithoutDatabaseNameParameter(),
             $connection->getDatabase()
         );
+    }
+
+    public function testProvidesAccessToTheNativeConnection(): void
+    {
+        $nativeConnection = $this->connection->getNativeConnection();
+
+        self::assertThat($nativeConnection, self::logicalOr(
+            new IsType(IsType::TYPE_OBJECT),
+            new IsType(IsType::TYPE_RESOURCE)
+        ));
     }
 
     abstract protected function createDriver(): Driver;

--- a/tests/Functional/Driver/PDO/SQLSrv/DriverTest.php
+++ b/tests/Functional/Driver/PDO/SQLSrv/DriverTest.php
@@ -71,7 +71,7 @@ class DriverTest extends AbstractDriverTest
         self::assertSame(
             PDO::CASE_UPPER,
             $connection
-                ->getWrappedConnection()
+                ->getNativeConnection()
                 ->getAttribute(PDO::ATTR_CASE)
         );
     }

--- a/tests/Portability/ConnectionTest.php
+++ b/tests/Portability/ConnectionTest.php
@@ -2,9 +2,11 @@
 
 namespace Doctrine\DBAL\Tests\Portability;
 
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Portability\Connection;
 use Doctrine\DBAL\Portability\Converter;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class ConnectionTest extends TestCase
@@ -20,4 +22,48 @@ class ConnectionTest extends TestCase
 
         self::assertSame('1.2.3', $connection->getServerVersion());
     }
+
+    public function testGetServerVersionFailsWithLegacyConnection(): void
+    {
+        $connection = new Connection(
+            $this->createMock(DriverConnection::class),
+            new Converter(false, false, 0)
+        );
+
+        $this->expectException(LogicException::class);
+        $connection->getServerVersion();
+    }
+
+    public function testGetNativeConnection(): void
+    {
+        $nativeConnection = new class () {
+        };
+
+        $driverConnection = $this->createMock(NativeDriverConnection::class);
+        $driverConnection->method('getNativeConnection')
+            ->willReturn($nativeConnection);
+
+        $connection = new Connection($driverConnection, new Converter(false, false, 0));
+
+        self::assertSame($nativeConnection, $connection->getNativeConnection());
+    }
+
+    public function testGetNativeConnectionFailsWithLegacyConnection(): void
+    {
+        $connection = new Connection(
+            $this->createMock(DriverConnection::class),
+            new Converter(false, false, 0)
+        );
+
+        $this->expectException(LogicException::class);
+        $connection->getNativeConnection();
+    }
+}
+
+interface NativeDriverConnection extends ServerInfoAwareConnection
+{
+    /**
+     * @return object|resource
+     */
+    public function getNativeConnection();
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | N/A

#### Summary

As discussed on #4966, accessing the native connection is a rare but valid use-case.

* Symfony Messenger ueses it to access the notify API from Postgres
* Sometimes, an application might want to temporarily alter attributes of the PDO connection.
* On batch operations, applications running on MySQL might want to switch to unbuffered queries.
* Our own portability middleware does this for PDO connections
* …

Unpacking the native connection is tedious and fragile. And with the middleware system, it gets close to impossible to access the native connection. Even our own portability middleware will fail to access it if we move it higher in the middleware stack.

Making the native connection accessible through a userland middleware as suggested in #4966 won't work reliably either because that middleware would have to be registered pretty low in the middleware stack. As soon as there's a lower middleware that wraps the connection, our userland middleware would fail. Our middleware would basically have the same problem as the portability middleware.

This PR proposes to standardize the access to the native connection by adding dedicated methods to the `Connection` class and the drivers' `Connection` interface. It also deprecates various old accessors from driver connection implementations.