### PR TITLE
More accurate params

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -119,7 +119,6 @@ class Connection
      * The parameters used during creation of the Connection instance.
      *
      * @var array<string,mixed>
-     * @phpstan-var array<string,mixed>
      * @psalm-var Params
      */
     private $params;
@@ -215,7 +214,6 @@ class Connection
      *
      * @return array<string,mixed>
      * @psalm-return Params
-     * @phpstan-return array<string,mixed>
      */
     public function getParams()
     {

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -45,6 +45,7 @@ use function substr;
  * @psalm-type Params = array{
  *     charset?: string,
  *     dbname?: string,
+ *     defaultTableOptions?: array<string, mixed>,
  *     default_dbname?: string,
  *     driver?: key-of<self::DRIVER_MAP>,
  *     driverClass?: class-string<Driver>,
@@ -61,6 +62,7 @@ use function substr;
  *     port?: int,
  *     primary?: OverrideParams,
  *     replica?: array<OverrideParams>,
+ *     serverVersion?: string,
  *     sharding?: array<string,mixed>,
  *     slaves?: array<OverrideParams>,
  *     user?: string,


### PR DESCRIPTION
While working on https://github.com/doctrine/DoctrineBundle/pull/1471, I found that `defaultTableOptions` was not documented.
This lead me to lift restrictions that prevent PHPStan from seeing the connection parameters as more than a hash of mixed, which in turn lead me to document `serverVersion` as well.