### PR TITLE
Fix SQLite date arithmetic for dynamic intervals

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SqlitePlatform.php
@@ -133,18 +133,22 @@ class SqlitePlatform extends AbstractPlatform
             case DateIntervalUnit::SECOND:
             case DateIntervalUnit::MINUTE:
             case DateIntervalUnit::HOUR:
+                if (! is_numeric($interval)) {
+                    $interval = "' || " . $interval . " || '";
+                }
+
                 return 'DATETIME(' . $date . ",'" . $operator . $interval . ' ' . $unit . "')";
         }
 
         switch ($unit) {
             case DateIntervalUnit::WEEK:
-                $interval *= 7;
-                $unit      = DateIntervalUnit::DAY;
+                $interval = is_numeric($interval) ? $interval * 7 : '(' . $interval . ' * 7)';
+                $unit     = DateIntervalUnit::DAY;
                 break;
 
             case DateIntervalUnit::QUARTER:
-                $interval *= 3;
-                $unit      = DateIntervalUnit::MONTH;
+                $interval = is_numeric($interval) ? $interval * 3 : '(' . $interval . ' * 3)';
+                $unit     = DateIntervalUnit::MONTH;
                 break;
         }
 

--- a/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/SqlitePlatformTest.php
@@ -777,6 +777,62 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function testDateAddStaticNumberOfWeeks(): void
+    {
+        self::assertSame(
+            "DATE(rentalBeginsOn,'+14 DAY')",
+            $this->platform->getDateAddWeeksExpression('rentalBeginsOn', 2)
+        );
+    }
+
+    public function testDateAddNumberOfWeeksFromColumn(): void
+    {
+        self::assertSame(
+            "DATE(rentalBeginsOn,'+' || (duration * 7) || ' DAY')",
+            $this->platform->getDateAddWeeksExpression('rentalBeginsOn', 'duration')
+        );
+    }
+
+    public function testDateAddStaticNumberOfSeconds(): void
+    {
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+45 SECOND')",
+            $this->platform->getDateAddSecondsExpression('rentalBeginsOn', 45)
+        );
+    }
+
+    public function testDateAddNumberOfSecondsFromColumn(): void
+    {
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+' || duration || ' SECOND')",
+            $this->platform->getDateAddSecondsExpression('rentalBeginsOn', 'duration')
+        );
+    }
+
+    public function testDateSubNumberOfSecondsFromColumn(): void
+    {
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'-' || duration || ' SECOND')",
+            $this->platform->getDateSubSecondsExpression('rentalBeginsOn', 'duration')
+        );
+    }
+
+    public function testDateAddNumberOfSecondsFromNamedParameter(): void
+    {
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+' || :duration || ' SECOND')",
+            $this->platform->getDateAddSecondsExpression('rentalBeginsOn', ':duration')
+        );
+    }
+
+    public function testDateSubNumberOfSecondsFromNamedParameter(): void
+    {
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'-' || :duration || ' SECOND')",
+            $this->platform->getDateSubSecondsExpression('rentalBeginsOn', ':duration')
+        );
+    }
+
     public function testSupportsColumnCollation(): void
     {
         self::assertTrue($this->platform->supportsColumnCollation());


### PR DESCRIPTION
|      Q             |   A
|------------- | -----------
| Type             | improvement
| BC Break      | no
| Fixed issues | #4426, #4462

#### Summary

Changes `SqlitePlatform::getDateArithmeticIntervalExpression` to make it consistently support dynamic intervals for any supported `DateIntervalUnit`. Also adds a test similar to `DataAccessTest::testDateArithmetics` that tests all of the `getDate(Add|Sub)(Unit)Expression` with a named parameter instead of a static integer.

To support weeks and quarters with dynamic intervals, I had to put the multiplication into the generated SQL. If this feels like maybe too much, I could instead have those cases throw if the value `!is_numeric`; that's still BC (since it doesn't work today) while providing a much clearer error message. (I only need seconds to work, for my project!)

First time contributing to a Doctrine project, so let me know if I've based the PR on the right branch!