### PR TITLE
Remove CA bundle from AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,6 @@ cache:
   - C:\ProgramData\chocolatey\bin -> .appveyor.yml
   - C:\ProgramData\chocolatey\lib -> .appveyor.yml
   - C:\tools\php -> .appveyor.yml
-  - C:\tools\cacert -> .appveyor.yml
   - C:\tools\composer -> .appveyor.yml
   - '%LOCALAPPDATA%\Composer\files -> composer.json'
 
@@ -69,7 +68,6 @@ install:
           Add-Content php.ini "`n extension=php_pdo_sqlite.dll"
           Add-Content php.ini "`n extension=php_sqlite3.dll"
           Add-Content php.ini "`n extension=php_curl.dll"
-          Add-Content php.ini "`n curl.cainfo=C:\tools\cacert\bundle.pem"
 
           # Get and install the latest stable sqlsrv DLL's
           $DLLVersion = (Invoke-WebRequest "https://pecl.php.net/rest/r/sqlsrv/stable.txt").Content
@@ -99,14 +97,6 @@ install:
           if (!(Test-Path c:\tools\composer\composer.phar)) {
             appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar -Filename C:\tools\composer\composer.phar
             Set-Content -path 'C:\tools\composer\composer.bat' -Value ('@php C:\tools\composer\composer.phar %*')
-          }
-
-          # download CA bundle
-          if (!(Test-Path C:\tools\cacert)) {
-            New-Item -path c:\tools\ -name cacert -itemtype directory
-          }
-          if (!(Test-Path c:\tools\cacert\bundle.pem)) {
-            appveyor-retry appveyor DownloadFile https://curl.haxx.se/ca/cacert.pem -Filename C:\tools\cacert\bundle.pem
           }
         }
     # install composer dependencies


### PR DESCRIPTION
The AppVeyor builds are [failing](https://ci.appveyor.com/project/doctrine/dbal/builds/43424224) with the following error:
> Error downloading remote file: One or more errors occurred.
> Inner Exception: The request was aborted: Could not create SSL/TLS secure channel.
Command "appveyor DownloadFile https://curl.haxx.se/ca/cacert.pem -Filename C:\tools\cacert\bundle.pem" failed with exit code 2. Retrying 2 of 3

It looks like the file has been moved but the client doesn't handle the redirect:
```
$ curl https://curl.haxx.se/ca/cacert.pem
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://curl.se/ca/cacert.pem">here</a>.</p>
<hr>
<address>Apache Server at curl.haxx.se Port 80</address>
</body></html>
```
UPD: changing the URL didn't help but it looks like the certificates bundled with the supported versions of PHP are okay, so we don't need to update them.