### PR TITLE
Add native property types

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -503,6 +503,12 @@
                 <file name="tests/Functional/Driver/AbstractDriverTest.php"/>
             </errorLevel>
         </RedundantConditionGivenDocblockType>
+        <RedundantPropertyInitializationCheck>
+            <errorLevel type="suppress">
+                <!-- Running isset() checks on properties that should be initialized by setUp() is fine. -->
+                <directory name="tests"/>
+            </errorLevel>
+        </RedundantPropertyInitializationCheck>
         <ReferenceConstraintViolation>
             <errorLevel type="suppress">
                 <!--

--- a/src/Cache/ArrayResult.php
+++ b/src/Cache/ArrayResult.php
@@ -15,13 +15,10 @@ use function reset;
 final class ArrayResult implements Result
 {
     /** @var list<array<string, mixed>> */
-    private $data;
+    private array $data;
 
-    /** @var int */
-    private $columnCount = 0;
-
-    /** @var int */
-    private $num = 0;
+    private int $columnCount = 0;
+    private int $num         = 0;
 
     /**
      * @param list<array<string, mixed>> $data

--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -23,8 +23,7 @@ use function sprintf;
  */
 class QueryCacheProfile
 {
-    /** @var CacheItemPoolInterface|null */
-    private $resultCache;
+    private ?CacheItemPoolInterface $resultCache = null;
 
     /** @var int */
     private $lifetime;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -16,7 +16,7 @@ use Psr\Cache\CacheItemPoolInterface;
 class Configuration
 {
     /** @var Middleware[] */
-    private $middlewares = [];
+    private array $middlewares = [];
 
     /**
      * The SQL logger in use. If null, SQL logging is disabled.
@@ -27,10 +27,8 @@ class Configuration
 
     /**
      * The cache driver implementation that is used for query result caching.
-     *
-     * @var CacheItemPoolInterface|null
      */
-    private $resultCache;
+    private ?CacheItemPoolInterface $resultCache = null;
 
     /**
      * The cache driver implementation that is used for query result caching.

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -89,17 +89,13 @@ class Connection
 
     /**
      * The current auto-commit mode of this connection.
-     *
-     * @var bool
      */
-    private $autoCommit = true;
+    private bool $autoCommit = true;
 
     /**
      * The transaction nesting level.
-     *
-     * @var int
      */
-    private $transactionNestingLevel = 0;
+    private int $transactionNestingLevel = 0;
 
     /**
      * The currently active transaction isolation level or NULL before it has been determined.
@@ -110,10 +106,8 @@ class Connection
 
     /**
      * If nested transactions should use savepoints.
-     *
-     * @var bool
      */
-    private $nestTransactionsWithSavepoints = false;
+    private bool $nestTransactionsWithSavepoints = false;
 
     /**
      * The parameters used during creation of the Connection instance.
@@ -121,20 +115,15 @@ class Connection
      * @var array<string,mixed>
      * @psalm-var Params
      */
-    private $params;
+    private array $params;
 
     /**
      * The database platform object used by the connection or NULL before it's initialized.
-     *
-     * @var AbstractPlatform|null
      */
-    private $platform;
+    private ?AbstractPlatform $platform = null;
 
-    /** @var ExceptionConverter|null */
-    private $exceptionConverter;
-
-    /** @var Parser|null */
-    private $parser;
+    private ?ExceptionConverter $exceptionConverter = null;
+    private ?Parser $parser                         = null;
 
     /**
      * The schema manager.
@@ -154,10 +143,8 @@ class Connection
 
     /**
      * Flag that indicates whether the current transaction is marked for rollback only.
-     *
-     * @var bool
      */
-    private $isRollbackOnly = false;
+    private bool $isRollbackOnly = false;
 
     /**
      * Initializes a new instance of the Connection class.

--- a/src/Driver/AbstractException.php
+++ b/src/Driver/AbstractException.php
@@ -18,10 +18,8 @@ abstract class AbstractException extends BaseException implements Exception
 {
     /**
      * The SQLSTATE of the driver.
-     *
-     * @var string|null
      */
-    private $sqlState;
+    private ?string $sqlState = null;
 
     /**
      * @param string         $message  The driver error message.

--- a/src/Driver/AbstractOracleDriver/EasyConnectString.php
+++ b/src/Driver/AbstractOracleDriver/EasyConnectString.php
@@ -15,8 +15,7 @@ use function sprintf;
  */
 final class EasyConnectString
 {
-    /** @var string */
-    private $string;
+    private string $string;
 
     private function __construct(string $string)
     {

--- a/src/Driver/IBMDB2/DataSourceName.php
+++ b/src/Driver/IBMDB2/DataSourceName.php
@@ -13,8 +13,7 @@ use function strpos;
  */
 final class DataSourceName
 {
-    /** @var string */
-    private $string;
+    private string $string;
 
     private function __construct(string $string)
     {

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -36,7 +36,7 @@ final class Statement implements StatementInterface
     private $stmt;
 
     /** @var mixed[] */
-    private $bindParam = [];
+    private array $bindParam = [];
 
     /**
      * Map of LOB parameter positions to the tuples containing reference to the variable bound to the driver statement
@@ -44,7 +44,7 @@ final class Statement implements StatementInterface
      *
      * @var mixed[][]
      */
-    private $lobs = [];
+    private array $lobs = [];
 
     /**
      * @internal The statement can be only instantiated by its driver connection.

--- a/src/Driver/Middleware/AbstractConnectionMiddleware.php
+++ b/src/Driver/Middleware/AbstractConnectionMiddleware.php
@@ -16,8 +16,7 @@ use function sprintf;
 
 abstract class AbstractConnectionMiddleware implements ServerInfoAwareConnection
 {
-    /** @var Connection */
-    private $wrappedConnection;
+    private Connection $wrappedConnection;
 
     public function __construct(Connection $wrappedConnection)
     {

--- a/src/Driver/Middleware/AbstractDriverMiddleware.php
+++ b/src/Driver/Middleware/AbstractDriverMiddleware.php
@@ -10,8 +10,7 @@ use Doctrine\DBAL\VersionAwarePlatformDriver;
 
 abstract class AbstractDriverMiddleware implements VersionAwarePlatformDriver
 {
-    /** @var Driver */
-    private $wrappedDriver;
+    private Driver $wrappedDriver;
 
     public function __construct(Driver $wrappedDriver)
     {

--- a/src/Driver/Middleware/AbstractResultMiddleware.php
+++ b/src/Driver/Middleware/AbstractResultMiddleware.php
@@ -6,8 +6,7 @@ use Doctrine\DBAL\Driver\Result;
 
 abstract class AbstractResultMiddleware implements Result
 {
-    /** @var Result */
-    private $wrappedResult;
+    private Result $wrappedResult;
 
     public function __construct(Result $result)
     {

--- a/src/Driver/Middleware/AbstractStatementMiddleware.php
+++ b/src/Driver/Middleware/AbstractStatementMiddleware.php
@@ -8,8 +8,7 @@ use Doctrine\DBAL\ParameterType;
 
 abstract class AbstractStatementMiddleware implements Statement
 {
-    /** @var Statement */
-    private $wrappedStatement;
+    private Statement $wrappedStatement;
 
     public function __construct(Statement $wrappedStatement)
     {

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -18,8 +18,7 @@ final class Connection implements ServerInfoAwareConnection
      */
     public const OPTION_FLAGS = 'flags';
 
-    /** @var mysqli */
-    private $connection;
+    private mysqli $connection;
 
     /**
      * @internal The connection can be only instantiated by its driver.

--- a/src/Driver/Mysqli/Initializer/Charset.php
+++ b/src/Driver/Mysqli/Initializer/Charset.php
@@ -11,8 +11,7 @@ use mysqli_sql_exception;
 
 final class Charset implements Initializer
 {
-    /** @var string */
-    private $charset;
+    private string $charset;
 
     public function __construct(string $charset)
     {

--- a/src/Driver/Mysqli/Initializer/Options.php
+++ b/src/Driver/Mysqli/Initializer/Options.php
@@ -13,7 +13,7 @@ use function mysqli_options;
 final class Options implements Initializer
 {
     /** @var array<int,mixed> */
-    private $options;
+    private array $options;
 
     /**
      * @param array<int,mixed> $options

--- a/src/Driver/Mysqli/Initializer/Secure.php
+++ b/src/Driver/Mysqli/Initializer/Secure.php
@@ -9,20 +9,11 @@ use mysqli;
 
 final class Secure implements Initializer
 {
-    /** @var string */
-    private $key;
-
-    /** @var string */
-    private $cert;
-
-    /** @var string */
-    private $ca;
-
-    /** @var string */
-    private $capath;
-
-    /** @var string */
-    private $cipher;
+    private string $key;
+    private string $cert;
+    private string $ca;
+    private string $capath;
+    private string $cipher;
 
     public function __construct(string $key, string $cert, string $ca, string $capath, string $cipher)
     {

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -18,16 +18,13 @@ use function count;
 
 final class Result implements ResultInterface
 {
-    /** @var mysqli_stmt */
-    private $statement;
+    private mysqli_stmt $statement;
 
     /**
      * Whether the statement result has columns. The property should be used only after the result metadata
      * has been fetched ({@see $metadataFetched}). Otherwise, the property value is undetermined.
-     *
-     * @var bool
      */
-    private $hasColumns = false;
+    private bool $hasColumns = false;
 
     /**
      * Mapping of statement result column indexes to their names. The property should be used only
@@ -35,10 +32,10 @@ final class Result implements ResultInterface
      *
      * @var array<int,string>
      */
-    private $columnNames = [];
+    private array $columnNames = [];
 
     /** @var mixed[] */
-    private $boundValues = [];
+    private array $boundValues = [];
 
     /**
      * @internal The result can be only instantiated by its driver connection or statement.

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -26,7 +26,7 @@ use function str_repeat;
 final class Statement implements StatementInterface
 {
     /** @var string[] */
-    private static $paramTypeMap = [
+    private static array $paramTypeMap = [
         ParameterType::ASCII => 's',
         ParameterType::STRING => 's',
         ParameterType::BINARY => 's',
@@ -36,21 +36,19 @@ final class Statement implements StatementInterface
         ParameterType::LARGE_OBJECT => 'b',
     ];
 
-    /** @var mysqli_stmt */
-    private $stmt;
+    private mysqli_stmt $stmt;
 
     /** @var mixed[] */
-    private $boundValues;
+    private array $boundValues;
 
-    /** @var string */
-    private $types;
+    private string $types;
 
     /**
      * Contains ref values for bindValue().
      *
      * @var mixed[]
      */
-    private $values = [];
+    private array $values = [];
 
     /**
      * @internal The statement can be only instantiated by its driver connection.

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -29,11 +29,8 @@ final class Connection implements ServerInfoAwareConnection
     /** @var resource */
     private $connection;
 
-    /** @var Parser */
-    private $parser;
-
-    /** @var ExecutionMode */
-    private $executionMode;
+    private Parser $parser;
+    private ExecutionMode $executionMode;
 
     /**
      * @internal The connection can be only instantiated by its driver.

--- a/src/Driver/OCI8/ConvertPositionalToNamedPlaceholders.php
+++ b/src/Driver/OCI8/ConvertPositionalToNamedPlaceholders.php
@@ -18,10 +18,10 @@ use function implode;
 final class ConvertPositionalToNamedPlaceholders implements Visitor
 {
     /** @var list<string> */
-    private $buffer = [];
+    private array $buffer = [];
 
     /** @var array<int,string> */
-    private $parameterMap = [];
+    private array $parameterMap = [];
 
     public function acceptOther(string $sql): void
     {

--- a/src/Driver/OCI8/ExecutionMode.php
+++ b/src/Driver/OCI8/ExecutionMode.php
@@ -11,8 +11,7 @@ namespace Doctrine\DBAL\Driver\OCI8;
  */
 final class ExecutionMode
 {
-    /** @var bool */
-    private $isAutoCommitEnabled = true;
+    private bool $isAutoCommitEnabled = true;
 
     public function enableAutoCommit(): void
     {

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -30,10 +30,9 @@ final class Statement implements StatementInterface
     private $statement;
 
     /** @var array<int,string> */
-    private $parameterMap;
+    private array $parameterMap;
 
-    /** @var ExecutionMode */
-    private $executionMode;
+    private ExecutionMode $executionMode;
 
     /**
      * @internal The statement can be only instantiated by its driver connection.

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -15,8 +15,7 @@ use function assert;
 
 final class Connection implements ServerInfoAwareConnection
 {
-    /** @var PDO */
-    private $connection;
+    private PDO $connection;
 
     /**
      * @internal The connection can be only instantiated by its driver.

--- a/src/Driver/PDO/Result.php
+++ b/src/Driver/PDO/Result.php
@@ -11,8 +11,7 @@ use PDOStatement;
 
 final class Result implements ResultInterface
 {
-    /** @var PDOStatement */
-    private $statement;
+    private PDOStatement $statement;
 
     /**
      * @internal The result can be only instantiated by its driver connection or statement.

--- a/src/Driver/PDO/SQLSrv/Connection.php
+++ b/src/Driver/PDO/SQLSrv/Connection.php
@@ -10,8 +10,7 @@ use PDO;
 
 final class Connection extends AbstractConnectionMiddleware
 {
-    /** @var PDOConnection */
-    private $connection;
+    private PDOConnection $connection;
 
     public function __construct(PDOConnection $connection)
     {

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -12,8 +12,7 @@ use function func_num_args;
 
 final class Statement extends AbstractStatementMiddleware
 {
-    /** @var PDOStatement */
-    private $statement;
+    private PDOStatement $statement;
 
     /**
      * @internal The statement can be only instantiated by its driver connection.

--- a/src/Driver/PDO/SQLite/Driver.php
+++ b/src/Driver/PDO/SQLite/Driver.php
@@ -14,7 +14,7 @@ use function array_merge;
 final class Driver extends AbstractSQLiteDriver
 {
     /** @var mixed[] */
-    private $userDefinedFunctions = [
+    private array $userDefinedFunctions = [
         'sqrt' => ['callback' => [SqlitePlatform::class, 'udfSqrt'], 'numArgs' => 1],
         'mod'  => ['callback' => [SqlitePlatform::class, 'udfMod'], 'numArgs' => 2],
         'locate'  => ['callback' => [SqlitePlatform::class, 'udfLocate'], 'numArgs' => -1],

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -28,8 +28,7 @@ final class Statement implements StatementInterface
         ParameterType::BOOLEAN => PDO::PARAM_BOOL,
     ];
 
-    /** @var PDOStatement */
-    private $stmt;
+    private PDOStatement $stmt;
 
     /**
      * @internal The statement can be only instantiated by its driver connection.

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -32,10 +32,8 @@ final class Statement implements StatementInterface
 
     /**
      * The SQL statement to execute.
-     *
-     * @var string
      */
-    private $sql;
+    private string $sql;
 
     /**
      * The SQLSRV statement resource.
@@ -49,14 +47,14 @@ final class Statement implements StatementInterface
      *
      * @var array<int, mixed>
      */
-    private $variables = [];
+    private array $variables = [];
 
     /**
      * Bound parameter types.
      *
      * @var array<int, int>
      */
-    private $types = [];
+    private array $types = [];
 
     /**
      * Append to any INSERT query to retrieve the last insert id.

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -94,7 +94,7 @@ final class DriverManager
      *
      * @var string[]
      */
-    private static $driverSchemeAliases = [
+    private static array $driverSchemeAliases = [
         'db2'        => 'ibm_db2',
         'mssql'      => 'pdo_sqlsrv',
         'mysql'      => 'pdo_mysql',

--- a/src/Event/ConnectionEventArgs.php
+++ b/src/Event/ConnectionEventArgs.php
@@ -10,8 +10,7 @@ use Doctrine\DBAL\Connection;
  */
 class ConnectionEventArgs extends EventArgs
 {
-    /** @var Connection */
-    private $connection;
+    private Connection $connection;
 
     public function __construct(Connection $connection)
     {

--- a/src/Event/SchemaAlterTableAddColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableAddColumnEventArgs.php
@@ -16,17 +16,12 @@ use function is_array;
  */
 class SchemaAlterTableAddColumnEventArgs extends SchemaEventArgs
 {
-    /** @var Column */
-    private $column;
-
-    /** @var TableDiff */
-    private $tableDiff;
-
-    /** @var AbstractPlatform */
-    private $platform;
+    private Column $column;
+    private TableDiff $tableDiff;
+    private AbstractPlatform $platform;
 
     /** @var string[] */
-    private $sql = [];
+    private array $sql = [];
 
     public function __construct(Column $column, TableDiff $tableDiff, AbstractPlatform $platform)
     {

--- a/src/Event/SchemaAlterTableChangeColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableChangeColumnEventArgs.php
@@ -15,17 +15,12 @@ use function is_array;
  */
 class SchemaAlterTableChangeColumnEventArgs extends SchemaEventArgs
 {
-    /** @var ColumnDiff */
-    private $columnDiff;
-
-    /** @var TableDiff */
-    private $tableDiff;
-
-    /** @var AbstractPlatform */
-    private $platform;
+    private ColumnDiff $columnDiff;
+    private TableDiff $tableDiff;
+    private AbstractPlatform $platform;
 
     /** @var string[] */
-    private $sql = [];
+    private array $sql = [];
 
     public function __construct(ColumnDiff $columnDiff, TableDiff $tableDiff, AbstractPlatform $platform)
     {

--- a/src/Event/SchemaAlterTableEventArgs.php
+++ b/src/Event/SchemaAlterTableEventArgs.php
@@ -14,14 +14,11 @@ use function is_array;
  */
 class SchemaAlterTableEventArgs extends SchemaEventArgs
 {
-    /** @var TableDiff */
-    private $tableDiff;
-
-    /** @var AbstractPlatform */
-    private $platform;
+    private TableDiff $tableDiff;
+    private AbstractPlatform $platform;
 
     /** @var string[] */
-    private $sql = [];
+    private array $sql = [];
 
     public function __construct(TableDiff $tableDiff, AbstractPlatform $platform)
     {

--- a/src/Event/SchemaAlterTableRemoveColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableRemoveColumnEventArgs.php
@@ -15,17 +15,12 @@ use function is_array;
  */
 class SchemaAlterTableRemoveColumnEventArgs extends SchemaEventArgs
 {
-    /** @var Column */
-    private $column;
-
-    /** @var TableDiff */
-    private $tableDiff;
-
-    /** @var AbstractPlatform */
-    private $platform;
+    private Column $column;
+    private TableDiff $tableDiff;
+    private AbstractPlatform $platform;
 
     /** @var string[] */
-    private $sql = [];
+    private array $sql = [];
 
     public function __construct(Column $column, TableDiff $tableDiff, AbstractPlatform $platform)
     {

--- a/src/Event/SchemaAlterTableRenameColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableRenameColumnEventArgs.php
@@ -18,17 +18,12 @@ class SchemaAlterTableRenameColumnEventArgs extends SchemaEventArgs
     /** @var string */
     private $oldColumnName;
 
-    /** @var Column */
-    private $column;
-
-    /** @var TableDiff */
-    private $tableDiff;
-
-    /** @var AbstractPlatform */
-    private $platform;
+    private Column $column;
+    private TableDiff $tableDiff;
+    private AbstractPlatform $platform;
 
     /** @var string[] */
-    private $sql = [];
+    private array $sql = [];
 
     /**
      * @param string $oldColumnName

--- a/src/Event/SchemaColumnDefinitionEventArgs.php
+++ b/src/Event/SchemaColumnDefinitionEventArgs.php
@@ -10,8 +10,7 @@ use Doctrine\DBAL\Schema\Column;
  */
 class SchemaColumnDefinitionEventArgs extends SchemaEventArgs
 {
-    /** @var Column|null */
-    private $column;
+    private ?Column $column = null;
 
     /**
      * Raw column data as fetched from the database.
@@ -26,8 +25,7 @@ class SchemaColumnDefinitionEventArgs extends SchemaEventArgs
     /** @var string */
     private $database;
 
-    /** @var Connection */
-    private $connection;
+    private Connection $connection;
 
     /**
      * @param mixed[] $tableColumn

--- a/src/Event/SchemaCreateTableColumnEventArgs.php
+++ b/src/Event/SchemaCreateTableColumnEventArgs.php
@@ -15,17 +15,12 @@ use function is_array;
  */
 class SchemaCreateTableColumnEventArgs extends SchemaEventArgs
 {
-    /** @var Column */
-    private $column;
-
-    /** @var Table */
-    private $table;
-
-    /** @var AbstractPlatform */
-    private $platform;
+    private Column $column;
+    private Table $table;
+    private AbstractPlatform $platform;
 
     /** @var string[] */
-    private $sql = [];
+    private array $sql = [];
 
     public function __construct(Column $column, Table $table, AbstractPlatform $platform)
     {

--- a/src/Event/SchemaCreateTableEventArgs.php
+++ b/src/Event/SchemaCreateTableEventArgs.php
@@ -14,20 +14,18 @@ use function is_array;
  */
 class SchemaCreateTableEventArgs extends SchemaEventArgs
 {
-    /** @var Table */
-    private $table;
+    private Table $table;
 
     /** @var mixed[][] */
-    private $columns;
+    private array $columns;
 
     /** @var mixed[] */
-    private $options;
+    private array $options;
 
-    /** @var AbstractPlatform */
-    private $platform;
+    private AbstractPlatform $platform;
 
     /** @var string[] */
-    private $sql = [];
+    private array $sql = [];
 
     /**
      * @param mixed[][] $columns

--- a/src/Event/SchemaDropTableEventArgs.php
+++ b/src/Event/SchemaDropTableEventArgs.php
@@ -14,8 +14,7 @@ class SchemaDropTableEventArgs extends SchemaEventArgs
     /** @var string|Table */
     private $table;
 
-    /** @var AbstractPlatform */
-    private $platform;
+    private AbstractPlatform $platform;
 
     /** @var string|null */
     private $sql;

--- a/src/Event/SchemaEventArgs.php
+++ b/src/Event/SchemaEventArgs.php
@@ -9,8 +9,7 @@ use Doctrine\Common\EventArgs;
  */
 class SchemaEventArgs extends EventArgs
 {
-    /** @var bool */
-    private $preventDefault = false;
+    private bool $preventDefault = false;
 
     /**
      * @return SchemaEventArgs

--- a/src/Event/SchemaIndexDefinitionEventArgs.php
+++ b/src/Event/SchemaIndexDefinitionEventArgs.php
@@ -10,21 +10,19 @@ use Doctrine\DBAL\Schema\Index;
  */
 class SchemaIndexDefinitionEventArgs extends SchemaEventArgs
 {
-    /** @var Index|null */
-    private $index;
+    private ?Index $index = null;
 
     /**
      * Raw index data as fetched from the database.
      *
      * @var mixed[]
      */
-    private $tableIndex;
+    private array $tableIndex;
 
     /** @var string */
     private $table;
 
-    /** @var Connection */
-    private $connection;
+    private Connection $connection;
 
     /**
      * @param mixed[] $tableIndex

--- a/src/Event/TransactionEventArgs.php
+++ b/src/Event/TransactionEventArgs.php
@@ -9,8 +9,7 @@ use Doctrine\DBAL\Connection;
 
 abstract class TransactionEventArgs extends EventArgs
 {
-    /** @var Connection */
-    private $connection;
+    private Connection $connection;
 
     public function __construct(Connection $connection)
     {

--- a/src/Exception/DriverException.php
+++ b/src/Exception/DriverException.php
@@ -17,10 +17,8 @@ class DriverException extends Exception implements TheDriverException
 {
     /**
      * The query that triggered the exception, if any.
-     *
-     * @var Query|null
      */
-    private $query;
+    private ?Query $query;
 
     /**
      * @internal

--- a/src/ExpandArrayParameters.php
+++ b/src/ExpandArrayParameters.php
@@ -16,22 +16,21 @@ use function substr;
 final class ExpandArrayParameters implements Visitor
 {
     /** @var array<int,mixed>|array<string,mixed> */
-    private $originalParameters;
+    private array $originalParameters;
 
     /** @var array<int,Type|int|string|null>|array<string,Type|int|string|null> */
-    private $originalTypes;
+    private array $originalTypes;
 
-    /** @var int */
-    private $originalParameterIndex = 0;
+    private int $originalParameterIndex = 0;
 
     /** @var list<string> */
-    private $convertedSQL = [];
+    private array $convertedSQL = [];
 
     /** @var list<mixed> */
-    private $convertedParameteres = [];
+    private array $convertedParameteres = [];
 
     /** @var array<int,Type|int|string|null> */
-    private $convertedTypes = [];
+    private array $convertedTypes = [];
 
     /**
      * @param array<int, mixed>|array<string, mixed>                             $parameters

--- a/src/Id/TableGenerator.php
+++ b/src/Id/TableGenerator.php
@@ -57,14 +57,13 @@ use const CASE_LOWER;
  */
 class TableGenerator
 {
-    /** @var Connection */
-    private $conn;
+    private Connection $conn;
 
     /** @var string */
     private $generatorTableName;
 
     /** @var mixed[][] */
-    private $sequences = [];
+    private array $sequences = [];
 
     /**
      * @param string $generatorTableName

--- a/src/Logging/Connection.php
+++ b/src/Logging/Connection.php
@@ -12,8 +12,7 @@ use Psr\Log\LoggerInterface;
 
 final class Connection extends AbstractConnectionMiddleware
 {
-    /** @var LoggerInterface */
-    private $logger;
+    private LoggerInterface $logger;
 
     /**
      * @internal This connection can be only instantiated by its driver.

--- a/src/Logging/Driver.php
+++ b/src/Logging/Driver.php
@@ -10,8 +10,7 @@ use Psr\Log\LoggerInterface;
 
 final class Driver extends AbstractDriverMiddleware
 {
-    /** @var LoggerInterface */
-    private $logger;
+    private LoggerInterface $logger;
 
     /**
      * @internal This driver can be only instantiated by its middleware.

--- a/src/Logging/LoggerChain.php
+++ b/src/Logging/LoggerChain.php
@@ -12,7 +12,7 @@ use Doctrine\Deprecations\Deprecation;
 class LoggerChain implements SQLLogger
 {
     /** @var iterable<SQLLogger> */
-    private $loggers;
+    private iterable $loggers;
 
     /**
      * @param iterable<SQLLogger> $loggers

--- a/src/Logging/Middleware.php
+++ b/src/Logging/Middleware.php
@@ -10,8 +10,7 @@ use Psr\Log\LoggerInterface;
 
 final class Middleware implements MiddlewareInterface
 {
-    /** @var LoggerInterface */
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(LoggerInterface $logger)
     {

--- a/src/Logging/Statement.php
+++ b/src/Logging/Statement.php
@@ -15,17 +15,14 @@ use function func_get_args;
 
 final class Statement extends AbstractStatementMiddleware
 {
-    /** @var LoggerInterface */
-    private $logger;
-
-    /** @var string */
-    private $sql;
+    private LoggerInterface $logger;
+    private string $sql;
 
     /** @var array<int,mixed>|array<string,mixed> */
-    private $params = [];
+    private array $params = [];
 
     /** @var array<int,int>|array<string,int> */
-    private $types = [];
+    private array $types = [];
 
     /**
      * @internal This statement can be only instantiated by its connection.

--- a/src/Platforms/Keywords/KeywordList.php
+++ b/src/Platforms/Keywords/KeywordList.php
@@ -14,7 +14,7 @@ use function strtoupper;
 abstract class KeywordList
 {
     /** @var string[]|null */
-    private $keywords;
+    private ?array $keywords = null;
 
     /**
      * Checks if the given word is a keyword of this dialect/vendor platform.

--- a/src/Platforms/Keywords/ReservedKeywordsValidator.php
+++ b/src/Platforms/Keywords/ReservedKeywordsValidator.php
@@ -21,10 +21,10 @@ use function str_replace;
 class ReservedKeywordsValidator implements Visitor
 {
     /** @var KeywordList[] */
-    private $keywordLists;
+    private array $keywordLists;
 
     /** @var string[] */
-    private $violations = [];
+    private array $violations = [];
 
     /**
      * @param KeywordList[] $keywordLists

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -36,11 +36,10 @@ use function trim;
  */
 class PostgreSQLPlatform extends AbstractPlatform
 {
-    /** @var bool */
-    private $useBooleanTrueFalseStrings = true;
+    private bool $useBooleanTrueFalseStrings = true;
 
     /** @var string[][] PostgreSQL booleans literals */
-    private $booleanLiterals = [
+    private array $booleanLiterals = [
         'true' => [
             't',
             'true',

--- a/src/Platforms/SQLServer/Comparator.php
+++ b/src/Platforms/SQLServer/Comparator.php
@@ -13,8 +13,7 @@ use Doctrine\DBAL\Schema\Table;
  */
 class Comparator extends BaseComparator
 {
-    /** @var string */
-    private $databaseCollation;
+    private string $databaseCollation;
 
     /**
      * @internal The comparator can be only instantiated by a schema manager.

--- a/src/Portability/Connection.php
+++ b/src/Portability/Connection.php
@@ -18,8 +18,7 @@ final class Connection extends AbstractConnectionMiddleware
     public const PORTABILITY_EMPTY_TO_NULL = 4;
     public const PORTABILITY_FIX_CASE      = 8;
 
-    /** @var Converter */
-    private $converter;
+    private Converter $converter;
 
     public function __construct(ConnectionInterface $connection, Converter $converter)
     {

--- a/src/Portability/Driver.php
+++ b/src/Portability/Driver.php
@@ -15,11 +15,9 @@ use const CASE_UPPER;
 
 final class Driver extends AbstractDriverMiddleware
 {
-    /** @var int */
-    private $mode;
+    private int $mode;
 
-    /** @var int */
-    private $case;
+    private int $case;
 
     public function __construct(DriverInterface $driver, int $mode, int $case)
     {

--- a/src/Portability/Middleware.php
+++ b/src/Portability/Middleware.php
@@ -9,11 +9,9 @@ use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
 
 final class Middleware implements MiddlewareInterface
 {
-    /** @var int */
-    private $mode;
+    private int $mode;
 
-    /** @var int */
-    private $case;
+    private int $case;
 
     public function __construct(int $mode, int $case)
     {

--- a/src/Portability/OptimizeFlags.php
+++ b/src/Portability/OptimizeFlags.php
@@ -19,7 +19,7 @@ final class OptimizeFlags
      *
      * @var array<string,int>
      */
-    private static $platforms = [
+    private static array $platforms = [
         DB2Platform::class        => 0,
         OraclePlatform::class     => Connection::PORTABILITY_EMPTY_TO_NULL,
         PostgreSQLPlatform::class => 0,

--- a/src/Portability/Result.php
+++ b/src/Portability/Result.php
@@ -9,8 +9,7 @@ use Doctrine\DBAL\Driver\Result as ResultInterface;
 
 final class Result extends AbstractResultMiddleware
 {
-    /** @var Converter */
-    private $converter;
+    private Converter $converter;
 
     /**
      * @internal The result can be only instantiated by the portability connection or statement.

--- a/src/Portability/Statement.php
+++ b/src/Portability/Statement.php
@@ -11,8 +11,7 @@ use Doctrine\DBAL\Driver\Statement as DriverStatement;
  */
 final class Statement extends AbstractStatementMiddleware
 {
-    /** @var Converter */
-    private $converter;
+    private Converter $converter;
 
     /**
      * Wraps <tt>Statement</tt> and applies portability measures.

--- a/src/Query.php
+++ b/src/Query.php
@@ -15,24 +15,22 @@ final class Query
 {
     /**
      * The SQL query.
-     *
-     * @var string
      */
-    private $sql;
+    private string $sql;
 
     /**
      * The parameters bound to the query.
      *
      * @var array<mixed>
      */
-    private $params;
+    private array $params;
 
     /**
      * The types of the parameters bound to the query.
      *
      * @var array<Type|int|string|null>
      */
-    private $types;
+    private array $types;
 
     /**
      * @param array<mixed>                $params

--- a/src/Query/Expression/CompositeExpression.php
+++ b/src/Query/Expression/CompositeExpression.php
@@ -37,7 +37,7 @@ class CompositeExpression implements Countable
      *
      * @var self[]|string[]
      */
-    private $parts = [];
+    private array $parts = [];
 
     /**
      * @internal Use the and() / or() factory methods.

--- a/src/Query/Expression/ExpressionBuilder.php
+++ b/src/Query/Expression/ExpressionBuilder.php
@@ -25,10 +25,8 @@ class ExpressionBuilder
 
     /**
      * The DBAL Connection.
-     *
-     * @var Connection
      */
-    private $connection;
+    private Connection $connection;
 
     /**
      * Initializes a new <tt>ExpressionBuilder</tt>.

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -53,10 +53,8 @@ class QueryBuilder
 
     /**
      * The DBAL Connection.
-     *
-     * @var Connection
      */
-    private $connection;
+    private Connection $connection;
 
     /*
      * The default values of SQL parts collection
@@ -79,14 +77,12 @@ class QueryBuilder
      *
      * @var mixed[]
      */
-    private $sqlParts = self::SQL_PARTS_DEFAULTS;
+    private array $sqlParts = self::SQL_PARTS_DEFAULTS;
 
     /**
      * The complete SQL string for this query.
-     *
-     * @var string|null
      */
-    private $sql;
+    private ?string $sql = null;
 
     /**
      * The query parameters.
@@ -100,42 +96,32 @@ class QueryBuilder
      *
      * @var array<int, int|string|Type|null>|array<string, int|string|Type|null>
      */
-    private $paramTypes = [];
+    private array $paramTypes = [];
 
     /**
      * The type of query this is. Can be select, update or delete.
-     *
-     * @var int
      */
-    private $type = self::SELECT;
+    private int $type = self::SELECT;
 
     /**
      * The state of the query object. Can be dirty or clean.
-     *
-     * @var int
      */
-    private $state = self::STATE_CLEAN;
+    private int $state = self::STATE_CLEAN;
 
     /**
      * The index of the first result to retrieve.
-     *
-     * @var int
      */
-    private $firstResult = 0;
+    private int $firstResult = 0;
 
     /**
      * The maximum number of results to retrieve or NULL to retrieve all results.
-     *
-     * @var int|null
      */
-    private $maxResults;
+    private ?int $maxResults = null;
 
     /**
      * The counter of bound parameters used with {@see bindValue).
-     *
-     * @var int
      */
-    private $boundCounter = 0;
+    private int $boundCounter = 0;
 
     /**
      * Initializes a new <tt>QueryBuilder</tt>.

--- a/src/Result.php
+++ b/src/Result.php
@@ -15,11 +15,8 @@ use function func_num_args;
 
 class Result
 {
-    /** @var DriverResult */
-    private $result;
-
-    /** @var Connection */
-    private $connection;
+    private DriverResult $result;
+    private Connection $connection;
 
     /**
      * @internal The result can be only instantiated by {@see Connection} or {@see Statement}.

--- a/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
@@ -12,8 +12,7 @@ use function array_merge;
 
 final class CreateSchemaObjectsSQLBuilder
 {
-    /** @var AbstractPlatform */
-    private $platform;
+    private AbstractPlatform $platform;
 
     public function __construct(AbstractPlatform $platform)
     {

--- a/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
@@ -12,8 +12,7 @@ use function array_merge;
 
 final class DropSchemaObjectsSQLBuilder
 {
-    /** @var AbstractPlatform */
-    private $platform;
+    private AbstractPlatform $platform;
 
     public function __construct(AbstractPlatform $platform)
     {

--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -44,8 +44,7 @@ final class Parser
     private const SPECIAL              = '[' . self::SPECIAL_CHARS . ']';
     private const OTHER                = '[^' . self::SPECIAL_CHARS . ']+';
 
-    /** @var string */
-    private $sqlPattern;
+    private string $sqlPattern;
 
     public function __construct(bool $mySQLStringEscaping)
     {

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -27,8 +27,7 @@ use function strtolower;
  */
 class Comparator
 {
-    /** @var AbstractPlatform|null */
-    private $platform;
+    private ?AbstractPlatform $platform = null;
 
     /**
      * @internal The comparator can be only instantiated by a schema manager.

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -43,7 +43,7 @@ class Index extends AbstractAsset implements Constraint
      * @todo $_flags should eventually be refactored into options
      * @var mixed[]
      */
-    private $options;
+    private array $options;
 
     /**
      * @param string   $name

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -38,7 +38,7 @@ use const CASE_LOWER;
 class PostgreSQLSchemaManager extends AbstractSchemaManager
 {
     /** @var string[]|null */
-    private $existingSchemaPaths;
+    private ?array $existingSchemaPaths = null;
 
     /**
      * {@inheritDoc}

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -30,8 +30,7 @@ use const CASE_LOWER;
  */
 class SQLServerSchemaManager extends AbstractSchemaManager
 {
-    /** @var string|null */
-    private $databaseCollation;
+    private ?string $databaseCollation = null;
 
     /**
      * {@inheritDoc}

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -45,7 +45,7 @@ class Schema extends AbstractAsset
      *
      * @var string[]
      */
-    private $namespaces = [];
+    private array $namespaces = [];
 
     /** @var Table[] */
     protected $_tables = [];

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -47,7 +47,7 @@ class Table extends AbstractAsset
     protected $_schemaConfig;
 
     /** @var Index[] */
-    private $implicitIndexes = [];
+    private array $implicitIndexes = [];
 
     /**
      * @param Column[]               $columns

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -34,7 +34,7 @@ class UniqueConstraint extends AbstractAsset implements Constraint
      *
      * @var mixed[]
      */
-    private $options;
+    private array $options;
 
     /**
      * @param string[] $columns

--- a/src/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/src/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -16,19 +16,18 @@ use function array_merge;
 class CreateSchemaSqlCollector extends AbstractVisitor
 {
     /** @var string[] */
-    private $createNamespaceQueries = [];
+    private array $createNamespaceQueries = [];
 
     /** @var string[] */
-    private $createTableQueries = [];
+    private array $createTableQueries = [];
 
     /** @var string[] */
-    private $createSequenceQueries = [];
+    private array $createSequenceQueries = [];
 
     /** @var string[] */
-    private $createFkConstraintQueries = [];
+    private array $createFkConstraintQueries = [];
 
-    /** @var AbstractPlatform */
-    private $platform;
+    private AbstractPlatform $platform;
 
     public function __construct(AbstractPlatform $platform)
     {

--- a/src/Schema/Visitor/DropSchemaSqlCollector.php
+++ b/src/Schema/Visitor/DropSchemaSqlCollector.php
@@ -20,17 +20,10 @@ use function strlen;
  */
 class DropSchemaSqlCollector extends AbstractVisitor
 {
-    /** @var SplObjectStorage */
-    private $constraints;
-
-    /** @var SplObjectStorage */
-    private $sequences;
-
-    /** @var SplObjectStorage */
-    private $tables;
-
-    /** @var AbstractPlatform */
-    private $platform;
+    private SplObjectStorage $constraints;
+    private SplObjectStorage $sequences;
+    private SplObjectStorage $tables;
+    private AbstractPlatform $platform;
 
     public function __construct(AbstractPlatform $platform)
     {

--- a/src/Schema/Visitor/Graphviz.php
+++ b/src/Schema/Visitor/Graphviz.php
@@ -18,8 +18,7 @@ use function strtolower;
  */
 class Graphviz extends AbstractVisitor
 {
-    /** @var string */
-    private $output = '';
+    private string $output = '';
 
     /**
      * {@inheritdoc}

--- a/src/Schema/Visitor/RemoveNamespacedAssets.php
+++ b/src/Schema/Visitor/RemoveNamespacedAssets.php
@@ -23,8 +23,7 @@ use Doctrine\Deprecations\Deprecation;
  */
 class RemoveNamespacedAssets extends AbstractVisitor
 {
-    /** @var Schema|null */
-    private $schema;
+    private ?Schema $schema = null;
 
     public function __construct()
     {

--- a/src/Tools/Console/Command/ReservedWordsCommand.php
+++ b/src/Tools/Console/Command/ReservedWordsCommand.php
@@ -37,10 +37,9 @@ use function is_string;
 class ReservedWordsCommand extends Command
 {
     /** @var array<string,KeywordList> */
-    private $keywordLists;
+    private array $keywordLists;
 
-    /** @var ConnectionProvider */
-    private $connectionProvider;
+    private ConnectionProvider $connectionProvider;
 
     public function __construct(ConnectionProvider $connectionProvider)
     {

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -26,8 +26,7 @@ use function stripos;
  */
 class RunSqlCommand extends Command
 {
-    /** @var ConnectionProvider */
-    private $connectionProvider;
+    private ConnectionProvider $connectionProvider;
 
     public function __construct(ConnectionProvider $connectionProvider)
     {

--- a/src/Tools/Console/ConnectionProvider/SingleConnectionProvider.php
+++ b/src/Tools/Console/ConnectionProvider/SingleConnectionProvider.php
@@ -10,11 +10,9 @@ use function sprintf;
 
 class SingleConnectionProvider implements ConnectionProvider
 {
-    /** @var Connection */
-    private $connection;
+    private Connection $connection;
 
-    /** @var string */
-    private $defaultConnectionName;
+    private string $defaultConnectionName;
 
     public function __construct(Connection $connection, string $defaultConnectionName = 'default')
     {

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -47,8 +47,7 @@ abstract class Type
         Types::TIME_IMMUTABLE       => TimeImmutableType::class,
     ];
 
-    /** @var TypeRegistry|null */
-    private static $typeRegistry;
+    private static ?TypeRegistry $typeRegistry = null;
 
     /**
      * @internal Do not instantiate directly - use {@see Type::addType()} method instead.

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -16,7 +16,7 @@ use function in_array;
 final class TypeRegistry
 {
     /** @var array<string, Type> Map of type names and their corresponding flyweight objects. */
-    private $instances;
+    private array $instances;
 
     /**
      * @param array<string, Type> $instances

--- a/tests/Cache/QueryCacheProfileTest.php
+++ b/tests/Cache/QueryCacheProfileTest.php
@@ -13,20 +13,17 @@ class QueryCacheProfileTest extends TestCase
     private const LIFETIME  = 3600;
     private const CACHE_KEY = 'user_specified_cache_key';
 
-    /** @var QueryCacheProfile */
-    private $queryCacheProfile;
-
-    /** @var string */
-    private $query = 'SELECT * FROM foo WHERE bar = ?';
+    private QueryCacheProfile $queryCacheProfile;
+    private string $query = 'SELECT * FROM foo WHERE bar = ?';
 
     /** @var int[] */
-    private $params = [666];
+    private array $params = [666];
 
     /** @var int[] */
-    private $types = [ParameterType::INTEGER];
+    private array $types = [ParameterType::INTEGER];
 
     /** @var string[] */
-    private $connectionParams = [
+    private array $connectionParams = [
         'dbname'   => 'database_name',
         'user'     => 'database_user',
         'password' => 'database_password',

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -12,10 +12,8 @@ class ConfigurationTest extends TestCase
 {
     /**
      * The configuration container instance under test.
-     *
-     * @var Configuration
      */
-    protected $config;
+    protected Configuration $config;
 
     protected function setUp(): void
     {

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -36,8 +36,7 @@ class ConnectionTest extends TestCase
 {
     use VerifyDeprecations;
 
-    /** @var Connection */
-    private $connection;
+    private Connection $connection;
 
     /** @var array{wrapperClass?: class-string<Connection>} */
     protected $params = [

--- a/tests/Driver/AbstractDriverTest.php
+++ b/tests/Driver/AbstractDriverTest.php
@@ -23,10 +23,8 @@ abstract class AbstractDriverTest extends TestCase
 {
     /**
      * The driver mock under test.
-     *
-     * @var Driver
      */
-    protected $driver;
+    protected Driver $driver;
 
     protected function setUp(): void
     {

--- a/tests/Driver/OCI8/ExecutionModeTest.php
+++ b/tests/Driver/OCI8/ExecutionModeTest.php
@@ -9,8 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ExecutionModeTest extends TestCase
 {
-    /** @var ExecutionMode */
-    private $mode;
+    private ExecutionMode $mode;
 
     protected function setUp(): void
     {

--- a/tests/Driver/PDO/ExceptionTest.php
+++ b/tests/Driver/PDO/ExceptionTest.php
@@ -19,17 +19,13 @@ class ExceptionTest extends TestCase
 
     /**
      * The PDO exception wrapper under test.
-     *
-     * @var Exception
      */
-    private $exception;
+    private Exception $exception;
 
     /**
      * The wrapped PDO exception mock.
-     *
-     * @var PDOException
      */
-    private $wrappedException;
+    private PDOException $wrappedException;
 
     protected function setUp(): void
     {

--- a/tests/Functional/AutoIncrementColumnTest.php
+++ b/tests/Functional/AutoIncrementColumnTest.php
@@ -8,8 +8,7 @@ use Doctrine\DBAL\Tests\FunctionalTestCase;
 
 class AutoIncrementColumnTest extends FunctionalTestCase
 {
-    /** @var bool */
-    private $shouldDisableIdentityInsert = false;
+    private bool $shouldDisableIdentityInsert = false;
 
     protected function setUp(): void
     {

--- a/tests/Functional/Connection/FetchEmptyTest.php
+++ b/tests/Functional/Connection/FetchEmptyTest.php
@@ -10,8 +10,7 @@ use function sprintf;
 
 final class FetchEmptyTest extends FunctionalTestCase
 {
-    /** @var string */
-    private $query;
+    private string $query;
 
     public function setUp(): void
     {

--- a/tests/Functional/Connection/FetchTest.php
+++ b/tests/Functional/Connection/FetchTest.php
@@ -11,8 +11,7 @@ use function iterator_to_array;
 
 class FetchTest extends FunctionalTestCase
 {
-    /** @var string */
-    private $query;
+    private string $query;
 
     public function setUp(): void
     {

--- a/tests/Functional/Driver/AbstractDriverTest.php
+++ b/tests/Functional/Driver/AbstractDriverTest.php
@@ -12,10 +12,8 @@ abstract class AbstractDriverTest extends FunctionalTestCase
 {
     /**
      * The driver instance under test.
-     *
-     * @var Driver
      */
-    protected $driver;
+    protected Driver $driver;
 
     protected function setUp(): void
     {

--- a/tests/Functional/Driver/OCI8/ResultTest.php
+++ b/tests/Functional/Driver/OCI8/ResultTest.php
@@ -25,7 +25,7 @@ class ResultTest extends FunctionalTestCase
      *
      * @var array<string,mixed>
      */
-    private $connectionParams;
+    private array $connectionParams;
 
     protected function setUp(): void
     {

--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -16,8 +16,7 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 
 class NoneTest extends FunctionalTestCase
 {
-    /** @var Connection */
-    private $connection2;
+    private Connection $connection2;
 
     public function setUp(): void
     {

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -18,8 +18,7 @@ use function var_export;
 
 class ComparatorTest extends FunctionalTestCase
 {
-    /** @var AbstractSchemaManager */
-    private $schemaManager;
+    private AbstractSchemaManager $schemaManager;
 
     protected function setUp(): void
     {

--- a/tests/Functional/Schema/MySQL/ComparatorTest.php
+++ b/tests/Functional/Schema/MySQL/ComparatorTest.php
@@ -15,14 +15,11 @@ use Doctrine\DBAL\Types\Types;
 
 final class ComparatorTest extends FunctionalTestCase
 {
-    /** @var AbstractPlatform */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var AbstractSchemaManager */
-    private $schemaManager;
+    private AbstractSchemaManager $schemaManager;
 
-    /** @var Comparator */
-    private $comparator;
+    private Comparator $comparator;
 
     protected function setUp(): void
     {

--- a/tests/Functional/Schema/SQLite/ComparatorTest.php
+++ b/tests/Functional/Schema/SQLite/ComparatorTest.php
@@ -13,14 +13,11 @@ use Doctrine\DBAL\Types\Types;
 
 final class ComparatorTest extends FunctionalTestCase
 {
-    /** @var AbstractPlatform */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var AbstractSchemaManager */
-    private $schemaManager;
+    private AbstractSchemaManager $schemaManager;
 
-    /** @var Comparator */
-    private $comparator;
+    private Comparator $comparator;
 
     protected function setUp(): void
     {

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -55,8 +55,7 @@ use function substr;
 
 abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 {
-    /** @var AbstractSchemaManager */
-    protected $schemaManager;
+    protected AbstractSchemaManager $schemaManager;
 
     abstract protected function supportsPlatform(AbstractPlatform $platform): bool;
 
@@ -73,7 +72,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        if ($this->schemaManager === null) {
+        if (! isset($this->schemaManager)) {
             return;
         }
 

--- a/tests/Functional/TableGeneratorTest.php
+++ b/tests/Functional/TableGeneratorTest.php
@@ -10,8 +10,7 @@ use Doctrine\DBAL\Tests\FunctionalTestCase;
 
 class TableGeneratorTest extends FunctionalTestCase
 {
-    /** @var TableGenerator */
-    private $generator;
+    private TableGenerator $generator;
 
     protected function setUp(): void
     {

--- a/tests/Functional/TypeConversionTest.php
+++ b/tests/Functional/TypeConversionTest.php
@@ -13,8 +13,7 @@ use function str_repeat;
 
 class TypeConversionTest extends FunctionalTestCase
 {
-    /** @var int */
-    private static $typeCounter = 0;
+    private static int $typeCounter = 0;
 
     protected function setUp(): void
     {

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -12,20 +12,15 @@ abstract class FunctionalTestCase extends TestCase
 {
     /**
      * Shared connection when a TestCase is run alone (outside of it's functional suite)
-     *
-     * @var Connection|null
      */
-    private static $sharedConnection;
+    private static ?Connection $sharedConnection = null;
 
-    /** @var Connection */
-    protected $connection;
+    protected Connection $connection;
 
     /**
      * Whether the shared connection could be reused by subsequent tests.
-     *
-     * @var bool
      */
-    private $isConnectionReusable = true;
+    private bool $isConnectionReusable = true;
 
     /**
      * Mark shared connection not reusable for subsequent tests.

--- a/tests/Logging/DebugStackTest.php
+++ b/tests/Logging/DebugStackTest.php
@@ -7,8 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class DebugStackTest extends TestCase
 {
-    /** @var DebugStack */
-    private $logger;
+    private DebugStack $logger;
 
     protected function setUp(): void
     {

--- a/tests/Logging/MiddlewareTest.php
+++ b/tests/Logging/MiddlewareTest.php
@@ -14,8 +14,7 @@ use Psr\Log\LoggerInterface;
 
 class MiddlewareTest extends TestCase
 {
-    /** @var Driver */
-    private $driver;
+    private Driver $driver;
 
     /** @var LoggerInterface&MockObject */
     private $logger;

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -34,10 +34,9 @@ use function str_repeat;
 abstract class AbstractPlatformTestCase extends TestCase
 {
     /** @var T */
-    protected $platform;
+    protected AbstractPlatform $platform;
 
-    /** @var Type|null */
-    private $backedUpType;
+    private ?Type $backedUpType = null;
 
     /**
      * @return T

--- a/tests/Platforms/ReservedKeywordsValidatorTest.php
+++ b/tests/Platforms/ReservedKeywordsValidatorTest.php
@@ -9,8 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ReservedKeywordsValidatorTest extends TestCase
 {
-    /** @var ReservedKeywordsValidator */
-    private $validator;
+    private ReservedKeywordsValidator $validator;
 
     protected function setUp(): void
     {

--- a/tests/Portability/OptimizeFlagsTest.php
+++ b/tests/Portability/OptimizeFlagsTest.php
@@ -12,8 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class OptimizeFlagsTest extends TestCase
 {
-    /** @var OptimizeFlags */
-    private $optimizeFlags;
+    private OptimizeFlags $optimizeFlags;
 
     protected function setUp(): void
     {

--- a/tests/Portability/StatementTest.php
+++ b/tests/Portability/StatementTest.php
@@ -12,11 +12,10 @@ use PHPUnit\Framework\TestCase;
 
 class StatementTest extends TestCase
 {
-    /** @var Statement */
-    protected $stmt;
+    protected Statement $stmt;
 
     /** @var DriverStatement&MockObject */
-    protected $wrappedStmt;
+    protected DriverStatement $wrappedStmt;
 
     protected function setUp(): void
     {

--- a/tests/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Query/Expression/ExpressionBuilderTest.php
@@ -9,8 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ExpressionBuilderTest extends TestCase
 {
-    /** @var ExpressionBuilder */
-    protected $expr;
+    protected ExpressionBuilder $expr;
 
     protected function setUp(): void
     {

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 class QueryBuilderTest extends TestCase
 {
     /** @var Connection&MockObject */
-    protected $conn;
+    protected Connection $conn;
 
     protected function setUp(): void
     {

--- a/tests/SQL/ParserTest.php
+++ b/tests/SQL/ParserTest.php
@@ -13,7 +13,7 @@ use function sprintf;
 class ParserTest extends TestCase implements Visitor
 {
     /** @var list<string> */
-    private $result = [];
+    private array $result = [];
 
     /**
      * @dataProvider statementsWithParametersProvider

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -25,8 +25,7 @@ class ComparatorTest extends TestCase
 {
     use VerifyDeprecations;
 
-    /** @var Comparator */
-    protected $comparator;
+    protected Comparator $comparator;
 
     protected function setUp(): void
     {

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -11,8 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class MySQLSchemaTest extends TestCase
 {
-    /** @var AbstractPlatform */
-    private $platform;
+    private AbstractPlatform $platform;
 
     protected function setUp(): void
     {

--- a/tests/Schema/TableDiffTest.php
+++ b/tests/Schema/TableDiffTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 class TableDiffTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
     public function setUp(): void
     {

--- a/tests/Schema/Visitor/CreateSchemaSqlCollectorTest.php
+++ b/tests/Schema/Visitor/CreateSchemaSqlCollectorTest.php
@@ -13,10 +13,9 @@ use PHPUnit\Framework\TestCase;
 class CreateSchemaSqlCollectorTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platformMock;
+    private AbstractPlatform $platformMock;
 
-    /** @var CreateSchemaSqlCollector */
-    private $visitor;
+    private CreateSchemaSqlCollector $visitor;
 
     protected function setUp(): void
     {

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -17,13 +17,13 @@ use PHPUnit\Framework\TestCase;
 class StatementTest extends TestCase
 {
     /** @var Connection&MockObject */
-    private $conn;
+    private Connection $conn;
 
     /** @var Configuration&MockObject */
-    private $configuration;
+    private Configuration $configuration;
 
     /** @var DriverStatement&MockObject */
-    private $driverStatement;
+    private DriverStatement $driverStatement;
 
     protected function setUp(): void
     {

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -33,8 +33,8 @@ use function unlink;
  */
 class TestUtil
 {
-    /** @var bool Whether the database schema is initialized. */
-    private static $initialized = false;
+    /** Whether the database schema is initialized. */
+    private static bool $initialized = false;
 
     /**
      * Creates a new <b>test</b> database connection using the following parameters

--- a/tests/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Tools/Console/RunSqlCommandTest.php
@@ -15,13 +15,11 @@ use function str_replace;
 
 class RunSqlCommandTest extends TestCase
 {
-    /** @var CommandTester */
-    private $commandTester;
-    /** @var RunSqlCommand */
-    private $command;
+    private CommandTester $commandTester;
+    private RunSqlCommand $command;
 
     /** @var Connection&MockObject */
-    private $connectionMock;
+    private Connection $connectionMock;
 
     protected function setUp(): void
     {

--- a/tests/Types/ArrayTest.php
+++ b/tests/Types/ArrayTest.php
@@ -13,10 +13,9 @@ use function serialize;
 class ArrayTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var ArrayType */
-    private $type;
+    private ArrayType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/AsciiStringTest.php
+++ b/tests/Types/AsciiStringTest.php
@@ -11,8 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class AsciiStringTest extends TestCase
 {
-    /** @var AsciiStringType */
-    private $type;
+    private AsciiStringType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/BaseDateTypeTestCase.php
+++ b/tests/Types/BaseDateTypeTestCase.php
@@ -17,13 +17,10 @@ use function date_default_timezone_set;
 abstract class BaseDateTypeTestCase extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    protected $platform;
+    protected AbstractPlatform $platform;
 
-    /** @var Type */
-    protected $type;
-
-    /** @var string */
-    private $currentTimezone;
+    protected Type $type;
+    private string $currentTimezone;
 
     protected function setUp(): void
     {

--- a/tests/Types/BinaryTest.php
+++ b/tests/Types/BinaryTest.php
@@ -17,10 +17,9 @@ use function stream_get_contents;
 class BinaryTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    protected $platform;
+    protected AbstractPlatform $platform;
 
-    /** @var BinaryType */
-    protected $type;
+    protected BinaryType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/BlobTest.php
+++ b/tests/Types/BlobTest.php
@@ -15,10 +15,9 @@ use function stream_get_contents;
 class BlobTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    protected $platform;
+    protected AbstractPlatform $platform;
 
-    /** @var BlobType */
-    protected $type;
+    protected BlobType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/BooleanTest.php
+++ b/tests/Types/BooleanTest.php
@@ -10,10 +10,9 @@ use PHPUnit\Framework\TestCase;
 class BooleanTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var BooleanType */
-    private $type;
+    private BooleanType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/DateImmutableTypeTest.php
+++ b/tests/Types/DateImmutableTypeTest.php
@@ -16,10 +16,9 @@ use function get_class;
 class DateImmutableTypeTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var DateImmutableType */
-    private $type;
+    private DateImmutableType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/DateIntervalTest.php
+++ b/tests/Types/DateIntervalTest.php
@@ -14,10 +14,9 @@ use stdClass;
 final class DateIntervalTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var DateIntervalType */
-    private $type;
+    private DateIntervalType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Types/DateTimeImmutableTypeTest.php
@@ -16,10 +16,9 @@ use function get_class;
 class DateTimeImmutableTypeTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var DateTimeImmutableType */
-    private $type;
+    private DateTimeImmutableType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Types/DateTimeTzImmutableTypeTest.php
@@ -16,10 +16,9 @@ use function get_class;
 class DateTimeTzImmutableTypeTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var DateTimeTzImmutableType */
-    private $type;
+    private DateTimeTzImmutableType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/DecimalTest.php
+++ b/tests/Types/DecimalTest.php
@@ -10,10 +10,9 @@ use PHPUnit\Framework\TestCase;
 class DecimalTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var DecimalType */
-    private $type;
+    private DecimalType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/FloatTest.php
+++ b/tests/Types/FloatTest.php
@@ -10,10 +10,9 @@ use PHPUnit\Framework\TestCase;
 class FloatTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var FloatType */
-    private $type;
+    private FloatType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/GuidTypeTest.php
+++ b/tests/Types/GuidTypeTest.php
@@ -10,10 +10,9 @@ use PHPUnit\Framework\TestCase;
 class GuidTypeTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var GuidType */
-    private $type;
+    private GuidType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/IntegerTest.php
+++ b/tests/Types/IntegerTest.php
@@ -10,10 +10,9 @@ use PHPUnit\Framework\TestCase;
 class IntegerTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var IntegerType */
-    private $type;
+    private IntegerType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/JsonTest.php
+++ b/tests/Types/JsonTest.php
@@ -20,10 +20,9 @@ use const JSON_THROW_ON_ERROR;
 class JsonTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    protected $platform;
+    protected AbstractPlatform $platform;
 
-    /** @var JsonType */
-    protected $type;
+    protected JsonType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/ObjectTest.php
+++ b/tests/Types/ObjectTest.php
@@ -14,10 +14,9 @@ use function serialize;
 class ObjectTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var ObjectType */
-    private $type;
+    private ObjectType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/SmallIntTest.php
+++ b/tests/Types/SmallIntTest.php
@@ -10,10 +10,9 @@ use PHPUnit\Framework\TestCase;
 class SmallIntTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var SmallIntType */
-    private $type;
+    private SmallIntType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/StringTest.php
+++ b/tests/Types/StringTest.php
@@ -10,10 +10,9 @@ use PHPUnit\Framework\TestCase;
 class StringTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var StringType */
-    private $type;
+    private StringType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/TimeImmutableTypeTest.php
+++ b/tests/Types/TimeImmutableTypeTest.php
@@ -16,10 +16,9 @@ use function get_class;
 class TimeImmutableTypeTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var TimeImmutableType */
-    private $type;
+    private TimeImmutableType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/TypeRegistryTest.php
+++ b/tests/Types/TypeRegistryTest.php
@@ -17,14 +17,9 @@ class TypeRegistryTest extends TestCase
     private const TEST_TYPE_NAME       = 'test';
     private const OTHER_TEST_TYPE_NAME = 'other';
 
-    /** @var TypeRegistry */
-    private $registry;
-
-    /** @var BlobType */
-    private $testType;
-
-    /** @var BinaryType */
-    private $otherTestType;
+    private TypeRegistry $registry;
+    private BlobType $testType;
+    private BinaryType $otherTestType;
 
     protected function setUp(): void
     {

--- a/tests/Types/VarDateTimeImmutableTypeTest.php
+++ b/tests/Types/VarDateTimeImmutableTypeTest.php
@@ -14,10 +14,9 @@ use PHPUnit\Framework\TestCase;
 class VarDateTimeImmutableTypeTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var VarDateTimeImmutableType */
-    private $type;
+    private VarDateTimeImmutableType $type;
 
     protected function setUp(): void
     {

--- a/tests/Types/VarDateTimeTest.php
+++ b/tests/Types/VarDateTimeTest.php
@@ -12,10 +12,9 @@ use PHPUnit\Framework\TestCase;
 class VarDateTimeTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
-    private $platform;
+    private AbstractPlatform $platform;
 
-    /** @var VarDateTimeType */
-    private $type;
+    private VarDateTimeType $type;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Now that we've bumped to PHP 7.4, we can make use of property types. This PR adds them where doing so should not be a breaking change.
