### PR TITLE
Ignore adding foreign keys if a table was not created

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SchemaDiff.php
+++ b/lib/Doctrine/DBAL/Schema/SchemaDiff.php
@@ -139,9 +139,15 @@ class SchemaDiff
 
         $foreignKeySql = [];
         foreach ($this->newTables as $table) {
+            $tableCreateSQL = $platform->getCreateTableSQL($table, AbstractPlatform::CREATE_INDEXES);
+
+            if (empty($tableCreateSQL)) {
+                continue;
+            }
+
             $sql = array_merge(
                 $sql,
-                $platform->getCreateTableSQL($table, AbstractPlatform::CREATE_INDEXES)
+                $tableCreateSQL
             );
 
             if (! $platform->supportsForeignKeyConstraints()) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #5125 

#### Summary

This is the proposed fix to the issue where foreign keys are still created even if a onSchemaCreateTable is told to `preventDefault`. 
