### PR TITLE
Remove parsing server version from the mysqli driver

### DIFF
--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -11,9 +11,6 @@ use Doctrine\Deprecations\Deprecation;
 use mysqli;
 use mysqli_sql_exception;
 
-use function floor;
-use function stripos;
-
 final class Connection implements ServerInfoAwareConnection
 {
     /**
@@ -51,26 +48,9 @@ final class Connection implements ServerInfoAwareConnection
         return $this->getNativeConnection();
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * The server version detection includes a special case for MariaDB
-     * to support '5.5.5-' prefixed versions introduced in Maria 10+
-     *
-     * @link https://jira.mariadb.org/browse/MDEV-4088
-     */
     public function getServerVersion(): string
     {
-        $serverInfos = $this->connection->get_server_info();
-        if (stripos($serverInfos, 'mariadb') !== false) {
-            return $serverInfos;
-        }
-
-        $majorVersion = floor($this->connection->server_version / 10000);
-        $minorVersion = floor(($this->connection->server_version - $majorVersion * 10000) / 100);
-        $patchVersion = floor($this->connection->server_version - $majorVersion * 10000 - $minorVersion * 100);
-
-        return $majorVersion . '.' . $minorVersion . '.' . $patchVersion;
+        return $this->connection->get_server_info();
     }
 
     public function prepare(string $sql): DriverStatement

--- a/src/Driver/ServerInfoAwareConnection.php
+++ b/src/Driver/ServerInfoAwareConnection.php
@@ -11,7 +11,7 @@ namespace Doctrine\DBAL\Driver;
 interface ServerInfoAwareConnection extends Connection
 {
     /**
-     * Returns the version number of the database server connected to.
+     * Returns information about the version of the database server connected to.
      *
      * @return string
      *


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | theoretically possible, minor

Closes #5170.

The fact that the `mysqli` driver does some interpretation of the server version creates the impression that the drivers are responsible for some unified representation of the server version which is not true. Furthermore, only the `mysqli` driver interprets the driver version while the `pdo_mysql` one doesn't as well as no other drivers do:
https://github.com/doctrine/dbal/blob/d9f969b366fcd4c7def89372b9c198edb2cc9fe5/src/Driver/PDO/Connection.php#L47-L50

On the one hand, the server version isn't part of the database abstraction. It's purely a means of instantiating the platform class corresponding the to server on the other end of the connection. On the other, stripping vendor-specific details from the version string is a disservice to the API consumer: if the details are there, the vendor has put them for a reason.

The only scenario where this change could introduce a potential break is if there is a non-MariaDB MySQL build that announces its version by adding a suffix (e.g. MySQL-compatible AWS Aurora returns "5.7.12-log"), and the DBAL API consumer relies on the exact value returned by `Driver::getServerVersion()`.

This won't break the platform detection logic which does the parsing: https://github.com/doctrine/dbal/blob/dfdb5fb2b2230237bf46761140ce9b2dd4edea39/src/Driver/AbstractMySQLDriver.php#L70-L83