### PR TITLE
Fix PHP 8.1 deprecation on `mysqli::real_connect()` calls

### DIFF
--- a/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
+++ b/lib/Doctrine/DBAL/Driver/Mysqli/MysqliConnection.php
@@ -68,7 +68,7 @@ class MysqliConnection implements ConnectionInterface, PingableConnection, Serve
         $socket = $params['unix_socket'] ?? ini_get('mysqli.default_socket');
         $dbname = $params['dbname'] ?? null;
 
-        $flags = $driverOptions[static::OPTION_FLAGS] ?? null;
+        $flags = $driverOptions[static::OPTION_FLAGS] ?? 0;
 
         $conn = mysqli_init();
         assert($conn !== false);


### PR DESCRIPTION
Current issue with the 2.13.x branch is that, as soon as deprecation exceptions are enabled, the `real_connect` method inside the `MysqliConnection` driver is throwing an exception; `mysqli::real_connect(): Passing null to parameter #7 ($flags) of type int is deprecated`.

To resolve this, a `0` instead of `null` will be used.
I'm not really familiar with bits values at all, so if `0` is a bad default value feel free to adjust that - was only able to track it down at that part here. :)

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #4869 

#### Summary

Replaced the `?? null` with `?? 0` when trying to retrieve the flags' driver-options since PHP 8.1 does no longer accept `null` for the 7th parameter `$flags` of the [`real_connect`](https://www.php.net/manual/en/mysqli.real-connect) method.
