### PR TITLE
Remove Type::canRequireSQLConversion()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -55,6 +55,10 @@ following methods are removed:
 The protected property `AbstractPlatform::$doctrineTypeComments` is removed as
 well.
 
+## BC BREAK: Removed `Type::canRequireSQLConversion()`
+
+The `Type::canRequireSQLConversion()` method has been removed.
+
 ## BC BREAK: Removed `Connection::getWrappedConnection()`, `Connection::connect()` made `protected`.
 
 The wrapper-level `Connection::getWrappedConnection()` method has been removed. The `Connection::connect()` method

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -46,11 +46,6 @@
                     See https://github.com/doctrine/dbal/pull/4317
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
-                <!--
-                    TODO: remove in 4.0.0
-                    See https://github.com/doctrine/dbal/pull/5136
-                -->
-                <referencedMethod name="Doctrine\DBAL\Types\Type::canRequireSQLConversion"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -204,22 +204,6 @@ abstract class Type
     }
 
     /**
-     * Does working with this column require SQL conversion functions?
-     *
-     * This is a metadata function that is required for example in the ORM.
-     * Usage of {@see convertToDatabaseValueSQL} and
-     * {@see convertToPHPValueSQL} works for any type and mostly
-     * does nothing. This method can additionally be used for optimization purposes.
-     *
-     * @deprecated Consumers should call {@see convertToDatabaseValueSQL} and {@see convertToPHPValueSQL}
-     * regardless of the type.
-     */
-    public function canRequireSQLConversion(): bool
-    {
-        return false;
-    }
-
-    /**
      * Modifies the SQL expression (identifier, parameter) to convert to a database value.
      */
     public function convertToDatabaseValueSQL(string $sqlExpr, AbstractPlatform $platform): string

--- a/tests/Types/StringTest.php
+++ b/tests/Types/StringTest.php
@@ -44,7 +44,6 @@ class StringTest extends TestCase
 
     public function testSQLConversion(): void
     {
-        self::assertFalse($this->type->canRequireSQLConversion());
         self::assertEquals('t.foo', $this->type->convertToDatabaseValueSQL('t.foo', $this->platform));
         self::assertEquals('t.foo', $this->type->convertToPHPValueSQL('t.foo', $this->platform));
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

Deprecated in https://github.com/doctrine/dbal/pull/5136.