### PR TITLE
PRAGMA queries rollback & unification

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -22,6 +22,7 @@ use function preg_match_all;
 use function preg_quote;
 use function preg_replace;
 use function rtrim;
+use function sprintf;
 use function str_replace;
 use function strpos;
 use function strtolower;

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -204,7 +204,10 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $indexBuffer = [];
 
         // fetch primary
-        $indexArray = $this->_conn->fetchAllAssociative('SELECT * FROM PRAGMA_TABLE_INFO (?)', [$tableName]);
+        $indexArray = $this->_conn->fetchAllAssociative(sprintf(
+            'PRAGMA TABLE_INFO (%s)',
+            $this->_conn->quote($tableName)
+        ));
 
         usort(
             $indexArray,
@@ -247,7 +250,10 @@ class SqliteSchemaManager extends AbstractSchemaManager
             $idx['primary']    = false;
             $idx['non_unique'] = ! $tableIndex['unique'];
 
-            $indexArray = $this->_conn->fetchAllAssociative('SELECT * FROM PRAGMA_INDEX_INFO (?)', [$keyName]);
+            $indexArray = $this->_conn->fetchAllAssociative(sprintf(
+                'PRAGMA INDEX_INFO (%s)',
+                $this->_conn->quote($keyName)
+            ));
 
             foreach ($indexArray as $indexColumnRow) {
                 $idx['column_name'] = $indexColumnRow['name'];


### PR DESCRIPTION
Rolling back to the `PRAGMA TABLE_INFO (%s)` instead of `SELECT * FROM PRAGMA_TABLE_INFO (?)` query.

|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| Fixed issues | #5133 

#### Summary

On travis CI, for Laravel projects, the PRAGMA_TABLE_INFO table does not exist.
Rolling back to the `PRAGMA TABLE_INFO (%s)` instead of `SELECT * FROM PRAGMA_TABLE_INFO (?)` query fix the issue.
Moreover, in `doctrine/dbal`, all queries related to the sqlite tables info use the `PRAGMA` statement instead of `SELECT`.
