### PR TITLE
Drop Type::getName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: Removed `Type::getName()`
+
+As a consequence, only types extending `JsonType` or that type itself can have
+the `jsonb` platform option set.
+
 ## BC BREAK: Deployed database schema no longer contains the information about abstract data types
 
 Database column comments no longer contain type comments added by DBAL.

--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -848,8 +848,6 @@ Now we implement our ``Doctrine\DBAL\Types\Type`` instance:
      */
     class MoneyType extends Type
     {
-        const MONEY = 'money'; // modify to match your type name
-
         public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
         {
             return 'MyMoney';
@@ -863,11 +861,6 @@ Now we implement our ``Doctrine\DBAL\Types\Type`` instance:
         public function convertToDatabaseValue($value, AbstractPlatform $platform)
         {
             return $value->toDecimal();
-        }
-
-        public function getName()
-        {
-            return self::MONEY;
         }
     }
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -6,8 +6,8 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
 
 use function array_change_key_case;
 use function array_keys;
@@ -422,7 +422,7 @@ SQL
             $column->setPlatformOption('collation', $tableColumn['collation']);
         }
 
-        if ($column->getType()->getName() === Types::JSON) {
+        if ($column->getType() instanceof JsonType) {
             $column->setPlatformOption('jsonb', $jsonb);
         }
 

--- a/src/Types/ArrayType.php
+++ b/src/Types/ArrayType.php
@@ -41,8 +41,8 @@ class ArrayType extends Type
 
         $value = is_resource($value) ? stream_get_contents($value) : $value;
 
-        set_error_handler(function (int $code, string $message) use ($value): bool {
-            throw ValueNotConvertible::new($value, $this->getName(), $message);
+        set_error_handler(static function (int $code, string $message) use ($value): bool {
+            throw ValueNotConvertible::new($value, 'array', $message);
         });
 
         try {
@@ -50,11 +50,6 @@ class ArrayType extends Type
         } finally {
             restore_error_handler();
         }
-    }
-
-    public function getName(): string
-    {
-        return Types::ARRAY;
     }
 
     public function requiresSQLCommentHint(AbstractPlatform $platform): bool

--- a/src/Types/AsciiStringType.php
+++ b/src/Types/AsciiStringType.php
@@ -21,9 +21,4 @@ final class AsciiStringType extends StringType
     {
         return ParameterType::ASCII;
     }
-
-    public function getName(): string
-    {
-        return Types::ASCII_STRING;
-    }
 }

--- a/src/Types/BigIntType.php
+++ b/src/Types/BigIntType.php
@@ -12,11 +12,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class BigIntType extends Type implements PhpIntegerMappingType
 {
-    public function getName(): string
-    {
-        return Types::BIGINT;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Types/BinaryType.php
+++ b/src/Types/BinaryType.php
@@ -42,11 +42,6 @@ class BinaryType extends Type
         return $value;
     }
 
-    public function getName(): string
-    {
-        return Types::BINARY;
-    }
-
     public function getBindingType(): int
     {
         return ParameterType::BINARY;

--- a/src/Types/BlobType.php
+++ b/src/Types/BlobType.php
@@ -49,11 +49,6 @@ class BlobType extends Type
         return $value;
     }
 
-    public function getName(): string
-    {
-        return Types::BLOB;
-    }
-
     public function getBindingType(): int
     {
         return ParameterType::LARGE_OBJECT;

--- a/src/Types/BooleanType.php
+++ b/src/Types/BooleanType.php
@@ -31,11 +31,6 @@ class BooleanType extends Type
         return $platform->convertFromBoolean($value);
     }
 
-    public function getName(): string
-    {
-        return Types::BOOLEAN;
-    }
-
     public function getBindingType(): int
     {
         return ParameterType::BOOLEAN;

--- a/src/Types/DateImmutableType.php
+++ b/src/Types/DateImmutableType.php
@@ -14,11 +14,6 @@ use Doctrine\DBAL\Types\Exception\InvalidType;
  */
 class DateImmutableType extends DateType
 {
-    public function getName(): string
-    {
-        return Types::DATE_IMMUTABLE;
-    }
-
     public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
@@ -31,7 +26,7 @@ class DateImmutableType extends DateType
 
         throw InvalidType::new(
             $value,
-            $this->getName(),
+            static::class,
             ['null', DateTimeImmutable::class]
         );
     }
@@ -47,7 +42,7 @@ class DateImmutableType extends DateType
         if ($dateTime === false) {
             throw InvalidFormat::new(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getDateFormatString()
             );
         }

--- a/src/Types/DateIntervalType.php
+++ b/src/Types/DateIntervalType.php
@@ -19,13 +19,8 @@ class DateIntervalType extends Type
 {
     public const FORMAT = '%RP%YY%MM%DDT%HH%IM%SS';
 
-    public function getName(): string
-    {
-        return Types::DATEINTERVAL;
-    }
-
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
@@ -44,7 +39,7 @@ class DateIntervalType extends Type
             return $value->format(self::FORMAT);
         }
 
-        throw InvalidType::new($value, $this->getName(), ['null', 'DateInterval']);
+        throw InvalidType::new($value, static::class, ['null', 'DateInterval']);
     }
 
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateInterval
@@ -69,7 +64,7 @@ class DateIntervalType extends Type
 
             return $interval;
         } catch (Throwable $exception) {
-            throw InvalidFormat::new($value, $this->getName(), self::FORMAT, $exception);
+            throw InvalidFormat::new($value, static::class, self::FORMAT, $exception);
         }
     }
 

