### PR TITLE
Create sequences before tables

### DIFF
--- a/src/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/src/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -91,8 +91,8 @@ class CreateSchemaSqlCollector extends AbstractVisitor
     {
         return array_merge(
             $this->createNamespaceQueries,
-            $this->createTableQueries,
             $this->createSequenceQueries,
+            $this->createTableQueries,
             $this->createFkConstraintQueries
         );
     }

--- a/tests/Functional/Schema/PostgreSQL/SchemaTest.php
+++ b/tests/Functional/Schema/PostgreSQL/SchemaTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Schema\PostgreSQL;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Sequence;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\IntegerType;
+
+final class SchemaTest extends FunctionalTestCase
+{
+    public function testCreateTableWithSequenceInColumnDefinition(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $platform instanceof PostgreSQLPlatform) {
+            self::markTestSkipped('Test is for PostgreSQL.');
+        }
+
+        $this->dropTableIfExists('my_table');
+
+        $options  = ['default' => 'nextval(\'my_table_id_seq\'::regclass)'];
+        $table    = new Table('my_table', [new Column('id', new IntegerType(), $options)]);
+        $sequence = new Sequence('my_table_id_seq');
+
+        $schema = new Schema([$table], [$sequence]);
+        foreach ($schema->toSql($platform) as $sql) {
+            $this->connection->executeStatement($sql);
+        }
+
+        $result = $this->connection->fetchAssociative(
+            'SELECT column_default FROM information_schema.columns WHERE table_name = ?',
+            ['my_table']
+        );
+
+        $this->assertNotFalse($result);
+        $this->assertEquals('nextval(\'my_table_id_seq\'::regclass)', $result['column_default']);
+    }
+}

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1257,6 +1257,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             self::markTestSkipped('Database does not support column comments.');
         }
 
+        $this->dropTableIfExists('my_table');
+
         $table = new Table('my_table');
         $table->addColumn('id', 'integer', ['comment' => "It's a comment with a quote"]);
         $table->setPrimaryKey(['id']);
@@ -1272,6 +1274,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         if (! $this->connection->getDatabasePlatform()->supportsInlineColumnComments()) {
             self::markTestSkipped('Database does not support column comments.');
         }
+
+        $this->dropTableIfExists('my_table');
 
         $options = [
             'type' => Type::getType('integer'),

--- a/tests/Schema/Visitor/SchemaSqlCollectorTest.php
+++ b/tests/Schema/Visitor/SchemaSqlCollectorTest.php
@@ -27,7 +27,7 @@ class SchemaSqlCollectorTest extends TestCase
 
         $sql = $schema->toSql($platformMock);
 
-        self::assertEquals(['foo', 'foo', 'bar', 'baz'], $sql);
+        self::assertEquals(['bar', 'foo', 'foo', 'baz'], $sql);
     }
 
     public function testDropSchema(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

When generating the schema, sequences must be created before tables if the sequence is referenced in a column definition.

```php
/**
 * @ORM\Column(name="id", options={"default":"nextval('my_table_id_seq'::regclass)"})
 */
```

Without this you will get the following error:
```
 SQLSTATE[42P01]: Undefined table: 7 ERROR:  relation "my_table_id_seq" does not exist
```

