### PR TITLE
Regression: comparator yields invalid diffs when `Column#$_columnDefinition` is set

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -57,7 +57,7 @@ class Comparator
             throw new BadMethodCallException(sprintf('Unknown method "%s"', $method));
         }
 
-        return $this->doCompareSchemas(...$args);
+        return (new self())->doCompareSchemas(...$args);
     }
 
     /**
@@ -69,9 +69,7 @@ class Comparator
             throw new BadMethodCallException(sprintf('Unknown method "%s"', $method));
         }
 
-        $comparator = new self();
-
-        return $comparator->doCompareSchemas(...$args);
+        return (new self())->doCompareSchemas(...$args);
     }
 
     /**

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -1286,4 +1286,34 @@ class ComparatorTest extends TestCase
         self::assertCount(1, $actual->changedTables['table2']->addedForeignKeys, 'FK to table3 should be added.');
         self::assertEquals('table3', $actual->changedTables['table2']->addedForeignKeys[0]->getForeignTableName());
     }
+
+    public function testWillNotProduceSchemaDiffOnTableWithAddedCustomSchemaDefinition(): void
+    {
+        $fromSchema = new Schema(
+            [
+                new Table(
+                    'a_table',
+                    [
+                        new Column('is_default', Type::getType('string')),
+                    ]
+                ),
+            ]
+        );
+        $toSchema   = new Schema(
+            [
+                new Table(
+                    'a_table',
+                    [
+                        new Column('is_default', Type::getType('string'), ['columnDefinition' => 'ENUM(\'default\')']),
+                    ]
+                ),
+            ]
+        );
+
+        self::assertEmpty(
+            $this->comparator->compareSchemas($fromSchema, $toSchema)
+                ->changedTables,
+            'Schema diff is empty, since only `columnDefinition` changed from `null` (not detected) to a defined one'
+        );
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #5223

#### Test Case

`Comparator` yields invalid diffs when `Column#$_columnDefinition` is set.

When a `Column` is compared against another `Column` with a `$_columnDefinition`, it yields invalid
results, because it generates a diff, but does not declare that the `columnDefinition` is the changed
property.
    
Before `3.3.1`, **not reporting a diff** was the norm, but https://github.com/doctrine/dbal/pull/5220 introduced
a regression that led to the schema comparison changing behavior here, and producing a diff for tables
that had this kind of `columnDefinition` set.

### Proposed change

When using the comparator via magic methods, reset the comparator state between calls.
    
Before this change, the comparator would have internal dirty state before `Comparator#doCompareSchemas()` was called: with
this change, the state is reset before each call, giving us better long-term stability, and effectively completely disables platform-aware schema comparison.

Correctness of this change is still unclear: no tests currently fail with it on SQLite, but it is possible that the `Comparator` design
was accounting for more complexity on more exotic platforms.

This may not necessarily be the correct fix to the https://github.com/doctrine/dbal/pull/5220 regression.