### PR TITLE
Remove suppression of the deprecated class error needed for Composer 1

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -42,11 +42,6 @@
         <DeprecatedClass>
             <errorLevel type="suppress">
                 <!--
-                    This suppression should be removed once Composer 1
-                    is no longer supported.
-                -->
-                <file name="src/Tools/Console/ConsoleRunner.php"/>
-                <!--
                     This suppression should be removed in 4.0.0.
                 -->
                 <referencedClass name="Doctrine\DBAL\Id\TableGenerator"/>


### PR DESCRIPTION
The suppression is not needed as of https://github.com/doctrine/dbal/pull/5078.