### PR TITLE
Honor requiresSQLCommentHint() for overriding types

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -448,9 +448,7 @@ abstract class AbstractPlatform
             $this->initializeCommentedDoctrineTypes();
         }
 
-        assert(is_array($this->doctrineTypeComments));
-
-        return in_array($doctrineType->getName(), $this->doctrineTypeComments, true);
+        return $doctrineType->requiresSQLCommentHint($this);
     }
 
     /**


### PR DESCRIPTION
The side-effect of isCommentedDoctrineType() is preserved for
backward-compatibility reasons.

Fixes #4983

