### PR TITLE
Deprecate ConsoleRunner

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `ConsolerRunner`.
+
+The `ConsoleRunner` class has been deprecated. Use Symfony Console documentation
+to bootstrap a command-line application.
+
 ## Deprecated `Visitor` interfaces and `visit()` methods on schema objects.
 
 The following interfaces and classes have been deprecated:

--- a/docs/en/reference/cli-tools.rst
+++ b/docs/en/reference/cli-tools.rst
@@ -1,37 +1,25 @@
 CLI Tools
 =========
 
-Doctrine DBAL bundles commands that can be integrated into a Symfony console application.
+Doctrine DBAL bundles the `dbal:run-sql` command that can be integrated into a Symfony console application.
 
-When you use DBAL inside a full-stack Symfony application, DoctrineBundle already integrates those into your
-application's console.
-
-There is also a standalone console runner available. To use it, make sure that Symfony console is installed::
-
-    composer require symfony/console
-
-With a small PHP script, you can bootstrap the console tools:
+The command may be added to the application as follows:
 
 .. code-block:: php
 
-    #!/usr/bin/env php
-    <?php
-
-    use Doctrine\DBAL\DriverManager;
+    use Doctrine\DBAL\Connection;
     use Doctrine\DBAL\Tools\Console\ConnectionProvider\SingleConnectionProvider;
-    use Doctrine\DBAL\Tools\Console\ConsoleRunner;
+    use Symfony\Component\Console\Application;
 
-    // The path to Composer's autoloader
-    // Adjust it according to your project's structure
-    require __DIR__ . '/vendor/autoload.php';
+    /** @var Connection $connection */
+    $connection = /* ... */;
 
-    $connection = DriverManager::getConnection([
-        // Configure your DBAL connection here.
-    ]);
+    /** @var Application $cli */
+    $cli = /* ... */;
 
-    ConsoleRunner::run(
-        new SingleConnectionProvider($connection)
-    );
+    $connectionProvider = new SingleConnectionProvider($connection);
+
+    $cli->add(new RunSqlCommand($connectionProvider));
 
 If your application uses more than one connection, write your own implementation of ``ConnectionProvider`` and use it
 instead of the ``SingleConnectionProvider`` class.

--- a/src/Tools/Console/ConsoleRunner.php
+++ b/src/Tools/Console/ConsoleRunner.php
@@ -13,6 +13,8 @@ use function assert;
 
 /**
  * Handles running the Console Tools inside Symfony Console context.
+ *
+ * @deprecated Use Symfony Console documentation to bootstrap a command-line application.
  */
 class ConsoleRunner
 {


### PR DESCRIPTION
The class serves two purposes:

1. Helping users bootstrap a CLI application. The class is not extensible by any means, so if a user needs to modify the CLI application, they will have to copy the code from the DBAL to their project. It's better if they start by implementing the application from scratch using the documentation.
2. Registering all DBAL-supplied commands in one call. The DBAL supplies a single non-deprecated command. Furthermore, the ORM [doesn't use](https://github.com/doctrine/orm/blob/2.13.x/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php#L98-L99) this class when registering DBAL commands, meaning that it's not that important.

See https://github.com/doctrine/dbal/pull/5337#pullrequestreview-995649396 for more details.