### PR TITLE
Remove psr/log downgrade from CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,10 +38,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: "Temporarily remove support for PSR Log 3 on PHP 8.1"
-        run: 'sed -i "s/\"psr\/log\": \"^1|^2|^3\"/\"psr\/log\": \"^1|^2\"/" composer.json'
-        if: "${{ matrix.php-version=='8.1' }}"
-
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
@@ -86,10 +82,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: "Temporarily remove support for PSR Log 3 on PHP 8.1"
-        run: 'sed -i "s/\"psr\/log\": \"^1|^2|^3\"/\"psr\/log\": \"^1|^2\"/" composer.json'
-        if: "${{ matrix.php-version=='8.1' }}"
-
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
@@ -132,10 +124,6 @@ jobs:
         uses: "actions/checkout@v2"
         with:
           fetch-depth: 2
-
-      - name: "Temporarily remove support for PSR Log 3 on PHP 8.1"
-        run: 'sed -i "s/\"psr\/log\": \"^1|^2|^3\"/\"psr\/log\": \"^1|^2\"/" composer.json'
-        if: "${{ matrix.php-version=='8.1' }}"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -191,10 +179,6 @@ jobs:
         uses: "actions/checkout@v2"
         with:
           fetch-depth: 2
-
-      - name: "Temporarily remove support for PSR Log 3 on PHP 8.1"
-        run: 'sed -i "s/\"psr\/log\": \"^1|^2|^3\"/\"psr\/log\": \"^1|^2\"/" composer.json'
-        if: "${{ matrix.php-version=='8.1' }}"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -257,10 +241,6 @@ jobs:
         uses: "actions/checkout@v2"
         with:
           fetch-depth: 2
-
-      - name: "Temporarily remove support for PSR Log 3 on PHP 8.1"
-        run: 'sed -i "s/\"psr\/log\": \"^1|^2|^3\"/\"psr\/log\": \"^1|^2\"/" composer.json'
-        if: "${{ matrix.php-version=='8.1' }}"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -350,10 +330,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: "Temporarily remove support for PSR Log 3 on PHP 8.1"
-        run: 'sed -i "s/\"psr\/log\": \"^1|^2|^3\"/\"psr\/log\": \"^1|^2\"/" composer.json'
-        if: "${{ matrix.php-version=='8.1' }}"
-
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
@@ -422,10 +398,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: "Temporarily remove support for PSR Log 3 on PHP 8.1"
-        run: 'sed -i "s/\"psr\/log\": \"^1|^2|^3\"/\"psr\/log\": \"^1|^2\"/" composer.json'
-        if: "${{ matrix.php-version=='8.1' }}"
-
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
@@ -482,10 +454,6 @@ jobs:
         uses: "actions/checkout@v2"
         with:
           fetch-depth: 2
-
-      - name: "Temporarily remove support for PSR Log 3 on PHP 8.1"
-        run: 'sed -i "s/\"psr\/log\": \"^1|^2|^3\"/\"psr\/log\": \"^1|^2\"/" composer.json'
-        if: "${{ matrix.php-version=='8.1' }}"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

Now that Symfony 6 has been released, we should not need to downgrade psr/log anymore.
