### PR TITLE
Update message when closing stale pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
             If you want to continue working on it, please leave a comment.
 
           close-pr-message: >
-            This pull request was closed due to a year of no activity.
+            This pull request was closed due to inactivity.
 
           days-before-stale:    -1
           days-before-pr-stale: 90


### PR DESCRIPTION
The current message mentions "a year of no activity" while the actual period is 90 days. It's better to remove the exact period from the message to reduce duplication. The period is already mentioned in the `stale-pr-message`.