### PR TITLE
Rename getWrappedResourceHandle() method to getWrappedConnection()

### DIFF
--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -37,7 +37,7 @@ final class Connection implements ServerInfoAwareConnection
      *
      * Could be used if part of your application is not using DBAL.
      */
-    public function getWrappedResourceHandle(): mysqli
+    public function getWrappedConnection(): mysqli
     {
         return $this->connection;
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

#### Summary

Unify the wrapped connection getter to match the PDO driver name.

The original method name should be kept and marked as deprecated.