### PR TITLE
Deprecate AbstractSchemaManager::getDatabasePlatform()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `AbstractSchemaManager::getDatabasePlatform()`
+
+The `AbstractSchemaManager::getDatabasePlatform()` method has been deprecated. Use `Connection::getDatabasePlatform()`
+instead.
+
 ## Deprecated passing date interval parameters as integer.
 
 Passing date interval parameters to the following `AbstractPlatform` methods as integer has been deprecated:

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -62,10 +62,19 @@ abstract class AbstractSchemaManager
     /**
      * Returns the associated platform.
      *
+     * @deprecated Use {@link Connection::getDatabasePlatform()} instead.
+     *
      * @return T
      */
     public function getDatabasePlatform()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5387',
+            'AbstractSchemaManager::getDatabasePlatform() is deprecated.'
+                . ' Use Connection::getDatabasePlatform() instead.'
+        );
+
         return $this->_platform;
     }
 
@@ -1551,7 +1560,7 @@ abstract class AbstractSchemaManager
 
     public function createComparator(): Comparator
     {
-        return new Comparator($this->getDatabasePlatform());
+        return new Comparator($this->_platform);
     }
 
     /**

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -361,7 +361,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
 
     public function createComparator(): Comparator
     {
-        return new MySQL\Comparator($this->getDatabasePlatform());
+        return new MySQL\Comparator($this->_platform);
     }
 
     protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -352,7 +352,7 @@ SQL
      */
     public function createComparator(): Comparator
     {
-        return new SQLServer\Comparator($this->getDatabasePlatform(), $this->getDatabaseCollation());
+        return new SQLServer\Comparator($this->_platform, $this->getDatabaseCollation());
     }
 
     /**

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -594,7 +594,7 @@ SQL
 
     public function createComparator(): Comparator
     {
-        return new SQLite\Comparator($this->getDatabasePlatform());
+        return new SQLite\Comparator($this->_platform);
     }
 
     /**

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -177,7 +177,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testDoesNotPropagateDefaultValuesForUnsupportedColumnTypes(): void
     {
-        if ($this->schemaManager->getDatabasePlatform() instanceof MariaDb1027Platform) {
+        if ($this->connection->getDatabasePlatform() instanceof MariaDb1027Platform) {
             self::markTestSkipped(
                 'MariaDb102Platform supports default values for BLOB and TEXT columns and will propagate values'
             );
@@ -303,7 +303,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $platform       = $this->schemaManager->getDatabasePlatform();
+        $platform       = $this->connection->getDatabasePlatform();
         $offlineColumns = $table->getColumns();
         $onlineColumns  = $this->schemaManager->listTableColumns($tableName);
 
@@ -406,7 +406,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testColumnDefaultCurrentTimestamp(): void
     {
-        $platform = $this->schemaManager->getDatabasePlatform();
+        $platform = $this->connection->getDatabasePlatform();
 
         $table = new Table('test_column_defaults_current_timestamp');
 
@@ -429,7 +429,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $table = new Table('test_column_defaults_are_valid');
 
-        $currentTimeStampSql = $this->schemaManager->getDatabasePlatform()->getCurrentTimestampSQL();
+        $currentTimeStampSql = $this->connection->getDatabasePlatform()->getCurrentTimestampSQL();
         $table->addColumn('col_datetime', 'datetime', ['default' => $currentTimeStampSql]);
         $table->addColumn('col_datetime_null', 'datetime', ['notnull' => false, 'default' => null]);
         $table->addColumn('col_int', 'integer', ['default' => 1]);
@@ -471,11 +471,11 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
      */
     public function testColumnDefaultValuesCurrentTimeAndDate(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform() instanceof MariaDb1027Platform) {
+        if (! $this->connection->getDatabasePlatform() instanceof MariaDb1027Platform) {
             self::markTestSkipped('Only relevant for MariaDb102Platform.');
         }
 
-        $platform = $this->schemaManager->getDatabasePlatform();
+        $platform = $this->connection->getDatabasePlatform();
 
         $table = new Table('test_column_defaults_current_time_and_date');
 

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -124,7 +124,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $onlinePrimaryTable = $this->schemaManager->listTableDetails($primaryTableName);
         $onlineForeignTable = $this->schemaManager->listTableDetails($foreignTableName);
 
-        $platform = $this->schemaManager->getDatabasePlatform();
+        $platform = $this->connection->getDatabasePlatform();
 
         // Primary table assertions
         self::assertSame($primaryTableName, $onlinePrimaryTable->getQuotedName($platform));

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -110,7 +110,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $column  = $tableTo->addColumn('id', 'integer');
         $column->setAutoincrement(true);
 
-        $platform = $this->schemaManager->getDatabasePlatform();
+        $platform = $this->connection->getDatabasePlatform();
         $diff     = $comparatorFactory($this->schemaManager)->diffTable($tableFrom, $tableTo);
         self::assertNotFalse($diff);
 
@@ -143,7 +143,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableTo = new Table('autoinc_table_drop');
         $tableTo->addColumn('id', 'integer');
 
-        $platform = $this->schemaManager->getDatabasePlatform();
+        $platform = $this->connection->getDatabasePlatform();
         $diff     = $comparatorFactory($this->schemaManager)->diffTable($tableFrom, $tableTo);
         self::assertNotFalse($diff);
 

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -153,7 +153,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testListDatabases(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsCreateDropDatabase()) {
+        if (! $this->connection->getDatabasePlatform()->supportsCreateDropDatabase()) {
             self::markTestSkipped('Cannot drop Database client side with this Driver.');
         }
 
@@ -353,7 +353,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $eventManager = new EventManager();
         $eventManager->addEventListener([Events::onSchemaColumnDefinition], $listenerMock);
 
-        $this->schemaManager->getDatabasePlatform()->setEventManager($eventManager);
+        $this->connection->getDatabasePlatform()->setEventManager($eventManager);
 
         $this->schemaManager->listTableColumns('list_table_columns');
     }
@@ -374,7 +374,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $eventManager = new EventManager();
         $eventManager->addEventListener([Events::onSchemaIndexDefinition], $listenerMock);
 
-        $this->schemaManager->getDatabasePlatform()->setEventManager($eventManager);
+        $this->connection->getDatabasePlatform()->setEventManager($eventManager);
 
         $this->schemaManager->listTableIndexes('list_table_indexes_test');
     }
