### PR TITLE
Deprecate Visitor API

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,22 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `Visitor` interfaces and `visit()` methods on schema objects.
+
+The following interfaces and classes have been deprecated:
+
+1. `Visitor`,
+2. `NamespaceVisitor`,
+3. `AbstractVisitor`.
+
+The following methods have been deprecated:
+
+1. `Schema::visit()`,
+2. `Table::visit()`,
+3. `Sequence::visit()`.
+
+Instead of having schema objects call the visitor API, call the API of the schema objects.
+
 ## Deprecated removal of namespaced assets from schema.
 
 The `RemoveNamespacedAssets` schema visitor and the usage of namespaced database object names with the platforms

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -90,6 +90,11 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedClass name="Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedClass name="Doctrine\DBAL\Schema\Visitor\AbstractVisitor"/>
+                <referencedClass name="Doctrine\DBAL\Schema\Visitor\Visitor"/>
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedInterface>
@@ -108,6 +113,11 @@
                     See https://github.com/doctrine/dbal/pull/4967
                 -->
                 <referencedClass name="Doctrine\DBAL\Logging\SQLLogger"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedClass name="Doctrine\DBAL\Schema\Visitor\Visitor"/>
+                <referencedClass name="Doctrine\DBAL\Schema\Visitor\NamespaceVisitor"/>
             </errorLevel>
         </DeprecatedInterface>
         <DeprecatedMethod>
@@ -301,6 +311,12 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\Keywords\KeywordList::getName"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\Schema::visit"/>
+                <referencedMethod name="Doctrine\DBAL\Schema\Sequence::visit"/>
+                <referencedMethod name="Doctrine\DBAL\Schema\Table::visit"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -482,10 +482,18 @@ class Schema extends AbstractAsset
     }
 
     /**
+     * @deprecated
+     *
      * @return void
      */
     public function visit(Visitor $visitor)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5435',
+            'Schema::visit() is deprecated.'
+        );
+
         $visitor->acceptSchema($this);
 
         if ($visitor instanceof NamespaceVisitor) {

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Visitor\Visitor;
+use Doctrine\Deprecations\Deprecation;
 
 use function count;
 use function sprintf;
@@ -139,10 +140,18 @@ class Sequence extends AbstractAsset
     }
 
     /**
+     * @deprecated
+     *
      * @return void
      */
     public function visit(Visitor $visitor)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5435',
+            'Sequence::visit() is deprecated.'
+        );
+
         $visitor->acceptSequence($this);
     }
 }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
 use function array_keys;
@@ -904,12 +905,20 @@ class Table extends AbstractAsset
     }
 
     /**
+     * @deprecated
+     *
      * @return void
      *
      * @throws SchemaException
      */
     public function visit(Visitor $visitor)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5435',
+            'Table::visit() is deprecated.'
+        );
+
         $visitor->acceptTable($this);
 
         foreach ($this->getColumns() as $column) {

--- a/src/Schema/Visitor/AbstractVisitor.php
+++ b/src/Schema/Visitor/AbstractVisitor.php
@@ -11,6 +11,8 @@ use Doctrine\DBAL\Schema\Table;
 
 /**
  * Abstract Visitor with empty methods for easy extension.
+ *
+ * @deprecated
  */
 class AbstractVisitor implements Visitor, NamespaceVisitor
 {

--- a/src/Schema/Visitor/NamespaceVisitor.php
+++ b/src/Schema/Visitor/NamespaceVisitor.php
@@ -4,6 +4,8 @@ namespace Doctrine\DBAL\Schema\Visitor;
 
 /**
  * Visitor that can visit schema namespaces.
+ *
+ * @deprecated
  */
 interface NamespaceVisitor
 {

--- a/src/Schema/Visitor/Visitor.php
+++ b/src/Schema/Visitor/Visitor.php
@@ -12,6 +12,8 @@ use Doctrine\DBAL\Schema\Table;
 
 /**
  * Schema Visitor used for Validation or Generation purposes.
+ *
+ * @deprecated
  */
 interface Visitor
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

1. All existing visitors are deprecated.
2. The Visitor pattern is inappropriate in all cases except for maybe `ReservedKeywordsValidator`. See more details in https://github.com/doctrine/dbal/pull/5416.

Related:
1. https://github.com/doctrine/dbal/pull/4681
2. https://github.com/doctrine/dbal/pull/5083
3. https://github.com/doctrine/dbal/pull/5416
4. https://github.com/doctrine/dbal/pull/5431
5. https://github.com/doctrine/dbal/pull/5432