### PR TITLE
Accept strings in AbstractPlatform::get*Expression() methods

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -823,8 +823,8 @@ abstract class AbstractPlatform
      *
      * @deprecated Use ROUND() in SQL instead.
      *
-     * @param string $column
-     * @param int    $decimals
+     * @param string     $column
+     * @param string|int $decimals
      *
      * @return string
      */
@@ -975,9 +975,9 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL snippet to get the position of the first occurrence of substring $substr in string $str.
      *
-     * @param string    $str      Literal string.
-     * @param string    $substr   Literal string to find.
-     * @param int|false $startPos Position to start at, beginning of string by default.
+     * @param string           $str      Literal string.
+     * @param string           $substr   Literal string to find.
+     * @param string|int|false $startPos Position to start at, beginning of string by default.
      *
      * @return string
      *
@@ -1013,9 +1013,9 @@ abstract class AbstractPlatform
      *
      * SQLite only supports the 2 parameter variant of this function.
      *
-     * @param string   $string An sql string literal or column name/alias.
-     * @param int      $start  Where to start the substring portion.
-     * @param int|null $length The substring portion length.
+     * @param string          $string An sql string literal or column name/alias.
+     * @param string|int      $start  Where to start the substring portion.
+     * @param string|int|null $length The substring portion length.
      *
      * @return string
      */

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -122,7 +122,7 @@ class PostgreSQLPlatform extends AbstractPlatform
             $str = $this->getSubstringExpression($str, $startPos);
 
             return 'CASE WHEN (POSITION(' . $substr . ' IN ' . $str . ') = 0) THEN 0'
-                . ' ELSE (POSITION(' . $substr . ' IN ' . $str . ') + ' . ($startPos - 1) . ') END';
+                . ' ELSE (POSITION(' . $substr . ' IN ' . $str . ') + ' . $startPos . ' - 1) END';
         }
 
         return 'POSITION(' . $substr . ' IN ' . $str . ')';


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

All `AbstractPlatform::get*Expression()` methods that build SQL by concatenating their parameters should accept strings. See https://github.com/doctrine/dbal/pull/3498.

Otherwise, passing an SQL expression as the`$startPos` argument of `getLocateExpression()` works but is flagged as a type issue. See https://github.com/doctrine/orm/pull/9266.