### PR TITLE
Use abstract middleware classes for PDO_sqlsrv

### DIFF
--- a/src/Driver/PDO/SQLSrv/Connection.php
+++ b/src/Driver/PDO/SQLSrv/Connection.php
@@ -2,21 +2,21 @@
 
 namespace Doctrine\DBAL\Driver\PDO\SQLSrv;
 
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
 use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
-use Doctrine\DBAL\Driver\Result;
-use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
-use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
 use PDO;
 
-final class Connection implements ServerInfoAwareConnection
+final class Connection extends AbstractConnectionMiddleware
 {
     /** @var PDOConnection */
     private $connection;
 
     public function __construct(PDOConnection $connection)
     {
+        parent::__construct($connection);
+
         $this->connection = $connection;
     }
 
@@ -27,31 +27,13 @@ final class Connection implements ServerInfoAwareConnection
         );
     }
 
-    public function query(string $sql): Result
-    {
-        return $this->connection->query($sql);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function quote($value, $type = ParameterType::STRING)
-    {
-        return $this->connection->quote($value, $type);
-    }
-
-    public function exec(string $sql): int
-    {
-        return $this->connection->exec($sql);
-    }
-
     /**
      * {@inheritDoc}
      */
     public function lastInsertId($name = null)
     {
         if ($name === null) {
-            return $this->connection->lastInsertId($name);
+            return parent::lastInsertId($name);
         }
 
         Deprecation::triggerIfCalledFromOutside(
@@ -63,29 +45,6 @@ final class Connection implements ServerInfoAwareConnection
         return $this->prepare('SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?')
             ->execute([$name])
             ->fetchOne();
-    }
-
-    public function beginTransaction(): bool
-    {
-        return $this->connection->beginTransaction();
-    }
-
-    public function commit(): bool
-    {
-        return $this->connection->commit();
-    }
-
-    public function rollBack(): bool
-    {
-        return $this->connection->rollBack();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getServerVersion()
-    {
-        return $this->connection->getServerVersion();
     }
 
     public function getNativeConnection(): PDO

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -2,16 +2,15 @@
 
 namespace Doctrine\DBAL\Driver\PDO\SQLSrv;
 
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
 use Doctrine\DBAL\Driver\PDO\Statement as PDOStatement;
-use Doctrine\DBAL\Driver\Result;
-use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
 use PDO;
 
 use function func_num_args;
 
-final class Statement implements StatementInterface
+final class Statement extends AbstractStatementMiddleware
 {
     /** @var PDOStatement */
     private $statement;
@@ -21,6 +20,8 @@ final class Statement implements StatementInterface
      */
     public function __construct(PDOStatement $statement)
     {
+        parent::__construct($statement);
+
         $this->statement = $statement;
     }
 
@@ -73,13 +74,5 @@ final class Statement implements StatementInterface
     public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
         return $this->bindParam($param, $value, $type);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function execute($params = null): Result
-    {
-        return $this->statement->execute($params);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

The PDO_sqlsrv driver is implemented middleware-style already, so the new abstract classes allow us to remove some boilerplate.
