### PR TITLE
Fix mysql primary key TextType, BlobType length

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -388,8 +388,18 @@ SQL
 
         // attach all primary keys
         if (isset($options['primary']) && ! empty($options['primary'])) {
-            $keyColumns   = array_unique(array_values($options['primary']));
-            $queryFields .= ', PRIMARY KEY(' . implode(', ', $keyColumns) . ')';
+            if (!$options['primary_index']->hasOption('lengths')) {
+                $lengths=[];
+                foreach ($options['primary'] as $columnName) {
+                    if ($columns[$columnName]['type'] instanceof TextType) {
+                        $lengths[]=255;
+                    } else {
+                        $lengths[]=null;
+                    }
+                }
+                $options['primary_index']->setOption('lengths',$lengths);
+            }
+            $queryFields .= ', PRIMARY KEY(' .$this->getIndexFieldDeclarationListSQL($options['primary_index']). ')';
         }
 
         $query = 'CREATE ';

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -391,7 +391,7 @@ SQL
             if (!$options['primary_index']->hasOption('lengths')) {
                 $lengths=[];
                 foreach ($options['primary'] as $columnName) {
-                    if ($columns[$columnName]['type'] instanceof TextType) {
+                    if ($columns[$columnName]['type'] instanceof TextType || $columns[$columnName]['type'] instanceof BlobType) {
                         $lengths[]=255;
                     } else {
                         $lengths[]=null;

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -318,6 +318,17 @@ class Index extends AbstractAsset implements Constraint
 
     /**
      * @param string $name
+     * @param mixed $value
+     * @return Index
+     */
+    public function setOption($name,$value)
+    {
+        $this->options[strtolower($name)]=$value;
+        return $this;
+    }
+
+    /**
+     * @param string $name
      *
      * @return mixed
      */

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -116,18 +116,19 @@ class Table extends AbstractAsset
      *
      * @param string[]     $columnNames
      * @param string|false $indexName
+     * @param mixed[]      $options
      *
      * @return self
      *
      * @throws SchemaException
      */
-    public function setPrimaryKey(array $columnNames, $indexName = false)
+    public function setPrimaryKey(array $columnNames, $indexName = false, array $options = [])
     {
         if ($indexName === false) {
             $indexName = 'primary';
         }
 
-        $this->_addIndex($this->_createIndex($columnNames, $indexName, true, true));
+        $this->_addIndex($this->_createIndex($columnNames, $indexName, true, true, [], $options));
 
         foreach ($columnNames as $columnName) {
             $column = $this->getColumn($columnName);

--- a/tests/Functional/Schema/MySQL/SchemaTest.php
+++ b/tests/Functional/Schema/MySQL/SchemaTest.php
@@ -8,11 +8,12 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\TextType;
+use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\IntegerType;
 
 final class SchemaTest extends FunctionalTestCase
 {
-    public function testCreatePrimaryKeyWithTextType(): void
+    public function testCreatePrimaryKeyWithBigTypes(): void
     {
         $platform = $this->connection->getDatabasePlatform();
 
@@ -22,9 +23,9 @@ final class SchemaTest extends FunctionalTestCase
 
         $this->dropTableIfExists('my_table');
 
-        $table    = new Table('my_table', [new Column('id', new TextType()), new Column('id_2', new IntegerType())]);
+        $table    = new Table('my_table', [new Column('id_integer', new IntegerType()), new Column('id_text', new TextType()), new Column('id_blob', new BlobType())]);
 
-        $table->setPrimaryKey(['id','id_2']);
+        $table->setPrimaryKey(['id_integer','id_text','id_blob']);
 
         $schema = new Schema([$table]);
         foreach ($schema->toSql($platform) as $sql) {

--- a/tests/Functional/Schema/MySQL/SchemaTest.php
+++ b/tests/Functional/Schema/MySQL/SchemaTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Schema\MySQL;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\TextType;
+use Doctrine\DBAL\Types\IntegerType;
+
+final class SchemaTest extends FunctionalTestCase
+{
+    public function testCreatePrimaryKeyWithTextType(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $platform instanceof MySQLPlatform) {
+            self::markTestSkipped('Test is for MySQL.');
+        }
+
+        $this->dropTableIfExists('my_table');
+
+        $table    = new Table('my_table', [new Column('id', new TextType()), new Column('id_2', new IntegerType())]);
+
+        $table->setPrimaryKey(['id','id_2']);
+
+        $schema = new Schema([$table]);
+        foreach ($schema->toSql($platform) as $sql) {
+            $this->connection->executeStatement( $sql );
+        }
+
+        $result = $this->connection->fetchAssociative(
+            'SELECT column_default FROM information_schema.columns WHERE table_name = ?',
+            ['my_table']
+        );
+
+        $this->assertNotFalse($result);
+
+        $result = $this->connection->fetchAssociative(
+            'SELECT table_name FROM information_schema.key_column_usage WHERE table_name = ? AND CONSTRAINT_NAME = "PRIMARY"',
+            ['my_table']
+        );
+        $this->assertNotFalse($result);
+    }
+}

--- a/tests/Schema/IndexTest.php
+++ b/tests/Schema/IndexTest.php
@@ -172,5 +172,10 @@ class IndexTest extends TestCase
         self::assertSame('name IS NULL', $idx2->getOption('where'));
         self::assertSame('name IS NULL', $idx2->getOption('WHERE'));
         self::assertSame(['where' => 'name IS NULL'], $idx2->getOptions());
+
+        $idx3 = $this->createIndex(true, true);
+        $idx3->setOption('lengths',[255]);
+        self::assertTrue($idx3->hasOption('lengths'));
+        self::assertSame([255], $idx3->getOption('lengths'));
     }
 }

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -73,12 +73,12 @@ class MySQLSchemaTest extends TestCase
         $tableOld->addColumn('foo_id', 'text');
         $tableOld->addColumn('bar_id', 'integer');
 
-        $tableOld->setPrimaryKey(['foo_id', 'bar_id'],false,["lengths"=>[255,null]]);
+        $tableOld->setPrimaryKey(['foo_id', 'bar_id'],false,["lengths"=>[200,null]]);
 
         $sql = $schema->toSql($this->platform);
 
         self::assertEquals(
-            ['CREATE TABLE test (foo_id LONGTEXT NOT NULL, bar_id INT NOT NULL, PRIMARY KEY(foo_id(255), bar_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB'],
+            ['CREATE TABLE test (foo_id LONGTEXT NOT NULL, bar_id INT NOT NULL, PRIMARY KEY(foo_id(200), bar_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB'],
             $sql
         );
     }

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -52,15 +52,16 @@ class MySQLSchemaTest extends TestCase
         $schema= new Schema();
         $tableOld = $schema->createTable('test');
 
-        $tableOld->addColumn('foo_id', 'text');
-        $tableOld->addColumn('bar_id', 'integer');
+        $tableOld->addColumn('bar_integer', 'integer');
+        $tableOld->addColumn('foo_text', 'text');
+        $tableOld->addColumn('foo_blob', 'blob');
 
-        $tableOld->setPrimaryKey(['foo_id', 'bar_id']);
+        $tableOld->setPrimaryKey(['bar_integer', 'foo_text', 'foo_blob']);
 
         $sql = $schema->toSql($this->platform);
 
         self::assertEquals(
-            ['CREATE TABLE test (foo_id LONGTEXT NOT NULL, bar_id INT NOT NULL, PRIMARY KEY(foo_id(255), bar_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB'],
+            ['CREATE TABLE test (bar_integer INT NOT NULL, foo_text LONGTEXT NOT NULL, foo_blob LONGBLOB NOT NULL, PRIMARY KEY(bar_integer, foo_text(255), foo_blob(255))) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB'],
             $sql
         );
     }
@@ -70,15 +71,16 @@ class MySQLSchemaTest extends TestCase
         $schema= new Schema();
         $tableOld = $schema->createTable('test');
 
-        $tableOld->addColumn('foo_id', 'text');
-        $tableOld->addColumn('bar_id', 'integer');
+        $tableOld->addColumn('bar_integer', 'integer');
+        $tableOld->addColumn('foo_text', 'text');
+        $tableOld->addColumn('foo_blob', 'blob');
 
-        $tableOld->setPrimaryKey(['foo_id', 'bar_id'],false,["lengths"=>[200,null]]);
+        $tableOld->setPrimaryKey(['bar_integer', 'foo_text', 'foo_blob'],false,["lengths"=>[null,200,210]]);
 
         $sql = $schema->toSql($this->platform);
 
         self::assertEquals(
-            ['CREATE TABLE test (foo_id LONGTEXT NOT NULL, bar_id INT NOT NULL, PRIMARY KEY(foo_id(200), bar_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB'],
+            ['CREATE TABLE test (bar_integer INT NOT NULL, foo_text LONGTEXT NOT NULL, foo_blob LONGBLOB NOT NULL, PRIMARY KEY(bar_integer, foo_text(200), foo_blob(210))) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB'],
             $sql
         );
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         |  bug
| Fixed issues | #5421

will add feature request #4405

#### Summary

This fixes the mysql error `SQLSTATE[42000]: Syntax error or access violation: 1170 BLOB/TEXT column 'document_id' used in key specification without a key length` when the length is missing which is only required for index column of TextType.

Length for column with TextType, BlobType will be set to 255 if no length is set or the values of the new parameter $options["lengths"] are used to set this value.

**changes:**
* extend existing MySQLSchemaTest to cover the problem
* add Functional/Schema/MySQL Test
* add additional parameter $options to `setPrimaryKey` to allow manual setting key length
* add function `setOption` on Schema Class to change options and add test
* change `AbstractMySQLPlatform` to add missing length options 