### PR TITLE
Deprecate passing $database to AbstractSchemaManager::list*()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,16 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `$database` parameter of `AbstractSchemaManager::list*()` methods
+
+Passing `$database` to the following methods has been deprecated:
+
+- `AbstractSchemaManager::listSequences()`,
+- `AbstractSchemaManager::listTableColumns()`,
+- `AbstractSchemaManager::listTableForeignKeys()`.
+
+Only introspection of the current database will be supported in DBAL 4.0.
+
 ## Deprecated `AbstractPlatform` schema introspection methods
 
 The following schema introspection methods have been deprecated:

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -217,7 +217,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $schemaManager->createTable($otherTable);
         $connection->close();
 
-        $columns = $this->schemaManager->listTableColumns($table->getName(), $this->connection->getDatabase());
+        $columns = $this->schemaManager->listTableColumns($table->getName());
         self::assertCount(7, $columns);
     }
 


### PR DESCRIPTION
See #5284.

Testing the support for introspecting multiple databases is non-trivial since the DBAL doesn't have an API for changing the database on an existing connection. This feature never worked properly and doesn't have a single related bug.