@@ -408,7 +408,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     public function testDiffListTableColumns(callable $comparatorFactory): void
     {
-        if ($this->schemaManager->getDatabasePlatform() instanceof OraclePlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
             self::markTestSkipped(
                 'Does not work with Oracle, since it cannot detect DateTime, Date and Time differences (at the moment).'
             );
@@ -498,7 +498,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testCreateTableWithForeignKeys(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
             self::markTestSkipped('Platform does not support foreign keys.');
         }
 
@@ -602,7 +602,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testAlterTableScenario(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsAlterTable()) {
+        if (! $this->connection->getDatabasePlatform()->supportsAlterTable()) {
             self::markTestSkipped('Alter Table is not supported by this platform.');
         }
 
@@ -683,7 +683,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         // dont check for index size here, some platforms automatically add indexes for foreign keys.
         self::assertFalse($table->hasIndex('bar_idx'));
 
-        if (! $this->schemaManager->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
             return;
         }
 
@@ -697,7 +697,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testTableInNamespace(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsSchemas()) {
+        if (! $this->connection->getDatabasePlatform()->supportsSchemas()) {
             self::markTestSkipped('Schema definition is not supported by this platform.');
         }
 
@@ -705,7 +705,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $diff                  = new SchemaDiff();
         $diff->newNamespaces[] = 'testschema';
 
-        foreach ($diff->toSql($this->schemaManager->getDatabasePlatform()) as $sql) {
+        foreach ($diff->toSql($this->connection->getDatabasePlatform()) as $sql) {
             $this->connection->executeStatement($sql);
         }
 
@@ -721,7 +721,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testCreateAndListViews(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsViews()) {
+        if (! $this->connection->getDatabasePlatform()->supportsViews()) {
             self::markTestSkipped('Views is not supported by this platform.');
         }
 
@@ -745,7 +745,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testAutoincrementDetection(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsIdentityColumns()) {
+        if (! $this->connection->getDatabasePlatform()->supportsIdentityColumns()) {
             self::markTestSkipped('This test is only supported on platforms that have autoincrement');
         }
 
@@ -763,7 +763,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testAutoincrementDetectionMulticolumns(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsIdentityColumns()) {
+        if (! $this->connection->getDatabasePlatform()->supportsIdentityColumns()) {
             self::markTestSkipped('This test is only supported on platforms that have autoincrement');
         }
 
@@ -787,7 +787,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     public function testUpdateSchemaWithForeignKeyRenaming(callable $comparatorFactory): void
     {
-        $platform = $this->schemaManager->getDatabasePlatform();
+        $platform = $this->connection->getDatabasePlatform();
 
         if (! $platform->supportsForeignKeyConstraints()) {
             self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
@@ -839,7 +839,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     public function testRenameIndexUsedInForeignKeyConstraint(callable $comparatorFactory): void
     {
-        $platform = $this->schemaManager->getDatabasePlatform();
+        $platform = $this->connection->getDatabasePlatform();
 
         if (! $platform->supportsForeignKeyConstraints()) {
             self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
@@ -1207,11 +1207,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testListTableDetailsWithFullQualifiedTableName(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsSchemas()) {
+        if (! $this->connection->getDatabasePlatform()->supportsSchemas()) {
             self::markTestSkipped('Test only works on platforms that support schemas.');
         }
 
-        $defaultSchemaName = $this->schemaManager->getDatabasePlatform()->getDefaultSchemaName();
+        $defaultSchemaName = $this->connection->getDatabasePlatform()->getDefaultSchemaName();
         $primaryTableName  = 'primary_table';
         $foreignTableName  = 'foreign_table';
 
@@ -1309,7 +1309,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         ?string $comment2,
         ?string $expectedComment2
     ): void {
-        $platform = $this->schemaManager->getDatabasePlatform();
+        $platform = $this->connection->getDatabasePlatform();
 
         if (
             ! $platform->supportsInlineColumnComments() &&
@@ -1381,7 +1381,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testDoesNotListIndexesImplicitlyCreatedByForeignKeys(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
             self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
         }
 
@@ -1413,7 +1413,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     public function testComparatorShouldNotAddCommentToJsonTypeSinceItIsTheDefaultNow(callable $comparatorFactory): void
     {
-        $platform = $this->schemaManager->getDatabasePlatform();
+        $platform = $this->connection->getDatabasePlatform();
 
         if (! $platform->hasNativeJsonType()) {
             self::markTestSkipped('This test is only supported on platforms that have native JSON type.');
@@ -1460,7 +1460,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testCreateAndListSequences(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsSequences()) {
+        if (! $this->connection->getDatabasePlatform()->supportsSequences()) {
             self::markTestSkipped('This test is only supported on platforms that support sequences.');
         }
 
@@ -1501,7 +1501,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     public function testComparisonWithAutoDetectedSequenceDefinition(callable $comparatorFactory): void
     {
-        $platform = $this->schemaManager->getDatabasePlatform();
+        $platform = $this->connection->getDatabasePlatform();
 
         if (! $platform->supportsSequences()) {
             self::markTestSkipped('This test is only supported on platforms that support sequences.');
@@ -1562,7 +1562,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testGenerateAnIndexWithPartialColumnLength(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsColumnLengthIndexes()) {
+        if (! $this->connection->getDatabasePlatform()->supportsColumnLengthIndexes()) {
             self::markTestSkipped(
                 'This test is only supported on platforms that support indexes with column length definitions.'
             );
@@ -1595,7 +1595,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testCreatedCompositeForeignKeyOrderIsCorrectAfterCreation(): void
     {
-        if (! $this->schemaManager->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
             self::markTestSkipped('Platform does not support foreign keys.');
         }
 

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -101,7 +101,7 @@ abstract class FunctionalTestCase extends TestCase
     public function dropAndCreateTable(Table $table): void
     {
         $schemaManager = $this->connection->createSchemaManager();
-        $platform      = $schemaManager->getDatabasePlatform();
+        $platform      = $this->connection->getDatabasePlatform();
         $tableName     = $table->getQuotedName($platform);
 
         $this->dropTableIfExists($tableName);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The connection is an internal dependency of the schema manager. There's no point in exposing it via the public API. The database platform is available via `Connection`.