### PR TITLE
Deprecate KeywordList::getName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,8 +10,13 @@ awareness about deprecated code.
 
 ## Deprecated the functionality of checking schema for the usage of reserved keywords.
 
-The `dbal:reserved-words` console command and the `ReservedWordsCommand` and `ReservedKeywordsValidator` classes
-have been deprecated. Use the documentation on the used database platform(s) instead.
+The following components have been deprecated:
+
+1. The `dbal:reserved-words` console command.
+2. The `ReservedWordsCommand` and `ReservedKeywordsValidator` classes.
+3. The `KeywordList::getName()` method.
+
+Use the documentation on the used database platform(s) instead.
 
 ## Deprecated `CreateSchemaSqlCollector` and `DropSchemaSqlCollector`.
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -293,6 +293,10 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::supportsForeignKeyConstraints"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\Keywords\KeywordList::getName"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Platforms/Keywords/DB2Keywords.php
+++ b/src/Platforms/Keywords/DB2Keywords.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * DB2 Keywords.
  */
@@ -9,9 +11,17 @@ class DB2Keywords extends KeywordList
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'DB2Keywords::getName() is deprecated.'
+        );
+
         return 'DB2';
     }
 

--- a/src/Platforms/Keywords/KeywordList.php
+++ b/src/Platforms/Keywords/KeywordList.php
@@ -50,6 +50,8 @@ abstract class KeywordList
     /**
      * Returns the name of this keyword list.
      *
+     * @deprecated
+     *
      * @return string
      */
     abstract public function getName();

--- a/src/Platforms/Keywords/MariaDBKeywords.php
+++ b/src/Platforms/Keywords/MariaDBKeywords.php
@@ -2,10 +2,21 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 class MariaDBKeywords extends MySQLKeywords
 {
+    /**
+     * @deprecated
+     */
     public function getName(): string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'MariaDBKeywords::getName() is deprecated.'
+        );
+
         return 'MariaDB';
     }
 

--- a/src/Platforms/Keywords/MariaDb102Keywords.php
+++ b/src/Platforms/Keywords/MariaDb102Keywords.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * MariaDb reserved keywords list.
  *
@@ -11,8 +13,17 @@ namespace Doctrine\DBAL\Platforms\Keywords;
  */
 final class MariaDb102Keywords extends MariaDBKeywords
 {
+    /**
+     * @deprecated
+     */
     public function getName(): string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'MariaDb102Keywords::getName() is deprecated.'
+        );
+
         return 'MariaDb102';
     }
 }

--- a/src/Platforms/Keywords/MySQL57Keywords.php
+++ b/src/Platforms/Keywords/MySQL57Keywords.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * MySQL 5.7 reserved keywords list.
  *
@@ -11,9 +13,17 @@ class MySQL57Keywords extends MySQLKeywords
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'MySQL57Keywords::getName() is deprecated.'
+        );
+
         return 'MySQL57';
     }
 

--- a/src/Platforms/Keywords/MySQL80Keywords.php
+++ b/src/Platforms/Keywords/MySQL80Keywords.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 use function array_merge;
 
 /**
@@ -11,9 +13,17 @@ class MySQL80Keywords extends MySQL57Keywords
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'MySQL80Keywords::getName() is deprecated.'
+        );
+
         return 'MySQL80';
     }
 

--- a/src/Platforms/Keywords/MySQLKeywords.php
+++ b/src/Platforms/Keywords/MySQLKeywords.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * MySQL Keywordlist.
  */
@@ -9,9 +11,17 @@ class MySQLKeywords extends KeywordList
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'MySQLKeywords::getName() is deprecated.'
+        );
+
         return 'MySQL';
     }
 

--- a/src/Platforms/Keywords/OracleKeywords.php
+++ b/src/Platforms/Keywords/OracleKeywords.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * Oracle Keywordlist.
  */
@@ -9,9 +11,17 @@ class OracleKeywords extends KeywordList
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'OracleKeywords::getName() is deprecated.'
+        );
+
         return 'Oracle';
     }
 

--- a/src/Platforms/Keywords/PostgreSQL100Keywords.php
+++ b/src/Platforms/Keywords/PostgreSQL100Keywords.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * PostgreSQL 10.0 reserved keywords list.
  *
@@ -11,8 +13,17 @@ namespace Doctrine\DBAL\Platforms\Keywords;
  */
 class PostgreSQL100Keywords extends PostgreSQL94Keywords
 {
+    /**
+     * @deprecated
+     */
     public function getName(): string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'PostgreSQL100Keywords::getName() is deprecated.'
+        );
+
         return 'PostgreSQL100';
     }
 }

--- a/src/Platforms/Keywords/PostgreSQLKeywords.php
+++ b/src/Platforms/Keywords/PostgreSQLKeywords.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * Reserved keywords list corresponding to the PostgreSQL database platform of the oldest supported version.
  */
@@ -9,9 +11,17 @@ class PostgreSQLKeywords extends KeywordList
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'PostgreSQLKeywords::getName() is deprecated.'
+        );
+
         return 'PostgreSQL';
     }
 

--- a/src/Platforms/Keywords/SQLServerKeywords.php
+++ b/src/Platforms/Keywords/SQLServerKeywords.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * Microsoft SQL Server 2012 reserved keyword dictionary.
  * Reserved keywords list corresponding to the Microsoft SQL Server database platform of the oldest supported version.
@@ -10,9 +12,17 @@ class SQLServerKeywords extends KeywordList
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'SQLServerKeywords::getName() is deprecated.'
+        );
+
         return 'SQLServer';
     }
 

--- a/src/Platforms/Keywords/SQLiteKeywords.php
+++ b/src/Platforms/Keywords/SQLiteKeywords.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 /**
  * SQLite Keywordlist.
  */
@@ -9,9 +11,17 @@ class SQLiteKeywords extends KeywordList
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getName()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'SQLiteKeywords::getName() is deprecated.'
+        );
+
         return 'SQLite';
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

Reserved keyword list names are used only by the reserved keywords validator which is deprecated as of https://github.com/doctrine/dbal/pull/5431.