### PR TITLE
Reset transactions' nesting level on deadlock exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ reports/
 dist/
 download/
 vendor/
+.idea/
 /*.phpunit.xml
 /phpunit.xml
 /.phpcs-cache

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ reports/
 dist/
 download/
 vendor/
-.idea/
 /*.phpunit.xml
 /phpunit.xml
 /.phpcs-cache

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -14,10 +14,14 @@ use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\Event\TransactionBeginEventArgs;
 use Doctrine\DBAL\Event\TransactionCommitEventArgs;
 use Doctrine\DBAL\Event\TransactionRollBackEventArgs;
+use Doctrine\DBAL\Exception\CommitFailedRollbackOnlyException;
 use Doctrine\DBAL\Exception\ConnectionLost;
 use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
+use Doctrine\DBAL\Exception\NoActiveTransactionException;
+use Doctrine\DBAL\Exception\NoAlterOfSavePointsDuringTransactionException;
+use Doctrine\DBAL\Exception\SavePointNotSupportedException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
@@ -1250,11 +1254,11 @@ class Connection
     public function setNestTransactionsWithSavepoints($nestTransactionsWithSavepoints)
     {
         if ($this->transactionNestingLevel > 0) {
-            throw ConnectionException::mayNotAlterNestedTransactionWithSavepointsInTransaction();
+            throw new NoAlterOfSavePointsDuringTransactionException();
         }
 
         if (! $this->getDatabasePlatform()->supportsSavepoints()) {
-            throw ConnectionException::savepointsNotSupported();
+            throw new SavePointNotSupportedException();
         }
 
         $this->nestTransactionsWithSavepoints = (bool) $nestTransactionsWithSavepoints;
@@ -1327,11 +1331,11 @@ class Connection
     public function commit()
     {
         if ($this->transactionNestingLevel === 0) {
-            throw ConnectionException::noActiveTransaction();
+            throw new NoActiveTransactionException();
         }
 
         if ($this->isRollbackOnly) {
-            throw ConnectionException::commitFailedRollbackOnly();
+            throw new CommitFailedRollbackOnlyException();
         }
 
         $result = true;
@@ -1404,7 +1408,7 @@ class Connection
     public function rollBack()
     {
         if ($this->transactionNestingLevel === 0) {
-            throw ConnectionException::noActiveTransaction();
+            throw new NoActiveTransactionException();
         }
 
         $connection = $this->getWrappedConnection();
@@ -1460,7 +1464,7 @@ class Connection
         $platform = $this->getDatabasePlatform();
 
         if (! $platform->supportsSavepoints()) {
-            throw ConnectionException::savepointsNotSupported();
+            throw new SavePointNotSupportedException();
         }
 
         $this->executeStatement($platform->createSavePoint($savepoint));
@@ -1480,7 +1484,7 @@ class Connection
         $platform = $this->getDatabasePlatform();
 
         if (! $platform->supportsSavepoints()) {
-            throw ConnectionException::savepointsNotSupported();
+            throw new SavePointNotSupportedException();
         }
 
         if (! $platform->supportsReleaseSavepoints()) {
@@ -1504,7 +1508,7 @@ class Connection
         $platform = $this->getDatabasePlatform();
 
         if (! $platform->supportsSavepoints()) {
-            throw ConnectionException::savepointsNotSupported();
+            throw new SavePointNotSupportedException();
         }
 
         $this->executeStatement($platform->rollbackSavePoint($savepoint));
@@ -1603,7 +1607,7 @@ class Connection
     public function setRollbackOnly()
     {
         if ($this->transactionNestingLevel === 0) {
-            throw ConnectionException::noActiveTransaction();
+            throw new NoActiveTransactionException();
         }
 
         $this->isRollbackOnly = true;
@@ -1619,7 +1623,7 @@ class Connection
     public function isRollbackOnly()
     {
         if ($this->transactionNestingLevel === 0) {
-            throw ConnectionException::noActiveTransaction();
+            throw new NoActiveTransactionException();
         }
 
         return $this->isRollbackOnly;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Event\TransactionBeginEventArgs;
 use Doctrine\DBAL\Event\TransactionCommitEventArgs;
 use Doctrine\DBAL\Event\TransactionRollBackEventArgs;
 use Doctrine\DBAL\Exception\ConnectionLost;
+use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -1814,6 +1815,11 @@ class Connection
 
         if ($exception instanceof ConnectionLost) {
             $this->close();
+        }
+
+        if ($exception instanceof DeadlockException) {
+            //Reset transaction nesting level since deadlocks always rollback.
+            $this->transactionNestingLevel = 0;
         }
 
         return $exception;

--- a/src/ConnectionException.php
+++ b/src/ConnectionException.php
@@ -7,35 +7,4 @@ namespace Doctrine\DBAL;
  */
 class ConnectionException extends Exception
 {
-    /**
-     * @return ConnectionException
-     */
-    public static function commitFailedRollbackOnly()
-    {
-        return new self('Transaction commit failed because the transaction has been marked for rollback only.');
-    }
-
-    /**
-     * @return ConnectionException
-     */
-    public static function noActiveTransaction()
-    {
-        return new self('There is no active transaction.');
-    }
-
-    /**
-     * @return ConnectionException
-     */
-    public static function savepointsNotSupported()
-    {
-        return new self('Savepoints are not supported by this driver.');
-    }
-
-    /**
-     * @return ConnectionException
-     */
-    public static function mayNotAlterNestedTransactionWithSavepointsInTransaction()
-    {
-        return new self('May not alter the nested transaction with savepoints behavior while a transaction is open.');
-    }
 }

