### PR TITLE
Make the SQL parser regular expression less greedy

### DIFF
--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -70,7 +70,7 @@ final class Parser
             self::OTHER,
         ]);
 
-        $this->sqlPattern = sprintf('(%s)+', implode('|', $patterns));
+        $this->sqlPattern = sprintf('(%s)', implode('|', $patterns));
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #5137.

Previously, the parser would use the `+` quantifier in order to accumulate all SQL fragments of the same kind in a batch and invoke the visitor methods as rarely as necessary. Now, it will have to call the visitor with each individual match in order to avoid extensive JIT stack usage.