### PR TITLE
Remove AbstractSchemaManager::getDatabasePlatform()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: removed `AbstractSchemaManager::getDatabasePlatform()`
+
+The `AbstractSchemaManager::getDatabasePlatform()` method has been removed.
+
 ## BC BREAK: removed Schema Visitor API.
 
 The following interfaces and classes have been removed:

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -13,7 +13,6 @@ use Doctrine\DBAL\Exception\DatabaseRequired;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Result;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
 use function array_intersect;
@@ -52,25 +51,6 @@ abstract class AbstractSchemaManager
     {
         $this->_conn     = $connection;
         $this->_platform = $platform;
-    }
-
-    /**
-     * Returns the associated platform.
-     *
-     * @deprecated Use {@link Connection::getDatabasePlatform()} instead.
-     *
-     * @return T
-     */
-    public function getDatabasePlatform(): AbstractPlatform
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5387',
-            'AbstractSchemaManager::getDatabasePlatform() is deprecated.'
-                . ' Use Connection::getDatabasePlatform() instead.'
-        );
-
-        return $this->_platform;
     }
 
     /**


### PR DESCRIPTION
The method was deprecated in https://github.com/doctrine/dbal/pull/5387.