### PR TITLE
Use native return type declarations

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,10 +48,6 @@
         <exclude-pattern>*/src/*</exclude-pattern>
     </rule>
 
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
-        <exclude-pattern>*/src/*</exclude-pattern>
-    </rule>
-
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>

--- a/src/Cache/CacheException.php
+++ b/src/Cache/CacheException.php
@@ -9,18 +9,12 @@ use Doctrine\DBAL\Exception;
  */
 class CacheException extends Exception
 {
-    /**
-     * @return CacheException
-     */
-    public static function noCacheKey()
+    public static function noCacheKey(): CacheException
     {
         return new self('No cache key was set.');
     }
 
-    /**
-     * @return CacheException
-     */
-    public static function noResultDriverConfigured()
+    public static function noResultDriverConfigured(): CacheException
     {
         return new self('Trying to cache a query but no result driver is configured.');
     }

--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -71,10 +71,8 @@ class QueryCacheProfile
 
     /**
      * @deprecated Use {@see getResultCache()} instead.
-     *
-     * @return Cache|null
      */
-    public function getResultCacheDriver()
+    public function getResultCacheDriver(): ?Cache
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -86,20 +84,15 @@ class QueryCacheProfile
         return $this->resultCache !== null ? DoctrineProvider::wrap($this->resultCache) : null;
     }
 
-    /**
-     * @return int
-     */
-    public function getLifetime()
+    public function getLifetime(): int
     {
         return $this->lifetime;
     }
 
     /**
-     * @return string
-     *
      * @throws CacheException
      */
