### PR TITLE
Deprecate Driver::getSchemaManager() in favor of AbstractPlatform::createSchemaManager()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `Driver::getSchemaManager()`.
+
+The `Driver::getSchemaManager()` method has been deprecated. Use `AbstractPlatform::createSchemaManager()` instead.
+
 ## Deprecated `ConsolerRunner`.
 
 The `ConsoleRunner` class has been deprecated. Use Symfony Console documentation

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -317,6 +317,10 @@
                 <referencedMethod name="Doctrine\DBAL\Schema\Schema::visit"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Sequence::visit"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::visit"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Driver::getSchemaManager"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -37,6 +37,8 @@ interface Driver
      * Gets the SchemaManager that can be used to inspect and change the underlying
      * database schema of the platform this driver connects to.
      *
+     * @deprecated Use {@link AbstractPlatform::createSchemaManager()} instead.
+     *
      * @return AbstractSchemaManager
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform);

--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\API\IBMDB2\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
+use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 
@@ -27,9 +28,18 @@ abstract class AbstractDB2Driver implements Driver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@link DB2Platform::createSchemaManager()} instead.
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5458',
+            'AbstractDB2Driver::getSchemaManager() is deprecated.'
+                . ' Use DB2Platform::createSchemaManager() instead.'
+        );
+
         assert($platform instanceof DB2Platform);
 
         return new DB2SchemaManager($conn, $platform);

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -132,10 +132,19 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
     /**
      * {@inheritdoc}
      *
+     * @deprecated Use {@link AbstractMySQLPlatform::createSchemaManager()} instead.
+     *
      * @return MySQLSchemaManager
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5458',
+            'AbstractMySQLDriver::getSchemaManager() is deprecated.'
+                . ' Use MySQLPlatform::createSchemaManager() instead.'
+        );
+
         assert($platform instanceof AbstractMySQLPlatform);
 
         return new MySQLSchemaManager($conn, $platform);

--- a/src/Driver/AbstractOracleDriver.php
+++ b/src/Driver/AbstractOracleDriver.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Driver\API\OCI;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\OracleSchemaManager;
+use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 
@@ -28,9 +29,18 @@ abstract class AbstractOracleDriver implements Driver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@link OraclePlatform::createSchemaManager()} instead.
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5458',
+            'AbstractOracleDriver::getSchemaManager() is deprecated.'
+                . ' Use OraclePlatform::createSchemaManager() instead.'
+        );
+
         assert($platform instanceof OraclePlatform);
 
         return new OracleSchemaManager($conn, $platform);

--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -64,9 +64,18 @@ abstract class AbstractPostgreSQLDriver implements VersionAwarePlatformDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@link PostgreSQLPlatform::createSchemaManager()} instead.
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5458',
+            'AbstractPostgreSQLDriver::getSchemaManager() is deprecated.'
+                . ' Use PostgreSQLPlatform::createSchemaManager() instead.'
+        );
+
         assert($platform instanceof PostgreSQLPlatform);
 
         return new PostgreSQLSchemaManager($conn, $platform);

--- a/src/Driver/AbstractSQLServerDriver.php
+++ b/src/Driver/AbstractSQLServerDriver.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\API\SQLSrv\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
+use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 
@@ -27,9 +28,18 @@ abstract class AbstractSQLServerDriver implements Driver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@link SQLServerPlatform::createSchemaManager()} instead.
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5458',
+            'AbstractSQLServerDriver::getSchemaManager() is deprecated.'
+                . ' Use SQLServerPlatform::createSchemaManager() instead.'
+        );
+
         assert($platform instanceof SQLServer2012Platform);
 
         return new SQLServerSchemaManager($conn, $platform);

--- a/src/Driver/AbstractSQLiteDriver.php
+++ b/src/Driver/AbstractSQLiteDriver.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\API\SQLite;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\SqliteSchemaManager;
+use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 
@@ -27,9 +28,18 @@ abstract class AbstractSQLiteDriver implements Driver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@link SqlitePlatform::createSchemaManager()} instead.
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5458',
+            'AbstractSQLiteDriver::getSchemaManager() is deprecated.'
+                . ' Use SqlitePlatform::createSchemaManager() instead.'
+        );
+
         assert($platform instanceof SqlitePlatform);
 
         return new SqliteSchemaManager($conn, $platform);

--- a/src/Driver/Middleware/AbstractDriverMiddleware.php
+++ b/src/Driver/Middleware/AbstractDriverMiddleware.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
+use Doctrine\Deprecations\Deprecation;
 
 abstract class AbstractDriverMiddleware implements VersionAwarePlatformDriver
 {
@@ -36,9 +37,18 @@ abstract class AbstractDriverMiddleware implements VersionAwarePlatformDriver
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@link AbstractPlatform::createSchemaManager()} instead.
      */
     public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5458',
