### PR TITLE
Remove workaround for PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require-dev": {
         "doctrine/coding-standard": "9.0.0",
         "jetbrains/phpstorm-stubs": "2022.1",
-        "phpstan/phpstan": "1.6.0",
+        "phpstan/phpstan": "1.6.1",
         "phpstan/phpstan-strict-rules": "^1.2",
         "phpunit/phpunit": "9.5.20",
         "psalm/plugin-phpunit": "0.16.1",

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -145,9 +145,8 @@ final class DriverManager
      * <b>driverClass</b>:
      * The driver class to use.
      *
-     * @param array<string,mixed> $params
-     * @param Configuration|null  $config       The configuration to use.
-     * @param EventManager|null   $eventManager The event manager to use.
+     * @param Configuration|null $config       The configuration to use.
+     * @param EventManager|null  $eventManager The event manager to use.
      * @psalm-param array{
      *     charset?: string,
      *     dbname?: string,
@@ -172,7 +171,6 @@ final class DriverManager
      *     user?: string,
      *     wrapperClass?: class-string<T>,
      * } $params
-     * @phpstan-param array<string,mixed> $params
      *
      * @psalm-return ($params is array{wrapperClass:mixed} ? T : Connection)
      *


### PR DESCRIPTION
Since PHPStan 1.6.0, conditional return types are supported, and 1.6.1
fixes a bug that affected one such return type we use on
`DriverManager::getConnection()`.


See https://github.com/phpstan/phpstan/issues/7111