### PR TITLE
Deprecate AbstractPlatform::getVarcharTypeDeclarationSQL()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `AbstractPlatform::getVarcharTypeDeclarationSQL()`
+
+The `AbstractPlatform::getVarcharTypeDeclarationSQL()` method has been deprecated.
+Use `AbstractPlatform::getStringTypeDeclarationSQL()` instead.
+
 ## Deprecated `$database` parameter of `AbstractSchemaManager::list*()` methods
 
 Passing `$database` to the following methods has been deprecated:

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -266,6 +266,10 @@
                 <referencedMethod name="Doctrine\DBAL\Platforms\OraclePlatform::getListTableConstraintsSQL"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::getListTableConstraintsSQL"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::getListTableConstraintsSQL"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getVarcharTypeDeclarationSQL"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -191,11 +191,13 @@ abstract class AbstractPlatform
      */
     public function getAsciiStringTypeDeclarationSQL(array $column): string
     {
-        return $this->getVarcharTypeDeclarationSQL($column);
+        return $this->getStringTypeDeclarationSQL($column);
     }
 
     /**
      * Returns the SQL snippet used to declare a VARCHAR column type.
+     *
+     * @deprecated Use {@link getStringTypeDeclarationSQL()} instead.
      *
      * @param mixed[] $column
      *
@@ -218,6 +220,18 @@ abstract class AbstractPlatform
         }
 
         return $this->getVarcharTypeDeclarationSQLSnippet($column['length'], $fixed);
+    }
+
+    /**
+     * Returns the SQL snippet used to declare a string column type.
+     *
+     * @param mixed[] $column
+     *
+     * @return string
+     */
+    public function getStringTypeDeclarationSQL(array $column)
+    {
+        return $this->getVarcharTypeDeclarationSQL($column);
     }
 
     /**
@@ -270,7 +284,7 @@ abstract class AbstractPlatform
         $column['length'] = 36;
         $column['fixed']  = true;
 
-        return $this->getVarcharTypeDeclarationSQL($column);
+        return $this->getStringTypeDeclarationSQL($column);
     }
 
     /**

--- a/src/Types/DateIntervalType.php
+++ b/src/Types/DateIntervalType.php
@@ -30,7 +30,7 @@ class DateIntervalType extends Type
     {
         $column['length'] = 255;
 
-        return $platform->getVarcharTypeDeclarationSQL($column);
+        return $platform->getStringTypeDeclarationSQL($column);
     }
 
     /**

--- a/src/Types/StringType.php
+++ b/src/Types/StringType.php
@@ -14,7 +14,7 @@ class StringType extends Type
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform)
     {
-        return $platform->getVarcharTypeDeclarationSQL($column);
+        return $platform->getStringTypeDeclarationSQL($column);
     }
 
     /**

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -129,17 +129,17 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         self::assertEquals(
             'CHAR(10)',
-            $this->platform->getVarcharTypeDeclarationSQL(
+            $this->platform->getStringTypeDeclarationSQL(
                 ['length' => 10, 'fixed' => true]
             )
         );
         self::assertEquals(
             'VARCHAR(50)',
-            $this->platform->getVarcharTypeDeclarationSQL(['length' => 50])
+            $this->platform->getStringTypeDeclarationSQL(['length' => 50])
         );
         self::assertEquals(
             'VARCHAR(255)',
-            $this->platform->getVarcharTypeDeclarationSQL([])
+            $this->platform->getStringTypeDeclarationSQL([])
         );
     }
 

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -246,10 +246,10 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             'autoincrement' => true,
         ];
 
-        self::assertEquals('VARCHAR(255)', $this->platform->getVarcharTypeDeclarationSQL([]));
-        self::assertEquals('VARCHAR(10)', $this->platform->getVarcharTypeDeclarationSQL(['length' => 10]));
-        self::assertEquals('CHAR(254)', $this->platform->getVarcharTypeDeclarationSQL(['fixed' => true]));
-        self::assertEquals('CHAR(10)', $this->platform->getVarcharTypeDeclarationSQL($fullColumnDef));
+        self::assertEquals('VARCHAR(255)', $this->platform->getStringTypeDeclarationSQL([]));
+        self::assertEquals('VARCHAR(10)', $this->platform->getStringTypeDeclarationSQL(['length' => 10]));
+        self::assertEquals('CHAR(254)', $this->platform->getStringTypeDeclarationSQL(['fixed' => true]));
+        self::assertEquals('CHAR(10)', $this->platform->getStringTypeDeclarationSQL($fullColumnDef));
 
         self::assertEquals('SMALLINT', $this->platform->getSmallIntTypeDeclarationSQL([]));
         self::assertEquals('SMALLINT', $this->platform->getSmallIntTypeDeclarationSQL(['unsigned' => true]));

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -186,17 +186,17 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     {
         self::assertEquals(
             'CHAR(10)',
-            $this->platform->getVarcharTypeDeclarationSQL(
+            $this->platform->getStringTypeDeclarationSQL(
                 ['length' => 10, 'fixed' => true]
             )
         );
         self::assertEquals(
             'VARCHAR2(50)',
-            $this->platform->getVarcharTypeDeclarationSQL(['length' => 50])
+            $this->platform->getStringTypeDeclarationSQL(['length' => 50])
         );
         self::assertEquals(
             'VARCHAR2(255)',
-            $this->platform->getVarcharTypeDeclarationSQL([])
+            $this->platform->getStringTypeDeclarationSQL([])
         );
     }
 

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -286,17 +286,17 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     {
         self::assertEquals(
             'CHAR(10)',
-            $this->platform->getVarcharTypeDeclarationSQL(
+            $this->platform->getStringTypeDeclarationSQL(
                 ['length' => 10, 'fixed' => true]
             )
         );
         self::assertEquals(
             'VARCHAR(50)',
-            $this->platform->getVarcharTypeDeclarationSQL(['length' => 50])
+            $this->platform->getStringTypeDeclarationSQL(['length' => 50])
         );
         self::assertEquals(
             'VARCHAR(255)',
-            $this->platform->getVarcharTypeDeclarationSQL([])
+            $this->platform->getStringTypeDeclarationSQL([])
         );
     }
 

--- a/tests/Platforms/SQLServerPlatformTestCase.php
+++ b/tests/Platforms/SQLServerPlatformTestCase.php
@@ -139,17 +139,17 @@ class SQLServerPlatformTestCase extends AbstractPlatformTestCase
     {
         self::assertEquals(
             'NCHAR(10)',
-            $this->platform->getVarcharTypeDeclarationSQL(
+            $this->platform->getStringTypeDeclarationSQL(
                 ['length' => 10, 'fixed' => true]
             )
         );
         self::assertEquals(
             'NVARCHAR(50)',
-            $this->platform->getVarcharTypeDeclarationSQL(['length' => 50])
+            $this->platform->getStringTypeDeclarationSQL(['length' => 50])
         );
         self::assertEquals(
             'NVARCHAR(255)',
-            $this->platform->getVarcharTypeDeclarationSQL([])
+            $this->platform->getStringTypeDeclarationSQL([])
         );
         self::assertSame('VARCHAR(MAX)', $this->platform->getClobTypeDeclarationSQL([]));
         self::assertSame(

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -227,17 +227,17 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     {
         self::assertEquals(
             'CHAR(10)',
-            $this->platform->getVarcharTypeDeclarationSQL(
+            $this->platform->getStringTypeDeclarationSQL(
                 ['length' => 10, 'fixed' => true]
             )
         );
         self::assertEquals(
             'VARCHAR(50)',
-            $this->platform->getVarcharTypeDeclarationSQL(['length' => 50])
+            $this->platform->getStringTypeDeclarationSQL(['length' => 50])
         );
         self::assertEquals(
             'VARCHAR(255)',
-            $this->platform->getVarcharTypeDeclarationSQL([])
+            $this->platform->getStringTypeDeclarationSQL([])
         );
     }
 

--- a/tests/Types/StringTest.php
+++ b/tests/Types/StringTest.php
@@ -21,13 +21,13 @@ class StringTest extends TestCase
         $this->type     = new StringType();
     }
 
-    public function testReturnsSqlDeclarationFromPlatformVarchar(): void
+    public function testReturnsSqlDeclarationFromPlatformString(): void
     {
         $this->platform->expects(self::once())
-            ->method('getVarcharTypeDeclarationSQL')
-            ->willReturn('TEST_VARCHAR');
+            ->method('getStringTypeDeclarationSQL')
+            ->willReturn('TEST_STRING');
 
-        self::assertEquals('TEST_VARCHAR', $this->type->getSQLDeclaration([], $this->platform));
+        self::assertEquals('TEST_STRING', $this->type->getSQLDeclaration([], $this->platform));
     }
 
     public function testConvertToPHPValue(): void


### PR DESCRIPTION
The method will be renamed in 4.0 (https://github.com/doctrine/dbal/pull/3586).