### PR TITLE
Unset url parameter before logging parameters

### DIFF
--- a/src/Logging/Driver.php
+++ b/src/Logging/Driver.php
@@ -47,6 +47,10 @@ final class Driver extends AbstractDriverMiddleware
             $params['password'] = '<redacted>';
         }
 
+        if (isset($params['url'])) {
+            unset($params['url']);
+        }
+
         return $params;
     }
 }

--- a/tests/Logging/MiddlewareTest.php
+++ b/tests/Logging/MiddlewareTest.php
@@ -54,6 +54,7 @@ class MiddlewareTest extends TestCase
         $this->driver->connect([
             'username' => 'admin',
             'password' => 'Passw0rd!',
+            'url' => 'contains a password',
         ]);
     }
 


### PR DESCRIPTION
It will often contain a password. We could do more clever things like
redacted only the password part, but this seems hard to do in a robust
way.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | security
| Fixed issues | closes #5339
