### PR TITLE
Use NVARCHAR to support unicode values in TEXT columns on SQLServer

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -1238,7 +1238,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getClobTypeDeclarationSQL(array $column)
     {
-        return 'VARCHAR(MAX)';
+        return 'NVARCHAR(MAX)';
     }
 
     /**

--- a/tests/Doctrine/Tests/DBAL/Functional/Platform/TextTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/Functional/Platform/TextTypeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DBAL\Functional\Platform;
+
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Tests\DbalFunctionalTestCase;
+
+class TextTypeTest extends DbalFunctionalTestCase
+{
+    public function testAddColumnWithDefault(): void
+    {
+        $schemaManager = $this->connection->getSchemaManager();
+
+        $table = new Table('text_type_test');
+
+        $table->addColumn('data', Types::TEXT);
+        $schemaManager->dropAndCreateTable($table);
+
+        $this->connection->executeStatement('INSERT INTO text_type_test (data) VALUES (?)', ['Zażółć']);
+
+        $query  = 'SELECT data FROM text_type_test';
+        $result = $this->connection->executeQuery($query)->fetch(FetchMode::NUMERIC);
+        self::assertSame(['Zażółć'], $result);
+    }
+}

--- a/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/AbstractSQLServerPlatformTestCase.php
@@ -143,9 +143,9 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
             'NVARCHAR(255)',
             $this->platform->getVarcharTypeDeclarationSQL([])
         );
-        self::assertSame('VARCHAR(MAX)', $this->platform->getClobTypeDeclarationSQL([]));
+        self::assertSame('NVARCHAR(MAX)', $this->platform->getClobTypeDeclarationSQL([]));
         self::assertSame(
-            'VARCHAR(MAX)',
+            'NVARCHAR(MAX)',
             $this->platform->getClobTypeDeclarationSQL(['length' => 5, 'fixed' => true])
         );
     }
@@ -741,7 +741,7 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
     public function getCreateTableColumnTypeCommentsSQL(): array
     {
         return [
-            'CREATE TABLE test (id INT NOT NULL, data VARCHAR(MAX) NOT NULL, PRIMARY KEY (id))',
+            'CREATE TABLE test (id INT NOT NULL, data NVARCHAR(MAX) NOT NULL, PRIMARY KEY (id))',
             "EXEC sp_addextendedproperty N'MS_Description', N'(DC2Type:array)', "
                 . "N'SCHEMA', 'dbo', N'TABLE', 'test', N'COLUMN', data",
         ];
@@ -780,8 +780,8 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
                     . 'comment INT NOT NULL, '
                     . '[comment_quoted] INT NOT NULL, '
                     . '[create] INT NOT NULL, '
-                    . 'commented_type VARCHAR(MAX) NOT NULL, '
-                    . 'commented_type_with_comment VARCHAR(MAX) NOT NULL, '
+                    . 'commented_type NVARCHAR(MAX) NOT NULL, '
+                    . 'commented_type_with_comment NVARCHAR(MAX) NOT NULL, '
                     . 'comment_with_string_literal_char NVARCHAR(255) NOT NULL, '
                     . 'PRIMARY KEY (id))',
                 "EXEC sp_addextendedproperty N'MS_Description', "
@@ -988,14 +988,14 @@ abstract class AbstractSQLServerPlatformTestCase extends AbstractPlatformTestCas
                 'ALTER TABLE mytable ADD added_comment INT NOT NULL',
                 'ALTER TABLE mytable ADD [added_comment_quoted] INT NOT NULL',
                 'ALTER TABLE mytable ADD [select] INT NOT NULL',
-                'ALTER TABLE mytable ADD added_commented_type VARCHAR(MAX) NOT NULL',
-                'ALTER TABLE mytable ADD added_commented_type_with_comment VARCHAR(MAX) NOT NULL',
+                'ALTER TABLE mytable ADD added_commented_type NVARCHAR(MAX) NOT NULL',
+                'ALTER TABLE mytable ADD added_commented_type_with_comment NVARCHAR(MAX) NOT NULL',
                 'ALTER TABLE mytable ADD added_comment_with_string_literal_char NVARCHAR(255) NOT NULL',
                 'ALTER TABLE mytable DROP COLUMN comment_integer_0',
                 'ALTER TABLE mytable ALTER COLUMN comment_null NVARCHAR(255) NOT NULL',
-                'ALTER TABLE mytable ALTER COLUMN comment_empty_string VARCHAR(MAX) NOT NULL',
-                'ALTER TABLE mytable ALTER COLUMN [comment_quoted] VARCHAR(MAX) NOT NULL',
-                'ALTER TABLE mytable ALTER COLUMN [create] VARCHAR(MAX) NOT NULL',
+                'ALTER TABLE mytable ALTER COLUMN comment_empty_string NVARCHAR(MAX) NOT NULL',
+                'ALTER TABLE mytable ALTER COLUMN [comment_quoted] NVARCHAR(MAX) NOT NULL',
+                'ALTER TABLE mytable ALTER COLUMN [create] NVARCHAR(MAX) NOT NULL',
                 'ALTER TABLE mytable ALTER COLUMN commented_type INT NOT NULL',
 
                 // Added columns.


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #2323 / #1351

#### Summary

When using the Doctrine type `text` some UTF-8 characters are converted to their ASCII equivalents. This PR uses a UTF-8 compatible column type to allow full support for UTF-8.

Requires #5236 & #5235 to be merged first
