### PR TITLE
Optimize PostgreSQLPlatform::getListSequencesSQL

### DIFF
--- a/src/Platforms/PostgreSQL100Platform.php
+++ b/src/Platforms/PostgreSQL100Platform.php
@@ -29,19 +29,4 @@ class PostgreSQL100Platform extends PostgreSQL94Platform
 
         return PostgreSQL100Keywords::class;
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getListSequencesSQL($database): string
-    {
-        return 'SELECT sequence_name AS relname,
-                       sequence_schema AS schemaname,
-                       minimum_value AS min_value, 
-                       increment AS increment_by
-                FROM   information_schema.sequences
-                WHERE  sequence_catalog = ' . $this->quoteStringLiteral($database) . "
-                AND    sequence_schema NOT LIKE 'pg\_%'
-                AND    sequence_schema != 'information_schema'";
-    }
 }

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -259,12 +259,13 @@ class PostgreSQLPlatform extends AbstractPlatform
      */
     public function getListSequencesSQL($database)
     {
-        return "SELECT sequence_name AS relname,
+        return 'SELECT sequence_name AS relname,
                        sequence_schema AS schemaname,
                        minimum_value AS min_value,
                        increment AS increment_by
                 FROM   information_schema.sequences
-                WHERE  sequence_schema NOT LIKE 'pg\_%'
+                WHERE  sequence_catalog = ' . $this->quoteStringLiteral($database) . "
+                AND    sequence_schema NOT LIKE 'pg\_%'
                 AND    sequence_schema != 'information_schema'";
     }
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -260,7 +260,9 @@ class PostgreSQLPlatform extends AbstractPlatform
     public function getListSequencesSQL($database)
     {
         return "SELECT sequence_name AS relname,
-                       sequence_schema AS schemaname
+                       sequence_schema AS schemaname,
+                       minimum_value AS min_value,
+                       increment AS increment_by
                 FROM   information_schema.sequences
                 WHERE  sequence_schema NOT LIKE 'pg\_%'
                 AND    sequence_schema != 'information_schema'";

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -337,15 +337,6 @@ SQL
             $sequenceName = $sequence['relname'];
         }
 
-        if (! isset($sequence['increment_by'], $sequence['min_value'])) {
-            /** @var string[] $data */
-            $data = $this->_conn->fetchAssociative(
-                'SELECT min_value, increment_by FROM ' . $this->_platform->quoteIdentifier($sequenceName)
-            );
-
-            $sequence += $data;
-        }
-
         return new Sequence($sequenceName, (int) $sequence['increment_by'], (int) $sequence['min_value']);
     }
 

--- a/tests/Platforms/PostgreSQL100PlatformTest.php
+++ b/tests/Platforms/PostgreSQL100PlatformTest.php
@@ -13,19 +13,4 @@ class PostgreSQL100PlatformTest extends PostgreSQLPlatformTest
     {
         return new PostgreSQL100Platform();
     }
-
-    public function testGetListSequencesSQL(): void
-    {
-        self::assertSame(
-            "SELECT sequence_name AS relname,
-                       sequence_schema AS schemaname,
-                       minimum_value AS min_value, 
-                       increment AS increment_by
-                FROM   information_schema.sequences
-                WHERE  sequence_catalog = 'test_db'
-                AND    sequence_schema NOT LIKE 'pg\_%'
-                AND    sequence_schema != 'information_schema'",
-            $this->platform->getListSequencesSQL('test_db')
-        );
-    }
 }

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -1071,4 +1071,19 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('jsonb'));
         self::assertEquals(Types::JSON, $this->platform->getDoctrineTypeMapping('jsonb'));
     }
+
+    public function testGetListSequencesSQL(): void
+    {
+        self::assertSame(
+            "SELECT sequence_name AS relname,
+                       sequence_schema AS schemaname,
+                       minimum_value AS min_value,
+                       increment AS increment_by
+                FROM   information_schema.sequences
+                WHERE  sequence_catalog = 'test_db'
+                AND    sequence_schema NOT LIKE 'pg\_%'
+                AND    sequence_schema != 'information_schema'",
+            $this->platform->getListSequencesSQL('test_db')
+        );
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no problem
| Fixed issues | -

#### Summary

This PR is bug fix for diff command.

#### Before

When using diff command with actual PostgreSQLPlatform, fatal error: `An exception occurred while executing a query: SQLSTATE[42703]: Undefined column: 7 ERROR:  column "min_value" does not exist LINE 1: SELECT min_value, increment_by FROM "test_id_seq"`


`SELECT * FROM test_id_seq`:

![image](https://user-images.githubusercontent.com/49632507/152107237-e1517921-61cb-47cb-804b-b66437c59fe0.png)

#### After
Diff command completed successfully.

#### Versions
PostgreSQL 13.5
Doctrine DBAL 3.3.1

P.s There is a fix in the deprecated class: https://github.com/doctrine/dbal/blob/21799795788fdd352b804c3b176da15d5f517eff/src/Platforms/PostgreSQL100Platform.php#L36