+            'AbstractDriverMiddleware::getSchemaManager() is deprecated.'
+                . ' Use AbstractPlatform::createSchemaManager() instead.'
+        );
+
         return $this->wrappedDriver->getSchemaManager($conn, $platform);
     }
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -2,10 +2,12 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
@@ -1279,5 +1281,10 @@ SQL
         }
 
         return $this->getCurrentDatabaseExpression();
+    }
+
+    public function createSchemaManager(Connection $connection): MySQLSchemaManager
+    {
+        return new MySQLSchemaManager($connection, $this);
     }
 }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Event\SchemaAlterTableAddColumnEventArgs;
 use Doctrine\DBAL\Event\SchemaAlterTableChangeColumnEventArgs;
 use Doctrine\DBAL\Event\SchemaAlterTableEventArgs;
@@ -16,6 +17,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\InvalidLockMode;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Constraint;
@@ -4334,5 +4336,18 @@ abstract class AbstractPlatform
         }
 
         return $column1->getType() === $column2->getType();
+    }
+
+    /**
+     * Creates the schema manager that can be used to inspect and change the underlying
+     * database schema according to the dialect of the platform.
+     *
+     * @throws Exception
+     *
+     * @abstract
+     */
+    public function createSchemaManager(Connection $connection): AbstractSchemaManager
+    {
+        throw Exception::notSupported(__METHOD__);
     }
 }

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -2,8 +2,10 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\DB2SchemaManager;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -967,5 +969,10 @@ SQL
             ,
             $this->quoteStringLiteral($table)
         );
+    }
+
+    public function createSchemaManager(Connection $connection): DB2SchemaManager
+    {
+        return new DB2SchemaManager($connection, $this);
     }
 }

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -2,10 +2,12 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\OracleSchemaManager;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -1250,5 +1252,10 @@ SQL
             $this->quoteStringLiteral($this->normalizeIdentifier($table)->getName()),
             $ownerCondition
         );
+    }
+
+    public function createSchemaManager(Connection $connection): OracleSchemaManager
+    {
+        return new OracleSchemaManager($connection, $this);
     }
 }

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -2,11 +2,13 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\BinaryType;
@@ -1276,5 +1278,10 @@ SQL
             ,
             $this->quoteStringLiteral($table)
         );
+    }
+
+    public function createSchemaManager(Connection $connection): PostgreSQLSchemaManager
+    {
+        return new PostgreSQLSchemaManager($connection, $this);
     }
 }

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\InvalidLockMode;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Schema\Column;
@@ -10,6 +11,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Sequence;
+use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\Deprecations\Deprecation;
@@ -1695,5 +1697,10 @@ class SQLServerPlatform extends AbstractPlatform
         }
 
         return true;
+    }
+
+    public function createSchemaManager(Connection $connection): SQLServerSchemaManager
+    {
+        return new SQLServerSchemaManager($connection, $this);
     }
 }

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\API\SQLite\UserDefinedFunctions;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Column;
@@ -10,6 +11,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
@@ -1380,5 +1382,10 @@ class SqlitePlatform extends AbstractPlatform
         }
 
         return $primaryIndex;
+    }
+
+    public function createSchemaManager(Connection $connection): SqliteSchemaManager
+    {
+        return new SqliteSchemaManager($connection, $this);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement, deprecation

The operation of creating a schema manager doesn't belong to the driver layer: the driver represents transport. Different transports use the same schema management logic for the same platform. The very fact that `Driver::getSchemaManager()` is implemented only in abstract driver classes illustrates that.

At the same time, the schema management logic may depend on the platform vendor and the platform version: https://github.com/doctrine/dbal/blob/d4d9389288f85a73dd850a537862a1f8ed307bc4/src/Schema/MySQLSchemaManager.php#L244-L248

But currently, it's challenging to have different schema managers for different platform vendors or versions.