### PR TITLE
Fix JSON Dbal type to properly encode whole number float values, preserving zero fractions.

### DIFF
--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -10,8 +10,8 @@ use function json_decode;
 use function json_encode;
 use function stream_get_contents;
 
-use const JSON_THROW_ON_ERROR;
 use const JSON_PRESERVE_ZERO_FRACTION;
+use const JSON_THROW_ON_ERROR;
 
 /**
  * Type generating json objects values

--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -11,6 +11,7 @@ use function json_encode;
 use function stream_get_contents;
 
 use const JSON_THROW_ON_ERROR;
+use const JSON_PRESERVE_ZERO_FRACTION;
 
 /**
  * Type generating json objects values
@@ -35,7 +36,7 @@ class JsonType extends Type
         }
 
         try {
-            return json_encode($value, JSON_THROW_ON_ERROR);
+            return json_encode($value, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION);
         } catch (JsonException $e) {
             throw ConversionException::conversionFailedSerialization($value, 'json', $e->getMessage(), $e);
         }

--- a/tests/Types/JsonTest.php
+++ b/tests/Types/JsonTest.php
@@ -62,7 +62,7 @@ class JsonTest extends TestCase
     public function testJsonStringConvertsToPHPValue(): void
     {
         $value         = ['foo' => 'bar', 'bar' => 'foo'];
-        $databaseValue = json_encode($value, 0, JSON_THROW_ON_ERROR);
+        $databaseValue = json_encode($value);
         $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
 
         self::assertEquals($value, $phpValue);
@@ -87,7 +87,7 @@ class JsonTest extends TestCase
     {
         $value         = ['foo' => 'bar', 'bar' => 'foo'];
         $databaseValue = fopen(
-            'data://text/plain;base64,' . base64_encode(json_encode($value, JSON_THROW_ON_ERROR)),
+            'data://text/plain;base64,' . base64_encode(json_encode($value, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION)),
             'r'
         );
         $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
@@ -98,6 +98,27 @@ class JsonTest extends TestCase
     public function testRequiresSQLCommentHint(): void
     {
         self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
+    }
+
+    public function testPHPNullValueConvertsToJsonNull(): void
+    {
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testPHPValueConvertsToJsonString(): void
+    {
+        $source = ['foo' => 'bar', 'bar' => 'foo'];
+        $databaseValue = $this->type->convertToDatabaseValue($source, $this->platform);
+
+        self::assertEquals('{"foo":"bar","bar":"foo"}', $databaseValue);
+    }
+
+    public function testPHPFloatValueConvertsToJsonString(): void
+    {
+        $source        = ['foo' => 11.4, 'bar' => 10.0];
+        $databaseValue = $this->type->convertToDatabaseValue($source, $this->platform);
+
+        self::assertEquals('{"foo":11.4,"bar":10.0}', $databaseValue);
     }
 
     public function testSerializationFailure(): void

--- a/tests/Types/JsonTest.php
+++ b/tests/Types/JsonTest.php
@@ -14,6 +14,7 @@ use function base64_encode;
 use function fopen;
 use function json_encode;
 
+use const JSON_PRESERVE_ZERO_FRACTION;
 use const JSON_THROW_ON_ERROR;
 
 class JsonTest extends TestCase
@@ -87,7 +88,10 @@ class JsonTest extends TestCase
     {
         $value         = ['foo' => 'bar', 'bar' => 'foo'];
         $databaseValue = fopen(
-            'data://text/plain;base64,' . base64_encode(json_encode($value, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION)),
+            'data://text/plain;base64,' . base64_encode(json_encode(
+                $value,
+                JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION
+            )),
             'r'
         );
         $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
@@ -107,7 +111,7 @@ class JsonTest extends TestCase
 
     public function testPHPValueConvertsToJsonString(): void
     {
-        $source = ['foo' => 'bar', 'bar' => 'foo'];
+        $source        = ['foo' => 'bar', 'bar' => 'foo'];
         $databaseValue = $this->type->convertToDatabaseValue($source, $this->platform);
 
         self::assertSame('{"foo":"bar","bar":"foo"}', $databaseValue);

--- a/tests/Types/JsonTest.php
+++ b/tests/Types/JsonTest.php
@@ -62,7 +62,7 @@ class JsonTest extends TestCase
     public function testJsonStringConvertsToPHPValue(): void
     {
         $value         = ['foo' => 'bar', 'bar' => 'foo'];
-        $databaseValue = json_encode($value);
+        $databaseValue = json_encode($value, 0, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION);
         $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
 
         self::assertEquals($value, $phpValue);
@@ -110,7 +110,7 @@ class JsonTest extends TestCase
         $source = ['foo' => 'bar', 'bar' => 'foo'];
         $databaseValue = $this->type->convertToDatabaseValue($source, $this->platform);
 
-        self::assertEquals('{"foo":"bar","bar":"foo"}', $databaseValue);
+        self::assertSame('{"foo":"bar","bar":"foo"}', $databaseValue);
     }
 
     public function testPHPFloatValueConvertsToJsonString(): void
@@ -118,7 +118,7 @@ class JsonTest extends TestCase
         $source        = ['foo' => 11.4, 'bar' => 10.0];
         $databaseValue = $this->type->convertToDatabaseValue($source, $this->platform);
 
-        self::assertEquals('{"foo":11.4,"bar":10.0}', $databaseValue);
+        self::assertSame('{"foo":11.4,"bar":10.0}', $databaseValue);
     }
 
     public function testSerializationFailure(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bugfix
| BC Break     | no
| Fixed issues | #5172

#### Summary

Fixes the zero fraction removal during JSON encoding. It is important for keeping the data integrity and really useful for strongly typed systems (value won't turn to integer during decode).
