### PR TITLE
Use see instead of link for references to structural elements

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -72,7 +72,7 @@ class Connection
     protected $_eventManager;
 
     /**
-     * @deprecated Use {@link createExpressionBuilder()} instead.
+     * @deprecated Use {@see createExpressionBuilder()} instead.
      *
      * @var ExpressionBuilder
      */
@@ -131,7 +131,7 @@ class Connection
     /**
      * The schema manager.
      *
-     * @deprecated Use {@link createSchemaManager()} instead.
+     * @deprecated Use {@see createSchemaManager()} instead.
      *
      * @var AbstractSchemaManager|null
      */
@@ -291,7 +291,7 @@ class Connection
     /**
      * Gets the ExpressionBuilder for the connection.
      *
-     * @deprecated Use {@link createExpressionBuilder()} instead.
+     * @deprecated Use {@see createExpressionBuilder()} instead.
      *
      * @return ExpressionBuilder
      */
@@ -785,7 +785,7 @@ class Connection
 
     /**
      * The usage of this method is discouraged. Use prepared statements
-     * or {@link AbstractPlatform::quoteStringLiteral()} instead.
+     * or {@see AbstractPlatform::quoteStringLiteral()} instead.
      *
      * @param mixed                $value
      * @param int|string|Type|null $type
@@ -1528,7 +1528,7 @@ class Connection
      * Gets the SchemaManager that can be used to inspect or change the
      * database schema through the connection.
      *
-     * @deprecated Use {@link createSchemaManager()} instead.
+     * @deprecated Use {@see createSchemaManager()} instead.
      *
      * @return AbstractSchemaManager
      *

--- a/src/Driver/API/ExceptionConverter.php
+++ b/src/Driver/API/ExceptionConverter.php
@@ -14,12 +14,12 @@ interface ExceptionConverter
      * Converts a given driver-level exception into a DBAL-level driver exception.
      *
      * Implementors should use the vendor-specific error code and SQLSTATE of the exception
-     * and instantiate the most appropriate specialized {@link DriverException} subclass.
+     * and instantiate the most appropriate specialized {@see DriverException} subclass.
      *
      * @param Exception  $exception The driver exception to convert.
      * @param Query|null $query     The SQL query that triggered the exception, if any.
      *
-     * @return DriverException An instance of {@link DriverException} or one of its subclasses.
+     * @return DriverException An instance of {@see DriverException} or one of its subclasses.
      */
     public function convert(Exception $exception, ?Query $query): DriverException;
 }

