### PR TITLE
Fix NCHAR typo for MSSQL

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1200,8 +1200,8 @@ class SQLServerPlatform extends AbstractPlatform
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed)
     {
         return $fixed
-            ? ($length > 0 ? 'NCHAR(' . $length . ')' : 'CHAR(255)')
-            : ($length > 0 ? 'NVARCHAR(' . $length . ')' : 'NVARCHAR(255)');
+            ? 'NCHAR(' . ($length > 0 ? $length : 255) . ')'
+            : 'NVARCHAR(' . ($length > 0 ? $length : 255) . ')';
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

fix `CHAR(255)` that should be `NCHAR(255)`, also prevent simillar issue by deduplicating the name as in `getBinaryTypeDeclarationSQLSnippet` method below