### PR TITLE
Allow dynamic call to compareSchemas

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -128,5 +128,13 @@ parameters:
         # Type check for legacy implementations of the Connection interface
         # TODO: remove in 4.0.0
         - "~Call to function method_exists\\(\\) with Doctrine\\\\DBAL\\\\Driver\\\\Connection and 'getNativeConnection' will always evaluate to true\\.~"
+
+        # TODO: remove in 4.0.0
+        -
+            message: '~^Call to an undefined method.*compareSchemas.*$~'
+            paths:
+                - src/Schema/AbstractSchemaManager.php
+                - src/Schema/Comparator.php
+                - src/Schema/Schema.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/tests/Platforms/SQLite/ComparatorTest.php
+++ b/tests/Platforms/SQLite/ComparatorTest.php
@@ -12,4 +12,9 @@ class ComparatorTest extends BaseComparatorTest
     {
         $this->comparator = new Comparator(new SqlitePlatform());
     }
+
+    public function testCompareChangedBinaryColumn(): void
+    {
+        self::markTestSkipped('Binary columns are BLOB in SQLite and do not support $length or $fixed.');
+    }
 }


### PR DESCRIPTION
This is necessary in order to benefit from platform-aware comparison.
As a result, tests now use platform-aware comparison, which implies
accepting changes in how `SQLitePlatform` behaves.

Since no deprecation is introduced this time, and since `compareSchemas` was intended to benefit from platform-aware comparison, I am targeting 3.3.x again.

Note that this approach does not require changes in the client code to benefit from platform-aware comparison.

Fixes #5216
Closes #5217