### PR TITLE
Doctrine/dbal 2.13.x; Mark Statement::rowCount() as deprecated

### DIFF
--- a/lib/Doctrine/DBAL/Statement.php
+++ b/lib/Doctrine/DBAL/Statement.php
@@ -779,10 +779,20 @@ class Statement implements IteratorAggregate, DriverStatement, Result
     /**
      * Returns the number of rows affected by the last execution of this statement.
      *
+     * @deprecated Use Result::rowCount() instead
+     *
      * @return int|string The number of affected rows.
      */
     public function rowCount()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4035',
+            'Statement::%s() is deprecated, use Result::%s() instead.',
+            __FUNCTION__,
+            __FUNCTION__
+        );
+
         return $this->stmt->rowCount();
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

I've added a deprecation-warning to `Doctrine\DBAL\Statement` for doctrine 2.13.x based on tag [2.13.9](https://github.com/doctrine/dbal/tree/2.13.9).

I've added this since I was trying to migrate a project from doctrine/dbal from version 2 to version 3 and ran into the problem that this method was now suddenly missing, although I previously removed all deprecation warnings thrown by the library.

While I was writing a test for my warning, I've added verification for the deprecation-warnings for all the tests in `Doctrine\Tests\DBAL\StatementTest`.

# Attention
The branch I'm trying to merge into is wrongly `3.3.x`, since there is no branch `2.13.x` to try to merge into.  

This PR should **not** be merged into the `3.3.x`-branch.
