### PR TITLE
Add missing `unix_socket` option to the array shape for the connection params

### DIFF
--- a/lib/Doctrine/DBAL/DriverManager.php
+++ b/lib/Doctrine/DBAL/DriverManager.php
@@ -42,6 +42,7 @@ use function substr;
  *     platform?: Platforms\AbstractPlatform,
  *     port?: int,
  *     user?: string,
+ *     unix_socket?: string,
  * }
  * @psalm-type Params = array{
  *     charset?: string,
@@ -66,6 +67,7 @@ use function substr;
  *     slaves?: array<OverrideParams>,
  *     user?: string,
  *     wrapperClass?: class-string<Connection>,
+ *     unix_socket?: string,
  * }
  */
 final class DriverManager


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

I noticed that the `unix_socket` option available for `pdo_mysql` and `mysqli` drivers is not part of the Psalm `Params` and `OverrideParams` types defined on the `DriverManager` class