### PR TITLE
Recommend a better charset by default

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -61,15 +61,15 @@ following simplified driver names that serve as aliases:
 -  ``sqlite``/``sqlite3``: alias for ``pdo_sqlite``
 
 For example, to connect to a "foo" MySQL DB using the ``pdo_mysql``
-driver on localhost port 4486 with the charset set to UTF-8, you
-would use the following URL::
+driver on localhost port 4486 with the "charset" option set to ``utf8mb4``,
+you would use the following URL::
 
-    mysql://localhost:4486/foo?charset=UTF8
+    mysql://localhost:4486/foo?charset=utf8mb4
 
 This is identical to the following connection string using the
 full driver name::
 
-    pdo-mysql://localhost:4486/foo?charset=UTF8
+    pdo-mysql://localhost:4486/foo?charset=utf8mb4
 
 In the example above, mind the dashes instead of the
 underscores in the URL scheme.


### PR DESCRIPTION
In MySQL, `utf8` is an alias for `utf8mb3`, which is not really utf8 since
it only uses 3 bytes.
As a result `utf8` has been deprecated and should not be used.
See https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8.html

Disclaimer: I am by no means a MySQL specialist, and find it a bit surprising that this hasn't been changed for such a long time (it was introduced in 59e17b53e39943884e37249a87fc09444f8dcd25 , 6 years ago).

Note that from my understanding, this will not affect the charset of new tables.

EDIT: it looks like I understood wrong:

https://github.com/doctrine/dbal/blob/7ac309579ac0a14e525144229c8feebf79e8d1e7/src/Schema/AbstractSchemaManager.php#L1256-L1258

Introduced in #3003