### PR TITLE
Test AbstractPlatform::getModExpression()

### DIFF
--- a/tests/Functional/Platform/ModExpressionTest.php
+++ b/tests/Functional/Platform/ModExpressionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Platform;
+
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+final class ModExpressionTest extends FunctionalTestCase
+{
+    public function testModExpression(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $query    = $platform->getDummySelectSQL($platform->getModExpression('5', '2'));
+
+        self::assertEquals('1', $this->connection->fetchOne($query));
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

`AbstractPlatform::getModExpression()` was mistakenly removed as part of https://github.com/doctrine/dbal/pull/4728 which went unnoticed because the method wasn't covered by tests. The method will be reinstated during the merge of this test up.