### PR TITLE
Provide a way to use platform aware comparison

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,16 @@ awareness about deprecated code.
 
 # Upgrade to 3.3
 
+## Deprecated omitting `Comparator::compareSchemas()` third argument
+
+In order to benefit from platform-aware comparison, it is necessary to pass the
+comparator to itself (yes, really) as a third argument.
+
+```php
+$comparator->compareSchemas($fromSchema, $toSchema); // before
+$comparator->compareSchemas($fromSchema, $toSchema, $comparator); // after
+```
+
 ## Deprecated `Type::canRequireSQLConversion()`.
 
 Consumers should call `Type::convertToDatabaseValueSQL()` and `Type::convertToPHPValueSQL()` regardless of the type.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -128,5 +128,10 @@ parameters:
         # Type check for legacy implementations of the Connection interface
         # TODO: remove in 4.0.0
         - "~Call to function method_exists\\(\\) with Doctrine\\\\DBAL\\\\Driver\\\\Connection and 'getNativeConnection' will always evaluate to true\\.~"
+
+        # TODO: remove in 4.0.0
+        -
+            message: '~PHPDoc tag @param references unknown parameter: \$comparator~'
+            path: src/Schema/Comparator.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -799,8 +799,9 @@ abstract class AbstractSchemaManager
      */
     public function migrateSchema(Schema $toSchema): void
     {
-        $schemaDiff = $this->createComparator()
-            ->compareSchemas($this->createSchema(), $toSchema);
+        $comparator = $this->createComparator();
+        $schemaDiff = $comparator
+            ->compareSchemas($this->createSchema(), $toSchema, $comparator);
 
         $this->alterSchema($schemaDiff);
     }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -459,7 +459,8 @@ class Schema extends AbstractAsset
      */
     public function getMigrateToSql(Schema $toSchema, AbstractPlatform $platform)
     {
-        $schemaDiff = (new Comparator())->compareSchemas($this, $toSchema);
+        $comparator = new Comparator();
+        $schemaDiff = $comparator->compareSchemas($this, $toSchema, $comparator);
 
         return $schemaDiff->toSql($platform);
     }
@@ -473,7 +474,8 @@ class Schema extends AbstractAsset
      */
     public function getMigrateFromSql(Schema $fromSchema, AbstractPlatform $platform)
     {
-        $schemaDiff = (new Comparator())->compareSchemas($fromSchema, $this);
+        $comparator = new Comparator();
+        $schemaDiff = $comparator->compareSchemas($fromSchema, $this, $comparator);
 
         return $schemaDiff->toSql($platform);
     }

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -406,12 +406,6 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testJsonbColumn(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $this->markTestSkipped('Requires PostgresSQL 9.4+');
-
-            return;
-        }
-
         $table = new Table('test_jsonb');
         $table->addColumn('foo', Types::JSON)->setPlatformOption('jsonb', true);
         $this->dropAndCreateTable($table);

--- a/tests/Platforms/SQLite/ComparatorTest.php
+++ b/tests/Platforms/SQLite/ComparatorTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\DBAL\Tests\Platforms\SQLite;
 
 use Doctrine\DBAL\Platforms\SQLite\Comparator;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Tests\Schema\ComparatorTest as BaseComparatorTest;
 
 class ComparatorTest extends BaseComparatorTest
@@ -11,5 +13,26 @@ class ComparatorTest extends BaseComparatorTest
     protected function setUp(): void
     {
         $this->comparator = new Comparator(new SqlitePlatform());
+    }
+
+    public function testCompareChangedBinaryColumn(): void
+    {
+        $oldSchema = new Schema();
+
+        $tableFoo = $oldSchema->createTable('foo');
+        $tableFoo->addColumn('id', 'binary');
+
+        $newSchema = new Schema();
+        $table     = $newSchema->createTable('foo');
+        $table->addColumn('id', 'binary', ['length' => 42, 'fixed' => true]);
+
+        $expected             = new SchemaDiff();
+        $expected->fromSchema = $oldSchema;
+
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $oldSchema,
+            $newSchema,
+            $this->comparator
+        ));
     }
 }

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Schema;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
@@ -15,13 +16,18 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypeError;
 
 use function array_keys;
 use function get_class;
 
 class ComparatorTest extends TestCase
 {
+    use VerifyDeprecations;
+
     /** @var Comparator */
     protected $comparator;
 
@@ -51,7 +57,11 @@ class ComparatorTest extends TestCase
 
         $expected             = new SchemaDiff();
         $expected->fromSchema = $schema1;
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $schema1,
+            $schema2,
+            $this->comparator
+        ));
     }
 
     public function testCompareSame2(): void
@@ -77,7 +87,11 @@ class ComparatorTest extends TestCase
 
         $expected             = new SchemaDiff();
         $expected->fromSchema = $schema1;
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $schema1,
+            $schema2,
+            $this->comparator
+        ));
     }
 
     public function testCompareMissingTable(): void
@@ -92,7 +106,11 @@ class ComparatorTest extends TestCase
 
         $expected = new SchemaDiff([], [], ['bugdb' => $table], $schema1);
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $schema1,
+            $schema2,
+            $this->comparator
+        ));
     }
 
     public function testCompareNewTable(): void
@@ -107,7 +125,11 @@ class ComparatorTest extends TestCase
 
         $expected = new SchemaDiff(['bugdb' => $table], [], [], $schema1);
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $schema1,
+            $schema2,
+            $this->comparator
+        ));
     }
 
     public function testCompareOnlyAutoincrementChanged(): void
