### PR TITLE
Fix SQLite Database creation error when special characters inside the path to the project

### DIFF
--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -305,7 +305,6 @@ final class DriverManager
             return !preg_match('/[\w:\\\\\/]/', $e) ? urlencode($e) : $e;
         }, str_split($url)) );
         $url = parse_url($url);
-        $url['path'] = urldecode($url['path']);
 
         if ($url === false) {
             throw new Exception('Malformed parameter "url".');

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -300,10 +300,11 @@ final class DriverManager
 
         // (pdo_)?sqlite3?:///... => (pdo_)?sqlite3?://localhost/... or else the URL will be invalid
         $url = preg_replace('#^((?:pdo_)?sqlite3?):///#', '$1://localhost/', $params['url']);
-
-        $url = join( array_map(function($e){
-            return !preg_match('/[\w:\\\\\/]/', $e) ? urlencode($e) : $e;
-        }, str_split($url)) );
+        if(preg_match('/sqlite:\\/\\//', $url)){
+            $url = join( array_map(function($e){
+                return !preg_match('/[\w=\-\?:\\\\\/@%]/', $e) ? rawurlencode($e) : $e;
+            }, str_split($url)) );
+        }
         $url = parse_url($url);
 
         if ($url === false) {

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -300,12 +300,12 @@ final class DriverManager
 
         // (pdo_)?sqlite3?:///... => (pdo_)?sqlite3?://localhost/... or else the URL will be invalid
         $url = preg_replace('#^((?:pdo_)?sqlite3?):///#', '$1://localhost/', $params['url']);
-        
+
         // parse_url() split the url after '#' (https://www.php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-returnvalues)
         // so it temporarily replace by the string 'DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT'
         $url = preg_replace('/#/', 'DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT', $url);
-        $url = parse_url($url); 
-        $url['path'] = preg_replace('/DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT/', '#', $url['path']);
+        $url = parse_url($url || '');
+        $url['path'] = preg_replace('/DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT/', '#', $url['path'] || '');
 
         if ($url === false) {
             throw new Exception('Malformed parameter "url".');

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -300,10 +300,10 @@ final class DriverManager
 
         // (pdo_)?sqlite3?:///... => (pdo_)?sqlite3?://localhost/... or else the URL will be invalid
         $url = preg_replace('#^((?:pdo_)?sqlite3?):///#', '$1://localhost/', $params['url']);
-        if(preg_match('/sqlite:\\/\\//', $url)){
-            $url = join( array_map(function($e){
+        if(1 === preg_match('/sqlite:\\/\\//', $url)){
+            $url = implode(array_map(function($e){
                 return !preg_match('/[\w=\-\?:\\\\\/@%]/', $e) ? rawurlencode($e) : $e;
-            }, str_split($url)) );
+            }, str_split($url)));
         }
         $url = parse_url($url);
 

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -301,8 +301,6 @@ final class DriverManager
         // (pdo_)?sqlite3?:///... => (pdo_)?sqlite3?://localhost/... or else the URL will be invalid
         $url = preg_replace('#^((?:pdo_)?sqlite3?):///#', '$1://localhost/', $params['url']);
 
-        // parse_url() split the url after '#' (https://www.php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-returnvalues)
-        // so it temporarily replace by the string 'DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT'
         $url = join( array_map(function($e){
             return !preg_match('/[\w:\\\\\/]/', $e) ? urlencode($e) : $e;
         }, str_split($url)) );

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -303,9 +303,11 @@ final class DriverManager
 
         // parse_url() split the url after '#' (https://www.php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-returnvalues)
         // so it temporarily replace by the string 'DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT'
-        $url = preg_replace('/#/', 'DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT', $url) ?? '';
+        $url = join( array_map(function($e){
+            return !preg_match('/[\w:\\\\\/]/', $e) ? urlencode($e) : $e;
+        }, str_split($url)) );
         $url = parse_url($url);
-        $url['path'] = preg_replace('/DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT/', '#', $url['path']) ?? '';
+        $url['path'] = urldecode($url['path']);
 
         if ($url === false) {
             throw new Exception('Malformed parameter "url".');

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -303,9 +303,9 @@ final class DriverManager
 
         // parse_url() split the url after '#' (https://www.php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-returnvalues)
         // so it temporarily replace by the string 'DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT'
-        $url = preg_replace('/#/', 'DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT', $url);
-        $url = parse_url($url || '');
-        $url['path'] = preg_replace('/DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT/', '#', $url['path'] || '');
+        $url = preg_replace('/#/', 'DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT', $url) ?? '';
+        $url = parse_url($url);
+        $url['path'] = preg_replace('/DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT/', '#', $url['path']) ?? '';
 
         if ($url === false) {
             throw new Exception('Malformed parameter "url".');

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -300,7 +300,12 @@ final class DriverManager
 
         // (pdo_)?sqlite3?:///... => (pdo_)?sqlite3?://localhost/... or else the URL will be invalid
         $url = preg_replace('#^((?:pdo_)?sqlite3?):///#', '$1://localhost/', $params['url']);
-        $url = parse_url($url);
+        
+        // parse_url() split the url after '#' (https://www.php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-returnvalues)
+        // so it temporarily replace by the string 'DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT'
+        $url = preg_replace('/#/', 'DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT', $url);
+        $url = parse_url($url); 
+        $url['path'] = preg_replace('/DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT/', '#', $url['path']);
 
         if ($url === false) {
             throw new Exception('Malformed parameter "url".');

--- a/tests/DriverManagerTest.php
+++ b/tests/DriverManagerTest.php
@@ -234,43 +234,43 @@ class DriverManagerTest extends TestCase
                 ],
             ],
             'sqlite relative URL without host and spetial characters in path' => [
-                'sqlite:///foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                'sqlite:///foo/u~z/#f`aa/f[ o/dbname.sqlite',
                 [
-                    'path'   => 'foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                    'path'   => 'foo/u~z/#f`aa/f[ o/dbname.sqlite',
                     'driver' => PDO\SQLite\Driver::class,
                 ],
             ],
             'sqlite relative URL with host and spetial characters in path' => [
-                'sqlite://localhost/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                'sqlite://localhost/foo/u~z/#f`aa/f[ o/dbname.sqlite',
                 [
                     'host'     => 'localhost',
-                    'path'   => 'foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
-                    'driver' => PDO\SQLite\Driver::class,
-                ],
-            ],
-            'sqlite absolute URL with host and spetial characters in path' => [
-                'sqlite:////tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
-                [
-                    'path'   => '/tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                    'path'   => 'foo/u~z/#f`aa/f[ o/dbname.sqlite',
                     'driver' => PDO\SQLite\Driver::class,
                 ],
             ],
             'sqlite absolute URL without host and spetial characters in path' => [
-                'sqlite://localhost//tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                'sqlite:////tmp/foo/u~z/#f`aa/f[ o/dbname.sqlite',
+                [
+                    'path'   => '/tmp/foo/u~z/#f`aa/f[ o/dbname.sqlite',
+                    'driver' => PDO\SQLite\Driver::class,
+                ],
+            ],
+            'sqlite absolute URL with host and spetial characters in path' => [
+                'sqlite://localhost//tmp/foo/u~z/#f`aa/f[ o/dbname.sqlite',
                 [
                     'host' => 'localhost',
-                    'path'   => '/tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                    'path'   => '/tmp/foo/u~z/#f`aa/f[ o/dbname.sqlite',
                     'driver' => PDO\SQLite\Driver::class,
                 ],
             ],
             'sqlite relative URL with host, port, user, password and spetial characters in path' => [
-                'sqlite://fo+o:b##`~&ar@loca~lhost:11211/tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                'sqlite://fo+o:b##`~&ar@loca~lhost:11211/tmp/foo/u~z/#f`aa/f[ o/dbname.sqlite',
                 [
                     'user'     => 'fo+o',
                     'password' => 'b##`~&ar',
                     'host'     => 'loca~lhost',
                     'port'     => 11211,
-                    'path'   => 'tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                    'path'   => 'tmp/foo/u~z/#f`aa/f[ o/dbname.sqlite',
                     'driver' => PDO\SQLite\Driver::class,
                 ],
             ],

--- a/tests/DriverManagerTest.php
+++ b/tests/DriverManagerTest.php
@@ -264,13 +264,13 @@ class DriverManagerTest extends TestCase
                 ],
             ],
             'sqlite relative URL with host, port, user, password and spetial characters in path' => [
-                'sqlite://fo+o:b##`~&ar@loca~lhost:11211//tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                'sqlite://fo+o:b##`~&ar@loca~lhost:11211/tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
                 [
                     'user'     => 'fo+o',
                     'password' => 'b##`~&ar',
                     'host'     => 'loca~lhost',
                     'port'     => 11211,
-                    'path'   => '/tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                    'path'   => 'tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
                     'driver' => PDO\SQLite\Driver::class,
                 ],
             ],

--- a/tests/DriverManagerTest.php
+++ b/tests/DriverManagerTest.php
@@ -233,6 +233,47 @@ class DriverManagerTest extends TestCase
                     'driver' => PDO\SQLite\Driver::class,
                 ],
             ],
+            'sqlite relative URL without host and spetial characters in path' => [
+                'sqlite:///foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                [
+                    'path'   => 'foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                    'driver' => PDO\SQLite\Driver::class,
+                ],
+            ],
+            'sqlite relative URL with host and spetial characters in path' => [
+                'sqlite://localhost/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                [
+                    'host'     => 'localhost',
+                    'path'   => 'foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                    'driver' => PDO\SQLite\Driver::class,
+                ],
+            ],
+            'sqlite absolute URL with host and spetial characters in path' => [
+                'sqlite:////tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                [
+                    'path'   => '/tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                    'driver' => PDO\SQLite\Driver::class,
+                ],
+            ],
+            'sqlite absolute URL without host and spetial characters in path' => [
+                'sqlite://localhost//tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                [
+                    'host' => 'localhost',
+                    'path'   => '/tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                    'driver' => PDO\SQLite\Driver::class,
+                ],
+            ],
+            'sqlite relative URL with host, port, user, password and spetial characters in path' => [
+                'sqlite://fo+o:b##`~&ar@loca~lhost:11211//tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                [
+                    'user'     => 'fo+o',
+                    'password' => 'b##`~&ar',
+                    'host'     => 'loca~lhost',
+                    'port'     => 11211,
+                    'path'   => '/tmp/foo/u~z/#f`aa/*  *o/dbna] me.sqlite',
+                    'driver' => PDO\SQLite\Driver::class,
+                ],
+            ],
             'sqlite memory' => [
                 'sqlite:///:memory:',
                 [


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

### Description

When i tried to init the database `SQLite` from a new Symfony project, a error appear :
```
Could not create database C:\Users\John\Symfony</comment> for connection named default
An exception occurred in the driver: SQLSTATE[HY000] [14] unable to open database file
```
I first thought it was from my user privilege, and after somes manipulations i tried to remove the `'#'` from the path to the project and this works !

### How to reproduce

* Create a new Symfony project in a directory with a `'#'` in the path, eg. `'C:\Users\John\Symfony\#Github'`,
* In the `.env` use a SQLite database `'sqlite:///%kernel.project_dir%/var/data.db'`,
* Run the command `php bin/console doctrine:database:create`,
An error must appear saying :
```
Could not create database C:\Users\John\Symfony</comment> for connection named default
An exception occurred in the driver: SQLSTATE[HY000] [14] unable to open database file
```

### Solution
The `parse_url()` split the url after `'#'` (https://www.php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-returnvalues), so it temporarily replace by the string `'DOCTRINE_HASHTAG_CHARACTER_REPLACEMENT'`
