### PR TITLE
PoC: Implementation for a more flexible type system

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -273,14 +273,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
-     */
-    public function getBooleanTypeDeclarationSQL(array $column)
-    {
-        return 'TINYINT(1)';
-    }
-
-    /**
-     * {@inheritDoc}
      *
      * @deprecated
      *

--- a/src/Platforms/DB2/Types/BooleanType.php
+++ b/src/Platforms/DB2/Types/BooleanType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\DB2\Types;
+
+use Doctrine\DBAL\Platforms\Types\BooleanType as PlatformBooleanType;
+
+class BooleanType extends PlatformBooleanType
+{
+    public function getSQLDeclaration(array $column)
+    {
+        return 'SMALLINT';
+    }
+
+    public function requiresSQLCommentHint()
+    {
+        return true;
+    }
+}

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -9,6 +9,8 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\DBAL\Types as DBALTypes;
+use Doctrine\DBAL\Platforms\DB2\Types as PlatformTypes;
 use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
@@ -23,6 +25,10 @@ use function strpos;
 
 class DB2Platform extends AbstractPlatform
 {
+    protected $types = [
+        DBALTypes\BooleanType::class => PlatformTypes\BooleanType::class
+    ];
+
     public function getCharMaxLength(): int
     {
         return 254;
@@ -149,14 +155,6 @@ class DB2Platform extends AbstractPlatform
         );
 
         return 'db2';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getBooleanTypeDeclarationSQL(array $column)
-    {
-        return 'SMALLINT';
     }
 
     /**

--- a/src/Platforms/MySQL/Types/BooleanType.php
+++ b/src/Platforms/MySQL/Types/BooleanType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\MySQL\Types;
+
+use Doctrine\DBAL\Platforms\Types\BooleanType as PlatformBooleanType;
+
+class BooleanType extends PlatformBooleanType
+{
+    public function getSQLDeclaration(array $column)
+    {
+        return 'TINYINT(1)';
+    }
+}

--- a/src/Platforms/Oracle/Types/BooleanType.php
+++ b/src/Platforms/Oracle/Types/BooleanType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\Oracle\Types;
+
+use Doctrine\DBAL\Platforms\Types\BooleanType as PlatformBooleanType;
+
+class BooleanType extends PlatformBooleanType
+{
+    public function getSQLDeclaration(array $column)
+    {
+        return 'NUMBER(1)';
+    }
+}

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -11,6 +11,8 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\BinaryType;
+use Doctrine\DBAL\Types as DBALTypes;
+use Doctrine\DBAL\Platforms\Oracle\Types as PlatformTypes;
 use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
@@ -32,6 +34,10 @@ use function substr;
  */
 class OraclePlatform extends AbstractPlatform
 {
+    protected $types = [
+        DBALTypes\BooleanType::class => PlatformTypes\BooleanType::class
+    ];
+
     /**
      * Assertion for Oracle identifiers.
      *
@@ -271,14 +277,6 @@ class OraclePlatform extends AbstractPlatform
             default:
                 return parent::_getTransactionIsolationLevelSQL($level);
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getBooleanTypeDeclarationSQL(array $column)
-    {
-        return 'NUMBER(1)';
     }
 
     /**

--- a/src/Platforms/PostgreSQL/Types/BooleanType.php
+++ b/src/Platforms/PostgreSQL/Types/BooleanType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\PostgreSQL\Types;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\Types\BooleanType as PlatformBooleanType;
+
+class BooleanType extends PlatformBooleanType
+{
+    /**
+     * @var PostgreSQLPlatform
+     */
+    protected $platform;
+
+    public function convertToPHPValue($value)
+    {
+        $booleanLiterals = $this->platform->getBooleanLiterals();
+
+        if ($value !== null && in_array(strtolower($value), $booleanLiterals['false'], true)) {
+            return false;
+        }
+
+        return parent::convertToPHPValue($value);
+    }
+
+    public function convertToDatabaseValue($value)
+    {
+        if (!$this->platform->isUseBooleanTrueFalseStrings()) {
+            return parent::convertToDatabaseValue($value);
+        }
+
+        return $this->platform->doConvertBooleans(
+            $value,
+            /**
+             * @param mixed $value
+             */
+            static function ($value): ?int {
+                return $value === null ? null : (int) $value;
+            }
+        );
+    }
+}