@@ -155,7 +177,11 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $schema1,
+            $schema2,
+            $this->comparator
+        ));
     }
 
     public function testCompareNewField(): void
@@ -192,7 +218,11 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $schema1,
+            $schema2,
+            $this->comparator
+        ));
     }
 
     public function testCompareChangedColumnsChangeType(): void
@@ -318,7 +348,11 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $schema1,
+            $schema2,
+            $this->comparator
+        ));
     }
 
     public function testCompareNewIndex(): void
@@ -370,7 +404,11 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $schema1,
+            $schema2,
+            $this->comparator
+        ));
     }
 
     public function testCompareChangedIndex(): void
@@ -433,7 +471,11 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $schema1,
+            $schema2,
+            $this->comparator
+        ));
     }
 
     public function testCompareChangedIndexFieldPositions(): void
@@ -481,7 +523,11 @@ class ComparatorTest extends TestCase
         $expected->fromSchema                        = $schema1;
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $schema1,
+            $schema2,
+            $this->comparator
+        ));
     }
 
     public function testCompareSequences(): void
@@ -868,7 +914,11 @@ class ComparatorTest extends TestCase
         $expected             = new SchemaDiff();
         $expected->fromSchema = $oldSchema;
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $oldSchema,
+            $newSchema,
+            $this->comparator
+        ));
     }
 
     public function testNamespacesComparison(): void
@@ -889,7 +939,11 @@ class ComparatorTest extends TestCase
         $expected->fromSchema    = $oldSchema;
         $expected->newNamespaces = ['bar' => 'bar', 'baz' => 'baz'];
 
-        $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
+        $diff = $this->comparator->compareSchemas(
+            $oldSchema,
+            $newSchema,
+            $this->comparator
+        );
 
         self::assertEquals(['bar' => 'bar', 'baz' => 'baz'], $diff->newNamespaces);
         self::assertCount(2, $diff->newTables);
@@ -909,7 +963,11 @@ class ComparatorTest extends TestCase
         $expected             = new SchemaDiff();
         $expected->fromSchema = $oldSchema;
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $oldSchema,
+            $newSchema,
+            $this->comparator
+        ));
     }
 
     public function testFqnSchemaComparisonNoSchemaSame(): void
@@ -925,7 +983,11 @@ class ComparatorTest extends TestCase
         $expected             = new SchemaDiff();
         $expected->fromSchema = $oldSchema;
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $oldSchema,
+            $newSchema,
+            $this->comparator
+        ));
     }
 
     public function testAutoIncrementSequences(): void
@@ -1027,7 +1089,11 @@ class ComparatorTest extends TestCase
         $columnDiff->fromColumn        = $tableFoo->getColumn('id');
         $columnDiff->changedProperties = ['type'];
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $oldSchema,
+            $newSchema,
+            $this->comparator
+        ));
     }
 
     public function testCompareChangedBinaryColumn(): void
@@ -1052,7 +1118,11 @@ class ComparatorTest extends TestCase
         $columnDiff->fromColumn        = $tableFoo->getColumn('id');
         $columnDiff->changedProperties = ['length', 'fixed'];
 
-        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
+        self::assertEquals($expected, $this->comparator->compareSchemas(
+            $oldSchema,
+            $newSchema,
+            $this->comparator
+        ));
     }
 
     public function testCompareQuotedAndUnquotedForeignKeyColumns(): void
@@ -1278,12 +1348,37 @@ class ComparatorTest extends TestCase
                 ]
             ),
         ]);
-        $actual     = $this->comparator->compareSchemas($fromSchema, $toSchema);
+        $actual     = $this->comparator->compareSchemas(
+            $fromSchema,
+            $toSchema,
+            $this->comparator
+        );
 
         self::assertArrayHasKey('table2', $actual->changedTables);
         self::assertCount(1, $actual->orphanedForeignKeys);
         self::assertEquals('fk_table2_table1', $actual->orphanedForeignKeys[0]->getName());
         self::assertCount(1, $actual->changedTables['table2']->addedForeignKeys, 'FK to table3 should be added.');
         self::assertEquals('table3', $actual->changedTables['table2']->addedForeignKeys[0]->getForeignTableName());
+    }
+
+    public function testItDeprecatesOmittingTheComparatorWhenCallingCompareSchemas(): void
+    {
+        $comparator = new Comparator($this->createStub(AbstractPlatform::class));
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/issues/5216');
+        $comparator->compareSchemas(new Schema(), new Schema());
+    }
+
+    public function testPassingAComparatorProvidesAccessToPlatformAwareComparison(): void
+    {
+        $comparator = new Comparator($this->createStub(AbstractPlatform::class));
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/issues/5216');
+        $comparator->compareSchemas(new Schema(), new Schema(), $comparator);
+    }
+
+    public function testPassingSomethingElseThanAComparatorToCompareSchemasThrows(): void
+    {
+        $comparator = new Comparator($this->createStub(AbstractPlatform::class));
+        $this->expectException(TypeError::class);
+        $comparator->compareSchemas(new Schema(), new Schema(), new stdClass());
     }
 }


### PR DESCRIPTION
Allowing a third argument without changing the signature makes the usage
ugly but preserves backwards-compatibility, which makes this major
feature available through `Comparator::compareSchemas()`, which is
probably the main use case for this class.

Fixes #5216

I'm targeting 3.3.x, but an alternative might be to release 3.4.x earlier than planned.
