### PR TITLE
Specify allowed plugins for Composer 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,11 @@
     },
     "bin": ["bin/doctrine-dbal"],
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/package-versions-deprecated": true
+        }
     },
     "autoload": {
         "psr-4": { "Doctrine\\DBAL\\": "lib/Doctrine/DBAL" }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Without having plugins allowed in `compose.json`, Composer 2.2 and newer will ask if the user trusts the plugins:
```
$ composer update
dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "dealerdirect/phpcodesniffer-composer-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
composer/package-versions-deprecated contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "composer/package-versions-deprecated" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
```