### PR TITLE
Support backed enums as defaults

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2576,12 +2576,12 @@ abstract class AbstractPlatform
 
         $default = $column['default'];
 
-        if (! isset($column['type'])) {
-            return " DEFAULT '" . $default . "'";
+        if ($default instanceof BackedEnum) {
+            $default = $default->value;
         }
 
-        if ($default instanceof BackedEnum) {
-            return ' DEFAULT ' . $this->quoteStringLiteral($default->value);
+        if (! isset($column['type'])) {
+            return " DEFAULT '" . $default . "'";
         }
 
         $type = $column['type'];

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2581,7 +2581,7 @@ abstract class AbstractPlatform
         }
 
         if ($default instanceof BackedEnum) {
-            return ' DEFAULT ' . is_string($default->value) ? $this->quoteStringLiteral($default->value) : $default->value;
+            return ' DEFAULT ' . $this->quoteStringLiteral($default->value);
         }
 
         $type = $column['type'];

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use BackedEnum;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Event\SchemaAlterTableAddColumnEventArgs;
 use Doctrine\DBAL\Event\SchemaAlterTableChangeColumnEventArgs;
@@ -2578,9 +2579,9 @@ abstract class AbstractPlatform
         if (! isset($column['type'])) {
             return " DEFAULT '" . $default . "'";
         }
-        
-        if ($default instanceof \BackedEnum) {
-            return ' DEFAULT ' . $this->quoteStringLiteral($default->value);
+
+        if ($default instanceof BackedEnum) {
+            return ' DEFAULT ' . is_string($default->value) ? $this->quoteStringLiteral($default->value) : $default->value;
         }
 
         $type = $column['type'];

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2578,6 +2578,10 @@ abstract class AbstractPlatform
         if (! isset($column['type'])) {
             return " DEFAULT '" . $default . "'";
         }
+        
+        if ($default instanceof \BackedEnum) {
+            return ' DEFAULT ' . $this->quoteStringLiteral($default->value);
+        }
 
         $type = $column['type'];
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -608,12 +608,12 @@ abstract class AbstractPlatformTestCase extends TestCase
 
         self::assertSame(" DEFAULT 'foo'", $this->platform->getDefaultValueDeclarationSQL([
             'type' => Type::getType('string'),
-            'default' => \EnumString::Foo
+            'default' => \EnumString::Foo,
         ]));
 
-        self::assertSame(" DEFAULT 1", $this->platform->getDefaultValueDeclarationSQL([
+        self::assertSame(' DEFAULT 1', $this->platform->getDefaultValueDeclarationSQL([
             'type' => Type::getType('integer'),
-            'default' => \EnumInt::Foo
+            'default' => \EnumInt::Foo,
         ]));
     }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -611,7 +611,7 @@ abstract class AbstractPlatformTestCase extends TestCase
             'default' => \EnumString::Foo
         ]));
 
-        self::assertSame(" DEFAULT '1'", $this->platform->getDefaultValueDeclarationSQL([
+        self::assertSame(" DEFAULT 1", $this->platform->getDefaultValueDeclarationSQL([
             'type' => Type::getType('integer'),
             'default' => \EnumInt::Foo
         ]));

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -616,7 +616,6 @@ abstract class AbstractPlatformTestCase extends TestCase
         } else {
             self::markTestSkipped('Enums are only supported in PHP >= 8.1');
         }
-
     }
 
     public function testKeywordList(): void

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -592,6 +592,33 @@ abstract class AbstractPlatformTestCase extends TestCase
         }
     }
 
+    public function testGetDefaultValueDeclarationSQLForBackedEnum(): void
+    {
+        if (\PHP_VERSION_ID >= 80100) {
+            eval(<<<'EOD'
+                enum EnumString: string {
+                    case Foo = 'foo';
+                }
+                enum EnumInt: int {
+                    case Foo = 1;
+                }
+            EOD);
+
+            self::assertSame(" DEFAULT 'foo'", $this->platform->getDefaultValueDeclarationSQL([
+                'type' => Type::getType('string'),
+                'default' => \EnumString::Foo
+            ]));
+
+            self::assertSame(" DEFAULT '1'", $this->platform->getDefaultValueDeclarationSQL([
+                'type' => Type::getType('integer'),
+                'default' => \EnumInt::Foo
+            ]));
+        } else {
+            self::markTestSkipped('Enums are only supported in PHP >= 8.1');
+        }
+
+    }
+
     public function testKeywordList(): void
     {
         $keywordList = $this->platform->getReservedKeywordsList();

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -592,30 +592,29 @@ abstract class AbstractPlatformTestCase extends TestCase
         }
     }
 
+    /**
+     * @requires PHP 8.1
+     */
     public function testGetDefaultValueDeclarationSQLForBackedEnum(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            eval(<<<'EOD'
-                enum EnumString: string {
-                    case Foo = 'foo';
-                }
-                enum EnumInt: int {
-                    case Foo = 1;
-                }
-            EOD);
+        eval(<<<'EOD'
+            enum EnumString: string {
+                case Foo = 'foo';
+            }
+            enum EnumInt: int {
+                case Foo = 1;
+            }
+        EOD);
 
-            self::assertSame(" DEFAULT 'foo'", $this->platform->getDefaultValueDeclarationSQL([
-                'type' => Type::getType('string'),
-                'default' => \EnumString::Foo
-            ]));
+        self::assertSame(" DEFAULT 'foo'", $this->platform->getDefaultValueDeclarationSQL([
+            'type' => Type::getType('string'),
+            'default' => \EnumString::Foo
+        ]));
 
-            self::assertSame(" DEFAULT '1'", $this->platform->getDefaultValueDeclarationSQL([
-                'type' => Type::getType('integer'),
-                'default' => \EnumInt::Foo
-            ]));
-        } else {
-            self::markTestSkipped('Enums are only supported in PHP >= 8.1');
-        }
+        self::assertSame(" DEFAULT '1'", $this->platform->getDefaultValueDeclarationSQL([
+            'type' => Type::getType('integer'),
+            'default' => \EnumInt::Foo
+        ]));
     }
 
     public function testKeywordList(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

we can use backed enums for a while now. today i noticed that we can't set enums as default though. the small fix changes that. now it's possible to use the following:

```php

enum MyEnum: string {
    case Foo = 'foo';
    case Bar = 'bar';
}

#[ORM\Column(enumType: MyEnum::class, options: ['default' => MyEnum::Foo])]
```
