### PR TITLE
Assert that the comparator should migrate collation

### DIFF
--- a/tests/Platforms/MySQL/ComparatorTest.php
+++ b/tests/Platforms/MySQL/ComparatorTest.php
@@ -4,12 +4,34 @@ namespace Doctrine\DBAL\Tests\Platforms\MySQL;
 
 use Doctrine\DBAL\Platforms\MySQL\Comparator;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Schema\ComparatorTest as BaseComparatorTest;
+use Doctrine\DBAL\Types\Type;
 
 class ComparatorTest extends BaseComparatorTest
 {
     protected function setUp(): void
     {
         $this->comparator = new Comparator(new MySQLPlatform());
+    }
+
+    public function testItMigratesUtf8ToUtf8Mb4(): void
+    {
+        $fromSchema = new Schema([
+            new Table('a_table', [
+                new Column('a_column', Type::getType('string')),
+            ], [], [], [], ['collation' => 'utf8_unicode_ci', 'charset' => 'utf8']),
+        ]);
+        $toSchema   = new Schema([
+            new Table('a_table', [
+                new Column('a_column', Type::getType('string')),
+            ], [], [], [], ['collation' => 'utf8_mb4_unicode_ci', 'charset' => 'utf8mb4']),
+        ]);
+
+        self::assertNotEmpty(
+            $this->comparator->compare($fromSchema, $toSchema)->toSql(new MySQLPlatform())
+        );
     }
 }


### PR DESCRIPTION
While trying to figure out what was going on in https://github.com/doctrine/DoctrineBundle/pull/1471 , I remembered that `utf8` is deprecated and not really supposed to be used. @floviolleau seems to be experiencing 2 problems:
1. `up()` and `down()` are not symmetrical
2. `up()` is empty

This failing test case tries to reproduce 2. 

Also, I'm a bit surprised because according to this test, we are supposed to default to `utf8`: https://github.com/doctrine/dbal/blob/7ac309579ac0a14e525144229c8feebf79e8d1e7/tests/Schema/MySQLInheritCharsetTest.php#L49-L56

This does not sound like a sensible default, maybe it's here for backward-compatibility reasons?