--- a/src/Exception/CommitFailedRollbackOnlyException.php
+++ b/src/Exception/CommitFailedRollbackOnlyException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\DBAL\Exception;
+
+use Doctrine\DBAL\ConnectionException;
+
+/**
+ * @psalm-immutable
+ */
+class CommitFailedRollbackOnlyException extends ConnectionException
+{
+}

--- a/src/Exception/NoActiveTransactionException.php
+++ b/src/Exception/NoActiveTransactionException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\DBAL\Exception;
+
+use Doctrine\DBAL\ConnectionException;
+
+/**
+ * @psalm-immutable
+ */
+class NoActiveTransactionException extends ConnectionException
+{
+}

--- a/src/Exception/NoAlterOfSavePointsDuringTransactionException.php
+++ b/src/Exception/NoAlterOfSavePointsDuringTransactionException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\DBAL\Exception;
+
+use Doctrine\DBAL\ConnectionException;
+
+/**
+ * @psalm-immutable
+ */
+class NoAlterOfSavePointsDuringTransactionException extends ConnectionException
+{
+}

--- a/src/Exception/SavePointNotSupportedException.php
+++ b/src/Exception/SavePointNotSupportedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\DBAL\Exception;
+
+use Doctrine\DBAL\ConnectionException;
+
+/**
+ * @psalm-immutable
+ */
+class SavePointNotSupportedException extends ConnectionException
+{
+}

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Event\TransactionRollBackEventArgs;
 use Doctrine\DBAL\Events;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
+use Doctrine\DBAL\Exception\NoActiveTransactionException;
 use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -83,25 +84,25 @@ class ConnectionTest extends TestCase
 
     public function testCommitWithNoActiveTransactionThrowsException(): void
     {
-        $this->expectException(ConnectionException::class);
+        $this->expectException(NoActiveTransactionException::class);
         $this->connection->commit();
     }
 
     public function testRollbackWithNoActiveTransactionThrowsException(): void
     {
-        $this->expectException(ConnectionException::class);
+        $this->expectException(NoActiveTransactionException::class);
         $this->connection->rollBack();
     }
 
     public function testSetRollbackOnlyNoActiveTransactionThrowsException(): void
     {
-        $this->expectException(ConnectionException::class);
+        $this->expectException(NoActiveTransactionException::class);
         $this->connection->setRollbackOnly();
     }
 
     public function testIsRollbackOnlyNoActiveTransactionThrowsException(): void
     {
-        $this->expectException(ConnectionException::class);
+        $this->expectException(NoActiveTransactionException::class);
         $this->connection->isRollbackOnly();
     }
 

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -7,7 +7,10 @@ use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception\CommitFailedRollbackOnlyException;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\NoAlterOfSavePointsDuringTransactionException;
+use Doctrine\DBAL\Exception\SavePointNotSupportedException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -49,7 +52,7 @@ class ConnectionTest extends FunctionalTestCase
         $this->connection->beginTransaction();
         $this->connection->setRollbackOnly();
 
-        $this->expectException(ConnectionException::class);
+        $this->expectException(CommitFailedRollbackOnlyException::class);
         $this->connection->commit();
     }
 
@@ -152,7 +155,7 @@ class ConnectionTest extends FunctionalTestCase
             try {
                 $this->connection->setNestTransactionsWithSavepoints(false);
                 self::fail('Should not be able to disable savepoints in usage inside a nested open transaction.');
-            } catch (ConnectionException $e) {
+            } catch (NoAlterOfSavePointsDuringTransactionException $e) {
                 self::assertTrue($this->connection->getNestTransactionsWithSavepoints());
             }
 
@@ -169,7 +172,7 @@ class ConnectionTest extends FunctionalTestCase
         }
 
         $this->connection->beginTransaction();
-        $this->expectException(ConnectionException::class);
+        $this->expectException(NoAlterOfSavePointsDuringTransactionException::class);
         $this->connection->setNestTransactionsWithSavepoints(true);
     }
 
@@ -187,8 +190,7 @@ class ConnectionTest extends FunctionalTestCase
             self::markTestSkipped('This test requires the platform not to support savepoints.');
         }
 
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Savepoints are not supported by this driver.');
+        $this->expectException(SavePointNotSupportedException::class);
 
         $this->connection->setNestTransactionsWithSavepoints(true);
     }
@@ -199,8 +201,7 @@ class ConnectionTest extends FunctionalTestCase
             self::markTestSkipped('This test requires the platform not to support savepoints.');
         }
 
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Savepoints are not supported by this driver.');
+        $this->expectException(SavePointNotSupportedException::class);
 
         $this->connection->createSavepoint('foo');
     }
@@ -211,8 +212,7 @@ class ConnectionTest extends FunctionalTestCase
             self::markTestSkipped('This test requires the platform not to support savepoints.');
         }
 
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Savepoints are not supported by this driver.');
+        $this->expectException(SavePointNotSupportedException::class);
 
         $this->connection->releaseSavepoint('foo');
     }
@@ -223,8 +223,7 @@ class ConnectionTest extends FunctionalTestCase
             self::markTestSkipped('This test requires the platform not to support savepoints.');
         }
 
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Savepoints are not supported by this driver.');
+        $this->expectException(SavePointNotSupportedException::class);
 
         $this->connection->rollbackSavepoint('foo');
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues |  partially fixes #4279 

#### Summary

Deadlock exceptions by definition rollback the transaction and any save points if used.
In such cases this lead to wrongly set internal counter.

The main issue for application developers is still present that in classical  try/catch manner
should add special catch block for "deadlock exceptions" and avoid calling the "rollback" method.

Currently I do not have a suggestion how to handle that cases.

Thank you for your time and suggestions, 
hope tis is good enough to go to 3.x and 4.x.



