### PR TITLE
Handle binding invalid named parameter errors

### DIFF
--- a/src/Driver/PDO/Exception.php
+++ b/src/Driver/PDO/Exception.php
@@ -18,6 +18,10 @@ final class Exception extends AbstractException
     {
         if ($exception->errorInfo !== null) {
             [$sqlState, $code] = $exception->errorInfo;
+
+            if ($code === null) {
+                $code = 0;
+            }
         } else {
             $code     = $exception->getCode();
             $sqlState = null;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #5130.

From the [documentation](https://www.php.net/manual/en/pdo.errorinfo.php):
> If the SQLSTATE error code is not set or there is no driver-specific error, the elements following element 0 will be set to null.