### PR TITLE
Deprecate Type::canRequireSQLConversion()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 3.3
 
+## Deprecated `Type::canRequireSQLConversion()`.
+
+Consumers should call `Type::convertToDatabaseValueSQL()` and `Type::convertToPHPValueSQL()` regardless of the type.
+
 ## Deprecated the `doctrine-dbal` binary.
 
 The documentation explains how the console tools can be bootstrapped for standalone usage.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -219,6 +219,11 @@
                 <referencedMethod name="Doctrine\DBAL\Platforms\DB2Platform::prefersIdentityColumns"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\SQLServerPlatform::prefersIdentityColumns"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::prefersIdentityColumns"/>
+                <!--
+                    TODO: remove in 4.0.0
+                    See https://github.com/doctrine/dbal/pull/5136
+                -->
+                <referencedMethod name="Doctrine\DBAL\Types\Type::canRequireSQLConversion"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -222,6 +222,9 @@ abstract class Type
      * {@see convertToPHPValueSQL} works for any type and mostly
      * does nothing. This method can additionally be used for optimization purposes.
      *
+     * @deprecated Consumers should call {@see convertToDatabaseValueSQL} and {@see convertToPHPValueSQL}
+     * regardless of the type.
+     *
      * @return bool
      */
     public function canRequireSQLConversion()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

The method was added at the times of PHP 5 as a means to optimize the ORM performance but is no longer necessary.