### PR TITLE
Remove Platform API about commented types

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,19 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: Removed Platform "commented type" API
+
+Since `Type::requiresSQLCommentTypeHint()` already allows determining whether a
+type should result in SQL columns with a type hint in their comments, the
+following methods are removed:
+
+- `AbstractPlatform::isCommentedDoctrineType()`
+- `AbstractPlatform::initializeCommentedDoctrineTypes()`
+- `AbstractPlatform::markDoctrineTypeCommented()`
+
+The protected property `AbstractPlatform::$doctrineTypeComments` is removed as
+well.
+
 ## BC BREAK: Removed `Connection::getWrappedConnection()`, `Connection::connect()` made `protected`.
 
 The wrapper-level `Connection::getWrappedConnection()` method has been removed. The `Connection::connect()` method

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -60,24 +60,8 @@
                     See https://github.com/doctrine/dbal/pull/4317
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
-                <!--
-                    See https://github.com/doctrine/dbal/pull/5058
-                    TODO: remove in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::isCommentedDoctrineType"/>
-                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::initializeCommentedDoctrineTypes"/>
-                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::markedDoctrineTypeCommented"/>
             </errorLevel>
         </DeprecatedMethod>
-        <DeprecatedProperty>
-            <errorLevel type="suppress">
-                <!--
-                    See https://github.com/doctrine/dbal/pull/5058
-                    TODO: remove in 4.0.0
-                -->
-                <referencedProperty name="Doctrine\DBAL\Platforms\AbstractPlatform::$doctrineTypeComments"/>
-            </errorLevel>
-        </DeprecatedProperty>
         <DocblockTypeContradiction>
             <errorLevel type="suppress">
                 <!--

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -35,7 +35,6 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 use UnexpectedValueException;
 
@@ -78,16 +77,6 @@ abstract class AbstractPlatform
 
     /** @var string[]|null */
     protected ?array $doctrineTypeMapping = null;
-
-    /**
-     * Contains a list of all columns that should generate parseable column comments for type-detection
-     * in reverse engineering scenarios.
-     *
-     * @deprecated This property is deprecated and will be removed in Doctrine DBAL 4.0.
-     *
-     * @var string[]|null
-     */
-    protected ?array $doctrineTypeComments = null;
 
     protected ?EventManager $_eventManager = null;
 
@@ -346,14 +335,6 @@ abstract class AbstractPlatform
 
         $dbType                             = strtolower($dbType);
         $this->doctrineTypeMapping[$dbType] = $doctrineType;
