### PR TITLE
Clean up SQL generation in MySQL platform

### DIFF
--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -155,13 +155,10 @@ class MySQLPlatform extends AbstractPlatform
     public function getListTableIndexesSQL($table, $database = null)
     {
         if ($database !== null) {
-            $database = $this->quoteStringLiteral($database);
-            $table    = $this->quoteStringLiteral($table);
-
             return 'SELECT NON_UNIQUE AS Non_Unique, INDEX_NAME AS Key_name, COLUMN_NAME AS Column_Name,' .
                    ' SUB_PART AS Sub_Part, INDEX_TYPE AS Index_Type' .
-                   ' FROM information_schema.STATISTICS WHERE TABLE_NAME = ' . $table .
-                   ' AND TABLE_SCHEMA = ' . $database .
+                   ' FROM information_schema.STATISTICS WHERE TABLE_NAME = ' . $this->quoteStringLiteral($table) .
+                   ' AND TABLE_SCHEMA = ' . $this->quoteStringLiteral($database) .
                    ' ORDER BY SEQ_IN_INDEX ASC';
         }
 
@@ -173,9 +170,7 @@ class MySQLPlatform extends AbstractPlatform
      */
     public function getListViewsSQL($database)
     {
-        $database = $this->quoteStringLiteral($database);
-
-        return 'SELECT * FROM information_schema.VIEWS WHERE TABLE_SCHEMA = ' . $database;
+        return 'SELECT * FROM information_schema.VIEWS WHERE TABLE_SCHEMA = ' . $this->quoteStringLiteral($database);
     }
 
     /**
@@ -186,25 +181,16 @@ class MySQLPlatform extends AbstractPlatform
      */
     public function getListTableForeignKeysSQL($table, $database = null)
     {
-        $table = $this->quoteStringLiteral($table);
-
-        if ($database !== null) {
-            $database = $this->quoteStringLiteral($database);
-        }
-
-        $sql = 'SELECT DISTINCT k.`CONSTRAINT_NAME`, k.`COLUMN_NAME`, k.`REFERENCED_TABLE_NAME`, ' .
-               'k.`REFERENCED_COLUMN_NAME`, k.`ORDINAL_POSITION` /*!50116 , c.update_rule, c.delete_rule */ ' .
-               'FROM information_schema.key_column_usage k /*!50116 ' .
-               'INNER JOIN information_schema.referential_constraints c ON ' .
-               '  c.constraint_name = k.constraint_name AND ' .
-               '  c.table_name = ' . $table . ' */ WHERE k.table_name = ' . $table;
-
-        $databaseNameSql = $database ?? 'DATABASE()';
-
-        return $sql . ' AND k.table_schema = ' . $databaseNameSql
-            . ' /*!50116 AND c.constraint_schema = ' . $databaseNameSql . ' */'
-            . ' AND k.`REFERENCED_COLUMN_NAME` is not NULL'
-            . ' ORDER BY k.`ORDINAL_POSITION`';
+        return 'SELECT k.CONSTRAINT_NAME, k.COLUMN_NAME, k.REFERENCED_TABLE_NAME, ' .
+               'k.REFERENCED_COLUMN_NAME /*!50116 , c.UPDATE_RULE, c.DELETE_RULE */ ' .
+               'FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE k /*!50116 ' .
+               'INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS c ON ' .
+               'c.CONSTRAINT_NAME = k.CONSTRAINT_NAME AND ' .
+               'c.TABLE_NAME = k.TABLE_NAME AND ' .
+               'c.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA */ ' .
+               'WHERE k.TABLE_NAME = ' . $this->quoteStringLiteral($table) . ' ' .
+               'AND k.TABLE_SCHEMA = ' . $this->getDatabaseNameSQL($database) . ' ' .
+               'ORDER BY k.ORDINAL_POSITION';
     }
 
     /**
@@ -342,18 +328,11 @@ class MySQLPlatform extends AbstractPlatform
      */
     public function getListTableColumnsSQL($table, $database = null)
     {
-        $table = $this->quoteStringLiteral($table);
-
-        if ($database !== null) {
-            $database = $this->quoteStringLiteral($database);
-        } else {
-            $database = 'DATABASE()';
-        }
-
         return 'SELECT COLUMN_NAME AS Field, COLUMN_TYPE AS Type, IS_NULLABLE AS `Null`, ' .
                'COLUMN_KEY AS `Key`, COLUMN_DEFAULT AS `Default`, EXTRA AS Extra, COLUMN_COMMENT AS Comment, ' .
                'CHARACTER_SET_NAME AS CharacterSet, COLLATION_NAME AS Collation ' .
-               'FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ' . $database . ' AND TABLE_NAME = ' . $table .
+               'FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ' . $this->getDatabaseNameSQL($database) .
+               ' AND TABLE_NAME = ' . $this->quoteStringLiteral($table) .
                ' ORDER BY ORDINAL_POSITION ASC';
     }
 
@@ -373,7 +352,7 @@ FROM information_schema.TABLES t
 WHERE TABLE_TYPE = 'BASE TABLE' AND TABLE_SCHEMA = %s AND TABLE_NAME = %s
 SQL
             ,
-            $database !== null ? $this->quoteStringLiteral($database) : 'DATABASE()',
+            $this->getDatabaseNameSQL($database),
             $this->quoteStringLiteral($table)
         );
     }
@@ -1183,5 +1162,14 @@ SQL
     public function supportsColumnLengthIndexes(): bool
     {
         return true;
+    }
+
+    private function getDatabaseNameSQL(?string $databaseName): string
+    {
+        if ($databaseName !== null) {
+            return $this->quoteStringLiteral($databaseName);
+        }
+
+        return $this->getCurrentDatabaseExpression();
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

As identified in https://github.com/doctrine/dbal/pull/4978#discussion_r747231236, the query generated by `getListTableForeignKeysSQL()` uses a `DISTINCT` clause which requires selecting the columns used in the `ORDER BY` clause.

What has been changed:
1. The `DISTINCT` clause has been removed since it's not necessary.
2. The `WHERE k.REFERENCED_COLUMN_NAME IS NOT NULL` condition has been removed since it's not necessary.
3. The `WHERE c.constraint_schema = $databaseNameSql` condition has been replaced with an analogous `ON` condition.
4. The original (upper) column case is used with the redundant quotes removed.

Additionally, the following has been done in multiple queries:
1. The logic of quoting the database name or defaulting to `DATABASE()` has been extracted into a private method.
2. All occurrences like `$string = quote($string)` have been replaced with inlining with the concatenation to avoid potential double quoting.

The last two changes likely would have happened in https://github.com/doctrine/dbal/pull/4882 but it's better to do the cleanup separately.