### PR TITLE
Oracle: Convert array keys to lowercase

### DIFF
--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -330,8 +330,8 @@ class OracleSchemaManager extends AbstractSchemaManager
         $tableOptions = $this->_conn->fetchAssociative($sql);
 
         if ($tableOptions !== false) {
-            $tableOptions = array_change_key_case($tableOptions, CASE_UPPER);
-            $table->addOption('comment', $tableOptions['COMMENTS']);
+            $tableOptions = array_change_key_case($tableOptions, CASE_LOWER);
+            $table->addOption('comment', $tableOptions['comments']);
         }
 
         return $table;

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -328,9 +328,9 @@ class OracleSchemaManager extends AbstractSchemaManager
         $sql = $this->_platform->getListTableCommentsSQL($name);
 
         $tableOptions = $this->_conn->fetchAssociative($sql);
-        $tableOptions = array_change_key_case($tableOptions, CASE_UPPER);
 
         if ($tableOptions !== false) {
+            $tableOptions = array_change_key_case($tableOptions, CASE_UPPER);
             $table->addOption('comment', $tableOptions['COMMENTS']);
         }
 

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -328,6 +328,7 @@ class OracleSchemaManager extends AbstractSchemaManager
         $sql = $this->_platform->getListTableCommentsSQL($name);
 
         $tableOptions = $this->_conn->fetchAssociative($sql);
+        $tableOptions = array_change_key_case($tableOptions, CASE_UPPER);
 
         if ($tableOptions !== false) {
             $table->addOption('comment', $tableOptions['COMMENTS']);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/yajra/laravel-oci8/issues/674

#### Summary

This PR will fix compatibility with Laravel & Oracle - Laravel OCI8:

#### Steps to replicate:

```php
Schema::getColumnType('users', 'name');
```

### ErrorException

```
  Undefined index: COMMENTS

  at vendor/doctrine/dbal/src/Schema/OracleSchemaManager.php:334
```
