### PR TITLE
Deprecate AbstractPlatform methods exposing quote characters

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `AbstractPlatform` methods exposing quote characters.
+
+The `AbstractPlatform::getStringLiteralQuoteCharacter()` and `::getIdentifierQuoteCharacter()` methods
+have been deprecated. Use `::quoteStringLiteral()` and `::quoteIdentifier()` to quote string literals and identifiers
+respectively.
+
 ## Deprecated `AbstractSchemaManager::getDatabasePlatform()`
 
 The `AbstractSchemaManager::getDatabasePlatform()` method has been deprecated. Use `Connection::getDatabasePlatform()`

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -270,6 +270,12 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getVarcharTypeDeclarationSQL"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform::getIdentifierQuoteCharacter"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getIdentifierQuoteCharacter"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getStringLiteralQuoteCharacter"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -65,9 +65,17 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use {@see quoteIdentifier()} to quote identifiers instead.
      */
     public function getIdentifierQuoteCharacter()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5388',
+            'AbstractMySQLPlatform::getIdentifierQuoteCharacter() is deprecated. Use quoteIdentifier() instead.'
+        );
+
         return '`';
     }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -563,10 +563,18 @@ abstract class AbstractPlatform
     /**
      * Gets the character used for identifier quoting.
      *
+     * @deprecated Use {@see quoteIdentifier()} to quote identifiers instead.
+     *
      * @return string
      */
     public function getIdentifierQuoteCharacter()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5388',
+            'AbstractPlatform::getIdentifierQuoteCharacter() is deprecated. Use quoteIdentifier() instead.'
+        );
+
         return '"';
     }
 
@@ -4130,10 +4138,19 @@ abstract class AbstractPlatform
     /**
      * Gets the character used for string literal quoting.
      *
+     * @deprecated Use {@see quoteStringLiteral()} to quote string literals instead.
+     *
      * @return string
      */
     public function getStringLiteralQuoteCharacter()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5388',
+            'AbstractPlatform::getStringLiteralQuoteCharacter() is deprecated.'
+                . ' Use quoteStringLiteral() instead.'
+        );
+
         return "'";
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The characters and the logic of quoting strings is a platform-specific implementation detail, not subject to exposure via the public API.