### PR TITLE
Return number of affected rows greater than PHP_INT_MAX as string

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+# BC Break: The number of affected rows is returned as `int|string`
+
+The signatures of the methods returning the number of affected rows changed as returning `int|string` instead of `int`.
+
 # BC Break: Dropped support for `collate` option for MySQL
 
 Use `collation` instead.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -97,13 +97,6 @@ parameters:
             message: '~^Parameter #2 \$lockMode of method Doctrine\\DBAL\\Platforms\\AbstractPlatform\:\:appendLockHint\(\) expects 0\|1\|2\|4, 128 given\.$~'
             path: tests/Platforms/AbstractPlatformTestCase.php
 
-        # Fixing the issue would cause a BC break.
-        # TODO: fix in 4.0.0
-        -
-            message: '~^Method Doctrine\\DBAL\\Driver\\Mysqli\\Connection::exec\(\) should return int but returns int\|string\.$~'
-            paths:
-                - src/Driver/Mysqli/Connection.php
-
         # DriverManagerTest::testDatabaseUrl() should be refactored as it's too dynamic.
         -
             message: '~^Offset string does not exist on array{.+}\.$~'

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -482,11 +482,11 @@ class Connection implements ServerVersionProvider
      * @param array<string, mixed>                                                 $criteria Deletion criteria
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
      *
      * @throws Exception
      */
-    public function delete(string $table, array $criteria, array $types = []): int
+    public function delete(string $table, array $criteria, array $types = []): int|string
     {
         if (count($criteria) === 0) {
             throw EmptyCriteriaNotAllowed::new();
@@ -551,11 +551,11 @@ class Connection implements ServerVersionProvider
      * @param array<string, mixed>                                                 $criteria Update criteria
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
      *
      * @throws Exception
      */
-    public function update(string $table, array $data, array $criteria, array $types = []): int
+    public function update(string $table, array $data, array $criteria, array $types = []): int|string
     {
         $columns = $values = $conditions = $set = [];
 
@@ -585,11 +585,11 @@ class Connection implements ServerVersionProvider
      * @param array<string, mixed>                                                 $data  Column-value pairs
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types Parameter types
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
      *
      * @throws Exception
      */
-    public function insert(string $table, array $data, array $types = []): int
+    public function insert(string $table, array $data, array $types = []): int|string
     {
         if (count($data) === 0) {
             return $this->executeStatement('INSERT INTO ' . $table . ' () VALUES ()');
@@ -950,7 +950,7 @@ class Connection implements ServerVersionProvider
      *
      * @throws Exception
      */
-    public function executeStatement(string $sql, array $params = [], array $types = []): int
+    public function executeStatement(string $sql, array $params = [], array $types = []): int|string
     {
         $connection = $this->connect();
 
@@ -1496,7 +1496,7 @@ class Connection implements ServerVersionProvider
      *
      * @throws Exception
      */
-    public function executeUpdate(string $sql, array $params = [], array $types = []): int
+    public function executeUpdate(string $sql, array $params = [], array $types = []): int|string
     {
         return $this->executeStatement($sql, $params, $types);
     }
@@ -1516,7 +1516,7 @@ class Connection implements ServerVersionProvider
      *
      * @deprecated This API is deprecated and will be removed after 2022
      */
-    public function exec(string $sql): int
+    public function exec(string $sql): int|string
     {
         return $this->executeStatement($sql);
     }

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -264,7 +264,7 @@ class PrimaryReadReplicaConnection extends Connection
     /**
      * {@inheritDoc}
      */
-    public function executeStatement(string $sql, array $params = [], array $types = []): int
+    public function executeStatement(string $sql, array $params = [], array $types = []): int|string
     {
         $this->ensureConnectedToPrimary();
 

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -39,7 +39,7 @@ interface Connection extends ServerVersionProvider
      *
      * @throws Exception
      */
-    public function exec(string $sql): int;
+    public function exec(string $sql): int|string;
 
     /**
      * Returns the ID of the last inserted row.

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -70,7 +70,7 @@ final class Connection implements ConnectionInterface
         return "'" . db2_escape_string($value) . "'";
     }
 
-    public function exec(string $sql): int
+    public function exec(string $sql): int|string
     {
         $stmt = @db2_exec($this->connection, $sql);
 

--- a/src/Driver/Middleware/AbstractConnectionMiddleware.php
+++ b/src/Driver/Middleware/AbstractConnectionMiddleware.php
@@ -32,7 +32,7 @@ abstract class AbstractConnectionMiddleware implements Connection
         return $this->wrappedConnection->quote($value);
     }
 
-    public function exec(string $sql): int
+    public function exec(string $sql): int|string
     {
         return $this->wrappedConnection->exec($sql);
     }

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -57,7 +57,7 @@ final class Connection implements ConnectionInterface
         return "'" . $this->connection->escape_string($value) . "'";
     }
 
-    public function exec(string $sql): int
+    public function exec(string $sql): int|string
     {
         try {
             $result = $this->connection->query($sql);

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -88,7 +88,7 @@ final class Connection implements ConnectionInterface
      * @throws Exception
      * @throws Parser\Exception
      */
-    public function exec(string $sql): int
+    public function exec(string $sql): int|string
     {
         return $this->prepare($sql)->execute()->rowCount();
     }

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -27,7 +27,7 @@ final class Connection implements ConnectionInterface
         $this->connection = $connection;
     }
 
-    public function exec(string $sql): int
+    public function exec(string $sql): int|string
     {
         try {
             $result = $this->connection->exec($sql);

--- a/src/Driver/SQLSrv/Connection.php
+++ b/src/Driver/SQLSrv/Connection.php
@@ -53,7 +53,7 @@ final class Connection implements ConnectionInterface
         return "'" . str_replace("'", "''", $value) . "'";
     }
 
-    public function exec(string $sql): int
+    public function exec(string $sql): int|string
     {
         $stmt = sqlsrv_query($this->connection, $sql);
 

--- a/src/Logging/Connection.php
+++ b/src/Logging/Connection.php
@@ -45,7 +45,7 @@ final class Connection extends AbstractConnectionMiddleware
         return parent::query($sql);
     }
 
-    public function exec(string $sql): int
+    public function exec(string $sql): int|string
     {
         $this->logger->debug('Executing statement: {sql}', ['sql' => $sql]);
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -341,11 +341,11 @@ class QueryBuilder
      *
      * Should be used for INSERT, UPDATE and DELETE
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
      *
      * @throws Exception
      */
-    public function executeStatement(): int
+    public function executeStatement(): int|string
     {
         return $this->connection->executeStatement($this->getSQL(), $this->params, $this->paramTypes);
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

If the number of affected rows is greater than `PHP_INT_MAX`, it should be returned as a string.