### PR TITLE
Use UTF-8 for SQLServer tests

### DIFF
--- a/ci/github/phpunit/sqlsrv.xml
+++ b/ci/github/phpunit/sqlsrv.xml
@@ -16,6 +16,7 @@
         <var name="db_user" value="sa" />
         <var name="db_password" value="Doctrine2018" />
         <var name="db_dbname" value="doctrine" />
+        <var name="db_charset" value="UTF-8" />
     </php>
 
     <testsuites>

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -39,6 +39,7 @@ class TestUtil
      * 'db_server':   The server name of the database to connect to
      *                (optional, some vendors allow multiple server instances with different names on the same host).
      * 'db_dbname':   The name of the database to connect to.
+     * 'db_charset':  The character set to use.
      * 'db_port':     The port of the database to connect to.
      *
      * Usually these variables of the $GLOBALS array are filled by PHPUnit based
@@ -185,6 +186,7 @@ class TestUtil
                 'password',
                 'host',
                 'dbname',
+                'charset',
                 'port',
                 'server',
                 'ssl_key',

--- a/tests/appveyor/mssql.sql2008r2sp2.sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2008r2sp2.sqlsrv.appveyor.xml
@@ -13,6 +13,7 @@
         <var name="db_user" value="sa" />
         <var name="db_password" value="Password12!" />
         <var name="db_dbname" value="doctrine_tests" />
+        <var name="db_charset" value="UTF-8" />
     </php>
 
     <testsuites>

--- a/tests/appveyor/mssql.sql2012sp1.sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2012sp1.sqlsrv.appveyor.xml
@@ -13,6 +13,7 @@
         <var name="db_user" value="sa" />
         <var name="db_password" value="Password12!" />
         <var name="db_dbname" value="doctrine_tests" />
+        <var name="db_charset" value="UTF-8" />
     </php>
 
     <testsuites>

--- a/tests/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
@@ -13,6 +13,7 @@
         <var name="db_user" value="sa" />
         <var name="db_password" value="Password12!" />
         <var name="db_dbname" value="doctrine_tests" />
+        <var name="db_charset" value="UTF-8" />
     </php>
 
     <testsuites>

--- a/tests/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
+++ b/tests/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
@@ -13,6 +13,7 @@
         <var name="db_user" value="sa" />
         <var name="db_password" value="Password12!" />
         <var name="db_dbname" value="doctrine_tests" />
+        <var name="db_charset" value="UTF-8" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

While working on the fix for a bug around how UTF-8 data is handled I discovered that the default test connections to sqlserver are not using UTF-8. I couldn't find any tests that just configured this for them, so figured it should perhaps just be the default. If there's another preferred approach for this please let me know