### PR TITLE
Add support for DECIMAL type

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -894,7 +894,12 @@ SQL
      */
     public function getDecimalTypeDeclarationSQL(array $column)
     {
-        return parent::getDecimalTypeDeclarationSQL($column) . $this->getUnsignedDeclaration($column);
+        $column['precision'] = ! isset($column['precision']) || empty($column['precision'])
+            ? self::DEFAULT_DECIMAL_PRECISION : $column['precision'];
+        $column['scale']     = ! isset($column['scale']) || empty($column['scale'])
+            ? self::DEFAULT_DECIMAL_SCALE : $column['scale'];
+
+        return 'DECIMAL(' . $column['precision'] . ', ' . $column['scale'] . ')' . $this->getUnsignedDeclaration($column);
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -72,6 +72,10 @@ abstract class AbstractPlatform
     public const CREATE_INDEXES = 1;
 
     public const CREATE_FOREIGNKEYS = 2;
+    
+    protected const DEFAULT_DECIMAL_PRECISION = 10;
+    
+    protected const DEFAULT_DECIMAL_SCALE = 0;
 
     /** @var string[]|null */
     protected $doctrineTypeMapping;
@@ -2552,9 +2556,9 @@ abstract class AbstractPlatform
     public function getDecimalTypeDeclarationSQL(array $column)
     {
         $column['precision'] = ! isset($column['precision']) || empty($column['precision'])
-            ? 10 : $column['precision'];
+            ? self::DEFAULT_DECIMAL_PRECISION : $column['precision'];
         $column['scale']     = ! isset($column['scale']) || empty($column['scale'])
-            ? 0 : $column['scale'];
+            ? self::DEFAULT_DECIMAL_SCALE : $column['scale'];
 
         return 'NUMERIC(' . $column['precision'] . ', ' . $column['scale'] . ')';
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #2802

#### Summary

There is a HUGE difference in MySQL-based databases between decimal and float. As the name suggests, decimal is strictly bound precision type. Float, is floating point. The current implementation of MySQL-based DBs treats decimal type as NUMERIC, which is wrong, as it leads to DOUBLE type in most cases in DB. DOUBLE is also a floating point type. The one and only correct MySQL type for DECIMAL is DECIMAL. Everything else is not giving you the expected precision.

I agree some DB types may not distinguish between NUMERIC and DECIMAL and FLOAT, but MySQL does. My Change keeps the behavior uniform and abstraction layer is untouched. Only when using MySQL, DECIMAL is used properly. For those who want to use floating points, there is a FloatType.
