### PR TITLE
Merge 3.3.x up into 3.4.x

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -128,5 +128,13 @@ parameters:
         # Type check for legacy implementations of the Connection interface
         # TODO: remove in 4.0.0
         - "~Call to function method_exists\\(\\) with Doctrine\\\\DBAL\\\\Driver\\\\Connection and 'getNativeConnection' will always evaluate to true\\.~"
+
+        # TODO: remove in 4.0.0
+        -
+            message: '~^Call to an undefined method.*compareSchemas.*$~'
+            paths:
+                - src/Schema/AbstractSchemaManager.php
+                - src/Schema/Comparator.php
+                - src/Schema/Schema.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/tests/Platforms/SQLite/ComparatorTest.php
+++ b/tests/Platforms/SQLite/ComparatorTest.php
@@ -12,4 +12,9 @@ class ComparatorTest extends BaseComparatorTest
     {
         $this->comparator = new Comparator(new SqlitePlatform());
     }
+
+    public function testCompareChangedBinaryColumn(): void
+    {
+        self::markTestSkipped('Binary columns are BLOB in SQLite and do not support $length or $fixed.');
+    }
 }


### PR DESCRIPTION
That way I can work on deprecating the static call to `Comparator::compareSchemas`