### PR TITLE
Add handling for default json_object

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2601,6 +2601,10 @@ abstract class AbstractPlatform
             return ' DEFAULT ' . $this->convertBooleans($default);
         }
 
+        if ($type instanceof Types\JsonType && $default === $this->getJsonObjectSQL()) {
+            return ' DEFAULT ' . $this->getJsonObjectSQL();
+        }
+
         return ' DEFAULT ' . $this->quoteStringLiteral($default);
     }
 
@@ -3018,6 +3022,16 @@ abstract class AbstractPlatform
     public function getCurrentTimestampSQL()
     {
         return 'CURRENT_TIMESTAMP';
+    }
+
+    /**
+     * Returns the SQL specific for the platform to get an empty JSON object
+     *
+     * @return string
+     */
+    public function getJsonObjectSQL()
+    {
+        return 'JSON_OBJECT';
     }
 
     /**

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -245,7 +245,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
      *
      * - Since MariaDb 10.2.7 column defaults stored in information_schema are now quoted
      *   to distinguish them from expressions (see MDEV-10134).
-     * - CURRENT_TIMESTAMP, CURRENT_TIME, CURRENT_DATE are stored in information_schema
+     * - CURRENT_TIMESTAMP, CURRENT_TIME, CURRENT_DATE, JSON_OBJECT are stored in information_schema
      *   as current_timestamp(), currdate(), currtime()
      * - Quoted 'NULL' is not enforced by Maria, it is technically possible to have
      *   null in some circumstances (see https://jira.mariadb.org/browse/MDEV-14053)
@@ -275,6 +275,9 @@ class MySQLSchemaManager extends AbstractSchemaManager
 
             case 'curtime()':
                 return $platform->getCurrentTimeSQL();
+
+            case 'json_object()':
+                return $platform->getJsonObjectSQL();
         }
 
         return $columnDefault;

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -592,6 +592,18 @@ abstract class AbstractPlatformTestCase extends TestCase
         }
     }
 
+    public function testGetDefaultValueDeclarationSQLForJsonType(): void
+    {
+        $jsonObjectSql = $this->platform->getJsonObjectSQL();
+        self::assertSame(
+            ' DEFAULT ' . $jsonObjectSql,
+            $this->platform->getDefaultValueDeclarationSQL([
+                'type'    => Type::getType('json'),
+                'default' => $jsonObjectSql,
+            ])
+        );
+    }
+
     public function testKeywordList(): void
     {
         $keywordList = $this->platform->getReservedKeywordsList();


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n.a.

#### Summary

Hello everyone,

I ran into an issue with migrating, while trying to change an existing json column by setting the default value to `json_object()` in MYSQL. It didn't work because Doctrine quotes the string and then it is not interpreted as a MYSQL keyword. So I made this change.

Please be advised that this is the first time I dive into the code of Doctrine. I changed the code until I got a working result. I may have missed some things out of sheer ignorance. Feel free to advise me on changes that I have forgotten.

Thank you.
