### PR TITLE
Deprecate support for Postgres 9

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 3.3
 
+## Deprecated support for Postgres 9
+
+Postgres 9 won't be actively supported in DBAL 4. Consider upgrading to Postgres 10 or later.
+The following classes have been deprecated:
+
+* `Doctrine\DBAL\Platforms\PostgreSQL100Platform`
+* `Doctrine\DBAL\Platforms\Keywords\PostgreSQL100Keywords`
+
 ## Deprecated `Connection::getWrappedConnection()`, `Connection::connect()` made `@internal`.
 
 The wrapper-level `Connection::getWrappedConnection()` method has been deprecated.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -59,8 +59,10 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\PostgreSQL100Keywords"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\PostgreSQL94Keywords"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\SQLServer2012Keywords"/>
+                <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL100Platform"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL94Platform"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\SQLServer2012Platform"/>
                 <!--

--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
+use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 use function preg_match;
@@ -41,6 +42,13 @@ abstract class AbstractPostgreSQLDriver implements VersionAwarePlatformDriver
         if (version_compare($version, '10.0', '>=')) {
             return new PostgreSQL100Platform();
         }
+
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5060',
+            'PostgreSQL 9 support is deprecated and will be removed in DBAL 4.'
+                . ' Consider upgrading to Postgres 10 or later.'
+        );
 
         return new PostgreSQL94Platform();
     }

--- a/src/Platforms/Keywords/PostgreSQL100Keywords.php
+++ b/src/Platforms/Keywords/PostgreSQL100Keywords.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Platforms\Keywords;
 
 /**
  * PostgreSQL 10.0 reserved keywords list.
+ *
+ * @deprecated Use {@link PostgreSQLKeywords} instead.
  */
 class PostgreSQL100Keywords extends PostgreSQL94Keywords
 {

--- a/src/Platforms/PostgreSQL100Platform.php
+++ b/src/Platforms/PostgreSQL100Platform.php
@@ -9,6 +9,9 @@ use Doctrine\Deprecations\Deprecation;
 
 /**
  * Provides the behavior, features and SQL dialect of the PostgreSQL 10.0 database platform.
+ *
+ * @deprecated This class will be merged with {@see PostgreSQLPlatform} in 4.0 because support for Postgres
+ *             releases prior to 10.0 will be dropped.
  */
 class PostgreSQL100Platform extends PostgreSQL94Platform
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

For reference: https://www.postgresql.org/support/versioning/

Postgres 9 should be dead an buried by now. Let's not carry over compat code for that ancient database into 4.0.