### PR TITLE
Improve foreign key introspection on SQLite

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `AbstractPlatform::supportsForeignKeyConstraints()`.
+
+The `AbstractPlatform::supportsForeignKeyConstraints()` method has been deprecated. All platforms should support
+foreign key constraints.
+
 ## Deprecated `AbstractPlatform` methods exposing quote characters.
 
 The `AbstractPlatform::getStringLiteralQuoteCharacter()` and `::getIdentifierQuoteCharacter()` methods

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -278,6 +278,10 @@
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform::getIdentifierQuoteCharacter"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getIdentifierQuoteCharacter"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getStringLiteralQuoteCharacter"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::supportsForeignKeyConstraints"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3708,10 +3708,18 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports foreign key constraints.
      *
+     * @deprecated All platforms should support foreign key constraints.
+     *
      * @return bool
      */
     public function supportsForeignKeyConstraints()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pulls/5409',
+            'AbstractPlatform::supportsForeignKeyConstraints() is deprecated.'
+        );
+
         return true;
     }
 

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -844,14 +844,6 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsForeignKeyConstraints()
-    {
-        return false;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getCreatePrimaryKeySQL(Index $index, $table)
     {
         throw new Exception('Sqlite platform does not support alter primary key.');

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -410,7 +410,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
         $sql = 'SELECT NAME, REMARKS';
 

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -469,7 +469,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
         $sql = <<<'SQL'
     SELECT t.TABLE_NAME,

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -464,7 +464,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
         $sql = 'SELECT TABLE_NAME, COMMENTS';
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -728,7 +728,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
         if ($tableName === null) {
             $tables = $this->listTableNames();

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -512,7 +512,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
         $sql = <<<'SQL'
           SELECT

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -713,7 +713,7 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function getTableOptions(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
         if ($tableName === null) {
             $tables = $this->listTableNames();

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -498,10 +498,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testCreateTableWithForeignKeys(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Platform does not support foreign keys.');
-        }
-
         $tableB = $this->getTestTable('test_foreign');
 
         $this->dropAndCreateTable($tableB);
@@ -679,10 +675,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         // dont check for index size here, some platforms automatically add indexes for foreign keys.
         self::assertFalse($table->hasIndex('bar_idx'));
 
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            return;
-        }
-
         $fks = $table->getForeignKeys();
         self::assertCount(1, $fks);
         $foreignKey = current($fks);
@@ -783,12 +775,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     public function testUpdateSchemaWithForeignKeyRenaming(callable $comparatorFactory): void
     {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if (! $platform->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
-        }
-
         $table = new Table('test_fk_base');
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
@@ -835,12 +821,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     public function testRenameIndexUsedInForeignKeyConstraint(callable $comparatorFactory): void
     {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if (! $platform->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
-        }
-
         $primaryTable = new Table('test_rename_index_primary');
         $primaryTable->addColumn('id', 'integer');
         $primaryTable->setPrimaryKey(['id']);
@@ -1583,10 +1563,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testCreatedCompositeForeignKeyOrderIsCorrectAfterCreation(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Platform does not support foreign keys.');
-        }
-
         $foreignKey     = 'fk_test_order';
         $localTable     = 'test_table_foreign';
         $foreignTable   = 'test_table_local';

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -273,18 +273,6 @@ abstract class AbstractPlatformTestCase extends TestCase
         self::assertEquals($this->getGenerateConstraintForeignKeySql($fk), $sql);
     }
 
-    public function testGeneratesForeignKeySqlOnlyWhenSupportingForeignKeys(): void
-    {
-        $fk = new ForeignKeyConstraint(['fk_name'], 'foreign', ['id'], 'constraint_fk');
-
-        if ($this->platform->supportsForeignKeyConstraints()) {
-            self::assertIsString($this->platform->getCreateForeignKeySQL($fk, 'test'));
-        } else {
-            $this->expectException(Exception::class);
-            $this->platform->getCreateForeignKeySQL($fk, 'test');
-        }
-    }
-
     protected function getBitAndComparisonExpressionSql(string $value1, string $value2): string
     {
         return '(' . $value1 . ' & ' . $value2 . ')';
@@ -1084,12 +1072,6 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     public function testQuotesDropForeignKeySQL(): void
     {
-        if (! $this->platform->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped(
-                sprintf('%s does not support foreign key constraints.', get_class($this->platform))
-            );
-        }
-
         $tableName      = 'table';
         $table          = new Table($tableName);
         $foreignKeyName = 'select';

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -774,6 +774,11 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function testQuotesDropForeignKeySQL(): void
+    {
+        $this->markTestSkipped('SQLite does not support altering foreign key constraints.');
+    }
+
     public function testDateAddStaticNumberOfDays(): void
     {
         self::assertSame(


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement, deprecation

With this patch, DBAL can support all foreign key operations except for altering foreign keys on an existing table. IMO, it's still sufficient to declare that the platform supports foreign keys.

This might be considered a minor breaking change (see [xkcd #1172](https://xkcd.com/1172/)) in the cases where code that alters a foreign key based on whether the current platform supports foreign keys. I'd argue that it's a made up/synthetic scenario that primarily applies to testing the DBAL or other libraries that provide an abstraction on top of the DBAL (e.g. the ORM).

In real practical cases, the application would use a subset of the features supported by all target platforms. So it would either not attempt to alter foreign keys because SQLite doesn't support that or it wouldn't support SQLite. In such cases, this change is backward-compatible.

UPD: it still looks like it will cause the same failure in the Laravel test suite that https://github.com/doctrine/dbal/pull/3762 caused since the test suite relies on `AbstractPlatform::supportsForeignKeyConstraints()` (see https://github.com/laravel/framework/issues/34093#issuecomment-685719863).