--- a/src/Types/DateTimeImmutableType.php
+++ b/src/Types/DateTimeImmutableType.php
@@ -16,11 +16,6 @@ use function date_create_immutable;
  */
 class DateTimeImmutableType extends DateTimeType
 {
-    public function getName(): string
-    {
-        return Types::DATETIME_IMMUTABLE;
-    }
-
     public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
@@ -33,7 +28,7 @@ class DateTimeImmutableType extends DateTimeType
 
         throw InvalidType::new(
             $value,
-            $this->getName(),
+            static::class,
             ['null', DateTimeImmutable::class]
         );
     }
@@ -53,7 +48,7 @@ class DateTimeImmutableType extends DateTimeType
         if ($dateTime === false) {
             throw InvalidFormat::new(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getDateTimeFormatString()
             );
         }

--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -17,13 +17,8 @@ use function date_create;
  */
 class DateTimeType extends Type implements PhpDateTimeMappingType
 {
-    public function getName(): string
-    {
-        return Types::DATETIME_MUTABLE;
-    }
-
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
@@ -40,7 +35,7 @@ class DateTimeType extends Type implements PhpDateTimeMappingType
             return $value->format($platform->getDateTimeFormatString());
         }
 
-        throw InvalidType::new($value, $this->getName(), ['null', 'DateTime']);
+        throw InvalidType::new($value, static::class, ['null', 'DateTime']);
     }
 
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeInterface
@@ -58,7 +53,7 @@ class DateTimeType extends Type implements PhpDateTimeMappingType
         if ($val === false) {
             throw InvalidFormat::new(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getDateTimeFormatString()
             );
         }

--- a/src/Types/DateTimeTzImmutableType.php
+++ b/src/Types/DateTimeTzImmutableType.php
@@ -14,11 +14,6 @@ use Doctrine\DBAL\Types\Exception\InvalidType;
  */
 class DateTimeTzImmutableType extends DateTimeTzType
 {
-    public function getName(): string
-    {
-        return Types::DATETIMETZ_IMMUTABLE;
-    }
-
     public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
@@ -31,7 +26,7 @@ class DateTimeTzImmutableType extends DateTimeTzType
 
         throw InvalidType::new(
             $value,
-            $this->getName(),
+            static::class,
             ['null', DateTimeImmutable::class]
         );
     }
@@ -47,7 +42,7 @@ class DateTimeTzImmutableType extends DateTimeTzType
         if ($dateTime === false) {
             throw InvalidFormat::new(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getDateTimeTzFormatString()
             );
         }

--- a/src/Types/DateTimeTzType.php
+++ b/src/Types/DateTimeTzType.php
@@ -28,13 +28,8 @@ use Doctrine\DBAL\Types\Exception\InvalidType;
  */
 class DateTimeTzType extends Type implements PhpDateTimeMappingType
 {
-    public function getName(): string
-    {
-        return Types::DATETIMETZ_MUTABLE;
-    }
-
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
@@ -53,7 +48,7 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
 
         throw InvalidType::new(
             $value,
-            $this->getName(),
+            static::class,
             ['null', 'DateTime']
         );
     }
