### PR TITLE
Fix return type of `_getNestedTransactionSavePointName()`

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1255,10 +1255,9 @@ class Connection
     }
 
     /**
-     * Returns the savepoint name to use for nested transactions are false if they are not supported
-     * "savepointFormat" parameter is not set
+     * Returns the savepoint name to use for nested transactions.
      *
-     * @return mixed A string with the savepoint name or false.
+     * @return string
      */
     protected function _getNestedTransactionSavePointName()
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/dbal/pull/5043#discussion_r757835266

#### Summary

This method must not return anything but a string. We funnel the value it returns directly into methods that only accept strings: `createSavepoint()`, `releaseSavepoint()`, `rollbackSavepoint()`.
