### PR TITLE
Do not mark PhpDateTimeMappingType as @internal

### DIFF
--- a/src/Types/PhpDateTimeMappingType.php
+++ b/src/Types/PhpDateTimeMappingType.php
@@ -4,8 +4,6 @@ namespace Doctrine\DBAL\Types;
 
 /**
  * Implementations should map a database type to a PHP DateTimeInterface instance.
- *
- * @internal
  */
 interface PhpDateTimeMappingType
 {


### PR DESCRIPTION
I wanted to build my own datetime type and I need https://github.com/doctrine/dbal/blob/3.3.x/src/Platforms/AbstractPlatform.php#L2588 to evaluate to true. Is there any reason why this interface is marked internal? If so, what's the recommended way to have a custom date time type then? I would adjust the PR then to contain information on what to do next to `@internal` for further reference :) 