### PR TITLE
Add deprecation annotation to `SQLServer2012Platform`

### DIFF
--- a/src/Platforms/SQLServer2012Platform.php
+++ b/src/Platforms/SQLServer2012Platform.php
@@ -5,6 +5,8 @@ namespace Doctrine\DBAL\Platforms;
 /**
  * Provides the behavior, features and SQL dialect of the Microsoft SQL Server database platform
  * of the oldest supported version.
+ *
+ * @deprecated Use {@see SQLServerPlatform} instead.
  */
 class SQLServer2012Platform extends SQLServerPlatform
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes/no
| Fixed issues | N/A

#### Summary

The class `SQLServer2012Platform` had been deprecated in 3.2 according to the upgrade documentation, but it was not flagged as `@deprecated`.
