### PR TITLE
Fix namespace building in AbstractAsset

### DIFF
--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -52,7 +52,7 @@ abstract class AbstractAsset
         }
 
         if (strpos($name, '.') !== false) {
-            $parts            = explode('.', $name);
+            $parts            = explode('.', $name, 2);
             $this->_namespace = $parts[0];
             $name             = $parts[1];
         }

--- a/tests/Schema/IndexTest.php
+++ b/tests/Schema/IndexTest.php
@@ -173,4 +173,16 @@ class IndexTest extends TestCase
         self::assertSame('name IS NULL', $idx2->getOption('WHERE'));
         self::assertSame(['where' => 'name IS NULL'], $idx2->getOptions());
     }
+
+    public function testIndexNamespaces(): void
+    {
+        $idx = new Index('namespace.product.fk', ['id']);
+        static::assertSame('namespace.product.fk', $idx->getName());
+        static::assertSame('namespace', $idx->getNamespaceName());
+        static::assertSame('product.fk', $idx->getShortestName('namespace'));
+
+        $idx = new Index('namespace.product', ['id']);
+        static::assertSame('namespace.product', $idx->getName());
+        static::assertSame('namespace', $idx->getNamespaceName());
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

We use multiple dots in our index names. This also works everywhere with the SchemaManager but not at this place: https://github.com/doctrine/dbal/blob/3.2.x/src/Schema/Table.php#L502.

Here, the "wrong" assembled name is used as array key.
