### PR TITLE
Use $maxLength = 0 by default when calling PDOStatement::bindParam()

### DIFF
--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -80,7 +80,13 @@ final class Statement implements StatementInterface
         $type = $this->convertParamType($type);
 
         try {
-            return $this->stmt->bindParam($param, $variable, $type, ...array_slice(func_get_args(), 3));
+            return $this->stmt->bindParam(
+                $param,
+                $variable,
+                $type,
+                $length ?? 0,
+                ...array_slice(func_get_args(), 4)
+            );
         } catch (PDOException $exception) {
             throw Exception::new($exception);
         }

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -224,6 +224,18 @@ EOF
         self::assertEquals(2, $result->fetchOne());
     }
 
+    public function testBindParamWithNullLength(): void
+    {
+        $this->connection->insert('stmt_test', ['id' => 1]);
+
+        $stmt = $this->connection->prepare('SELECT id FROM stmt_test WHERE id = ?');
+
+        $value = 1;
+        $stmt->bindParam(1, $value, ParameterType::INTEGER, null);
+
+        self::assertEquals(1, $stmt->executeQuery()->fetchOne());
+    }
+
     /**
      * @param mixed $expected
      *


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #5134.