### PR TITLE
Run static analysis jobs on PHP 8.1

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.0"
+          - "8.1"
 
     steps:
       - name: "Checkout code"
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.0"
+          - "8.1"
 
     steps:
       - name: Checkout code

--- a/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
+++ b/lib/Doctrine/DBAL/Cache/ResultCacheStatement.php
@@ -301,7 +301,7 @@ class ResultCacheStatement implements IteratorAggregate, ResultStatement, Result
      * this behaviour is not guaranteed for all databases and should not be
      * relied on for portable applications.
      *
-     * @return int The number of rows.
+     * @return int|string The number of rows.
      */
     public function rowCount()
     {

--- a/lib/Doctrine/DBAL/Connection.php
+++ b/lib/Doctrine/DBAL/Connection.php
@@ -799,7 +799,7 @@ class Connection implements DriverConnection
      * @param array<string, mixed>                                                 $criteria Deletion criteria
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
      *
      * @throws Exception
      */
@@ -835,7 +835,7 @@ class Connection implements DriverConnection
      *
      * @param int $level The level to set.
      *
-     * @return int
+     * @return int|string
      */
     public function setTransactionIsolation($level)
     {
@@ -868,7 +868,7 @@ class Connection implements DriverConnection
      * @param array<string, mixed>                                                 $criteria Update criteria
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
      *
      * @throws Exception
      */
@@ -903,7 +903,7 @@ class Connection implements DriverConnection
      * @param array<string, mixed>                                                 $data  Column-value pairs
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types Parameter types
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
      *
      * @throws Exception
      */
@@ -1472,7 +1472,7 @@ class Connection implements DriverConnection
      * @param array<int, mixed>|array<string, mixed>                               $params Statement parameters
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
      *
      * @throws Exception
      */
@@ -1503,7 +1503,7 @@ class Connection implements DriverConnection
      * @param array<int, mixed>|array<string, mixed>                               $params Statement parameters
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
      *
      * @throws Exception
      */
@@ -1556,7 +1556,7 @@ class Connection implements DriverConnection
      *
      * @param string $sql
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
      *
      * @throws Exception
      */

--- a/lib/Doctrine/DBAL/Driver/Connection.php
+++ b/lib/Doctrine/DBAL/Driver/Connection.php
@@ -43,7 +43,7 @@ interface Connection
      *
      * @param string $sql
      *
-     * @return int
+     * @return int|string
      */
     public function exec($sql);
 

--- a/lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionFailed.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionFailed.php
@@ -9,6 +9,8 @@ use mysqli;
 use mysqli_sql_exception;
 use ReflectionProperty;
 
+use function assert;
+
 /**
  * @internal
  *
@@ -18,7 +20,10 @@ final class ConnectionFailed extends MysqliException
 {
     public static function new(mysqli $connection): self
     {
-        return new self($connection->connect_error, 'HY000', $connection->connect_errno);
+        $error = $connection->connect_error;
+        assert($error !== null);
+
+        return new self($error, 'HY000', $connection->connect_errno);
     }
 
     public static function upcast(mysqli_sql_exception $exception): self

--- a/lib/Doctrine/DBAL/Driver/Result.php
+++ b/lib/Doctrine/DBAL/Driver/Result.php
@@ -70,7 +70,7 @@ interface Result
      * some database drivers may return the number of rows returned by that query. However, this behaviour
      * is not guaranteed for all drivers and should not be relied on in portable applications.
      *
-     * @return int The number of rows.
+     * @return int|string The number of rows.
      */
     public function rowCount();
 

--- a/lib/Doctrine/DBAL/Driver/Statement.php
+++ b/lib/Doctrine/DBAL/Driver/Statement.php
@@ -103,7 +103,7 @@ interface Statement extends ResultStatement
      * this behaviour is not guaranteed for all databases and should not be
      * relied on for portable applications.
      *
-     * @return int The number of rows.
+     * @return int|string The number of rows.
      */
     public function rowCount();
 }

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -201,7 +201,7 @@ class QueryBuilder
     /**
      * Executes this query using the bound parameters and their types.
      *
-     * @return ForwardCompatibility\Result|int
+     * @return ForwardCompatibility\Result|int|string
      *
      * @throws Exception
      */

--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -779,7 +779,7 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /**
      * Returns the number of rows affected by the last execution of this statement.
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
      */
     public function rowCount()
     {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -125,3 +125,10 @@ parameters:
             message: '~^Parameter #2 \$code of class RuntimeException constructor expects int, string given\.$~'
             paths:
                 - lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php
+
+        # Fixing the issue would cause a BC break.
+        # TODO: fix in 4.0.0
+        -
+            message: '~^Method Doctrine\\DBAL\\Statement::executeStatement\(\) should return int but returns int\|string\.$~'
+            paths:
+                - lib/Doctrine/DBAL/Statement.php

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -402,10 +402,24 @@
                 <file name="tests/Doctrine/Tests/DBAL/DriverManagerTest.php"/>
             </errorLevel>
         </InvalidArgument>
+        <InvalidReturnStatement>
+            <errorLevel type="suppress">
+                <!-- lastInsertId has a return type that does not match the one defined in the interface-->
+                <file name="lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php"/>
+                <!--
+                    This issue should be fixed in 4.0
+                -->
+                <file name="lib/Doctrine/DBAL/Statement.php"/>
+            </errorLevel>
+        </InvalidReturnStatement>
         <InvalidReturnType>
             <errorLevel type="suppress">
                 <!-- lastInsertId has a return type that does not match the one defined in the interface-->
                 <file name="lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php"/>
+                <!--
+                    This issue should be fixed in 4.0
+                -->
+                <file name="lib/Doctrine/DBAL/Statement.php"/>
             </errorLevel>
         </InvalidReturnType>
         <InvalidScalarArgument>
@@ -439,11 +453,5 @@
                 <referencedFunction name="db2_autocommit"/>
             </errorLevel>
         </InvalidScalarArgument>
-        <InvalidReturnStatement>
-            <errorLevel type="suppress">
-                <!-- lastInsertId has a return type that does not match the one defined in the interface-->
-                <file name="lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php"/>
-            </errorLevel>
-        </InvalidReturnStatement>
     </issueHandlers>
 </psalm>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -309,6 +309,14 @@
                 <file name="lib/Doctrine/DBAL/Schema/View.php"/>
             </errorLevel>
         </PropertyNotSetInConstructor>
+        <RedundantCondition>
+            <errorLevel type="suppress">
+                <!--
+                    See https://github.com/vimeo/psalm/pull/7660
+                -->
+                <file name="lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionFailed.php"/>
+            </errorLevel>
+        </RedundantCondition>
         <!-- This is necessary pre 4.0  -->
         <RedundantCastGivenDocblockType>
             <errorLevel type="suppress">


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

Currently, PHPStan fails on PHP 8.1 since the code doesn't take some recent PHP documentation changes into account:

1. [`mysql::connect_error`](https://www.php.net/manual/en/mysqli.connect-error.php) is nullable.
2. [`mysqli_stmt::affected_rows`](https://www.php.net/manual/en/mysqli.affected-rows.php) may contain a string. Addressing this issue requires a BC break, e.g. here: https://github.com/doctrine/dbal/blob/ae37075ed2fed080abd30ca32c8f0c872ad7313b/lib/Doctrine/DBAL/Statement.php#L220