### PR TITLE
Fix: use correct constants in transaction documentation

### DIFF
--- a/docs/en/reference/transactions.rst
+++ b/docs/en/reference/transactions.rst
@@ -42,10 +42,10 @@ constants:
 ::
 
     <?php
-    Connection::TRANSACTION_READ_UNCOMMITTED
-    Connection::TRANSACTION_READ_COMMITTED
-    Connection::TRANSACTION_REPEATABLE_READ
-    Connection::TRANSACTION_SERIALIZABLE
+    TransactionIsolationLevel::READ_UNCOMMITTED
+    TransactionIsolationLevel::READ_COMMITTED
+    TransactionIsolationLevel::REPEATABLE_READ
+    TransactionIsolationLevel::SERIALIZABLE
 
 The default transaction isolation level of a
 ``Doctrine\DBAL\Connection`` is chosen by the underlying platform


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | documentation fix

#### Summary

Use the correct class and constant names for the transaction isolation levels in the documentation
