### PR TITLE
Improve performance of Oracle constraint query.

### DIFF
--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -462,6 +462,7 @@ class OraclePlatform extends AbstractPlatform
                            SELECT ucon.constraint_type
                            FROM   user_constraints ucon
                            WHERE  ucon.index_name = uind_col.index_name
+                             AND  ucon.table_name = uind_col.table_name
                        ) AS is_primary
              FROM      user_ind_columns uind_col
              WHERE     uind_col.table_name = " . $table . '


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

This patch slightly qualifies the query used to obtain Oracle constraint metadata so that it can make better use of indexes on the constraint view's underlying tables. There is no change in functionality or output, just an improvement in speed. On my Oracle system, this patch provides a 4X improvement in speed, dropping a scan of about 400 tables from a painfully slow 12 minutes to a slightly less painfully slow 3 minutes.