### PR TITLE
Unset the default value if the given column definition is an integer …

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -431,7 +431,7 @@ SQL
         }
 
         // Unset the default value if the given column definition is an integer and the default value is a string
-        if ($column['type'] instanceof PhpIntegerMappingType && is_string( $column['default'])) {
+        if ($column['type'] instanceof PhpIntegerMappingType && is_string($column['default'])) {
             $column['default'] = null;
         }
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\TextType;
+use Doctrine\DBAL\Types\PhpIntegerMappingType;
 use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
@@ -426,6 +427,11 @@ SQL
     {
         // Unset the default value if the given column definition does not allow default values.
         if ($column['type'] instanceof TextType || $column['type'] instanceof BlobType) {
+            $column['default'] = null;
+        }
+
+        // Unset the default value if the given column definition is an integer and the default value is an empty string
+        if ($column['type'] instanceof PhpIntegerMappingType && $column['default'] === '') {
             $column['default'] = null;
         }
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -430,8 +430,8 @@ SQL
             $column['default'] = null;
         }
 
-        // Unset the default value if the given column definition is an integer and the default value is an empty string
-        if ($column['type'] instanceof PhpIntegerMappingType && $column['default'] === '') {
+        // Unset the default value if the given column definition is an integer and the default value is a string
+        if ($column['type'] instanceof PhpIntegerMappingType && is_string( $column['default'])) {
             $column['default'] = null;
         }
 


### PR DESCRIPTION
Unset the default value if the given column definition is an integer and the default value is a string

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

This is kinda of an edge case that I found when working with Laravel migrations. I wanted to change a column type from VARCHAR(32) DEFAULT '' to INT and got the following malformed SQL expression from Doctrine\DBAL\Platforms\AbstractMySQLPlatform\getAlterTableSQL()

`"ALTER TABLE location_details CHANGE location_id location_id INT DEFAULT   NOT NULL"`

Since the column's original default value was a string, in this case an empty one '', it got carried over to the ALTER statement. The fix I propose is to check if the new column type is an PhpIntegerMappingType and if its default value a string then unset the default, similar to what we already do with TextType and BlobType. After this fix, the resulting SQL statement should be the following:

`"ALTER TABLE location_details CHANGE location_id location_id INT NOT NULL"`

