### PR TITLE
Fix detecting changes in the default value

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -508,10 +508,16 @@ class Comparator
         // null != 0, null != false, null != '' etc. This affects platform's table alteration SQL generation.
         if ($properties1['default'] === 'NULL') {
             $properties1['default'] = null;
+        } elseif ($properties1['default'] === 'current_timestamp()') {
+            $properties1['default'] = 'CURRENT_TIMESTAMP';
         }
+
         if ($properties2['default'] === 'NULL') {
             $properties2['default'] = null;
+        } elseif ($properties2['default'] === 'current_timestamp()') {
+            $properties2['default'] = 'CURRENT_TIMESTAMP';
         }
+
         if (
             ($properties1['default'] === null) !== ($properties2['default'] === null)
             || $properties1['default'] != $properties2['default']

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -506,6 +506,12 @@ class Comparator
 
         // Null values need to be checked additionally as they tell whether to create or drop a default value.
         // null != 0, null != false, null != '' etc. This affects platform's table alteration SQL generation.
+        if ($properties1['default'] === 'NULL') {
+            $properties1['default'] = null;
+        }
+        if ($properties2['default'] === 'NULL') {
+            $properties2['default'] = null;
+        }
         if (
             ($properties1['default'] === null) !== ($properties2['default'] === null)
             || $properties1['default'] != $properties2['default']


### PR DESCRIPTION
This fixes the bug described in https://github.com/doctrine/dbal/issues/5158. 
This only fixes the sympton, maybe another fix for the deep-rooted problem is necessary.

|      Q       |   A
|------------- | -----------
| Type         | bug-fix
| BC Break     | yes/no
| Fixed issues | https://github.com/doctrine/dbal/issues/5158

#### Summary

If a default-value is `"NULL"`, `null` is assumed for comparisons between the expected database schema and the current version.
