### PR TITLE
Natural order of SQLite foreign keys

### DIFF
--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -73,11 +73,11 @@ EOS
 
         $expected = [
             new ForeignKeyConstraint(
-                ['log'],
-                'log',
-                [],
-                'FK_3',
-                ['onUpdate' => 'SET NULL', 'onDelete' => 'NO ACTION', 'deferrable' => false, 'deferred' => false]
+                ['page'],
+                'page',
+                ['key'],
+                'FK_1',
+                ['onUpdate' => 'NO ACTION', 'onDelete' => 'NO ACTION', 'deferrable' => true, 'deferred' => true]
             ),
             new ForeignKeyConstraint(
                 ['parent'],
@@ -87,11 +87,11 @@ EOS
                 ['onUpdate' => 'NO ACTION', 'onDelete' => 'CASCADE', 'deferrable' => false, 'deferred' => false]
             ),
             new ForeignKeyConstraint(
-                ['page'],
-                'page',
-                ['key'],
-                'FK_1',
-                ['onUpdate' => 'NO ACTION', 'onDelete' => 'NO ACTION', 'deferrable' => true, 'deferred' => true]
+                ['log'],
+                'log',
+                [],
+                'FK_3',
+                ['onUpdate' => 'SET NULL', 'onDelete' => 'NO ACTION', 'deferrable' => false, 'deferred' => false]
             ),
         ];
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

Currently, the DBAL returns foreign keys of a given SQLite table in the reverse order of declaration. For instance, it declares the foreign keys as `FK_1`, `<anonymous>`, `FK_3`: https://github.com/doctrine/dbal/blob/2bf974eb787b5e6938fbde726db7af96f1f04a75/tests/Functional/Schema/SqliteSchemaManagerTest.php#L64-L70
And then expects the introspection results to look like `FK_3`, (irrelevant), `FK_1`: https://github.com/doctrine/dbal/blob/2bf974eb787b5e6938fbde726db7af96f1f04a75/tests/Functional/Schema/SqliteSchemaManagerTest.php#L74-L96

This may be explained by the fact that `PRAGMA foreign_key_list()` assigns identifiers to the foreign keys in their reverse order of declaration (i.e. `FK_1` → `2`, `<anonymous>` → `1`, `FK_1` → `0`) and returns them ordered by the identifier ([stackoverflow](https://stackoverflow.com/questions/54070607/is-there-a-way-to-order-the-result-of-a-sqlite-pragma-foreign-key-list-query-b/54072013#54072013)). But it doesn't justify DBAL returning them in reverse order.

For instance, the [JDBC driver](https://github.com/xerial/sqlite-jdbc) for SQLite returns them [ordered by the referenced table name](https://github.com/xerial/sqlite-jdbc/blob/3.36.0.3/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java#L1638), which at least makes some sense.

The IntelliJ products return named constraints first ordered by name and then the anonymous ones: ![Screen Shot 2022-05-17 at 9 27 57 AM](https://user-images.githubusercontent.com/59683/168861997-5cef2065-ad1c-4863-8e8e-b1fdaf11e954.png)

I want to take a stab at restoring the work originally implemented in https://github.com/doctrine/dbal/pull/3762 and then reverted in https://github.com/doctrine/dbal/pull/4255. So I need to extract the code that fetches the details into a reusable method.