### PR TITLE
Add support for collation option to MySQL

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -452,12 +452,16 @@ SQL
 
         $tableOptions[] = sprintf('DEFAULT CHARACTER SET %s', $options['charset']);
 
-        // Collate
-        if (! isset($options['collate'])) {
-            $options['collate'] = $options['charset'] . '_unicode_ci';
+        if (isset($options['collate'])) {
+            $options['collation'] = $options['collate'];
         }
 
-        $tableOptions[] = $this->getColumnCollationDeclarationSQL($options['collate']);
+        // Collation
+        if (! isset($options['collation'])) {
+            $options['collation'] = $options['charset'] . '_unicode_ci';
+        }
+
+        $tableOptions[] = $this->getColumnCollationDeclarationSQL($options['collation']);
 
         // Engine
         if (! isset($options['engine'])) {

--- a/tests/Platforms/MySQLPlatformTest.php
+++ b/tests/Platforms/MySQLPlatformTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tests\Platforms;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use InvalidArgumentException;
 
@@ -26,5 +27,27 @@ class MySQLPlatformTest extends AbstractMySQLPlatformTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->platform->getDropIndexSQL('foo');
+    }
+
+    public function testCollationOptionIsTakenIntoAccount(): void
+    {
+        $table = new Table('quotations');
+        $table->addColumn('id', 'integer');
+        $table->addOption('collation', 'my_collation');
+        self::assertStringContainsString(
+            'my_collation',
+            $this->platform->getCreateTableSQL($table)[0]
+        );
+    }
+
+    public function testCollateOptionIsStillSupported(): void
+    {
+        $table = new Table('quotations');
+        $table->addColumn('id', 'integer');
+        $table->addOption('collate', 'my_collation');
+        self::assertStringContainsString(
+            'my_collation',
+            $this->platform->getCreateTableSQL($table)[0]
+        );
     }
 }


### PR DESCRIPTION
Our documentation advertises it:
https://www.doctrine-project.org/projects/doctrine-dbal/en/3.3.1/reference/schema-representation.html
The option `collate` stays supported and should be deprecated in 3.4

Fixes #5214
Fixes #5243