### PR TITLE
Do not use quotes to represent a boolean default

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2597,7 +2597,7 @@ abstract class AbstractPlatform
         }
 
         if ($type instanceof Types\BooleanType) {
-            return " DEFAULT '" . $this->convertBooleans($default) . "'";
+            return ' DEFAULT ' . $this->convertBooleans($default);
         }
 
         return ' DEFAULT ' . $this->quoteStringLiteral($default);

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -63,7 +63,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         return [
             'ALTER TABLE mytable RENAME TO userlist, ADD quota INT DEFAULT NULL, DROP foo, '
                 . "CHANGE bar baz VARCHAR(255) DEFAULT 'def' NOT NULL, "
-                . "CHANGE bloo bloo TINYINT(1) DEFAULT '0' NOT NULL",
+                . 'CHANGE bloo bloo TINYINT(1) DEFAULT 0 NOT NULL',
         ];
     }
 

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -33,7 +33,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             "ALTER TABLE mytable ALTER COLUMN baz SET DEFAULT 'def'",
             'ALTER TABLE mytable ALTER COLUMN bloo SET DATA TYPE SMALLINT',
             'ALTER TABLE mytable ALTER COLUMN bloo SET NOT NULL',
-            "ALTER TABLE mytable ALTER COLUMN bloo SET DEFAULT '0'",
+            'ALTER TABLE mytable ALTER COLUMN bloo SET DEFAULT 0',
             'ALTER TABLE mytable ' .
             'ADD COLUMN quota INTEGER DEFAULT NULL ' .
             'DROP COLUMN foo',

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -107,7 +107,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         return [
             'ALTER TABLE mytable ADD (quota NUMBER(10) DEFAULT NULL NULL)',
             "ALTER TABLE mytable MODIFY (baz VARCHAR2(255) DEFAULT 'def' NOT NULL, "
-                . "bloo NUMBER(1) DEFAULT '0' NOT NULL)",
+                . 'bloo NUMBER(1) DEFAULT 0 NOT NULL)',
             'ALTER TABLE mytable DROP (foo)',
             'ALTER TABLE mytable RENAME TO userlist',
         ];

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -56,7 +56,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
             "ALTER TABLE mytable ALTER bar SET DEFAULT 'def'",
             'ALTER TABLE mytable ALTER bar SET NOT NULL',
             'ALTER TABLE mytable ALTER bloo TYPE BOOLEAN',
-            "ALTER TABLE mytable ALTER bloo SET DEFAULT 'false'",
+            'ALTER TABLE mytable ALTER bloo SET DEFAULT false',
             'ALTER TABLE mytable ALTER bloo SET NOT NULL',
             'ALTER TABLE mytable RENAME TO userlist',
         ];

--- a/tests/Platforms/SQLServerPlatformTestCase.php
+++ b/tests/Platforms/SQLServerPlatformTestCase.php
@@ -55,7 +55,7 @@ class SQLServerPlatformTestCase extends AbstractPlatformTestCase
             'ALTER TABLE mytable ALTER COLUMN baz NVARCHAR(255) NOT NULL',
             "ALTER TABLE mytable ADD CONSTRAINT DF_6B2BD609_78240498 DEFAULT 'def' FOR baz",
             'ALTER TABLE mytable ALTER COLUMN bloo BIT NOT NULL',
-            "ALTER TABLE mytable ADD CONSTRAINT DF_6B2BD609_CECED971 DEFAULT '0' FOR bloo",
+            'ALTER TABLE mytable ADD CONSTRAINT DF_6B2BD609_CECED971 DEFAULT 0 FOR bloo',
             "sp_rename 'mytable', 'userlist'",
             "DECLARE @sql NVARCHAR(MAX) = N''; " .
             "SELECT @sql += N'EXEC sp_rename N''' + dc.name + ''', N''' " .

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -298,7 +298,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'DROP TABLE mytable',
             'CREATE TABLE mytable (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, '
                 . "baz VARCHAR(255) DEFAULT 'def' NOT NULL, "
-                . "bloo BOOLEAN DEFAULT '0' NOT NULL, "
+                . 'bloo BOOLEAN DEFAULT 0 NOT NULL, '
                 . 'quota INTEGER DEFAULT NULL)',
             'INSERT INTO mytable (id, baz, bloo) SELECT id, bar, bloo FROM __temp__mytable',
             'DROP TABLE __temp__mytable',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Representing boolean default as a string literal may cause false-positive diffs during platform-aware schema comparison if the platform doesn't support boolean columns natively (IBM DB2, Oracle, MySQL) and doesn't implement any hacks for introspection of boolean columns:
https://github.com/doctrine/dbal/blob/2b3504fd214849ee1f7a12e84d27c62614c96f65/src/Platforms/AbstractMySQLPlatform.php#L1052
https://github.com/doctrine/dbal/blob/2b3504fd214849ee1f7a12e84d27c62614c96f65/src/Platforms/OraclePlatform.php#L1148

See https://github.com/doctrine/dbal/pull/5107#issuecomment-991715998 for more details.

The existing assertions that expect SQL like `TINYINT(1) DEFAULT '0'` are obviously wrong and were likely implemented by copy/pasting the actual value as expected.

According to the functional tests, there are no cases where a boolean default would have to be represented as a string literal. All supported platforms use integer `0` and `1` to represent boolean values. PostgreSQL [supports](https://www.postgresql.org/docs/10/datatype-boolean.html) booleans literals `true`/`false`.

Note that the [documentation for PostgreSQL 9.3](https://www.postgresql.org/docs/9.3/datatype-boolean.html) is the last version that mentions the support for quoted `'true'` and `'false'` as valid boolean literals.