### PR TITLE
Inject EventManager when using a custom platform

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -182,14 +182,6 @@ class Connection
         $this->_driver = $driver;
         $this->params  = $params;
 
-        if (isset($params['platform'])) {
-            if (! $params['platform'] instanceof Platforms\AbstractPlatform) {
-                throw Exception::invalidPlatformType($params['platform']);
-            }
-
-            $this->platform = $params['platform'];
-        }
-
         // Create default config and event manager if none given
         if ($config === null) {
             $config = new Configuration();
@@ -201,6 +193,15 @@ class Connection
 
         $this->_config       = $config;
         $this->_eventManager = $eventManager;
+
+        if (isset($params['platform'])) {
+            if (! $params['platform'] instanceof Platforms\AbstractPlatform) {
+                throw Exception::invalidPlatformType($params['platform']);
+            }
+
+            $this->platform = $params['platform'];
+            $this->platform->setEventManager($this->_eventManager);
+        }
 
         $this->_expr = $this->createExpressionBuilder();
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #3649

#### Summary

This fix ensures that schema-related events (e.g. `onSchemaAlterTable`) get fired when a `Connection` receives a `Platform` instead of relying on [auto-detection](https://github.com/doctrine/dbal/blob/82331b861727c15b1f457ef05a8729e508e7ead5/src/Connection.php#L284). 
