### PR TITLE
Make transacional function return type generic

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1216,11 +1216,13 @@ class Connection
      * If an exception occurs during execution of the function or transaction commit,
      * the transaction is rolled back and the exception re-thrown.
      *
-     * @param Closure $func The function to execute transactionally.
+     * @param Closure(self):T $func The function to execute transactionally.
      *
-     * @return mixed The value returned by $func
+     * @return T The value returned by $func
      *
      * @throws Throwable
+     *
+     * @template T
      */
     public function transactional(Closure $func)
     {

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -291,11 +291,11 @@ class ConnectionTest extends FunctionalTestCase
     {
         $this->createTestTable();
 
-        $res = $this->connection->transactional(static function (Connection $connection): void {
-            $connection->insert(self::TABLE, ['id' => 2]);
+        $res = $this->connection->transactional(static function (Connection $connection) {
+            return $connection->insert(self::TABLE, ['id' => 2]);
         });
 
-        self::assertNull($res);
+        self::assertSame(1, $res);
         self::assertSame(0, $this->connection->getTransactionNestingLevel());
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature

#### Summary

`transactional()` return type can be generic