@@ -68,7 +63,7 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
         if ($val === false) {
             throw InvalidFormat::new(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getDateTimeTzFormatString()
             );
         }

--- a/src/Types/DateType.php
+++ b/src/Types/DateType.php
@@ -15,11 +15,6 @@ use Doctrine\DBAL\Types\Exception\InvalidType;
  */
 class DateType extends Type
 {
-    public function getName(): string
-    {
-        return Types::DATE_MUTABLE;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -38,7 +33,7 @@ class DateType extends Type
             return $value->format($platform->getDateFormatString());
         }
 
-        throw InvalidType::new($value, $this->getName(), ['null', 'DateTime']);
+        throw InvalidType::new($value, static::class, ['null', 'DateTime']);
     }
 
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeInterface
@@ -51,7 +46,7 @@ class DateType extends Type
         if ($val === false) {
             throw InvalidFormat::new(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getDateFormatString()
             );
         }

--- a/src/Types/DecimalType.php
+++ b/src/Types/DecimalType.php
@@ -16,11 +16,6 @@ use const PHP_VERSION_ID;
  */
 class DecimalType extends Type
 {
-    public function getName(): string
-    {
-        return Types::DECIMAL;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Types/FloatType.php
+++ b/src/Types/FloatType.php
@@ -8,11 +8,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class FloatType extends Type
 {
-    public function getName(): string
-    {
-        return Types::FLOAT;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Types/GuidType.php
+++ b/src/Types/GuidType.php
@@ -19,11 +19,6 @@ class GuidType extends StringType
         return $platform->getGuidTypeDeclarationSQL($column);
     }
 
-    public function getName(): string
-    {
-        return Types::GUID;
-    }
-
     public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return ! $platform->hasNativeGuidType();

--- a/src/Types/IntegerType.php
+++ b/src/Types/IntegerType.php
@@ -12,11 +12,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class IntegerType extends Type implements PhpIntegerMappingType
 {
-    public function getName(): string
-    {
-        return Types::INTEGER;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -56,13 +56,8 @@ class JsonType extends Type
         try {
             return json_decode($value, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
-            throw ValueNotConvertible::new($value, $this->getName(), $e->getMessage(), $e);
+            throw ValueNotConvertible::new($value, 'json', $e->getMessage(), $e);
         }
-    }
-
-    public function getName(): string
-    {
-        return Types::JSON;
     }
 
     public function requiresSQLCommentHint(AbstractPlatform $platform): bool

--- a/src/Types/ObjectType.php
+++ b/src/Types/ObjectType.php
@@ -40,8 +40,8 @@ class ObjectType extends Type
 
         $value = is_resource($value) ? stream_get_contents($value) : $value;
 
-        set_error_handler(function (int $code, string $message) use ($value): bool {
-            throw ValueNotConvertible::new($value, $this->getName(), $message);
+        set_error_handler(static function (int $code, string $message) use ($value): bool {
+            throw ValueNotConvertible::new($value, 'object', $message);
         });
 
         try {
@@ -49,11 +49,6 @@ class ObjectType extends Type
         } finally {
             restore_error_handler();
         }
-    }
-
-    public function getName(): string
-    {
-        return Types::OBJECT;
     }
 
     public function requiresSQLCommentHint(AbstractPlatform $platform): bool

--- a/src/Types/SimpleArrayType.php
+++ b/src/Types/SimpleArrayType.php
@@ -51,11 +51,6 @@ class SimpleArrayType extends Type
         return explode(',', $value);
     }
 
-    public function getName(): string
-    {
-        return Types::SIMPLE_ARRAY;
-    }
-
     public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;

--- a/src/Types/SmallIntType.php
+++ b/src/Types/SmallIntType.php
@@ -12,11 +12,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class SmallIntType extends Type implements PhpIntegerMappingType
 {
-    public function getName(): string
-    {
-        return Types::SMALLINT;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Types/StringType.php
+++ b/src/Types/StringType.php
@@ -18,9 +18,4 @@ class StringType extends Type
     {
         return $platform->getStringTypeDeclarationSQL($column);
     }
-
-    public function getName(): string
-    {
-        return Types::STRING;
-    }
 }

--- a/src/Types/TextType.php
+++ b/src/Types/TextType.php
@@ -26,9 +26,4 @@ class TextType extends Type
     {
         return is_resource($value) ? stream_get_contents($value) : $value;
     }
-
-    public function getName(): string
-    {
-        return Types::TEXT;
-    }
 }

--- a/src/Types/TimeImmutableType.php
+++ b/src/Types/TimeImmutableType.php
@@ -14,11 +14,6 @@ use Doctrine\DBAL\Types\Exception\InvalidType;
  */
 class TimeImmutableType extends TimeType
 {
-    public function getName(): string
-    {
-        return Types::TIME_IMMUTABLE;
-    }
-
     public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
@@ -31,7 +26,7 @@ class TimeImmutableType extends TimeType
 
         throw InvalidType::new(
             $value,
-            $this->getName(),
+            static::class,
             ['null', DateTimeImmutable::class]
         );
     }
@@ -47,7 +42,7 @@ class TimeImmutableType extends TimeType
         if ($dateTime === false) {
             throw InvalidFormat::new(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getTimeFormatString()
             );
         }

--- a/src/Types/TimeType.php
+++ b/src/Types/TimeType.php
@@ -15,11 +15,6 @@ use Doctrine\DBAL\Types\Exception\InvalidType;
  */
 class TimeType extends Type
 {
-    public function getName(): string
-    {
-        return Types::TIME_MUTABLE;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -38,7 +33,7 @@ class TimeType extends Type
             return $value->format($platform->getTimeFormatString());
         }
 
-        throw InvalidType::new($value, $this->getName(), ['null', 'DateTime']);
+        throw InvalidType::new($value, static::class, ['null', 'DateTime']);
     }
 
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeInterface
@@ -51,7 +46,7 @@ class TimeType extends Type
         if ($val === false) {
             throw InvalidFormat::new(
                 $value,
-                $this->getName(),
+                static::class,
                 $platform->getTimeFormatString()
             );
         }

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -99,13 +99,6 @@ abstract class Type
      */
     abstract public function getSQLDeclaration(array $column, AbstractPlatform $platform): string;
 
-    /**
-     * Gets the name of this type.
-     *
-     * @todo Needed?
-     */
-    abstract public function getName(): string;
-
     final public static function getTypeRegistry(): TypeRegistry
     {
         if (self::$typeRegistry === null) {

--- a/src/Types/VarDateTimeImmutableType.php
+++ b/src/Types/VarDateTimeImmutableType.php
@@ -16,11 +16,6 @@ use function date_create_immutable;
  */
 class VarDateTimeImmutableType extends VarDateTimeType
 {
-    public function getName(): string
-    {
-        return Types::DATETIME_IMMUTABLE;
-    }
-
     public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
@@ -33,7 +28,7 @@ class VarDateTimeImmutableType extends VarDateTimeType
 
         throw InvalidType::new(
             $value,
-            $this->getName(),
+            static::class,
             ['null', DateTimeImmutable::class]
         );
     }
@@ -47,7 +42,7 @@ class VarDateTimeImmutableType extends VarDateTimeType
         $dateTime = date_create_immutable($value);
 
         if ($dateTime === false) {
-            throw ValueNotConvertible::new($value, $this->getName());
+            throw ValueNotConvertible::new($value, DateTimeImmutable::class);
         }
 
         return $dateTime;

--- a/src/Types/VarDateTimeType.php
+++ b/src/Types/VarDateTimeType.php
@@ -28,7 +28,7 @@ class VarDateTimeType extends DateTimeType
 
         $val = date_create($value);
         if ($val === false) {
-            throw ValueNotConvertible::new($value, $this->getName());
+            throw ValueNotConvertible::new($value, DateTime::class);
         }
 
         return $val;

--- a/tests/Functional/Schema/MySQL/PointType.php
+++ b/tests/Functional/Schema/MySQL/PointType.php
@@ -7,21 +7,14 @@ namespace Doctrine\DBAL\Tests\Functional\Schema\MySQL;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 
-use function strtoupper;
-
 class PointType extends Type
 {
-    public function getName(): string
-    {
-        return 'point';
-    }
-
     /**
      * {@inheritDoc}
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return strtoupper($this->getName());
+        return 'POINT';
     }
 
     /**

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -11,6 +11,9 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\BinaryType;
+use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\DateTimeTzType;
+use Doctrine\DBAL\Types\DateType;
 use Doctrine\DBAL\Types\Types;
 
 use function array_map;
@@ -247,9 +250,9 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $columns = $this->schemaManager->listTableColumns('tbl_date');
 
-        self::assertSame('date', $columns['col_date']->getType()->getName());
-        self::assertSame('datetime', $columns['col_datetime']->getType()->getName());
-        self::assertSame('datetimetz', $columns['col_datetimetz']->getType()->getName());
+        self::assertInstanceOf(DateType::class, $columns['col_date']->getType());
+        self::assertInstanceOf(DateTimeType::class, $columns['col_datetime']->getType());
+        self::assertInstanceOf(DateTimeTzType::class, $columns['col_datetimetz']->getType());
     }
 
     public function testCreateAndListSequences(): void

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\View;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\DecimalType;
+use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
@@ -381,7 +382,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $columns = $this->schemaManager->listTableColumns('test_jsonb');
 
-        self::assertSame(Types::JSON, $columns['foo']->getType()->getName());
+        self::assertInstanceOf(JsonType::class, $columns['foo']->getType());
         self::assertTrue($columns['foo']->getPlatformOption('jsonb'));
     }
 
@@ -495,11 +496,6 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
 class MoneyType extends Type
 {
-    public function getName(): string
-    {
-        return 'MyMoney';
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -27,10 +27,12 @@ use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\DateType;
 use Doctrine\DBAL\Types\DecimalType;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
+use Doctrine\DBAL\Types\TimeType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
@@ -42,6 +44,7 @@ use function array_shift;
 use function array_values;
 use function count;
 use function current;
+use function get_class;
 use function get_debug_type;
 use function sprintf;
 use function strcasecmp;
@@ -273,13 +276,19 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         self::assertEquals('baz2', strtolower($columns['baz2']->getName()));
         self::assertEquals(5, array_search('baz2', $columnsKeys, true));
-        self::assertContains($columns['baz2']->getType()->getName(), ['time', 'date', 'datetime']);
+        self::assertContains(
+            get_class($columns['baz2']->getType()),
+            [TimeType::class, DateType::class, DateTimeType::class]
+        );
         self::assertEquals(true, $columns['baz2']->getNotnull());
         self::assertEquals(null, $columns['baz2']->getDefault());
 
         self::assertEquals('baz3', strtolower($columns['baz3']->getName()));
         self::assertEquals(6, array_search('baz3', $columnsKeys, true));
-        self::assertContains($columns['baz3']->getType()->getName(), ['time', 'date', 'datetime']);
+        self::assertContains(
+            get_class($columns['baz3']->getType()),
+            [TimeType::class, DateType::class, DateTimeType::class]
+        );
         self::assertEquals(true, $columns['baz3']->getNotnull());
         self::assertEquals(null, $columns['baz3']->getDefault());
     }

--- a/tests/Functional/Ticket/DBAL752Test.php
+++ b/tests/Functional/Ticket/DBAL752Test.php
@@ -6,6 +6,9 @@ namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\BigIntType;
+use Doctrine\DBAL\Types\IntegerType;
+use Doctrine\DBAL\Types\SmallIntType;
 
 class DBAL752Test extends FunctionalTestCase
 {
@@ -38,14 +41,14 @@ SQL
 
         $fetchedTable = $schemaManager->listTableDetails('dbal752_unsigneds');
 
-        self::assertEquals('smallint', $fetchedTable->getColumn('small')->getType()->getName());
-        self::assertEquals('smallint', $fetchedTable->getColumn('small_unsigned')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('medium')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('medium_unsigned')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('integer')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('integer_unsigned')->getType()->getName());
-        self::assertEquals('bigint', $fetchedTable->getColumn('big')->getType()->getName());
-        self::assertEquals('bigint', $fetchedTable->getColumn('big_unsigned')->getType()->getName());
+        self::assertInstanceOf(SmallIntType::class, $fetchedTable->getColumn('small')->getType());
+        self::assertInstanceOf(SmallIntType::class, $fetchedTable->getColumn('small_unsigned')->getType());
+        self::assertInstanceOf(IntegerType::class, $fetchedTable->getColumn('medium')->getType());
+        self::assertInstanceOf(IntegerType::class, $fetchedTable->getColumn('medium_unsigned')->getType());
+        self::assertInstanceOf(IntegerType::class, $fetchedTable->getColumn('integer')->getType());
+        self::assertInstanceOf(IntegerType::class, $fetchedTable->getColumn('integer_unsigned')->getType());
+        self::assertInstanceOf(BigIntType::class, $fetchedTable->getColumn('big')->getType());
+        self::assertInstanceOf(BigIntType::class, $fetchedTable->getColumn('big_unsigned')->getType());
 
         self::assertTrue($fetchedTable->getColumn('small_unsigned')->getUnsigned());
         self::assertTrue($fetchedTable->getColumn('medium_unsigned')->getUnsigned());

--- a/tests/Types/BinaryTest.php
+++ b/tests/Types/BinaryTest.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\ConversionException;
-use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -34,11 +33,6 @@ class BinaryTest extends TestCase
     public function testReturnsBindingType(): void
     {
         self::assertSame(ParameterType::BINARY, $this->type->getBindingType());
-    }
-
-    public function testReturnsName(): void
-    {
-        self::assertSame(Types::BINARY, $this->type->getName());
     }
 
     /**

--- a/tests/Types/DateImmutableTypeTest.php
+++ b/tests/Types/DateImmutableTypeTest.php
@@ -33,11 +33,6 @@ class DateImmutableTypeTest extends TestCase
         self::assertSame(DateImmutableType::class, get_class($this->type));
     }
 
-    public function testReturnsName(): void
-    {
-        self::assertSame('date_immutable', $this->type->getName());
-    }
-
     public function testReturnsBindingType(): void
     {
         self::assertSame(ParameterType::STRING, $this->type->getBindingType());

--- a/tests/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Types/DateTimeImmutableTypeTest.php
@@ -33,11 +33,6 @@ class DateTimeImmutableTypeTest extends TestCase
         self::assertSame(DateTimeImmutableType::class, get_class($this->type));
     }
 
-    public function testReturnsName(): void
-    {
-        self::assertSame('datetime_immutable', $this->type->getName());
-    }
-
     public function testReturnsBindingType(): void
     {
         self::assertSame(ParameterType::STRING, $this->type->getBindingType());

--- a/tests/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Types/DateTimeTzImmutableTypeTest.php
@@ -33,11 +33,6 @@ class DateTimeTzImmutableTypeTest extends TestCase
         self::assertSame(DateTimeTzImmutableType::class, get_class($this->type));
     }
 
-    public function testReturnsName(): void
-    {
-        self::assertSame('datetimetz_immutable', $this->type->getName());
-    }
-
     public function testReturnsBindingType(): void
     {
         self::assertSame(ParameterType::STRING, $this->type->getBindingType());

--- a/tests/Types/JsonTest.php
+++ b/tests/Types/JsonTest.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\JsonType;
-use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -31,11 +30,6 @@ class JsonTest extends TestCase
     public function testReturnsBindingType(): void
     {
         self::assertSame(ParameterType::STRING, $this->type->getBindingType());
-    }
-
-    public function testReturnsName(): void
-    {
-        self::assertSame(Types::JSON, $this->type->getName());
     }
 
     public function testReturnsSQLDeclaration(): void

--- a/tests/Types/TimeImmutableTypeTest.php
+++ b/tests/Types/TimeImmutableTypeTest.php
@@ -33,11 +33,6 @@ class TimeImmutableTypeTest extends TestCase
         self::assertSame(TimeImmutableType::class, get_class($this->type));
     }
 
-    public function testReturnsName(): void
-    {
-        self::assertSame('time_immutable', $this->type->getName());
-    }
-
     public function testReturnsBindingType(): void
     {
         self::assertSame(ParameterType::STRING, $this->type->getBindingType());

--- a/tests/Types/VarDateTimeImmutableTypeTest.php
+++ b/tests/Types/VarDateTimeImmutableTypeTest.php
@@ -26,11 +26,6 @@ class VarDateTimeImmutableTypeTest extends TestCase
         $this->type     = new VarDateTimeImmutableType();
     }
 
-    public function testReturnsName(): void
-    {
-        self::assertSame('datetime_immutable', $this->type->getName());
-    }
-
     public function testReturnsBindingType(): void
     {
         self::assertSame(ParameterType::STRING, $this->type->getBindingType());


### PR DESCRIPTION
Following https://github.com/doctrine/dbal/pull/5107, this method serves little to no purpose. Let's avoid duplicating the name in the method and in the type registry.