### PR TITLE
Use Native JSON type instead of LONGTEXT for MariaDB

### DIFF
--- a/src/Platforms/MariaDb1027Platform.php
+++ b/src/Platforms/MariaDb1027Platform.php
@@ -19,7 +19,7 @@ class MariaDb1027Platform extends MySQLPlatform
      */
     public function getJsonTypeDeclarationSQL(array $column): string
     {
-        return 'LONGTEXT';
+        return 'JSON';
     }
 
     /**

--- a/src/Platforms/MariaDb1027Platform.php
+++ b/src/Platforms/MariaDb1027Platform.php
@@ -14,6 +14,14 @@ class MariaDb1027Platform extends MySQLPlatform
 {
     /**
      * {@inheritdoc}
+     */
+    public function hasNativeJsonType()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * @link https://mariadb.com/kb/en/library/json-data-type/
      */

--- a/tests/Platforms/MariaDb1027PlatformTest.php
+++ b/tests/Platforms/MariaDb1027PlatformTest.php
@@ -19,13 +19,11 @@ class MariaDb1027PlatformTest extends AbstractMySQLPlatformTestCase
     }
 
     /**
-     * From MariaDB 10.2.7, JSON type is an alias to LONGTEXT
-     *
      * @link https://mariadb.com/kb/en/library/json-data-type/
      */
     public function testReturnsJsonTypeDeclarationSQL(): void
     {
-        self::assertSame('LONGTEXT', $this->platform->getJsonTypeDeclarationSQL([]));
+        self::assertSame('JSON', $this->platform->getJsonTypeDeclarationSQL([]));
     }
 
     public function testInitializesJsonTypeMapping(): void

--- a/tests/Platforms/MariaDb1027PlatformTest.php
+++ b/tests/Platforms/MariaDb1027PlatformTest.php
@@ -15,7 +15,7 @@ class MariaDb1027PlatformTest extends AbstractMySQLPlatformTestCase
 
     public function testHasNativeJsonType(): void
     {
-        self::assertFalse($this->platform->hasNativeJsonType());
+        self::assertTrue($this->platform->hasNativeJsonType());
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | yes/no 
| Fixed issues | fixes #3202

#### Summary

Use JSON type instead of LONGTEXT for MariaDB. See https://github.com/doctrine/dbal/issues/3202
