### PR TITLE
Deprecate `Type::getName()`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+# Deprecated `Type::getName()`
+
+This will method is not useful for the DBAL anymore, and will be removed in 4.0.
+As a consequence, depending on the name of a type being `json` for `jsonb` to
+be used for the Postgres platform is deprecated in favor of extending
+`Doctrine\DBAL\Types\JsonType`.
+
 # Deprecated `AbstractPlatform::getColumnComment()` and `AbstractPlatform::getDoctrineTypeComment()`
 
 DBAL no longer needs column comments to ensure proper diffing. Note that both

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -229,6 +229,11 @@
                     See https://github.com/doctrine/dbal/pull/5204
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getColumnComment"/>
+                <!--
+                    TODO: remove in 4.0.0
+                    See https://github.com/doctrine/dbal/pull/5049
+                -->
+                <referencedMethod name="Doctrine\DBAL\Types\Type::getName"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
@@ -15,6 +16,7 @@ use function array_map;
 use function array_shift;
 use function assert;
 use function explode;
+use function get_class;
 use function implode;
 use function in_array;
 use function preg_match;
@@ -530,6 +532,20 @@ SQL
         }
 
         if ($column->getType()->getName() === Types::JSON) {
+            if (! $column->getType() instanceof JsonType) {
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/5049',
+                    <<<'DEPRECATION'
+                    %s not extending %s while being named %s is deprecated,
+                    and will lead to jsonb never to being used in 4.0.,
+                    DEPRECATION,
+                    get_class($column->getType()),
+                    JsonType::class,
+                    Types::JSON
+                );
+            }
+
             $column->setPlatformOption('jsonb', $jsonb);
         }
 

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -102,9 +102,9 @@ abstract class Type
     /**
      * Gets the name of this type.
      *
-     * @return string
+     * @deprecated this method will be removed in Doctrine DBAL 4.0.
      *
-     * @todo Needed?
+     * @return string
      */
     abstract public function getName();
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

~The consequence of this is that it no longer need to be implemented in
child classes. This means users no longer need to make sure the name
they use in getName() is the same they use when registering the type.~

~`Type` already has a dependency on `TypeRegistry`, which should make this
change OK and should not make it harder to get rid of getName() entirely
in the future.~

~Apart from rare scenarios where one would use a type without registering
it, that implementation should work reliably. That scenario happens
quite frequently in tests, which is why there were some changes in the
test suite.~

~This should unlock https://github.com/doctrine/dbal/pull/5036 without requiring we get rid of `getName()` entirely, which would be a bigger endeavor.~

Note: the ORM has docs on types: https://www.doctrine-project.org/projects/doctrine-orm/en/2.10/cookbook/custom-mapping-types.html#custom-mapping-types

They will probably need to be replaced with a link to the DBAL docs otherwise things are going to get confusing, especially if there are more consequential refactorings in the type system.