### PR TITLE
Declare abstract AbstractSchemaManager methods as such

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,17 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## Abstract methods in the `AbstractSchemaManager` class have been declared as `abstract`
+
+The following abstract methods in the `AbstractSchemaManager` class have been declared as `abstract`:
+
+- `selectDatabaseColumns()`,
+- `selectDatabaseIndexes()`,
+- `selectDatabaseForeignKeys()`,
+- `getDatabaseTableOptions()`.
+
+Every non-abstract schema manager class must implement them in order to satisfy the API.
+
 # BC Break: The number of affected rows is returned as `int|string`
 
 The signatures of the methods returning the number of affected rows changed as returning `int|string` instead of `int`.

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -220,23 +220,6 @@ abstract class AbstractSchemaManager
      */
     public function listTables(): array
     {
-        $tableNames = $this->listTableNames();
-
-        $tables = [];
-        foreach ($tableNames as $tableName) {
-            $tables[] = $this->listTableDetails($tableName);
-        }
-
-        return $tables;
-    }
-
-    /**
-     * @return list<Table>
-     *
-     * @throws Exception
-     */
-    protected function doListTables(): array
-    {
         $currentDatabase = $this->_conn->getDatabase();
 
         if ($currentDatabase === null) {
@@ -282,23 +265,6 @@ abstract class AbstractSchemaManager
      * @throws Exception
      */
     public function listTableDetails(string $name): Table
-    {
-        $columns     = $this->listTableColumns($name);
-        $foreignKeys = [];
-
-        if ($this->_platform->supportsForeignKeyConstraints()) {
-            $foreignKeys = $this->listTableForeignKeys($name);
-        }
-
-        $indexes = $this->listTableIndexes($name);
-
-        return new Table($name, $columns, $indexes, [], $foreignKeys, []);
-    }
-
-    /**
-     * @throws Exception
-     */
-    protected function doListTableDetails(string $name): Table
     {
         $currentDatabase = $this->_conn->getDatabase();
 
@@ -353,13 +319,8 @@ abstract class AbstractSchemaManager
      * the selection to this table.
      *
      * @throws Exception
-     *
-     * @abstract
      */
-    protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result
-    {
-        throw NotSupported::new(__METHOD__);
-    }
+    abstract protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result;
 
     /**
      * Selects index definitions of the tables in the specified database. If the table name is specified, narrows down
@@ -367,10 +328,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    protected function selectDatabaseIndexes(string $databaseName, ?string $tableName = null): Result
-    {
-        throw NotSupported::new(__METHOD__);
-    }
+    abstract protected function selectDatabaseIndexes(string $databaseName, ?string $tableName = null): Result;
 
     /**
      * Selects foreign key definitions of the tables in the specified database. If the table name is specified,
@@ -378,10 +336,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    protected function selectDatabaseForeignKeys(string $databaseName, ?string $tableName = null): Result
-    {
-        throw NotSupported::new(__METHOD__);
-    }
+    abstract protected function selectDatabaseForeignKeys(string $databaseName, ?string $tableName = null): Result;
 
     /**
      * Returns table options for the tables in the specified database. If the table name is specified, narrows down
@@ -391,10 +346,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    protected function getDatabaseTableOptions(string $databaseName, ?string $tableName = null): array
-    {
-        throw NotSupported::new(__METHOD__);
-    }
+    abstract protected function getDatabaseTableOptions(string $databaseName, ?string $tableName = null): array;
 
     /**
      * Lists the views this connection has.

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -44,19 +44,6 @@ class DB2SchemaManager extends AbstractSchemaManager
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function listTables(): array
-    {
-        return $this->doListTables();
-    }
-
-    public function listTableDetails(string $name): Table
-    {
-        return $this->doListTableDetails($name);
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @throws Exception

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -51,19 +51,6 @@ class MySQLSchemaManager extends AbstractSchemaManager
     ];
 
     /**
-     * {@inheritDoc}
-     */
-    public function listTables(): array
-    {
-        return $this->doListTables();
-    }
-
-    public function listTableDetails(string $name): Table
-    {
-        return $this->doListTableDetails($name);
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function _getPortableViewDefinition(array $view): View

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -32,19 +32,6 @@ use const CASE_LOWER;
 class OracleSchemaManager extends AbstractSchemaManager
 {
     /**
-     * {@inheritDoc}
-     */
-    public function listTables(): array
-    {
-        return $this->doListTables();
-    }
-
-    public function listTableDetails(string $name): Table
-    {
-        return $this->doListTableDetails($name);
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function _getPortableViewDefinition(array $view): View

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -39,19 +39,6 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    public function listTables(): array
-    {
-        return $this->doListTables();
-    }
-
-    public function listTableDetails(string $name): Table
-    {
-        return $this->doListTableDetails($name);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function listSchemaNames(): array
     {
         return $this->_conn->fetchFirstColumn(

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -37,19 +37,6 @@ class SQLServerSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    public function listTables(): array
-    {
-        return $this->doListTables();
-    }
-
-    public function listTableDetails(string $name): Table
-    {
-        return $this->doListTableDetails($name);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function listSchemaNames(): array
     {
         return $this->_conn->fetchFirstColumn(

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -41,19 +41,6 @@ use const CASE_LOWER;
  */
 class SqliteSchemaManager extends AbstractSchemaManager
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function listTables(): array
-    {
-        return $this->doListTables();
-    }
-
-    public function listTableDetails(string $name): Table
-    {
-        return $this->doListTableDetails($name);
-    }
-
     public function renameTable(string $name, string $newName): void
     {
         $tableDiff            = new TableDiff($name);


### PR DESCRIPTION
This patch removes the backward compatibility layer introduced in https://github.com/doctrine/dbal/pull/5268.