### PR TITLE
Fix Driver\Connection::getServerVersion() for MariaDB

### DIFF
--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -42,26 +42,15 @@ final class Connection implements ServerInfoAwareConnection
         return $this->connection;
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * The server version detection includes a special case for MariaDB
-     * to support '5.5.5-' prefixed versions introduced in Maria 10+
-     *
-     * @link https://jira.mariadb.org/browse/MDEV-4088
-     */
     public function getServerVersion(): string
     {
-        $serverInfos = $this->connection->get_server_info();
-        if (stripos($serverInfos, 'mariadb') !== false) {
-            return $serverInfos;
-        }
+        $isMariadb = stripos($this->connection->get_server_info(), 'mariadb') !== false;
 
         $majorVersion = floor($this->connection->server_version / 10000);
         $minorVersion = floor(($this->connection->server_version - $majorVersion * 10000) / 100);
         $patchVersion = floor($this->connection->server_version - $majorVersion * 10000 - $minorVersion * 100);
 
-        return $majorVersion . '.' . $minorVersion . '.' . $patchVersion;
+        return $majorVersion . '.' . $minorVersion . '.' . $patchVersion . ($isMariadb ? '-MariaDB' : '');
     }
 
     public function prepare(string $sql): DriverStatement

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -12,6 +12,7 @@ use PDOException;
 use PDOStatement;
 
 use function assert;
+use function preg_replace;
 
 final class Connection implements ServerInfoAwareConnection
 {
@@ -46,7 +47,15 @@ final class Connection implements ServerInfoAwareConnection
      */
     public function getServerVersion()
     {
-        return $this->connection->getAttribute(PDO::ATTR_SERVER_VERSION);
+        // remove "5.5.5-" prefix for MariaDB introduced in
+        // https://jira.mariadb.org/browse/MDEV-4088
+        // as a pure protocol fix to match version from "SELECT VERSION()"
+
+        return preg_replace(
+            '~^5\.5\.5-(?=\d+\.\d+\.\d+.*MariaDB)~i',
+            '',
+            $this->connection->getAttribute(PDO::ATTR_SERVER_VERSION)
+        );
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #5170

#### Summary

`5.5.5-` is a protocol fix, with this PR, returned version matches the version from `SELECT VERSION()`

MariaDB detection in `src/Driver/Mysqli/Connection.php` is kept