### PR TITLE
Implement AbstractSchemaManager::_getPortableTableForeignKeyDefinition() across platforms

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -1470,6 +1470,8 @@ abstract class AbstractSchemaManager
      * @param mixed $tableForeignKey
      *
      * @return ForeignKeyConstraint
+     *
+     * @abstract
      */
     protected function _getPortableTableForeignKeyDefinition($tableForeignKey)
     {

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -350,21 +350,24 @@ class MySQLSchemaManager extends AbstractSchemaManager
             $list[$value['constraint_name']]['foreign'][] = $value['referenced_column_name'];
         }
 
-        $result = [];
-        foreach ($list as $constraint) {
-            $result[] = new ForeignKeyConstraint(
-                $constraint['local'],
-                $constraint['foreignTable'],
-                $constraint['foreign'],
-                $constraint['name'],
-                [
-                    'onDelete' => $constraint['onDelete'],
-                    'onUpdate' => $constraint['onUpdate'],
-                ]
-            );
-        }
+        return parent::_getPortableTableForeignKeysList($list);
+    }
 
-        return $result;
+    /**
+     * {@inheritDoc}
+     */
+    protected function _getPortableTableForeignKeyDefinition($tableForeignKey): ForeignKeyConstraint
+    {
+        return new ForeignKeyConstraint(
+            $tableForeignKey['local'],
+            $tableForeignKey['foreignTable'],
+            $tableForeignKey['foreign'],
+            $tableForeignKey['name'],
+            [
+                'onDelete' => $tableForeignKey['onDelete'],
+                'onUpdate' => $tableForeignKey['onUpdate'],
+            ]
+        );
     }
 
     public function createComparator(): Comparator

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -254,18 +254,21 @@ class OracleSchemaManager extends AbstractSchemaManager
             $list[$value['constraint_name']]['foreign'][$value['position']] = $foreignColumn;
         }
 
-        $result = [];
-        foreach ($list as $constraint) {
-            $result[] = new ForeignKeyConstraint(
-                array_values($constraint['local']),
-                $this->getQuotedIdentifierName($constraint['foreignTable']),
-                array_values($constraint['foreign']),
-                $this->getQuotedIdentifierName($constraint['name']),
-                ['onDelete' => $constraint['onDelete']]
-            );
-        }
+        return parent::_getPortableTableForeignKeysList($list);
+    }
 
-        return $result;
+    /**
+     * {@inheritDoc}
+     */
+    protected function _getPortableTableForeignKeyDefinition($tableForeignKey): ForeignKeyConstraint
+    {
+        return new ForeignKeyConstraint(
+            array_values($tableForeignKey['local']),
+            $this->getQuotedIdentifierName($tableForeignKey['foreignTable']),
+            array_values($tableForeignKey['foreign']),
+            $this->getQuotedIdentifierName($tableForeignKey['name']),
+            ['onDelete' => $tableForeignKey['onDelete']]
+        );
     }
 
     /**

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -474,23 +474,26 @@ class SqliteSchemaManager extends AbstractSchemaManager
             $list[$name]['foreign'][] = $value['to'];
         }
 
-        $result = [];
-        foreach ($list as $constraint) {
-            $result[] = new ForeignKeyConstraint(
-                $constraint['local'],
-                $constraint['foreignTable'],
-                $constraint['foreign'],
-                $constraint['name'],
-                [
-                    'onDelete' => $constraint['onDelete'],
-                    'onUpdate' => $constraint['onUpdate'],
-                    'deferrable' => $constraint['deferrable'],
-                    'deferred' => $constraint['deferred'],
-                ]
-            );
-        }
+        return parent::_getPortableTableForeignKeysList($list);
+    }
 
-        return $result;
+    /**
+     * {@inheritDoc}
+     */
+    protected function _getPortableTableForeignKeyDefinition($tableForeignKey): ForeignKeyConstraint
+    {
+        return new ForeignKeyConstraint(
+            $tableForeignKey['local'],
+            $tableForeignKey['foreignTable'],
+            $tableForeignKey['foreign'],
+            $tableForeignKey['name'],
+            [
+                'onDelete' => $tableForeignKey['onDelete'],
+                'onUpdate' => $tableForeignKey['onUpdate'],
+                'deferrable' => $tableForeignKey['deferrable'],
+                'deferred' => $tableForeignKey['deferred'],
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
As such, this change is non-substantial since this API still doesn't make any sense, but:
1. It will allow making `AbstractSchemaManager::_getPortableTableForeignKeyDefinition()` abstract because its current implementation makes even less sense and is probably not used anywhere: https://github.com/doctrine/dbal/blob/d4d9389288f85a73dd850a537862a1f8ed307bc4/src/Schema/AbstractSchemaManager.php#L1474-L1477
2. It will set the ground for future refactoring of the schema introspection API.