### PR TITLE
Remove DB2Platform::supportsReleaseSavepoints()

### DIFF
--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -418,14 +418,6 @@ class DB2Platform extends AbstractPlatform
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function supportsReleaseSavepoints()
-    {
-        return false;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function supportsCommentOnStatement()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The method overrides the default implementation but returns the same value, so it's can be removed in favor of the default implementation.