### PR TITLE
Mark SQLite platform as supporting foreign keys

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3804,10 +3804,18 @@ abstract class AbstractPlatform
     /**
      * Whether the platform supports foreign key constraints.
      *
+     * @deprecated All platforms should support foreign key constraints.
+     *
      * @return bool
      */
     public function supportsForeignKeyConstraints()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5409',
+            'AbstractPlatform::supportsForeignKeyConstraints() is deprecated.'
+        );
+
         return true;
     }
 

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -844,14 +844,6 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function supportsForeignKeyConstraints()
-    {
-        return false;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getCreateTablesSQL(array $tables): array
     {
         $sql = [];

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -498,10 +498,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testCreateTableWithForeignKeys(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Platform does not support foreign keys.');
-        }
-
         $tableB = $this->getTestTable('test_foreign');
 
         $this->dropAndCreateTable($tableB);
@@ -679,10 +675,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         // dont check for index size here, some platforms automatically add indexes for foreign keys.
         self::assertFalse($table->hasIndex('bar_idx'));
 
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            return;
-        }
-
         $fks = $table->getForeignKeys();
         self::assertCount(1, $fks);
         $foreignKey = current($fks);
@@ -783,12 +775,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     public function testUpdateSchemaWithForeignKeyRenaming(callable $comparatorFactory): void
     {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if (! $platform->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
-        }
-
         $table = new Table('test_fk_base');
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
@@ -835,12 +821,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      */
     public function testRenameIndexUsedInForeignKeyConstraint(callable $comparatorFactory): void
     {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if (! $platform->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('This test is only supported on platforms that have foreign keys.');
-        }
-
         $primaryTable = new Table('test_rename_index_primary');
         $primaryTable->addColumn('id', 'integer');
         $primaryTable->setPrimaryKey(['id']);
@@ -1587,10 +1567,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testCreatedCompositeForeignKeyOrderIsCorrectAfterCreation(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Platform does not support foreign keys.');
-        }
-
         $foreignKey     = 'fk_test_order';
         $localTable     = 'test_table_foreign';
         $foreignTable   = 'test_table_local';

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -1075,12 +1075,6 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     public function testQuotesDropForeignKeySQL(): void
     {
-        if (! $this->platform->supportsForeignKeyConstraints()) {
-            $this->markTestSkipped(
-                sprintf('%s does not support foreign key constraints.', get_class($this->platform))
-            );
-        }
-
         $tableName      = 'table';
         $table          = new Table($tableName);
         $foreignKeyName = 'select';


### PR DESCRIPTION
This patch re-introduces the changes reverted in https://github.com/doctrine/dbal/pull/5411. These changes will no longer break the ORM tests thanks to the following prep work done:

1. https://github.com/doctrine/dbal/pull/5416
2. https://github.com/doctrine/dbal/pull/5425
3. https://github.com/doctrine/orm/pull/9799

The compatibility of the changes with the ORM test suite has been tested with ORM 2.13.x and 3.0.x on SQLite, MySQL, and PostgreSQL.