### PR TITLE
Extended Connection to use different Type Registry between instances

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1595,7 +1595,7 @@ class Connection
      */
     public function convertToDatabaseValue($value, $type)
     {
-        return Type::getType($type)->convertToDatabaseValue($value, $this->getDatabasePlatform());
+        return Type::getType($type, $this->getTypeRegistryName())->convertToDatabaseValue($value, $this->getDatabasePlatform());
     }
 
     /**
@@ -1611,7 +1611,7 @@ class Connection
      */
     public function convertToPHPValue($value, $type)
     {
-        return Type::getType($type)->convertToPHPValue($value, $this->getDatabasePlatform());
+        return Type::getType($type, $this->getTypeRegistryName())->convertToPHPValue($value, $this->getDatabasePlatform());
     }
 
     /**
@@ -1668,7 +1668,7 @@ class Connection
     private function getBindingInfo($value, $type): array
     {
         if (is_string($type)) {
-            $type = Type::getType($type);
+            $type = Type::getType($type, $this->getTypeRegistryName());
         }
 
         if ($type instanceof Type) {
@@ -1804,5 +1804,13 @@ class Connection
     public function exec(string $sql): int
     {
         return $this->executeStatement($sql);
+    }
+
+    /**
+     * @psalm-return non-empty-string
+     */
+    public function getTypeRegistryName(): string
+    {
+        return $this->params['type_registry_name'] ?? 'default';
     }
 }

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -66,6 +66,7 @@ use function substr;
  *     user?: string,
  *     wrapperClass?: class-string<Connection>,
  *     unix_socket?: string,
+ *     type_registry_name?: non-empty-string,
  * }
  */
 final class DriverManager

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -120,7 +120,7 @@ class DB2SchemaManager extends AbstractSchemaManager
             $options['precision'] = $precision;
         }
 
