### PR TITLE
Deprecate checking keywords in schema object names

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated the functionality of checking schema for the usage of reserved keywords.
+
+The `dbal:reserved-words` console command and the `ReservedWordsCommand` and `ReservedKeywordsValidator` classes
+have been deprecated. Use the documentation on the used database platform(s) instead.
+
 ## Deprecated `CreateSchemaSqlCollector` and `DropSchemaSqlCollector`.
 
 The `CreateSchemaSqlCollector` and `DropSchemaSqlCollector` classes have been deprecated in favor of

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -81,6 +81,11 @@
                 -->
                 <referencedClass name="Doctrine\DBAL\Schema\Visitor\CreateSchemaSqlCollector"/>
                 <referencedClass name="Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\ReservedKeywordsValidator"/>
+                <referencedClass name="Doctrine\DBAL\Tools\Console\Command\ReservedWordsCommand"/>
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedInterface>

--- a/src/Platforms/Keywords/ReservedKeywordsValidator.php
+++ b/src/Platforms/Keywords/ReservedKeywordsValidator.php
@@ -9,11 +9,15 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
+use Doctrine\Deprecations\Deprecation;
 
 use function count;
 use function implode;
 use function str_replace;
 
+/**
+ * @deprecated Use database documentation instead.
+ */
 class ReservedKeywordsValidator implements Visitor
 {
     /** @var KeywordList[] */
@@ -27,6 +31,12 @@ class ReservedKeywordsValidator implements Visitor
      */
     public function __construct(array $keywordLists)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5431',
+            'ReservedKeywordsValidator is deprecated. Use database documentation instead.'
+        );
+
         $this->keywordLists = $keywordLists;
     }
 

--- a/src/Tools/Console/Command/ReservedWordsCommand.php
+++ b/src/Tools/Console/Command/ReservedWordsCommand.php
@@ -31,6 +31,9 @@ use function implode;
 use function is_array;
 use function is_string;
 
+/**
+ * @deprecated Use database documentation instead.
+ */
 class ReservedWordsCommand extends Command
 {
     /** @var array<string,KeywordList> */
@@ -41,6 +44,12 @@ class ReservedWordsCommand extends Command
 
     public function __construct(ConnectionProvider $connectionProvider)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5431',
+            'ReservedWordsCommand is deprecated. Use database documentation instead.'
+        );
+
         parent::__construct();
         $this->connectionProvider = $connectionProvider;
 
@@ -139,6 +148,12 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $output->writeln(
+            '<comment>The <info>dbal:reserved-words</info> command is deprecated.</comment>'
+                . ' Use the documentation on the used database platform(s) instead.'
+        );
+        $output->writeln('');
+
         $conn = $this->getConnection($input);
 
         $keywordLists = $input->getOption('list');


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

Here's an example of running the command on the database produced by the ORM test suite:
```
$ bin/doctrine-dbal dbal:reserved-words -l mysql -l pgsql
[Warning] The use of this script is discouraged. You find instructions on how to
boostrap the console runner in our documentation.

Checking keyword violations for mysql, pgsql...
There are 4 reserved keyword violations in your database schema:
  - Table ddc2602biographyfieldchoice column label keyword violations: MySQL
  - Table ddc2602biographyfield column label keyword violations: MySQL
  - Table table keyword violations: MySQL, PostgreSQL
  - Table decimal_model column decimal keyword violations: MySQL
```

The logic behind the functionality of checking keywords in schema object names is flawed:

1. There is no rule that the usage of reserved keywords in schema object names violates. The DBAL can quote object names in some places. Furthermore, the very fact that the DBAL managed to deploy the schema with such object names and (probably) use it for queries, means that they are valid.
2. More importantly than handling reserved keywords, the DBAL is poor at handling the names that aren't reserved keywords but still don't comply with the SQL syntax and thus need to be quoted (e.g. the ones that start with a digit or contain a dot). But this command doesn't report them.
3. The output of this command is mostly false-positive. If, in theory, it outputs some useful line item, there will be no way a user can find it among all the noise.
4. The DBAL isn't the source of truth on the list of reserved keywords for a given platform, the DBAL's version of such lists is never complete. The DBAL doesn't define the SQL syntax either. So it cannot be relied upon as the source of truth about which identifiers need to be escaped and which don't.