### PR TITLE
Remove $database from AbstractSchemaManager::list*() methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## Removed support for the `$database` parameter of `AbstractSchemaManager::list*()` methods
+
+Passing `$database` to the following methods is no longer supported:
+
+- `AbstractSchemaManager::listSequences()`,
+- `AbstractSchemaManager::listTableColumns()`,
+- `AbstractSchemaManager::listTableForeignKeys()`.
+
 ## Removed `AbstractPlatform` schema introspection methods
 
 The following schema introspection methods have been removed:

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -13,7 +13,6 @@ use Doctrine\DBAL\Exception\DatabaseRequired;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Result;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
 use function array_intersect;
@@ -98,17 +97,9 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listSequences(?string $database = null): array
+    public function listSequences(): array
     {
-        if ($database === null) {
-            $database = $this->getDatabase(__METHOD__);
-        } else {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/issues/5284',
-                'Passing $database to AbstractSchemaManager::listSequences() is deprecated.'
-            );
-        }
+        $database = $this->getDatabase(__METHOD__);
 
         $sql = $this->_platform->getListSequencesSQL($database);
 
@@ -131,17 +122,9 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listTableColumns(string $table, ?string $database = null): array
+    public function listTableColumns(string $table): array
     {
-        if ($database === null) {
-            $database = $this->getDatabase(__METHOD__);
-        } else {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/issues/5284',
-                'Passing $database to AbstractSchemaManager::listTableColumns() is deprecated.'
-            );
-        }
+        $database = $this->getDatabase(__METHOD__);
 
         return $this->_getPortableTableColumnList(
             $table,
@@ -292,7 +275,7 @@ abstract class AbstractSchemaManager
 
         return new Table(
             $name,
-            $this->listTableColumns($name, $database),
+            $this->listTableColumns($name),
             $this->listTableIndexes($name),
             [],
             $foreignKeys,
@@ -368,17 +351,9 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listTableForeignKeys(string $table, ?string $database = null): array
+    public function listTableForeignKeys(string $table): array
     {
-        if ($database === null) {
-            $database = $this->getDatabase(__METHOD__);
-        } else {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/issues/5284',
-                'Passing $database to AbstractSchemaManager::listTableForeignKeys() is deprecated.'
-            );
-        }
+        $database = $this->getDatabase(__METHOD__);
 
         return $this->_getPortableTableForeignKeysList(
             $this->selectDatabaseForeignKeys(

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -93,7 +93,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritdoc}
      */
-    public function listTableForeignKeys(string $table, ?string $database = null): array
+    public function listTableForeignKeys(string $table): array
     {
         $tableForeignKeys = $this->selectDatabaseForeignKeys('', $this->normalizeName($table))
             ->fetchAllAssociative();


### PR DESCRIPTION
Previously deprecated in #5287.

Fixes #5284.