### PR TITLE
SQLite: Allow dynamic time intervals in DATE_ADD & DATE_SUB

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -133,6 +133,10 @@ class SqlitePlatform extends AbstractPlatform
             case DateIntervalUnit::SECOND:
             case DateIntervalUnit::MINUTE:
             case DateIntervalUnit::HOUR:
+                if (! is_numeric($interval)) {
+                    $interval = "' || " . $interval . " || '";
+                }
+
                 return 'DATETIME(' . $date . ",'" . $operator . $interval . ' ' . $unit . "')";
         }
 

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -790,6 +790,22 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function testDatetimeAddStaticNumberOfMinutes(): void
+    {
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+12 MINUTE')",
+            $this->platform->getDateAddMinutesExpression('rentalBeginsOn', 12)
+        );
+    }
+
+    public function testDatetimeAddNumberOfMinutesFromColumn(): void
+    {
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+' || duration || ' MINUTE')",
+            $this->platform->getDateAddMinutesExpression('rentalBeginsOn', 'duration')
+        );
+    }
+
     public function testSupportsColumnCollation(): void
     {
         self::assertTrue($this->platform->supportsColumnCollation());


### PR DESCRIPTION
Allow dynamic time (second, minute, hour) intervals in DATE_ADD & DATE_SUB for SQLite.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues |  #2983

#### Summary

Previous fix fixed DAY, WEEK, MONTH, QUARTER intervals only. This commit provides fix for SECOND, MINUTE, HOUR intervals.
