### PR TITLE
Leverage int-mask-of to make types more precise

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1761,6 +1761,7 @@ abstract class AbstractPlatform
      * on this platform.
      *
      * @param int $createFlags
+     * @psalm-param int-mask-of<self::CREATE_*> $createFlags
      *
      * @return string[] The sequence of SQL statements.
      *

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -871,6 +871,7 @@ class SqlitePlatform extends AbstractPlatform
      * {@inheritDoc}
      *
      * @param int|null $createFlags
+     * @psalm-param int-mask-of<AbstractPlatform::CREATE_*>|null $createFlags
      */
     public function getCreateTableSQL(Table $table, $createFlags = null)
     {


### PR DESCRIPTION
`int-mask-of` restricts to a bitmask composed of the provided integers