### PR TITLE
Additional documentation for prior deprecations

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -153,6 +153,8 @@
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getBinaryMaxLength"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getIsNullExpression"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getUniqueFieldDeclarationSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\DB2Platform::getCharMaxLength"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\OraclePlatform::getBinaryMaxLength"/>
                 <!--
                     See https://github.com/doctrine/dbal/pull/5058
                     TODO: remove in 4.0.0

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -1103,17 +1103,33 @@ SQL
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function getVarcharMaxLength()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'AbstractMySQLPlatform::getVarcharMaxLength() is deprecated.'
+        );
+
         return 65535;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getBinaryMaxLength()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'AbstractMySQLPlatform::getBinaryMaxLength() is deprecated.'
+        );
+
         return 65535;
     }
 

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -23,24 +23,51 @@ use function strpos;
 
 class DB2Platform extends AbstractPlatform
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
     public function getCharMaxLength(): int
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'DB2Platform::getCharMaxLength() is deprecated.'
+        );
+
         return 254;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getBinaryMaxLength()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'DB2Platform::getBinaryMaxLength() is deprecated.'
+        );
+
         return 32704;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getBinaryDefaultLength()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'Relying on the default binary column length is deprecated, specify the length explicitly.'
+        );
+
         return 1;
     }
 

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -382,9 +382,17 @@ class OraclePlatform extends AbstractPlatform
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getBinaryMaxLength()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'OraclePlatform::getBinaryMaxLength() is deprecated.'
+        );
+
         return 2000;
     }
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -1139,9 +1139,17 @@ SQL
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function getVarcharMaxLength()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'PostgreSQLPlatform::getVarcharMaxLength() is deprecated.'
+        );
+
         return 65535;
     }
 
@@ -1150,14 +1158,28 @@ SQL
      */
     public function getBinaryMaxLength()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'PostgreSQLPlatform::getBinaryMaxLength() is deprecated.'
+        );
+
         return 0;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getBinaryDefaultLength()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'Relying on the default binary column length is deprecated, specify the length explicitly.'
+        );
+
         return 0;
     }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1242,9 +1242,17 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getBinaryMaxLength()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'SQLServerPlatform::getBinaryMaxLength() is deprecated.'
+        );
+
         return 8000;
     }
 

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -434,17 +434,33 @@ class SqlitePlatform extends AbstractPlatform
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getBinaryMaxLength()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'SqlitePlatform::getBinaryMaxLength() is deprecated.'
+        );
+
         return 0;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getBinaryDefaultLength()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/3263',
+            'Relying on the default binary column length is deprecated, specify the length explicitly.'
+        );
+
         return 0;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

Add more phpDoc tags and runtime deprecations to the previously deprecated methods. See https://github.com/doctrine/dbal/pull/4724.