-        return new Column($tableColumn['colname'], Type::getType($type), $options);
+        return new Column($tableColumn['colname'], Type::getType($type, $this->_conn->getTypeRegistryName()), $options);
     }
 
     /**

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -227,7 +227,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
             $options['precision'] = (int) $precision;
         }
 
-        $column = new Column($tableColumn['field'], Type::getType($type), $options);
+        $column = new Column($tableColumn['field'], Type::getType($type, $this->_conn->getTypeRegistryName()), $options);
 
         if (isset($tableColumn['characterset'])) {
             $column->setPlatformOption('charset', $tableColumn['characterset']);

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -183,7 +183,7 @@ class OracleSchemaManager extends AbstractSchemaManager
                 : null,
         ];
 
-        return new Column($this->getQuotedIdentifierName($tableColumn['column_name']), Type::getType($type), $options);
+        return new Column($this->getQuotedIdentifierName($tableColumn['column_name']), Type::getType($type, $this->_conn->getTypeRegistryName()), $options);
     }
 
     /**

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -523,7 +523,7 @@ SQL
                 : null,
         ];
 
-        $column = new Column($tableColumn['field'], Type::getType($type), $options);
+        $column = new Column($tableColumn['field'], Type::getType($type, $this->_conn->getTypeRegistryName()), $options);
 
         if (isset($tableColumn['collation']) && ! empty($tableColumn['collation'])) {
             $column->setPlatformOption('collation', $tableColumn['collation']);

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -116,7 +116,7 @@ SQL
             $options['length'] = $length;
         }
 
-        $column = new Column($tableColumn['name'], Type::getType($type), $options);
+        $column = new Column($tableColumn['name'], Type::getType($type, $this->_conn->getTypeRegistryName()), $options);
 
         if (isset($tableColumn['collation']) && $tableColumn['collation'] !== 'NULL') {
             $column->setPlatformOption('collation', $tableColumn['collation']);

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -314,7 +314,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
             $type = $this->extractDoctrineTypeFromComment($comment, '');
 
             if ($type !== '') {
-                $column->setType(Type::getType($type));
+                $column->setType(Type::getType($type, $this->_conn->getTypeRegistryName()));
 
                 $comment = $this->removeDoctrineTypeFromComment($comment, $type);
             }
@@ -401,7 +401,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
             'autoincrement' => false,
         ];
 
-        return new Column($tableColumn['name'], Type::getType($type), $options);
+        return new Column($tableColumn['name'], Type::getType($type, $this->_conn->getTypeRegistryName()), $options);
     }
 
     /**

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -100,7 +100,7 @@ class Statement
 
         if ($type !== null) {
             if (is_string($type)) {
-                $type = Type::getType($type);
+                $type = Type::getType($type, $this->conn->getTypeRegistryName());
             }
 
             $bindingType = $type;

--- a/tests/Connection/MultipleConnectionsWithDifferentTypeRegistriesTest.php
+++ b/tests/Connection/MultipleConnectionsWithDifferentTypeRegistriesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Connection;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class MultipleConnectionsWithDifferentTypeRegistriesTest extends TestCase
+{
+    private const SQL = 'SELECT * FROM table WHERE column = ?';
+
+    public function testConnections(): void
+    {
+        $now = new DateTimeImmutable();
+
+        $mockedTypeForSecondaryConnection = $this->createType();
+        $mockedTypeForSecondaryConnection
+            ->expects(self::atLeastOnce())
+            ->method('getBindingType')
+            ->willReturn('secondary_string');
+        $mockedTypeForSecondaryConnection
+            ->expects(self::atLeastOnce())
+            ->method('convertToDatabaseValue')
+            ->with($now)
+            ->willReturn($now->format('Ymd H:i:s.000'));
+
+        Type::getTypeRegistry('secondary')
+            ->override(Types::DATE_IMMUTABLE, $mockedTypeForSecondaryConnection);
+
+        $this->createConnection('default')
+            ->executeQuery(self::SQL, [$now], [Types::DATE_IMMUTABLE]);
+
+        $this->createConnection('secondary')
+            ->executeQuery(self::SQL, [$now], [Types::DATE_IMMUTABLE]);
+    }
+
+    /** @psalm-param non-empty-string $registryName */
+    public function createConnection(string $registryName): Connection
+    {
+        $driver = $this->createMock(Driver::class);
+        $driver
+            ->method('connect')
+            ->willReturn($connection = $this->createMock(Driver\Connection::class));
+
+        $driver
+            ->expects(self::once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform = $this->getMockForAbstractClass(AbstractPlatform::class));
+
+        $connection
+            ->expects(self::once())
+            ->method('prepare')
+            ->with(self::SQL)
+            ->willReturn($this->createMock(Driver\Statement::class));
+
+        return new Connection(['type_registry_name' => $registryName], $driver);
+    }
+
+    /** @return Type&MockObject */
+    private function createType(): Type
+    {
+        return $this->getMockForAbstractClass(Type::class, [], '', true, true, true, [
+            'convertToDatabaseValue',
+            'getBindingType',
+        ]);
+    }
+}

--- a/tests/Types/TypeTest.php
+++ b/tests/Types/TypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Types;
 
+use Doctrine\DBAL\Tests\Functional\Schema\MySQL\PointType;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -16,6 +17,18 @@ class TypeTest extends TestCase
     public function testDefaultTypesAreRegistered(string $name): void
     {
         self::assertTrue(Type::hasType($name));
+    }
+
+    public function testMultipleRegistries(): void
+    {
+        Type::addType(PointType::class, PointType::class, 'secondary');
+
+        $default   = Type::getTypeRegistry();
+        $secondary = Type::getTypeRegistry('secondary');
+
+        self::assertNotSame($default, $secondary);
+        self::assertArrayNotHasKey(PointType::class, $default->getMap());
+        self::assertArrayHasKey(PointType::class, $secondary->getMap());
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

Currently, every connection is using the same Type registry with the same static types, this can be problematic when we need to override a built-in type for one connection but not for the other.

A good example is a mysql and a mssql connection where the datetime types needs to be overridden for the mssql connection.

Another example could be a multi-tenant application where different clients use custom types with different configurations.
