### PR TITLE
Remove PostgreSQLSchemaManager::_getPortableSequencesList()

### DIFF
--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -12,7 +12,6 @@ use Doctrine\Deprecations\Deprecation;
 
 use function array_change_key_case;
 use function array_filter;
-use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_shift;
@@ -314,32 +313,6 @@ SQL
     protected function _getPortableDatabaseDefinition($database)
     {
         return $database['datname'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _getPortableSequencesList($sequences)
-    {
-        $sequenceDefinitions = [];
-
-        foreach ($sequences as $sequence) {
-            if ($sequence['schemaname'] !== 'public') {
-                $sequenceName = $sequence['schemaname'] . '.' . $sequence['relname'];
-            } else {
-                $sequenceName = $sequence['relname'];
-            }
-
-            $sequenceDefinitions[$sequenceName] = $sequence;
-        }
-
-        $list = [];
-
-        foreach ($this->filterAssetNames(array_keys($sequenceDefinitions)) as $sequenceName) {
-            $list[] = $this->_getPortableSequenceDefinition($sequenceDefinitions[$sequenceName]);
-        }
-
-        return $list;
     }
 
     /**


### PR DESCRIPTION
This code is redundant:
1. Concatenation of the schema name and the sequence name in a qualified name is already implemented in `_getPortableSequenceDefinition()`: https://github.com/doctrine/dbal/blob/bd983fb9d6d60e5beec67401dc86d9864df61b25/src/Schema/PostgreSQLSchemaManager.php#L367-L371
2. Filtering the list according to the configuration is already implemented in `listSequences()`: https://github.com/doctrine/dbal/blob/2d388f023ca43f6435a1dc1351cf5eafd775e5cd/src/Schema/AbstractSchemaManager.php#L196