### PR TITLE
Rework the logic of handling TEXT default value for Oracle MySQL

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -13,8 +13,6 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
-use Doctrine\DBAL\Types\BlobType;
-use Doctrine\DBAL\Types\TextType;
 
 use function array_merge;
 use function array_unique;
@@ -269,19 +267,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         }
 
         return $sql;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultValueDeclarationSQL(array $column): string
-    {
-        // Unset the default value if the given column definition does not allow default values.
-        if ($column['type'] instanceof TextType || $column['type'] instanceof BlobType) {
-            $column['default'] = null;
-        }
-
-        return parent::getDefaultValueDeclarationSQL($column);
     }
 
     /**

--- a/src/Platforms/MariaDBPlatform.php
+++ b/src/Platforms/MariaDBPlatform.php
@@ -20,17 +20,6 @@ use function in_array;
 class MariaDBPlatform extends AbstractMySQLPlatform
 {
     /**
-     * {@inheritDoc}
-     *
-     * Hop over the {@see AbstractMySQLPlatform} implementation until 4.0.x
-     * where {@see MariaDBPlatform} no longer extends {@see MySQLPlatform}.
-     */
-    public function getDefaultValueDeclarationSQL(array $column): string
-    {
-        return AbstractPlatform::getDefaultValueDeclarationSQL($column);
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @link https://mariadb.com/kb/en/library/json-data-type/

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Platforms;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\MySQLKeywords;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Types\BlobType;
+use Doctrine\DBAL\Types\TextType;
 
 /**
  * Provides the behavior, features and SQL dialect of the Oracle MySQL database platform
@@ -14,6 +16,22 @@ use Doctrine\DBAL\Schema\Index;
  */
 class MySQLPlatform extends AbstractMySQLPlatform
 {
+    /**
+     * {@inheritDoc}
+     *
+     * Oracle MySQL does not support default values on TEXT/BLOB columns until 8.0.13.
+     *
+     * @link https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-13.html#mysqld-8-0-13-data-types
+     */
+    public function getDefaultValueDeclarationSQL(array $column): string
+    {
+        if ($column['type'] instanceof TextType || $column['type'] instanceof BlobType) {
+            unset($column['default']);
+        }
+
+        return parent::getDefaultValueDeclarationSQL($column);
+    }
+
     public function hasNativeJsonType(): bool
     {
         return true;


### PR DESCRIPTION
Only Oracle MySQL doesn't support the default value of the TEXT and BLOB columns and only up until version 8.0.13.

Instead of being implemented in `AbstractMySQLPlatform` (which the MariaDB platform also inherits), the corresponding DDL builder logic should be implemented in the MySQL platform.