### PR TITLE
Clearer Connection return types for affectedRows

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -120,24 +120,28 @@ parameters:
         # TODO: remove in 4.0.0
         - "~Call to function method_exists\\(\\) with Doctrine\\\\DBAL\\\\Driver\\\\Connection and 'getNativeConnection' will always evaluate to true\\.~"
 
-        # Fixing the issue would cause a BC break.
-        # TODO: fix in 4.0.0
+        # https://github.com/phpstan/phpstan-src/pull/1116
         -
-            message: '~^Method Doctrine\\DBAL\\Connection::executeUpdate\(\) should return int but returns int\|string\.$~'
-            paths:
-                - src/Connection.php
+            message: "~^Method Doctrine\\\\DBAL\\\\Driver\\\\IBMDB2\\\\Connection\\:\\:exec\\(\\) should return int\\<0, max\\> but returns int\\.$~"
+            path: src/Driver/IBMDB2/Connection.php
         -
-            message: '~^Method Doctrine\\DBAL\\Connection::exec\(\) should return int but returns int\|string\.$~'
-            paths:
-                - src/Connection.php
+            message: "~^Method Doctrine\\\\DBAL\\\\Driver\\\\IBMDB2\\\\Result\\:\\:rowCount\\(\\) should return int\\<0, max\\> but returns int\\.$~"
+            path: src/Driver/IBMDB2/Result.php
         -
-            message: '~^Method Doctrine\\DBAL\\Driver\\Mysqli\\Connection::exec\(\) should return int but returns int\|string\.$~'
-            paths:
-                - src/Driver/Mysqli/Connection.php
+            message: "~^Call to function is_string\\(\\) with int will always evaluate to false\\.$~"
+            path: src/Driver/Mysqli/Connection.php
         -
-            message: '~^Method Doctrine\\DBAL\\Query\\QueryBuilder::executeStatement\(\) should return int but returns int\|string\.$~'
-            paths:
-                - src/Query/QueryBuilder.php
+            message: "~^Strict comparison using \\!\\=\\= between string and null will always evaluate to true\\.$~"
+            path: src/Driver/Mysqli/Exception/ConnectionFailed.php
+        -
+            message: "~^Method Doctrine\\\\DBAL\\\\Driver\\\\OCI8\\\\Result\\:\\:rowCount\\(\\) should return int\\<0, max\\> but returns int\\.$~"
+            path: src/Driver/OCI8/Result.php
+        -
+            message: "~^Method Doctrine\\\\DBAL\\\\Driver\\\\PDO\\\\Connection\\:\\:exec\\(\\) should return int\\<0, max\\> but returns int\\.$~"
+            path: src/Driver/PDO/Connection.php
+        -
+            message: "~^Method Doctrine\\\\DBAL\\\\Driver\\\\PDO\\\\Result\\:\\:rowCount\\(\\) should return int\\<0, max\\> but returns int\\.$~"
+            path: src/Driver/PDO/Result.php
 
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -623,7 +623,8 @@ class Connection
      * @param array<string, mixed>                                                 $criteria Deletion criteria
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
      *
-     * @return int|string The number of affected rows.
+     * @return int The number of affected rows.
+     * @psalm-return int<0, max>
      *
      * @throws Exception
      */
@@ -660,7 +661,8 @@ class Connection
      *
      * @param int $level The level to set.
      *
-     * @return int|string
+     * @return int
+     * @psalm-return int<0, max>
      *
      * @throws Exception
      */
@@ -697,7 +699,8 @@ class Connection
      * @param array<string, mixed>                                                 $criteria Update criteria
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
      *
-     * @return int|string The number of affected rows.
+     * @return int The number of affected rows.
+     * @psalm-return int<0, max>
      *
      * @throws Exception
      */
@@ -732,7 +735,8 @@ class Connection
      * @param array<string, mixed>                                                 $data  Column-value pairs
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types Parameter types
      *
-     * @return int|string The number of affected rows.
+     * @return int The number of affected rows.
+     * @psalm-return int<0, max>
      *
      * @throws Exception
      */
