### PR TITLE
Mark SQLite platform as not supporting foreign keys

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3708,18 +3708,10 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports foreign key constraints.
      *
-     * @deprecated All platforms should support foreign key constraints.
-     *
      * @return bool
      */
     public function supportsForeignKeyConstraints()
     {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pulls/5409',
-            'AbstractPlatform::supportsForeignKeyConstraints() is deprecated.'
-        );
-
         return true;
     }
 

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -844,6 +844,14 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function supportsForeignKeyConstraints()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getCreatePrimaryKeySQL(Index $index, $table)
     {
         throw new Exception('Sqlite platform does not support alter primary key.');

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -498,6 +498,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testCreateTableWithForeignKeys(): void
     {
+        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            self::markTestSkipped('Platform does not support foreign keys.');
+        }
+
         $tableB = $this->getTestTable('test_foreign');
 
         $this->dropAndCreateTable($tableB);
@@ -675,6 +679,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         // dont check for index size here, some platforms automatically add indexes for foreign keys.
         self::assertFalse($table->hasIndex('bar_idx'));
 
+        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            return;
+        }
+
         $fks = $table->getForeignKeys();
         self::assertCount(1, $fks);
         $foreignKey = current($fks);
@@ -775,6 +783,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     public function testUpdateSchemaWithForeignKeyRenaming(callable $comparatorFactory): void
     {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $platform->supportsForeignKeyConstraints()) {
+            self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
+        }
+
         $table = new Table('test_fk_base');
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
@@ -821,6 +835,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     public function testRenameIndexUsedInForeignKeyConstraint(callable $comparatorFactory): void
     {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $platform->supportsForeignKeyConstraints()) {
+            self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
+        }
+
         $primaryTable = new Table('test_rename_index_primary');
         $primaryTable->addColumn('id', 'integer');
         $primaryTable->setPrimaryKey(['id']);
@@ -1563,6 +1583,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testCreatedCompositeForeignKeyOrderIsCorrectAfterCreation(): void
     {
+        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            self::markTestSkipped('Platform does not support foreign keys.');
+        }
+
         $foreignKey     = 'fk_test_order';
         $localTable     = 'test_table_foreign';
         $foreignTable   = 'test_table_local';

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -1072,6 +1072,12 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     public function testQuotesDropForeignKeySQL(): void
     {
+        if (! $this->platform->supportsForeignKeyConstraints()) {
+            $this->markTestSkipped(
+                sprintf('%s does not support foreign key constraints.', get_class($this->platform))
+            );
+        }
+
         $tableName      = 'table';
         $table          = new Table($tableName);
         $foreignKeyName = 'select';


### PR DESCRIPTION
This is a partial revert of https://github.com/doctrine/dbal/pull/5409. See https://github.com/doctrine/dbal/pull/5409#issuecomment-1135237936 for details.

I'll add a regression test for the scenario identified in the ORM later.