### PR TITLE
Deprecate ignoring foreign keys DDL on non-InnoDB MySQL

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,11 @@ awareness about deprecated code.
 The `AbstractPlatform::supportsForeignKeyConstraints()` method has been deprecated. All platforms should support
 foreign key constraints.
 
+## Deprecated `AbstractPlatform::supportsForeignKeyConstraints()`.
+
+Relying on the DBAL not generating DDL for foreign keys on MySQL engines other than InnoDB is deprecated.
+Define foreign key constraints only if they are necessary.
+
 ## Deprecated `AbstractPlatform` methods exposing quote characters.
 
 The `AbstractPlatform::getStringLiteralQuoteCharacter()` and `::getIdentifierQuoteCharacter()` methods

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -451,9 +451,18 @@ SQL
         }
 
         // Propagate foreign key constraints only for InnoDB.
-        if (isset($options['foreignKeys']) && $engine === 'INNODB') {
-            foreach ($options['foreignKeys'] as $definition) {
-                $sql[] = $this->getCreateForeignKeySQL($definition, $name);
+        if (isset($options['foreignKeys'])) {
+            if ($engine === 'INNODB') {
+                foreach ($options['foreignKeys'] as $definition) {
+                    $sql[] = $this->getCreateForeignKeySQL($definition, $name);
+                }
+            } elseif (count($options['foreignKeys']) > 0) {
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pulls/5414',
+                    'Relying on the DBAL not generating DDL for foreign keys on MySQL engines'
+                        . ' other than InnoDB is deprecated. Define foreign key constraints only if they are necessary.'
+                );
             }
         }
 


### PR DESCRIPTION
I'm working on replacing `CreateSchemaSqlCollector` and `DropSchemaSqlCollector` with another set of SQL builders to enable seamless support for foreign keys on SQLite (see https://github.com/doctrine/dbal/pull/5409#issuecomment-1135237936).

There will be a new platform method that will generate SQL to create a set of tables that may reference each other via foreign keys at once.

The default implementation in the `AbstractPlatform` class will first create all tables without foreign keys and then create all foreign keys. This way, the foreign key dependencies will be satisfied at every step of the migration.

The implementation for the SQLite platform will just create the tables with the foreign keys because:
1. SQLite doesn't support adding foreign keys to an existing table.
2. SQLite doesn't require the table referenced by a foreign key to exist when the table is created. 

In order to support the feature being deprecated, I'll have to create another implementation of the above method for MySQL which would ignore foreign keys in the new method if the target engine will ignore them.

While it's not a big deal, I believe this functionality is pointless: if the application that owns the schema doesn't require the support for foreign keys across all target platforms and storage engines, it should enforce referential integrity itself, at which point it won't require it enforced by the database platform. If it does need them, it should use only the platforms and the engines that support them.