### PR TITLE
Fix redundant orphaned foreign key

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -157,7 +157,13 @@ class Comparator
                 continue;
             }
 
-            $diff->orphanedForeignKeys = array_merge($diff->orphanedForeignKeys, $foreignKeysToTable[$tableName]);
+            foreach ($foreignKeysToTable[$tableName] as $foreignKey) {
+                if (isset($diff->removedTables[strtolower($foreignKey->getLocalTableName())])) {
+                    continue;
+                }
+
+                $diff->orphanedForeignKeys[] = $foreignKey;
+            }
 
             // deleting duplicated foreign keys present on both on the orphanedForeignKey
             // and the removedForeignKeys from changedTables

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -143,9 +143,7 @@ class SchemaDiff
         $sql = array_merge($sql, $platform->getCreateTablesSQL($this->newTables));
 
         if ($saveMode === false) {
-            foreach ($this->removedTables as $table) {
-                $sql[] = $platform->getDropTableSQL($table);
-            }
+            $sql = array_merge($sql, $platform->getDropTablesSQL($this->removedTables));
         }
 
         foreach ($this->changedTables as $tableDiff) {

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -1325,4 +1325,23 @@ class ComparatorTest extends TestCase
             'Schema diff is empty, since only `columnDefinition` changed from `null` (not detected) to a defined one'
         );
     }
+
+    public function testNoOrphanedForeignKeyIfReferencingTableIsDropped(): void
+    {
+        $schema1 = new Schema();
+
+        $parent = $schema1->createTable('parent');
+        $parent->addColumn('id', 'integer');
+
+        $child = $schema1->createTable('child');
+        $child->addColumn('id', 'integer');
+        $child->addColumn('parent_id', 'integer');
+        $child->addForeignKeyConstraint('parent', ['parent_id'], ['id']);
+
+        $schema2 = new Schema();
+
+        $diff = $this->comparator->compareSchemas($schema1, $schema2);
+
+        self::assertEmpty($diff->orphanedForeignKeys);
+    }
 }


### PR DESCRIPTION
There's no documentation that would explain the meaning of an orphaned foreign key but according to the code, it's a key whose referenced table and/or columns no longer exist. This key should be dropped before dropping the referenced table or columns in order for the database engine to allow dropping the table and/or column.

The name is a bit misleading since the parent (the referencing table) of the "orphan" still exists, so it rather should be named a "dangling" foreign key similar to dangling references and/or pointers.

The problem is reproduced on SQLite when both the referencing and the referenced tables are dropped as a result of schema comparison.

Prior to the fix, the diff produced by `testNoOrphanedForeignKeyIfReferencingTableIsDropped()` would generate the following DDL on MySQL:

```sql
ALTER TABLE child DROP FOREIGN KEY FK_22B35429727ACA70;
DROP TABLE parent;
DROP TABLE child;
```

This is not only acceptable but was necessary prior to https://github.com/doctrine/dbal/pull/5416 (the Platform API didn't support dropping multiple tables referencing each other via a foreign key, `DropSchemaSqlCollector` would drop the foreign keys explicitly prior to dropping the tables).

The problem with SQLite is that it doesn't support dropping foreign keys and doesn't require that. It just needs to drop the tables in any order:
```sql
DROP TABLE parent;
DROP TABLE child;
```

The fix is to consider the foreign key orphaned only if its parent (referencing) table will be preserved after the migration. If the referencing table is dropped, the foreign key will be dropped as part of the table, so it won't be orphaned.