### PR TITLE
MariaDB 5.5.5 transport prefix hack is stripped in recent PHP releases

### DIFF
--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -95,7 +95,7 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
 
     /**
      * Detect MariaDB server version, including hack for some mariadb distributions
-     * that starts with the prefix '5.5.5-'
+     * that starts with the prefix '5.5.5-' (fixed since PHP 8.0.16/8.1.3)
      *
      * @param string $versionString Version string as returned by mariadb server, i.e. '5.5.5-Mariadb-10.0.8-xenial'
      *


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

related to:
- fix https://github.com/php/php-src/commit/5fc0db989ea6fdc4a37ed60216cdba751da6fde6
- issue https://github.com/doctrine/dbal/issues/5170
- fix for older PHP releases https://github.com/doctrine/dbal/pull/5177