### PR TITLE
Use native IBM DB2 11 syntax for Top-N queries

### DIFF
--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -643,26 +643,15 @@ class DB2Platform extends AbstractPlatform
 
     protected function doModifyLimitQuery(string $query, ?int $limit, int $offset): string
     {
-        $where = [];
-
         if ($offset > 0) {
-            $where[] = sprintf('db22.DC_ROWNUM >= %d', $offset + 1);
+            $query .= sprintf(' OFFSET %d ROWS', $offset);
         }
 
         if ($limit !== null) {
-            $where[] = sprintf('db22.DC_ROWNUM <= %d', $offset + $limit);
+            $query .= sprintf(' FETCH NEXT %d ROWS ONLY', $limit);
         }
 
-        if (empty($where)) {
-            return $query;
-        }
-
-        // Todo OVER() needs ORDER BY data!
-        return sprintf(
-            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER() AS DC_ROWNUM FROM (%s) db21) db22 WHERE %s',
-            $query,
-            implode(' AND ', $where)
-        );
+        return $query;
     }
 
     public function getLocateExpression(string $string, string $substring, ?string $start = null): string

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -392,34 +392,6 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         self::assertEquals('SUBSTR(column, 5, 2)', $this->platform->getSubstringExpression('column', '5', '2'));
     }
 
-    public function testModifiesLimitQuery(): void
-    {
-        self::assertEquals(
-            'SELECT * FROM user',
-            $this->platform->modifyLimitQuery('SELECT * FROM user', null, 0)
-        );
-
-        self::assertEquals(
-            'SELECT db22.* FROM ('
-                . 'SELECT db21.*, ROW_NUMBER() OVER() AS DC_ROWNUM FROM (SELECT * FROM user) db21'
-                . ') db22 WHERE db22.DC_ROWNUM <= 10',
-            $this->platform->modifyLimitQuery('SELECT * FROM user', 10)
-        );
-
-        self::assertEquals(
-            'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER() AS DC_ROWNUM FROM ('
-                . 'SELECT * FROM user) db21'
-                . ') db22 WHERE db22.DC_ROWNUM >= 6 AND db22.DC_ROWNUM <= 15',
-            $this->platform->modifyLimitQuery('SELECT * FROM user', 10, 5)
-        );
-        self::assertEquals(
-            'SELECT db22.* FROM ('
-                . 'SELECT db21.*, ROW_NUMBER() OVER() AS DC_ROWNUM FROM (SELECT * FROM user) db21'
-                . ') db22 WHERE db22.DC_ROWNUM >= 6 AND db22.DC_ROWNUM <= 5',
-            $this->platform->modifyLimitQuery('SELECT * FROM user', 0, 5)
-        );
-    }
-
     public function testSupportsIdentityColumns(): void
     {
         self::assertTrue($this->platform->supportsIdentityColumns());


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

IBM DB2 supports the MySQL syntax without additional configuration as of release 11.1 ([source](https://www.ibm.com/docs/en/db2/11.1?topic=features-db2-compatibility-vector-registry-variable)):
> 0x4000 (obsolete) This bit formerly activated LIMIT and OFFSET support, but that feature is now always active and this bit is now ignored.

UPD: it doesn't seem to support `OFFSET` without a `LIMIT` in the MySQL syntax but it supports the Oracle's one.
UPD: I also checked that IBM DB2 10.5 (implicitly supported in DBAL 3.x) also supports the `FETCH n ROWS ONLY` clause but doesn't support the `OFFSET n ROWS` clause, so this patch can be only accepted for DBAL 4.0.