@@ -1125,7 +1129,8 @@ class Connection
      * @param list<mixed>|array<string, mixed>                                     $params Statement parameters
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
-     * @return int|string The number of affected rows.
+     * @return int The number of affected rows.
+     * @psalm-return int<0, max>
      *
      * @throws Exception
      */
@@ -1826,6 +1831,9 @@ class Connection
      *
      * @param array<mixed>           $params The query parameters
      * @param array<int|string|null> $types  The parameter types
+     *
+     * @return int The number of affected rows.
+     * @psalm-return int<0, max>
      */
     public function executeUpdate(string $sql, array $params = [], array $types = []): int
     {
@@ -1846,6 +1854,9 @@ class Connection
      * BC layer for a wide-spread use-case of old DBAL APIs
      *
      * @deprecated This API is deprecated and will be removed after 2022
+     *
+     * @return int The number of affected rows.
+     * @psalm-return int<0, max>
      */
     public function exec(string $sql): int
     {

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -42,6 +42,8 @@ interface Connection
     /**
      * Executes an SQL statement and return the number of affected rows.
      *
+     * @psalm-return int<0, max>
+     *
      * @throws Exception
      */
     public function exec(string $sql): int;

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -93,7 +93,13 @@ final class Connection implements ServerInfoAwareConnection
             throw ConnectionError::new($this->connection);
         }
 
-        return $this->connection->affected_rows;
+        $count = $this->connection->affected_rows;
+
+        if (is_string($count)) {
+            $count = PHP_INT_MAX;
+        }
+
+        return max(0, $count);
     }
 
     /**

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -164,10 +164,16 @@ final class Result implements ResultInterface
     public function rowCount(): int
     {
         if ($this->hasColumns) {
-            return $this->statement->num_rows;
+            $count = $this->statement->num_rows;
+        } else {
+            $count = $this->statement->affected_rows;
         }
 
-        return $this->statement->affected_rows;
+        if (is_string($count)) {
+            $count = PHP_INT_MAX;
+        }
+
+        return max(0, $count);
     }
 
     public function columnCount(): int

--- a/src/Driver/Result.php
+++ b/src/Driver/Result.php
@@ -71,6 +71,7 @@ interface Result
      * is not guaranteed for all drivers and should not be relied on in portable applications.
      *
      * @return int The number of rows.
+     * @psalm-return int<0, max>
      *
      * @throws Exception
      */

--- a/src/Driver/SQLSrv/Connection.php
+++ b/src/Driver/SQLSrv/Connection.php
@@ -85,7 +85,7 @@ final class Connection implements ServerInfoAwareConnection
             throw Error::new();
         }
 
-        return $rowsAffected;
+        return max(0, $rowsAffected);
     }
 
     /**

--- a/src/Driver/SQLSrv/Result.php
+++ b/src/Driver/SQLSrv/Result.php
@@ -83,7 +83,7 @@ final class Result implements ResultInterface
         $count = sqlsrv_rows_affected($this->statement);
 
         if ($count !== false) {
-            return $count;
+            return max(0, $count);
         }
 
         return 0;

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -316,6 +316,7 @@ class QueryBuilder
      * Should be used for INSERT, UPDATE and DELETE
      *
      * @return int The number of affected rows.
+     * @psalm-return int<0, max>
      *
      * @throws Exception
      */
@@ -329,7 +330,8 @@ class QueryBuilder
      *
      * @deprecated Use {@see executeQuery()} or {@see executeStatement()} instead.
      *
-     * @return Result|int|string
+     * @return Result|int
+     * @psalm-return Result|int<0, max>
      *
      * @throws Exception
      */


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Alternative to/closes https://github.com/doctrine/dbal/pull/5317

#### Summary

Per https://github.com/doctrine/dbal/blob/83f779beaea1893c0bece093ab2104c6d15a7f26/src/Connection.php#L1157-L1160 the two ways executeStatement can return is via Result::rowCount and DriverConnection::exec but those two have an int return type, so it is currently impossible for executeStatement to return a string.