### PR TITLE
Run Psalm with language level PHP 8.1

### DIFF
--- a/psalm-strict.xml
+++ b/psalm-strict.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
+    phpVersion="8.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="2"
+    phpVersion="8.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"


### PR DESCRIPTION
The static analysis builds recently started failing after the Symfony Console 6.1 release ([example](https://github.com/doctrine/dbal/runs/6663934513?check_suite_focus=true)). It uses the PHP 8.1 syntax, it is compatible with the runtime PHP version which Composer uses to resolve the dependency constraints but Psalm assumes the PHP 7.3 syntax according to `composer.json`.

The ORM uses the same approach to configuring Psalm: https://github.com/doctrine/orm/pull/9314.