### PR TITLE
Make phpdoc accurate

### DIFF
--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -46,7 +46,7 @@ class PortabilityTest extends FunctionalTestCase
     }
 
     /**
-     * @param array{int, list<string>} $expected
+     * @param list<string> $expected
      *
      * @dataProvider caseProvider
      */


### PR DESCRIPTION
I don't know why this is caught on 4.0.x but not on 3.3.x

UPD: `tests` is ignored on 3.3.x