### PR TITLE
Drop requirement for PostgreSQL 9.4+

### DIFF
--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -406,12 +406,6 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testJsonbColumn(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $this->markTestSkipped('Requires PostgresSQL 9.4+');
-
-            return;
-        }
-
         $table = new Table('test_jsonb');
         $table->addColumn('foo', Types::JSON)->setPlatformOption('jsonb', true);
         $this->dropAndCreateTable($table);


### PR DESCRIPTION
PostgreSQL 9.4 is our minimum supported versions.
Also, that return statement was useless since `markTestSkipped` never
returns.
