### PR TITLE
Fix array types on ArrayResult

### DIFF
--- a/src/Cache/ArrayResult.php
+++ b/src/Cache/ArrayResult.php
@@ -14,7 +14,7 @@ use function reset;
  */
 final class ArrayResult implements Result
 {
-    /** @var mixed[] */
+    /** @var list<array<string, mixed>> */
     private $data;
 
     /** @var int */
@@ -24,7 +24,7 @@ final class ArrayResult implements Result
     private $num = 0;
 
     /**
-     * @param mixed[] $data
+     * @param list<array<string, mixed>> $data
      */
     public function __construct(array $data)
     {
@@ -112,7 +112,7 @@ final class ArrayResult implements Result
     }
 
     /**
-     * @return mixed|false
+     * @return array<string, mixed>|false
      */
     private function fetch()
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/A

#### Summary

Let's make the internal types of `ArrayResult` a little less `mixed`.