### PR TITLE
Optimize schema managers' ::listTables() methods 

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,17 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+# Deprecated `AbstractPlatform` schema introspection methods
+
+The following schema introspection methods have been deprecated:
+
+- `AbstractPlatform::getListTablesSQL()`,
+- `AbstractPlatform::getListTableColumnsSQL()`,
+- `AbstractPlatform::getListTableIndexesSQL()`,
+- `AbstractPlatform::getListTableForeignKeysSQL()`.
+
+The queries used for schema introspection are an internal implementation detail of the DBAL.
+
 # Deprecated `collate` option for MySQL
 
 This undocumented option is deprecated in favor of `collation`.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -212,6 +212,32 @@
                 <referencedMethod name="Doctrine\DBAL\Connection::getWrappedConnection"/>
                 <!--
                     TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform::getListTableColumnsSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform::getListTableForeignKeysSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform::getListTableIndexesSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getListTableColumnsSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getListTableForeignKeysSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getListTableIndexesSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\DB2Platform::getListTableColumnsSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\DB2Platform::getListTableCommentsSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\DB2Platform::getListTableForeignKeysSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\DB2Platform::getListTableIndexesSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\OraclePlatform::getListTableColumnsSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\OraclePlatform::getListTableForeignKeysSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\OraclePlatform::getListTableIndexesSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::getListTableColumnsSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::getListTableForeignKeysSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::getListTableIndexesSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::getListTableMetadataSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\SQLServerPlatform::getListTableColumnsSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\SQLServerPlatform::getListTableForeignKeysSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\SQLServerPlatform::getListTableIndexesSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\SQLServerPlatform::getListTableMetadataSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::getListTableColumnsSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::getListTableForeignKeysSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::getListTableIndexesSQL"/>
+                <!--
                     See https://github.com/doctrine/dbal/pull/1519
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform::prefersIdentityColumns"/>

--- a/src/Exception/DatabaseRequired.php
+++ b/src/Exception/DatabaseRequired.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Exception;
+
+use Doctrine\DBAL\Exception;
+
+use function sprintf;
+
+/**
+ * @psalm-immutable
+ */
+class DatabaseRequired extends Exception
+{
+    public static function new(string $methodName): self
+    {
+        return new self(sprintf('A database is required for the method: %s.', $methodName));
+    }
+}

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -147,6 +147,8 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      *
      * Two approaches to listing the table indexes. The information_schema is
@@ -174,6 +176,8 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * @param string      $table
      * @param string|null $database
      *
@@ -327,6 +331,8 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTablesSQL()
@@ -335,6 +341,8 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTableColumnsSQL($table, $database = null)
@@ -347,6 +355,9 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
                ' ORDER BY ORDINAL_POSITION ASC';
     }
 
