### PR TITLE
Deprecate removal of namespaced assets from schema

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated removal of namespaced assets from schema.
+
+The `RemoveNamespacedAssets` schema visitor and the usage of namespaced database object names with the platforms
+that don't support them have been deprecated.
+
 ## Deprecated the functionality of checking schema for the usage of reserved keywords.
 
 The `dbal:reserved-words` console command and the `ReservedWordsCommand` and `ReservedKeywordsValidator` classes

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -86,6 +86,10 @@
                 -->
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\ReservedKeywordsValidator"/>
                 <referencedClass name="Doctrine\DBAL\Tools\Console\Command\ReservedWordsCommand"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedClass name="Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets"/>
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedInterface>

--- a/src/Schema/Visitor/RemoveNamespacedAssets.php
+++ b/src/Schema/Visitor/RemoveNamespacedAssets.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Removes assets from a schema that are not in the default namespace.
@@ -16,12 +17,24 @@ use Doctrine\DBAL\Schema\Table;
  * non default namespaces.
  *
  * This visitor filters all these non-default namespaced tables and sequences
- * and removes them from the SChema instance.
+ * and removes them from the Schema instance.
+ *
+ * @deprecated Do not use namespaces if the target database platform doesn't support them.
  */
 class RemoveNamespacedAssets extends AbstractVisitor
 {
     /** @var Schema|null */
     private $schema;
+
+    public function __construct()
+    {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5432',
+            'RemoveNamespacedAssets is deprecated. Do not use namespaces'
+                . " if the target database platform doesn't support them."
+        );
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

Silently dropping database objects from the schema looks like a disservice. If the application declares certain schema objects, it means that it expects them to exist in the resulting schema, so it won't work properly if these objects don't exist.

It will be easier to spot such issues if the visitor drops a table (all the queries against it will fail) but the problems may be way harder to diagnose if a foreign key is dropped. This way, the application will rely on the referential integrity being preserved by the database but in fact it the database won't have the expected constraints in place.

According to the `GH6823Test` in the ORM, there is a flaw in this logic: https://github.com/doctrine/dbal/blob/4be7e2f0c98a551ea4af9700a2ba7e96f56df406/src/Schema/Visitor/RemoveNamespacedAssets.php#L75-L79

The entities being deployed in the test don't declare a namespaced object name but the visitor drops a valid foreign key because the referenced entity (`GH6823Tag`) isn't being deployed as part of the schema.

The following statement is missing as a result of processing schema by the visitor:
```sql
ALTER TABLE gh6823_user_tags ADD FOREIGN KEY (tag_id) REFERENCES gh6823_tag (id)
```