### PR TITLE
Modernize array syntax used in code examples

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -11,13 +11,13 @@ You can get a DBAL Connection through the
 
     <?php
     //..
-    $connectionParams = array(
+    $connectionParams = [
         'dbname' => 'mydb',
         'user' => 'user',
         'password' => 'secret',
         'host' => 'localhost',
         'driver' => 'pdo_mysql',
-    );
+    ];
     $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams);
 
 Or, using the simpler URL form:
@@ -26,9 +26,9 @@ Or, using the simpler URL form:
 
     <?php
     //..
-    $connectionParams = array(
+    $connectionParams = [
         'url' => 'mysql://user:secret@localhost/mydb',
-    );
+    ];
     $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams);
 
 The ``DriverManager`` returns an instance of

--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -238,7 +238,7 @@ Since you are using an ``IN`` expression you would really like to use it in the 
     <?php
     $stmt = $conn->prepare('SELECT * FROM articles WHERE id IN (?)');
     // THIS WILL NOT WORK:
-    $stmt->bindValue(1, array(1, 2, 3, 4, 5, 6));
+    $stmt->bindValue(1, [1, 2, 3, 4, 5, 6]);
     $resultSet = $stmt->executeQuery();
 
 Implementing a generic way to handle this kind of query is tedious work. This is why most
@@ -260,8 +260,8 @@ the SQL and flattens the specified values into the set of parameters. Consider o
 
     <?php
     $stmt = $conn->executeQuery('SELECT * FROM articles WHERE id IN (?)',
-        array(array(1, 2, 3, 4, 5, 6)),
-        array(\Doctrine\DBAL\Connection::PARAM_INT_ARRAY)
+        [[1, 2, 3, 4, 5, 6]],
+        [\Doctrine\DBAL\Connection::PARAM_INT_ARRAY]
     );
 
 The SQL statement passed to ``Connection#executeQuery`` is not the one actually passed to the
@@ -273,15 +273,15 @@ be specified as well:
     <?php
     // Same SQL WITHOUT usage of Doctrine\DBAL\Connection::PARAM_INT_ARRAY
     $stmt = $conn->executeQuery('SELECT * FROM articles WHERE id IN (?, ?, ?, ?, ?, ?)',
-        array(1, 2, 3, 4, 5, 6),
-        array(
+        [1, 2, 3, 4, 5, 6],
+        [
             ParameterType::INTEGER,
             ParameterType::INTEGER,
             ParameterType::INTEGER,
             ParameterType::INTEGER,
             ParameterType::INTEGER,
             ParameterType::INTEGER,
-        )
+        ]
     );
 
 This is much more complicated and is ugly to write generically.
@@ -335,7 +335,7 @@ returns the affected rows count:
 .. code-block:: php
 
     <?php
-    $count = $conn->executeStatement('UPDATE user SET username = ? WHERE id = ?', array('jwage', 1));
+    $count = $conn->executeStatement('UPDATE user SET username = ? WHERE id = ?', ['jwage', 1]);
     echo $count; // 1
 
 The ``$types`` variable contains the PDO or Doctrine Type constants
@@ -352,7 +352,7 @@ parameters to the executeQuery method, then returning the result set:
 .. code-block:: php
 
     <?php
