### PR TITLE
[Bugfix] Comparator should include the "length" of the text type fiel…

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -537,6 +537,15 @@ class Comparator
             }
         }
 
+        if ($properties1['type'] instanceof Types\TextType) {
+            // check if value of length is set at all, default value assumed otherwise.
+            $length1 = $properties1['length'] ?? 4294967295;
+            $length2 = $properties2['length'] ?? 4294967295;
+            if ($length1 !== $length2) {
+                $changedProperties[] = 'length';
+            }
+        }
+
         // A null value and an empty string are actually equal for a comment so they should not trigger a change.
         if (
             $properties1['comment'] !== $properties2['comment'] &&


### PR DESCRIPTION
…d in changed properties.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

There is a problem with generating the migration for "length" property changes for fields of "text" type:
- If we have an existing property of "text" type without length. 
- We want to set its length. 
- When run doctrine:migration:diff - no difference is generated.
- If the field is new - the length is taken into consideration and the migration is created as it should.
