### PR TITLE
Return numeric-string instead of just string to represent row count

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -624,6 +624,7 @@ class Connection
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
      *
      * @return int|string The number of affected rows.
+     * @psalm-return int<0,max>|numeric-string
      *
      * @throws Exception
      */
@@ -661,6 +662,7 @@ class Connection
      * @param int $level The level to set.
      *
      * @return int|string
+     * @psalm-return int<0,max>|numeric-string
      *
      * @throws Exception
      */
@@ -698,6 +700,7 @@ class Connection
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
      *
      * @return int|string The number of affected rows.
+     * @psalm-return int<0,max>|numeric-string
      *
      * @throws Exception
      */
@@ -733,6 +736,7 @@ class Connection
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types Parameter types
      *
      * @return int|string The number of affected rows.
+     * @psalm-return int<0,max>|numeric-string
      *
      * @throws Exception
      */
@@ -1126,6 +1130,7 @@ class Connection
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
      * @return int|string The number of affected rows.
+     * @psalm-return int<0,max>|numeric-string
      *
      * @throws Exception
      */
@@ -1826,8 +1831,11 @@ class Connection
      *
      * @param array<mixed>           $params The query parameters
      * @param array<int|string|null> $types  The parameter types
+     *
+     * @return int|string
+     * @psalm-return int<0,max>|numeric-string
      */
-    public function executeUpdate(string $sql, array $params = [], array $types = []): int
+    public function executeUpdate(string $sql, array $params = [], array $types = [])
     {
         return $this->executeStatement($sql, $params, $types);
     }
@@ -1846,8 +1854,11 @@ class Connection
      * BC layer for a wide-spread use-case of old DBAL APIs
      *
      * @deprecated This API is deprecated and will be removed after 2022
+     *
+     * @return int|string
+     * @psalm-return int<0,max>|numeric-string
      */
-    public function exec(string $sql): int
+    public function exec(string $sql)
     {
         return $this->executeStatement($sql);
     }

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -42,9 +42,12 @@ interface Connection
     /**
      * Executes an SQL statement and return the number of affected rows.
      *
+     * @return int|string
+     * @psalm-return int<0,max>|numeric-string
+     *
      * @throws Exception
      */
-    public function exec(string $sql): int;
+    public function exec(string $sql);
 
     /**
      * Returns the ID of the last inserted row or sequence value.

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -84,7 +84,10 @@ final class Connection implements ServerInfoAwareConnection
         return "'" . $value . "'";
     }
 
-    public function exec(string $sql): int
+    /**
+     * {@inheritdoc}
+     */
+    public function exec(string $sql)
     {
         $stmt = @db2_exec($this->connection, $sql);
 

--- a/src/Driver/Middleware/AbstractConnectionMiddleware.php
+++ b/src/Driver/Middleware/AbstractConnectionMiddleware.php
@@ -42,7 +42,10 @@ abstract class AbstractConnectionMiddleware implements ServerInfoAwareConnection
         return $this->wrappedConnection->quote($value, $type);
     }
 
-    public function exec(string $sql): int
+    /**
+     * {@inheritdoc}
+     */
+    public function exec(string $sql)
     {
         return $this->wrappedConnection->exec($sql);
     }

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -81,7 +81,10 @@ final class Connection implements ServerInfoAwareConnection
         return "'" . $this->connection->escape_string($value) . "'";
     }
 
-    public function exec(string $sql): int
+    /**
+     * {@inheritdoc}
+     */
+    public function exec(string $sql)
     {
         try {
             $result = $this->connection->query($sql);

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -100,10 +100,12 @@ final class Connection implements ServerInfoAwareConnection
     }
 
     /**
+     * {@inheritdoc}
+     *
      * @throws Exception
      * @throws Parser\Exception
      */
-    public function exec(string $sql): int
+    public function exec(string $sql)
     {
         return $this->prepare($sql)->execute()->rowCount();
     }

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -28,7 +28,10 @@ final class Connection implements ServerInfoAwareConnection
         $this->connection = $connection;
     }
 
-    public function exec(string $sql): int
+    /**
+     * {@inheritdoc}
+     */
+    public function exec(string $sql)
     {
         try {
             $result = $this->connection->exec($sql);

--- a/src/Driver/SQLSrv/Connection.php
+++ b/src/Driver/SQLSrv/Connection.php
@@ -71,7 +71,10 @@ final class Connection implements ServerInfoAwareConnection
         return "'" . str_replace("'", "''", $value) . "'";
     }
 
-    public function exec(string $sql): int
+    /**
+     * {@inheritdoc}
+     */
+    public function exec(string $sql)
     {
         $stmt = sqlsrv_query($this->connection, $sql);
 

--- a/src/Logging/Connection.php
+++ b/src/Logging/Connection.php
@@ -46,7 +46,10 @@ final class Connection extends AbstractConnectionMiddleware
         return parent::query($sql);
     }
 
-    public function exec(string $sql): int
+    /**
+     * {@inheritDoc}
+     */
+    public function exec(string $sql)
     {
         $this->logger->debug('Executing statement: {sql}', ['sql' => $sql]);
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -315,11 +315,12 @@ class QueryBuilder
      *
      * Should be used for INSERT, UPDATE and DELETE
      *
-     * @return int The number of affected rows.
+     * @return int|string The number of affected rows.
+     * @psalm-return int<0,max>|numeric-string
      *
      * @throws Exception
      */
-    public function executeStatement(): int
+    public function executeStatement()
     {
         return $this->connection->executeStatement($this->getSQL(), $this->params, $this->paramTypes);
     }
@@ -330,6 +331,7 @@ class QueryBuilder
      * @deprecated Use {@see executeQuery()} or {@see executeStatement()} instead.
      *
      * @return Result|int|string
+     * @psalm-return Result|int<0,max>|numeric-string
      *
      * @throws Exception
      */

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -124,6 +124,6 @@ EOT
      */
     private function runStatement(SymfonyStyle $io, Connection $conn, string $sql): void
     {
-        $io->success(sprintf('%d rows affected.', $conn->executeStatement($sql)));
+        $io->success(sprintf('%s rows affected.', $conn->executeStatement($sql)));
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         |improvement
| Fixed issues | Follows up https://github.com/doctrine/dbal/pull/5269

#### Summary

The returned string representing row count is always a number so it makes sense to constrain it a little bit more.