+    /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     */
     public function getListTableMetadataSQL(string $table, ?string $database = null): string
     {
         return sprintf(

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3125,6 +3125,8 @@ abstract class AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * @param string $table
      * @param string $database
      *
@@ -3138,6 +3140,8 @@ abstract class AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * @return string
      *
      * @throws Exception If not supported on this platform.
@@ -3180,6 +3184,8 @@ abstract class AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * Returns the list of indexes for the current database.
      *
      * The current database parameter is optional but will always be passed
@@ -3202,6 +3208,8 @@ abstract class AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * @param string $table
      *
      * @return string

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -279,6 +279,8 @@ class DB2Platform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * This code fragment is originally from the Zend_Db_Adapter_Db2 class, but has been edited.
      *
      * @param string $table
@@ -352,6 +354,8 @@ class DB2Platform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTableIndexesSQL($table, $database = null)
@@ -376,6 +380,8 @@ class DB2Platform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTableForeignKeysSQL($table)
@@ -900,6 +906,9 @@ class DB2Platform extends AbstractPlatform
         return Keywords\DB2Keywords::class;
     }
 
+    /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     */
     public function getListTableCommentsSQL(string $table): string
     {
         return sprintf(

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -430,6 +430,8 @@ class OraclePlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      *
      * @link http://ezcomponents.org/docs/api/trunk/DatabaseSchema/ezcDbSchemaOracleReader.html
@@ -626,6 +628,8 @@ END;';
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTableForeignKeysSQL($table)
@@ -671,6 +675,8 @@ END;';
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTableColumnsSQL($table, $database = null)
@@ -1192,6 +1198,9 @@ SQL
         return 'BLOB';
     }
 
+    /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     */
     public function getListTableCommentsSQL(string $table, ?string $database = null): string
     {
         $tableCommentsName = 'user_tab_comments';

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -297,6 +297,8 @@ class PostgreSQLPlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * @param string      $table
      * @param string|null $database
      *
@@ -345,6 +347,8 @@ SQL
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      *
      * @link http://ezcomponents.org/docs/api/trunk/DatabaseSchema/ezcDbSchemaPgsqlReader.html
@@ -391,6 +395,8 @@ SQL
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTableColumnsSQL($table, $database = null)
@@ -1265,6 +1271,9 @@ SQL
         return $columnDiff->fromColumn !== null ? $this->getColumnComment($columnDiff->fromColumn) : null;
     }
 
+    /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     */
     public function getListTableMetadataSQL(string $table, ?string $schema = null): string
     {
         if ($schema !== null) {

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -904,6 +904,8 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTableColumnsSQL($table, $database = null)
@@ -937,6 +939,8 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * @param string      $table
      * @param string|null $database
      *
@@ -963,6 +967,8 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTableIndexesSQL($table, $database = null)
@@ -1610,6 +1616,9 @@ class SQLServerPlatform extends AbstractPlatform
         );
     }
 
+    /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     */
     public function getListTableMetadataSQL(string $table): string
     {
         return sprintf(

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -472,6 +472,8 @@ class SqlitePlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTableColumnsSQL($table, $database = null)
@@ -482,6 +484,8 @@ class SqlitePlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTableIndexesSQL($table, $database = null)
@@ -876,6 +880,8 @@ class SqlitePlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * @param string      $table
      * @param string|null $database
      *

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -4,14 +4,17 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_change_key_case;
+use function implode;
 use function preg_match;
 use function str_replace;
 use function strpos;
 use function strtolower;
+use function strtoupper;
 use function substr;
 
 use const CASE_LOWER;
@@ -36,6 +39,22 @@ class DB2SchemaManager extends AbstractSchemaManager
         $tables = $this->_conn->fetchAllAssociative($sql);
 
         return $this->filterAssetNames($this->_getPortableTablesList($tables));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function listTables()
+    {
+        return $this->doListTables();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function listTableDetails($name)
+    {
+        return $this->doListTableDetails($name);
     }
 
     /**
@@ -229,21 +248,173 @@ class DB2SchemaManager extends AbstractSchemaManager
         return new View($view['name'], $sql);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function listTableDetails($name): Table
+    protected function normalizeName(string $name): string
     {
-        $table = parent::listTableDetails($name);
+        $identifier = new Identifier($name);
 
-        $sql = $this->_platform->getListTableCommentsSQL($name);
+        return $identifier->isQuoted() ? $identifier->getName() : strtoupper($name);
+    }
 
-        $tableOptions = $this->_conn->fetchAssociative($sql);
+    protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result
+    {
+        $sql = 'SELECT';
 
-        if ($tableOptions !== false) {
-            $table->addOption('comment', $tableOptions['REMARKS']);
+        if ($tableName === null) {
+            $sql .= ' C.TABNAME,';
         }
 
-        return $table;
+        $sql .= <<<'SQL'
+       C.COLNAME,
+       C.TYPENAME,
+       C.CODEPAGE,
+       C.NULLS,
+       C.LENGTH,
+       C.SCALE,
+       C.REMARKS AS COMMENT,
+       CASE
+           WHEN C.GENERATED = 'D' THEN 1
+           ELSE 0
+           END   AS AUTOINCREMENT,
+       C.DEFAULT
+FROM SYSCAT.COLUMNS C
+         JOIN SYSCAT.TABLES AS T
+              ON T.TABSCHEMA = C.TABSCHEMA
+                  AND T.TABNAME = C.TABNAME
+SQL;
+
+        $conditions = ['C.TABSCHEMA = ?', "T.TYPE = 'T'"];
+        $params     = [$databaseName];
+
+        if ($tableName !== null) {
+            $conditions[] = 'C.TABNAME = ?';
+            $params[]     = $tableName;
+        }
+
+        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY C.TABNAME, C.COLNO';
+
+        return $this->_conn->executeQuery($sql, $params);
+    }
+
+    protected function selectDatabaseIndexes(string $databaseName, ?string $tableName = null): Result
+    {
+        $sql = 'SELECT';
+
+        if ($tableName === null) {
+            $sql .= ' IDX.TABNAME,';
+        }
+
+        $sql .= <<<'SQL'
+             IDX.INDNAME AS KEY_NAME,
+             IDXCOL.COLNAME AS COLUMN_NAME,
+             CASE
+                 WHEN IDX.UNIQUERULE = 'P' THEN 1
+                 ELSE 0
+             END AS PRIMARY,
+             CASE
+                 WHEN IDX.UNIQUERULE = 'D' THEN 1
+                 ELSE 0
+             END AS NON_UNIQUE
+        FROM SYSCAT.INDEXES AS IDX
+        JOIN SYSCAT.TABLES AS T
+          ON IDX.TABSCHEMA = T.TABSCHEMA AND IDX.TABNAME = T.TABNAME
+        JOIN SYSCAT.INDEXCOLUSE AS IDXCOL
+          ON IDX.INDSCHEMA = IDXCOL.INDSCHEMA AND IDX.INDNAME = IDXCOL.INDNAME
+SQL;
+
+        $conditions = ['IDX.TABSCHEMA = ?', "T.TYPE = 'T'"];
+        $params     = [$databaseName];
+
+        if ($tableName !== null) {
+            $conditions[] = 'IDX.TABNAME = ?';
+            $params[]     = $tableName;
+        }
+
+        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY IDX.INDNAME, IDXCOL.COLSEQ';
+
+        return $this->_conn->executeQuery($sql, $params);
+    }
+
+    protected function selectDatabaseForeignKeys(string $databaseName, ?string $tableName = null): Result
+    {
+        $sql = 'SELECT';
+
+        if ($tableName === null) {
+            $sql .= ' R.TABNAME,';
+        }
+
+        $sql .= <<<'SQL'
+             FKCOL.COLNAME AS LOCAL_COLUMN,
+             R.REFTABNAME AS FOREIGN_TABLE,
+             PKCOL.COLNAME AS FOREIGN_COLUMN,
+             R.CONSTNAME AS INDEX_NAME,
+             CASE
+                 WHEN R.UPDATERULE = 'R' THEN 'RESTRICT'
+             END AS ON_UPDATE,
+             CASE
+                 WHEN R.DELETERULE = 'C' THEN 'CASCADE'
+                 WHEN R.DELETERULE = 'N' THEN 'SET NULL'
+                 WHEN R.DELETERULE = 'R' THEN 'RESTRICT'
+             END AS ON_DELETE
+        FROM SYSCAT.REFERENCES AS R
+         JOIN SYSCAT.TABLES AS T
+              ON T.TABSCHEMA = R.TABSCHEMA
+                  AND T.TABNAME = R.TABNAME
+         JOIN SYSCAT.KEYCOLUSE AS FKCOL
+              ON FKCOL.CONSTNAME = R.CONSTNAME
+                  AND FKCOL.TABSCHEMA = R.TABSCHEMA
+                  AND FKCOL.TABNAME = R.TABNAME
+         JOIN SYSCAT.KEYCOLUSE AS PKCOL
+              ON PKCOL.CONSTNAME = R.REFKEYNAME
+                  AND PKCOL.TABSCHEMA = R.REFTABSCHEMA
+                  AND PKCOL.TABNAME = R.REFTABNAME
+                  AND PKCOL.COLSEQ = FKCOL.COLSEQ
+SQL;
+
+        $conditions = ['R.TABSCHEMA = ?', "T.TYPE = 'T'"];
+        $params     = [$databaseName];
+
+        if ($tableName !== null) {
+            $conditions[] = 'R.TABNAME = ?';
+            $params[]     = $tableName;
+        }
+
+        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY R.CONSTNAME, FKCOL.COLSEQ';
+
+        return $this->_conn->executeQuery($sql, $params);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDatabaseTableOptions(string $databaseName, ?string $tableName = null): array
+    {
+        $sql = 'SELECT NAME, REMARKS';
+
+        $conditions = [];
+        $params     = [];
+
+        if ($tableName !== null) {
+            $conditions[] = 'NAME = ?';
+            $params[]     = $tableName;
+        }
+
+        $sql .= ' FROM SYSIBM.SYSTABLES';
+
+        if ($conditions !== []) {
+            $sql .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+
+        /** @var array<string,array<string,mixed>> $metadata */
+        $metadata = $this->_conn->executeQuery($sql, $params)
+            ->fetchAllAssociativeIndexed();
+
+        $tableOptions = [];
+        foreach ($metadata as $table => $data) {
+            $data = array_change_key_case($data, CASE_LOWER);
+
+            $tableOptions[$table] = ['comment' => $data['remarks']];
+        }
+
+        return $tableOptions;
     }
 }

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
@@ -38,6 +39,22 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
 {
     /** @var string[]|null */
     private $existingSchemaPaths;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function listTables()
+    {
+        return $this->doListTables();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function listTableDetails($name)
+    {
+        return $this->doListTableDetails($name);
+    }
 
     /**
      * Gets all the existing schema names.
@@ -571,21 +588,180 @@ SQL
         return str_replace("''", "'", $default);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function listTableDetails($name): Table
+    protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $table = parent::listTableDetails($name);
+        $sql = 'SELECT';
 
-        $sql = $this->_platform->getListTableMetadataSQL($name);
-
-        $tableOptions = $this->_conn->fetchAssociative($sql);
-
-        if ($tableOptions !== false) {
-            $table->addOption('comment', $tableOptions['table_comment']);
+        if ($tableName === null) {
+            $sql .= ' c.relname,';
         }
 
-        return $table;
+        $sql .= <<<'SQL'
+            a.attnum,
+            quote_ident(a.attname) AS field,
+            t.typname AS type,
+            format_type(a.atttypid, a.atttypmod) AS complete_type,
+            (SELECT tc.collcollate FROM pg_catalog.pg_collation tc WHERE tc.oid = a.attcollation) AS collation,
+            (SELECT t1.typname FROM pg_catalog.pg_type t1 WHERE t1.oid = t.typbasetype) AS domain_type,
+            (SELECT format_type(t2.typbasetype, t2.typtypmod) FROM
+              pg_catalog.pg_type t2 WHERE t2.typtype = 'd' AND t2.oid = a.atttypid) AS domain_complete_type,
+            a.attnotnull AS isnotnull,
+            (SELECT 't'
+             FROM pg_index
+             WHERE c.oid = pg_index.indrelid
+                AND pg_index.indkey[0] = a.attnum
+                AND pg_index.indisprimary = 't'
+            ) AS pri,
+            (SELECT pg_get_expr(adbin, adrelid)
+             FROM pg_attrdef
+             WHERE c.oid = pg_attrdef.adrelid
+                AND pg_attrdef.adnum=a.attnum
+            ) AS default,
+            (SELECT pg_description.description
+                FROM pg_description WHERE pg_description.objoid = c.oid AND a.attnum = pg_description.objsubid
+            ) AS comment
+            FROM pg_attribute a, pg_class c, pg_type t, pg_namespace n
+SQL;
+
+        $conditions = [
+            'a.attnum > 0',
+            'a.attrelid = c.oid',
+            'a.atttypid = t.oid',
+            'n.oid = c.relnamespace',
+            "c.relkind = 'r'",
+        ];
+        $params     = [];
+
+        if ($tableName !== null) {
+            $conditions[] = $this->getTableWhereClause($tableName, 'c', 'n');
+        } else {
+            $conditions[] = "n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')";
+            $conditions[] = 'n.nspname = ANY(current_schemas(false))';
+        }
+
+        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY a.attnum';
+
+        return $this->_conn->executeQuery($sql, $params);
+    }
+
+    protected function selectDatabaseIndexes(string $databaseName, ?string $tableName = null): Result
+    {
+        $sql = 'SELECT';
+
+        if ($tableName === null) {
+            $sql .= ' pg_index.indrelid::REGCLASS AS tablename,';
+        }
+
+        $sql .= <<<'SQL'
+                   quote_ident(relname) AS relname,
+                   pg_index.indisunique,
+                   pg_index.indisprimary,
+                   pg_index.indkey,
+                   pg_index.indrelid,
+                   pg_get_expr(indpred, indrelid) AS where
+              FROM pg_class, pg_index
+             WHERE oid IN (
+                SELECT indexrelid
+                FROM pg_index si, pg_class sc, pg_namespace sn
+SQL;
+
+        $conditions = ['sc.oid=si.indrelid', 'sc.relnamespace = sn.oid'];
+        $params     = [];
+
+        if ($tableName !== null) {
+            $conditions[] = $this->getTableWhereClause($tableName, 'sc', 'sn');
+        } else {
+            $conditions[] = "sn.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')";
+            $conditions[] = 'sn.nspname = ANY(current_schemas(false))';
+        }
+
+        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ') AND pg_index.indexrelid = oid';
+
+        return $this->_conn->executeQuery($sql, $params);
+    }
+
+    protected function selectDatabaseForeignKeys(string $databaseName, ?string $tableName = null): Result
+    {
+        $sql = 'SELECT';
+
+        if ($tableName === null) {
+            $sql .= ' r.conrelid :: REGCLASS as tablename,';
+        }
+
+        $sql .= <<<'SQL'
+                  quote_ident(r.conname) as conname, pg_catalog.pg_get_constraintdef(r.oid, true) as condef
+                  FROM pg_catalog.pg_constraint r
+                  WHERE r.conrelid IN
+                  (
+                      SELECT c.oid
+                      FROM pg_catalog.pg_class c, pg_catalog.pg_namespace n
+SQL;
+
+        $conditions = ['n.oid = c.relnamespace'];
+        $params     = [];
+
+        if ($tableName !== null) {
+            $conditions[] = $this->getTableWhereClause($tableName);
+        } else {
+            $conditions[] = "n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')";
+            $conditions[] = 'n.nspname = ANY(current_schemas(false))';
+        }
+
+        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ") AND r.contype = 'f'";
+
+        return $this->_conn->executeQuery($sql, $params);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDatabaseTableOptions(string $databaseName, ?string $tableName = null): array
+    {
+        if ($tableName === null) {
+            $tables = $this->listTableNames();
+        } else {
+            $tables = [$tableName];
+        }
+
+        $tableOptions = [];
+        foreach ($tables as $table) {
+            $sql     = 'SELECT obj_description(?::regclass) AS table_comment;';
+            $comment = $this->_conn->executeQuery($sql, [$table])->fetchOne();
+
+            if ($comment === null) {
+                continue;
+            }
+
+            $tableOptions[$table]['comment'] = $comment;
+        }
+
+        return $tableOptions;
+    }
+
+    /**
+     * @param string $table
+     * @param string $classAlias
+     * @param string $namespaceAlias
+     */
+    private function getTableWhereClause($table, $classAlias = 'c', $namespaceAlias = 'n'): string
+    {
+        $whereClause = $namespaceAlias . ".nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast') AND ";
+        if (strpos($table, '.') !== false) {
+            [$schema, $table] = explode('.', $table);
+            $schema           = $this->_platform->quoteStringLiteral($schema);
+        } else {
+            $schema = 'ANY(current_schemas(false))';
+        }
+
+        $table = new Identifier($table);
+        $table = $this->_platform->quoteStringLiteral($table->getName());
+
+        return $whereClause . sprintf(
+            '%s.relname = %s AND %s.nspname = %s',
+            $classAlias,
+            $table,
+            $namespaceAlias,
+            $schema
+        );
     }
 }

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -5,17 +5,23 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SQLServer;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 
+use function array_change_key_case;
 use function assert;
 use function count;
+use function explode;
+use function implode;
 use function is_string;
 use function preg_match;
 use function sprintf;
 use function str_replace;
 use function strpos;
 use function strtok;
+
+use const CASE_LOWER;
 
 /**
  * SQL Server Schema Manager.
@@ -26,6 +32,22 @@ class SQLServerSchemaManager extends AbstractSchemaManager
 {
     /** @var string|null */
     private $databaseCollation;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function listTables()
+    {
+        return $this->doListTables();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function listTableDetails($name)
+    {
+        return $this->doListTableDetails($name);
+    }
 
     /**
      * {@inheritDoc}
@@ -322,26 +344,6 @@ SQL
     }
 
     /**
-     * @param string $name
-     *
-     * @throws Exception
-     */
-    public function listTableDetails($name): Table
-    {
-        $table = parent::listTableDetails($name);
-
-        $sql = $this->_platform->getListTableMetadataSQL($name);
-
-        $tableOptions = $this->_conn->fetchAssociative($sql);
-
-        if ($tableOptions !== false) {
-            $table->addOption('comment', $tableOptions['table_comment']);
-        }
-
-        return $table;
-    }
-
-    /**
      * @throws Exception
      */
     public function createComparator(): Comparator
@@ -367,5 +369,199 @@ SQL
         }
 
         return $this->databaseCollation;
+    }
+
+    protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result
+    {
+        $sql = 'SELECT';
+
+        if ($tableName === null) {
+            $sql .= ' obj.name AS tablename,';
+        }
+
+        $sql .= <<<'SQL'
+                          col.name,
+                          type.name AS type,
+                          col.max_length AS length,
+                          ~col.is_nullable AS notnull,
+                          def.definition AS [default],
+                          col.scale,
+                          col.precision,
+                          col.is_identity AS autoincrement,
+                          col.collation_name AS collation,
+                          -- CAST avoids driver error for sql_variant type
+                          CAST(prop.value AS NVARCHAR(MAX)) AS comment
+                FROM      sys.columns AS col
+                JOIN      sys.types AS type
+                ON        col.user_type_id = type.user_type_id
+                JOIN      sys.objects AS obj
+                ON        col.object_id = obj.object_id
+                JOIN      sys.schemas AS scm
+                ON        obj.schema_id = scm.schema_id
+                LEFT JOIN sys.default_constraints def
+                ON        col.default_object_id = def.object_id
+                AND       col.object_id = def.parent_object_id
+                LEFT JOIN sys.extended_properties AS prop
+                ON        obj.object_id = prop.major_id
+                AND       col.column_id = prop.minor_id
+                AND       prop.name = 'MS_Description'
+SQL;
+
+        $conditions = ["obj.type = 'U'"];
+        $params     = [];
+
+        if ($tableName !== null) {
+            $conditions[] = $this->getTableWhereClause($tableName, 'scm.name', 'obj.name');
+        }
+
+        $sql .= ' WHERE ' . implode(' AND ', $conditions);
+
+        return $this->_conn->executeQuery($sql, $params);
+    }
+
+    protected function selectDatabaseIndexes(string $databaseName, ?string $tableName = null): Result
+    {
+        $sql = 'SELECT';
+
+        if ($tableName === null) {
+            $sql .= ' tbl.name AS tablename,';
+        }
+
+        $sql .= <<<'SQL'
+                       idx.name AS key_name,
+                       col.name AS column_name,
+                       ~idx.is_unique AS non_unique,
+                       idx.is_primary_key AS [primary],
+                       CASE idx.type
+                           WHEN '1' THEN 'clustered'
+                           WHEN '2' THEN 'nonclustered'
+                           ELSE NULL
+                       END AS flags
+                FROM sys.tables AS tbl
+                JOIN sys.schemas AS scm
+                  ON tbl.schema_id = scm.schema_id
+                JOIN sys.indexes AS idx
+                  ON tbl.object_id = idx.object_id
+                JOIN sys.index_columns AS idxcol
+                  ON idx.object_id = idxcol.object_id
+                 AND idx.index_id = idxcol.index_id
+                JOIN sys.columns AS col
+                  ON idxcol.object_id = col.object_id
+                 AND idxcol.column_id = col.column_id
+SQL;
+
+        $conditions = [];
+        $params     = [];
+
+        if ($tableName !== null) {
+            $conditions[] = $this->getTableWhereClause($tableName, 'scm.name', 'tbl.name');
+            $sql         .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+
+        $sql .= ' ORDER BY idx.index_id, idxcol.key_ordinal';
+
+        return $this->_conn->executeQuery($sql, $params);
+    }
+
+    protected function selectDatabaseForeignKeys(string $databaseName, ?string $tableName = null): Result
+    {
+        $sql = 'SELECT';
+
+        if ($tableName === null) {
+            $sql .= ' OBJECT_NAME (f.parent_object_id),';
+        }
+
+        $sql .= <<<'SQL'
+                f.name AS ForeignKey,
+                SCHEMA_NAME (f.SCHEMA_ID) AS SchemaName,
+                OBJECT_NAME (f.parent_object_id) AS TableName,
+                COL_NAME (fc.parent_object_id,fc.parent_column_id) AS ColumnName,
+                SCHEMA_NAME (o.SCHEMA_ID) ReferenceSchemaName,
+                OBJECT_NAME (f.referenced_object_id) AS ReferenceTableName,
+                COL_NAME(fc.referenced_object_id,fc.referenced_column_id) AS ReferenceColumnName,
+                f.delete_referential_action_desc,
+                f.update_referential_action_desc
+                FROM sys.foreign_keys AS f
+                INNER JOIN sys.foreign_key_columns AS fc
+                INNER JOIN sys.objects AS o ON o.OBJECT_ID = fc.referenced_object_id
+                ON f.OBJECT_ID = fc.constraint_object_id
+SQL;
+
+        $conditions = [];
+        $params     = [];
+
+        if ($tableName !== null) {
+            $conditions[] = $this->getTableWhereClause(
+                $tableName,
+                'SCHEMA_NAME(f.schema_id)',
+                'OBJECT_NAME(f.parent_object_id)'
+            );
+
+            $sql .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+
+        $sql .= ' ORDER BY fc.constraint_column_id';
+
+        return $this->_conn->executeQuery($sql, $params);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDatabaseTableOptions(string $databaseName, ?string $tableName = null): array
+    {
+        $sql = <<<'SQL'
+          SELECT
+            tbl.name,
+            p.value AS [table_comment]
+          FROM
+            sys.tables AS tbl
+            INNER JOIN sys.extended_properties AS p ON p.major_id=tbl.object_id AND p.minor_id=0 AND p.class=1
+SQL;
+
+        $conditions = ["SCHEMA_NAME(tbl.schema_id) = N'dbo'", "p.name = N'MS_Description'"];
+        $params     = [];
+
+        if ($tableName !== null) {
+            $conditions[] = "tbl.name = N'" . $tableName . "'";
+        }
+
+        $sql .= ' WHERE ' . implode(' AND ', $conditions);
+
+        /** @var array<string,array<string,mixed>> $metadata */
+        $metadata = $this->_conn->executeQuery($sql, $params)
+            ->fetchAllAssociativeIndexed();
+
+        $tableOptions = [];
+        foreach ($metadata as $table => $data) {
+            $data = array_change_key_case($data, CASE_LOWER);
+
+            $tableOptions[$table] = [
+                'comment' => $data['table_comment'],
+            ];
+        }
+
+        return $tableOptions;
+    }
+
+    /**
+     * Returns the where clause to filter schema and table name in a query.
+     *
+     * @param string $table        The full qualified name of the table.
+     * @param string $schemaColumn The name of the column to compare the schema to in the where clause.
+     * @param string $tableColumn  The name of the column to compare the table to in the where clause.
+     */
+    private function getTableWhereClause($table, $schemaColumn, $tableColumn): string
+    {
+        if (strpos($table, '.') !== false) {
+            [$schema, $table] = explode('.', $table);
+            $schema           = $this->_platform->quoteStringLiteral($schema);
+            $table            = $this->_platform->quoteStringLiteral($table);
+        } else {
+            $schema = 'SCHEMA_NAME()';
+            $table  = $this->_platform->quoteStringLiteral($table);
+        }
+
+        return sprintf('(%s = %s AND %s = %s)', $tableColumn, $table, $schemaColumn, $schema);
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

Fixes #2676
Closes #2766
Closes #4882

### Change summary

If an entire schema needs to be introspected, instead of listing the tables and then introspecting each table individually, the new implementation fetches all schema objects of each type in one query and then groups them into tables. This reduces the number of queries used for introspection from _O_(_N_) (where _N_ is the number of tables in the schema) to _O_(1).

#### Design considerations

From the design standpoint, schema introspection deserves a separate API. Similar to the wrapper connection and the platform classes, the schema manager is already a God object.

Introducing a schema introspection API is the next logical step in improving the quality of the codebase but I decided not to do it now:

1. The performance aspect (which is the problem the API consumers are facing) could be addressed without changing the API.
2. There is a lot of technical debt that makes the introduction of such an API non-trivial (although there's nothing impossible, here's a [PoC](https://github.com/morozov/dbal/compare/optimize-list-tables...morozov:schema-introspection)).
3. The time I can spend on this right now is quite limited.

#### Proposed design

~~All common logic for introspecting the entire schema in one shot is implemented in the abstract schema manager class. In order to be able to introduce new abstract methods, we introduce a temporary internal `AbstractIntrospectingSchemaManager` and extend all concrete schema managers from it. This temporary class will be merged into `AbstractSchemaManager` in the next major release.~~ See https://github.com/doctrine/dbal/pull/5268#discussion_r806062501.

Instead of using the now deprecated `AbstractPlatform::getList*SQL()` methods, the schema managers build the queries themselves. This has the following advantages:

1. The logic of building queries and fetching their results is now more coherent (located within the schema manager).
2. This allows for using prepared statements in the schema introspection queries.
3. In the future, it will allow removing the column aliases like `SELECT COLUMN_NAME AS field` from the schema introspection queries since each schema manager will process the result of the query that it builds itself for itself.

### Performance considerations

From my previous experience with Oracle, the time a query against a schema introspection view takes doesn't depend that much on whether a single table or the entire schema is introspected. Introspecting N tables via an individual query each would take N times longer than introspecting them all at once.

In my development environment, the integration test suite takes ~40% less time to run with this change:
```
$ git checkout 3.4.x
$ phpunit -c oci8.phpunit.xml tests/Functional
PHPUnit 9.5.11 by Sebastian Bergmann and contributors.

...

Time: 01:50.276, Memory: 34.00 MB

$ git checkout optimize-list-tables
$ phpunit -c oci8.phpunit.xml tests/Functional

PHPUnit 9.5.11 by Sebastian Bergmann and contributors.

...

Time: 01:05.771, Memory: 34.00 MB
```

### Compatibility considerations

Depending on whether the `AbstractPlatform::getList*SQL()` methods are considered part of the SPI, the proposed changes may imply a BC break. If an API consumer uses a bundled platform and a schema manager and overrides one of these methods, the overridden logic will be no longer taken into account since the schema managers now use their own implementation.

Until the next major release, the implementation of the `AbstractPlatform::getList*SQL()` methods remains intact, tested but no longer used.

### Deprecations

The public Platform methods that generated SQL for introspecting a single table have been deprecated.

### Implementation details

**Changes in schema introspection logic**:
1. IBM DB2:
   1. Compare `COLSEQ` when joining referencing and referenced columns of a foreign key constraint. Otherwise, the query would return a product of the two sets and result in columns being returned out of order:
      ```
      1) Doctrine\DBAL\Tests\Functional\Schema\Db2SchemaManagerTest::testCreatedCompositeForeignKeyOrderIsCorrectAfterCreation
      Failed asserting that two arrays are identical.
      --- Expected
      +++ Actual
      @@ @@
       Array &0 (
      -    0 => 'col2'
      -    1 => 'col1'
      +    0 => 'col1'
      +    1 => 'col2'
       )
      ```
      **Before**: https://github.com/doctrine/dbal/blob/699aad821664393bea16d8ae5c434492ff998efb/src/Platforms/DB2Platform.php#L410-L413
      **After**: https://github.com/doctrine/dbal/blob/699aad821664393bea16d8ae5c434492ff998efb/src/Schema/DB2SchemaManager.php#L350-L354
   2. Added the `WHERE TABSCHEMA = <database>` clause to the column, index, etc. introspection queries. Otherwise, they might return objects from other schemas.
   3. Removed the "We do the funky subquery […]" logic. It existed to have a `DISTINCT` clause in the query (which is rarely a good idea) which in turn was used to select the columns that weren't used anywhere.

**TODO**:

- [x] Document semantics of `AbstractIntrospectingSchemaManager::normalizeIdentifier()`.
- [x] Document the new API and the design decisions.