### PR TITLE
Deprecate Type::getName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -25,7 +25,7 @@ This option does not have any effect anymore and will be removed in DBAL 4.
 
 ## Deprecated platform "commented type" API
 
-Since `Type::requiresSQLCommentTypeHint()` already allows determining whether a
+Since `Doctrine\DBAL\Types\Type::requiresSQLCommentTypeHint()` already allows determining whether a
 type should result in SQL columns with a type hint in their comments, the
 following methods are deprecated:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 3.3
 
+## Deprecated `Doctrine\DBAL\Types\Type::getName()`
+
+Basing logic on type name of a type should be avoided.
+
 ## Deprecated the `doctrine-dbal` binary.
 
 The documentation explains how the console tools can be bootstrapped for standalone usage.

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -7,8 +7,8 @@ use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Types\BooleanType;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
@@ -102,7 +102,7 @@ class DB2Platform extends AbstractPlatform
             __METHOD__
         );
 
-        if ($doctrineType->getName() === Types::BOOLEAN) {
+        if ($doctrineType instanceof BooleanType) {
             // We require a commented boolean type in order to distinguish between boolean and smallint
             // as both (have to) map to the same native type.
             return true;

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -5,7 +5,6 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 
 use function array_change_key_case;
@@ -529,7 +528,7 @@ SQL
             $column->setPlatformOption('collation', $tableColumn['collation']);
         }
 
-        if ($column->getType()->getName() === Types::JSON) {
+        if (isset($jsonb)) {
             $column->setPlatformOption('jsonb', $jsonb);
         }
 

--- a/src/Schema/Visitor/Graphviz.php
+++ b/src/Schema/Visitor/Graphviz.php
@@ -8,8 +8,8 @@ use Doctrine\DBAL\Schema\Table;
 
 use function current;
 use function file_put_contents;
+use function get_class;
 use function in_array;
-use function strtolower;
 
 /**
  * Create a Graphviz output of a Schema.
@@ -83,7 +83,7 @@ class Graphviz extends AbstractVisitor
                 . '</TD>'
                 . '<TD BORDER="0" ALIGN="LEFT" BGCOLOR="#eeeeec">'
                 . '<FONT COLOR="#2e3436" FACE="Helvetica" POINT-SIZE="10">'
-                . strtolower($column->getType()->getName())
+                . get_class($column->getType())
                 . '</FONT>'
                 . '</TD>'
                 . '<TD BORDER="0" ALIGN="RIGHT" BGCOLOR="#eeeeec" PORT="col' . $column->getName() . '">';

--- a/src/Types/ArrayType.php
+++ b/src/Types/ArrayType.php
@@ -44,8 +44,8 @@ class ArrayType extends Type
 
         $value = is_resource($value) ? stream_get_contents($value) : $value;
 
-        set_error_handler(function (int $code, string $message): bool {
-            throw ConversionException::conversionFailedUnserialization($this->getName(), $message);
+        set_error_handler(static function (int $code, string $message): bool {
+            throw ConversionException::conversionFailedUnserialization(static::class, $message);
         });
 
         try {

--- a/src/Types/DateIntervalType.php
+++ b/src/Types/DateIntervalType.php
@@ -46,7 +46,11 @@ class DateIntervalType extends Type
             return $value->format(self::FORMAT);
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateInterval']);
+        throw ConversionException::conversionFailedInvalidType(
+            $value,
+            static::class,
+            ['null', 'DateInterval']
+        );
     }
 
     /**
@@ -74,7 +78,12 @@ class DateIntervalType extends Type
 
             return $interval;
         } catch (Throwable $exception) {
-            throw ConversionException::conversionFailedFormat($value, $this->getName(), self::FORMAT, $exception);
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                static::class,
+                self::FORMAT,
+                $exception
+            );
         }
     }
 

--- a/src/Types/DateTimeImmutableType.php
+++ b/src/Types/DateTimeImmutableType.php
@@ -35,7 +35,7 @@ class DateTimeImmutableType extends DateTimeType
 
         throw ConversionException::conversionFailedInvalidType(
             $value,
-            $this->getName(),
+            static::class,
             ['null', DateTimeImmutable::class]
         );
     }
@@ -58,7 +58,7 @@ class DateTimeImmutableType extends DateTimeType
         if ($dateTime === false) {
             throw ConversionException::conversionFailedFormat(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getDateTimeFormatString()
             );
         }

--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -42,7 +42,11 @@ class DateTimeType extends Type implements PhpDateTimeMappingType
             return $value->format($platform->getDateTimeFormatString());
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
+        throw ConversionException::conversionFailedInvalidType(
+            $value,
+            static::class,
+            ['null', 'DateTime']
+        );
     }
 
     /**
@@ -63,7 +67,7 @@ class DateTimeType extends Type implements PhpDateTimeMappingType
         if ($val === false) {
             throw ConversionException::conversionFailedFormat(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getDateTimeFormatString()
             );
         }

--- a/src/Types/DateTimeTzImmutableType.php
+++ b/src/Types/DateTimeTzImmutableType.php
@@ -33,7 +33,7 @@ class DateTimeTzImmutableType extends DateTimeTzType
 
         throw ConversionException::conversionFailedInvalidType(
             $value,
-            $this->getName(),
+            static::class,
             ['null', DateTimeImmutable::class]
         );
     }
@@ -52,7 +52,7 @@ class DateTimeTzImmutableType extends DateTimeTzType
         if ($dateTime === false) {
             throw ConversionException::conversionFailedFormat(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getDateTimeTzFormatString()
             );
         }

--- a/src/Types/DateTimeTzType.php
+++ b/src/Types/DateTimeTzType.php
@@ -55,7 +55,7 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
 
         throw ConversionException::conversionFailedInvalidType(
             $value,
-            $this->getName(),
+            static::class,
             ['null', 'DateTime']
         );
     }
@@ -73,7 +73,7 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
         if ($val === false) {
             throw ConversionException::conversionFailedFormat(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getDateTimeTzFormatString()
             );
         }

--- a/src/Types/DateType.php
+++ b/src/Types/DateType.php
@@ -40,7 +40,11 @@ class DateType extends Type
             return $value->format($platform->getDateFormatString());
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
+        throw ConversionException::conversionFailedInvalidType(
+            $value,
+            static::class,
+            ['null', 'DateTime']
+        );
     }
 
     /**
@@ -56,7 +60,7 @@ class DateType extends Type
         if ($val === false) {
             throw ConversionException::conversionFailedFormat(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getDateFormatString()
             );
         }

--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -57,7 +57,11 @@ class JsonType extends Type
         try {
             return json_decode($value, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
-            throw ConversionException::conversionFailed($value, $this->getName(), $e);
+            throw ConversionException::conversionFailed(
+                $value,
+                static::class,
+                $e
+            );
         }
     }
 

--- a/src/Types/ObjectType.php
+++ b/src/Types/ObjectType.php
@@ -43,8 +43,11 @@ class ObjectType extends Type
 
         $value = is_resource($value) ? stream_get_contents($value) : $value;
 
-        set_error_handler(function (int $code, string $message): bool {
-            throw ConversionException::conversionFailedUnserialization($this->getName(), $message);
+        set_error_handler(static function (int $code, string $message): bool {
+            throw ConversionException::conversionFailedUnserialization(
+                static::class,
+                $message
+            );
         });
 
         try {

--- a/src/Types/TimeType.php
+++ b/src/Types/TimeType.php
@@ -40,7 +40,11 @@ class TimeType extends Type
             return $value->format($platform->getTimeFormatString());
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
+        throw ConversionException::conversionFailedInvalidType(
+            $value,
+            static::class,
+            ['null', 'DateTime']
+        );
     }
 
     /**
@@ -56,7 +60,7 @@ class TimeType extends Type
         if ($val === false) {
             throw ConversionException::conversionFailedFormat(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getTimeFormatString()
             );
         }

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -102,9 +102,9 @@ abstract class Type
     /**
      * Gets the name of this type.
      *
-     * @return string
+     * @deprecated Identify types by their class, or their name inside {@link TypeRegistry}
      *
-     * @todo Needed?
+     * @return string
      */
     abstract public function getName();
 

--- a/src/Types/VarDateTimeImmutableType.php
+++ b/src/Types/VarDateTimeImmutableType.php
@@ -35,7 +35,7 @@ class VarDateTimeImmutableType extends VarDateTimeType
 
         throw ConversionException::conversionFailedInvalidType(
             $value,
-            $this->getName(),
+            static::class,
             ['null', DateTimeImmutable::class]
         );
     }
@@ -52,7 +52,10 @@ class VarDateTimeImmutableType extends VarDateTimeType
         $dateTime = date_create_immutable($value);
 
         if ($dateTime === false) {
-            throw ConversionException::conversionFailed($value, $this->getName());
+            throw ConversionException::conversionFailed(
+                $value,
+                static::class
+            );
         }
 
         return $dateTime;

--- a/src/Types/VarDateTimeType.php
+++ b/src/Types/VarDateTimeType.php
@@ -27,7 +27,7 @@ class VarDateTimeType extends DateTimeType
 
         $val = date_create($value);
         if ($val === false) {
-            throw ConversionException::conversionFailed($value, $this->getName());
+            throw ConversionException::conversionFailed($value, static::class);
         }
 
         return $val;

--- a/tests/Functional/Schema/MySQL/PointType.php
+++ b/tests/Functional/Schema/MySQL/PointType.php
@@ -5,8 +5,6 @@ namespace Doctrine\DBAL\Tests\Functional\Schema\MySQL;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 
-use function strtoupper;
-
 class PointType extends Type
 {
     /**
@@ -22,7 +20,7 @@ class PointType extends Type
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform)
     {
-        return strtoupper($this->getName());
+        return 'POINT';
     }
 
     /**

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -10,8 +10,8 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Functional\Schema\MySQL\PointType;
 use Doctrine\DBAL\Types\BlobType;
+use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
 
 class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
@@ -414,7 +414,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $columns = $this->schemaManager->listTableColumns('test_mysql_json');
 
-        self::assertSame(Types::JSON, $columns['col_json']->getType()->getName());
+        self::assertInstanceOf(JsonType::class, $columns['col_json']->getType());
     }
 
     public function testColumnDefaultCurrentTimestamp(): void

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -11,6 +11,9 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\BinaryType;
+use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\DateTimeTzType;
+use Doctrine\DBAL\Types\DateType;
 use Doctrine\DBAL\Types\Types;
 
 use function array_map;
@@ -253,9 +256,9 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $columns = $this->schemaManager->listTableColumns('tbl_date');
 
-        self::assertSame('date', $columns['col_date']->getType()->getName());
-        self::assertSame('datetime', $columns['col_datetime']->getType()->getName());
-        self::assertSame('datetimetz', $columns['col_datetimetz']->getType()->getName());
+        self::assertInstanceOf(DateType::class, $columns['col_date']->getType());
+        self::assertInstanceOf(DateTimeType::class, $columns['col_datetime']->getType());
+        self::assertInstanceOf(DateTimeTzType::class, $columns['col_datetimetz']->getType());
     }
 
     public function testCreateAndListSequences(): void

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\View;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\DecimalType;
+use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
@@ -418,7 +419,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $columns = $this->schemaManager->listTableColumns('test_jsonb');
 
-        self::assertSame(Types::JSON, $columns['foo']->getType()->getName());
+        self::assertInstanceOf(JsonType::class, $columns['foo']->getType());
         self::assertTrue(true, $columns['foo']->getPlatformOption('jsonb'));
     }
 

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -29,11 +29,13 @@ use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\DateIntervalType;
 use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\DateType;
 use Doctrine\DBAL\Types\DecimalType;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\ObjectType;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
+use Doctrine\DBAL\Types\TimeType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
@@ -308,14 +310,20 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         self::assertEquals('baz2', strtolower($columns['baz2']->getname()));
         self::assertEquals(5, array_search('baz2', $columnsKeys, true));
-        self::assertContains($columns['baz2']->gettype()->getName(), ['time', 'date', 'datetime']);
+        self::assertContains(
+            get_class($columns['baz2']->getType()),
+            [TimeType::class, DateType::class, DateTimeType::class]
+        );
         self::assertEquals(true, $columns['baz2']->getnotnull());
         self::assertEquals(null, $columns['baz2']->getdefault());
         self::assertIsArray($columns['baz2']->getPlatformOptions());
 
         self::assertEquals('baz3', strtolower($columns['baz3']->getname()));
         self::assertEquals(6, array_search('baz3', $columnsKeys, true));
-        self::assertContains($columns['baz3']->gettype()->getName(), ['time', 'date', 'datetime']);
+        self::assertContains(
+            get_class($columns['baz3']->getType()),
+            [TimeType::class, DateType::class, DateTimeType::class]
+        );
         self::assertEquals(true, $columns['baz3']->getnotnull());
         self::assertEquals(null, $columns['baz3']->getdefault());
         self::assertIsArray($columns['baz3']->getPlatformOptions());

--- a/tests/Functional/Ticket/DBAL752Test.php
+++ b/tests/Functional/Ticket/DBAL752Test.php
@@ -4,6 +4,9 @@ namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\BigIntType;
+use Doctrine\DBAL\Types\IntegerType;
+use Doctrine\DBAL\Types\SmallIntType;
 
 class DBAL752Test extends FunctionalTestCase
 {
@@ -36,14 +39,14 @@ SQL
 
         $fetchedTable = $schemaManager->listTableDetails('dbal752_unsigneds');
 
-        self::assertEquals('smallint', $fetchedTable->getColumn('small')->getType()->getName());
-        self::assertEquals('smallint', $fetchedTable->getColumn('small_unsigned')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('medium')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('medium_unsigned')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('integer')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('integer_unsigned')->getType()->getName());
-        self::assertEquals('bigint', $fetchedTable->getColumn('big')->getType()->getName());
-        self::assertEquals('bigint', $fetchedTable->getColumn('big_unsigned')->getType()->getName());
+        self::assertInstanceOf(SmallIntType::class, $fetchedTable->getColumn('small')->getType());
+        self::assertInstanceOf(SmallIntType::class, $fetchedTable->getColumn('small_unsigned')->getType());
+        self::assertInstanceOf(IntegerType::class, $fetchedTable->getColumn('medium')->getType());
+        self::assertInstanceOf(IntegerType::class, $fetchedTable->getColumn('medium_unsigned')->getType());
+        self::assertInstanceOf(IntegerType::class, $fetchedTable->getColumn('integer')->getType());
+        self::assertInstanceOf(IntegerType::class, $fetchedTable->getColumn('integer_unsigned')->getType());
+        self::assertInstanceOf(BigIntType::class, $fetchedTable->getColumn('big')->getType());
+        self::assertInstanceOf(BigIntType::class, $fetchedTable->getColumn('big_unsigned')->getType());
 
         self::assertTrue($fetchedTable->getColumn('small_unsigned')->getUnsigned());
         self::assertTrue($fetchedTable->getColumn('medium_unsigned')->getUnsigned());

--- a/tests/Types/ArrayTest.php
+++ b/tests/Types/ArrayTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 use function serialize;
+use function sprintf;
 
 class ArrayTest extends TestCase
 {
@@ -37,10 +38,11 @@ class ArrayTest extends TestCase
     public function testConversionFailure(): void
     {
         $this->expectException(ConversionException::class);
-        $this->expectExceptionMessage(
-            "Could not convert database value to 'array' as an error was triggered by the unserialization:"
-                . " 'unserialize(): Error at offset 0 of 7 bytes'"
-        );
+        $this->expectExceptionMessage(sprintf(
+            "Could not convert database value to '%s' as an error was triggered by the unserialization:"
+            . " 'unserialize(): Error at offset 0 of 7 bytes'",
+            ArrayType::class
+        ));
 
         $this->type->convertToPHPValue('abcdefg', $this->platform);
     }

--- a/tests/Types/ObjectTest.php
+++ b/tests/Types/ObjectTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function serialize;
+use function sprintf;
 
 class ObjectTest extends TestCase
 {
@@ -38,10 +39,11 @@ class ObjectTest extends TestCase
     public function testConversionFailure(): void
     {
         $this->expectException(ConversionException::class);
-        $this->expectExceptionMessage(
-            "Could not convert database value to 'object' as an error was triggered by the unserialization:"
-                . " 'unserialize(): Error at offset 0 of 7 bytes'"
-        );
+        $this->expectExceptionMessage(sprintf(
+            "Could not convert database value to '%s' as an error was triggered by the unserialization:"
+            . " 'unserialize(): Error at offset 0 of 7 bytes'",
+            ObjectType::class
+        ));
         $this->type->convertToPHPValue('abcdefg', $this->platform);
     }
 


### PR DESCRIPTION
The name of the class or the name of the type inside the type registry
should be enough to identify it.