### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -22,7 +22,12 @@ on:
       - src/**
       - tests/**
 
+permissions:
+  contents: read
+
 jobs:
   coding-standards:
+    permissions:
+      contents: none
     name: "Coding Standards"
     uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.1.1"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,9 @@ on:
 env:
   fail-fast: true
 
+permissions:
+  contents: read
+
 jobs:
   phpunit-smoke-check:
     name: "PHPUnit with SQLite"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,8 +3,14 @@ on:
   schedule:
     - cron: '0 3 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v4

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -26,6 +26,9 @@ on:
       - static-analysis/**
       - tests/**
 
+permissions:
+  contents: read
+
 jobs:
   static-analysis-phpstan:
     name: "Static Analysis with PHPStan"


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
