### PR TITLE
Remove AbstractPlatform::supportsForeignKeyConstraints()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: removed `AbstractPlatform::supportsForeignKeyConstraints()`.
+
+The `AbstractPlatform::supportsForeignKeyConstraints()` method has been removed.
+
 ## BC BREAK: foreign key DDL is generated on MySQL regardless of the storage engine.
 
 The DBAL generates DDL for foreign keys regardless of the MySQL storage engines used by the table

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -51,10 +51,6 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getListTablesSQL"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::supportsForeignKeyConstraints"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -35,7 +35,6 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 use UnexpectedValueException;
 
@@ -1420,14 +1419,13 @@ abstract class AbstractPlatform
         $tableName = $diff->getName($this)->getQuotedName($this);
 
         $sql = [];
-        if ($this->supportsForeignKeyConstraints()) {
-            foreach ($diff->removedForeignKeys as $foreignKey) {
-                $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableName);
-            }
 
-            foreach ($diff->changedForeignKeys as $foreignKey) {
-                $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableName);
-            }
+        foreach ($diff->removedForeignKeys as $foreignKey) {
+            $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableName);
+        }
+
+        foreach ($diff->changedForeignKeys as $foreignKey) {
+            $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableName);
         }
 
         foreach ($diff->removedIndexes as $index) {
@@ -1455,14 +1453,12 @@ abstract class AbstractPlatform
             $tableName = $diff->getName($this)->getQuotedName($this);
         }
 
-        if ($this->supportsForeignKeyConstraints()) {
-            foreach ($diff->addedForeignKeys as $foreignKey) {
-                $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableName);
-            }
+        foreach ($diff->addedForeignKeys as $foreignKey) {
+            $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableName);
+        }
 
-            foreach ($diff->changedForeignKeys as $foreignKey) {
-                $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableName);
-            }
+        foreach ($diff->changedForeignKeys as $foreignKey) {
+            $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableName);
         }
 
         foreach ($diff->addedIndexes as $index) {
@@ -2246,22 +2242,6 @@ abstract class AbstractPlatform
     public function supportsReleaseSavepoints(): bool
     {
         return $this->supportsSavepoints();
-    }
-
-    /**
-     * Whether the platform supports foreign key constraints.
-     *
-     * @deprecated All platforms should support foreign key constraints.
-     */
-    public function supportsForeignKeyConstraints(): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5409',
-            'AbstractPlatform::supportsForeignKeyConstraints() is deprecated.'
-        );
-
-        return true;
     }
 
     /**

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -264,18 +264,12 @@ abstract class AbstractSchemaManager
 
         $tableOptionsByTable = $this->fetchTableOptionsByTable($database, $normalizedName);
 
-        if ($this->_platform->supportsForeignKeyConstraints()) {
-            $foreignKeys = $this->listTableForeignKeys($name);
-        } else {
-            $foreignKeys = [];
-        }
-
         return new Table(
             $name,
             $this->listTableColumns($name),
             $this->listTableIndexes($name),
             [],
-            $foreignKeys,
+            $this->listTableForeignKeys($name),
             $tableOptionsByTable[$normalizedName] ?? []
         );
     }
@@ -347,10 +341,6 @@ abstract class AbstractSchemaManager
      */
     protected function fetchForeignKeyColumnsByTable(string $databaseName): array
     {
-        if (! $this->_platform->supportsForeignKeyConstraints()) {
-            return [];
-        }
-
         return $this->fetchAllAssociativeGrouped(
             $this->selectForeignKeyColumns($databaseName)
         );

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -126,7 +126,7 @@ class SchemaDiff
             }
         }
 
-        if ($platform->supportsForeignKeyConstraints() && $saveMode === false) {
+        if ($saveMode === false) {
             foreach ($this->orphanedForeignKeys as $localTableName => $tableOrphanedForeignKey) {
                 foreach ($tableOrphanedForeignKey as $orphanedForeignKey) {
                     $sql[] = $platform->getDropForeignKeySQL(

--- a/tests/Functional/ForeignKeyExceptionTest.php
+++ b/tests/Functional/ForeignKeyExceptionTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
@@ -51,14 +50,6 @@ class ForeignKeyExceptionTest extends FunctionalTestCase
 
     public function testForeignKeyConstraintViolationExceptionOnInsert(): void
     {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if ($platform instanceof SqlitePlatform) {
-            $this->connection->executeStatement('PRAGMA foreign_keys = ON');
-        } elseif (! $platform->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Only fails on platforms with foreign key constraints.');
-        }
-
         $this->connection->insert('constraint_error_table', ['id' => 1]);
         $this->connection->insert('owning_table', ['id' => 1, 'constraint_id' => 1]);
 
@@ -69,14 +60,6 @@ class ForeignKeyExceptionTest extends FunctionalTestCase
 
     public function testForeignKeyConstraintViolationExceptionOnUpdate(): void
     {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if ($platform instanceof SqlitePlatform) {
-            $this->connection->executeStatement('PRAGMA foreign_keys = ON');
-        } elseif (! $platform->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Only fails on platforms with foreign key constraints.');
-        }
-
         $this->connection->insert('constraint_error_table', ['id' => 1]);
         $this->connection->insert('owning_table', ['id' => 1, 'constraint_id' => 1]);
 
@@ -87,14 +70,6 @@ class ForeignKeyExceptionTest extends FunctionalTestCase
 
     public function testForeignKeyConstraintViolationExceptionOnDelete(): void
     {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if ($platform instanceof SqlitePlatform) {
-            $this->connection->executeStatement('PRAGMA foreign_keys = ON');
-        } elseif (! $platform->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Only fails on platforms with foreign key constraints.');
-        }
-
         $this->connection->insert('constraint_error_table', ['id' => 1]);
         $this->connection->insert('owning_table', ['id' => 1, 'constraint_id' => 1]);
 
@@ -106,12 +81,6 @@ class ForeignKeyExceptionTest extends FunctionalTestCase
     public function testForeignKeyConstraintViolationExceptionOnTruncate(): void
     {
         $platform = $this->connection->getDatabasePlatform();
-
-        if ($platform instanceof SqlitePlatform) {
-            $this->connection->executeStatement('PRAGMA foreign_keys = ON');
-        } elseif (! $platform->supportsForeignKeyConstraints()) {
-            self::markTestSkipped('Only fails on platforms with foreign key constraints.');
-        }
 
         $this->connection->insert('constraint_error_table', ['id' => 1]);
         $this->connection->insert('owning_table', ['id' => 1, 'constraint_id' => 1]);


### PR DESCRIPTION
The method was deprecated in https://github.com/doctrine/dbal/pull/5427.