### PR TITLE
Document `$lockMode` value range

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -300,6 +300,12 @@
                 <file name="src/Driver/OCI8/Connection.php"/>
             </errorLevel>
         </ImplementedReturnTypeMismatch>
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <!-- We're testing with invalid input here. -->
+                <file name="tests/Platforms/AbstractPlatformTestCase.php"/>
+            </errorLevel>
+        </InvalidArgument>
         <InvalidDocblock>
             <errorLevel type="suppress">
                 <!-- See https://github.com/vimeo/psalm/issues/5472 -->

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1563,6 +1563,7 @@ abstract class AbstractPlatform
      *
      * @param string $fromClause The FROM clause to append the hint for the given lock mode to
      * @param int    $lockMode   One of the Doctrine\DBAL\LockMode::* constants
+     * @psalm-param LockMode::* $lockMode
      */
     public function appendLockHint(string $fromClause, int $lockMode): string
     {

--- a/tests/Platforms/SQLServerPlatformTestCase.php
+++ b/tests/Platforms/SQLServerPlatformTestCase.php
@@ -1822,6 +1822,8 @@ class SQLServerPlatformTestCase extends AbstractPlatformTestCase
     }
 
     /**
+     * @psalm-param LockMode::* $lockMode
+     *
      * @dataProvider getLockHints
      */
     public function testAppendsLockHint(int $lockMode, string $lockHint): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

This PR narrows down the allowed value range for `$lockMode` parameters. This way, Psalm and PHPStan can inspect userland code that calls our methods and warn about invalid `$lockMode` values.