--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -13,7 +13,7 @@ use Doctrine\DBAL\Schema\DB2SchemaManager;
 use function assert;
 
 /**
- * Abstract base implementation of the {@link Driver} interface for IBM DB2 based drivers.
+ * Abstract base implementation of the {@see Driver} interface for IBM DB2 based drivers.
  */
 abstract class AbstractDB2Driver implements Driver
 {

--- a/src/Driver/AbstractException.php
+++ b/src/Driver/AbstractException.php
@@ -8,7 +8,7 @@ use Exception as BaseException;
 use Throwable;
 
 /**
- * Base implementation of the {@link Exception} interface.
+ * Base implementation of the {@see Exception} interface.
  *
  * @internal
  *

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -20,7 +20,7 @@ use function stripos;
 use function version_compare;
 
 /**
- * Abstract base implementation of the {@link Driver} interface for MySQL based drivers.
+ * Abstract base implementation of the {@see Driver} interface for MySQL based drivers.
  */
 abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
 {

--- a/src/Driver/AbstractOracleDriver.php
+++ b/src/Driver/AbstractOracleDriver.php
@@ -14,7 +14,7 @@ use Doctrine\DBAL\Schema\OracleSchemaManager;
 use function assert;
 
 /**
- * Abstract base implementation of the {@link Driver} interface for Oracle based drivers.
+ * Abstract base implementation of the {@see Driver} interface for Oracle based drivers.
  */
 abstract class AbstractOracleDriver implements Driver
 {

--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -17,7 +17,7 @@ use function preg_match;
 use function version_compare;
 
 /**
- * Abstract base implementation of the {@link Driver} interface for PostgreSQL based drivers.
+ * Abstract base implementation of the {@see Driver} interface for PostgreSQL based drivers.
  */
 abstract class AbstractPostgreSQLDriver implements VersionAwarePlatformDriver
 {

--- a/src/Driver/AbstractSQLServerDriver.php
+++ b/src/Driver/AbstractSQLServerDriver.php
@@ -13,7 +13,7 @@ use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use function assert;
 
 /**
- * Abstract base implementation of the {@link Driver} interface for Microsoft SQL Server based drivers.
+ * Abstract base implementation of the {@see Driver} interface for Microsoft SQL Server based drivers.
  */
 abstract class AbstractSQLServerDriver implements Driver
 {

--- a/src/Driver/AbstractSQLiteDriver.php
+++ b/src/Driver/AbstractSQLiteDriver.php
@@ -13,7 +13,7 @@ use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use function assert;
 
 /**
- * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for SQLite based drivers.
+ * Abstract base implementation of the {@see Doctrine\DBAL\Driver} interface for SQLite based drivers.
  */
 abstract class AbstractSQLiteDriver implements Driver
 {

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -28,7 +28,7 @@ interface Connection
      * Quotes a string for use in a query.
      *
      * The usage of this method is discouraged. Use prepared statements
-     * or {@link AbstractPlatform::quoteStringLiteral()} instead.
+     * or {@see AbstractPlatform::quoteStringLiteral()} instead.
      *
      * @param mixed $value
      * @param int   $type

--- a/src/Driver/ServerInfoAwareConnection.php
+++ b/src/Driver/ServerInfoAwareConnection.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL\Driver;
 /**
  * Contract for a connection that is able to provide information about the server it is connected to.
  *
- * @deprecated The methods defined in this interface will be made part of the {@link Driver} interface
+ * @deprecated The methods defined in this interface will be made part of the {@see Driver} interface
  * in the next major release.
  */
 interface ServerInfoAwareConnection extends Connection

--- a/src/Driver/Statement.php
+++ b/src/Driver/Statement.php
@@ -20,7 +20,7 @@ interface Statement
      *                          this will be a parameter name of the form :name. For a prepared statement
      *                          using question mark placeholders, this will be the 1-indexed position of the parameter.
      * @param mixed      $value The value to bind to the parameter.
-     * @param int        $type  Explicit data type for the parameter using the {@link ParameterType}
+     * @param int        $type  Explicit data type for the parameter using the {@see ParameterType}
      *                          constants.
      *
      * @return bool TRUE on success or FALSE on failure.
@@ -31,7 +31,7 @@ interface Statement
 
     /**
      * Binds a PHP variable to a corresponding named (not supported by mysqli driver, see comment below) or question
-     * mark placeholder in the SQL statement that was use to prepare the statement. Unlike {@link bindValue()},
+     * mark placeholder in the SQL statement that was use to prepare the statement. Unlike {@see bindValue()},
      * the variable is bound as a reference and will only be evaluated at the time
      * that PDOStatement->execute() is called.
      *
@@ -47,7 +47,7 @@ interface Statement
      *                             this will be a parameter name of the form :name. For a prepared statement using
      *                             question mark placeholders, this will be the 1-indexed position of the parameter.
      * @param mixed      $variable Name of the PHP variable to bind to the SQL statement parameter.
-     * @param int        $type     Explicit data type for the parameter using the {@link ParameterType}
+     * @param int        $type     Explicit data type for the parameter using the {@see ParameterType}
      *                             constants.
      * @param int|null   $length   You must specify maxlength when using an OUT bind
      *                             so that PHP allocates enough memory to hold the returned value.
@@ -62,7 +62,7 @@ interface Statement
      * Executes a prepared statement
      *
      * If the prepared statement included parameter markers, you must either:
-     * call {@link bindParam()} to bind PHP variables to the parameter markers:
+     * call {@see bindParam()} to bind PHP variables to the parameter markers:
      * bound variables pass their value as input and receive the output value,
      * if any, of their associated parameter markers or pass an array of input-only
      * parameter values.

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -24,7 +24,7 @@ use function strpos;
 use function substr;
 
 /**
- * Factory for creating {@link Connection} instances.
+ * Factory for creating {@see Connection} instances.
  *
  * @psalm-type OverrideParams = array{
  *     charset?: string,
@@ -71,7 +71,7 @@ final class DriverManager
     /**
      * List of supported drivers and their mappings to the driver classes.
      *
-     * To add your own driver use the 'driverClass' parameter to {@link DriverManager::getConnection()}.
+     * To add your own driver use the 'driverClass' parameter to {@see DriverManager::getConnection()}.
      */
     private const DRIVER_MAP = [
         'pdo_mysql'          => PDO\MySQL\Driver::class,
@@ -118,7 +118,7 @@ final class DriverManager
      *
      * $params must contain at least one of the following.
      *
-     * Either 'driver' with one of the array keys of {@link DRIVER_MAP},
+     * Either 'driver' with one of the array keys of {@see DRIVER_MAP},
      * OR 'driverClass' that contains the full class name (with namespace) of the
      * driver class to instantiate.
      *
@@ -340,7 +340,7 @@ final class DriverManager
      * Parses the given connection URL and resolves the given connection parameters.
      *
      * Assumes that the connection URL scheme is already parsed and resolved into the given connection parameters
-     * via {@link parseDatabaseUrlScheme}.
+     * via {@see parseDatabaseUrlScheme}.
      *
      * @see parseDatabaseUrlScheme
      *
@@ -394,7 +394,7 @@ final class DriverManager
     /**
      * Parses the given regular connection URL and resolves the given connection parameters.
      *
-     * Assumes that the "path" URL part is already normalized via {@link normalizeDatabaseUrlPath}.
+     * Assumes that the "path" URL part is already normalized via {@see normalizeDatabaseUrlPath}.
      *
      * @see normalizeDatabaseUrlPath
      *
@@ -413,7 +413,7 @@ final class DriverManager
     /**
      * Parses the given SQLite connection URL and resolves the given connection parameters.
      *
-     * Assumes that the "path" URL part is already normalized via {@link normalizeDatabaseUrlPath}.
+     * Assumes that the "path" URL part is already normalized via {@see normalizeDatabaseUrlPath}.
      *
      * @see normalizeDatabaseUrlPath
      *

--- a/src/Event/SchemaAlterTableAddColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableAddColumnEventArgs.php
@@ -12,7 +12,7 @@ use function func_get_args;
 use function is_array;
 
 /**
- * Event Arguments used when SQL queries for adding table columns are generated inside {@link AbstractPlatform}.
+ * Event Arguments used when SQL queries for adding table columns are generated inside {@see AbstractPlatform}.
  */
 class SchemaAlterTableAddColumnEventArgs extends SchemaEventArgs
 {

--- a/src/Event/SchemaAlterTableChangeColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableChangeColumnEventArgs.php
@@ -11,7 +11,7 @@ use function func_get_args;
 use function is_array;
 
 /**
- * Event Arguments used when SQL queries for changing table columns are generated inside {@link AbstractPlatform}.
+ * Event Arguments used when SQL queries for changing table columns are generated inside {@see AbstractPlatform}.
  */
 class SchemaAlterTableChangeColumnEventArgs extends SchemaEventArgs
 {

--- a/src/Event/SchemaAlterTableEventArgs.php
+++ b/src/Event/SchemaAlterTableEventArgs.php
@@ -10,7 +10,7 @@ use function func_get_args;
 use function is_array;
 
 /**
- * Event Arguments used when SQL queries for creating tables are generated inside {@link AbstractPlatform}.
+ * Event Arguments used when SQL queries for creating tables are generated inside {@see AbstractPlatform}.
  */
 class SchemaAlterTableEventArgs extends SchemaEventArgs
 {

--- a/src/Event/SchemaAlterTableRemoveColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableRemoveColumnEventArgs.php
@@ -11,7 +11,7 @@ use function func_get_args;
 use function is_array;
 
 /**
- * Event Arguments used when SQL queries for removing table columns are generated inside {@link AbstractPlatform}.
+ * Event Arguments used when SQL queries for removing table columns are generated inside {@see AbstractPlatform}.
  */
 class SchemaAlterTableRemoveColumnEventArgs extends SchemaEventArgs
 {

--- a/src/Event/SchemaAlterTableRenameColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableRenameColumnEventArgs.php
@@ -11,7 +11,7 @@ use function func_get_args;
 use function is_array;
 
 /**
- * Event Arguments used when SQL queries for renaming table columns are generated inside {@link AbstractPlatform}.
+ * Event Arguments used when SQL queries for renaming table columns are generated inside {@see AbstractPlatform}.
  */
 class SchemaAlterTableRenameColumnEventArgs extends SchemaEventArgs
 {

--- a/src/Event/SchemaColumnDefinitionEventArgs.php
+++ b/src/Event/SchemaColumnDefinitionEventArgs.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Column;
 
 /**
- * Event Arguments used when the portable column definition is generated inside {@link AbstractPlatform}.
+ * Event Arguments used when the portable column definition is generated inside {@see AbstractPlatform}.
  */
 class SchemaColumnDefinitionEventArgs extends SchemaEventArgs
 {

--- a/src/Event/SchemaCreateTableColumnEventArgs.php
+++ b/src/Event/SchemaCreateTableColumnEventArgs.php
@@ -11,7 +11,7 @@ use function func_get_args;
 use function is_array;
 
 /**
- * Event Arguments used when SQL queries for creating table columns are generated inside {@link AbstractPlatform}.
+ * Event Arguments used when SQL queries for creating table columns are generated inside {@see AbstractPlatform}.
  */
 class SchemaCreateTableColumnEventArgs extends SchemaEventArgs
 {

--- a/src/Event/SchemaCreateTableEventArgs.php
+++ b/src/Event/SchemaCreateTableEventArgs.php
@@ -10,7 +10,7 @@ use function func_get_args;
 use function is_array;
 
 /**
- * Event Arguments used when SQL queries for creating tables are generated inside {@link AbstractPlatform}.
+ * Event Arguments used when SQL queries for creating tables are generated inside {@see AbstractPlatform}.
  */
 class SchemaCreateTableEventArgs extends SchemaEventArgs
 {

--- a/src/Event/SchemaDropTableEventArgs.php
+++ b/src/Event/SchemaDropTableEventArgs.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Schema\Table;
 use InvalidArgumentException;
 
 /**
- * Event Arguments used when the SQL query for dropping tables are generated inside {@link AbstractPlatform}.
+ * Event Arguments used when the SQL query for dropping tables are generated inside {@see AbstractPlatform}.
  */
 class SchemaDropTableEventArgs extends SchemaEventArgs
 {

--- a/src/Event/SchemaIndexDefinitionEventArgs.php
+++ b/src/Event/SchemaIndexDefinitionEventArgs.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Index;
 
 /**
- * Event Arguments used when the portable index definition is generated inside {@link AbstractSchemaManager}.
+ * Event Arguments used when the portable index definition is generated inside {@see AbstractSchemaManager}.
  */
 class SchemaIndexDefinitionEventArgs extends SchemaEventArgs
 {

--- a/src/Logging/SQLLogger.php
+++ b/src/Logging/SQLLogger.php
@@ -7,8 +7,8 @@ use Doctrine\DBAL\Types\Type;
 /**
  * Interface for SQL loggers.
  *
- * @deprecated Use {@link \Doctrine\DBAL\Logging\Middleware} or implement
- *            {@link \Doctrine\DBAL\Driver\Middleware} instead.
+ * @deprecated Use {@see \Doctrine\DBAL\Logging\Middleware} or implement
+ *            {@see \Doctrine\DBAL\Driver\Middleware} instead.
  */
 interface SQLLogger
 {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -634,7 +634,7 @@ abstract class AbstractPlatform
     /**
      * Gets all SQL wildcard characters of the platform.
      *
-     * @deprecated Use {@link AbstractPlatform::getLikeWildcardCharacters()} instead.
+     * @deprecated Use {@see AbstractPlatform::getLikeWildcardCharacters()} instead.
      *
      * @return string[]
      */
@@ -1657,7 +1657,7 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to drop a constraint.
      *
-     * @internal The method should be only used from within the {@link AbstractPlatform} class hierarchy.
+     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      *
      * @param Constraint|string $constraint
      * @param Table|string      $table
@@ -1980,8 +1980,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to create a constraint on a table on this platform.
      *
-     * @deprecated Use {@link getCreateIndexSQL()}, {@link getCreateForeignKeySQL()}
-     *             or {@link getCreateUniqueConstraintSQL()} instead.
+     * @deprecated Use {@see getCreateIndexSQL()}, {@see getCreateForeignKeySQL()}
+     *             or {@see getCreateUniqueConstraintSQL()} instead.
      *
      * @param Table|string $table
      *
@@ -3028,7 +3028,7 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL statement for retrieving the namespaces defined in the database.
      *
-     * @deprecated Use {@link AbstractSchemaManager::listSchemaNames()} instead.
+     * @deprecated Use {@see AbstractSchemaManager::listSchemaNames()} instead.
      *
      * @return string
      *
@@ -3511,7 +3511,7 @@ abstract class AbstractPlatform
      * @deprecated
      *
      * Platforms that either support or emulate schemas don't automatically
-     * filter a schema for the namespaced elements in {@link AbstractManager::createSchema()}.
+     * filter a schema for the namespaced elements in {@see AbstractManager::createSchema()}.
      *
      * @return bool
      */
@@ -3879,7 +3879,7 @@ abstract class AbstractPlatform
     /**
      * Returns the class name of the reserved keywords list.
      *
-     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
      *
      * @return string
      * @psalm-return class-string<KeywordList>

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -879,7 +879,7 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      *
-     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/Keywords/PostgreSQL94Keywords.php
+++ b/src/Platforms/Keywords/PostgreSQL94Keywords.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL\Platforms\Keywords;
 /**
  * PostgreSQL 9.4 reserved keywords list.
  *
- * @deprecated Use {@link PostgreSQLKeywords} instead.
+ * @deprecated Use {@see PostgreSQLKeywords} instead.
  */
 class PostgreSQL94Keywords extends PostgreSQLKeywords
 {

--- a/src/Platforms/Keywords/SQLServer2012Keywords.php
+++ b/src/Platforms/Keywords/SQLServer2012Keywords.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL\Platforms\Keywords;
 /**
  * Microsoft SQL Server 2012 reserved keyword dictionary.
  *
- * @deprecated Use {@link SQLServerKeywords} instead.
+ * @deprecated Use {@see SQLServerKeywords} instead.
  */
 class SQLServer2012Keywords extends SQLServerKeywords
 {

--- a/src/Platforms/MariaDb1027Platform.php
+++ b/src/Platforms/MariaDb1027Platform.php
@@ -23,7 +23,7 @@ class MariaDb1027Platform extends MySQLPlatform
     }
 
     /**
-     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass(): string
     {

--- a/src/Platforms/MySQL57Platform.php
+++ b/src/Platforms/MySQL57Platform.php
@@ -61,7 +61,7 @@ class MySQL57Platform extends MySQLPlatform
     /**
      * {@inheritdoc}
      *
-     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/MySQL80Platform.php
+++ b/src/Platforms/MySQL80Platform.php
@@ -12,7 +12,7 @@ class MySQL80Platform extends MySQL57Platform
     /**
      * {@inheritdoc}
      *
-     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -1099,7 +1099,7 @@ SQL
     /**
      * {@inheritDoc}
      *
-     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -1167,7 +1167,7 @@ SQL
     /**
      * {@inheritDoc}
      *
-     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/PostgreSQL100Platform.php
+++ b/src/Platforms/PostgreSQL100Platform.php
@@ -13,7 +13,7 @@ use Doctrine\Deprecations\Deprecation;
 class PostgreSQL100Platform extends PostgreSQL94Platform
 {
     /**
-     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass(): string
     {

--- a/src/Platforms/PostgreSQL94Platform.php
+++ b/src/Platforms/PostgreSQL94Platform.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL\Platforms;
 /**
  * Provides the behavior, features and SQL dialect of the PostgreSQL 9.4+ database platform.
  *
- * @deprecated Use {@link PostgreSQLPlatform} instead.
+ * @deprecated Use {@see PostgreSQLPlatform} instead.
  */
 class PostgreSQL94Platform extends PostgreSQLPlatform
 {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -237,7 +237,7 @@ class PostgreSQLPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      *
-     * @deprecated Use {@link PostgreSQLSchemaManager::listSchemaNames()} instead.
+     * @deprecated Use {@see PostgreSQLSchemaManager::listSchemaNames()} instead.
      */
     public function getListNamespacesSQL()
     {
@@ -615,7 +615,7 @@ SQL
      * Checks whether a given column diff is a logically unchanged binary type column.
      *
      * Used to determine whether a column alteration for a binary type column can be skipped.
-     * Doctrine's {@link BinaryType} and {@link BlobType} are mapped to the same database column type on this platform
+     * Doctrine's {@see BinaryType} and {@see BlobType} are mapped to the same database column type on this platform
      * as this platform does not have a native VARBINARY/BINARY column type. Therefore the comparator
      * might detect differences for binary type columns which do not have to be propagated
      * to database as there actually is no difference at database level.
@@ -1161,7 +1161,7 @@ SQL
     /**
      * {@inheritDoc}
      *
-     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1085,7 +1085,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      *
-     * @deprecated Use {@link SQLServerSchemaManager::listSchemaNames()} instead.
+     * @deprecated Use {@see SQLServerSchemaManager::listSchemaNames()} instead.
      */
     public function getListNamespacesSQL()
     {
@@ -1481,7 +1481,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      *
-     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -586,7 +586,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * User-defined function for Sqlite that is used with PDO::sqliteCreateFunction().
      *
-     * @deprecated The driver will use {@link sqrt()} in the next major release.
+     * @deprecated The driver will use {@see sqrt()} in the next major release.
      *
      * @param int|float $value
      *
@@ -600,7 +600,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * User-defined function for Sqlite that implements MOD(a, b).
      *
-     * @deprecated The driver will use {@link UserDefinedFunctions::mod()} in the next major release.
+     * @deprecated The driver will use {@see UserDefinedFunctions::mod()} in the next major release.
      *
      * @param int $a
      * @param int $b
@@ -613,7 +613,7 @@ class SqlitePlatform extends AbstractPlatform
     }
 
     /**
-     * @deprecated The driver will use {@link UserDefinedFunctions::locate()} in the next major release.
+     * @deprecated The driver will use {@see UserDefinedFunctions::locate()} in the next major release.
      *
      * @param string $str
      * @param string $substr
@@ -691,7 +691,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      *
-     * @deprecated Implement {@link createReservedKeywordsList()} instead.
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()
     {

--- a/src/Portability/Converter.php
+++ b/src/Portability/Converter.php
@@ -34,7 +34,7 @@ final class Converter
      * @param bool     $convertEmptyStringToNull Whether each empty string should be converted to NULL
      * @param bool     $rightTrimString          Whether each string should right-trimmed
      * @param int|null $case                     Convert the case of the column names
-     *                                           (one of {@link CASE_LOWER} and {@link CASE_UPPER})
+     *                                           (one of {@see CASE_LOWER} and {@see CASE_UPPER})
      */
     public function __construct(bool $convertEmptyStringToNull, bool $rightTrimString, ?int $case)
     {

--- a/src/Query/Expression/ExpressionBuilder.php
+++ b/src/Query/Expression/ExpressionBuilder.php
@@ -311,7 +311,7 @@ class ExpressionBuilder
      * Builds an SQL literal from a given input parameter.
      *
      * The usage of this method is discouraged. Use prepared statements
-     * or {@link AbstractPlatform::quoteStringLiteral()} instead.
+     * or {@see AbstractPlatform::quoteStringLiteral()} instead.
      *
      * @param mixed    $input The parameter to be quoted.
      * @param int|null $type  The type of the parameter.

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -327,7 +327,7 @@ class QueryBuilder
     /**
      * Executes this query using the bound parameters and their types.
      *
-     * @deprecated Use {@link executeQuery()} or {@link executeStatement()} instead.
+     * @deprecated Use {@see executeQuery()} or {@see executeStatement()} instead.
      *
      * @return Result|int
      *
@@ -1437,7 +1437,7 @@ class QueryBuilder
     /**
      * Creates a new named parameter and bind the value $value to it.
      *
-     * This method provides a shortcut for {@link Statement::bindValue()}
+     * This method provides a shortcut for {@see Statement::bindValue()}
      * when using prepared statements.
      *
      * The parameter $value specifies the value that you want to bind. If

--- a/src/Result.php
+++ b/src/Result.php
@@ -22,7 +22,7 @@ class Result
     private $connection;
 
     /**
-     * @internal The result can be only instantiated by {@link Connection} or {@link Statement}.
+     * @internal The result can be only instantiated by {@see Connection} or {@see Statement}.
      */
     public function __construct(DriverResult $result, Connection $connection)
     {

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -111,7 +111,7 @@ abstract class AbstractAsset
      * Every non-namespaced element is prefixed with the default namespace
      * name which is passed as argument to this method.
      *
-     * @deprecated Use {@link getNamespaceName()} and {@link getName()} instead.
+     * @deprecated Use {@see getNamespaceName()} and {@see getName()} instead.
      *
      * @param string $defaultNamespaceName
      *

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -122,7 +122,7 @@ abstract class AbstractSchemaManager
     /**
      * Returns a list of all namespaces in the current database.
      *
-     * @deprecated Use {@link listSchemaNames()} instead.
+     * @deprecated Use {@see listSchemaNames()} instead.
      *
      * @return string[]
      *
@@ -432,7 +432,7 @@ abstract class AbstractSchemaManager
     /**
      * Drops the constraint from the given table.
      *
-     * @deprecated Use {@link dropIndex()}, {@link dropForeignKey()} or {@link dropUniqueConstraint()} instead.
+     * @deprecated Use {@see dropIndex()}, {@see dropForeignKey()} or {@see dropUniqueConstraint()} instead.
      *
      * @param Table|string $table The name of the table.
      *
@@ -544,7 +544,7 @@ abstract class AbstractSchemaManager
     /**
      * Creates a constraint on a table.
      *
-     * @deprecated Use {@link createIndex()}, {@link createForeignKey()} or {@link createUniqueConstraint()} instead.
+     * @deprecated Use {@see createIndex()}, {@see createForeignKey()} or {@see createUniqueConstraint()} instead.
      *
      * @param Table|string $table
      *
@@ -613,9 +613,9 @@ abstract class AbstractSchemaManager
     /**
      * Drops and creates a constraint.
      *
-     * @deprecated Use {@link dropIndex()} and {@link createIndex()},
-     *             {@link dropForeignKey()} and {@link createForeignKey()}
-     *             or {@link dropUniqueConstraint()} and {@link createUniqueConstraint()} instead.
+     * @deprecated Use {@see dropIndex()} and {@see createIndex()},
+     *             {@see dropForeignKey()} and {@see createForeignKey()}
+     *             or {@see dropUniqueConstraint()} and {@see createUniqueConstraint()} instead.
      *
      * @see dropConstraint()
      * @see createConstraint()
@@ -645,7 +645,7 @@ abstract class AbstractSchemaManager
     /**
      * Drops and creates a new index on a table.
      *
-     * @deprecated Use {@link dropIndex()} and {@link createIndex()} instead.
+     * @deprecated Use {@see dropIndex()} and {@see createIndex()} instead.
      *
      * @param Table|string $table The name of the table on which the index is to be created.
      *
@@ -669,7 +669,7 @@ abstract class AbstractSchemaManager
     /**
      * Drops and creates a new foreign key.
      *
-     * @deprecated Use {@link dropForeignKey()} and {@link createForeignKey()} instead.
+     * @deprecated Use {@see dropForeignKey()} and {@see createForeignKey()} instead.
      *
      * @param ForeignKeyConstraint $foreignKey An associative array that defines properties
      *                                         of the foreign key to be created.
@@ -695,7 +695,7 @@ abstract class AbstractSchemaManager
     /**
      * Drops and create a new sequence.
      *
-     * @deprecated Use {@link dropSequence()} and {@link createSequence()} instead.
+     * @deprecated Use {@see dropSequence()} and {@see createSequence()} instead.
      *
      * @return void
      *
@@ -717,7 +717,7 @@ abstract class AbstractSchemaManager
     /**
      * Drops and creates a new table.
      *
-     * @deprecated Use {@link dropTable()} and {@link createTable()} instead.
+     * @deprecated Use {@see dropTable()} and {@see createTable()} instead.
      *
      * @return void
      *
@@ -739,7 +739,7 @@ abstract class AbstractSchemaManager
     /**
      * Drops and creates a new database.
      *
-     * @deprecated Use {@link dropDatabase()} and {@link createDatabase()} instead.
+     * @deprecated Use {@see dropDatabase()} and {@see createDatabase()} instead.
      *
      * @param string $database The name of the database to create.
      *
@@ -763,7 +763,7 @@ abstract class AbstractSchemaManager
     /**
      * Drops and creates a new view.
      *
-     * @deprecated Use {@link dropView()} and {@link createView()} instead.
+     * @deprecated Use {@see dropView()} and {@see createView()} instead.
      *
      * @return void
      *
@@ -861,7 +861,7 @@ abstract class AbstractSchemaManager
     /**
      * Converts a list of namespace names from the native DBMS data definition to a portable Doctrine definition.
      *
-     * @deprecated Use {@link listSchemaNames()} instead.
+     * @deprecated Use {@see listSchemaNames()} instead.
      *
      * @param array<int, array<string, mixed>> $namespaces The list of namespace names
      *                                                     in the native DBMS data definition.
@@ -899,7 +899,7 @@ abstract class AbstractSchemaManager
     /**
      * Converts a namespace definition from the native DBMS data definition to a portable Doctrine definition.
      *
-     * @deprecated Use {@link listSchemaNames()} instead.
+     * @deprecated Use {@see listSchemaNames()} instead.
      *
      * @param array<string, mixed> $namespace The native DBMS namespace definition.
      *

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -175,7 +175,7 @@ class Comparator
     }
 
     /**
-     * @deprecated Use non-static call to {@link compareSchemas()} instead.
+     * @deprecated Use non-static call to {@see compareSchemas()} instead.
      *
      * @return SchemaDiff
      *

--- a/src/Schema/Constraint.php
+++ b/src/Schema/Constraint.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 /**
  * Marker interface for constraints.
  *
- * @deprecated Use {@link ForeignKeyConstraint}, {@link Index} or {@link UniqueConstraint} instead.
+ * @deprecated Use {@see ForeignKeyConstraint}, {@see Index} or {@see UniqueConstraint} instead.
  */
 interface Constraint
 {

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -105,7 +105,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * Returns the name of the referencing table
      * the foreign key constraint is associated with.
      *
-     * @deprecated Use the table that contains the foreign key as part of its {@link Table::$_fkConstraints} instead.
+     * @deprecated Use the table that contains the foreign key as part of its {@see Table::$_fkConstraints} instead.
      *
      * @return string
      */
@@ -118,7 +118,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * Sets the Table instance of the referencing table
      * the foreign key constraint is associated with.
      *
-     * @deprecated Use the table that contains the foreign key as part of its {@link Table::$_fkConstraints} instead.
+     * @deprecated Use the table that contains the foreign key as part of its {@see Table::$_fkConstraints} instead.
      *
      * @param Table $table Instance of the referencing table.
      *
@@ -130,7 +130,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
     }
 
     /**
-     * @deprecated Use the table that contains the foreign key as part of its {@link Table::$_fkConstraints} instead.
+     * @deprecated Use the table that contains the foreign key as part of its {@see Table::$_fkConstraints} instead.
      *
      * @return Table
      */
@@ -196,7 +196,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
     /**
      * {@inheritdoc}
      *
-     * @deprecated Use {@link getLocalColumns()} instead.
+     * @deprecated Use {@see getLocalColumns()} instead.
      *
      * @see getLocalColumns
      */
@@ -213,7 +213,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * is a keyword reserved by the platform.
      * Otherwise the plain unquoted value as inserted is returned.
      *
-     * @deprecated Use {@link getQuotedLocalColumns()} instead.
+     * @deprecated Use {@see getQuotedLocalColumns()} instead.
      *
      * @see getQuotedLocalColumns
      *

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -40,7 +40,7 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
     /**
      * Gets all the existing schema names.
      *
-     * @deprecated Use {@link listSchemaNames()} instead.
+     * @deprecated Use {@see listSchemaNames()} instead.
      *
      * @return string[]
      *
@@ -312,7 +312,7 @@ SQL
     /**
      * {@inheritdoc}
      *
-     * @deprecated Use {@link listSchemaNames()} instead.
+     * @deprecated Use {@see listSchemaNames()} instead.
      */
     protected function getPortableNamespaceDefinition(array $namespace)
     {

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -227,7 +227,7 @@ SQL
     /**
      * {@inheritdoc}
      *
-     * @deprecated Use {@link listSchemaNames()} instead.
+     * @deprecated Use {@see listSchemaNames()} instead.
      */
     protected function getPortableNamespaceDefinition(array $namespace)
     {

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -256,7 +256,7 @@ class Schema extends AbstractAsset
     /**
      * Gets all table names, prefixed with a schema name, even the default one if present.
      *
-     * @deprecated Use {@link getTables()} and {@link Table::getName()} instead.
+     * @deprecated Use {@see getTables()} and {@see Table::getName()} instead.
      *
      * @return string[]
      */

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -108,7 +108,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritdoc}
      *
-     * @deprecated Use {@link dropForeignKey()} and {@link createForeignKey()} instead.
+     * @deprecated Use {@see dropForeignKey()} and {@see createForeignKey()} instead.
      */
     public function dropAndCreateForeignKey(ForeignKeyConstraint $foreignKey, $table)
     {

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -59,7 +59,7 @@ class Statement
     /**
      * Creates a new <tt>Statement</tt> for the given SQL and <tt>Connection</tt>.
      *
-     * @internal The statement can be only instantiated by {@link Connection}.
+     * @internal The statement can be only instantiated by {@see Connection}.
      *
      * @param Connection       $conn      The connection for handling statement errors.
      * @param Driver\Statement $statement The underlying driver-level statement.

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -12,7 +12,7 @@ use function get_class;
 /**
  * The base class for so-called Doctrine mapping types.
  *
- * A Type object is obtained by calling the static {@link getType()} method.
+ * A Type object is obtained by calling the static {@see getType()} method.
  */
 abstract class Type
 {
@@ -189,7 +189,7 @@ abstract class Type
      * Gets the (preferred) binding type for values of this type that
      * can be used when binding parameters to prepared statements.
      *
-     * This method should return one of the {@link ParameterType} constants.
+     * This method should return one of the {@see ParameterType} constants.
      *
      * @return int
      */
@@ -218,8 +218,8 @@ abstract class Type
      * Does working with this column require SQL conversion functions?
      *
      * This is a metadata function that is required for example in the ORM.
-     * Usage of {@link convertToDatabaseValueSQL} and
-     * {@link convertToPHPValueSQL} works for any type and mostly
+     * Usage of {@see convertToDatabaseValueSQL} and
+     * {@see convertToPHPValueSQL} works for any type and mostly
      * does nothing. This method can additionally be used for optimization purposes.
      *
      * @return bool


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

We use `@link` and `@see` inconsistently for references to structural elements. According to the phpDoc spec, we should use `@link` for URIs only.

* https://docs.phpdoc.org/guide/references/phpdoc/tags/link.html
* https://docs.phpdoc.org/guide/references/phpdoc/tags/see.html
