### PR TITLE
Rework introspection of table names

### DIFF
--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -383,6 +383,8 @@ class DB2Platform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTablesSQL()

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -498,6 +498,8 @@ class OraclePlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTablesSQL()

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -267,6 +267,8 @@ class PostgreSQLPlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTablesSQL()

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -895,6 +895,8 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTablesSQL()

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -512,6 +512,8 @@ class SqlitePlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon.
+     *
      * {@inheritDoc}
      */
     public function getListTablesSQL()

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -345,6 +345,23 @@ abstract class AbstractSchemaManager
     }
 
     /**
+     * @return list<string>
+     *
+     * @throws Exception
+     */
+    protected function doListTableNames(): array
+    {
+        $database = $this->getDatabase(__METHOD__);
+
+        return $this->filterAssetNames(
+            $this->_getPortableTablesList(
+                $this->selectTableNames($database)
+                    ->fetchAllAssociative()
+            )
+        );
+    }
+
+    /**
      * Filters asset names if they are configured to return only a subset of all
      * the found elements.
      *
@@ -469,6 +486,18 @@ abstract class AbstractSchemaManager
     protected function normalizeName(string $name): string
     {
         return $name;
+    }
+
+    /**
+     * Selects names of tables in the specified database.
+     *
+     * @throws Exception
+     *
+     * @abstract
+     */
+    protected function selectTableNames(string $databaseName): Result
+    {
+        throw Exception::notSupported(__METHOD__);
     }
 
     /**

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -29,6 +29,14 @@ class DB2SchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
+    public function listTableNames()
+    {
+        return $this->doListTableNames();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function listTables()
     {
         return $this->doListTables();
@@ -258,6 +266,18 @@ class DB2SchemaManager extends AbstractSchemaManager
         $identifier = new Identifier($name);
 
         return $identifier->isQuoted() ? $identifier->getName() : strtoupper($name);
+    }
+
+    protected function selectTableNames(string $databaseName): Result
+    {
+        $sql = <<<'SQL'
+SELECT NAME
+FROM SYSIBM.SYSTABLES
+WHERE TYPE = 'T'
+  AND CREATOR = ?
+SQL;
+
+        return $this->_conn->executeQuery($sql, [$databaseName]);
     }
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -52,6 +52,14 @@ class MySQLSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
+    public function listTableNames()
+    {
+        return $this->doListTableNames();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function listTables()
     {
         return $this->doListTables();
@@ -362,6 +370,19 @@ class MySQLSchemaManager extends AbstractSchemaManager
     public function createComparator(): Comparator
     {
         return new MySQL\Comparator($this->_platform);
+    }
+
+    protected function selectTableNames(string $databaseName): Result
+    {
+        $sql = <<<'SQL'
+SELECT TABLE_NAME
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = ?
+  AND TABLE_TYPE = 'BASE TABLE'
+ORDER BY TABLE_NAME
+SQL;
+
+        return $this->_conn->executeQuery($sql, [$databaseName]);
     }
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -30,6 +30,14 @@ class OracleSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
+    public function listTableNames()
+    {
+        return $this->doListTableNames();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function listTables()
     {
         return $this->doListTables();
@@ -347,6 +355,18 @@ class OracleSchemaManager extends AbstractSchemaManager
         }
 
         return $identifier;
+    }
+
+    protected function selectTableNames(string $databaseName): Result
+    {
+        $sql = <<<'SQL'
+SELECT TABLE_NAME
+FROM ALL_TABLES
+WHERE OWNER = :OWNER
+ORDER BY TABLE_NAME
+SQL;
+
+        return $this->_conn->executeQuery($sql, ['OWNER' => $databaseName]);
     }
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -44,6 +44,14 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
+    public function listTableNames()
+    {
+        return $this->doListTableNames();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function listTables()
     {
         return $this->doListTables();
@@ -600,6 +608,23 @@ SQL
         }
 
         return str_replace("''", "'", $default);
+    }
+
+    protected function selectTableNames(string $databaseName): Result
+    {
+        $sql = <<<'SQL'
+SELECT quote_ident(table_name) AS table_name,
+       table_schema AS schema_name
+FROM information_schema.tables
+WHERE table_catalog = ?
+  AND table_schema NOT LIKE 'pg\_%'
+  AND table_schema != 'information_schema'
+  AND table_name != 'geometry_columns'
+  AND table_name != 'spatial_ref_sys'
+  AND table_type = 'BASE TABLE'
+SQL;
+
+        return $this->_conn->executeQuery($sql, [$databaseName]);
     }
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -44,6 +44,14 @@ class SqliteSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
+    public function listTableNames()
+    {
+        return $this->doListTableNames();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function listTables()
     {
         return $this->doListTables();
@@ -662,6 +670,25 @@ SQL
 
         // SQLite does not support schemas or databases
         return [];
+    }
+
+    protected function selectTableNames(string $databaseName): Result
+    {
+        $sql = <<<'SQL'
+SELECT name
+FROM sqlite_master
+WHERE type = 'table'
+  AND name != 'sqlite_sequence'
+  AND name != 'geometry_columns'
+  AND name != 'spatial_ref_sys'
+UNION ALL
+SELECT name
+FROM sqlite_temp_master
+WHERE type = 'table'
+ORDER BY name
+SQL;
+
+        return $this->_conn->executeQuery($sql);
     }
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result


### PR DESCRIPTION
The `AbstractPlatform::getListTablesSQL()` method deprecated in https://github.com/doctrine/dbal/pull/5268 cannot be removed yet because it's used by `AbstractSchemaManager::listTableNames()`. Following the same principle as earlier, this patch moves the logic of building schema introspection queries from the platform classes to the schema managers making the queries an internal implementation detail rather than a public API.