### PR TITLE
Add CI Job for testing with SQLite on Ubuntu 18.04

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,10 +31,12 @@ env:
 jobs:
   phpunit-smoke-check:
     name: "PHPUnit with SQLite"
-    runs-on: "ubuntu-20.04"
+    runs-on: "${{ matrix.os }}"
 
     strategy:
       matrix:
+        os:
+          - "ubuntu-20.04"
         php-version:
           - "7.3"
           - "7.4"
@@ -43,8 +45,12 @@ jobs:
         dependencies:
           - "highest"
         include:
-          - dependencies: "lowest"
+          - os: "ubuntu-20.04"
             php-version: "7.3"
+            dependencies: "lowest"
+          - os: "ubuntu-18.04"
+            php-version: "8.1"
+            dependencies: "highest"
 
     steps:
       - name: "Checkout"
@@ -63,6 +69,10 @@ jobs:
         uses: "ramsey/composer-install@v1"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
+
+      - name: "Print SQLite version"
+        run: >
+          php -r 'printf("Testing with libsqlite version %s\n", (new PDO("sqlite::memory:"))->query("select sqlite_version()")->fetch()[0]);'
 
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit -c ci/github/phpunit/sqlite.xml --coverage-clover=coverage.xml"


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

We are currently runing our tests with PHP linked against libsqlite 3.31.1. This creates a blind spot when it comes to compatibility with older SQLite releases.

This PR adds an `os` dimension to our SQLite test matrix. This allows me to schedule a test run on Ubuntu's old LTS (18.04) which bundles libsqlite 3.22.0. I have also added a step that outputs the libsqlite versions the PDO driver is compiled against.