### PR TITLE
Optimize introspection of table comments on PostgreSQL

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -141,5 +141,12 @@ parameters:
             paths:
                 - src/Platforms/AbstractPlatform.php
 
+        # There is no way to make this assertion in the code,
+        # and the API doesn't support parametrization of returned column types.
+        -
+            message: '~^Method Doctrine\\DBAL\\Schema\\PostgreSQLSchemaManager::fetchTableOptionsByTable\(\) should return array<string, array<string, mixed>> but returns array<int\|string, array<string, mixed>>\.$~'
+            paths:
+                - src/Schema/PostgreSQLSchemaManager.php
+
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -14,6 +14,7 @@ use function array_change_key_case;
 use function array_filter;
 use function array_keys;
 use function array_map;
+use function array_merge;
 use function array_shift;
 use function assert;
 use function explode;
@@ -636,25 +637,17 @@ SQL
             FROM pg_attribute a, pg_class c, pg_type t, pg_namespace n
 SQL;
 
-        $conditions = [
+        $conditions = array_merge([
             'a.attnum > 0',
             'a.attrelid = c.oid',
             'a.atttypid = t.oid',
             'n.oid = c.relnamespace',
             "c.relkind = 'r'",
-        ];
-        $params     = [];
-
-        if ($tableName !== null) {
-            $conditions[] = $this->getTableWhereClause($tableName, 'c', 'n');
-        } else {
-            $conditions[] = "n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')";
-            $conditions[] = 'n.nspname = ANY(current_schemas(false))';
-        }
+        ], $this->buildQueryConditions($tableName));
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY a.attnum';
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->_conn->executeQuery($sql);
     }
 
     protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
@@ -678,19 +671,14 @@ SQL;
                 FROM pg_index i, pg_class c, pg_namespace n
 SQL;
 
-        $conditions = ['c.oid = i.indrelid', 'c.relnamespace = n.oid'];
-        $params     = [];
-
-        if ($tableName !== null) {
-            $conditions[] = $this->getTableWhereClause($tableName);
-        } else {
-            $conditions[] = "n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')";
-            $conditions[] = 'n.nspname = ANY(current_schemas(false))';
-        }
+        $conditions = array_merge([
+            'c.oid = i.indrelid',
+            'c.relnamespace = n.oid',
+        ], $this->buildQueryConditions($tableName));
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ') AND pg_index.indexrelid = oid';
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->_conn->executeQuery($sql);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
@@ -710,19 +698,11 @@ SQL;
                       FROM pg_catalog.pg_class c, pg_catalog.pg_namespace n
 SQL;
 
-        $conditions = ['n.oid = c.relnamespace'];
-        $params     = [];
-
-        if ($tableName !== null) {
-            $conditions[] = $this->getTableWhereClause($tableName, 'c', 'n');
-        } else {
-            $conditions[] = "n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')";
-            $conditions[] = 'n.nspname = ANY(current_schemas(false))';
-        }
+        $conditions = array_merge(['n.oid = c.relnamespace'], $this->buildQueryConditions($tableName));
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ") AND r.contype = 'f'";
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->_conn->executeQuery($sql);
     }
 
     /**
@@ -752,21 +732,31 @@ SQL;
     }
 
     /**
-     * @param string $table
+     * @param string|null $tableName
+     *
+     * @return list<string>
      */
-    private function getTableWhereClause($table): string
+    private function buildQueryConditions($tableName): array
     {
-        $whereClause = "n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast') AND ";
-        if (strpos($table, '.') !== false) {
-            [$schema, $table] = explode('.', $table);
-            $schema           = $this->_platform->quoteStringLiteral($schema);
-        } else {
-            $schema = 'ANY(current_schemas(false))';
+        $conditions = [];
+        $schemaName = null;
+
+        if ($tableName !== null) {
+            if (strpos($tableName, '.') !== false) {
+                [$schemaName, $tableName] = explode('.', $tableName);
+            }
+
+            $identifier   = new Identifier($tableName);
+            $conditions[] = 'c.relname = ' . $this->_platform->quoteStringLiteral($identifier->getName());
         }
 
-        $table = new Identifier($table);
-        $table = $this->_platform->quoteStringLiteral($table->getName());
+        if ($schemaName !== null) {
+            $conditions[] = 'n.nspname = ' . $this->_platform->quoteStringLiteral($schemaName);
+        } else {
+            $conditions[] = 'n.nspname = ANY(current_schemas(false))';
+            $conditions[] = "n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')";
+        }
 
-        return $whereClause . sprintf('c.relname = %s AND n.nspname = %s', $table, $schema);
+        return $conditions;
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

The current implementation of `PostgreSQLSchemaManager::fetchTableOptionsByTable()` fetches the comment of each table individually although the API introduced in https://github.com/doctrine/dbal/pull/5268 enables fetching schema metadata in a fixed number of queries.

Additionally, some cleanup is done in the codebase.