### PR TITLE
Merge 3.3.x into 4.0.x

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -426,6 +426,17 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Returns the SQL snippet to get the remainder of the operation of division of dividend by divisor.
+     *
+     * @param string $dividend SQL expression producing the dividend.
+     * @param string $divisor  SQL expression producing the divisor.
+     */
+    public function getModExpression(string $dividend, string $divisor): string
+    {
+        return 'MOD(' . $dividend . ', ' . $divisor . ')';
+    }
+
+    /**
      * Returns the SQL snippet to trim a string.
      *
      * @param string      $str  The expression to apply the trim to.

--- a/tests/Functional/Platform/ModExpressionTest.php
+++ b/tests/Functional/Platform/ModExpressionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Platform;
+
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+final class ModExpressionTest extends FunctionalTestCase
+{
+    public function testModExpression(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $query    = $platform->getDummySelectSQL($platform->getModExpression('5', '2'));
+
+        self::assertEquals('1', $this->connection->fetchOne($query));
+    }
+}


### PR DESCRIPTION
Besides merging the changes from `3.3.x`, this patch reinstates `AbstractPlatform::getModExpression()` mistakenly removed as part of #4728.