### PR TITLE
Remove hard-coded string column length

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -848,9 +848,6 @@ class SqlitePlatform extends AbstractPlatform
             }
 
             $definition['name'] = $column->getQuotedName($this);
-            if ($type instanceof Types\StringType && $definition['length'] === null) {
-                $definition['length'] = 255;
-            }
 
             $sql[] = 'ALTER TABLE ' . $table->getQuotedName($this) . ' ADD COLUMN '
                 . $this->getColumnDeclarationSQL($definition['name'], $definition);

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -309,7 +309,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         ]);
 
         $expected = [
-            'ALTER TABLE user ADD COLUMN foo VARCHAR(255) NOT NULL',
+            'ALTER TABLE user ADD COLUMN foo VARCHAR NOT NULL',
             'ALTER TABLE user ADD COLUMN count INTEGER DEFAULT 1',
         ];
 


### PR DESCRIPTION
This code isn't needed as of https://github.com/doctrine/dbal/pull/3586.