### PR TITLE
Deprecate support for IBM DB2 10.5 and older

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -40,6 +40,10 @@ following methods are deprecated:
 The protected property `AbstractPlatform::$doctrineTypeComments` is deprecated
 as well.
 
+## Deprecated support for IBM DB2 10.5 and older
+
+IBM DB2 10.5 and older won't be supported in DBAL 4. Consider upgrading to IBM DB2 11.1 or later.
+
 ## Deprecated support for Oracle 12c (12.2.0.1) and older
 
 Oracle 12c (12.2.0.1) won't be supported in DBAL 4. Consider upgrading to Oracle 18c (12.2.0.2) or later.

--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -58,6 +58,11 @@ PostgreSQL
 -  ``PostgreSQLPlatform`` for version 9.4 and above.
 -  ``PostgreSQL100Platform`` for version 10.0 and above.
 
+IBM DB2
+^^^^^^^
+
+-  ``Db2Platform`` for all versions.
+
 SQLite
 ^^^^^^
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no

Basic support for IBM DB2 10.5 ended on April 30, 2020 ([source](https://www.ibm.com/support/pages/node/578841)).

We have never tested the support for IBM DB2 on versions older than 11.5 but most likely the latest DBAL version will work with the old DB2 versions like 9.x and we cannot break that all of a sudden.

On the other hand, the DBAL never specified the supported DB2 versions, so we can start doing this at least starting the next major release.