### PR TITLE
Non-public API cleanup in AbstractSchemaManager

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -780,10 +780,7 @@ abstract class AbstractSchemaManager
      *
      * @abstract
      */
-    protected function _getPortableViewDefinition(array $view): View
-    {
-        throw NotSupported::new('Views');
-    }
+    abstract protected function _getPortableViewDefinition(array $view): View;
 
     /**
      * @param array<int|string, array<string, mixed>> $tableForeignKeys

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -62,11 +62,11 @@ abstract class AbstractSchemaManager
      */
     public function listDatabases(): array
     {
-        $sql = $this->_platform->getListDatabasesSQL();
-
-        $databases = $this->_conn->fetchAllAssociative($sql);
-
-        return $this->_getPortableDatabasesList($databases);
+        return array_map(function (array $row): string {
+            return $this->_getPortableDatabaseDefinition($row);
+        }, $this->_conn->fetchAllAssociative(
+            $this->_platform->getListDatabasesSQL()
+        ));
     }
 
     /**
@@ -90,13 +90,15 @@ abstract class AbstractSchemaManager
      */
     public function listSequences(): array
     {
-        $database = $this->getDatabase(__METHOD__);
-
-        $sql = $this->_platform->getListSequencesSQL($database);
-
-        $sequences = $this->_conn->fetchAllAssociative($sql);
-
-        return $this->filterAssetNames($this->_getPortableSequencesList($sequences));
+        return $this->filterAssetNames(
+            array_map(function (array $row): Sequence {
+                return $this->_getPortableSequenceDefinition($row);
+            }, $this->_conn->fetchAllAssociative(
+                $this->_platform->getListSequencesSQL(
+                    $this->getDatabase(__METHOD__)
+                )
+            ))
+        );
     }
 
     /**
@@ -175,13 +177,12 @@ abstract class AbstractSchemaManager
      */
     public function listTableNames(): array
     {
-        $database = $this->getDatabase(__METHOD__);
-
         return $this->filterAssetNames(
-            $this->_getPortableTablesList(
-                $this->selectTableNames($database)
-                    ->fetchAllAssociative()
-            )
+            array_map(function (array $row): string {
+                return $this->_getPortableTableDefinition($row);
+            }, $this->selectTableNames(
+                $this->getDatabase(__METHOD__)
+            )->fetchAllAssociative())
         );
     }
 
@@ -348,18 +349,19 @@ abstract class AbstractSchemaManager
     /**
      * Lists the views this connection has.
      *
-     * @return array<string, View>
+     * @return list<View>
      *
      * @throws Exception
      */
     public function listViews(): array
     {
-        $database = $this->getDatabase(__METHOD__);
-
-        $sql   = $this->_platform->getListViewsSQL($database);
-        $views = $this->_conn->fetchAllAssociative($sql);
-
-        return $this->_getPortableViewsList($views);
+        return array_map(function (array $row): View {
+            return $this->_getPortableViewDefinition($row);
+        }, $this->_conn->fetchAllAssociative(
+            $this->_platform->getListViewsSQL(
+                $this->getDatabase(__METHOD__)
+            )
+        ));
     }
 
     /**
@@ -613,21 +615,6 @@ abstract class AbstractSchemaManager
      */
 
     /**
-     * @param array<int, mixed> $databases
-     *
-     * @return array<int, string>
-     */
-    protected function _getPortableDatabasesList(array $databases): array
-    {
-        $list = [];
-        foreach ($databases as $value) {
-            $list[] = $this->_getPortableDatabaseDefinition($value);
-        }
-
-        return $list;
-    }
-
-    /**
      * @param array<string, string> $database
      */
     protected function _getPortableDatabaseDefinition(array $database): string
