### PR TITLE
Add return types to Command::execute() overrides

### DIFF
--- a/src/Tools/Console/Command/ReservedWordsCommand.php
+++ b/src/Tools/Console/Command/ReservedWordsCommand.php
@@ -113,11 +113,9 @@ EOT
     /**
      * {@inheritdoc}
      *
-     * @return int
-     *
      * @throws Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $conn = $this->getConnection($input);
 

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -59,11 +59,9 @@ EOT
     /**
      * {@inheritdoc}
      *
-     * @return int
-     *
      * @throws Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $conn = $this->getConnection($input);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | N/A

#### Summary

Symfony 7 will enforce the return types. We can already prepare for this now. 😎 