### PR TITLE
Allow dynamic call to compareSchemas

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Schema;
 
+use BadMethodCallException;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types;
@@ -16,6 +17,7 @@ use function array_unique;
 use function assert;
 use function count;
 use function get_class;
+use function sprintf;
 use function strtolower;
 
 /**
@@ -44,6 +46,26 @@ class Comparator
         $this->platform = $platform;
     }
 
+    public function __call(string $method, array $args)
+    {
+        if ($method !== 'compareSchemas') {
+            throw new BadMethodCallException(sprintf('Unknown method "%s"', $method));
+        }
+
+        return $this->doCompareSchemas(...$args);
+    }
+
+    public static function __callStatic(string $method, array $args)
+    {
+        if ($method !== 'compareSchemas') {
+            throw new BadMethodCallException(sprintf('Unknown method "%s"', $method));
+        }
+
+        $comparator = new self();
+
+        return $comparator->doCompareSchemas(...$args);
+    }
+
     /**
      * Returns a SchemaDiff object containing the differences between the schemas $fromSchema and $toSchema.
      *
@@ -53,11 +75,10 @@ class Comparator
      *
      * @throws SchemaException
      */
-    public static function compareSchemas(
+    private function doCompareSchemas(
         Schema $fromSchema,
         Schema $toSchema
     ) {
-        $comparator       = new self();
         $diff             = new SchemaDiff();
         $diff->fromSchema = $fromSchema;
 
@@ -84,7 +105,7 @@ class Comparator
             if (! $fromSchema->hasTable($tableName)) {
                 $diff->newTables[$tableName] = $toSchema->getTable($tableName);
             } else {
-                $tableDifferences = $comparator->diffTable(
+                $tableDifferences = $this->diffTable(
                     $fromSchema->getTable($tableName),
                     $toSchema->getTable($tableName)
                 );
@@ -147,18 +168,18 @@ class Comparator
         foreach ($toSchema->getSequences() as $sequence) {
             $sequenceName = $sequence->getShortestName($toSchema->getName());
             if (! $fromSchema->hasSequence($sequenceName)) {
-                if (! $comparator->isAutoIncrementSequenceInSchema($fromSchema, $sequence)) {
+                if (! $this->isAutoIncrementSequenceInSchema($fromSchema, $sequence)) {
                     $diff->newSequences[] = $sequence;
                 }
             } else {
-                if ($comparator->diffSequence($sequence, $fromSchema->getSequence($sequenceName))) {
+                if ($this->diffSequence($sequence, $fromSchema->getSequence($sequenceName))) {
                     $diff->changedSequences[] = $toSchema->getSequence($sequenceName);
                 }
             }
         }
 
         foreach ($fromSchema->getSequences() as $sequence) {
-            if ($comparator->isAutoIncrementSequenceInSchema($toSchema, $sequence)) {
+            if ($this->isAutoIncrementSequenceInSchema($toSchema, $sequence)) {
                 continue;
             }
 

--- a/tests/Platforms/SQLite/ComparatorTest.php
+++ b/tests/Platforms/SQLite/ComparatorTest.php
@@ -12,4 +12,9 @@ class ComparatorTest extends BaseComparatorTest
     {
         $this->comparator = new Comparator(new SqlitePlatform());
     }
+
+    public function testChangedBinaryColumn(): void
+    {
+        self::markTestSkipped('All columns are already binary in SQLite');
+    }
 }


### PR DESCRIPTION
This is necessary in order to benefit from platform-aware comparison.
As a result, tests now use platform-aware comparison, which implies
accepting changes in how `SQLitePlatform` behaves.

Since no deprecation is introduced this time, and since `compareSchemas` was intended to benefit from platform-aware comparison, I am targeting 3.3.x again.

Note that this approach does not require changes in the client code to benefit from platform-aware comparison.

Fixes #5216
Closes #5217