@@ -635,24 +622,6 @@ abstract class AbstractSchemaManager
         assert(! empty($database));
 
         return array_shift($database);
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $sequences
-     *
-     * @return array<int, Sequence>
-     *
-     * @throws Exception
-     */
-    protected function _getPortableSequencesList(array $sequences): array
-    {
-        $list = [];
-
-        foreach ($sequences as $value) {
-            $list[] = $this->_getPortableSequenceDefinition($value);
-        }
-
-        return $list;
     }
 
     /**
@@ -797,21 +766,6 @@ abstract class AbstractSchemaManager
     }
 
     /**
-     * @param array<int, array<string, mixed>> $tables
-     *
-     * @return array<int, string>
-     */
-    protected function _getPortableTablesList(array $tables): array
-    {
-        $list = [];
-        foreach ($tables as $value) {
-            $list[] = $this->_getPortableTableDefinition($value);
-        }
-
-        return $list;
-    }
-
-    /**
      * @param array<string, string> $table
      */
     protected function _getPortableTableDefinition(array $table): string
@@ -822,24 +776,9 @@ abstract class AbstractSchemaManager
     }
 
     /**
-     * @param array<int, array<string, mixed>> $views
-     *
-     * @return array<string, View>
-     */
-    protected function _getPortableViewsList(array $views): array
-    {
-        $list = [];
-        foreach ($views as $value) {
-            $view        = $this->_getPortableViewDefinition($value);
-            $name        = strtolower($view->getQuotedName($this->_platform));
-            $list[$name] = $view;
-        }
-
-        return $list;
-    }
-
-    /**
      * @param array<string, mixed> $view
+     *
+     * @abstract
      */
     protected function _getPortableViewDefinition(array $view): View
     {

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -194,7 +194,7 @@ abstract class AbstractSchemaManager
      *
      * @return array<int, mixed>
      */
-    protected function filterAssetNames(array $assetNames): array
+    private function filterAssetNames(array $assetNames): array
     {
         $filter = $this->_conn->getConfiguration()->getSchemaAssetsFilter();
         if ($filter === null) {

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -616,12 +616,12 @@ abstract class AbstractSchemaManager
 
     /**
      * @param array<string, string> $database
+     *
+     * @throws Exception
      */
     protected function _getPortableDatabaseDefinition(array $database): string
     {
-        assert(! empty($database));
-
-        return array_shift($database);
+        throw NotSupported::new(__METHOD__);
     }
 
     /**

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -768,12 +768,7 @@ abstract class AbstractSchemaManager
     /**
      * @param array<string, string> $table
      */
-    protected function _getPortableTableDefinition(array $table): string
-    {
-        assert(! empty($table));
-
-        return array_shift($table);
-    }
+    abstract protected function _getPortableTableDefinition(array $table): string;
 
     /**
      * @param array<string, mixed> $view

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -53,6 +53,14 @@ class MySQLSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritdoc}
      */
+    protected function _getPortableTableDefinition(array $table): string
+    {
+        return $table['TABLE_NAME'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function _getPortableViewDefinition(array $view): View
     {
         return new View($view['TABLE_NAME'], $view['VIEW_DEFINITION']);

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -107,9 +107,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     }
 
     /**
-     * @param AbstractAsset[] $items
+     * @param T[] $items
      *
-     * @return AbstractAsset[]
+     * @return T[]
+     *
+     * @template T of AbstractAsset
      */
     private function filterElementsByName(array $items, string $name): array
     {
@@ -671,8 +673,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $filtered = array_values($this->filterElementsByName($views, $name));
         self::assertCount(1, $filtered);
 
-        $viewKey = strtolower($filtered[0]->getName());
-        self::assertStringContainsString('view_test_table', $views[$viewKey]->getSql());
+        self::assertStringContainsString('view_test_table', $filtered[0]->getSql());
     }
 
     public function testAutoincrementDetection(): void


### PR DESCRIPTION
1. To reduce the API surface, we can inline some `AbstractSchemaManager::_getPortable*List()` methods: they are invoked only from the corresponding `list*()` methods and aren't overridden by any bundled implementations. Removing the rest of such methods requires additional changes and is out of scope.
2. All `_getPortable*Definition()` methods should not have an implementation since their logic is platform-specific.
3. The `filterAssetNames()` method is now only used by `AbstractSchemaManager` so it can be made private.