### PR TITLE
Fix coding standard violation in the IBM DB2 driver

### DIFF
--- a/src/Driver/IBMDB2/Driver.php
+++ b/src/Driver/IBMDB2/Driver.php
@@ -5,6 +5,9 @@ namespace Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\AbstractDB2Driver;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionFailed;
 
+use function db2_connect;
+use function db2_pconnect;
+
 final class Driver extends AbstractDB2Driver
 {
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

PHP_CodeSniffer flags this issue only if the `ibm_db2` extension is installed.