### PR TITLE
Ignore DB2 warning when reaching end

### DIFF
--- a/src/Driver/IBMDB2/Result.php
+++ b/src/Driver/IBMDB2/Result.php
@@ -37,7 +37,7 @@ final class Result implements ResultInterface
     {
         $row = @db2_fetch_array($this->statement);
 
-        if ($row === false && db2_stmt_error($this->statement) !== '02000') {
+        if ($row === false && @db2_stmt_error($this->statement) !== '02000') {
             throw StatementError::new($this->statement);
         }
 
@@ -51,7 +51,7 @@ final class Result implements ResultInterface
     {
         $row = @db2_fetch_assoc($this->statement);
 
-        if ($row === false && db2_stmt_error($this->statement) !== '02000') {
+        if ($row === false && @db2_stmt_error($this->statement) !== '02000') {
             throw StatementError::new($this->statement);
         }
 

--- a/tests/Functional/Driver/IBMDB2/StatementTest.php
+++ b/tests/Functional/Driver/IBMDB2/StatementTest.php
@@ -38,4 +38,18 @@ class StatementTest extends FunctionalTestCase
         $this->expectException(StatementError::class);
         $stmt->execute([[]]);
     }
+
+    public function testWarningDoNotBreakFetchAll(): void
+    {
+        $driverConnection = $this->connection->getWrappedConnection();
+
+        $stmt = $driverConnection->prepare('SELECT current time AS time FROM sysibm.sysdummy1');
+
+        // prevent the PHPUnit error handler from handling the errors that db2_execute() may trigger
+        $this->iniSet('error_reporting', (string) E_ALL);
+
+        $result = $stmt->execute([[]])->fetchAllAssociative();
+        $this->assertCount(1, $result);
+        $this->assertArrayHasKey('TIME', $result[0]);
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

|                          |                                                              |
|------------------|------------------------------------------|
| System              | OS400 NEPTUNE 4 7 00210009E53W |
| PHP Version      | 7.4.27                                                   |
| ibm_db2            | 2.1.5                                                     |
| error_reporting | 32767 (E_ALL)                                       |

Ignore DB2 warning when reaching the end of a rowset.

Error in French: 

> Warning: db2_stmt_error(): La ligne n'a pas {t{ trouv{e pour C65399500002000003. SQLCODE=100"

I don't have an IBMi configured in English sorry, it says row not found for C65399500002000003).

When ignoring this warning, there is no more execution problem. The error is checked in the condition just below, and there should always be a db2_error when an actual error is raised.
