### PR TITLE
Mark pull request as stale in 90 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@v4
         with:
           stale-pr-message: >
-            There hasn't been any activity on this pull request in the past year, so
+            There hasn't been any activity on this pull request in the past 90 days, so
             it has been marked as stale and it will be closed automatically if no
             further activity occurs in the next 7 days.
 
@@ -20,5 +20,5 @@ jobs:
             This pull request was closed due to a year of no activity.
 
           days-before-stale:    -1
-          days-before-pr-stale: 365
+          days-before-pr-stale: 90
           days-before-pr-close: 7


### PR DESCRIPTION
The workflow originally implemented in https://github.com/doctrine/dbal/pull/4935 works (see  https://github.com/doctrine/dbal/pull/3870#issuecomment-1019402113). I believe we can move forward and decrease the period from 365 to 90 days. It is still up to the PR author to leave a comment and reset the counter if they are willing to work on their PR.