### PR TITLE
Adding the constant PARAM_ASCII_ARRAY to Doctrine\DBAL\Connection

### DIFF
--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -83,6 +83,11 @@ class Connection implements DriverConnection
     public const PARAM_STR_ARRAY = ParameterType::STRING + self::ARRAY_PARAM_OFFSET;
 
     /**
+     * Represents an array of ascii strings to be expanded by Doctrine SQL parsing.
+     */
+    public const PARAM_ASCII_STR_ARRAY = ParameterType::ASCII + self::ARRAY_PARAM_OFFSET;
+
+    /**
      * Offset by which PARAM_* constants are detected as arrays of the param type.
      */
     public const ARRAY_PARAM_OFFSET = 100;

--- a/lib/Doctrine/DBAL/SQLParserUtils.php
+++ b/lib/Doctrine/DBAL/SQLParserUtils.php
@@ -158,7 +158,11 @@ class SQLParserUtils
         foreach ($types as $name => $type) {
             ++$bindIndex;
 
-            if ($type !== Connection::PARAM_INT_ARRAY && $type !== Connection::PARAM_STR_ARRAY) {
+            if (
+                $type !== Connection::PARAM_INT_ARRAY
+                && $type !== Connection::PARAM_STR_ARRAY
+                && $type !== Connection::PARAM_ASCII_STR_ARRAY
+            ) {
                 continue;
             }
 


### PR DESCRIPTION
This fix enable to use ASCII_STRING as type for Arrays of strings.
This new parameter was added in version 2.11.x but unfortunately we don't have a way to use in a array.

Also added it in the check for Param array in SQLParserUtils.php so we can handle it there too

For instance, if we use setParameter('string' ['string1','string2'], Types::ASCII_STRING), it will fail, because we should use something like \Doctrine\DBAL\Connection::PARAM_STR_ARRAY. But unfortunately we don't have an option like that for ASCII_STRING, and if we are working with PDOSqlServer and Varchar, we should use it for performance

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

<!-- Provide a summary of your change. -->
