### PR TITLE
Rework table introspection for DB2

### DIFF
--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -169,15 +169,11 @@ class DB2SchemaManager extends AbstractSchemaManager
     /**
      * {@inheritdoc}
      */
-    protected function _getPortableTablesList($tables)
+    protected function _getPortableTableDefinition($table)
     {
-        $tableNames = [];
-        foreach ($tables as $tableRow) {
-            $tableRow     = array_change_key_case($tableRow, CASE_LOWER);
-            $tableNames[] = $tableRow['name'];
-        }
+        $table = array_change_key_case($table, CASE_LOWER);
 
-        return $tableNames;
+        return $table['name'];
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

The current implementation of `DB2SchemaManager` overrides `_getPortableTablesList()` of its parent class but doesn't change any of its logic other than the logic implemented in `_getPortableTableDefinition()`.

We can override the proper method and thus make the default implementation of `AbstractSchemaManager::_getPortableTableDefinition()` obsolete. We can make it abstract in 4.0.