### PR TITLE
fix typo: `\Doctrine\DBAL\Statement` vs. `\Doctrine\DBAL\Driver\Statement`

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -304,7 +304,7 @@ prepare()
 ~~~~~~~~~
 
 Prepare a given SQL statement and return the
-``\Doctrine\DBAL\Driver\Statement`` instance:
+``\Doctrine\DBAL\Statement`` instance:
 
 .. code-block:: php
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->

I think this is a typo.

I guess you made this observation already, but if not: same-named types within this package are really confusing.
