### PR TITLE
Source column defaults from its own table

### DIFF
--- a/src/Platforms/MySQL/Comparator.php
+++ b/src/Platforms/MySQL/Comparator.php
@@ -31,27 +31,25 @@ class Comparator extends BaseComparator
      */
     public function diffTable(Table $fromTable, Table $toTable)
     {
-        $defaults = array_intersect_key($fromTable->getOptions(), [
+        return parent::diffTable(
+            $this->normalizeColumns($fromTable),
+            $this->normalizeColumns($toTable)
+        );
+    }
+
+    private function normalizeColumns(Table $table): Table
+    {
+        $defaults = array_intersect_key($table->getOptions(), [
             'charset'   => null,
             'collation' => null,
         ]);
 
-        if ($defaults !== []) {
-            $fromTable = clone $fromTable;
-            $toTable   = clone $toTable;
-
-            $this->normalizeColumns($fromTable, $defaults);
-            $this->normalizeColumns($toTable, $defaults);
+        if ($defaults === []) {
+            return $table;
         }
 
-        return parent::diffTable($fromTable, $toTable);
-    }
+        $table = clone $table;
 
-    /**
-     * @param array<string,mixed> $defaults
-     */
-    private function normalizeColumns(Table $table, array $defaults): void
-    {
         foreach ($table->getColumns() as $column) {
             $options = $column->getPlatformOptions();
             $diff    = array_diff_assoc($options, $defaults);
@@ -62,5 +60,7 @@ class Comparator extends BaseComparator
 
             $column->setPlatformOptions($diff);
         }
+
+        return $table;
     }
 }

--- a/tests/Functional/Schema/ComparatorTestUtils.php
+++ b/tests/Functional/Schema/ComparatorTestUtils.php
@@ -17,14 +17,30 @@ final class ComparatorTestUtils
      *
      * @throws Exception
      */
-    public static function diffOnlineAndOfflineTable(
+    public static function diffFromActualToDesiredTable(
         AbstractSchemaManager $schemaManager,
         Comparator $comparator,
-        Table $table
+        Table $desiredTable
     ) {
         return $comparator->diffTable(
-            $schemaManager->listTableDetails($table->getName()),
-            $table
+            $schemaManager->listTableDetails($desiredTable->getName()),
+            $desiredTable
+        );
+    }
+
+    /**
+     * @return TableDiff|false
+     *
+     * @throws Exception
+     */
+    public static function diffFromDesiredToActualTable(
+        AbstractSchemaManager $schemaManager,
+        Comparator $comparator,
+        Table $desiredTable
+    ) {
+        return $comparator->diffTable(
+            $desiredTable,
+            $schemaManager->listTableDetails($desiredTable->getName())
         );
     }
 
@@ -32,13 +48,14 @@ final class ComparatorTestUtils
     {
         $schemaManager = $connection->createSchemaManager();
 
-        $diff = self::diffOnlineAndOfflineTable($schemaManager, $comparator, $table);
+        $diff = self::diffFromActualToDesiredTable($schemaManager, $comparator, $table);
 
         TestCase::assertNotFalse($diff);
 
         $schemaManager->alterTable($diff);
 
-        TestCase::assertFalse(self::diffOnlineAndOfflineTable($schemaManager, $comparator, $table));
+        TestCase::assertFalse(self::diffFromActualToDesiredTable($schemaManager, $comparator, $table));
+        TestCase::assertFalse(self::diffFromDesiredToActualTable($schemaManager, $comparator, $table));
     }
 
     /**

--- a/tests/Functional/Schema/MySQL/ComparatorTest.php
+++ b/tests/Functional/Schema/MySQL/ComparatorTest.php
@@ -44,7 +44,13 @@ final class ComparatorTest extends FunctionalTestCase
         $table = $this->createLobTable($type, $length - 1);
         $this->increaseLobLength($table);
 
-        self::assertFalse(ComparatorTestUtils::diffOnlineAndOfflineTable(
+        self::assertFalse(ComparatorTestUtils::diffFromActualToDesiredTable(
+            $this->schemaManager,
+            $this->comparator,
+            $table
+        ));
+
+        self::assertFalse(ComparatorTestUtils::diffFromDesiredToActualTable(
             $this->schemaManager,
             $this->comparator,
             $table
@@ -102,7 +108,13 @@ final class ComparatorTest extends FunctionalTestCase
         [$table, $column] = $this->createCollationTable();
         $column->setPlatformOption('collation', 'utf8mb4_general_ci');
 
-        self::assertFalse(ComparatorTestUtils::diffOnlineAndOfflineTable(
+        self::assertFalse(ComparatorTestUtils::diffFromActualToDesiredTable(
+            $this->schemaManager,
+            $this->comparator,
+            $table
+        ));
+
+        self::assertFalse(ComparatorTestUtils::diffFromDesiredToActualTable(
             $this->schemaManager,
             $this->comparator,
             $table
@@ -135,7 +147,7 @@ final class ComparatorTest extends FunctionalTestCase
     {
         $table = new Table('comparator_test');
         $table->addOption('charset', 'utf8mb4');
-        $table->addOption('collate', 'utf8mb4_general_ci');
+        $table->addOption('collation', 'utf8mb4_general_ci');
         $column = $table->addColumn('id', Types::STRING);
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -202,18 +202,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $diff = $this->schemaManager->createComparator()
             ->diffTable($table, $onlineTable);
-        self::assertNotFalse($diff);
-
-        $this->schemaManager->alterTable($diff);
-
-        $onlineTable = $this->schemaManager->listTableDetails('text_blob_default_value');
-
-        self::assertNull($onlineTable->getColumn('def_text')->getDefault());
-        self::assertNull($onlineTable->getColumn('def_text_null')->getDefault());
-        self::assertFalse($onlineTable->getColumn('def_text_null')->getNotnull());
-        self::assertNull($onlineTable->getColumn('def_blob')->getDefault());
-        self::assertNull($onlineTable->getColumn('def_blob_null')->getDefault());
-        self::assertFalse($onlineTable->getColumn('def_blob_null')->getNotnull());
+        self::assertFalse($diff);
     }
 
     public function testColumnCharset(): void


### PR DESCRIPTION
**Change summary**:
1. Instead of sourcing column defaults from the from/online table, source them from its own table.
2. Add some more assertions that test the inverse diff. Those assertions would fail without the fix so I believe they cover the originally reported scenario.

Fixes #5322.