### PR TITLE
Remove SqliteSchemaManager::dropAndCreateForeignKey()

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_change_key_case;
 use function array_merge;
@@ -72,26 +71,6 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $tableDiff = $this->getTableDiffForAlterForeignKey($table);
 
         $tableDiff->addedForeignKeys[] = $foreignKey;
-
-        $this->alterTable($tableDiff);
-    }
-
-    /**
-     * @deprecated Use {@see dropForeignKey()} and {@see createForeignKey()} instead.
-     */
-    public function dropAndCreateForeignKey(ForeignKeyConstraint $foreignKey, string $table): void
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/4897',
-            'SqliteSchemaManager::dropAndCreateForeignKey() is deprecated.'
-                . ' Use SqliteSchemaManager::dropForeignKey() and SqliteSchemaManager::createForeignKey() instead.'
-        );
-
-        $table = $this->ensureTable($table);
-
-        $tableDiff                       = $this->getTableDiffForAlterForeignKey($table);
-        $tableDiff->changedForeignKeys[] = $foreignKey;
 
         $this->alterTable($tableDiff);
     }


### PR DESCRIPTION
The code looks like a leftover from https://github.com/doctrine/dbal/pull/4933.