-    public function getCacheKey()
+    public function getCacheKey(): string
     {
         if ($this->cacheKey === null) {
             throw CacheException::noCacheKey();
@@ -118,7 +111,7 @@ class QueryCacheProfile
      *
      * @return string[]
      */
-    public function generateCacheKeys($sql, $params, $types, array $connectionParams = [])
+    public function generateCacheKeys($sql, $params, $types, array $connectionParams = []): array
     {
         if (isset($connectionParams['password'])) {
             unset($connectionParams['password']);
@@ -146,10 +139,8 @@ class QueryCacheProfile
 
     /**
      * @deprecated Use {@see setResultCache()} instead.
-     *
-     * @return QueryCacheProfile
      */
-    public function setResultCacheDriver(Cache $cache)
+    public function setResultCacheDriver(Cache $cache): QueryCacheProfile
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -163,20 +154,16 @@ class QueryCacheProfile
 
     /**
      * @param string|null $cacheKey
-     *
-     * @return QueryCacheProfile
      */
-    public function setCacheKey($cacheKey)
+    public function setCacheKey($cacheKey): QueryCacheProfile
     {
         return new QueryCacheProfile($this->lifetime, $cacheKey, $this->resultCache);
     }
 
     /**
      * @param int $lifetime
-     *
-     * @return QueryCacheProfile
      */
-    public function setLifetime($lifetime)
+    public function setLifetime($lifetime): QueryCacheProfile
     {
         return new QueryCacheProfile($lifetime, $this->cacheKey, $this->resultCache);
     }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -216,7 +216,7 @@ class Connection
      * @return array<string,mixed>
      * @psalm-return Params
      */
-    public function getParams()
+    public function getParams(): array
     {
         return $this->params;
     }
@@ -230,7 +230,7 @@ class Connection
      *
      * @throws Exception
      */
-    public function getDatabase()
+    public function getDatabase(): ?string
     {
         $platform = $this->getDatabasePlatform();
         $query    = $platform->getDummySelectSQL($platform->getCurrentDatabaseExpression());
@@ -243,30 +243,24 @@ class Connection
 
     /**
      * Gets the DBAL driver instance.
-     *
-     * @return Driver
      */
-    public function getDriver()
+    public function getDriver(): Driver
     {
         return $this->_driver;
     }
 
     /**
      * Gets the Configuration used by the Connection.
-     *
-     * @return Configuration
      */
-    public function getConfiguration()
+    public function getConfiguration(): Configuration
     {
         return $this->_config;
     }
 
     /**
      * Gets the EventManager used by the Connection.
-     *
-     * @return EventManager
      */
-    public function getEventManager()
+    public function getEventManager(): EventManager
     {
         return $this->_eventManager;
     }
@@ -274,11 +268,9 @@ class Connection
     /**
      * Gets the DatabasePlatform for the connection.
      *
-     * @return AbstractPlatform
-     *
      * @throws Exception
      */
-    public function getDatabasePlatform()
+    public function getDatabasePlatform(): AbstractPlatform
     {
         if ($this->platform === null) {
             $this->platform = $this->detectDatabasePlatform();
@@ -300,10 +292,8 @@ class Connection
      * Gets the ExpressionBuilder for the connection.
      *
      * @deprecated Use {@see createExpressionBuilder()} instead.
-     *
-     * @return ExpressionBuilder
      */
-    public function getExpressionBuilder()
+    public function getExpressionBuilder(): ExpressionBuilder
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -325,7 +315,7 @@ class Connection
      *
      * @throws Exception
      */
-    public function connect()
+    public function connect(): bool
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -383,11 +373,9 @@ class Connection
      * or the underlying driver connection cannot determine the platform
      * version without having to query it (performance reasons).
      *
-     * @return string|null
-     *
      * @throws Throwable
      */
-    private function getDatabasePlatformVersion()
+    private function getDatabasePlatformVersion(): ?string
     {
         // Driver does not support version specific platforms.
         if (! $this->_driver instanceof VersionAwarePlatformDriver) {
@@ -439,11 +427,9 @@ class Connection
     /**
      * Returns the database server version if the underlying driver supports it.
      *
-     * @return string|null
-     *
      * @throws Exception
      */
-    private function getServerVersion()
+    private function getServerVersion(): ?string
     {
         $connection = $this->getWrappedConnection();
 
@@ -474,7 +460,7 @@ class Connection
      *
      * @return bool True if auto-commit mode is currently enabled for this connection, false otherwise.
      */
-    public function isAutoCommit()
+    public function isAutoCommit(): bool
     {
         return $this->autoCommit === true;
     }
@@ -492,10 +478,8 @@ class Connection
      * @see   isAutoCommit
      *
      * @param bool $autoCommit True to enable auto-commit mode; false to disable it.
-     *
-     * @return void
      */
-    public function setAutoCommit($autoCommit)
+    public function setAutoCommit($autoCommit): void
     {
         $autoCommit = (bool) $autoCommit;
 
@@ -567,10 +551,8 @@ class Connection
 
     /**
      * Whether an actual connection to the database is established.
-     *
-     * @return bool
      */
-    public function isConnected()
+    public function isConnected(): bool
     {
         return $this->_conn !== null;
     }
@@ -580,7 +562,7 @@ class Connection
      *
      * @return bool TRUE if a transaction is currently active, FALSE otherwise.
      */
-    public function isTransactionActive()
+    public function isTransactionActive(): bool
     {
         return $this->transactionNestingLevel > 0;
     }
@@ -647,10 +629,8 @@ class Connection
 
     /**
      * Closes the connection.
-     *
-     * @return void
      */
-    public function close()
+    public function close(): void
     {
         $this->_conn                   = null;
         $this->transactionNestingLevel = 0;
@@ -679,7 +659,7 @@ class Connection
      *
      * @throws Exception
      */
-    public function getTransactionIsolation()
+    public function getTransactionIsolation(): int
     {
         if ($this->transactionIsolationLevel === null) {
             $this->transactionIsolationLevel = $this->getDatabasePlatform()->getDefaultTransactionIsolationLevel();
@@ -794,7 +774,7 @@ class Connection
      *
      * @return string The quoted name.
      */
-    public function quoteIdentifier($str)
+    public function quoteIdentifier($str): string
     {
         return $this->getDatabasePlatform()->quoteIdentifier($str);
     }
@@ -1173,7 +1153,7 @@ class Connection
      *
      * @return int The nesting level. A value of 0 means there's no active transaction.
      */
-    public function getTransactionNestingLevel()
+    public function getTransactionNestingLevel(): int
     {
         return $this->transactionNestingLevel;
     }
@@ -1245,11 +1225,9 @@ class Connection
      *
      * @param bool $nestTransactionsWithSavepoints
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function setNestTransactionsWithSavepoints($nestTransactionsWithSavepoints)
+    public function setNestTransactionsWithSavepoints($nestTransactionsWithSavepoints): void
     {
         if ($this->transactionNestingLevel > 0) {
             throw ConnectionException::mayNotAlterNestedTransactionWithSavepointsInTransaction();
@@ -1264,30 +1242,24 @@ class Connection
 
     /**
      * Gets if nested transactions should use savepoints.
-     *
-     * @return bool
      */
-    public function getNestTransactionsWithSavepoints()
+    public function getNestTransactionsWithSavepoints(): bool
     {
         return $this->nestTransactionsWithSavepoints;
     }
 
     /**
      * Returns the savepoint name to use for nested transactions.
-     *
-     * @return string
      */
-    protected function _getNestedTransactionSavePointName()
+    protected function _getNestedTransactionSavePointName(): string
     {
         return 'DOCTRINE2_SAVEPOINT_' . $this->transactionNestingLevel;
     }
 
     /**
-     * @return bool
-     *
      * @throws Exception
      */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         $connection = $this->getWrappedConnection();
 
@@ -1322,11 +1294,9 @@ class Connection
     }
 
     /**
-     * @return bool
-     *
      * @throws Exception
      */
-    public function commit()
+    public function commit(): bool
     {
         if ($this->transactionNestingLevel === 0) {
             throw ConnectionException::noActiveTransaction();
@@ -1399,11 +1369,9 @@ class Connection
     /**
      * Cancels any database changes done during the current transaction.
      *
-     * @return bool
-     *
      * @throws Exception
      */
-    public function rollBack()
+    public function rollBack(): bool
     {
         if ($this->transactionNestingLevel === 0) {
             throw ConnectionException::noActiveTransaction();
@@ -1453,11 +1421,9 @@ class Connection
      *
      * @param string $savepoint The name of the savepoint to create.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function createSavepoint($savepoint)
+    public function createSavepoint($savepoint): void
     {
         $platform = $this->getDatabasePlatform();
 
@@ -1473,11 +1439,9 @@ class Connection
      *
      * @param string $savepoint The name of the savepoint to release.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function releaseSavepoint($savepoint)
+    public function releaseSavepoint($savepoint): void
     {
         $platform = $this->getDatabasePlatform();
 
@@ -1497,11 +1461,9 @@ class Connection
      *
      * @param string $savepoint The name of the savepoint to rollback to.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function rollbackSavepoint($savepoint)
+    public function rollbackSavepoint($savepoint): void
     {
         $platform = $this->getDatabasePlatform();
 
@@ -1517,11 +1479,9 @@ class Connection
      *
      * @deprecated Use {@link getNativeConnection()} to access the native connection.
      *
-     * @return DriverConnection
-     *
      * @throws Exception
      */
-    public function getWrappedConnection()
+    public function getWrappedConnection(): DriverConnection
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -1575,11 +1535,9 @@ class Connection
      *
      * @deprecated Use {@see createSchemaManager()} instead.
      *
-     * @return AbstractSchemaManager
-     *
      * @throws Exception
      */
-    public function getSchemaManager()
+    public function getSchemaManager(): AbstractSchemaManager
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -1598,11 +1556,9 @@ class Connection
      * Marks the current transaction so that the only possible
      * outcome for the transaction to be rolled back.
      *
-     * @return void
-     *
      * @throws ConnectionException If no transaction is active.
      */
-    public function setRollbackOnly()
+    public function setRollbackOnly(): void
     {
         if ($this->transactionNestingLevel === 0) {
             throw ConnectionException::noActiveTransaction();
@@ -1614,11 +1570,9 @@ class Connection
     /**
      * Checks whether the current transaction is marked for rollback only.
      *
-     * @return bool
-     *
      * @throws ConnectionException If no transaction is active.
      */
-    public function isRollbackOnly()
+    public function isRollbackOnly(): bool
     {
         if ($this->transactionNestingLevel === 0) {
             throw ConnectionException::noActiveTransaction();
@@ -1728,10 +1682,8 @@ class Connection
 
     /**
      * Creates a new instance of a SQL query builder.
-     *
-     * @return QueryBuilder
      */
-    public function createQueryBuilder()
+    public function createQueryBuilder(): QueryBuilder
     {
         return new Query\QueryBuilder($this);
     }

--- a/src/ConnectionException.php
+++ b/src/ConnectionException.php
@@ -7,34 +7,22 @@ namespace Doctrine\DBAL;
  */
 class ConnectionException extends Exception
 {
-    /**
-     * @return ConnectionException
-     */
-    public static function commitFailedRollbackOnly()
+    public static function commitFailedRollbackOnly(): ConnectionException
     {
         return new self('Transaction commit failed because the transaction has been marked for rollback only.');
     }
 
-    /**
-     * @return ConnectionException
-     */
-    public static function noActiveTransaction()
+    public static function noActiveTransaction(): ConnectionException
     {
         return new self('There is no active transaction.');
     }
 
-    /**
-     * @return ConnectionException
-     */
-    public static function savepointsNotSupported()
+    public static function savepointsNotSupported(): ConnectionException
     {
         return new self('Savepoints are not supported by this driver.');
     }
 
-    /**
-     * @return ConnectionException
-     */
-    public static function mayNotAlterNestedTransactionWithSavepointsInTransaction()
+    public static function mayNotAlterNestedTransactionWithSavepointsInTransaction(): ConnectionException
     {
         return new self('May not alter the nested transaction with savepoints behavior while a transaction is open.');
     }

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -139,10 +139,8 @@ class PrimaryReadReplicaConnection extends Connection
 
     /**
      * @param string|null $connectionName
-     *
-     * @return bool
      */
-    public function connect($connectionName = null)
+    public function connect($connectionName = null): bool
     {
         if ($connectionName !== null) {
             throw new InvalidArgumentException(
@@ -233,11 +231,9 @@ class PrimaryReadReplicaConnection extends Connection
      *
      * @param string $connectionName
      *
-     * @return DriverConnection
-     *
      * @throws Exception
      */
-    protected function connectTo($connectionName)
+    protected function connectTo($connectionName): DriverConnection
     {
         $params = $this->getParams();
 

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -23,7 +23,7 @@ interface Driver
      *
      * @throws Exception
      */
-    public function connect(array $params);
+    public function connect(array $params): DriverConnection;
 
     /**
      * Gets the DatabasePlatform instance that provides all the metadata about
@@ -31,15 +31,13 @@ interface Driver
      *
      * @return AbstractPlatform The database platform.
      */
-    public function getDatabasePlatform();
+    public function getDatabasePlatform(): AbstractPlatform;
 
     /**
      * Gets the SchemaManager that can be used to inspect and change the underlying
      * database schema of the platform this driver connects to.
-     *
-     * @return AbstractSchemaManager
      */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform);
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager;
 
     /**
      * Gets the ExceptionConverter that can be used to convert driver-level exceptions into DBAL exceptions.

--- a/src/Driver/AbstractOracleDriver.php
+++ b/src/Driver/AbstractOracleDriver.php
@@ -45,10 +45,8 @@ abstract class AbstractOracleDriver implements Driver
      * Returns an appropriate Easy Connect String for the given parameters.
      *
      * @param mixed[] $params The connection parameters to return the Easy Connect String for.
-     *
-     * @return string
      */
-    protected function getEasyConnectString(array $params)
+    protected function getEasyConnectString(array $params): string
     {
         return (string) EasyConnectString::fromConnectionParameters($params);
     }

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -64,7 +64,7 @@ interface Connection
      *
      * @throws Exception
      */
-    public function beginTransaction();
+    public function beginTransaction(): bool;
 
     /**
      * Commits a transaction.
@@ -73,7 +73,7 @@ interface Connection
      *
      * @throws Exception
      */
-    public function commit();
+    public function commit(): bool;
 
     /**
      * Rolls back the current transaction, as initiated by beginTransaction().
@@ -82,5 +82,5 @@ interface Connection
      *
      * @throws Exception
      */
-    public function rollBack();
+    public function rollBack(): bool;
 }

--- a/src/Driver/Exception.php
+++ b/src/Driver/Exception.php
@@ -15,8 +15,6 @@ interface Exception extends Throwable
      * Returns the SQLSTATE the driver was in at the time the error occurred.
      *
      * Returns null if the driver does not provide a SQLSTATE for the error occurred.
-     *
-     * @return string|null
      */
-    public function getSQLState();
+    public function getSQLState(): ?string;
 }

--- a/src/Driver/ServerInfoAwareConnection.php
+++ b/src/Driver/ServerInfoAwareConnection.php
@@ -13,9 +13,7 @@ interface ServerInfoAwareConnection extends Connection
     /**
      * Returns information about the version of the database server connected to.
      *
-     * @return string
-     *
      * @throws Exception
      */
-    public function getServerVersion();
+    public function getServerVersion(): string;
 }

--- a/src/Driver/Statement.php
+++ b/src/Driver/Statement.php
@@ -27,7 +27,7 @@ interface Statement
      *
      * @throws Exception
      */
-    public function bindValue($param, $value, $type = ParameterType::STRING);
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool;
 
     /**
      * Binds a PHP variable to a corresponding named (not supported by mysqli driver, see comment below) or question
@@ -56,7 +56,7 @@ interface Statement
      *
      * @throws Exception
      */
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null);
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool;
 
     /**
      * Executes a prepared statement

--- a/src/Event/ConnectionEventArgs.php
+++ b/src/Event/ConnectionEventArgs.php
@@ -18,10 +18,7 @@ class ConnectionEventArgs extends EventArgs
         $this->connection = $connection;
     }
 
-    /**
-     * @return Connection
-     */
-    public function getConnection()
+    public function getConnection(): Connection
     {
         return $this->connection;
     }

--- a/src/Event/Listeners/OracleSessionInit.php
+++ b/src/Event/Listeners/OracleSessionInit.php
@@ -44,11 +44,9 @@ class OracleSessionInit implements EventSubscriber
     }
 
     /**
-     * @return void
-     *
      * @throws Exception
      */
-    public function postConnect(ConnectionEventArgs $args)
+    public function postConnect(ConnectionEventArgs $args): void
     {
         if (count($this->_defaultSessionVars) === 0) {
             return;

--- a/src/Event/Listeners/SQLSessionInit.php
+++ b/src/Event/Listeners/SQLSessionInit.php
@@ -24,11 +24,9 @@ class SQLSessionInit implements EventSubscriber
     }
 
     /**
-     * @return void
-     *
      * @throws Exception
      */
-    public function postConnect(ConnectionEventArgs $args)
+    public function postConnect(ConnectionEventArgs $args): void
     {
         $args->getConnection()->executeStatement($this->sql);
     }

--- a/src/Event/SchemaAlterTableAddColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableAddColumnEventArgs.php
@@ -35,26 +35,17 @@ class SchemaAlterTableAddColumnEventArgs extends SchemaEventArgs
         $this->platform  = $platform;
     }
 
-    /**
-     * @return Column
-     */
-    public function getColumn()
+    public function getColumn(): Column
     {
         return $this->column;
     }
 
-    /**
-     * @return TableDiff
-     */
-    public function getTableDiff()
+    public function getTableDiff(): TableDiff
     {
         return $this->tableDiff;
     }
 
-    /**
-     * @return AbstractPlatform
-     */
-    public function getPlatform()
+    public function getPlatform(): AbstractPlatform
     {
         return $this->platform;
     }
@@ -63,10 +54,8 @@ class SchemaAlterTableAddColumnEventArgs extends SchemaEventArgs
      * Passing multiple SQL statements as an array is deprecated. Pass each statement as an individual argument instead.
      *
      * @param string|string[] $sql
-     *
-     * @return SchemaAlterTableAddColumnEventArgs
      */
-    public function addSql($sql)
+    public function addSql($sql): SchemaAlterTableAddColumnEventArgs
     {
         if (is_array($sql)) {
             Deprecation::trigger(
@@ -85,7 +74,7 @@ class SchemaAlterTableAddColumnEventArgs extends SchemaEventArgs
     /**
      * @return string[]
      */
-    public function getSql()
+    public function getSql(): array
     {
         return $this->sql;
     }

--- a/src/Event/SchemaAlterTableChangeColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableChangeColumnEventArgs.php
@@ -34,26 +34,17 @@ class SchemaAlterTableChangeColumnEventArgs extends SchemaEventArgs
         $this->platform   = $platform;
     }
 
-    /**
-     * @return ColumnDiff
-     */
-    public function getColumnDiff()
+    public function getColumnDiff(): ColumnDiff
     {
         return $this->columnDiff;
     }
 
-    /**
-     * @return TableDiff
-     */
-    public function getTableDiff()
+    public function getTableDiff(): TableDiff
     {
         return $this->tableDiff;
     }
 
-    /**
-     * @return AbstractPlatform
-     */
-    public function getPlatform()
+    public function getPlatform(): AbstractPlatform
     {
         return $this->platform;
     }
@@ -62,10 +53,8 @@ class SchemaAlterTableChangeColumnEventArgs extends SchemaEventArgs
      * Passing multiple SQL statements as an array is deprecated. Pass each statement as an individual argument instead.
      *
      * @param string|string[] $sql
-     *
-     * @return SchemaAlterTableChangeColumnEventArgs
      */
-    public function addSql($sql)
+    public function addSql($sql): SchemaAlterTableChangeColumnEventArgs
     {
         $this->sql = array_merge($this->sql, is_array($sql) ? $sql : func_get_args());
 
@@ -75,7 +64,7 @@ class SchemaAlterTableChangeColumnEventArgs extends SchemaEventArgs
     /**
      * @return string[]
      */
-    public function getSql()
+    public function getSql(): array
     {
         return $this->sql;
     }

--- a/src/Event/SchemaAlterTableEventArgs.php
+++ b/src/Event/SchemaAlterTableEventArgs.php
@@ -29,18 +29,12 @@ class SchemaAlterTableEventArgs extends SchemaEventArgs
         $this->platform  = $platform;
     }
 
-    /**
-     * @return TableDiff
-     */
-    public function getTableDiff()
+    public function getTableDiff(): TableDiff
     {
         return $this->tableDiff;
     }
 
-    /**
-     * @return AbstractPlatform
-     */
-    public function getPlatform()
+    public function getPlatform(): AbstractPlatform
     {
         return $this->platform;
     }
@@ -49,10 +43,8 @@ class SchemaAlterTableEventArgs extends SchemaEventArgs
      * Passing multiple SQL statements as an array is deprecated. Pass each statement as an individual argument instead.
      *
      * @param string|string[] $sql
-     *
-     * @return SchemaAlterTableEventArgs
      */
-    public function addSql($sql)
+    public function addSql($sql): SchemaAlterTableEventArgs
     {
         $this->sql = array_merge($this->sql, is_array($sql) ? $sql : func_get_args());
 
@@ -62,7 +54,7 @@ class SchemaAlterTableEventArgs extends SchemaEventArgs
     /**
      * @return string[]
      */
-    public function getSql()
+    public function getSql(): array
     {
         return $this->sql;
     }

--- a/src/Event/SchemaAlterTableRemoveColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableRemoveColumnEventArgs.php
@@ -34,26 +34,17 @@ class SchemaAlterTableRemoveColumnEventArgs extends SchemaEventArgs
         $this->platform  = $platform;
     }
 
-    /**
-     * @return Column
-     */
-    public function getColumn()
+    public function getColumn(): Column
     {
         return $this->column;
     }
 
-    /**
-     * @return TableDiff
-     */
-    public function getTableDiff()
+    public function getTableDiff(): TableDiff
     {
         return $this->tableDiff;
     }
 
-    /**
-     * @return AbstractPlatform
-     */
-    public function getPlatform()
+    public function getPlatform(): AbstractPlatform
     {
         return $this->platform;
     }
@@ -62,10 +53,8 @@ class SchemaAlterTableRemoveColumnEventArgs extends SchemaEventArgs
      * Passing multiple SQL statements as an array is deprecated. Pass each statement as an individual argument instead.
      *
      * @param string|string[] $sql
-     *
-     * @return SchemaAlterTableRemoveColumnEventArgs
      */
-    public function addSql($sql)
+    public function addSql($sql): SchemaAlterTableRemoveColumnEventArgs
     {
         $this->sql = array_merge($this->sql, is_array($sql) ? $sql : func_get_args());
 
@@ -75,7 +64,7 @@ class SchemaAlterTableRemoveColumnEventArgs extends SchemaEventArgs
     /**
      * @return string[]
      */
-    public function getSql()
+    public function getSql(): array
     {
         return $this->sql;
     }

--- a/src/Event/SchemaAlterTableRenameColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableRenameColumnEventArgs.php
@@ -41,34 +41,22 @@ class SchemaAlterTableRenameColumnEventArgs extends SchemaEventArgs
         $this->platform      = $platform;
     }
 
-    /**
-     * @return string
-     */
-    public function getOldColumnName()
+    public function getOldColumnName(): string
     {
         return $this->oldColumnName;
     }
 
-    /**
-     * @return Column
-     */
-    public function getColumn()
+    public function getColumn(): Column
     {
         return $this->column;
     }
 
-    /**
-     * @return TableDiff
-     */
-    public function getTableDiff()
+    public function getTableDiff(): TableDiff
     {
         return $this->tableDiff;
     }
 
-    /**
-     * @return AbstractPlatform
-     */
-    public function getPlatform()
+    public function getPlatform(): AbstractPlatform
     {
         return $this->platform;
     }
@@ -77,10 +65,8 @@ class SchemaAlterTableRenameColumnEventArgs extends SchemaEventArgs
      * Passing multiple SQL statements as an array is deprecated. Pass each statement as an individual argument instead.
      *
      * @param string|string[] $sql
-     *
-     * @return SchemaAlterTableRenameColumnEventArgs
      */
-    public function addSql($sql)
+    public function addSql($sql): SchemaAlterTableRenameColumnEventArgs
     {
         $this->sql = array_merge($this->sql, is_array($sql) ? $sql : func_get_args());
 
@@ -90,7 +76,7 @@ class SchemaAlterTableRenameColumnEventArgs extends SchemaEventArgs
     /**
      * @return string[]
      */
-    public function getSql()
+    public function getSql(): array
     {
         return $this->sql;
     }

--- a/src/Event/SchemaColumnDefinitionEventArgs.php
+++ b/src/Event/SchemaColumnDefinitionEventArgs.php
@@ -45,20 +45,15 @@ class SchemaColumnDefinitionEventArgs extends SchemaEventArgs
     /**
      * Allows to clear the column which means the column will be excluded from
      * tables column list.
-     *
-     * @return SchemaColumnDefinitionEventArgs
      */
-    public function setColumn(?Column $column = null)
+    public function setColumn(?Column $column = null): SchemaColumnDefinitionEventArgs
     {
         $this->column = $column;
 
         return $this;
     }
 
-    /**
-     * @return Column|null
-     */
-    public function getColumn()
+    public function getColumn(): ?Column
     {
         return $this->column;
     }
@@ -66,31 +61,22 @@ class SchemaColumnDefinitionEventArgs extends SchemaEventArgs
     /**
      * @return mixed[]
      */
-    public function getTableColumn()
+    public function getTableColumn(): array
     {
         return $this->tableColumn;
     }
 
-    /**
-     * @return string
-     */
-    public function getTable()
+    public function getTable(): string
     {
         return $this->table;
     }
 
-    /**
-     * @return string
-     */
-    public function getDatabase()
+    public function getDatabase(): string
     {
         return $this->database;
     }
 
-    /**
-     * @return Connection
-     */
-    public function getConnection()
+    public function getConnection(): Connection
     {
         return $this->connection;
     }

--- a/src/Event/SchemaCreateTableColumnEventArgs.php
+++ b/src/Event/SchemaCreateTableColumnEventArgs.php
@@ -34,26 +34,17 @@ class SchemaCreateTableColumnEventArgs extends SchemaEventArgs
         $this->platform = $platform;
     }
 
-    /**
-     * @return Column
-     */
-    public function getColumn()
+    public function getColumn(): Column
     {
         return $this->column;
     }
 
-    /**
-     * @return Table
-     */
-    public function getTable()
+    public function getTable(): Table
     {
         return $this->table;
     }
 
-    /**
-     * @return AbstractPlatform
-     */
-    public function getPlatform()
+    public function getPlatform(): AbstractPlatform
     {
         return $this->platform;
     }
@@ -62,10 +53,8 @@ class SchemaCreateTableColumnEventArgs extends SchemaEventArgs
      * Passing multiple SQL statements as an array is deprecated. Pass each statement as an individual argument instead.
      *
      * @param string|string[] $sql
-     *
-     * @return SchemaCreateTableColumnEventArgs
      */
-    public function addSql($sql)
+    public function addSql($sql): SchemaCreateTableColumnEventArgs
     {
         $this->sql = array_merge($this->sql, is_array($sql) ? $sql : func_get_args());
 
@@ -75,7 +64,7 @@ class SchemaCreateTableColumnEventArgs extends SchemaEventArgs
     /**
      * @return string[]
      */
-    public function getSql()
+    public function getSql(): array
     {
         return $this->sql;
     }

--- a/src/Event/SchemaCreateTableEventArgs.php
+++ b/src/Event/SchemaCreateTableEventArgs.php
@@ -41,10 +41,7 @@ class SchemaCreateTableEventArgs extends SchemaEventArgs
         $this->platform = $platform;
     }
 
-    /**
-     * @return Table
-     */
-    public function getTable()
+    public function getTable(): Table
     {
         return $this->table;
     }
@@ -52,7 +49,7 @@ class SchemaCreateTableEventArgs extends SchemaEventArgs
     /**
      * @return mixed[][]
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         return $this->columns;
     }
@@ -60,15 +57,12 @@ class SchemaCreateTableEventArgs extends SchemaEventArgs
     /**
      * @return mixed[]
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
 
-    /**
-     * @return AbstractPlatform
-     */
-    public function getPlatform()
+    public function getPlatform(): AbstractPlatform
     {
         return $this->platform;
     }
@@ -77,10 +71,8 @@ class SchemaCreateTableEventArgs extends SchemaEventArgs
      * Passing multiple SQL statements as an array is deprecated. Pass each statement as an individual argument instead.
      *
      * @param string|string[] $sql
-     *
-     * @return SchemaCreateTableEventArgs
      */
-    public function addSql($sql)
+    public function addSql($sql): SchemaCreateTableEventArgs
     {
         $this->sql = array_merge($this->sql, is_array($sql) ? $sql : func_get_args());
 
@@ -90,7 +82,7 @@ class SchemaCreateTableEventArgs extends SchemaEventArgs
     /**
      * @return string[]
      */
-    public function getSql()
+    public function getSql(): array
     {
         return $this->sql;
     }

--- a/src/Event/SchemaDropTableEventArgs.php
+++ b/src/Event/SchemaDropTableEventArgs.php
@@ -39,30 +39,22 @@ class SchemaDropTableEventArgs extends SchemaEventArgs
         return $this->table;
     }
 
-    /**
-     * @return AbstractPlatform
-     */
-    public function getPlatform()
+    public function getPlatform(): AbstractPlatform
     {
         return $this->platform;
     }
 
     /**
      * @param string $sql
-     *
-     * @return SchemaDropTableEventArgs
      */
-    public function setSql($sql)
+    public function setSql($sql): SchemaDropTableEventArgs
     {
         $this->sql = $sql;
 
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getSql()
+    public function getSql(): ?string
     {
         return $this->sql;
     }

--- a/src/Event/SchemaEventArgs.php
+++ b/src/Event/SchemaEventArgs.php
@@ -12,20 +12,14 @@ class SchemaEventArgs extends EventArgs
     /** @var bool */
     private $preventDefault = false;
 
-    /**
-     * @return SchemaEventArgs
-     */
-    public function preventDefault()
+    public function preventDefault(): SchemaEventArgs
     {
         $this->preventDefault = true;
 
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isDefaultPrevented()
+    public function isDefaultPrevented(): bool
     {
         return $this->preventDefault;
     }

--- a/src/Event/SchemaIndexDefinitionEventArgs.php
+++ b/src/Event/SchemaIndexDefinitionEventArgs.php
@@ -39,20 +39,15 @@ class SchemaIndexDefinitionEventArgs extends SchemaEventArgs
 
     /**
      * Allows to clear the index which means the index will be excluded from tables index list.
-     *
-     * @return SchemaIndexDefinitionEventArgs
      */
-    public function setIndex(?Index $index = null)
+    public function setIndex(?Index $index = null): SchemaIndexDefinitionEventArgs
     {
         $this->index = $index;
 
         return $this;
     }
 
-    /**
-     * @return Index|null
-     */
-    public function getIndex()
+    public function getIndex(): ?Index
     {
         return $this->index;
     }
@@ -60,23 +55,17 @@ class SchemaIndexDefinitionEventArgs extends SchemaEventArgs
     /**
      * @return mixed[]
      */
-    public function getTableIndex()
+    public function getTableIndex(): array
     {
         return $this->tableIndex;
     }
 
-    /**
-     * @return string
-     */
-    public function getTable()
+    public function getTable(): string
     {
         return $this->table;
     }
 
-    /**
-     * @return Connection
-     */
-    public function getConnection()
+    public function getConnection(): Connection
     {
         return $this->connection;
     }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -11,10 +11,7 @@ use Doctrine\DBAL\Exception;
  */
 class InvalidArgumentException extends Exception
 {
-    /**
-     * @return self
-     */
-    public static function fromEmptyCriteria()
+    public static function fromEmptyCriteria(): self
     {
         return new self('Empty criteria was used, expected non-empty criteria');
     }

--- a/src/Id/TableGenerator.php
+++ b/src/Id/TableGenerator.php
@@ -97,11 +97,9 @@ class TableGenerator
      *
      * @param string $sequence
      *
-     * @return int
-     *
      * @throws Exception
      */
-    public function nextValue($sequence)
+    public function nextValue($sequence): int
     {
         if (isset($this->sequences[$sequence])) {
             $value = $this->sequences[$sequence]['value'];

--- a/src/Logging/SQLLogger.php
+++ b/src/Logging/SQLLogger.php
@@ -18,15 +18,11 @@ interface SQLLogger
      * @param string                                                                    $sql    SQL statement
      * @param list<mixed>|array<string, mixed>|null                                     $params Statement parameters
      * @param array<int, Type|int|string|null>|array<string, Type|int|string|null>|null $types  Parameter types
-     *
-     * @return void
      */
-    public function startQuery($sql, ?array $params = null, ?array $types = null);
+    public function startQuery($sql, ?array $params = null, ?array $types = null): void;
 
     /**
      * Marks the last started query as stopped. This can be used for timing of queries.
-     *
-     * @return void
      */
-    public function stopQuery();
+    public function stopQuery(): void;
 }

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -180,10 +180,8 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
      *
      * @param string      $table
      * @param string|null $database
-     *
-     * @return string
      */
-    public function getListTableForeignKeysSQL($table, $database = null)
+    public function getListTableForeignKeysSQL($table, $database = null): string
     {
         // The schema name is passed multiple times as a literal in the WHERE clause instead of using a JOIN condition
         // in order to avoid performance issues on MySQL older than 8.0 and the corresponding MariaDB versions
@@ -759,7 +757,7 @@ SQL
      *
      * @return string[]
      */
-    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff): array
     {
         $sql       = [];
         $tableName = $diff->getName($this)->getQuotedName($this);
@@ -827,7 +825,7 @@ SQL
      *
      * @return string[]
      */
-    protected function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    protected function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff): array
     {
         $sql     = [];
         $newName = $diff->getNewName();
@@ -994,10 +992,8 @@ SQL
 
     /**
      * @param string $table
-     *
-     * @return string
      */
-    protected function getDropPrimaryKeySQL($table)
+    protected function getDropPrimaryKeySQL($table): string
     {
         return 'ALTER TABLE ' . $table . ' DROP PRIMARY KEY';
     }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -98,20 +98,16 @@ abstract class AbstractPlatform
 
     /**
      * Sets the EventManager used by the Platform.
-     *
-     * @return void
      */
-    public function setEventManager(EventManager $eventManager)
+    public function setEventManager(EventManager $eventManager): void
     {
         $this->_eventManager = $eventManager;
     }
 
     /**
      * Gets the EventManager used by the Platform.
-     *
-     * @return EventManager|null
      */
-    public function getEventManager()
+    public function getEventManager(): ?EventManager
     {
         return $this->_eventManager;
     }
@@ -120,53 +116,41 @@ abstract class AbstractPlatform
      * Returns the SQL snippet that declares a boolean column.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    abstract public function getBooleanTypeDeclarationSQL(array $column);
+    abstract public function getBooleanTypeDeclarationSQL(array $column): string;
 
     /**
      * Returns the SQL snippet that declares a 4 byte integer column.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    abstract public function getIntegerTypeDeclarationSQL(array $column);
+    abstract public function getIntegerTypeDeclarationSQL(array $column): string;
 
     /**
      * Returns the SQL snippet that declares an 8 byte integer column.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    abstract public function getBigIntTypeDeclarationSQL(array $column);
+    abstract public function getBigIntTypeDeclarationSQL(array $column): string;
 
     /**
      * Returns the SQL snippet that declares a 2 byte integer column.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    abstract public function getSmallIntTypeDeclarationSQL(array $column);
+    abstract public function getSmallIntTypeDeclarationSQL(array $column): string;
 
     /**
      * Returns the SQL snippet that declares common properties of an integer column.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    abstract protected function _getCommonIntegerTypeDeclarationSQL(array $column);
+    abstract protected function _getCommonIntegerTypeDeclarationSQL(array $column): string;
 
     /**
      * Lazy load Doctrine Type Mappings.
-     *
-     * @return void
      */
-    abstract protected function initializeDoctrineTypeMappings();
+    abstract protected function initializeDoctrineTypeMappings(): void;
 
     /**
      * Initializes Doctrine Type Mappings with the platform defaults
@@ -200,10 +184,8 @@ abstract class AbstractPlatform
      * @deprecated Use {@link getStringTypeDeclarationSQL()} instead.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    public function getVarcharTypeDeclarationSQL(array $column)
+    public function getVarcharTypeDeclarationSQL(array $column): string
     {
         if (! isset($column['length'])) {
             $column['length'] = $this->getVarcharDefaultLength();
@@ -226,10 +208,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet used to declare a string column type.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    public function getStringTypeDeclarationSQL(array $column)
+    public function getStringTypeDeclarationSQL(array $column): string
     {
         return $this->getVarcharTypeDeclarationSQL($column);
     }
@@ -238,10 +218,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet used to declare a BINARY/VARBINARY column type.
      *
      * @param mixed[] $column The column definition.
-     *
-     * @return string
      */
-    public function getBinaryTypeDeclarationSQL(array $column)
+    public function getBinaryTypeDeclarationSQL(array $column): string
     {
         if (! isset($column['length'])) {
             $column['length'] = $this->getBinaryDefaultLength();
@@ -276,10 +254,8 @@ abstract class AbstractPlatform
      * special datatypes when the underlying databases support this datatype.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    public function getGuidTypeDeclarationSQL(array $column)
+    public function getGuidTypeDeclarationSQL(array $column): string
     {
         $column['length'] = 36;
         $column['fixed']  = true;
@@ -294,10 +270,8 @@ abstract class AbstractPlatform
      * special datatypes when the underlying databases support this datatype.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    public function getJsonTypeDeclarationSQL(array $column)
+    public function getJsonTypeDeclarationSQL(array $column): string
     {
         return $this->getClobTypeDeclarationSQL($column);
     }
@@ -306,11 +280,9 @@ abstract class AbstractPlatform
      * @param int|false $length
      * @param bool      $fixed
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed): string
     {
         throw Exception::notSupported('VARCHARs not supported by Platform.');
     }
@@ -321,11 +293,9 @@ abstract class AbstractPlatform
      * @param int|false $length The length of the column.
      * @param bool      $fixed  Whether the column length is fixed.
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed)
+    protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed): string
     {
         throw Exception::notSupported('BINARY/VARBINARY column types are not supported by this platform.');
     }
@@ -334,28 +304,22 @@ abstract class AbstractPlatform
      * Returns the SQL snippet used to declare a CLOB column type.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    abstract public function getClobTypeDeclarationSQL(array $column);
+    abstract public function getClobTypeDeclarationSQL(array $column): string;
 
     /**
      * Returns the SQL Snippet used to declare a BLOB column type.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    abstract public function getBlobTypeDeclarationSQL(array $column);
+    abstract public function getBlobTypeDeclarationSQL(array $column): string;
 
     /**
      * Gets the name of the platform.
      *
      * @deprecated Identify platforms by their class.
-     *
-     * @return string
      */
-    abstract public function getName();
+    abstract public function getName(): string;
 
     /**
      * Registers a doctrine type to be used in conjunction with a column type of this platform.
@@ -363,11 +327,9 @@ abstract class AbstractPlatform
      * @param string $dbType
      * @param string $doctrineType
      *
-     * @return void
-     *
      * @throws Exception If the type is not found.
      */
-    public function registerDoctrineTypeMapping($dbType, $doctrineType)
+    public function registerDoctrineTypeMapping($dbType, $doctrineType): void
     {
         if ($this->doctrineTypeMapping === null) {
             $this->initializeAllDoctrineTypeMappings();
@@ -394,11 +356,9 @@ abstract class AbstractPlatform
      *
      * @param string $dbType
      *
-     * @return string
-     *
      * @throws Exception
      */
-    public function getDoctrineTypeMapping($dbType)
+    public function getDoctrineTypeMapping($dbType): string
     {
         if ($this->doctrineTypeMapping === null) {
             $this->initializeAllDoctrineTypeMappings();
@@ -419,10 +379,8 @@ abstract class AbstractPlatform
      * Checks if a database type is currently supported by this platform.
      *
      * @param string $dbType
-     *
-     * @return bool
      */
-    public function hasDoctrineTypeMappingFor($dbType)
+    public function hasDoctrineTypeMappingFor($dbType): bool
     {
         if ($this->doctrineTypeMapping === null) {
             $this->initializeAllDoctrineTypeMappings();
@@ -437,10 +395,8 @@ abstract class AbstractPlatform
      * Initializes the Doctrine Type comments instance variable for in_array() checks.
      *
      * @deprecated This API will be removed in Doctrine DBAL 4.0.
-     *
-     * @return void
      */
-    protected function initializeCommentedDoctrineTypes()
+    protected function initializeCommentedDoctrineTypes(): void
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -466,10 +422,8 @@ abstract class AbstractPlatform
      * Is it necessary for the platform to add a parsable type comment to allow reverse engineering the given type?
      *
      * @deprecated Use {@link Type::requiresSQLCommentHint()} instead.
-     *
-     * @return bool
      */
-    public function isCommentedDoctrineType(Type $doctrineType)
+    public function isCommentedDoctrineType(Type $doctrineType): bool
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -489,10 +443,8 @@ abstract class AbstractPlatform
      * Marks this type as to be commented in ALTER TABLE and CREATE TABLE statements.
      *
      * @param string|Type $doctrineType
-     *
-     * @return void
      */
-    public function markDoctrineTypeCommented($doctrineType)
+    public function markDoctrineTypeCommented($doctrineType): void
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -514,10 +466,8 @@ abstract class AbstractPlatform
      * Gets the comment to append to a column comment that helps parsing this type in reverse engineering.
      *
      * @deprecated This method will be removed without replacement.
-     *
-     * @return string
      */
-    public function getDoctrineTypeComment(Type $doctrineType)
+    public function getDoctrineTypeComment(Type $doctrineType): string
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -533,10 +483,8 @@ abstract class AbstractPlatform
      * Gets the comment of a passed column modified by potential doctrine type comment hints.
      *
      * @deprecated This method will be removed without replacement.
-     *
-     * @return string|null
      */
-    protected function getColumnComment(Column $column)
+    protected function getColumnComment(Column $column): ?string
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -556,10 +504,8 @@ abstract class AbstractPlatform
 
     /**
      * Gets the character used for identifier quoting.
-     *
-     * @return string
      */
-    public function getIdentifierQuoteCharacter()
+    public function getIdentifierQuoteCharacter(): string
     {
         return '"';
     }
@@ -568,10 +514,8 @@ abstract class AbstractPlatform
      * Gets the string portion that starts an SQL comment.
      *
      * @deprecated
-     *
-     * @return string
      */
-    public function getSqlCommentStartString()
+    public function getSqlCommentStartString(): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -586,10 +530,8 @@ abstract class AbstractPlatform
      * Gets the string portion that ends an SQL comment.
      *
      * @deprecated
-     *
-     * @return string
      */
-    public function getSqlCommentEndString()
+    public function getSqlCommentEndString(): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -620,10 +562,8 @@ abstract class AbstractPlatform
      * Gets the maximum length of a varchar column.
      *
      * @deprecated
-     *
-     * @return int
      */
-    public function getVarcharMaxLength()
+    public function getVarcharMaxLength(): int
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -638,10 +578,8 @@ abstract class AbstractPlatform
      * Gets the default length of a varchar column.
      *
      * @deprecated
-     *
-     * @return int
      */
-    public function getVarcharDefaultLength()
+    public function getVarcharDefaultLength(): int
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -656,10 +594,8 @@ abstract class AbstractPlatform
      * Gets the maximum length of a binary column.
      *
      * @deprecated
-     *
-     * @return int
      */
-    public function getBinaryMaxLength()
+    public function getBinaryMaxLength(): int
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -674,10 +610,8 @@ abstract class AbstractPlatform
      * Gets the default length of a binary column.
      *
      * @deprecated
-     *
-     * @return int
      */
-    public function getBinaryDefaultLength()
+    public function getBinaryDefaultLength(): int
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -695,7 +629,7 @@ abstract class AbstractPlatform
      *
      * @return string[]
      */
-    public function getWildcards()
+    public function getWildcards(): array
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -710,11 +644,9 @@ abstract class AbstractPlatform
     /**
      * Returns the regular expression operator.
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getRegexpExpression()
+    public function getRegexpExpression(): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -728,7 +660,7 @@ abstract class AbstractPlatform
      *
      * @return string Generated SQL including an AVG aggregate function.
      */
-    public function getAvgExpression($column)
+    public function getAvgExpression($column): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -750,7 +682,7 @@ abstract class AbstractPlatform
      *
      * @return string Generated SQL including a COUNT aggregate function.
      */
-    public function getCountExpression($column)
+    public function getCountExpression($column): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -770,7 +702,7 @@ abstract class AbstractPlatform
      *
      * @return string Generated SQL including a MAX aggregate function.
      */
-    public function getMaxExpression($column)
+    public function getMaxExpression($column): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -790,7 +722,7 @@ abstract class AbstractPlatform
      *
      * @return string Generated SQL including a MIN aggregate function.
      */
-    public function getMinExpression($column)
+    public function getMinExpression($column): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -810,7 +742,7 @@ abstract class AbstractPlatform
      *
      * @return string Generated SQL including a SUM aggregate function.
      */
-    public function getSumExpression($column)
+    public function getSumExpression($column): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -831,10 +763,8 @@ abstract class AbstractPlatform
      * @deprecated
      *
      * @param string $column
-     *
-     * @return string
      */
-    public function getMd5Expression($column)
+    public function getMd5Expression($column): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -849,10 +779,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet to get the length of a text column in characters.
      *
      * @param string $column
-     *
-     * @return string
      */
-    public function getLengthExpression($column)
+    public function getLengthExpression($column): string
     {
         return 'LENGTH(' . $column . ')';
     }
@@ -866,7 +794,7 @@ abstract class AbstractPlatform
      *
      * @return string Generated SQL including an SQRT aggregate function.
      */
-    public function getSqrtExpression($column)
+    public function getSqrtExpression($column): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -884,10 +812,8 @@ abstract class AbstractPlatform
      *
      * @param string     $column
      * @param string|int $decimals
-     *
-     * @return string
      */
-    public function getRoundExpression($column, $decimals = 0)
+    public function getRoundExpression($column, $decimals = 0): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -903,10 +829,8 @@ abstract class AbstractPlatform
      *
      * @param string $expression1
      * @param string $expression2
-     *
-     * @return string
      */
-    public function getModExpression($expression1, $expression2)
+    public function getModExpression($expression1, $expression2): string
     {
         return 'MOD(' . $expression1 . ', ' . $expression2 . ')';
     }
@@ -917,10 +841,8 @@ abstract class AbstractPlatform
      * @param string      $str  The expression to apply the trim to.
      * @param int         $mode The position of the trim (leading/trailing/both).
      * @param string|bool $char The char to trim, has to be quoted already. Defaults to space.
-     *
-     * @return string
      */
-    public function getTrimExpression($str, $mode = TrimMode::UNSPECIFIED, $char = false)
+    public function getTrimExpression($str, $mode = TrimMode::UNSPECIFIED, $char = false): string
     {
         $expression = '';
 
@@ -955,10 +877,8 @@ abstract class AbstractPlatform
      * @deprecated Use RTRIM() in SQL instead.
      *
      * @param string $str Literal string or column name.
-     *
-     * @return string
      */
-    public function getRtrimExpression($str)
+    public function getRtrimExpression($str): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -975,10 +895,8 @@ abstract class AbstractPlatform
      * @deprecated Use LTRIM() in SQL instead.
      *
      * @param string $str Literal string or column name.
-     *
-     * @return string
      */
-    public function getLtrimExpression($str)
+    public function getLtrimExpression($str): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -996,10 +914,8 @@ abstract class AbstractPlatform
      * @deprecated Use UPPER() in SQL instead.
      *
      * @param string $str Literal string or column name.
-     *
-     * @return string
      */
-    public function getUpperExpression($str)
+    public function getUpperExpression($str): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1017,10 +933,8 @@ abstract class AbstractPlatform
      * @deprecated Use LOWER() in SQL instead.
      *
      * @param string $str Literal string or column name.
-     *
-     * @return string
      */
-    public function getLowerExpression($str)
+    public function getLowerExpression($str): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1038,11 +952,9 @@ abstract class AbstractPlatform
      * @param string           $substr   Literal string to find.
      * @param string|int|false $startPos Position to start at, beginning of string by default.
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getLocateExpression($str, $substr, $startPos = false)
+    public function getLocateExpression($str, $substr, $startPos = false): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -1051,10 +963,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet to get the current system date.
      *
      * @deprecated Generate dates within the application.
-     *
-     * @return string
      */
-    public function getNowExpression()
+    public function getNowExpression(): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1075,10 +985,8 @@ abstract class AbstractPlatform
      * @param string          $string An sql string literal or column name/alias.
      * @param string|int      $start  Where to start the substring portion.
      * @param string|int|null $length The substring portion length.
-     *
-     * @return string
      */
-    public function getSubstringExpression($string, $start, $length = null)
+    public function getSubstringExpression($string, $start, $length = null): string
     {
         if ($length === null) {
             return 'SUBSTRING(' . $string . ' FROM ' . $start . ')';
@@ -1091,10 +999,8 @@ abstract class AbstractPlatform
      * Returns a SQL snippet to concatenate the given expressions.
      *
      * Accepts an arbitrary number of string parameters. Each parameter must contain an expression.
-     *
-     * @return string
      */
-    public function getConcatExpression()
+    public function getConcatExpression(): string
     {
         return implode(' || ', func_get_args());
     }
@@ -1116,7 +1022,7 @@ abstract class AbstractPlatform
      *
      * @return string The logical expression.
      */
-    public function getNotExpression($expression)
+    public function getNotExpression($expression): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1136,7 +1042,7 @@ abstract class AbstractPlatform
      *
      * @return string The logical expression.
      */
-    public function getIsNullExpression($expression)
+    public function getIsNullExpression($expression): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1156,7 +1062,7 @@ abstract class AbstractPlatform
      *
      * @return string The logical expression.
      */
-    public function getIsNotNullExpression($expression)
+    public function getIsNotNullExpression($expression): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1184,7 +1090,7 @@ abstract class AbstractPlatform
      *
      * @return string The logical expression.
      */
-    public function getBetweenExpression($expression, $value1, $value2)
+    public function getBetweenExpression($expression, $value1, $value2): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1201,10 +1107,8 @@ abstract class AbstractPlatform
      * @deprecated Use ACOS() in SQL instead.
      *
      * @param string $value
-     *
-     * @return string
      */
-    public function getAcosExpression($value)
+    public function getAcosExpression($value): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1221,10 +1125,8 @@ abstract class AbstractPlatform
      * @deprecated Use SIN() in SQL instead.
      *
      * @param string $value
-     *
-     * @return string
      */
-    public function getSinExpression($value)
+    public function getSinExpression($value): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1239,10 +1141,8 @@ abstract class AbstractPlatform
      * Returns the SQL to get the PI value.
      *
      * @deprecated Use PI() in SQL instead.
-     *
-     * @return string
      */
-    public function getPiExpression()
+    public function getPiExpression(): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1259,10 +1159,8 @@ abstract class AbstractPlatform
      * @deprecated Use COS() in SQL instead.
      *
      * @param string $value
-     *
-     * @return string
      */
-    public function getCosExpression($value)
+    public function getCosExpression($value): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1281,11 +1179,9 @@ abstract class AbstractPlatform
      * @param string $date1
      * @param string $date2
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateDiffExpression($date1, $date2)
+    public function getDateDiffExpression($date1, $date2): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -1296,11 +1192,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $seconds
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateAddSecondsExpression($date, $seconds)
+    public function getDateAddSecondsExpression($date, $seconds): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '+', $seconds, DateIntervalUnit::SECOND);
     }
@@ -1311,11 +1205,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $seconds
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateSubSecondsExpression($date, $seconds)
+    public function getDateSubSecondsExpression($date, $seconds): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '-', $seconds, DateIntervalUnit::SECOND);
     }
@@ -1326,11 +1218,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $minutes
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateAddMinutesExpression($date, $minutes)
+    public function getDateAddMinutesExpression($date, $minutes): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '+', $minutes, DateIntervalUnit::MINUTE);
     }
@@ -1341,11 +1231,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $minutes
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateSubMinutesExpression($date, $minutes)
+    public function getDateSubMinutesExpression($date, $minutes): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '-', $minutes, DateIntervalUnit::MINUTE);
     }
@@ -1356,11 +1244,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $hours
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateAddHourExpression($date, $hours)
+    public function getDateAddHourExpression($date, $hours): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '+', $hours, DateIntervalUnit::HOUR);
     }
@@ -1371,11 +1257,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $hours
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateSubHourExpression($date, $hours)
+    public function getDateSubHourExpression($date, $hours): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '-', $hours, DateIntervalUnit::HOUR);
     }
@@ -1386,11 +1270,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $days
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateAddDaysExpression($date, $days)
+    public function getDateAddDaysExpression($date, $days): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '+', $days, DateIntervalUnit::DAY);
     }
@@ -1401,11 +1283,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $days
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateSubDaysExpression($date, $days)
+    public function getDateSubDaysExpression($date, $days): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '-', $days, DateIntervalUnit::DAY);
     }
@@ -1416,11 +1296,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $weeks
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateAddWeeksExpression($date, $weeks)
+    public function getDateAddWeeksExpression($date, $weeks): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '+', $weeks, DateIntervalUnit::WEEK);
     }
@@ -1431,11 +1309,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $weeks
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateSubWeeksExpression($date, $weeks)
+    public function getDateSubWeeksExpression($date, $weeks): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '-', $weeks, DateIntervalUnit::WEEK);
     }
@@ -1446,11 +1322,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $months
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateAddMonthExpression($date, $months)
+    public function getDateAddMonthExpression($date, $months): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '+', $months, DateIntervalUnit::MONTH);
     }
@@ -1461,11 +1335,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $months
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateSubMonthExpression($date, $months)
+    public function getDateSubMonthExpression($date, $months): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '-', $months, DateIntervalUnit::MONTH);
     }
@@ -1476,11 +1348,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $quarters
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateAddQuartersExpression($date, $quarters)
+    public function getDateAddQuartersExpression($date, $quarters): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '+', $quarters, DateIntervalUnit::QUARTER);
     }
@@ -1491,11 +1361,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $quarters
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateSubQuartersExpression($date, $quarters)
+    public function getDateSubQuartersExpression($date, $quarters): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '-', $quarters, DateIntervalUnit::QUARTER);
     }
@@ -1506,11 +1374,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $years
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateAddYearsExpression($date, $years)
+    public function getDateAddYearsExpression($date, $years): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '+', $years, DateIntervalUnit::YEAR);
     }
@@ -1521,11 +1387,9 @@ abstract class AbstractPlatform
      * @param string $date
      * @param int    $years
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateSubYearsExpression($date, $years)
+    public function getDateSubYearsExpression($date, $years): string
     {
         return $this->getDateArithmeticIntervalExpression($date, '-', $years, DateIntervalUnit::YEAR);
     }
@@ -1539,11 +1403,9 @@ abstract class AbstractPlatform
      * @param string $unit     The unit of the interval that shall be calculated into the date.
      *                         One of the DATE_INTERVAL_UNIT_* constants.
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    protected function getDateArithmeticIntervalExpression($date, $operator, $interval, $unit)
+    protected function getDateArithmeticIntervalExpression($date, $operator, $interval, $unit): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -1553,10 +1415,8 @@ abstract class AbstractPlatform
      *
      * @param string $value1
      * @param string $value2
-     *
-     * @return string
      */
-    public function getBitAndComparisonExpression($value1, $value2)
+    public function getBitAndComparisonExpression($value1, $value2): string
     {
         return '(' . $value1 . ' & ' . $value2 . ')';
     }
@@ -1566,10 +1426,8 @@ abstract class AbstractPlatform
      *
      * @param string $value1
      * @param string $value2
-     *
-     * @return string
      */
-    public function getBitOrComparisonExpression($value1, $value2)
+    public function getBitOrComparisonExpression($value1, $value2): string
     {
         return '(' . $value1 . ' | ' . $value2 . ')';
     }
@@ -1581,10 +1439,8 @@ abstract class AbstractPlatform
 
     /**
      * Returns the FOR UPDATE expression.
-     *
-     * @return string
      */
-    public function getForUpdateSQL()
+    public function getForUpdateSQL(): string
     {
         return 'FOR UPDATE';
     }
@@ -1616,10 +1472,8 @@ abstract class AbstractPlatform
      *
      * This defaults to the ANSI SQL "FOR UPDATE", which is an exclusive lock (Write). Some database
      * vendors allow to lighten this constraint up to be a real read lock.
-     *
-     * @return string
      */
-    public function getReadLockSQL()
+    public function getReadLockSQL(): string
     {
         return $this->getForUpdateSQL();
     }
@@ -1628,10 +1482,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet to append to any SELECT statement which obtains an exclusive lock on the rows.
      *
      * The semantics of this lock mode should equal the SELECT .. FOR UPDATE of the ANSI SQL standard.
-     *
-     * @return string
      */
-    public function getWriteLockSQL()
+    public function getWriteLockSQL(): string
     {
         return $this->getForUpdateSQL();
     }
@@ -1641,11 +1493,9 @@ abstract class AbstractPlatform
      *
      * @param Table|string $table
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getDropTableSQL($table)
+    public function getDropTableSQL($table): string
     {
         $tableArg = $table;
 
@@ -1681,10 +1531,8 @@ abstract class AbstractPlatform
      * Returns the SQL to safely drop a temporary table WITHOUT implicitly committing an open transaction.
      *
      * @param Table|string $table
-     *
-     * @return string
      */
-    public function getDropTemporaryTableSQL($table)
+    public function getDropTemporaryTableSQL($table): string
     {
         return $this->getDropTableSQL($table);
     }
@@ -1695,11 +1543,9 @@ abstract class AbstractPlatform
      * @param Index|string      $index
      * @param Table|string|null $table
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getDropIndexSQL($index, $table = null)
+    public function getDropIndexSQL($index, $table = null): string
     {
         if ($index instanceof Index) {
             $index = $index->getQuotedName($this);
@@ -1719,10 +1565,8 @@ abstract class AbstractPlatform
      *
      * @param Constraint|string $constraint
      * @param Table|string      $table
-     *
-     * @return string
      */
-    public function getDropConstraintSQL($constraint, $table)
+    public function getDropConstraintSQL($constraint, $table): string
     {
         if (! $constraint instanceof Constraint) {
             $constraint = new Identifier($constraint);
@@ -1743,10 +1587,8 @@ abstract class AbstractPlatform
      *
      * @param ForeignKeyConstraint|string $foreignKey
      * @param Table|string                $table
-     *
-     * @return string
      */
-    public function getDropForeignKeySQL($foreignKey, $table)
+    public function getDropForeignKeySQL($foreignKey, $table): string
     {
         if (! $foreignKey instanceof ForeignKeyConstraint) {
             $foreignKey = new Identifier($foreignKey);
@@ -1782,7 +1624,7 @@ abstract class AbstractPlatform
      * @throws Exception
      * @throws InvalidArgumentException
      */
-    public function getCreateTableSQL(Table $table, $createFlags = self::CREATE_INDEXES)
+    public function getCreateTableSQL(Table $table, $createFlags = self::CREATE_INDEXES): array
     {
         if (! is_int($createFlags)) {
             throw new InvalidArgumentException(
@@ -1899,10 +1741,8 @@ abstract class AbstractPlatform
      * @param string      $tableName
      * @param string      $columnName
      * @param string|null $comment
-     *
-     * @return string
      */
-    public function getCommentOnColumnSQL($tableName, $columnName, $comment)
+    public function getCommentOnColumnSQL($tableName, $columnName, $comment): string
     {
         $tableName  = new Identifier($tableName);
         $columnName = new Identifier($columnName);
@@ -1920,11 +1760,9 @@ abstract class AbstractPlatform
      *
      * @param string $comment
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getInlineColumnCommentSQL($comment)
+    public function getInlineColumnCommentSQL($comment): string
     {
         if (! $this->supportsInlineColumnComments()) {
             throw Exception::notSupported(__METHOD__);
@@ -1942,7 +1780,7 @@ abstract class AbstractPlatform
      *
      * @return string[]
      */
-    protected function _getCreateTableSQL($name, array $columns, array $options = [])
+    protected function _getCreateTableSQL($name, array $columns, array $options = []): array
     {
         $columnListSql = $this->getColumnDeclarationListSQL($columns);
 
@@ -1982,10 +1820,7 @@ abstract class AbstractPlatform
         return $sql;
     }
 
-    /**
-     * @return string
-     */
-    public function getCreateTemporaryTableSnippetSQL()
+    public function getCreateTemporaryTableSnippetSQL(): string
     {
         return 'CREATE TEMPORARY TABLE';
     }
@@ -1993,11 +1828,9 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to create a sequence on this platform.
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getCreateSequenceSQL(Sequence $sequence)
+    public function getCreateSequenceSQL(Sequence $sequence): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -2005,11 +1838,9 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to change a sequence on this platform.
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getAlterSequenceSQL(Sequence $sequence)
+    public function getAlterSequenceSQL(Sequence $sequence): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -2019,11 +1850,9 @@ abstract class AbstractPlatform
      *
      * @param Sequence|string $sequence
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDropSequenceSQL($sequence)
+    public function getDropSequenceSQL($sequence): string
     {
         if (! $this->supportsSequences()) {
             throw Exception::notSupported(__METHOD__);
@@ -2044,11 +1873,9 @@ abstract class AbstractPlatform
      *
      * @param Table|string $table
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getCreateConstraintSQL(Constraint $constraint, $table)
+    public function getCreateConstraintSQL(Constraint $constraint, $table): string
     {
         if ($table instanceof Table) {
             $table = $table->getQuotedName($this);
@@ -2088,11 +1915,9 @@ abstract class AbstractPlatform
      *
      * @param Table|string $table The name of the table on which the index is to be created.
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getCreateIndexSQL(Index $index, $table)
+    public function getCreateIndexSQL(Index $index, $table): string
     {
         if ($table instanceof Table) {
             $table = $table->getQuotedName($this);
@@ -2117,10 +1942,8 @@ abstract class AbstractPlatform
 
     /**
      * Adds condition for partial index.
-     *
-     * @return string
      */
-    protected function getPartialIndexSQL(Index $index)
+    protected function getPartialIndexSQL(Index $index): string
     {
         if ($this->supportsPartialIndexes() && $index->hasOption('where')) {
             return ' WHERE ' . $index->getOption('where');
@@ -2131,10 +1954,8 @@ abstract class AbstractPlatform
 
     /**
      * Adds additional flags for index generation.
-     *
-     * @return string
      */
-    protected function getCreateIndexSQLFlags(Index $index)
+    protected function getCreateIndexSQLFlags(Index $index): string
     {
         return $index->isUnique() ? 'UNIQUE ' : '';
     }
@@ -2143,10 +1964,8 @@ abstract class AbstractPlatform
      * Returns the SQL to create an unnamed primary key constraint.
      *
      * @param Table|string $table
-     *
-     * @return string
      */
-    public function getCreatePrimaryKeySQL(Index $index, $table)
+    public function getCreatePrimaryKeySQL(Index $index, $table): string
     {
         if ($table instanceof Table) {
             $table = $table->getQuotedName($this);
@@ -2160,11 +1979,9 @@ abstract class AbstractPlatform
      *
      * @param string $schemaName
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getCreateSchemaSQL($schemaName)
+    public function getCreateSchemaSQL($schemaName): string
     {
         if (! $this->supportsSchemas()) {
             throw Exception::notSupported(__METHOD__);
@@ -2208,7 +2025,7 @@ abstract class AbstractPlatform
      *
      * @return string The quoted identifier string.
      */
-    public function quoteIdentifier($str)
+    public function quoteIdentifier($str): string
     {
         if (strpos($str, '.') !== false) {
             $parts = array_map([$this, 'quoteSingleIdentifier'], explode('.', $str));
@@ -2226,7 +2043,7 @@ abstract class AbstractPlatform
      *
      * @return string The quoted identifier string.
      */
-    public function quoteSingleIdentifier($str)
+    public function quoteSingleIdentifier($str): string
     {
         $c = $this->getIdentifierQuoteCharacter();
 
@@ -2238,10 +2055,8 @@ abstract class AbstractPlatform
      *
      * @param ForeignKeyConstraint $foreignKey The foreign key constraint.
      * @param Table|string         $table      The name of the table on which the foreign key is to be created.
-     *
-     * @return string
      */
-    public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, $table)
+    public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, $table): string
     {
         if ($table instanceof Table) {
             $table = $table->getQuotedName($this);
@@ -2259,17 +2074,15 @@ abstract class AbstractPlatform
      *
      * @throws Exception If not supported on this platform.
      */
-    public function getAlterTableSQL(TableDiff $diff)
+    public function getAlterTableSQL(TableDiff $diff): array
     {
         throw Exception::notSupported(__METHOD__);
     }
 
     /**
      * @param mixed[] $columnSql
-     *
-     * @return bool
      */
-    protected function onSchemaAlterTableAddColumn(Column $column, TableDiff $diff, &$columnSql)
+    protected function onSchemaAlterTableAddColumn(Column $column, TableDiff $diff, &$columnSql): bool
     {
         if ($this->_eventManager === null) {
             return false;
@@ -2289,10 +2102,8 @@ abstract class AbstractPlatform
 
     /**
      * @param string[] $columnSql
-     *
-     * @return bool
      */
-    protected function onSchemaAlterTableRemoveColumn(Column $column, TableDiff $diff, &$columnSql)
+    protected function onSchemaAlterTableRemoveColumn(Column $column, TableDiff $diff, &$columnSql): bool
     {
         if ($this->_eventManager === null) {
             return false;
@@ -2312,10 +2123,8 @@ abstract class AbstractPlatform
 
     /**
      * @param string[] $columnSql
-     *
-     * @return bool
      */
-    protected function onSchemaAlterTableChangeColumn(ColumnDiff $columnDiff, TableDiff $diff, &$columnSql)
+    protected function onSchemaAlterTableChangeColumn(ColumnDiff $columnDiff, TableDiff $diff, &$columnSql): bool
     {
         if ($this->_eventManager === null) {
             return false;
@@ -2336,10 +2145,8 @@ abstract class AbstractPlatform
     /**
      * @param string   $oldColumnName
      * @param string[] $columnSql
-     *
-     * @return bool
      */
-    protected function onSchemaAlterTableRenameColumn($oldColumnName, Column $column, TableDiff $diff, &$columnSql)
+    protected function onSchemaAlterTableRenameColumn($oldColumnName, Column $column, TableDiff $diff, &$columnSql): bool
     {
         if ($this->_eventManager === null) {
             return false;
@@ -2359,10 +2166,8 @@ abstract class AbstractPlatform
 
     /**
      * @param string[] $sql
-     *
-     * @return bool
      */
-    protected function onSchemaAlterTable(TableDiff $diff, &$sql)
+    protected function onSchemaAlterTable(TableDiff $diff, &$sql): bool
     {
         if ($this->_eventManager === null) {
             return false;
@@ -2383,7 +2188,7 @@ abstract class AbstractPlatform
     /**
      * @return string[]
      */
-    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff)
+    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff): array
     {
         $tableName = $diff->getName($this)->getQuotedName($this);
 
@@ -2412,7 +2217,7 @@ abstract class AbstractPlatform
     /**
      * @return string[]
      */
-    protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff)
+    protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff): array
     {
         $sql     = [];
         $newName = $diff->getNewName();
@@ -2461,7 +2266,7 @@ abstract class AbstractPlatform
      *
      * @return string[] The sequence of SQL statements for renaming the given index.
      */
-    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
+    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName): array
     {
         return [
             $this->getDropIndexSQL($oldIndexName, $tableName),
@@ -2495,10 +2300,8 @@ abstract class AbstractPlatform
      *          Text value with the default COLLATION for this column.
      *      unique
      *          unique constraint
-     *
-     * @return string
      */
-    public function getColumnDeclarationListSQL(array $columns)
+    public function getColumnDeclarationListSQL(array $columns): string
     {
         $declarations = [];
 
@@ -2544,7 +2347,7 @@ abstract class AbstractPlatform
      *
      * @throws Exception
      */
-    public function getColumnDeclarationSQL($name, array $column)
+    public function getColumnDeclarationSQL($name, array $column): string
     {
         if (isset($column['columnDefinition'])) {
             $declaration = $this->getCustomTypeDeclarationSQL($column);
@@ -2579,10 +2382,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet that declares a floating point column of arbitrary precision.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    public function getDecimalTypeDeclarationSQL(array $column)
+    public function getDecimalTypeDeclarationSQL(array $column): string
     {
         $column['precision'] = ! isset($column['precision']) || empty($column['precision'])
             ? 10 : $column['precision'];
@@ -2600,7 +2401,7 @@ abstract class AbstractPlatform
      *
      * @return string DBMS specific SQL code portion needed to set a default value.
      */
-    public function getDefaultValueDeclarationSQL($column)
+    public function getDefaultValueDeclarationSQL($column): string
     {
         if (! isset($column['default'])) {
             return empty($column['notnull']) ? ' DEFAULT NULL' : '';
@@ -2645,7 +2446,7 @@ abstract class AbstractPlatform
      *
      * @return string DBMS specific SQL code portion needed to set a CHECK constraint.
      */
-    public function getCheckDeclarationSQL(array $definition)
+    public function getCheckDeclarationSQL(array $definition): string
     {
         $constraints = [];
         foreach ($definition as $column => $def) {
@@ -2676,7 +2477,7 @@ abstract class AbstractPlatform
      *
      * @throws InvalidArgumentException
      */
-    public function getUniqueConstraintDeclarationSQL($name, UniqueConstraint $constraint)
+    public function getUniqueConstraintDeclarationSQL($name, UniqueConstraint $constraint): string
     {
         $columns = $constraint->getQuotedColumns($this);
         $name    = new Identifier($name);
@@ -2703,7 +2504,7 @@ abstract class AbstractPlatform
      *
      * @throws InvalidArgumentException
      */
-    public function getIndexDeclarationSQL($name, Index $index)
+    public function getIndexDeclarationSQL($name, Index $index): string
     {
         $columns = $index->getColumns();
         $name    = new Identifier($name);
@@ -2722,10 +2523,8 @@ abstract class AbstractPlatform
      * Only "AUTOINCREMENT" and "PRIMARY KEY" are added if appropriate.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    public function getCustomTypeDeclarationSQL(array $column)
+    public function getCustomTypeDeclarationSQL(array $column): string
     {
         return $column['columnDefinition'];
     }
@@ -2776,7 +2575,7 @@ abstract class AbstractPlatform
      * @return string The string required to be placed between "CREATE" and "TABLE"
      *                to generate a temporary table, if possible.
      */
-    public function getTemporaryTableSQL()
+    public function getTemporaryTableSQL(): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -2791,10 +2590,8 @@ abstract class AbstractPlatform
      * Some vendors require temporary table names to be qualified specially.
      *
      * @param string $tableName
-     *
-     * @return string
      */
-    public function getTemporaryTableName($tableName)
+    public function getTemporaryTableName($tableName): string
     {
         return $tableName;
     }
@@ -2806,7 +2603,7 @@ abstract class AbstractPlatform
      * @return string DBMS specific SQL code portion needed to set the FOREIGN KEY constraint
      *                of a column declaration.
      */
-    public function getForeignKeyDeclarationSQL(ForeignKeyConstraint $foreignKey)
+    public function getForeignKeyDeclarationSQL(ForeignKeyConstraint $foreignKey): string
     {
         $sql  = $this->getForeignKeyBaseDeclarationSQL($foreignKey);
         $sql .= $this->getAdvancedForeignKeyOptionsSQL($foreignKey);
@@ -2819,10 +2616,8 @@ abstract class AbstractPlatform
      * as MATCH, INITIALLY DEFERRED, ON UPDATE, ...
      *
      * @param ForeignKeyConstraint $foreignKey The foreign key definition.
-     *
-     * @return string
      */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
+    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
     {
         $query = '';
         if ($foreignKey->hasOption('onUpdate')) {
@@ -2841,11 +2636,9 @@ abstract class AbstractPlatform
      *
      * @param string $action The foreign key referential action.
      *
-     * @return string
-     *
      * @throws InvalidArgumentException If unknown referential action given.
      */
-    public function getForeignKeyReferentialActionSQL($action)
+    public function getForeignKeyReferentialActionSQL($action): string
     {
         $upper = strtoupper($action);
         switch ($upper) {
@@ -2865,11 +2658,9 @@ abstract class AbstractPlatform
      * Obtains DBMS specific SQL code portion needed to set the FOREIGN KEY constraint
      * of a column declaration to be used in statements like CREATE TABLE.
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey)
+    public function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey): string
     {
         $sql = '';
         if (strlen($foreignKey->getName()) > 0) {
@@ -2905,7 +2696,7 @@ abstract class AbstractPlatform
      * @return string DBMS specific SQL code portion needed to set the UNIQUE constraint
      *                of a column declaration.
      */
-    public function getUniqueFieldDeclarationSQL()
+    public function getUniqueFieldDeclarationSQL(): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -2925,7 +2716,7 @@ abstract class AbstractPlatform
      * @return string DBMS specific SQL code portion needed to set the CHARACTER SET
      *                of a column declaration.
      */
-    public function getColumnCharsetDeclarationSQL($charset)
+    public function getColumnCharsetDeclarationSQL($charset): string
     {
         return '';
     }
@@ -2939,7 +2730,7 @@ abstract class AbstractPlatform
      * @return string DBMS specific SQL code portion needed to set the COLLATION
      *                of a column declaration.
      */
-    public function getColumnCollationDeclarationSQL($collation)
+    public function getColumnCollationDeclarationSQL($collation): string
     {
         return $this->supportsColumnCollation() ? 'COLLATE ' . $collation : '';
     }
@@ -2949,10 +2740,8 @@ abstract class AbstractPlatform
      * Subclasses should override this method to return TRUE if they prefer identity columns.
      *
      * @deprecated
-     *
-     * @return bool
      */
-    public function prefersIdentityColumns()
+    public function prefersIdentityColumns(): bool
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -3000,10 +2789,8 @@ abstract class AbstractPlatform
      * The default conversion tries to convert value into bool "(bool)$item"
      *
      * @param mixed $item
-     *
-     * @return bool|null
      */
-    public function convertFromBoolean($item)
+    public function convertFromBoolean($item): ?bool
     {
         return $item === null ? null : (bool) $item;
     }
@@ -3025,30 +2812,24 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL specific for the platform to get the current date.
-     *
-     * @return string
      */
-    public function getCurrentDateSQL()
+    public function getCurrentDateSQL(): string
     {
         return 'CURRENT_DATE';
     }
 
     /**
      * Returns the SQL specific for the platform to get the current time.
-     *
-     * @return string
      */
-    public function getCurrentTimeSQL()
+    public function getCurrentTimeSQL(): string
     {
         return 'CURRENT_TIME';
     }
 
     /**
      * Returns the SQL specific for the platform to get the current timestamp
-     *
-     * @return string
      */
-    public function getCurrentTimestampSQL()
+    public function getCurrentTimestampSQL(): string
     {
         return 'CURRENT_TIMESTAMP';
     }
@@ -3058,11 +2839,9 @@ abstract class AbstractPlatform
      *
      * @param int $level
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    protected function _getTransactionIsolationLevelSQL($level)
+    protected function _getTransactionIsolationLevelSQL($level): string
     {
         switch ($level) {
             case TransactionIsolationLevel::READ_UNCOMMITTED:
@@ -3083,11 +2862,9 @@ abstract class AbstractPlatform
     }
 
     /**
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getListDatabasesSQL()
+    public function getListDatabasesSQL(): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3097,11 +2874,9 @@ abstract class AbstractPlatform
      *
      * @deprecated Use {@see AbstractSchemaManager::listSchemaNames()} instead.
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getListNamespacesSQL()
+    public function getListNamespacesSQL(): string
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -3116,11 +2891,9 @@ abstract class AbstractPlatform
     /**
      * @param string $database
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getListSequencesSQL($database)
+    public function getListSequencesSQL($database): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3130,11 +2903,9 @@ abstract class AbstractPlatform
      *
      * @param string $table
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getListTableConstraintsSQL($table)
+    public function getListTableConstraintsSQL($table): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3145,11 +2916,9 @@ abstract class AbstractPlatform
      * @param string $table
      * @param string $database
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getListTableColumnsSQL($table, $database = null)
+    public function getListTableColumnsSQL($table, $database = null): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3157,11 +2926,9 @@ abstract class AbstractPlatform
     /**
      * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getListTablesSQL()
+    public function getListTablesSQL(): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3169,11 +2936,9 @@ abstract class AbstractPlatform
     /**
      * @deprecated
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getListUsersSQL()
+    public function getListUsersSQL(): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -3189,11 +2954,9 @@ abstract class AbstractPlatform
      *
      * @param string $database
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getListViewsSQL($database)
+    public function getListViewsSQL($database): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3213,11 +2976,9 @@ abstract class AbstractPlatform
      * @param string $table
      * @param string $database
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getListTableIndexesSQL($table, $database = null)
+    public function getListTableIndexesSQL($table, $database = null): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3227,11 +2988,9 @@ abstract class AbstractPlatform
      *
      * @param string $table
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getListTableForeignKeysSQL($table)
+    public function getListTableForeignKeysSQL($table): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3239,20 +2998,16 @@ abstract class AbstractPlatform
     /**
      * @param string $name
      * @param string $sql
-     *
-     * @return string
      */
-    public function getCreateViewSQL($name, $sql)
+    public function getCreateViewSQL($name, $sql): string
     {
         return 'CREATE VIEW ' . $name . ' AS ' . $sql;
     }
 
     /**
      * @param string $name
-     *
-     * @return string
      */
-    public function getDropViewSQL($name)
+    public function getDropViewSQL($name): string
     {
         return 'DROP VIEW ' . $name;
     }
@@ -3260,11 +3015,9 @@ abstract class AbstractPlatform
     /**
      * @param string $sequence
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getSequenceNextValSQL($sequence)
+    public function getSequenceNextValSQL($sequence): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3274,11 +3027,9 @@ abstract class AbstractPlatform
      *
      * @param string $name The name of the database that should be created.
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getCreateDatabaseSQL($name)
+    public function getCreateDatabaseSQL($name): string
     {
         if (! $this->supportsCreateDropDatabase()) {
             throw Exception::notSupported(__METHOD__);
@@ -3291,10 +3042,8 @@ abstract class AbstractPlatform
      * Returns the SQL snippet to drop an existing database.
      *
      * @param string $name The name of the database that should be dropped.
-     *
-     * @return string
      */
-    public function getDropDatabaseSQL($name)
+    public function getDropDatabaseSQL($name): string
     {
         if (! $this->supportsCreateDropDatabase()) {
             throw Exception::notSupported(__METHOD__);
@@ -3308,11 +3057,9 @@ abstract class AbstractPlatform
      *
      * @param int $level
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getSetTransactionIsolationSQL($level)
+    public function getSetTransactionIsolationSQL($level): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3323,11 +3070,9 @@ abstract class AbstractPlatform
      *
      * @param mixed[] $column
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateTimeTypeDeclarationSQL(array $column)
+    public function getDateTimeTypeDeclarationSQL(array $column): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3336,10 +3081,8 @@ abstract class AbstractPlatform
      * Obtains DBMS specific SQL to be used to create datetime with timezone offset columns.
      *
      * @param mixed[] $column
-     *
-     * @return string
      */
-    public function getDateTimeTzTypeDeclarationSQL(array $column)
+    public function getDateTimeTzTypeDeclarationSQL(array $column): string
     {
         return $this->getDateTimeTypeDeclarationSQL($column);
     }
@@ -3350,11 +3093,9 @@ abstract class AbstractPlatform
      *
      * @param mixed[] $column
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDateTypeDeclarationSQL(array $column)
+    public function getDateTypeDeclarationSQL(array $column): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3365,21 +3106,17 @@ abstract class AbstractPlatform
      *
      * @param mixed[] $column
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getTimeTypeDeclarationSQL(array $column)
+    public function getTimeTypeDeclarationSQL(array $column): string
     {
         throw Exception::notSupported(__METHOD__);
     }
 
     /**
      * @param mixed[] $column
-     *
-     * @return string
      */
-    public function getFloatDeclarationSQL(array $column)
+    public function getFloatDeclarationSQL(array $column): string
     {
         return 'DOUBLE PRECISION';
     }
@@ -3391,7 +3128,7 @@ abstract class AbstractPlatform
      *
      * @return int The default isolation level.
      */
-    public function getDefaultTransactionIsolationLevel()
+    public function getDefaultTransactionIsolationLevel(): int
     {
         return TransactionIsolationLevel::READ_COMMITTED;
     }
@@ -3400,10 +3137,8 @@ abstract class AbstractPlatform
 
     /**
      * Whether the platform supports sequences.
-     *
-     * @return bool
      */
-    public function supportsSequences()
+    public function supportsSequences(): bool
     {
         return false;
     }
@@ -3413,10 +3148,8 @@ abstract class AbstractPlatform
      *
      * Identity columns are columns that receive an auto-generated value from the
      * database on insert of a row.
-     *
-     * @return bool
      */
-    public function supportsIdentityColumns()
+    public function supportsIdentityColumns(): bool
     {
         return false;
     }
@@ -3427,10 +3160,8 @@ abstract class AbstractPlatform
      * Some platforms that do not support identity columns natively
      * but support sequences can emulate identity columns by using
      * sequences.
-     *
-     * @return bool
      */
-    public function usesSequenceEmulatedIdentityColumns()
+    public function usesSequenceEmulatedIdentityColumns(): bool
     {
         return false;
     }
@@ -3443,11 +3174,9 @@ abstract class AbstractPlatform
      * @param string $tableName  The name of the table to return the sequence name for.
      * @param string $columnName The name of the identity column in the table to return the sequence name for.
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getIdentitySequenceName($tableName, $columnName)
+    public function getIdentitySequenceName($tableName, $columnName): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3456,10 +3185,8 @@ abstract class AbstractPlatform
      * Whether the platform supports indexes.
      *
      * @deprecated
-     *
-     * @return bool
      */
-    public function supportsIndexes()
+    public function supportsIndexes(): bool
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -3472,10 +3199,8 @@ abstract class AbstractPlatform
 
     /**
      * Whether the platform supports partial indexes.
-     *
-     * @return bool
      */
-    public function supportsPartialIndexes()
+    public function supportsPartialIndexes(): bool
     {
         return false;
     }
@@ -3492,10 +3217,8 @@ abstract class AbstractPlatform
      * Whether the platform supports altering tables.
      *
      * @deprecated All platforms must implement altering tables.
-     *
-     * @return bool
      */
-    public function supportsAlterTable()
+    public function supportsAlterTable(): bool
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -3510,10 +3233,8 @@ abstract class AbstractPlatform
      * Whether the platform supports transactions.
      *
      * @deprecated
-     *
-     * @return bool
      */
-    public function supportsTransactions()
+    public function supportsTransactions(): bool
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -3526,20 +3247,16 @@ abstract class AbstractPlatform
 
     /**
      * Whether the platform supports savepoints.
-     *
-     * @return bool
      */
-    public function supportsSavepoints()
+    public function supportsSavepoints(): bool
     {
         return true;
     }
 
     /**
      * Whether the platform supports releasing savepoints.
-     *
-     * @return bool
      */
-    public function supportsReleaseSavepoints()
+    public function supportsReleaseSavepoints(): bool
     {
         return $this->supportsSavepoints();
     }
@@ -3548,10 +3265,8 @@ abstract class AbstractPlatform
      * Whether the platform supports primary key constraints.
      *
      * @deprecated
-     *
-     * @return bool
      */
-    public function supportsPrimaryConstraints()
+    public function supportsPrimaryConstraints(): bool
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -3564,20 +3279,16 @@ abstract class AbstractPlatform
 
     /**
      * Whether the platform supports foreign key constraints.
-     *
-     * @return bool
      */
-    public function supportsForeignKeyConstraints()
+    public function supportsForeignKeyConstraints(): bool
     {
         return true;
     }
 
     /**
      * Whether the platform supports database schemas.
-     *
-     * @return bool
      */
-    public function supportsSchemas()
+    public function supportsSchemas(): bool
     {
         return false;
     }
@@ -3589,10 +3300,8 @@ abstract class AbstractPlatform
      *
      * Platforms that either support or emulate schemas don't automatically
      * filter a schema for the namespaced elements in {@see AbstractManager::createSchema()}.
-     *
-     * @return bool
      */
-    public function canEmulateSchemas()
+    public function canEmulateSchemas(): bool
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -3606,11 +3315,9 @@ abstract class AbstractPlatform
     /**
      * Returns the default schema name.
      *
-     * @return string
-     *
      * @throws Exception If not supported on this platform.
      */
-    public function getDefaultSchemaName()
+    public function getDefaultSchemaName(): string
     {
         throw Exception::notSupported(__METHOD__);
     }
@@ -3619,10 +3326,8 @@ abstract class AbstractPlatform
      * Whether this platform supports create database.
      *
      * Some databases don't allow to create and drop databases at all or only with certain tools.
-     *
-     * @return bool
      */
-    public function supportsCreateDropDatabase()
+    public function supportsCreateDropDatabase(): bool
     {
         return true;
     }
@@ -3631,10 +3336,8 @@ abstract class AbstractPlatform
      * Whether the platform supports getting the affected rows of a recent update/delete type query.
      *
      * @deprecated
-     *
-     * @return bool
      */
-    public function supportsGettingAffectedRows()
+    public function supportsGettingAffectedRows(): bool
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -3647,40 +3350,32 @@ abstract class AbstractPlatform
 
     /**
      * Whether this platform support to add inline column comments as postfix.
-     *
-     * @return bool
      */
-    public function supportsInlineColumnComments()
+    public function supportsInlineColumnComments(): bool
     {
         return false;
     }
 
     /**
      * Whether this platform support the proprietary syntax "COMMENT ON asset".
-     *
-     * @return bool
      */
-    public function supportsCommentOnStatement()
+    public function supportsCommentOnStatement(): bool
     {
         return false;
     }
 
     /**
      * Does this platform have native guid type.
-     *
-     * @return bool
      */
-    public function hasNativeGuidType()
+    public function hasNativeGuidType(): bool
     {
         return false;
     }
 
     /**
      * Does this platform have native JSON type.
-     *
-     * @return bool
      */
-    public function hasNativeJsonType()
+    public function hasNativeJsonType(): bool
     {
         return false;
     }
@@ -3689,10 +3384,8 @@ abstract class AbstractPlatform
      * Whether this platform supports views.
      *
      * @deprecated All platforms must implement support for views.
-     *
-     * @return bool
      */
-    public function supportsViews()
+    public function supportsViews(): bool
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -3705,10 +3398,8 @@ abstract class AbstractPlatform
 
     /**
      * Does this platform support column collation?
-     *
-     * @return bool
      */
-    public function supportsColumnCollation()
+    public function supportsColumnCollation(): bool
     {
         return false;
     }
@@ -3719,7 +3410,7 @@ abstract class AbstractPlatform
      *
      * @return string The format string.
      */
-    public function getDateTimeFormatString()
+    public function getDateTimeFormatString(): string
     {
         return 'Y-m-d H:i:s';
     }
@@ -3730,7 +3421,7 @@ abstract class AbstractPlatform
      *
      * @return string The format string.
      */
-    public function getDateTimeTzFormatString()
+    public function getDateTimeTzFormatString(): string
     {
         return 'Y-m-d H:i:s';
     }
@@ -3741,7 +3432,7 @@ abstract class AbstractPlatform
      *
      * @return string The format string.
      */
-    public function getDateFormatString()
+    public function getDateFormatString(): string
     {
         return 'Y-m-d';
     }
@@ -3752,7 +3443,7 @@ abstract class AbstractPlatform
      *
      * @return string The format string.
      */
-    public function getTimeFormatString()
+    public function getTimeFormatString(): string
     {
         return 'H:i:s';
     }
@@ -3795,10 +3486,8 @@ abstract class AbstractPlatform
      * @param string   $query
      * @param int|null $limit
      * @param int      $offset
-     *
-     * @return string
      */
-    protected function doModifyLimitQuery($query, $limit, $offset)
+    protected function doModifyLimitQuery($query, $limit, $offset): string
     {
         if ($limit !== null) {
             $query .= sprintf(' LIMIT %d', $limit);
@@ -3815,10 +3504,8 @@ abstract class AbstractPlatform
      * Whether the database platform support offsets in modify limit clauses.
      *
      * @deprecated All platforms must implement support for offsets in modify limit clauses.
-     *
-     * @return bool
      */
-    public function supportsLimitOffset()
+    public function supportsLimitOffset(): bool
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -3832,10 +3519,8 @@ abstract class AbstractPlatform
 
     /**
      * Maximum length of any given database identifier, like tables or column names.
-     *
-     * @return int
      */
-    public function getMaxIdentifierLength()
+    public function getMaxIdentifierLength(): int
     {
         return 63;
     }
@@ -3845,10 +3530,8 @@ abstract class AbstractPlatform
      *
      * @param string $quotedTableName
      * @param string $quotedIdentifierColumnName
-     *
-     * @return string
      */
-    public function getEmptyIdentityInsertSQL($quotedTableName, $quotedIdentifierColumnName)
+    public function getEmptyIdentityInsertSQL($quotedTableName, $quotedIdentifierColumnName): string
     {
         return 'INSERT INTO ' . $quotedTableName . ' (' . $quotedIdentifierColumnName . ') VALUES (null)';
     }
@@ -3861,10 +3544,8 @@ abstract class AbstractPlatform
      *
      * @param string $tableName
      * @param bool   $cascade
-     *
-     * @return string
      */
-    public function getTruncateTableSQL($tableName, $cascade = false)
+    public function getTruncateTableSQL($tableName, $cascade = false): string
     {
         $tableIdentifier = new Identifier($tableName);
 
@@ -3873,10 +3554,8 @@ abstract class AbstractPlatform
 
     /**
      * This is for test reasons, many vendors have special requirements for dummy statements.
-     *
-     * @return string
      */
-    public function getDummySelectSQL()
+    public function getDummySelectSQL(): string
     {
         $expression = func_num_args() > 0 ? func_get_arg(0) : '1';
 
@@ -3887,10 +3566,8 @@ abstract class AbstractPlatform
      * Returns the SQL to create a new savepoint.
      *
      * @param string $savepoint
-     *
-     * @return string
      */
-    public function createSavePoint($savepoint)
+    public function createSavePoint($savepoint): string
     {
         return 'SAVEPOINT ' . $savepoint;
     }
@@ -3899,10 +3576,8 @@ abstract class AbstractPlatform
      * Returns the SQL to release a savepoint.
      *
      * @param string $savepoint
-     *
-     * @return string
      */
-    public function releaseSavePoint($savepoint)
+    public function releaseSavePoint($savepoint): string
     {
         return 'RELEASE SAVEPOINT ' . $savepoint;
     }
@@ -3911,10 +3586,8 @@ abstract class AbstractPlatform
      * Returns the SQL to rollback a savepoint.
      *
      * @param string $savepoint
-     *
-     * @return string
      */
-    public function rollbackSavePoint($savepoint)
+    public function rollbackSavePoint($savepoint): string
     {
         return 'ROLLBACK TO SAVEPOINT ' . $savepoint;
     }
@@ -3958,12 +3631,11 @@ abstract class AbstractPlatform
      *
      * @deprecated Implement {@see createReservedKeywordsList()} instead.
      *
-     * @return string
      * @psalm-return class-string<KeywordList>
      *
      * @throws Exception If not supported on this platform.
      */
-    protected function getReservedKeywordsClass()
+    protected function getReservedKeywordsClass(): string
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -3985,7 +3657,7 @@ abstract class AbstractPlatform
      *
      * @return string The quoted literal string.
      */
-    public function quoteStringLiteral($str)
+    public function quoteStringLiteral($str): string
     {
         $c = $this->getStringLiteralQuoteCharacter();
 
@@ -3994,10 +3666,8 @@ abstract class AbstractPlatform
 
     /**
      * Gets the character used for string literal quoting.
-     *
-     * @return string
      */
-    public function getStringLiteralQuoteCharacter()
+    public function getStringLiteralQuoteCharacter(): string
     {
         return "'";
     }

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -285,10 +285,8 @@ class DB2Platform extends AbstractPlatform
      *
      * @param string $table
      * @param string $database
-     *
-     * @return string
      */
-    public function getListTableColumnsSQL($table, $database = null)
+    public function getListTableColumnsSQL($table, $database = null): string
     {
         $table = $this->quoteStringLiteral($table);
 

--- a/src/Platforms/Keywords/KeywordList.php
+++ b/src/Platforms/Keywords/KeywordList.php
@@ -20,10 +20,8 @@ abstract class KeywordList
      * Checks if the given word is a keyword of this dialect/vendor platform.
      *
      * @param string $word
-     *
-     * @return bool
      */
-    public function isKeyword($word)
+    public function isKeyword($word): bool
     {
         if ($this->keywords === null) {
             $this->initializeKeywords();
@@ -32,10 +30,7 @@ abstract class KeywordList
         return isset($this->keywords[strtoupper($word)]);
     }
 
-    /**
-     * @return void
-     */
-    protected function initializeKeywords()
+    protected function initializeKeywords(): void
     {
         $this->keywords = array_flip(array_map('strtoupper', $this->getKeywords()));
     }
@@ -45,12 +40,10 @@ abstract class KeywordList
      *
      * @return string[]
      */
-    abstract protected function getKeywords();
+    abstract protected function getKeywords(): array;
 
     /**
      * Returns the name of this keyword list.
-     *
-     * @return string
      */
-    abstract public function getName();
+    abstract public function getName(): string;
 }

--- a/src/Platforms/Keywords/ReservedKeywordsValidator.php
+++ b/src/Platforms/Keywords/ReservedKeywordsValidator.php
@@ -33,7 +33,7 @@ class ReservedKeywordsValidator implements Visitor
     /**
      * @return string[]
      */
-    public function getViolations()
+    public function getViolations(): array
     {
         return $this->violations;
     }

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -41,11 +41,9 @@ class OraclePlatform extends AbstractPlatform
      *
      * @param string $identifier
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public static function assertValidIdentifier($identifier)
+    public static function assertValidIdentifier($identifier): void
     {
         if (preg_match('(^(([a-zA-Z]{1}[a-zA-Z0-9_$#]{0,})|("[^"]+"))$)', $identifier) === 0) {
             throw new Exception('Invalid Oracle identifier');
@@ -68,10 +66,8 @@ class OraclePlatform extends AbstractPlatform
      * @deprecated Generate dates within the application.
      *
      * @param string $type
-     *
-     * @return string
      */
-    public function getNowExpression($type = 'timestamp')
+    public function getNowExpression($type = 'timestamp'): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -496,7 +492,7 @@ class OraclePlatform extends AbstractPlatform
      *
      * @return string[]
      */
-    public function getCreateAutoincrementSql($name, $table, $start = 1)
+    public function getCreateAutoincrementSql($name, $table, $start = 1): array
     {
         $tableIdentifier   = $this->normalizeIdentifier($table);
         $quotedTableName   = $tableIdentifier->getQuotedName($this);
@@ -565,7 +561,7 @@ END;';
      *
      * @return string[]
      */
-    public function getDropAutoincrementSql($table)
+    public function getDropAutoincrementSql($table): array
     {
         $table                       = $this->normalizeIdentifier($table);
         $autoincrementIdentifierName = $this->getAutoincrementIdentifierName($table);

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -69,10 +69,8 @@ class PostgreSQLPlatform extends AbstractPlatform
      * Enables use of 'true'/'false' or otherwise 1 and 0 instead.
      *
      * @param bool $flag
-     *
-     * @return void
      */
-    public function setUseBooleanTrueFalseStrings($flag)
+    public function setUseBooleanTrueFalseStrings($flag): void
     {
         $this->useBooleanTrueFalseStrings = (bool) $flag;
     }
@@ -301,10 +299,8 @@ class PostgreSQLPlatform extends AbstractPlatform
      *
      * @param string      $table
      * @param string|null $database
-     *
-     * @return string
      */
-    public function getListTableForeignKeysSQL($table, $database = null)
+    public function getListTableForeignKeysSQL($table, $database = null): string
     {
         return 'SELECT quote_ident(r.conname) as conname, pg_catalog.pg_get_constraintdef(r.oid, true) as condef
                   FROM pg_catalog.pg_constraint r

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -358,10 +358,8 @@ class SQLServerPlatform extends AbstractPlatform
      * @param string      $tableName  The quoted table name to which the column belongs.
      * @param string      $columnName The quoted column name to create the comment for.
      * @param string|null $comment    The column's comment.
-     *
-     * @return string
      */
-    protected function getCreateColumnCommentSQL($tableName, $columnName, $comment)
+    protected function getCreateColumnCommentSQL($tableName, $columnName, $comment): string
     {
         if (strpos($tableName, '.') !== false) {
             [$schemaSQL, $tableSQL] = explode('.', $tableName);
@@ -392,11 +390,9 @@ class SQLServerPlatform extends AbstractPlatform
      * @param string  $table  Name of the table to return the default constraint declaration for.
      * @param mixed[] $column Column definition.
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      */
-    public function getDefaultConstraintDeclarationSQL($table, array $column)
+    public function getDefaultConstraintDeclarationSQL($table, array $column): string
     {
         if (! isset($column['default'])) {
             throw new InvalidArgumentException("Incomplete column definition. 'default' required.");
@@ -703,10 +699,8 @@ class SQLServerPlatform extends AbstractPlatform
      * @param string      $tableName  The quoted table name to which the column belongs.
      * @param string      $columnName The quoted column name to alter the comment for.
      * @param string|null $comment    The column's comment.
-     *
-     * @return string
      */
-    protected function getAlterColumnCommentSQL($tableName, $columnName, $comment)
+    protected function getAlterColumnCommentSQL($tableName, $columnName, $comment): string
     {
         if (strpos($tableName, '.') !== false) {
             [$schemaSQL, $tableSQL] = explode('.', $tableName);
@@ -742,10 +736,8 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * @param string $tableName  The quoted table name to which the column belongs.
      * @param string $columnName The quoted column name to drop the comment for.
-     *
-     * @return string
      */
-    protected function getDropColumnCommentSQL($tableName, $columnName)
+    protected function getDropColumnCommentSQL($tableName, $columnName): string
     {
         if (strpos($tableName, '.') !== false) {
             [$schemaSQL, $tableSQL] = explode('.', $tableName);
@@ -796,8 +788,6 @@ class SQLServerPlatform extends AbstractPlatform
      * @param string|null $level1Name The name of the object at level 1 the property belongs to.
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
-     *
-     * @return string
      */
     public function getAddExtendedPropertySQL(
         $name,
@@ -808,7 +798,7 @@ class SQLServerPlatform extends AbstractPlatform
         $level1Name = null,
         $level2Type = null,
         $level2Name = null
-    ) {
+    ): string {
         return 'EXEC sp_addextendedproperty ' .
             'N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral((string) $value) . ', ' .
             'N' . $this->quoteStringLiteral((string) $level0Type) . ', ' . $level0Name . ', ' .
@@ -830,8 +820,6 @@ class SQLServerPlatform extends AbstractPlatform
      * @param string|null $level1Name The name of the object at level 1 the property belongs to.
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
-     *
-     * @return string
      */
     public function getDropExtendedPropertySQL(
         $name,
@@ -841,7 +829,7 @@ class SQLServerPlatform extends AbstractPlatform
         $level1Name = null,
         $level2Type = null,
         $level2Name = null
-    ) {
+    ): string {
         return 'EXEC sp_dropextendedproperty ' .
             'N' . $this->quoteStringLiteral($name) . ', ' .
             'N' . $this->quoteStringLiteral((string) $level0Type) . ', ' . $level0Name . ', ' .
@@ -864,8 +852,6 @@ class SQLServerPlatform extends AbstractPlatform
      * @param string|null $level1Name The name of the object at level 1 the property belongs to.
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
-     *
-     * @return string
      */
     public function getUpdateExtendedPropertySQL(
         $name,
@@ -876,7 +862,7 @@ class SQLServerPlatform extends AbstractPlatform
         $level1Name = null,
         $level2Type = null,
         $level2Name = null
-    ) {
+    ): string {
         return 'EXEC sp_updateextendedproperty ' .
             'N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral((string) $value) . ', ' .
             'N' . $this->quoteStringLiteral((string) $level0Type) . ', ' . $level0Name . ', ' .
@@ -943,10 +929,8 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * @param string      $table
      * @param string|null $database
-     *
-     * @return string
      */
-    public function getListTableForeignKeysSQL($table, $database = null)
+    public function getListTableForeignKeysSQL($table, $database = null): string
     {
         return 'SELECT f.name AS ForeignKey,
                 SCHEMA_NAME (f.SCHEMA_ID) AS SchemaName,

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -51,10 +51,8 @@ class SqlitePlatform extends AbstractPlatform
      * @deprecated Generate dates within the application.
      *
      * @param string $type
-     *
-     * @return string
      */
-    public function getNowExpression($type = 'timestamp')
+    public function getNowExpression($type = 'timestamp'): string
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -250,10 +248,8 @@ class SqlitePlatform extends AbstractPlatform
 
     /**
      * @param array<string, mixed> $column
-     *
-     * @return string
      */
-    public function getTinyIntTypeDeclarationSQL(array $column)
+    public function getTinyIntTypeDeclarationSQL(array $column): string
     {
         // SQLite autoincrement is implicit for INTEGER PKs, but not for TINYINT columns
         if (! empty($column['autoincrement'])) {
@@ -278,10 +274,8 @@ class SqlitePlatform extends AbstractPlatform
 
     /**
      * @param array<string, mixed> $column
-     *
-     * @return string
      */
-    public function getMediumIntTypeDeclarationSQL(array $column)
+    public function getMediumIntTypeDeclarationSQL(array $column): string
     {
         // SQLite autoincrement is implicit for INTEGER PKs, but not for MEDIUMINT columns
         if (! empty($column['autoincrement'])) {
@@ -603,10 +597,8 @@ class SqlitePlatform extends AbstractPlatform
      * @deprecated The driver will use {@see sqrt()} in the next major release.
      *
      * @param int|float $value
-     *
-     * @return float
      */
-    public static function udfSqrt($value)
+    public static function udfSqrt($value): float
     {
         return sqrt($value);
     }
@@ -618,10 +610,8 @@ class SqlitePlatform extends AbstractPlatform
      *
      * @param int $a
      * @param int $b
-     *
-     * @return int
      */
-    public static function udfMod($a, $b)
+    public static function udfMod($a, $b): int
     {
         return UserDefinedFunctions::mod($a, $b);
     }
@@ -632,10 +622,8 @@ class SqlitePlatform extends AbstractPlatform
      * @param string $str
      * @param string $substr
      * @param int    $offset
-     *
-     * @return int
      */
-    public static function udfLocate($str, $substr, $offset = 0)
+    public static function udfLocate($str, $substr, $offset = 0): int
     {
         return UserDefinedFunctions::locate($str, $substr, $offset);
     }
@@ -885,10 +873,8 @@ class SqlitePlatform extends AbstractPlatform
      *
      * @param string      $table
      * @param string|null $database
-     *
-     * @return string
      */
-    public function getListTableForeignKeysSQL($table, $database = null)
+    public function getListTableForeignKeysSQL($table, $database = null): string
     {
         $table = str_replace('.', '__', $table);
 

--- a/src/Query/Expression/CompositeExpression.php
+++ b/src/Query/Expression/CompositeExpression.php
@@ -82,10 +82,8 @@ class CompositeExpression implements Countable
      * @deprecated This class will be made immutable. Use with() instead.
      *
      * @param self[]|string[] $parts
-     *
-     * @return CompositeExpression
      */
-    public function addMultiple(array $parts = [])
+    public function addMultiple(array $parts = []): CompositeExpression
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -106,10 +104,8 @@ class CompositeExpression implements Countable
      * @deprecated This class will be made immutable. Use with() instead.
      *
      * @param mixed $part
-     *
-     * @return CompositeExpression
      */
-    public function add($part)
+    public function add($part): CompositeExpression
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -147,21 +143,17 @@ class CompositeExpression implements Countable
 
     /**
      * Retrieves the amount of expressions on composite expression.
-     *
-     * @return int
      */
     #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->parts);
     }
 
     /**
      * Retrieves the string representation of this composite expression.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if ($this->count() === 1) {
             return (string) $this->parts[0];
@@ -172,10 +164,8 @@ class CompositeExpression implements Countable
 
     /**
      * Returns the type of this composite expression (AND/OR).
-     *
-     * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }

--- a/src/Query/Expression/ExpressionBuilder.php
+++ b/src/Query/Expression/ExpressionBuilder.php
@@ -67,10 +67,8 @@ class ExpressionBuilder
      *
      * @param mixed $x Optional clause. Defaults = null, but requires
      *                 at least one defined when converting to string.
-     *
-     * @return CompositeExpression
      */
-    public function andX($x = null)
+    public function andX($x = null): CompositeExpression
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -86,10 +84,8 @@ class ExpressionBuilder
      *
      * @param mixed $x Optional clause. Defaults = null, but requires
      *                 at least one defined when converting to string.
-     *
-     * @return CompositeExpression
      */
-    public function orX($x = null)
+    public function orX($x = null): CompositeExpression
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -106,10 +102,8 @@ class ExpressionBuilder
      * @param mixed  $x        The left expression.
      * @param string $operator One of the ExpressionBuilder::* constants.
      * @param mixed  $y        The right expression.
-     *
-     * @return string
      */
-    public function comparison($x, $operator, $y)
+    public function comparison($x, $operator, $y): string
     {
         return $x . ' ' . $operator . ' ' . $y;
     }
@@ -126,10 +120,8 @@ class ExpressionBuilder
      *
      * @param mixed $x The left expression.
      * @param mixed $y The right expression.
-     *
-     * @return string
      */
-    public function eq($x, $y)
+    public function eq($x, $y): string
     {
         return $this->comparison($x, self::EQ, $y);
     }
@@ -145,10 +137,8 @@ class ExpressionBuilder
      *
      * @param mixed $x The left expression.
      * @param mixed $y The right expression.
-     *
-     * @return string
      */
-    public function neq($x, $y)
+    public function neq($x, $y): string
     {
         return $this->comparison($x, self::NEQ, $y);
     }
@@ -164,10 +154,8 @@ class ExpressionBuilder
      *
      * @param mixed $x The left expression.
      * @param mixed $y The right expression.
-     *
-     * @return string
      */
-    public function lt($x, $y)
+    public function lt($x, $y): string
     {
         return $this->comparison($x, self::LT, $y);
     }
@@ -183,10 +171,8 @@ class ExpressionBuilder
      *
      * @param mixed $x The left expression.
      * @param mixed $y The right expression.
-     *
-     * @return string
      */
-    public function lte($x, $y)
+    public function lte($x, $y): string
     {
         return $this->comparison($x, self::LTE, $y);
     }
@@ -202,10 +188,8 @@ class ExpressionBuilder
      *
      * @param mixed $x The left expression.
      * @param mixed $y The right expression.
-     *
-     * @return string
      */
-    public function gt($x, $y)
+    public function gt($x, $y): string
     {
         return $this->comparison($x, self::GT, $y);
     }
@@ -221,10 +205,8 @@ class ExpressionBuilder
      *
      * @param mixed $x The left expression.
      * @param mixed $y The right expression.
-     *
-     * @return string
      */
-    public function gte($x, $y)
+    public function gte($x, $y): string
     {
         return $this->comparison($x, self::GTE, $y);
     }
@@ -233,10 +215,8 @@ class ExpressionBuilder
      * Creates an IS NULL expression with the given arguments.
      *
      * @param string $x The expression to be restricted by IS NULL.
-     *
-     * @return string
      */
-    public function isNull($x)
+    public function isNull($x): string
     {
         return $x . ' IS NULL';
     }
@@ -245,10 +225,8 @@ class ExpressionBuilder
      * Creates an IS NOT NULL expression with the given arguments.
      *
      * @param string $x The expression to be restricted by IS NOT NULL.
-     *
-     * @return string
      */
-    public function isNotNull($x)
+    public function isNotNull($x): string
     {
         return $x . ' IS NOT NULL';
     }
@@ -258,10 +236,8 @@ class ExpressionBuilder
      *
      * @param string $x The expression to be inspected by the LIKE comparison
      * @param mixed  $y The pattern to compare against
-     *
-     * @return string
      */
-    public function like($x, $y/*, ?string $escapeChar = null */)
+    public function like($x, $y/*, ?string $escapeChar = null */): string
     {
         return $this->comparison($x, 'LIKE', $y) .
             (func_num_args() >= 3 ? sprintf(' ESCAPE %s', func_get_arg(2)) : '');
@@ -272,10 +248,8 @@ class ExpressionBuilder
      *
      * @param string $x The expression to be inspected by the NOT LIKE comparison
      * @param mixed  $y The pattern to compare against
-     *
-     * @return string
      */
-    public function notLike($x, $y/*, ?string $escapeChar = null */)
+    public function notLike($x, $y/*, ?string $escapeChar = null */): string
     {
         return $this->comparison($x, 'NOT LIKE', $y) .
             (func_num_args() >= 3 ? sprintf(' ESCAPE %s', func_get_arg(2)) : '');
@@ -286,10 +260,8 @@ class ExpressionBuilder
      *
      * @param string          $x The SQL expression to be matched against the set.
      * @param string|string[] $y The SQL expression or an array of SQL expressions representing the set.
-     *
-     * @return string
      */
-    public function in($x, $y)
+    public function in($x, $y): string
     {
         return $this->comparison($x, 'IN', '(' . implode(', ', (array) $y) . ')');
     }
@@ -299,10 +271,8 @@ class ExpressionBuilder
      *
      * @param string          $x The SQL expression to be matched against the set.
      * @param string|string[] $y The SQL expression or an array of SQL expressions representing the set.
-     *
-     * @return string
      */
-    public function notIn($x, $y)
+    public function notIn($x, $y): string
     {
         return $this->comparison($x, 'NOT IN', '(' . implode(', ', (array) $y) . ')');
     }
@@ -315,10 +285,8 @@ class ExpressionBuilder
      *
      * @param mixed    $input The parameter to be quoted.
      * @param int|null $type  The type of the parameter.
-     *
-     * @return string
      */
-    public function literal($input, $type = null)
+    public function literal($input, $type = null): string
     {
         return $this->connection->quote($input, $type);
     }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -160,30 +160,24 @@ class QueryBuilder
      *
      * For more complex expression construction, consider storing the expression
      * builder object in a local variable.
-     *
-     * @return ExpressionBuilder
      */
-    public function expr()
+    public function expr(): ExpressionBuilder
     {
         return $this->connection->getExpressionBuilder();
     }
 
     /**
      * Gets the type of the currently built query.
-     *
-     * @return int
      */
-    public function getType()
+    public function getType(): int
     {
         return $this->type;
     }
 
     /**
      * Gets the associated DBAL Connection for this query builder.
-     *
-     * @return Connection
      */
-    public function getConnection()
+    public function getConnection(): Connection
     {
         return $this->connection;
     }
@@ -193,7 +187,7 @@ class QueryBuilder
      *
      * @return int Either QueryBuilder::STATE_DIRTY or QueryBuilder::STATE_CLEAN.
      */
-    public function getState()
+    public function getState(): int
     {
         return $this->state;
     }
@@ -366,7 +360,7 @@ class QueryBuilder
      *
      * @return string The SQL query string.
      */
-    public function getSQL()
+    public function getSQL(): string
     {
         if ($this->sql !== null && $this->state === self::STATE_CLEAN) {
             return $this->sql;
@@ -480,7 +474,7 @@ class QueryBuilder
      * @return array<int, int|string|Type|null>|array<string, int|string|Type|null> The currently defined
      *                                                                              query parameter types
      */
-    public function getParameterTypes()
+    public function getParameterTypes(): array
     {
         return $this->paramTypes;
     }
@@ -517,7 +511,7 @@ class QueryBuilder
      *
      * @return int The position of the first result.
      */
-    public function getFirstResult()
+    public function getFirstResult(): int
     {
         return $this->firstResult;
     }
@@ -543,7 +537,7 @@ class QueryBuilder
      *
      * @return int|null The maximum number of results.
      */
-    public function getMaxResults()
+    public function getMaxResults(): ?int
     {
         return $this->maxResults;
     }
@@ -1273,7 +1267,7 @@ class QueryBuilder
      *
      * @return mixed[]
      */
-    public function getQueryParts()
+    public function getQueryParts(): array
     {
         return $this->sqlParts;
     }
@@ -1429,7 +1423,7 @@ class QueryBuilder
      *
      * @return string The string representation of this QueryBuilder.
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getSQL();
     }
@@ -1460,7 +1454,7 @@ class QueryBuilder
      *
      * @return string the placeholder name used.
      */
-    public function createNamedParameter($value, $type = ParameterType::STRING, $placeHolder = null)
+    public function createNamedParameter($value, $type = ParameterType::STRING, $placeHolder = null): string
     {
         if ($placeHolder === null) {
             $this->boundCounter++;
@@ -1491,10 +1485,8 @@ class QueryBuilder
      *
      * @param mixed                $value
      * @param int|string|Type|null $type
-     *
-     * @return string
      */
-    public function createPositionalParameter($value, $type = ParameterType::STRING)
+    public function createPositionalParameter($value, $type = ParameterType::STRING): string
     {
         $this->setParameter($this->boundCounter, $value, $type);
         $this->boundCounter++;

--- a/src/Query/QueryException.php
+++ b/src/Query/QueryException.php
@@ -14,10 +14,8 @@ class QueryException extends Exception
     /**
      * @param string   $alias
      * @param string[] $registeredAliases
-     *
-     * @return QueryException
      */
-    public static function unknownAlias($alias, $registeredAliases)
+    public static function unknownAlias($alias, $registeredAliases): QueryException
     {
         return new self("The given alias '" . $alias . "' is not part of " .
             'any FROM or JOIN clause table. The currently registered ' .
@@ -27,10 +25,8 @@ class QueryException extends Exception
     /**
      * @param string   $alias
      * @param string[] $registeredAliases
-     *
-     * @return QueryException
      */
-    public static function nonUniqueAlias($alias, $registeredAliases)
+    public static function nonUniqueAlias($alias, $registeredAliases): QueryException
     {
         return new self("The given alias '" . $alias . "' is not unique " .
             'in FROM and JOIN clause table. The currently registered ' .

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -41,10 +41,8 @@ abstract class AbstractAsset
      * Sets the name of this asset.
      *
      * @param string $name
-     *
-     * @return void
      */
-    protected function _setName($name)
+    protected function _setName($name): void
     {
         if ($this->isIdentifierQuoted($name)) {
             $this->_quoted = true;
@@ -64,10 +62,8 @@ abstract class AbstractAsset
      * Is this asset in the default namespace?
      *
      * @param string $defaultNamespaceName
-     *
-     * @return bool
      */
-    public function isInDefaultNamespace($defaultNamespaceName)
+    public function isInDefaultNamespace($defaultNamespaceName): bool
     {
         return $this->_namespace === $defaultNamespaceName || $this->_namespace === null;
     }
@@ -76,10 +72,8 @@ abstract class AbstractAsset
      * Gets the namespace name of this asset.
      *
      * If NULL is returned this means the default namespace is used.
-     *
-     * @return string|null
      */
-    public function getNamespaceName()
+    public function getNamespaceName(): ?string
     {
         return $this->_namespace;
     }
@@ -89,10 +83,8 @@ abstract class AbstractAsset
      * namespaced elements are returned as full-qualified names.
      *
      * @param string|null $defaultNamespaceName
-     *
-     * @return string
      */
-    public function getShortestName($defaultNamespaceName)
+    public function getShortestName($defaultNamespaceName): string
     {
         $shortestName = $this->getName();
         if ($this->_namespace === $defaultNamespaceName) {
@@ -114,10 +106,8 @@ abstract class AbstractAsset
      * @deprecated Use {@see getNamespaceName()} and {@see getName()} instead.
      *
      * @param string $defaultNamespaceName
-     *
-     * @return string
      */
-    public function getFullQualifiedName($defaultNamespaceName)
+    public function getFullQualifiedName($defaultNamespaceName): string
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -136,10 +126,8 @@ abstract class AbstractAsset
 
     /**
      * Checks if this asset's name is quoted.
-     *
-     * @return bool
      */
-    public function isQuoted()
+    public function isQuoted(): bool
     {
         return $this->_quoted;
     }
@@ -148,10 +136,8 @@ abstract class AbstractAsset
      * Checks if this identifier is quoted.
      *
      * @param string $identifier
-     *
-     * @return bool
      */
-    protected function isIdentifierQuoted($identifier)
+    protected function isIdentifierQuoted($identifier): bool
     {
         return isset($identifier[0]) && ($identifier[0] === '`' || $identifier[0] === '"' || $identifier[0] === '[');
     }
@@ -160,20 +146,16 @@ abstract class AbstractAsset
      * Trim quotes from the identifier.
      *
      * @param string $identifier
-     *
-     * @return string
      */
-    protected function trimQuotes($identifier)
+    protected function trimQuotes($identifier): string
     {
         return str_replace(['`', '"', '[', ']'], '', $identifier);
     }
 
     /**
      * Returns the name of this schema asset.
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         if ($this->_namespace !== null) {
             return $this->_namespace . '.' . $this->_name;
@@ -185,10 +167,8 @@ abstract class AbstractAsset
     /**
      * Gets the quoted representation of this asset but only if it was defined with one. Otherwise
      * return the plain unquoted value as inserted.
-     *
-     * @return string
      */
-    public function getQuotedName(AbstractPlatform $platform)
+    public function getQuotedName(AbstractPlatform $platform): string
     {
         $keywords = $platform->getReservedKeywordsList();
         $parts    = explode('.', $this->getName());
@@ -209,10 +189,8 @@ abstract class AbstractAsset
      * @param string[] $columnNames
      * @param string   $prefix
      * @param int      $maxSize
-     *
-     * @return string
      */
-    protected function _generateIdentifierName($columnNames, $prefix = '', $maxSize = 30)
+    protected function _generateIdentifierName($columnNames, $prefix = '', $maxSize = 30): string
     {
         $hash = implode('', array_map(static function ($column): string {
             return dechex(crc32($column));

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -113,7 +113,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listDatabases()
+    public function listDatabases(): array
     {
         $sql = $this->_platform->getListDatabasesSQL();
 
@@ -131,7 +131,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listNamespaceNames()
+    public function listNamespaceNames(): array
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -168,7 +168,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listSequences($database = null)
+    public function listSequences($database = null): array
     {
         if ($database === null) {
             $database = $this->getDatabase(__METHOD__);
@@ -204,7 +204,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listTableColumns($table, $database = null)
+    public function listTableColumns($table, $database = null): array
     {
         if ($database === null) {
             $database = $this->getDatabase(__METHOD__);
@@ -262,7 +262,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listTableIndexes($table)
+    public function listTableIndexes($table): array
     {
         $sql = $this->_platform->getListTableIndexesSQL($table, $this->_conn->getDatabase());
 
@@ -298,11 +298,9 @@ abstract class AbstractSchemaManager
      *
      * @param string|string[] $names
      *
-     * @return bool
-     *
      * @throws Exception
      */
-    public function tablesExist($names)
+    public function tablesExist($names): bool
     {
         if (is_string($names)) {
             Deprecation::trigger(
@@ -325,7 +323,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listTableNames()
+    public function listTableNames(): array
     {
         $sql = $this->_platform->getListTablesSQL();
 
@@ -343,7 +341,7 @@ abstract class AbstractSchemaManager
      *
      * @return mixed[]
      */
-    protected function filterAssetNames($assetNames)
+    protected function filterAssetNames($assetNames): array
     {
         $filter = $this->_conn->getConfiguration()->getSchemaAssetsFilter();
         if ($filter === null) {
@@ -360,7 +358,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listTables()
+    public function listTables(): array
     {
         $tableNames = $this->listTableNames();
 
@@ -419,11 +417,9 @@ abstract class AbstractSchemaManager
     /**
      * @param string $name
      *
-     * @return Table
-     *
      * @throws Exception
      */
-    public function listTableDetails($name)
+    public function listTableDetails($name): Table
     {
         $columns     = $this->listTableColumns($name);
         $foreignKeys = [];
@@ -531,7 +527,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listViews()
+    public function listViews(): array
     {
         $database = $this->_conn->getDatabase();
         $sql      = $this->_platform->getListViewsSQL($database);
@@ -550,7 +546,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listTableForeignKeys($table, $database = null)
+    public function listTableForeignKeys($table, $database = null): array
     {
         if ($database === null) {
             $database = $this->getDatabase(__METHOD__);
@@ -605,11 +601,9 @@ abstract class AbstractSchemaManager
      *
      * @param string $database The name of the database to drop.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropDatabase($database)
+    public function dropDatabase($database): void
     {
         $this->_execSql($this->_platform->getDropDatabaseSQL($database));
     }
@@ -629,11 +623,9 @@ abstract class AbstractSchemaManager
      *
      * @param string $name The name of the table to drop.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropTable($name)
+    public function dropTable($name): void
     {
         $this->_execSql($this->_platform->getDropTableSQL($name));
     }
@@ -644,11 +636,9 @@ abstract class AbstractSchemaManager
      * @param Index|string $index The name of the index.
      * @param Table|string $table The name of the table.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropIndex($index, $table)
+    public function dropIndex($index, $table): void
     {
         if ($index instanceof Index) {
             $index = $index->getQuotedName($this->_platform);
@@ -664,11 +654,9 @@ abstract class AbstractSchemaManager
      *
      * @param Table|string $table The name of the table.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropConstraint(Constraint $constraint, $table)
+    public function dropConstraint(Constraint $constraint, $table): void
     {
         $this->_execSql($this->_platform->getDropConstraintSQL($constraint, $table));
     }
@@ -679,11 +667,9 @@ abstract class AbstractSchemaManager
      * @param ForeignKeyConstraint|string $foreignKey The name of the foreign key.
      * @param Table|string                $table      The name of the table with the foreign key.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropForeignKey($foreignKey, $table)
+    public function dropForeignKey($foreignKey, $table): void
     {
         $this->_execSql($this->_platform->getDropForeignKeySQL($foreignKey, $table));
     }
@@ -693,11 +679,9 @@ abstract class AbstractSchemaManager
      *
      * @param string $name The name of the sequence to drop.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropSequence($name)
+    public function dropSequence($name): void
     {
         $this->_execSql($this->_platform->getDropSequenceSQL($name));
     }
@@ -717,11 +701,9 @@ abstract class AbstractSchemaManager
      *
      * @param string $name The name of the view.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropView($name)
+    public function dropView($name): void
     {
         $this->_execSql($this->_platform->getDropViewSQL($name));
     }
@@ -733,11 +715,9 @@ abstract class AbstractSchemaManager
      *
      * @param string $database The name of the database to create.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function createDatabase($database)
+    public function createDatabase($database): void
     {
         $this->_execSql($this->_platform->getCreateDatabaseSQL($database));
     }
@@ -745,11 +725,9 @@ abstract class AbstractSchemaManager
     /**
      * Creates a new table.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function createTable(Table $table)
+    public function createTable(Table $table): void
     {
         $createFlags = AbstractPlatform::CREATE_INDEXES | AbstractPlatform::CREATE_FOREIGNKEYS;
         $this->_execSql($this->_platform->getCreateTableSQL($table, $createFlags));
@@ -760,11 +738,9 @@ abstract class AbstractSchemaManager
      *
      * @param Sequence $sequence
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function createSequence($sequence)
+    public function createSequence($sequence): void
     {
         $this->_execSql($this->_platform->getCreateSequenceSQL($sequence));
     }
@@ -776,11 +752,9 @@ abstract class AbstractSchemaManager
      *
      * @param Table|string $table
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function createConstraint(Constraint $constraint, $table)
+    public function createConstraint(Constraint $constraint, $table): void
     {
         $this->_execSql($this->_platform->getCreateConstraintSQL($constraint, $table));
     }
@@ -790,11 +764,9 @@ abstract class AbstractSchemaManager
      *
      * @param Table|string $table The name of the table on which the index is to be created.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function createIndex(Index $index, $table)
+    public function createIndex(Index $index, $table): void
     {
         $this->_execSql($this->_platform->getCreateIndexSQL($index, $table));
     }
@@ -805,11 +777,9 @@ abstract class AbstractSchemaManager
      * @param ForeignKeyConstraint $foreignKey The ForeignKey instance.
      * @param Table|string         $table      The name of the table on which the foreign key is to be created.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function createForeignKey(ForeignKeyConstraint $foreignKey, $table)
+    public function createForeignKey(ForeignKeyConstraint $foreignKey, $table): void
     {
         $this->_execSql($this->_platform->getCreateForeignKeySQL($foreignKey, $table));
     }
@@ -827,11 +797,9 @@ abstract class AbstractSchemaManager
     /**
      * Creates a new view.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function createView(View $view)
+    public function createView(View $view): void
     {
         $this->_execSql($this->_platform->getCreateViewSQL($view->getQuotedName($this->_platform), $view->getSql()));
     }
@@ -850,11 +818,9 @@ abstract class AbstractSchemaManager
      *
      * @param Table|string $table
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropAndCreateConstraint(Constraint $constraint, $table)
+    public function dropAndCreateConstraint(Constraint $constraint, $table): void
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -877,11 +843,9 @@ abstract class AbstractSchemaManager
      *
      * @param Table|string $table The name of the table on which the index is to be created.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropAndCreateIndex(Index $index, $table)
+    public function dropAndCreateIndex(Index $index, $table): void
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -903,11 +867,9 @@ abstract class AbstractSchemaManager
      *                                         of the foreign key to be created.
      * @param Table|string         $table      The name of the table on which the foreign key is to be created.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropAndCreateForeignKey(ForeignKeyConstraint $foreignKey, $table)
+    public function dropAndCreateForeignKey(ForeignKeyConstraint $foreignKey, $table): void
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -925,11 +887,9 @@ abstract class AbstractSchemaManager
      *
      * @deprecated Use {@see dropSequence()} and {@see createSequence()} instead.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropAndCreateSequence(Sequence $sequence)
+    public function dropAndCreateSequence(Sequence $sequence): void
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -947,11 +907,9 @@ abstract class AbstractSchemaManager
      *
      * @deprecated Use {@see dropTable()} and {@see createTable()} instead.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropAndCreateTable(Table $table)
+    public function dropAndCreateTable(Table $table): void
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -971,11 +929,9 @@ abstract class AbstractSchemaManager
      *
      * @param string $database The name of the database to create.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropAndCreateDatabase($database)
+    public function dropAndCreateDatabase($database): void
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -993,11 +949,9 @@ abstract class AbstractSchemaManager
      *
      * @deprecated Use {@see dropView()} and {@see createView()} instead.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function dropAndCreateView(View $view)
+    public function dropAndCreateView(View $view): void
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -1038,11 +992,9 @@ abstract class AbstractSchemaManager
     /**
      * Alters an existing tables schema.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function alterTable(TableDiff $tableDiff)
+    public function alterTable(TableDiff $tableDiff): void
     {
         foreach ($this->_platform->getAlterTableSQL($tableDiff) as $ddlQuery) {
             $this->_execSql($ddlQuery);
@@ -1055,11 +1007,9 @@ abstract class AbstractSchemaManager
      * @param string $name    The current name of the table.
      * @param string $newName The new name of the table.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function renameTable($name, $newName)
+    public function renameTable($name, $newName): void
     {
         $tableDiff          = new TableDiff($name);
         $tableDiff->newName = $newName;
@@ -1076,7 +1026,7 @@ abstract class AbstractSchemaManager
      *
      * @return string[]
      */
-    protected function _getPortableDatabasesList($databases)
+    protected function _getPortableDatabasesList($databases): array
     {
         $list = [];
         foreach ($databases as $value) {
@@ -1096,7 +1046,7 @@ abstract class AbstractSchemaManager
      *
      * @return string[]
      */
-    protected function getPortableNamespacesList(array $namespaces)
+    protected function getPortableNamespacesList(array $namespaces): array
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -1152,7 +1102,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    protected function _getPortableSequencesList($sequences)
+    protected function _getPortableSequencesList($sequences): array
     {
         $list = [];
 
@@ -1166,11 +1116,9 @@ abstract class AbstractSchemaManager
     /**
      * @param mixed[] $sequence
      *
-     * @return Sequence
-     *
      * @throws Exception
      */
-    protected function _getPortableSequenceDefinition($sequence)
+    protected function _getPortableSequenceDefinition($sequence): Sequence
     {
         throw Exception::notSupported('Sequences');
     }
@@ -1188,7 +1136,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    protected function _getPortableTableColumnList($table, $database, $tableColumns)
+    protected function _getPortableTableColumnList($table, $database, $tableColumns): array
     {
         $eventManager = $this->_platform->getEventManager();
 
@@ -1225,11 +1173,9 @@ abstract class AbstractSchemaManager
      *
      * @param mixed[] $tableColumn
      *
-     * @return Column
-     *
      * @throws Exception
      */
-    abstract protected function _getPortableTableColumnDefinition($tableColumn);
+    abstract protected function _getPortableTableColumnDefinition($tableColumn): Column;
 
     /**
      * Aggregates and groups the index results according to the required data result.
@@ -1241,7 +1187,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    protected function _getPortableTableIndexesList($tableIndexes, $tableName = null)
+    protected function _getPortableTableIndexesList($tableIndexes, $tableName = null): array
     {
         $result = [];
         foreach ($tableIndexes as $tableIndex) {
@@ -1316,7 +1262,7 @@ abstract class AbstractSchemaManager
      *
      * @return string[]
      */
-    protected function _getPortableTablesList($tables)
+    protected function _getPortableTablesList($tables): array
     {
         $list = [];
         foreach ($tables as $value) {
@@ -1328,10 +1274,8 @@ abstract class AbstractSchemaManager
 
     /**
      * @param mixed $table
-     *
-     * @return string
      */
-    protected function _getPortableTableDefinition($table)
+    protected function _getPortableTableDefinition($table): string
     {
         return $table;
     }
@@ -1341,7 +1285,7 @@ abstract class AbstractSchemaManager
      *
      * @return View[]
      */
-    protected function _getPortableViewsList($views)
+    protected function _getPortableViewsList($views): array
     {
         $list = [];
         foreach ($views as $value) {
@@ -1373,7 +1317,7 @@ abstract class AbstractSchemaManager
      *
      * @return ForeignKeyConstraint[]
      */
-    protected function _getPortableTableForeignKeysList($tableForeignKeys)
+    protected function _getPortableTableForeignKeysList($tableForeignKeys): array
     {
         $list = [];
 
@@ -1386,10 +1330,8 @@ abstract class AbstractSchemaManager
 
     /**
      * @param mixed $tableForeignKey
-     *
-     * @return ForeignKeyConstraint
      */
-    protected function _getPortableTableForeignKeyDefinition($tableForeignKey)
+    protected function _getPortableTableForeignKeyDefinition($tableForeignKey): ForeignKeyConstraint
     {
         return $tableForeignKey;
     }
@@ -1397,11 +1339,9 @@ abstract class AbstractSchemaManager
     /**
      * @param string[]|string $sql
      *
-     * @return void
-     *
      * @throws Exception
      */
-    protected function _execSql($sql)
+    protected function _execSql($sql): void
     {
         foreach ((array) $sql as $query) {
             $this->_conn->executeStatement($query);
@@ -1411,11 +1351,9 @@ abstract class AbstractSchemaManager
     /**
      * Creates a schema instance for the current database.
      *
-     * @return Schema
-     *
      * @throws Exception
      */
-    public function createSchema()
+    public function createSchema(): Schema
     {
         $schemaNames = [];
 
@@ -1437,11 +1375,9 @@ abstract class AbstractSchemaManager
     /**
      * Creates the configuration for this schema.
      *
-     * @return SchemaConfig
-     *
      * @throws Exception
      */
-    public function createSchemaConfig()
+    public function createSchemaConfig(): SchemaConfig
     {
         $schemaConfig = new SchemaConfig();
         $schemaConfig->setMaxIdentifierLength($this->_platform->getMaxIdentifierLength());
@@ -1481,7 +1417,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function getSchemaSearchPaths()
+    public function getSchemaSearchPaths(): array
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -1506,10 +1442,8 @@ abstract class AbstractSchemaManager
      *
      * @param string|null $comment
      * @param string      $currentType
-     *
-     * @return string
      */
-    public function extractDoctrineTypeFromComment($comment, $currentType)
+    public function extractDoctrineTypeFromComment($comment, $currentType): string
     {
         if ($comment !== null && preg_match('(\(DC2Type:(((?!\)).)+)\))', $comment, $match) === 1) {
             return $match[1];
@@ -1523,10 +1457,8 @@ abstract class AbstractSchemaManager
      *
      * @param string|null $comment
      * @param string|null $type
-     *
-     * @return string|null
      */
-    public function removeDoctrineTypeFromComment($comment, $type)
+    public function removeDoctrineTypeFromComment($comment, $type): ?string
     {
         if ($comment === null) {
             return null;

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -71,11 +71,9 @@ class Column extends AbstractAsset
     /**
      * @param mixed[] $options
      *
-     * @return Column
-     *
      * @throws SchemaException
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): Column
     {
         foreach ($options as $name => $value) {
             $method = 'set' . $name;
@@ -90,10 +88,7 @@ class Column extends AbstractAsset
         return $this;
     }
 
-    /**
-     * @return Column
-     */
-    public function setType(Type $type)
+    public function setType(Type $type): Column
     {
         $this->_type = $type;
 
@@ -102,10 +97,8 @@ class Column extends AbstractAsset
 
     /**
      * @param int|null $length
-     *
-     * @return Column
      */
-    public function setLength($length)
+    public function setLength($length): Column
     {
         if ($length !== null) {
             $this->_length = (int) $length;
@@ -118,10 +111,8 @@ class Column extends AbstractAsset
 
     /**
      * @param int $precision
-     *
-     * @return Column
      */
-    public function setPrecision($precision)
+    public function setPrecision($precision): Column
     {
         if (! is_numeric($precision)) {
             $precision = 10; // defaults to 10 when no valid precision is given.
@@ -134,10 +125,8 @@ class Column extends AbstractAsset
 
     /**
      * @param int $scale
-     *
-     * @return Column
      */
-    public function setScale($scale)
+    public function setScale($scale): Column
     {
         if (! is_numeric($scale)) {
             $scale = 0;
@@ -150,10 +139,8 @@ class Column extends AbstractAsset
 
     /**
      * @param bool $unsigned
-     *
-     * @return Column
      */
-    public function setUnsigned($unsigned)
+    public function setUnsigned($unsigned): Column
     {
         $this->_unsigned = (bool) $unsigned;
 
@@ -162,10 +149,8 @@ class Column extends AbstractAsset
 
     /**
      * @param bool $fixed
-     *
-     * @return Column
      */
-    public function setFixed($fixed)
+    public function setFixed($fixed): Column
     {
         $this->_fixed = (bool) $fixed;
 
@@ -174,10 +159,8 @@ class Column extends AbstractAsset
 
     /**
      * @param bool $notnull
-     *
-     * @return Column
      */
-    public function setNotnull($notnull)
+    public function setNotnull($notnull): Column
     {
         $this->_notnull = (bool) $notnull;
 
@@ -186,10 +169,8 @@ class Column extends AbstractAsset
 
     /**
      * @param mixed $default
-     *
-     * @return Column
      */
-    public function setDefault($default)
+    public function setDefault($default): Column
     {
         $this->_default = $default;
 
@@ -198,10 +179,8 @@ class Column extends AbstractAsset
 
     /**
      * @param mixed[] $platformOptions
-     *
-     * @return Column
      */
-    public function setPlatformOptions(array $platformOptions)
+    public function setPlatformOptions(array $platformOptions): Column
     {
         $this->_platformOptions = $platformOptions;
 
@@ -211,10 +190,8 @@ class Column extends AbstractAsset
     /**
      * @param string $name
      * @param mixed  $value
-     *
-     * @return Column
      */
-    public function setPlatformOption($name, $value)
+    public function setPlatformOption($name, $value): Column
     {
         $this->_platformOptions[$name] = $value;
 
@@ -223,76 +200,50 @@ class Column extends AbstractAsset
 
     /**
      * @param string $value
-     *
-     * @return Column
      */
-    public function setColumnDefinition($value)
+    public function setColumnDefinition($value): Column
     {
         $this->_columnDefinition = $value;
 
         return $this;
     }
 
-    /**
-     * @return Type
-     */
-    public function getType()
+    public function getType(): Type
     {
         return $this->_type;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getLength()
+    public function getLength(): ?int
     {
         return $this->_length;
     }
 
-    /**
-     * @return int
-     */
-    public function getPrecision()
+    public function getPrecision(): int
     {
         return $this->_precision;
     }
 
-    /**
-     * @return int
-     */
-    public function getScale()
+    public function getScale(): int
     {
         return $this->_scale;
     }
 
-    /**
-     * @return bool
-     */
-    public function getUnsigned()
+    public function getUnsigned(): bool
     {
         return $this->_unsigned;
     }
 
-    /**
-     * @return bool
-     */
-    public function getFixed()
+    public function getFixed(): bool
     {
         return $this->_fixed;
     }
 
-    /**
-     * @return bool
-     */
-    public function getNotnull()
+    public function getNotnull(): bool
     {
         return $this->_notnull;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getDefault()
+    public function getDefault(): ?string
     {
         return $this->_default;
     }
@@ -300,17 +251,15 @@ class Column extends AbstractAsset
     /**
      * @return mixed[]
      */
-    public function getPlatformOptions()
+    public function getPlatformOptions(): array
     {
         return $this->_platformOptions;
     }
 
     /**
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasPlatformOption($name)
+    public function hasPlatformOption($name): bool
     {
         return isset($this->_platformOptions[$name]);
     }
@@ -325,28 +274,20 @@ class Column extends AbstractAsset
         return $this->_platformOptions[$name];
     }
 
-    /**
-     * @return string|null
-     */
-    public function getColumnDefinition()
+    public function getColumnDefinition(): ?string
     {
         return $this->_columnDefinition;
     }
 
-    /**
-     * @return bool
-     */
-    public function getAutoincrement()
+    public function getAutoincrement(): bool
     {
         return $this->_autoincrement;
     }
 
     /**
      * @param bool $flag
-     *
-     * @return Column
      */
-    public function setAutoincrement($flag)
+    public function setAutoincrement($flag): Column
     {
         $this->_autoincrement = $flag;
 
@@ -355,20 +296,15 @@ class Column extends AbstractAsset
 
     /**
      * @param string|null $comment
-     *
-     * @return Column
      */
-    public function setComment($comment)
+    public function setComment($comment): Column
     {
         $this->_comment = $comment;
 
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getComment()
+    public function getComment(): ?string
     {
         return $this->_comment;
     }
@@ -376,10 +312,8 @@ class Column extends AbstractAsset
     /**
      * @param string $name
      * @param mixed  $value
-     *
-     * @return Column
      */
-    public function setCustomSchemaOption($name, $value)
+    public function setCustomSchemaOption($name, $value): Column
     {
         $this->_customSchemaOptions[$name] = $value;
 
@@ -388,10 +322,8 @@ class Column extends AbstractAsset
 
     /**
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasCustomSchemaOption($name)
+    public function hasCustomSchemaOption($name): bool
     {
         return isset($this->_customSchemaOptions[$name]);
     }
@@ -408,10 +340,8 @@ class Column extends AbstractAsset
 
     /**
      * @param mixed[] $customSchemaOptions
-     *
-     * @return Column
      */
-    public function setCustomSchemaOptions(array $customSchemaOptions)
+    public function setCustomSchemaOptions(array $customSchemaOptions): Column
     {
         $this->_customSchemaOptions = $customSchemaOptions;
 
@@ -421,7 +351,7 @@ class Column extends AbstractAsset
     /**
      * @return mixed[]
      */
-    public function getCustomSchemaOptions()
+    public function getCustomSchemaOptions(): array
     {
         return $this->_customSchemaOptions;
     }
@@ -429,7 +359,7 @@ class Column extends AbstractAsset
     /**
      * @return mixed[]
      */
-    public function toArray()
+    public function toArray(): array
     {
         return array_merge([
             'name'          => $this->_name,

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -50,18 +50,13 @@ class ColumnDiff
 
     /**
      * @param string $propertyName
-     *
-     * @return bool
      */
-    public function hasChanged($propertyName)
+    public function hasChanged($propertyName): bool
     {
         return in_array($propertyName, $this->changedProperties, true);
     }
 
-    /**
-     * @return Identifier
-     */
-    public function getOldColumnName()
+    public function getOldColumnName(): Identifier
     {
         $quote = $this->fromColumn !== null && $this->fromColumn->isQuoted();
 

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -87,14 +87,12 @@ class Comparator
      *
      * This method should be called non-statically since it will be declared as non-static in the next major release.
      *
-     * @return SchemaDiff
-     *
      * @throws SchemaException
      */
     private function doCompareSchemas(
         Schema $fromSchema,
         Schema $toSchema
-    ) {
+    ): SchemaDiff {
         $diff             = new SchemaDiff();
         $diff->fromSchema = $fromSchema;
 
@@ -214,11 +212,9 @@ class Comparator
     /**
      * @deprecated Use non-static call to {@see compareSchemas()} instead.
      *
-     * @return SchemaDiff
-     *
      * @throws SchemaException
      */
-    public function compare(Schema $fromSchema, Schema $toSchema)
+    public function compare(Schema $fromSchema, Schema $toSchema): SchemaDiff
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -244,10 +240,7 @@ class Comparator
         return false;
     }
 
-    /**
-     * @return bool
-     */
-    public function diffSequence(Sequence $sequence1, Sequence $sequence2)
+    public function diffSequence(Sequence $sequence1, Sequence $sequence2): bool
     {
         if ($sequence1->getAllocationSize() !== $sequence2->getAllocationSize()) {
             return true;
@@ -470,10 +463,7 @@ class Comparator
         }
     }
 
-    /**
-     * @return bool
-     */
-    public function diffForeignKey(ForeignKeyConstraint $key1, ForeignKeyConstraint $key2)
+    public function diffForeignKey(ForeignKeyConstraint $key1, ForeignKeyConstraint $key2): bool
     {
         if (
             array_map('strtolower', $key1->getUnquotedLocalColumns())
@@ -522,7 +512,7 @@ class Comparator
      *
      * @return string[]
      */
-    public function diffColumn(Column $column1, Column $column2)
+    public function diffColumn(Column $column1, Column $column2): array
     {
         $properties1 = $column1->toArray();
         $properties2 = $column2->toArray();
@@ -613,10 +603,8 @@ class Comparator
      *
      * Compares $index1 with $index2 and returns $index2 if there are any
      * differences or false in case there are no differences.
-     *
-     * @return bool
      */
-    public function diffIndex(Index $index1, Index $index2)
+    public function diffIndex(Index $index1, Index $index2): bool
     {
         return ! ($index1->isFullfilledBy($index2) && $index2->isFullfilledBy($index1));
     }

--- a/src/Schema/Constraint.php
+++ b/src/Schema/Constraint.php
@@ -11,15 +11,9 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 interface Constraint
 {
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): string;
 
-    /**
-     * @return string
-     */
-    public function getQuotedName(AbstractPlatform $platform);
+    public function getQuotedName(AbstractPlatform $platform): string;
 
     /**
      * Returns the names of the referencing table columns
@@ -27,7 +21,7 @@ interface Constraint
      *
      * @return string[]
      */
-    public function getColumns();
+    public function getColumns(): array;
 
     /**
      * Returns the quoted representation of the column names
@@ -41,5 +35,5 @@ interface Constraint
      *
      * @return string[]
      */
-    public function getQuotedColumns(AbstractPlatform $platform);
+    public function getQuotedColumns(AbstractPlatform $platform): array;
 }

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -239,10 +239,8 @@ class DB2SchemaManager extends AbstractSchemaManager
 
     /**
      * @param string $def
-     *
-     * @return string|null
      */
-    protected function _getPortableForeignKeyRuleDef($def)
+    protected function _getPortableForeignKeyRuleDef($def): ?string
     {
         if ($def === 'C') {
             return 'CASCADE';

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -106,10 +106,8 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * the foreign key constraint is associated with.
      *
      * @deprecated Use the table that contains the foreign key as part of its {@see Table::$_fkConstraints} instead.
-     *
-     * @return string
      */
-    public function getLocalTableName()
+    public function getLocalTableName(): string
     {
         return $this->_localTable->getName();
     }
@@ -121,20 +119,16 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * @deprecated Use the table that contains the foreign key as part of its {@see Table::$_fkConstraints} instead.
      *
      * @param Table $table Instance of the referencing table.
-     *
-     * @return void
      */
-    public function setLocalTable(Table $table)
+    public function setLocalTable(Table $table): void
     {
         $this->_localTable = $table;
     }
 
     /**
      * @deprecated Use the table that contains the foreign key as part of its {@see Table::$_fkConstraints} instead.
-     *
-     * @return Table
      */
-    public function getLocalTable()
+    public function getLocalTable(): Table
     {
         return $this->_localTable;
     }
@@ -145,7 +139,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      *
      * @return string[]
      */
-    public function getLocalColumns()
+    public function getLocalColumns(): array
     {
         return array_keys($this->_localColumnNames);
     }
@@ -162,7 +156,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      *
      * @return string[]
      */
-    public function getQuotedLocalColumns(AbstractPlatform $platform)
+    public function getQuotedLocalColumns(AbstractPlatform $platform): array
     {
         $columns = [];
 
@@ -178,7 +172,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      *
      * @return string[]
      */
-    public function getUnquotedLocalColumns()
+    public function getUnquotedLocalColumns(): array
     {
         return array_map([$this, 'trimQuotes'], $this->getLocalColumns());
     }
@@ -188,7 +182,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      *
      * @return string[]
      */
-    public function getUnquotedForeignColumns()
+    public function getUnquotedForeignColumns(): array
     {
         return array_map([$this, 'trimQuotes'], $this->getForeignColumns());
     }
@@ -221,7 +215,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      *
      * @return string[]
      */
-    public function getQuotedColumns(AbstractPlatform $platform)
+    public function getQuotedColumns(AbstractPlatform $platform): array
     {
         return $this->getQuotedLocalColumns($platform);
     }
@@ -229,20 +223,16 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
     /**
      * Returns the name of the referenced table
      * the foreign key constraint is associated with.
-     *
-     * @return string
      */
-    public function getForeignTableName()
+    public function getForeignTableName(): string
     {
         return $this->_foreignTableName->getName();
     }
 
     /**
      * Returns the non-schema qualified foreign table name.
-     *
-     * @return string
      */
-    public function getUnqualifiedForeignTableName()
+    public function getUnqualifiedForeignTableName(): string
     {
         $name     = $this->_foreignTableName->getName();
         $position = strrpos($name, '.');
@@ -263,10 +253,8 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * Otherwise the plain unquoted value as inserted is returned.
      *
      * @param AbstractPlatform $platform The platform to use for quotation.
-     *
-     * @return string
      */
-    public function getQuotedForeignTableName(AbstractPlatform $platform)
+    public function getQuotedForeignTableName(AbstractPlatform $platform): string
     {
         return $this->_foreignTableName->getQuotedName($platform);
     }
@@ -277,7 +265,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      *
      * @return string[]
      */
-    public function getForeignColumns()
+    public function getForeignColumns(): array
     {
         return array_keys($this->_foreignColumnNames);
     }
@@ -294,7 +282,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      *
      * @return string[]
      */
-    public function getQuotedForeignColumns(AbstractPlatform $platform)
+    public function getQuotedForeignColumns(AbstractPlatform $platform): array
     {
         $columns = [];
 
@@ -310,10 +298,8 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * is associated with the foreign key constraint.
      *
      * @param string $name Name of the option to check.
-     *
-     * @return bool
      */
-    public function hasOption($name)
+    public function hasOption($name): bool
     {
         return isset($this->_options[$name]);
     }
@@ -335,7 +321,7 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      *
      * @return mixed[]
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->_options;
     }
@@ -343,10 +329,8 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
     /**
      * Returns the referential action for UPDATE operations
      * on the referenced table the foreign key constraint is associated with.
-     *
-     * @return string|null
      */
-    public function onUpdate()
+    public function onUpdate(): ?string
     {
         return $this->onEvent('onUpdate');
     }
@@ -354,10 +338,8 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
     /**
      * Returns the referential action for DELETE operations
      * on the referenced table the foreign key constraint is associated with.
-     *
-     * @return string|null
      */
-    public function onDelete()
+    public function onDelete(): ?string
     {
         return $this->onEvent('onDelete');
     }
@@ -388,10 +370,8 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
      * matches one of the given index's columns, `false` otherwise.
      *
      * @param Index $index The index to be checked against.
-     *
-     * @return bool
      */
-    public function intersectsIndexColumns(Index $index)
+    public function intersectsIndexColumns(Index $index): bool
     {
         foreach ($index->getColumns() as $indexColumn) {
             foreach ($this->_localColumnNames as $localColumn) {

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -121,33 +121,25 @@ class Index extends AbstractAsset implements Constraint
     /**
      * @return string[]
      */
-    public function getUnquotedColumns()
+    public function getUnquotedColumns(): array
     {
         return array_map([$this, 'trimQuotes'], $this->getColumns());
     }
 
     /**
      * Is the index neither unique nor primary key?
-     *
-     * @return bool
      */
-    public function isSimpleIndex()
+    public function isSimpleIndex(): bool
     {
         return ! $this->_isPrimary && ! $this->_isUnique;
     }
 
-    /**
-     * @return bool
-     */
-    public function isUnique()
+    public function isUnique(): bool
     {
         return $this->_isUnique;
     }
 
-    /**
-     * @return bool
-     */
-    public function isPrimary()
+    public function isPrimary(): bool
     {
         return $this->_isPrimary;
     }
@@ -155,10 +147,8 @@ class Index extends AbstractAsset implements Constraint
     /**
      * @param string $name
      * @param int    $pos
-     *
-     * @return bool
      */
-    public function hasColumnAtPosition($name, $pos = 0)
+    public function hasColumnAtPosition($name, $pos = 0): bool
     {
         $name         = $this->trimQuotes(strtolower($name));
         $indexColumns = array_map('strtolower', $this->getUnquotedColumns());
@@ -170,10 +160,8 @@ class Index extends AbstractAsset implements Constraint
      * Checks if this index exactly spans the given column names in the correct order.
      *
      * @param string[] $columnNames
-     *
-     * @return bool
      */
-    public function spansColumns(array $columnNames)
+    public function spansColumns(array $columnNames): bool
     {
         $columns         = $this->getColumns();
         $numberOfColumns = count($columns);
@@ -195,10 +183,8 @@ class Index extends AbstractAsset implements Constraint
 
     /**
      * Checks if the other index already fulfills all the indexing and constraint needs of the current one.
-     *
-     * @return bool
      */
-    public function isFullfilledBy(Index $other)
+    public function isFullfilledBy(Index $other): bool
     {
         // allow the other index to be equally large only. It being larger is an option
         // but it creates a problem with scenarios of the kind PRIMARY KEY(foo,bar) UNIQUE(foo)
@@ -238,10 +224,8 @@ class Index extends AbstractAsset implements Constraint
 
     /**
      * Detects if the other index is a non-unique, non primary index that can be overwritten by this one.
-     *
-     * @return bool
      */
-    public function overrules(Index $other)
+    public function overrules(Index $other): bool
     {
         if ($other->isPrimary()) {
             return false;
@@ -261,7 +245,7 @@ class Index extends AbstractAsset implements Constraint
      *
      * @return string[]
      */
-    public function getFlags()
+    public function getFlags(): array
     {
         return array_keys($this->_flags);
     }
@@ -271,11 +255,9 @@ class Index extends AbstractAsset implements Constraint
      *
      * @param string $flag
      *
-     * @return Index
-     *
      * @example $index->addFlag('CLUSTERED')
      */
-    public function addFlag($flag)
+    public function addFlag($flag): Index
     {
         $this->_flags[strtolower($flag)] = true;
 
@@ -286,10 +268,8 @@ class Index extends AbstractAsset implements Constraint
      * Does this index have a specific flag?
      *
      * @param string $flag
-     *
-     * @return bool
      */
-    public function hasFlag($flag)
+    public function hasFlag($flag): bool
     {
         return isset($this->_flags[strtolower($flag)]);
     }
@@ -298,20 +278,16 @@ class Index extends AbstractAsset implements Constraint
      * Removes a flag.
      *
      * @param string $flag
-     *
-     * @return void
      */
-    public function removeFlag($flag)
+    public function removeFlag($flag): void
     {
         unset($this->_flags[strtolower($flag)]);
     }
 
     /**
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasOption($name)
+    public function hasOption($name): bool
     {
         return isset($this->options[strtolower($name)]);
     }
@@ -329,7 +305,7 @@ class Index extends AbstractAsset implements Constraint
     /**
      * @return mixed[]
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -308,11 +308,9 @@ class OracleSchemaManager extends AbstractSchemaManager
      *
      * @param string $table
      *
-     * @return bool
-     *
      * @throws Exception
      */
-    public function dropAutoincrement($table)
+    public function dropAutoincrement($table): bool
     {
         $sql = $this->_platform->getDropAutoincrementSql($table);
         foreach ($sql as $query) {

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -89,7 +89,7 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function getSchemaNames()
+    public function getSchemaNames(): array
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -154,7 +154,7 @@ SQL
      *
      * @throws Exception
      */
-    public function getExistingSchemaSearchPaths()
+    public function getExistingSchemaSearchPaths(): array
     {
         if ($this->existingSchemaPaths === null) {
             $this->determineExistingSchemaSearchPaths();
@@ -168,11 +168,9 @@ SQL
     /**
      * Returns the name of the current schema.
      *
-     * @return string|null
-     *
      * @throws Exception
      */
-    protected function getCurrentSchema()
+    protected function getCurrentSchema(): ?string
     {
         $schemas = $this->getExistingSchemaSearchPaths();
 
@@ -186,11 +184,9 @@ SQL
      *
      * @internal The method should be only used from within the PostgreSQLSchemaManager class hierarchy.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public function determineExistingSchemaSearchPaths()
+    public function determineExistingSchemaSearchPaths(): void
     {
         $names = $this->listSchemaNames();
         $paths = $this->getSchemaSearchPaths();

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -90,10 +90,8 @@ class Schema extends AbstractAsset
 
     /**
      * @deprecated
-     *
-     * @return bool
      */
-    public function hasExplicitForeignKeyIndexes()
+    public function hasExplicitForeignKeyIndexes(): bool
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -105,11 +103,9 @@ class Schema extends AbstractAsset
     }
 
     /**
-     * @return void
-     *
      * @throws SchemaException
      */
-    protected function _addTable(Table $table)
+    protected function _addTable(Table $table): void
     {
         $namespaceName = $table->getNamespaceName();
         $tableName     = $this->normalizeName($table);
@@ -131,11 +127,9 @@ class Schema extends AbstractAsset
     }
 
     /**
-     * @return void
-     *
      * @throws SchemaException
      */
-    protected function _addSequence(Sequence $sequence)
+    protected function _addSequence(Sequence $sequence): void
     {
         $namespaceName = $sequence->getNamespaceName();
         $seqName       = $this->normalizeName($sequence);
@@ -160,7 +154,7 @@ class Schema extends AbstractAsset
      *
      * @return string[] A list of namespace names.
      */
-    public function getNamespaces()
+    public function getNamespaces(): array
     {
         return $this->namespaces;
     }
@@ -170,7 +164,7 @@ class Schema extends AbstractAsset
      *
      * @return Table[]
      */
-    public function getTables()
+    public function getTables(): array
     {
         return $this->_tables;
     }
@@ -178,11 +172,9 @@ class Schema extends AbstractAsset
     /**
      * @param string $name
      *
-     * @return Table
-     *
      * @throws SchemaException
      */
-    public function getTable($name)
+    public function getTable($name): Table
     {
         $name = $this->getFullQualifiedAssetName($name);
         if (! isset($this->_tables[$name])) {
@@ -229,10 +221,8 @@ class Schema extends AbstractAsset
      * Does this schema have a namespace with the given name?
      *
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasNamespace($name)
+    public function hasNamespace($name): bool
     {
         $name = strtolower($this->getUnquotedAssetName($name));
 
@@ -243,10 +233,8 @@ class Schema extends AbstractAsset
      * Does this schema have a table with the given name?
      *
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasTable($name)
+    public function hasTable($name): bool
     {
         $name = $this->getFullQualifiedAssetName($name);
 
@@ -260,7 +248,7 @@ class Schema extends AbstractAsset
      *
      * @return string[]
      */
-    public function getTableNames()
+    public function getTableNames(): array
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -275,10 +263,8 @@ class Schema extends AbstractAsset
 
     /**
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasSequence($name)
+    public function hasSequence($name): bool
     {
         $name = $this->getFullQualifiedAssetName($name);
 
@@ -288,11 +274,9 @@ class Schema extends AbstractAsset
     /**
      * @param string $name
      *
-     * @return Sequence
-     *
      * @throws SchemaException
      */
-    public function getSequence($name)
+    public function getSequence($name): Sequence
     {
         $name = $this->getFullQualifiedAssetName($name);
         if (! $this->hasSequence($name)) {
@@ -305,7 +289,7 @@ class Schema extends AbstractAsset
     /**
      * @return Sequence[]
      */
-    public function getSequences()
+    public function getSequences(): array
     {
         return $this->_sequences;
     }
@@ -319,7 +303,7 @@ class Schema extends AbstractAsset
      *
      * @throws SchemaException
      */
-    public function createNamespace($name)
+    public function createNamespace($name): Schema
     {
         $unquotedName = strtolower($this->getUnquotedAssetName($name));
 
@@ -337,11 +321,9 @@ class Schema extends AbstractAsset
      *
      * @param string $name
      *
-     * @return Table
-     *
      * @throws SchemaException
      */
-    public function createTable($name)
+    public function createTable($name): Table
     {
         $table = new Table($name);
         $this->_addTable($table);
@@ -359,11 +341,9 @@ class Schema extends AbstractAsset
      * @param string $oldName
      * @param string $newName
      *
-     * @return Schema
-     *
      * @throws SchemaException
      */
-    public function renameTable($oldName, $newName)
+    public function renameTable($oldName, $newName): Schema
     {
         $table = $this->getTable($oldName);
         $table->_setName($newName);
@@ -379,11 +359,9 @@ class Schema extends AbstractAsset
      *
      * @param string $name
      *
-     * @return Schema
-     *
      * @throws SchemaException
      */
-    public function dropTable($name)
+    public function dropTable($name): Schema
     {
         $name = $this->getFullQualifiedAssetName($name);
         $this->getTable($name);
@@ -399,11 +377,9 @@ class Schema extends AbstractAsset
      * @param int    $allocationSize
      * @param int    $initialValue
      *
-     * @return Sequence
-     *
      * @throws SchemaException
      */
-    public function createSequence($name, $allocationSize = 1, $initialValue = 1)
+    public function createSequence($name, $allocationSize = 1, $initialValue = 1): Sequence
     {
         $seq = new Sequence($name, $allocationSize, $initialValue);
         $this->_addSequence($seq);
@@ -413,10 +389,8 @@ class Schema extends AbstractAsset
 
     /**
      * @param string $name
-     *
-     * @return Schema
      */
-    public function dropSequence($name)
+    public function dropSequence($name): Schema
     {
         $name = $this->getFullQualifiedAssetName($name);
         unset($this->_sequences[$name]);
@@ -429,7 +403,7 @@ class Schema extends AbstractAsset
      *
      * @return string[]
      */
-    public function toSql(AbstractPlatform $platform)
+    public function toSql(AbstractPlatform $platform): array
     {
         $sqlCollector = new CreateSchemaSqlCollector($platform);
         $this->visit($sqlCollector);
@@ -442,7 +416,7 @@ class Schema extends AbstractAsset
      *
      * @return string[]
      */
-    public function toDropSql(AbstractPlatform $platform)
+    public function toDropSql(AbstractPlatform $platform): array
     {
         $dropSqlCollector = new DropSchemaSqlCollector($platform);
         $this->visit($dropSqlCollector);
@@ -457,7 +431,7 @@ class Schema extends AbstractAsset
      *
      * @throws SchemaException
      */
-    public function getMigrateToSql(Schema $toSchema, AbstractPlatform $platform)
+    public function getMigrateToSql(Schema $toSchema, AbstractPlatform $platform): array
     {
         $schemaDiff = (new Comparator())->compareSchemas($this, $toSchema);
 
@@ -471,17 +445,14 @@ class Schema extends AbstractAsset
      *
      * @throws SchemaException
      */
-    public function getMigrateFromSql(Schema $fromSchema, AbstractPlatform $platform)
+    public function getMigrateFromSql(Schema $fromSchema, AbstractPlatform $platform): array
     {
         $schemaDiff = (new Comparator())->compareSchemas($fromSchema, $this);
 
         return $schemaDiff->toSql($platform);
     }
 
-    /**
-     * @return void
-     */
-    public function visit(Visitor $visitor)
+    public function visit(Visitor $visitor): void
     {
         $visitor->acceptSchema($this);
 

--- a/src/Schema/SchemaConfig.php
+++ b/src/Schema/SchemaConfig.php
@@ -27,10 +27,8 @@ class SchemaConfig
 
     /**
      * @deprecated
-     *
-     * @return bool
      */
-    public function hasExplicitForeignKeyIndexes()
+    public function hasExplicitForeignKeyIndexes(): bool
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
@@ -45,10 +43,8 @@ class SchemaConfig
      * @deprecated
      *
      * @param bool $flag
-     *
-     * @return void
      */
-    public function setExplicitForeignKeyIndexes($flag)
+    public function setExplicitForeignKeyIndexes($flag): void
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -61,28 +57,21 @@ class SchemaConfig
 
     /**
      * @param int $length
-     *
-     * @return void
      */
-    public function setMaxIdentifierLength($length)
+    public function setMaxIdentifierLength($length): void
     {
         $this->maxIdentifierLength = (int) $length;
     }
 
-    /**
-     * @return int
-     */
-    public function getMaxIdentifierLength()
+    public function getMaxIdentifierLength(): int
     {
         return $this->maxIdentifierLength;
     }
 
     /**
      * Gets the default namespace of schema objects.
-     *
-     * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -91,10 +80,8 @@ class SchemaConfig
      * Sets the default namespace name of schema objects.
      *
      * @param string $name The value to set.
-     *
-     * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -105,17 +92,15 @@ class SchemaConfig
      *
      * @return mixed[]
      */
-    public function getDefaultTableOptions()
+    public function getDefaultTableOptions(): array
     {
         return $this->defaultTableOptions;
     }
 
     /**
      * @param mixed[] $defaultTableOptions
-     *
-     * @return void
      */
-    public function setDefaultTableOptions(array $defaultTableOptions)
+    public function setDefaultTableOptions(array $defaultTableOptions): void
     {
         $this->defaultTableOptions = $defaultTableOptions;
     }

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -90,7 +90,7 @@ class SchemaDiff
      *
      * @return string[]
      */
-    public function toSaveSql(AbstractPlatform $platform)
+    public function toSaveSql(AbstractPlatform $platform): array
     {
         return $this->_toSql($platform, true);
     }
@@ -98,7 +98,7 @@ class SchemaDiff
     /**
      * @return string[]
      */
-    public function toSql(AbstractPlatform $platform)
+    public function toSql(AbstractPlatform $platform): array
     {
         return $this->_toSql($platform, false);
     }
@@ -108,7 +108,7 @@ class SchemaDiff
      *
      * @return string[]
      */
-    protected function _toSql(AbstractPlatform $platform, $saveMode = false)
+    protected function _toSql(AbstractPlatform $platform, $saveMode = false): array
     {
         $sql = [];
 

--- a/src/Schema/SchemaException.php
+++ b/src/Schema/SchemaException.php
@@ -27,20 +27,16 @@ class SchemaException extends Exception
 
     /**
      * @param string $tableName
-     *
-     * @return SchemaException
      */
-    public static function tableDoesNotExist($tableName)
+    public static function tableDoesNotExist($tableName): SchemaException
     {
         return new self("There is no table with name '" . $tableName . "' in the schema.", self::TABLE_DOESNT_EXIST);
     }
 
     /**
      * @param string $indexName
-     *
-     * @return SchemaException
      */
-    public static function indexNameInvalid($indexName)
+    public static function indexNameInvalid($indexName): SchemaException
     {
         return new self(
             sprintf('Invalid index-name %s given, has to be [a-zA-Z0-9_]', $indexName),
@@ -51,10 +47,8 @@ class SchemaException extends Exception
     /**
      * @param string $indexName
      * @param string $table
-     *
-     * @return SchemaException
      */
-    public static function indexDoesNotExist($indexName, $table)
+    public static function indexDoesNotExist($indexName, $table): SchemaException
     {
         return new self(
             sprintf("Index '%s' does not exist on table '%s'.", $indexName, $table),
@@ -65,10 +59,8 @@ class SchemaException extends Exception
     /**
      * @param string $indexName
      * @param string $table
-     *
-     * @return SchemaException
      */
-    public static function indexAlreadyExists($indexName, $table)
+    public static function indexAlreadyExists($indexName, $table): SchemaException
     {
         return new self(
             sprintf("An index with name '%s' was already defined on table '%s'.", $indexName, $table),
@@ -79,10 +71,8 @@ class SchemaException extends Exception
     /**
      * @param string $columnName
      * @param string $table
-     *
-     * @return SchemaException
      */
-    public static function columnDoesNotExist($columnName, $table)
+    public static function columnDoesNotExist($columnName, $table): SchemaException
     {
         return new self(
             sprintf("There is no column with name '%s' on table '%s'.", $columnName, $table),
@@ -92,10 +82,8 @@ class SchemaException extends Exception
 
     /**
      * @param string $namespaceName
-     *
-     * @return SchemaException
      */
-    public static function namespaceAlreadyExists($namespaceName)
+    public static function namespaceAlreadyExists($namespaceName): SchemaException
     {
         return new self(
             sprintf("The namespace with name '%s' already exists.", $namespaceName),
@@ -105,10 +93,8 @@ class SchemaException extends Exception
 
     /**
      * @param string $tableName
-     *
-     * @return SchemaException
      */
-    public static function tableAlreadyExists($tableName)
+    public static function tableAlreadyExists($tableName): SchemaException
     {
         return new self("The table with name '" . $tableName . "' already exists.", self::TABLE_ALREADY_EXISTS);
     }
@@ -116,10 +102,8 @@ class SchemaException extends Exception
     /**
      * @param string $tableName
      * @param string $columnName
-     *
-     * @return SchemaException
      */
-    public static function columnAlreadyExists($tableName, $columnName)
+    public static function columnAlreadyExists($tableName, $columnName): SchemaException
     {
         return new self(
             "The column '" . $columnName . "' on table '" . $tableName . "' already exists.",
@@ -129,20 +113,16 @@ class SchemaException extends Exception
 
     /**
      * @param string $name
-     *
-     * @return SchemaException
      */
-    public static function sequenceAlreadyExists($name)
+    public static function sequenceAlreadyExists($name): SchemaException
     {
         return new self("The sequence '" . $name . "' already exists.", self::SEQUENCE_ALREADY_EXISTS);
     }
 
     /**
      * @param string $name
-     *
-     * @return SchemaException
      */
-    public static function sequenceDoesNotExist($name)
+    public static function sequenceDoesNotExist($name): SchemaException
     {
         return new self("There exists no sequence with the name '" . $name . "'.", self::SEQUENCE_DOENST_EXIST);
     }
@@ -150,10 +130,8 @@ class SchemaException extends Exception
     /**
      * @param string $constraintName
      * @param string $table
-     *
-     * @return SchemaException
      */
-    public static function uniqueConstraintDoesNotExist($constraintName, $table)
+    public static function uniqueConstraintDoesNotExist($constraintName, $table): SchemaException
     {
         return new self(
             sprintf('There exists no unique constraint with the name "%s" on table "%s".', $constraintName, $table),
@@ -164,10 +142,8 @@ class SchemaException extends Exception
     /**
      * @param string $fkName
      * @param string $table
-     *
-     * @return SchemaException
      */
-    public static function foreignKeyDoesNotExist($fkName, $table)
+    public static function foreignKeyDoesNotExist($fkName, $table): SchemaException
     {
         return new self(
             sprintf("There exists no foreign key with the name '%s' on table '%s'.", $fkName, $table),
@@ -175,10 +151,7 @@ class SchemaException extends Exception
         );
     }
 
-    /**
-     * @return SchemaException
-     */
-    public static function namedForeignKeyRequired(Table $localTable, ForeignKeyConstraint $foreignKey)
+    public static function namedForeignKeyRequired(Table $localTable, ForeignKeyConstraint $foreignKey): SchemaException
     {
         return new self(
             'The performed schema operation on ' . $localTable->getName() . ' requires a named foreign key, ' .
@@ -190,10 +163,8 @@ class SchemaException extends Exception
 
     /**
      * @param string $changeName
-     *
-     * @return SchemaException
      */
-    public static function alterTableChangeNotSupported($changeName)
+    public static function alterTableChangeNotSupported($changeName): SchemaException
     {
         return new self(
             sprintf("Alter table change not supported, given '%s'", $changeName)

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -35,36 +35,25 @@ class Sequence extends AbstractAsset
         $this->cache = $cache;
     }
 
-    /**
-     * @return int
-     */
-    public function getAllocationSize()
+    public function getAllocationSize(): int
     {
         return $this->allocationSize;
     }
 
-    /**
-     * @return int
-     */
-    public function getInitialValue()
+    public function getInitialValue(): int
     {
         return $this->initialValue;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getCache()
+    public function getCache(): ?int
     {
         return $this->cache;
     }
 
     /**
      * @param int $allocationSize
-     *
-     * @return Sequence
      */
-    public function setAllocationSize($allocationSize)
+    public function setAllocationSize($allocationSize): Sequence
     {
         if ($allocationSize > 0) {
             $this->allocationSize = $allocationSize;
@@ -77,10 +66,8 @@ class Sequence extends AbstractAsset
 
     /**
      * @param int $initialValue
-     *
-     * @return Sequence
      */
-    public function setInitialValue($initialValue)
+    public function setInitialValue($initialValue): Sequence
     {
         if ($initialValue > 0) {
             $this->initialValue = $initialValue;
@@ -93,10 +80,8 @@ class Sequence extends AbstractAsset
 
     /**
      * @param int $cache
-     *
-     * @return Sequence
      */
-    public function setCache($cache)
+    public function setCache($cache): Sequence
     {
         $this->cache = $cache;
 
@@ -108,10 +93,8 @@ class Sequence extends AbstractAsset
      *
      * This is used inside the comparator to not report sequences as missing,
      * when the "from" schema implicitly creates the sequences.
-     *
-     * @return bool
      */
-    public function isAutoIncrementsFor(Table $table)
+    public function isAutoIncrementsFor(Table $table): bool
     {
         $primaryKey = $table->getPrimaryKey();
 
@@ -138,10 +121,7 @@ class Sequence extends AbstractAsset
         return $tableSequenceName === $sequenceName;
     }
 
-    /**
-     * @return void
-     */
-    public function visit(Visitor $visitor)
+    public function visit(Visitor $visitor): void
     {
         $visitor->acceptSequence($this);
     }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -91,18 +91,12 @@ class Table extends AbstractAsset
         $this->_options = array_merge($this->_options, $options);
     }
 
-    /**
-     * @return void
-     */
-    public function setSchemaConfig(SchemaConfig $schemaConfig)
+    public function setSchemaConfig(SchemaConfig $schemaConfig): void
     {
         $this->_schemaConfig = $schemaConfig;
     }
 
-    /**
-     * @return int
-     */
-    protected function _getMaxIdentifierLength()
+    protected function _getMaxIdentifierLength(): int
     {
         if ($this->_schemaConfig instanceof SchemaConfig) {
             return $this->_schemaConfig->getMaxIdentifierLength();
@@ -117,11 +111,9 @@ class Table extends AbstractAsset
      * @param string[]     $columnNames
      * @param string|false $indexName
      *
-     * @return self
-     *
      * @throws SchemaException
      */
-    public function setPrimaryKey(array $columnNames, $indexName = false)
+    public function setPrimaryKey(array $columnNames, $indexName = false): self
     {
         if ($indexName === false) {
             $indexName = 'primary';
@@ -142,11 +134,9 @@ class Table extends AbstractAsset
      * @param string[] $flags
      * @param mixed[]  $options
      *
-     * @return self
-     *
      * @throws SchemaException
      */
-    public function addIndex(array $columnNames, ?string $indexName = null, array $flags = [], array $options = [])
+    public function addIndex(array $columnNames, ?string $indexName = null, array $flags = [], array $options = []): self
     {
         if ($indexName === null) {
             $indexName = $this->_generateIdentifierName(
@@ -186,11 +176,9 @@ class Table extends AbstractAsset
     /**
      * Drops the primary key from this table.
      *
-     * @return void
-     *
      * @throws SchemaException
      */
-    public function dropPrimaryKey()
+    public function dropPrimaryKey(): void
     {
         if ($this->_primaryKeyName === null) {
             return;
@@ -205,11 +193,9 @@ class Table extends AbstractAsset
      *
      * @param string $name The index name.
      *
-     * @return void
-     *
      * @throws SchemaException If the index does not exist.
      */
-    public function dropIndex($name)
+    public function dropIndex($name): void
     {
         $name = $this->normalizeIdentifier($name);
 
@@ -225,11 +211,9 @@ class Table extends AbstractAsset
      * @param string|null $indexName
      * @param mixed[]     $options
      *
-     * @return self
-     *
      * @throws SchemaException
      */
-    public function addUniqueIndex(array $columnNames, $indexName = null, array $options = [])
+    public function addUniqueIndex(array $columnNames, $indexName = null, array $options = []): self
     {
         if ($indexName === null) {
             $indexName = $this->_generateIdentifierName(
@@ -254,7 +238,7 @@ class Table extends AbstractAsset
      * @throws SchemaException If no index exists for the given current name
      *                         or if an index with the given new name already exists on this table.
      */
-    public function renameIndex($oldName, $newName = null)
+    public function renameIndex($oldName, $newName = null): self
     {
         $oldName           = $this->normalizeIdentifier($oldName);
         $normalizedNewName = $this->normalizeIdentifier($newName);
@@ -292,10 +276,8 @@ class Table extends AbstractAsset
      * Checks if an index begins in the order of the given columns.
      *
      * @param string[] $columnNames
-     *
-     * @return bool
      */
-    public function columnsAreIndexed(array $columnNames)
+    public function columnsAreIndexed(array $columnNames): bool
     {
         foreach ($this->getIndexes() as $index) {
             if ($index->spansColumns($columnNames)) {
@@ -342,11 +324,9 @@ class Table extends AbstractAsset
      * @param string  $typeName
      * @param mixed[] $options
      *
-     * @return Column
-     *
      * @throws SchemaException
      */
-    public function addColumn($name, $typeName, array $options = [])
+    public function addColumn($name, $typeName, array $options = []): Column
     {
         $column = new Column($name, Type::getType($typeName), $options);
 
@@ -361,11 +341,9 @@ class Table extends AbstractAsset
      * @param string  $name
      * @param mixed[] $options
      *
-     * @return self
-     *
      * @throws SchemaException
      */
-    public function changeColumn($name, array $options)
+    public function changeColumn($name, array $options): self
     {
         $column = $this->getColumn($name);
         $column->setOptions($options);
@@ -377,10 +355,8 @@ class Table extends AbstractAsset
      * Drops a Column from the Table.
      *
      * @param string $name
-     *
-     * @return self
      */
-    public function dropColumn($name)
+    public function dropColumn($name): self
     {
         $name = $this->normalizeIdentifier($name);
 
@@ -400,8 +376,6 @@ class Table extends AbstractAsset
      * @param mixed[]      $options
      * @param string|null  $name
      *
-     * @return self
-     *
      * @throws SchemaException
      */
     public function addForeignKeyConstraint(
@@ -410,7 +384,7 @@ class Table extends AbstractAsset
         array $foreignColumnNames,
         array $options = [],
         $name = null
-    ) {
+    ): self {
         if ($name === null) {
             $name = $this->_generateIdentifierName(
                 array_merge((array) $this->getName(), $localColumnNames),
@@ -447,10 +421,8 @@ class Table extends AbstractAsset
     /**
      * @param string $name
      * @param mixed  $value
-     *
-     * @return self
      */
-    public function addOption($name, $value)
+    public function addOption($name, $value): self
     {
         $this->_options[$name] = $value;
 
@@ -458,11 +430,9 @@ class Table extends AbstractAsset
     }
 
     /**
-     * @return void
-     *
      * @throws SchemaException
      */
-    protected function _addColumn(Column $column)
+    protected function _addColumn(Column $column): void
     {
         $columnName = $column->getName();
         $columnName = $this->normalizeIdentifier($columnName);
@@ -477,11 +447,9 @@ class Table extends AbstractAsset
     /**
      * Adds an index to the table.
      *
-     * @return self
-     *
      * @throws SchemaException
      */
-    protected function _addIndex(Index $indexCandidate)
+    protected function _addIndex(Index $indexCandidate): self
     {
         $indexName               = $indexCandidate->getName();
         $indexName               = $this->normalizeIdentifier($indexName);
@@ -547,10 +515,7 @@ class Table extends AbstractAsset
         return $this;
     }
 
-    /**
-     * @return self
-     */
-    protected function _addForeignKeyConstraint(ForeignKeyConstraint $constraint)
+    protected function _addForeignKeyConstraint(ForeignKeyConstraint $constraint): self
     {
         $constraint->setLocalTable($this);
 
@@ -599,10 +564,8 @@ class Table extends AbstractAsset
      * Returns whether this table has a foreign key constraint with the given name.
      *
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasForeignKey($name)
+    public function hasForeignKey($name): bool
     {
         $name = $this->normalizeIdentifier($name);
 
@@ -614,11 +577,9 @@ class Table extends AbstractAsset
      *
      * @param string $name The constraint name.
      *
-     * @return ForeignKeyConstraint
-     *
      * @throws SchemaException If the foreign key does not exist.
      */
-    public function getForeignKey($name)
+    public function getForeignKey($name): ForeignKeyConstraint
     {
         $name = $this->normalizeIdentifier($name);
 
@@ -634,11 +595,9 @@ class Table extends AbstractAsset
      *
      * @param string $name The constraint name.
      *
-     * @return void
-     *
      * @throws SchemaException
      */
-    public function removeForeignKey($name)
+    public function removeForeignKey($name): void
     {
         $name = $this->normalizeIdentifier($name);
 
@@ -696,7 +655,7 @@ class Table extends AbstractAsset
      *
      * @return Column[]
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         $primaryKeyColumns = $this->hasPrimaryKey() ? $this->getPrimaryKeyColumns() : [];
         $foreignKeyColumns = $this->getForeignKeyColumns();
@@ -713,7 +672,7 @@ class Table extends AbstractAsset
      *
      * @return Column[]
      */
-    public function getForeignKeyColumns()
+    public function getForeignKeyColumns(): array
     {
         $foreignKeyColumns = [];
 
@@ -742,10 +701,8 @@ class Table extends AbstractAsset
      * Returns whether this table has a Column with the given name.
      *
      * @param string $name The column name.
-     *
-     * @return bool
      */
-    public function hasColumn($name)
+    public function hasColumn($name): bool
     {
         $name = $this->normalizeIdentifier($name);
 
@@ -757,11 +714,9 @@ class Table extends AbstractAsset
      *
      * @param string $name The column name.
      *
-     * @return Column
-     *
      * @throws SchemaException If the column does not exist.
      */
-    public function getColumn($name)
+    public function getColumn($name): Column
     {
         $name = $this->normalizeIdentifier($name);
 
@@ -777,7 +732,7 @@ class Table extends AbstractAsset
      *
      * @return Index|null The primary key, or null if this Table has no primary key.
      */
-    public function getPrimaryKey()
+    public function getPrimaryKey(): ?Index
     {
         if ($this->_primaryKeyName !== null) {
             return $this->getIndex($this->_primaryKeyName);
@@ -793,7 +748,7 @@ class Table extends AbstractAsset
      *
      * @throws Exception
      */
-    public function getPrimaryKeyColumns()
+    public function getPrimaryKeyColumns(): array
     {
         $primaryKey = $this->getPrimaryKey();
 
@@ -806,10 +761,8 @@ class Table extends AbstractAsset
 
     /**
      * Returns whether this table has a primary key.
-     *
-     * @return bool
      */
-    public function hasPrimaryKey()
+    public function hasPrimaryKey(): bool
     {
         return $this->_primaryKeyName !== null && $this->hasIndex($this->_primaryKeyName);
     }
@@ -818,10 +771,8 @@ class Table extends AbstractAsset
      * Returns whether this table has an Index with the given name.
      *
      * @param string $name The index name.
-     *
-     * @return bool
      */
-    public function hasIndex($name)
+    public function hasIndex($name): bool
     {
         $name = $this->normalizeIdentifier($name);
 
@@ -833,11 +784,9 @@ class Table extends AbstractAsset
      *
      * @param string $name The index name.
      *
-     * @return Index
-     *
      * @throws SchemaException If the index does not exist.
      */
-    public function getIndex($name)
+    public function getIndex($name): Index
     {
         $name = $this->normalizeIdentifier($name);
         if (! $this->hasIndex($name)) {
@@ -850,7 +799,7 @@ class Table extends AbstractAsset
     /**
      * @return Index[]
      */
-    public function getIndexes()
+    public function getIndexes(): array
     {
         return $this->_indexes;
     }
@@ -870,17 +819,15 @@ class Table extends AbstractAsset
      *
      * @return ForeignKeyConstraint[]
      */
-    public function getForeignKeys()
+    public function getForeignKeys(): array
     {
         return $this->_fkConstraints;
     }
 
     /**
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasOption($name)
+    public function hasOption($name): bool
     {
         return isset($this->_options[$name]);
     }
@@ -898,17 +845,15 @@ class Table extends AbstractAsset
     /**
      * @return mixed[]
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->_options;
     }
 
     /**
-     * @return void
-     *
      * @throws SchemaException
      */
-    public function visit(Visitor $visitor)
+    public function visit(Visitor $visitor): void
     {
         $visitor->acceptTable($this);
 

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -128,10 +128,8 @@ class TableDiff
 
     /**
      * @param AbstractPlatform $platform The platform to use for retrieving this table diff's name.
-     *
-     * @return Identifier
      */
-    public function getName(AbstractPlatform $platform)
+    public function getName(AbstractPlatform $platform): Identifier
     {
         return new Identifier(
             $this->fromTable instanceof Table ? $this->fromTable->getQuotedName($platform) : $this->name

--- a/src/Schema/View.php
+++ b/src/Schema/View.php
@@ -20,10 +20,7 @@ class View extends AbstractAsset
         $this->sql = $sql;
     }
 
-    /**
-     * @return string
-     */
-    public function getSql()
+    public function getSql(): string
     {
         return $this->sql;
     }

--- a/src/Schema/Visitor/AbstractVisitor.php
+++ b/src/Schema/Visitor/AbstractVisitor.php
@@ -14,7 +14,7 @@ use Doctrine\DBAL\Schema\Table;
  */
 class AbstractVisitor implements Visitor, NamespaceVisitor
 {
-    public function acceptSchema(Schema $schema)
+    public function acceptSchema(Schema $schema): void
     {
     }
 
@@ -25,23 +25,23 @@ class AbstractVisitor implements Visitor, NamespaceVisitor
     {
     }
 
-    public function acceptTable(Table $table)
+    public function acceptTable(Table $table): void
     {
     }
 
-    public function acceptColumn(Table $table, Column $column)
+    public function acceptColumn(Table $table, Column $column): void
     {
     }
 
-    public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint)
+    public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint): void
     {
     }
 
-    public function acceptIndex(Table $table, Index $index)
+    public function acceptIndex(Table $table, Index $index): void
     {
     }
 
-    public function acceptSequence(Sequence $sequence)
+    public function acceptSequence(Sequence $sequence): void
     {
     }
 }

--- a/src/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/src/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -71,10 +71,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
         $this->createSequenceQueries[] = $this->platform->getCreateSequenceSQL($sequence);
     }
 
-    /**
-     * @return void
-     */
-    public function resetQueries()
+    public function resetQueries(): void
     {
         $this->createNamespaceQueries    = [];
         $this->createTableQueries        = [];
@@ -87,7 +84,7 @@ class CreateSchemaSqlCollector extends AbstractVisitor
      *
      * @return string[]
      */
-    public function getQueries()
+    public function getQueries(): array
     {
         return array_merge(
             $this->createNamespaceQueries,

--- a/src/Schema/Visitor/DropSchemaSqlCollector.php
+++ b/src/Schema/Visitor/DropSchemaSqlCollector.php
@@ -63,10 +63,7 @@ class DropSchemaSqlCollector extends AbstractVisitor
         $this->sequences->attach($sequence);
     }
 
-    /**
-     * @return void
-     */
-    public function clearQueries()
+    public function clearQueries(): void
     {
         $this->initializeQueries();
     }
@@ -74,7 +71,7 @@ class DropSchemaSqlCollector extends AbstractVisitor
     /**
      * @return string[]
      */
-    public function getQueries()
+    public function getQueries(): array
     {
         $sql = [];
 

--- a/src/Schema/Visitor/Graphviz.php
+++ b/src/Schema/Visitor/Graphviz.php
@@ -138,10 +138,8 @@ class Graphviz extends AbstractVisitor
 
     /**
      * Get Graphviz Output
-     *
-     * @return string
      */
-    public function getOutput()
+    public function getOutput(): string
     {
         return $this->output . '}';
     }
@@ -155,10 +153,8 @@ class Graphviz extends AbstractVisitor
      *  neato -Tpng -o er.png er.dot
      *
      * @param string $filename
-     *
-     * @return void
      */
-    public function write($filename)
+    public function write($filename): void
     {
         file_put_contents($filename, $this->getOutput());
     }

--- a/src/Schema/Visitor/NamespaceVisitor.php
+++ b/src/Schema/Visitor/NamespaceVisitor.php
@@ -11,8 +11,6 @@ interface NamespaceVisitor
      * Accepts a schema namespace name.
      *
      * @param string $namespaceName The schema namespace name to accept.
-     *
-     * @return void
      */
-    public function acceptNamespace($namespaceName);
+    public function acceptNamespace($namespaceName): void;
 }

--- a/src/Schema/Visitor/SchemaDiffVisitor.php
+++ b/src/Schema/Visitor/SchemaDiffVisitor.php
@@ -14,37 +14,26 @@ interface SchemaDiffVisitor
 {
     /**
      * Visit an orphaned foreign key whose table was deleted.
-     *
-     * @return void
      */
-    public function visitOrphanedForeignKey(ForeignKeyConstraint $foreignKey);
+    public function visitOrphanedForeignKey(ForeignKeyConstraint $foreignKey): void;
 
     /**
      * Visit a sequence that has changed.
-     *
-     * @return void
      */
-    public function visitChangedSequence(Sequence $sequence);
+    public function visitChangedSequence(Sequence $sequence): void;
 
     /**
      * Visit a sequence that has been removed.
-     *
-     * @return void
      */
-    public function visitRemovedSequence(Sequence $sequence);
+    public function visitRemovedSequence(Sequence $sequence): void;
 
-    /** @return void */
-    public function visitNewSequence(Sequence $sequence);
+    public function visitNewSequence(Sequence $sequence): void;
 
-    /** @return void */
-    public function visitNewTable(Table $table);
+    public function visitNewTable(Table $table): void;
 
-    /** @return void */
-    public function visitNewTableForeignKey(Table $table, ForeignKeyConstraint $foreignKey);
+    public function visitNewTableForeignKey(Table $table, ForeignKeyConstraint $foreignKey): void;
 
-    /** @return void */
-    public function visitRemovedTable(Table $table);
+    public function visitRemovedTable(Table $table): void;
 
-    /** @return void */
-    public function visitChangedTable(TableDiff $tableDiff);
+    public function visitChangedTable(TableDiff $tableDiff): void;
 }

--- a/src/Schema/Visitor/Visitor.php
+++ b/src/Schema/Visitor/Visitor.php
@@ -16,36 +16,20 @@ use Doctrine\DBAL\Schema\Table;
 interface Visitor
 {
     /**
-     * @return void
-     *
      * @throws SchemaException
      */
-    public function acceptSchema(Schema $schema);
+    public function acceptSchema(Schema $schema): void;
+
+    public function acceptTable(Table $table): void;
+
+    public function acceptColumn(Table $table, Column $column): void;
 
     /**
-     * @return void
-     */
-    public function acceptTable(Table $table);
-
-    /**
-     * @return void
-     */
-    public function acceptColumn(Table $table, Column $column);
-
-    /**
-     * @return void
-     *
      * @throws SchemaException
      */
-    public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint);
+    public function acceptForeignKey(Table $localTable, ForeignKeyConstraint $fkConstraint): void;
 
-    /**
-     * @return void
-     */
-    public function acceptIndex(Table $table, Index $index);
+    public function acceptIndex(Table $table, Index $index): void;
 
-    /**
-     * @return void
-     */
-    public function acceptSequence(Sequence $sequence);
+    public function acceptSequence(Sequence $sequence): void;
 }

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -91,7 +91,7 @@ class Statement
      *
      * @throws Exception
      */
-    public function bindValue($param, $value, $type = ParameterType::STRING)
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
         $this->params[$param] = $value;
         $this->types[$param]  = $type;
@@ -133,7 +133,7 @@ class Statement
      *
      * @throws Exception
      */
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
         $this->params[$param] = $variable;
         $this->types[$param]  = $type;
@@ -223,10 +223,8 @@ class Statement
 
     /**
      * Gets the wrapped driver statement.
-     *
-     * @return Driver\Statement
      */
-    public function getWrappedStatement()
+    public function getWrappedStatement(): Driver\Statement
     {
         return $this->stmt;
     }

--- a/src/Tools/Console/Command/ReservedWordsCommand.php
+++ b/src/Tools/Console/Command/ReservedWordsCommand.php
@@ -71,10 +71,8 @@ class ReservedWordsCommand extends Command
      *
      * @param string                    $name
      * @param class-string<KeywordList> $class
-     *
-     * @return void
      */
-    public function setKeywordListClass($name, $class)
+    public function setKeywordListClass($name, $class): void
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -86,8 +84,7 @@ class ReservedWordsCommand extends Command
         $this->keywordLists[$name] = new $class();
     }
 
-    /** @return void */
-    protected function configure()
+    protected function configure(): void
     {
         $this
         ->setName('dbal:reserved-words')

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -35,8 +35,7 @@ class RunSqlCommand extends Command
         $this->connectionProvider = $connectionProvider;
     }
 
-    /** @return void */
-    protected function configure()
+    protected function configure(): void
     {
         $this
         ->setName('dbal:run-sql')

--- a/src/Tools/Console/ConsoleRunner.php
+++ b/src/Tools/Console/ConsoleRunner.php
@@ -21,11 +21,9 @@ class ConsoleRunner
      *
      * @param Command[] $commands
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public static function run(ConnectionProvider $connectionProvider, $commands = [])
+    public static function run(ConnectionProvider $connectionProvider, $commands = []): void
     {
         $version = InstalledVersions::getVersion('doctrine/dbal');
         assert($version !== null);
@@ -38,10 +36,7 @@ class ConsoleRunner
         $cli->run();
     }
 
-    /**
-     * @return void
-     */
-    public static function addCommands(Application $cli, ConnectionProvider $connectionProvider)
+    public static function addCommands(Application $cli, ConnectionProvider $connectionProvider): void
     {
         $cli->addCommands([
             new RunSqlCommand($connectionProvider),
@@ -53,10 +48,8 @@ class ConsoleRunner
      * Prints the instructions to create a configuration file
      *
      * @deprecated This method will be removed without replacement.
-     *
-     * @return void
      */
-    public static function printCliConfigTemplate()
+    public static function printCliConfigTemplate(): void
     {
         echo <<<'HELP'
 You are missing a "cli-config.php" or "config/cli-config.php" file in your

--- a/src/Types/BooleanType.php
+++ b/src/Types/BooleanType.php
@@ -51,10 +51,7 @@ class BooleanType extends Type
         return ParameterType::BOOLEAN;
     }
 
-    /**
-     * @return bool
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         // We require a commented boolean type in order to distinguish between
         // boolean and smallint as both (have to) map to the same native type.

--- a/src/Types/ConversionException.php
+++ b/src/Types/ConversionException.php
@@ -29,10 +29,8 @@ class ConversionException extends Exception
      *
      * @param mixed  $value
      * @param string $toType
-     *
-     * @return ConversionException
      */
-    public static function conversionFailed($value, $toType, ?Throwable $previous = null)
+    public static function conversionFailed($value, $toType, ?Throwable $previous = null): ConversionException
     {
         $value = strlen($value) > 32 ? substr($value, 0, 20) . '...' : $value;
 
@@ -46,10 +44,8 @@ class ConversionException extends Exception
      * @param mixed  $value
      * @param string $toType
      * @param string $expectedFormat
-     *
-     * @return ConversionException
      */
-    public static function conversionFailedFormat($value, $toType, $expectedFormat, ?Throwable $previous = null)
+    public static function conversionFailedFormat($value, $toType, $expectedFormat, ?Throwable $previous = null): ConversionException
     {
         $value = strlen($value) > 32 ? substr($value, 0, 20) . '...' : $value;
 
@@ -67,15 +63,13 @@ class ConversionException extends Exception
      * @param mixed    $value
      * @param string   $toType
      * @param string[] $possibleTypes
-     *
-     * @return ConversionException
      */
     public static function conversionFailedInvalidType(
         $value,
         $toType,
         array $possibleTypes,
         ?Throwable $previous = null
-    ) {
+    ): ConversionException {
         if (is_scalar($value) || $value === null) {
             return new self(sprintf(
                 'Could not convert PHP value %s to type %s. Expected one of the following types: %s',
@@ -97,10 +91,8 @@ class ConversionException extends Exception
      * @param mixed  $value
      * @param string $format
      * @param string $error
-     *
-     * @return ConversionException
      */
-    public static function conversionFailedSerialization($value, $format, $error /*, ?Throwable $previous = null */)
+    public static function conversionFailedSerialization($value, $format, $error /*, ?Throwable $previous = null */): ConversionException
     {
         $actualType = is_object($value) ? get_class($value) : gettype($value);
 

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -94,19 +94,15 @@ abstract class Type
      *
      * @param mixed[]          $column   The column definition
      * @param AbstractPlatform $platform The currently used database platform.
-     *
-     * @return string
      */
-    abstract public function getSQLDeclaration(array $column, AbstractPlatform $platform);
+    abstract public function getSQLDeclaration(array $column, AbstractPlatform $platform): string;
 
     /**
      * Gets the name of this type.
      *
      * @deprecated this method will be removed in Doctrine DBAL 4.0.
-     *
-     * @return string
      */
-    abstract public function getName();
+    abstract public function getName(): string;
 
     final public static function getTypeRegistry(): TypeRegistry
     {
@@ -134,11 +130,9 @@ abstract class Type
      *
      * @param string $name The name of the type (as returned by getName()).
      *
-     * @return Type
-     *
      * @throws Exception
      */
-    public static function getType($name)
+    public static function getType($name): Type
     {
         return self::getTypeRegistry()->get($name);
     }
@@ -149,11 +143,9 @@ abstract class Type
      * @param string             $name      The name of the type. This should correspond to what getName() returns.
      * @param class-string<Type> $className The class name of the custom type.
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public static function addType($name, $className)
+    public static function addType($name, $className): void
     {
         self::getTypeRegistry()->register($name, new $className());
     }
@@ -165,7 +157,7 @@ abstract class Type
      *
      * @return bool TRUE if type is supported; FALSE otherwise.
      */
-    public static function hasType($name)
+    public static function hasType($name): bool
     {
         return self::getTypeRegistry()->has($name);
     }
@@ -176,11 +168,9 @@ abstract class Type
      * @param string             $name
      * @param class-string<Type> $className
      *
-     * @return void
-     *
      * @throws Exception
      */
-    public static function overrideType($name, $className)
+    public static function overrideType($name, $className): void
     {
         self::getTypeRegistry()->override($name, new $className());
     }
@@ -190,10 +180,8 @@ abstract class Type
      * can be used when binding parameters to prepared statements.
      *
      * This method should return one of the {@see ParameterType} constants.
-     *
-     * @return int
      */
-    public function getBindingType()
+    public function getBindingType(): int
     {
         return ParameterType::STRING;
     }
@@ -204,7 +192,7 @@ abstract class Type
      *
      * @return array<string, string>
      */
-    public static function getTypesMap()
+    public static function getTypesMap(): array
     {
         return array_map(
             static function (Type $type): string {
@@ -224,10 +212,8 @@ abstract class Type
      *
      * @deprecated Consumers should call {@see convertToDatabaseValueSQL} and {@see convertToPHPValueSQL}
      * regardless of the type.
-     *
-     * @return bool
      */
-    public function canRequireSQLConversion()
+    public function canRequireSQLConversion(): bool
     {
         return false;
     }
@@ -236,10 +222,8 @@ abstract class Type
      * Modifies the SQL expression (identifier, parameter) to convert to a database value.
      *
      * @param string $sqlExpr
-     *
-     * @return string
      */
-    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform)
+    public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform): string
     {
         return $sqlExpr;
     }
@@ -249,10 +233,8 @@ abstract class Type
      *
      * @param string           $sqlExpr
      * @param AbstractPlatform $platform
-     *
-     * @return string
      */
-    public function convertToPHPValueSQL($sqlExpr, $platform)
+    public function convertToPHPValueSQL($sqlExpr, $platform): string
     {
         return $sqlExpr;
     }
@@ -262,7 +244,7 @@ abstract class Type
      *
      * @return string[]
      */
-    public function getMappedDatabaseTypes(AbstractPlatform $platform)
+    public function getMappedDatabaseTypes(AbstractPlatform $platform): array
     {
         return [];
     }
@@ -272,10 +254,8 @@ abstract class Type
      * reverse schema engineering can't tell them apart. You need to mark
      * one of those types as commented, which will have Doctrine use an SQL
      * comment to typehint the actual Doctrine Type.
-     *
-     * @return bool
      */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return false;
     }

--- a/src/VersionAwarePlatformDriver.php
+++ b/src/VersionAwarePlatformDriver.php
@@ -22,9 +22,7 @@ interface VersionAwarePlatformDriver extends Driver
      * @param string $version The platform/server version string to evaluate. This should be given in the notation
      *                        the underlying database vendor uses.
      *
-     * @return AbstractPlatform
-     *
      * @throws Exception If the given version string could not be evaluated.
      */
-    public function createDatabasePlatformForVersion($version);
+    public function createDatabasePlatformForVersion($version): AbstractPlatform;
 }


### PR DESCRIPTION
Since we are requiring PHP 7.2, the only possible BC-break here is when
an extending class uses a return type declaration that is not the one we
introduce here. That BC-break would only impact PHP < 7.4 users though.