-    $resultSet = $conn->executeQuery('SELECT * FROM user WHERE username = ?', array('jwage'));
+    $resultSet = $conn->executeQuery('SELECT * FROM user WHERE username = ?', ['jwage']);
     $user = $resultSet->fetchAssociative();
 
     /*
@@ -433,7 +433,7 @@ Numeric index retrieval of first result row of the given query:
 .. code-block:: php
 
     <?php
-    $user = $conn->fetchNumeric('SELECT * FROM user WHERE username = ?', array('jwage'));
+    $user = $conn->fetchNumeric('SELECT * FROM user WHERE username = ?', ['jwage']);
 
     /*
     array(
@@ -450,7 +450,7 @@ Retrieve only the value of the first column of the first result row.
 .. code-block:: php
 
     <?php
-    $username = $conn->fetchOne('SELECT username FROM user WHERE id = ?', array(1), 0);
+    $username = $conn->fetchOne('SELECT username FROM user WHERE id = ?', [1], 0);
     echo $username; // jwage
 
 fetchAssociative()
@@ -461,7 +461,7 @@ Retrieve associative array of the first result row.
 .. code-block:: php
 
     <?php
-    $user = $conn->fetchAssociative('SELECT * FROM user WHERE username = ?', array('jwage'));
+    $user = $conn->fetchAssociative('SELECT * FROM user WHERE username = ?', ['jwage']);
     /*
     array(
       'username' => 'jwage',
@@ -508,7 +508,7 @@ keys are column names.
 .. code-block:: php
 
     <?php
-    $conn->delete('user', array('id' => 1));
+    $conn->delete('user', ['id' => 1]);
     // DELETE FROM user WHERE id = ? (1)
 
 insert()
@@ -520,7 +520,7 @@ data.
 .. code-block:: php
 
     <?php
-    $conn->insert('user', array('username' => 'jwage'));
+    $conn->insert('user', ['username' => 'jwage']);
     // INSERT INTO user (username) VALUES (?) (jwage)
 
 update()
@@ -532,5 +532,5 @@ given data.
 .. code-block:: php
 
     <?php
-    $conn->update('user', array('username' => 'jwage'), array('id' => 1));
+    $conn->update('user', ['username' => 'jwage'], ['id' => 1]);
     // UPDATE user (username) VALUES (?) WHERE id = ? (jwage, 1)

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -31,9 +31,9 @@ instance passed to the Connection factory:
 
     <?php
     $evm = new EventManager();
-    $evm->addEventSubscriber(new OracleSessionInit(array(
+    $evm->addEventSubscriber(new OracleSessionInit([
         'NLS_TIME_FORMAT' => 'HH24:MI:SS',
-    )));
+    ]));
 
     $conn = DriverManager::getConnection($connectionParams, null, $evm);
 
@@ -59,7 +59,7 @@ methods must be named like the events itself.
 
     <?php
     $evm = new EventManager();
-    $eventNames = array(Events::onSchemaCreateTable, Events::onSchemaCreateTableColumn);
+    $eventNames = [Events::onSchemaCreateTable, Events::onSchemaCreateTableColumn];
     $evm->addEventListener($eventNames, new MyEventListener());
 
 The following events are available.

--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -81,11 +81,11 @@ an instance of the platform you want the connection to use:
 
     <?php
     $myPlatform = new MyPlatform();
-    $options = array(
+    $options = [
         'driver' => 'pdo_sqlite',
         'path' => 'database.sqlite',
-        'platform' => $myPlatform
-    );
+        'platform' => $myPlatform,
+    ];
     $conn = DriverManager::getConnection($options);
 
 This way you can optimize your schema or generated SQL code with

--- a/docs/en/reference/portability.rst
+++ b/docs/en/reference/portability.rst
@@ -55,13 +55,13 @@ Using the following code block in your initialization will:
     use Doctrine\DBAL\ColumnCase;
     use Doctrine\DBAL\Portability\Connection as PortableConnection;
 
-    $params = array(
+    $params = [
         // vendor specific configuration
         //...
         'wrapperClass' => PortableConnection::class,
         'portability'  => PortableConnection::PORTABILITY_ALL,
         'fetch_case'   => ColumnCase::LOWER,
-    );
+    ];
 
 This sort of portability handling is pretty expensive because all the result
 rows and columns have to be looped inside PHP before being returned to you.

--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -11,7 +11,7 @@ You can access the QueryBuilder by calling ``Doctrine\DBAL\Connection#createQuer
 
     <?php
 
-    $conn = DriverManager::getConnection(array(/*..*/));
+    $conn = DriverManager::getConnection([/*..*/]);
     $queryBuilder = $conn->createQueryBuilder();
 
 Security: Safely preventing SQL Injection
@@ -233,10 +233,10 @@ done with the ``values()`` method on the query builder:
     $queryBuilder
         ->insert('users')
         ->values(
-            array(
+            [
                 'name' => '?',
-                'password' => '?'
-            )
+                'password' => '?',
+            ]
         )
         ->setParameter(0, $username)
         ->setParameter(1, $password)
@@ -269,9 +269,9 @@ Of course you can also use both methods in combination:
     $queryBuilder
         ->insert('users')
         ->values(
-            array(
-                'name' => '?'
-            )
+            [
+                'name' => '?',
+            ]
         )
         ->setParameter(0, $username)
     ;

--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -24,17 +24,17 @@ example shows:
     <?php
     $schema = new \Doctrine\DBAL\Schema\Schema();
     $myTable = $schema->createTable("my_table");
-    $myTable->addColumn("id", "integer", array("unsigned" => true));
-    $myTable->addColumn("username", "string", array("length" => 32));
-    $myTable->setPrimaryKey(array("id"));
-    $myTable->addUniqueIndex(array("username"));
+    $myTable->addColumn("id", "integer", ["unsigned" => true]);
+    $myTable->addColumn("username", "string", ["length" => 32]);
+    $myTable->setPrimaryKey(["id"]);
+    $myTable->addUniqueIndex(["username"]);
     $myTable->setComment('Some comment');
     $schema->createSequence("my_table_seq");
 
     $myForeign = $schema->createTable("my_foreign");
     $myForeign->addColumn("id", "integer");
     $myForeign->addColumn("user_id", "integer");
-    $myForeign->addForeignKeyConstraint($myTable, array("user_id"), array("id"), array("onUpdate" => "CASCADE"));
+    $myForeign->addForeignKeyConstraint($myTable, ["user_id"], ["id"], ["onUpdate" => "CASCADE"]);
 
     $queries = $schema->toSql($myPlatform); // get queries to create this schema.
     $dropSchema = $schema->toDropSql($myPlatform); // get queries to safely delete this schema.

--- a/docs/en/reference/security.rst
+++ b/docs/en/reference/security.rst
@@ -133,7 +133,7 @@ are using just the DBAL there are also helper methods which simplify the usage q
     <?php
     // bind parameters and execute query at once.
     $sql = "SELECT * FROM users WHERE username = ?";
-    $resultSet = $connection->executeQuery($sql, array($_GET['username']));
+    $resultSet = $connection->executeQuery($sql, [$_GET['username']]);
 
 There is also ``executeStatement`` which does not return a statement but the number of affected rows.
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

In our code examples, we apparantly still use old-school array constructors (`array()`). In modern PHP apps, people are probably more used to modern array constructors (`[]`), so I adjusted the affected code examples.
