### PR TITLE
Merge 2.13.x into 3.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,13 +41,13 @@
     "require-dev": {
         "doctrine/coding-standard": "9.0.0",
         "jetbrains/phpstorm-stubs": "2021.1",
-        "phpstan/phpstan": "1.2.0",
-        "phpunit/phpunit": "^7.5.20|^8.5|9.5.10",
+        "phpstan/phpstan": "1.3.0",
+        "phpunit/phpunit": "^7.5.20|^8.5|9.5.11",
         "psalm/plugin-phpunit": "0.16.1",
         "squizlabs/php_codesniffer": "3.6.2",
         "symfony/cache": "^4.4",
         "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-        "vimeo/psalm": "4.15.0"
+        "vimeo/psalm": "4.16.1"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -87,12 +87,6 @@ parameters:
             paths:
                 - lib/Doctrine/DBAL/Connection.php
 
-        # PHPStan fails to parse this type alias which is meant for Psalm only.
-        -
-            message: '~^Invalid type definition detected in type alias (Override)?Params\.$~'
-            paths:
-                - lib/Doctrine/DBAL/DriverManager.php
-
         -
             message: '~Template type T of method Doctrine\\DBAL\\DriverManager::getConnection\(\) is not referenced in a parameter\.~'
             paths:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -132,8 +132,18 @@ parameters:
             path: src/Driver/Mysqli/Result.php
 
         -
-            message: '~Method Doctrine\\DBAL\\Driver\\Mysqli\\Result::rowCount\(\) should return int but returns int\|string\.~'
+            message: '~Method Doctrine\\DBAL\\Driver\\Mysqli\\Result::rowCount\(\) should return int but returns int(:?<0, max>)?\|string\.~'
             paths:
                 - src/Driver/Mysqli/Result.php
+
+        -
+            message: '~Method Doctrine\\DBAL\\Driver\\Mysqli\\Connection::exec\(\) should return int but returns int\|string\.~'
+            paths:
+                - src/Driver/Mysqli/Connection.php
+
+        -
+            message: '~^Parameter #1 \$message of class Doctrine\\DBAL\\Driver\\Mysqli\\Exception\\ConnectionFailed constructor expects string, string\|null given\.$~'
+            paths:
+                - src/Driver/Mysqli/Exception/ConnectionFailed.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon


### PR DESCRIPTION
Note that I've included an additional commit that ignores some errors that the new PHPStan release  reports because it ships with updated `mysqli` stubs.