### PR TITLE
Mark AbstractSchemaManager::extractDoctrineTypeFromComment() and ::removeDoctrineTypeFromComment() internal

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -1299,6 +1299,8 @@ abstract class AbstractSchemaManager
      * Given a table comment this method tries to extract a typehint for Doctrine Type, or returns
      * the type given as default.
      *
+     * @internal This method should be only used from within the AbstractSchemaManager class hierarchy.
+     *
      * @param string|null $comment
      * @param string      $currentType
      *
@@ -1314,6 +1316,8 @@ abstract class AbstractSchemaManager
     }
 
     /**
+     * @internal This method should be only used from within the AbstractSchemaManager class hierarchy.
+     *
      * @param string|null $comment
      * @param string|null $type
      *


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

These methods won't be publicly accessible in DBAL 4 (see https://github.com/doctrine/dbal/pull/3501).