-
-        $doctrineType = Type::getType($doctrineType);
-
-        if (! $doctrineType->requiresSQLCommentHint($this)) {
-            return;
-        }
-
-        $this->markDoctrineTypeCommented($doctrineType);
     }
 
     /**
@@ -392,77 +373,6 @@ abstract class AbstractPlatform
         $dbType = strtolower($dbType);
 
         return isset($this->doctrineTypeMapping[$dbType]);
-    }
-
-    /**
-     * Initializes the Doctrine Type comments instance variable for in_array() checks.
-     *
-     * @deprecated This API will be removed in Doctrine DBAL 4.0.
-     */
-    protected function initializeCommentedDoctrineTypes(): void
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5058',
-            '%s is deprecated and will be removed in Doctrine DBAL 4.0.',
-            __METHOD__
-        );
-
-        $this->doctrineTypeComments = [];
-
-        foreach (Type::getTypesMap() as $typeName => $className) {
-            $type = Type::getType($typeName);
-
-            if (! $type->requiresSQLCommentHint($this)) {
-                continue;
-            }
-
-            $this->doctrineTypeComments[] = $typeName;
-        }
-    }
-
-    /**
-     * Is it necessary for the platform to add a parsable type comment to allow reverse engineering the given type?
-     *
-     * @deprecated Use {@link Type::requiresSQLCommentHint()} instead.
-     */
-    public function isCommentedDoctrineType(Type $doctrineType): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5058',
-            '%s is deprecated and will be removed in Doctrine DBAL 4.0. Use Type::requiresSQLCommentHint() instead.',
-            __METHOD__
-        );
-
-        if ($this->doctrineTypeComments === null) {
-            $this->initializeCommentedDoctrineTypes();
-        }
-
-        assert(is_array($this->doctrineTypeComments));
-
-        return in_array($doctrineType->getName(), $this->doctrineTypeComments, true);
-    }
-
-    /**
-     * Marks this type as to be commented in ALTER TABLE and CREATE TABLE statements.
-     */
-    public function markDoctrineTypeCommented(string|Type $doctrineType): void
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5058',
-            '%s is deprecated and will be removed in Doctrine DBAL 4.0. Use Type::requiresSQLCommentHint() instead.',
-            __METHOD__
-        );
-
-        if ($this->doctrineTypeComments === null) {
-            $this->initializeCommentedDoctrineTypes();
-        }
-
-        assert(is_array($this->doctrineTypeComments));
-
-        $this->doctrineTypeComments[] = $doctrineType instanceof Type ? $doctrineType->getName() : $doctrineType;
     }
 
     /**

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -12,9 +12,6 @@ use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
-use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function count;
@@ -54,24 +51,6 @@ class DB2Platform extends AbstractPlatform
             'varbinary' => 'binary',
             'varchar'   => 'string',
         ];
-    }
-
-    public function isCommentedDoctrineType(Type $doctrineType): bool
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5058',
-            '%s is deprecated and will be removed in Doctrine DBAL 4.0. Use Type::requiresSQLCommentHint() instead.',
-            __METHOD__
-        );
-
-        if ($doctrineType->getName() === Types::BOOLEAN) {
-            // We require a commented boolean type in order to distinguish between boolean and smallint
-            // as both (have to) map to the same native type.
-            return true;
-        }
-
-        return parent::isCommentedDoctrineType($doctrineType);
     }
 
     protected function getBinaryTypeDeclarationSQLSnippet(?int $length): string

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -121,43 +121,6 @@ abstract class AbstractPlatformTestCase extends TestCase
         $this->platform->registerDoctrineTypeMapping('foo', 'bar');
     }
 
-    public function testRegistersCommentedDoctrineMappingTypeImplicitly(): void
-    {
-        $type = Type::getType('array');
-        $this->platform->registerDoctrineTypeMapping('foo', 'array');
-
-        self::assertTrue($this->platform->isCommentedDoctrineType($type));
-    }
-
-    /**
-     * @dataProvider getIsCommentedDoctrineType
-     */
-    public function testIsCommentedDoctrineType(Type $type, bool $commented): void
-    {
-        self::assertSame($commented, $this->platform->isCommentedDoctrineType($type));
-    }
-
-    /**
-     * @return mixed[]
-     */
-    public function getIsCommentedDoctrineType(): iterable
-    {
-        $this->setUp();
-
-        $data = [];
-
-        foreach (Type::getTypesMap() as $typeName => $className) {
-            $type = Type::getType($typeName);
-
-            $data[$typeName] = [
-                $type,
-                $type->requiresSQLCommentHint($this->platform),
-            ];
-        }
-
-        return $data;
-    }
-
     public function testCreateWithNoColumns(): void
     {
         $table = new Table('test');

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -13,7 +13,6 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
 
 /**
  * @extends AbstractPlatformTestCase<DB2Platform>
@@ -280,22 +279,6 @@ class DB2PlatformTest extends AbstractPlatformTestCase
 
         self::assertEquals('TIMESTAMP(0)', $this->platform->getDateTimeTypeDeclarationSQL($fullColumnDef));
         self::assertEquals('TIME', $this->platform->getTimeTypeDeclarationSQL($fullColumnDef));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getIsCommentedDoctrineType(): iterable
-    {
-        $types = [];
-
-        foreach (parent::getIsCommentedDoctrineType() as $key => $value) {
-            $types[$key] = $value;
-        }
-
-        $types[Types::BOOLEAN] = [Type::getType(Types::BOOLEAN), true];
-
-        return $types;
     }
 
     public function testGeneratesDDLSnippets(): void


### PR DESCRIPTION
`Type::requiresSQLCommentHint()` already does the job.