### PR TITLE
Workaround for "mixed is a reserved word" error

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -387,6 +387,13 @@
                 <file name="src/Query/QueryBuilder.php"/>
             </errorLevel>
         </ReferenceConstraintViolation>
+        <!-- Workaround for https://github.com/vimeo/psalm/issues/7026 -->
+        <ReservedWord>
+            <errorLevel type="suppress">
+                <directory name="src"/>
+                <directory name="tests"/>
+            </errorLevel>
+        </ReservedWord>
         <TooManyArguments>
             <errorLevel type="suppress">
                 <!-- See https://github.com/doctrine/dbal/pull/3562 -->


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/A

#### Summary

This PR suppresses a Psalm error that appeared after the Symfony 6 release. I've reported the issue as vimeo/psalm#7026.
