### PR TITLE
Consider CASE_LOWER being equal to 0 in portability middleware

### DIFF
--- a/src/Portability/Driver.php
+++ b/src/Portability/Driver.php
@@ -41,7 +41,7 @@ final class Driver extends AbstractDriverMiddleware
             $this->mode
         );
 
-        $case = 0;
+        $case = null;
 
         if ($this->case !== 0 && ($portability & Connection::PORTABILITY_FIX_CASE) !== 0) {
             $nativeConnection = null;
@@ -63,7 +63,7 @@ final class Driver extends AbstractDriverMiddleware
         $convertEmptyStringToNull = ($portability & Connection::PORTABILITY_EMPTY_TO_NULL) !== 0;
         $rightTrimString          = ($portability & Connection::PORTABILITY_RTRIM) !== 0;
 
-        if (! $convertEmptyStringToNull && ! $rightTrimString && $case === 0) {
+        if (! $convertEmptyStringToNull && ! $rightTrimString && $case === null) {
             return $connection;
         }
 

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Portability\Middleware;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
+use function array_keys;
 use function array_merge;
 use function strlen;
 
@@ -42,6 +43,31 @@ class PortabilityTest extends FunctionalTestCase
         while (($row = $result->fetchAssociative())) {
             $this->assertFetchResultRow($row);
         }
+    }
+
+    /**
+     * @param array{int, list<string>} $expected
+     *
+     * @dataProvider caseProvider
+     */
+    public function testCaseConversion(int $case, array $expected): void
+    {
+        $this->connectWithPortability(Connection::PORTABILITY_FIX_CASE, $case);
+        $this->createTable();
+
+        $row = $this->connection->fetchAssociative('SELECT * FROM portability_table');
+
+        self::assertNotFalse($row);
+        self::assertSame($expected, array_keys($row));
+    }
+
+    /**
+     * @return iterable<string, array{int, list<string>}>
+     */
+    public static function caseProvider(): iterable
+    {
+        yield 'lower' => [ColumnCase::LOWER, ['test_int', 'test_string', 'test_null']];
+        yield 'upper' => [ColumnCase::UPPER, ['TEST_INT', 'TEST_STRING', 'TEST_NULL']];
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

Fixes #5231.

While refactoring the test, I removed `testConnFetchMode()` since it looked identical to `testFullFetchMode()`.