### PR TITLE
Run more foreign key tests on SQLite

### DIFF
--- a/src/Driver/API/SQLite/ExceptionConverter.php
+++ b/src/Driver/API/SQLite/ExceptionConverter.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\InvalidFieldNameException;
 use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
@@ -77,6 +78,10 @@ final class ExceptionConverter implements ExceptionConverterInterface
 
         if (strpos($exception->getMessage(), 'unable to open database file') !== false) {
             return new ConnectionException($exception, $query);
+        }
+
+        if (strpos($exception->getMessage(), 'FOREIGN KEY constraint failed') !== false) {
+            return new ForeignKeyConstraintViolationException($exception, $query);
         }
 
         return new DriverException($exception, $query);

--- a/src/Event/Listeners/SQLiteSessionInit.php
+++ b/src/Event/Listeners/SQLiteSessionInit.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\DBAL\Event\Listeners;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Event\ConnectionEventArgs;
+use Doctrine\DBAL\Events;
+use Doctrine\DBAL\Exception;
+
+class SQLiteSessionInit implements EventSubscriber
+{
+    /**
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function postConnect(ConnectionEventArgs $args)
+    {
+        $args->getConnection()->executeStatement('PRAGMA foreign_keys=ON');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubscribedEvents()
+    {
+        return [Events::postConnect];
+    }
+}

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -279,7 +279,7 @@ class DB2SchemaManager extends AbstractSchemaManager
         return $identifier->isQuoted() ? $identifier->getName() : strtoupper($name);
     }
 
-    protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -319,7 +319,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseIndexes(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -358,7 +358,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseForeignKeys(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -410,7 +410,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getDatabaseTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
     {
         $sql = 'SELECT NAME, REMARKS';
 

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -364,7 +364,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
         return new MySQL\Comparator($this->_platform);
     }
 
-    protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -398,7 +398,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseIndexes(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -428,7 +428,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseForeignKeys(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT DISTINCT';
 
@@ -469,7 +469,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getDatabaseTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
     {
         $sql = <<<'SQL'
     SELECT t.TABLE_NAME,

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -349,7 +349,7 @@ class OracleSchemaManager extends AbstractSchemaManager
         return $identifier;
     }
 
-    protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -387,7 +387,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseIndexes(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -425,7 +425,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseForeignKeys(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -464,7 +464,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getDatabaseTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
     {
         $sql = 'SELECT TABLE_NAME, COMMENTS';
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -601,7 +601,7 @@ SQL
         return str_replace("''", "'", $default);
     }
 
-    protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -657,7 +657,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseIndexes(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -693,7 +693,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseForeignKeys(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -728,7 +728,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getDatabaseTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
     {
         if ($tableName === null) {
             $tables = $this->listTableNames();

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -375,7 +375,7 @@ SQL
         return $this->databaseCollation;
     }
 
-    protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -423,7 +423,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseIndexes(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -467,7 +467,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseForeignKeys(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = 'SELECT';
 
@@ -512,7 +512,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getDatabaseTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
     {
         $sql = <<<'SQL'
           SELECT

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -175,18 +175,18 @@ class SqliteSchemaManager extends AbstractSchemaManager
      */
     public function listTableForeignKeys($table, $database = null)
     {
-        $tableForeignKeys = $this->selectDatabaseForeignKeys('', $this->normalizeName($table))
+        $columns = $this->selectForeignKeyColumns('', $this->normalizeName($table))
             ->fetchAllAssociative();
 
-        if (! empty($tableForeignKeys)) {
-            $details = $this->getTableForeignKeyDetails($table);
+        if (! empty($columns)) {
+            $foreignKeyDetails = $this->getForeignKeyDetails($table);
 
-            foreach ($tableForeignKeys as $i => $foreignKey) {
-                $tableForeignKeys[$i] = array_merge($foreignKey, $details[$i]);
+            foreach ($columns as $i => $column) {
+                $columns[$i] = array_merge($column, $foreignKeyDetails[$i]);
             }
         }
 
-        return $this->_getPortableTableForeignKeysList($tableForeignKeys);
+        return $this->_getPortableTableForeignKeysList($columns);
     }
 
     /**
@@ -572,7 +572,7 @@ SQL
      *
      * @throws Exception
      */
-    private function getTableForeignKeyDetails($table)
+    private function getForeignKeyDetails($table)
     {
         $createSql = $this->getCreateTableSQL($table);
 
@@ -632,7 +632,7 @@ SQL
         return [];
     }
 
-    protected function selectDatabaseColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = <<<SQL
             SELECT t.name AS table_name,
@@ -657,7 +657,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseIndexes(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = <<<SQL
             SELECT t.name AS table_name,
@@ -682,7 +682,7 @@ SQL;
         return $this->_conn->executeQuery($sql, $params);
     }
 
-    protected function selectDatabaseForeignKeys(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
         $sql = <<<SQL
             SELECT t.name AS table_name,
@@ -711,7 +711,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getDatabaseTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
     {
         if ($tableName === null) {
             $tables = $this->listTableNames();

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -178,11 +178,13 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $columns = $this->selectForeignKeyColumns('', $this->normalizeName($table))
             ->fetchAllAssociative();
 
-        if (! empty($columns)) {
+        if (count($columns) > 0) {
             $foreignKeyDetails = $this->getForeignKeyDetails($table);
+            $foreignKeyCount   = count($foreignKeyDetails);
 
             foreach ($columns as $i => $column) {
-                $columns[$i] = array_merge($column, $foreignKeyDetails[$i]);
+                // SQLite identifies foreign keys in reverse order of appearance in SQL
+                $columns[$i] = array_merge($column, $foreignKeyDetails[$foreignKeyCount - $column['id'] - 1]);
             }
         }
 

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -64,10 +64,6 @@ class ExceptionTest extends FunctionalTestCase
 
     public function testForeignKeyConstraintViolationExceptionOnInsert(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
-        }
-
         $this->setUpForeignKeyConstraintViolationExceptionTest();
 
         try {
@@ -98,10 +94,6 @@ class ExceptionTest extends FunctionalTestCase
 
     public function testForeignKeyConstraintViolationExceptionOnUpdate(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
-        }
-
         $this->setUpForeignKeyConstraintViolationExceptionTest();
 
         try {
@@ -132,10 +124,6 @@ class ExceptionTest extends FunctionalTestCase
 
     public function testForeignKeyConstraintViolationExceptionOnDelete(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
-        }
-
         $this->setUpForeignKeyConstraintViolationExceptionTest();
 
         try {
@@ -167,10 +155,6 @@ class ExceptionTest extends FunctionalTestCase
     public function testForeignKeyConstraintViolationExceptionOnTruncate(): void
     {
         $platform = $this->connection->getDatabasePlatform();
-
-        if (! $platform->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped('Only fails on platforms with foreign key constraints.');
-        }
 
         $this->setUpForeignKeyConstraintViolationExceptionTest();
 

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -242,10 +242,6 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testListForeignKeys(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Does not support foreign key constraints.');
-        }
-
         $fkOptions   = ['SET NULL', 'SET DEFAULT', 'NO ACTION', 'CASCADE', 'RESTRICT'];
         $foreignKeys = [];
         $fkTable     = $this->getTestTable('test_create_fk1');

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -526,10 +526,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testListForeignKeys(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Does not support foreign key constraints.');
-        }
-
         $this->createTestTable('test_create_fk1');
         $this->createTestTable('test_create_fk2');
 
@@ -1092,10 +1088,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testListForeignKeysComposite(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Does not support foreign key constraints.');
-        }
-
         $this->schemaManager->createTable($this->getTestTable('test_create_fk3'));
         $this->schemaManager->createTable($this->getTestCompositeTable('test_create_fk4'));
 
@@ -1381,10 +1373,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testDoesNotListIndexesImplicitlyCreatedByForeignKeys(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
-        }
-
         $primaryTable = new Table('test_list_index_impl_primary');
         $primaryTable->addColumn('id', 'integer');
         $primaryTable->setPrimaryKey(['id']);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug, improvement

https://github.com/doctrine/dbal/pull/5402 introduced a regression in introspecting foreign keys with multiple columns. This scenario is covered by `SchemaManagerFunctionalTestCase::testListForeignKeysComposite()` but it's not executed with SQLite because it's marked as not supporting foreign keys ¯\_(ツ)_/¯.

Besides others, one of the reasons that contributed to the regression was the inaccurate naming of the existing schema introspection methods. For instance, `AbstractPlatform::getListTableForeignKeysSQL()` implies that the SQL will produce a list of foreign keys (one row per key) but it produces a list of foreign key columns (one row per column) on all platforms except for PostgreSQL (which produces one row per foreign key).

Even though PostgreSQL implements the API as prescribed, it does it at the cost of introspecting the foreign key declaration SQL (as opposed to structured metadata) and then parsing it: https://github.com/doctrine/dbal/blob/40466e90d1d2e4b4feec044b17fb56bcb431af26/src/Schema/PostgreSQLSchemaManager.php#L231

We may want to address this issue later during further refactoring of the schema introspection logic.

**What's changed**:
1. The schema introspection `AbstractSchemaManager::select*()` methods introduced in https://github.com/doctrine/dbal/pull/5268 have been renamed more accurately. This isn't a breaking change since this API wasn't yet released.
2. The regression has been fixed.
3. Those foreign key integration tests that don't require code changes to pass on SQLite have been enabled. Those include the test that would prevent the regression.