### PR TITLE
Remove package-versions-deprecated dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "composer/package-versions-deprecated": "^1.11.99",
+        "composer-runtime-api": "^2",
         "doctrine/cache": "^1.11|^2.0",
         "doctrine/deprecations": "^0.5.3",
         "doctrine/event-manager": "^1.0",

--- a/src/Tools/Console/ConsoleRunner.php
+++ b/src/Tools/Console/ConsoleRunner.php
@@ -2,12 +2,14 @@
 
 namespace Doctrine\DBAL\Tools\Console;
 
+use Composer\InstalledVersions;
 use Doctrine\DBAL\Tools\Console\Command\ReservedWordsCommand;
 use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
 use Exception;
-use PackageVersions\Versions;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
+
+use function assert;
 
 /**
  * Handles running the Console Tools inside Symfony Console context.
@@ -25,7 +27,10 @@ class ConsoleRunner
      */
     public static function run(ConnectionProvider $connectionProvider, $commands = [])
     {
-        $cli = new Application('Doctrine Command Line Interface', Versions::getVersion('doctrine/dbal'));
+        $version = InstalledVersions::getVersion('doctrine/dbal');
+        assert($version !== null);
+
+        $cli = new Application('Doctrine Command Line Interface', $version);
 
         $cli->setCatchExceptions(true);
         self::addCommands($cli, $connectionProvider);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | maybe?
| Fixed issues | N/A

#### Summary

A the moment, we depend on a package called `package-versions-deprecated`, so we're able to display DBAL's version in our `ConsoleRunner`.

The runtime API of Composer 2 provides the same functionality, so let's use that instead. The breaking change of this PR is that if you use Composer 1 to install your dependencies, `ConsoleRunner` would not display the DBAL version anymore. Given that there should not be a reason to still use Composer 1, I think we can live with that.

We could alternatively add a dependency for the Composer 2 runtime API, but that would render this package uninstallable for Composer 1.