### PR TITLE
Drop support for PHP 7.3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,7 +38,6 @@ jobs:
         os:
           - "ubuntu-20.04"
         php-version:
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"
@@ -46,7 +45,7 @@ jobs:
           - "highest"
         include:
           - os: "ubuntu-20.04"
-            php-version: "7.3"
+            php-version: "7.4"
             dependencies: "lowest"
           - os: "ubuntu-18.04"
             php-version: "8.1"
@@ -336,16 +335,6 @@ jobs:
         config-file-suffix:
           - ""
         include:
-          - php-version: "7.3"
-            mysql-version: "8.0"
-            extension: "mysqli"
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
-          - php-version: "7.3"
-            mysql-version: "8.0"
-            extension: "pdo_mysql"
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
           - mysql-version: "5.7"
           - mysql-version: "8.0"
             # https://stackoverflow.com/questions/60902904/how-to-pass-mysql-native-password-to-mysql-service-in-github-actions
@@ -417,7 +406,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.3"
           - "7.4"
           - "8.1"
         extension:
@@ -482,7 +470,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.3"
           - "7.4"
 
     services:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "composer-runtime-api": "^2",
         "doctrine/cache": "^1.11|^2.0",
         "doctrine/deprecations": "^0.5.3|^1",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,7 @@
     <!-- Show progress of the run and show sniff names -->
     <arg value="ps"/>
 
-    <config name="php_version" value="70300"/>
+    <config name="php_version" value="70400"/>
 
     <file>bin</file>
     <file>src</file>
@@ -20,6 +20,7 @@
 
     <rule ref="Doctrine">
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants.DisallowedLateStaticBindingForConstant"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -538,7 +538,7 @@
                 <!-- See https://github.com/vimeo/psalm/issues/5472 -->
                 <referencedClass name="Doctrine\DBAL\Portability\T"/>
                 <!--
-                    The OCI-Lob class was renamed to OCILob in PHP 8 while Psalm infers PHP 7.3 from composer.json
+                    The OCI-Lob class was renamed to OCILob in PHP 8 while Psalm infers PHP 7 from composer.json
                     and may not properly interpret the LanguageLevelTypeAware annotation from the stubs.
                 -->
                 <referencedClass name="OCILob"/>

--- a/src/Driver/API/PostgreSQL/ExceptionConverter.php
+++ b/src/Driver/API/PostgreSQL/ExceptionConverter.php
@@ -81,7 +81,7 @@ final class ExceptionConverter implements ExceptionConverterInterface
                 return new ConnectionException($exception, $query);
         }
 
-        // Prior to fixing https://bugs.php.net/bug.php?id=64705 (PHP 7.3.22 and PHP 7.4.10),
+        // Prior to fixing https://bugs.php.net/bug.php?id=64705 (PHP 7.4.10),
         // in some cases (mainly connection errors) the PDO exception wouldn't provide a SQLSTATE via its code.
         // We have to match against the SQLSTATE in the error message in these cases.
         if ($exception->getCode() === 7 && strpos($exception->getMessage(), 'SQLSTATE[08006]') !== false) {

--- a/tests/Functional/Connection/ConnectionLostTest.php
+++ b/tests/Functional/Connection/ConnectionLostTest.php
@@ -29,7 +29,7 @@ class ConnectionLostTest extends FunctionalTestCase
             ->getDummySelectSQL();
 
         try {
-            // in addition to the error, PHP 7.3 will generate a warning that needs to be
+            // in addition to the error, PHP 7 will generate a warning that needs to be
             // suppressed in order to not let PHPUnit handle it before the actual error
             @$this->connection->executeQuery($query);
         } catch (ConnectionLost $e) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

PHP 7.3 is no longer supported by the community. The support for PHP 7.3 doesn't allow using covariant return types in https://github.com/doctrine/dbal/pull/5458.