### PR TITLE
Deprecate support for MySQL 5.6 and older

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,6 +21,14 @@ following methods are deprecated:
 The protected property `AbstractPlatform::$doctrineTypeComments` is deprecated
 as well.
 
+## Deprecated support for MySQL 5.6 and older
+
+MySQL 5.6 and older won't be actively supported in DBAL 4. Consider upgrading to MySQL 5.7 or later.
+The following classes have been deprecated:
+
+* `Doctrine\DBAL\Platforms\MySQL57Platform`
+* `Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords`
+
 ## Deprecated support for Postgres 9
 
 Postgres 9 won't be actively supported in DBAL 4. Consider upgrading to Postgres 10 or later.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -59,9 +59,11 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\PostgreSQL100Keywords"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\PostgreSQL94Keywords"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\SQLServer2012Keywords"/>
+                <referencedClass name="Doctrine\DBAL\Platforms\MySQL57Platform"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL100Platform"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL94Platform"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\SQLServer2012Platform"/>

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
+use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 use function preg_match;
@@ -46,6 +47,13 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
                 return new MySQL57Platform();
             }
         }
+
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5060',
+            'MySQL 5.6 support is deprecated and will be removed in DBAL 4.'
+                . ' Consider upgrading to MySQL 5.7 or later.'
+        );
 
         return $this->getDatabasePlatform();
     }

--- a/src/Platforms/Keywords/MySQL57Keywords.php
+++ b/src/Platforms/Keywords/MySQL57Keywords.php
@@ -4,6 +4,8 @@ namespace Doctrine\DBAL\Platforms\Keywords;
 
 /**
  * MySQL 5.7 reserved keywords list.
+ *
+ * @deprecated Use {@link MySQLKeywords} instead.
  */
 class MySQL57Keywords extends MySQLKeywords
 {

--- a/src/Platforms/MySQL57Platform.php
+++ b/src/Platforms/MySQL57Platform.php
@@ -10,6 +10,9 @@ use Doctrine\Deprecations\Deprecation;
 
 /**
  * Provides the behavior, features and SQL dialect of the MySQL 5.7 (5.7.9 GA) database platform.
+ *
+ * @deprecated This class will be merged with {@see MySQLPlatform} in 4.0 because support for MySQL
+ *             releases prior to 5.7 will be dropped.
  */
 class MySQL57Platform extends MySQLPlatform
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

MySQL 5.6 support ended in February 2021 ([reference](https://www.mysql.com/support/supportedplatforms/database.html)).