--- a/src/Platforms/SQLServer/Types/BooleanType.php
+++ b/src/Platforms/SQLServer/Types/BooleanType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\SQLServer\Types;
+
+use Doctrine\DBAL\Platforms\Types\BooleanType as PlatformBooleanType;
+
+class BooleanType extends PlatformBooleanType
+{
+    public function getSQLDeclaration(array $column)
+    {
+        return 'BIT';
+    }
+}

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -12,6 +12,8 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Types as DBALTypes;
+use Doctrine\DBAL\Platforms\SQLServer\Types as PlatformTypes;
 use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
@@ -44,6 +46,10 @@ use const PREG_OFFSET_CAPTURE;
  */
 class SQLServerPlatform extends AbstractPlatform
 {
+    protected $types = [
+        DBALTypes\BooleanType::class => PlatformTypes\BooleanType::class
+    ];
+
     /**
      * {@inheritdoc}
      */
@@ -1262,14 +1268,6 @@ class SQLServerPlatform extends AbstractPlatform
     public function getTimeTypeDeclarationSQL(array $column)
     {
         return 'TIME(0)';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getBooleanTypeDeclarationSQL(array $column)
-    {
-        return 'BIT';
     }
 
     /**

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -222,14 +222,6 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getBooleanTypeDeclarationSQL(array $column)
-    {
-        return 'BOOLEAN';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getIntegerTypeDeclarationSQL(array $column)
     {
         return 'INTEGER' . $this->_getCommonIntegerTypeDeclarationSQL($column);

--- a/src/Platforms/Types/BooleanType.php
+++ b/src/Platforms/Types/BooleanType.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+class BooleanType implements Type
+{
+    /**
+     * @var AbstractPlatform
+     */
+    protected $platform;
+
+    public function __construct(AbstractPlatform $platform)
+    {
+        $this->platform = $platform;
+    }
+
+    public function getSQLDeclaration(array $column)
+    {
+        return 'BOOLEAN';
+    }
+
+    public function convertToDatabaseValue($value)
+    {
+        return $this->platform->convertBooleans($value);
+    }
+
+    public function convertToPHPValue($value)
+    {
+        return $value === null ? null : (bool) $value;
+    }
+
+    public function requiresSQLCommentHint()
+    {
+        return false;
+    }
+}

--- a/src/Platforms/Types/Type.php
+++ b/src/Platforms/Types/Type.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\Types;
+
+interface Type
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $column);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value);
+    /**
+     * @return bool
+     */
+    public function requiresSQLCommentHint();
+}

--- a/src/Platforms/Types/UnsupportedTypeException.php
+++ b/src/Platforms/Types/UnsupportedTypeException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\Types;
+
+class UnsupportedTypeException extends \RuntimeException
+{
+
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | 

#### Summary

Following up the discussion in https://github.com/doctrine/dbal/pull/2362 and https://github.com/doctrine/dbal/pull/2450#issuecomment-234503360 i would like to propose a solution for for following problems:

- Complexity of `AbstractPlatform` is very high as it contains a lot of methods
- Flexibility for platform specific type conversions is only given if there is a method in `AbstractPlatform` to support it, which sometimes requires changes to `AbstractPlatform` in order to create a new driver

My PR moves type conversions from `AbstractPlatform` to separate classes, making them more reusable and allowing overrides for specific platform implementations.

This PR demonstrates the idea using the `BooleanType`. If the concept is good then i would update the PR to apply the same strategy to all other types.