### PR TITLE
Make AbstractSchemaManager::_getPortableTableForeignKeyDefinition() abstract

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -772,8 +772,6 @@ abstract class AbstractSchemaManager
 
     /**
      * @param array<string, mixed> $view
-     *
-     * @abstract
      */
     abstract protected function _getPortableViewDefinition(array $view): View;
 
@@ -795,13 +793,8 @@ abstract class AbstractSchemaManager
 
     /**
      * @param array<string, mixed> $tableForeignKey
-     *
-     * @abstract
      */
-    protected function _getPortableTableForeignKeyDefinition(array $tableForeignKey): ForeignKeyConstraint
-    {
-        throw NotSupported::new('ForeignKey');
-    }
+    abstract protected function _getPortableTableForeignKeyDefinition(array $tableForeignKey): ForeignKeyConstraint;
 
     /**
      * @param array<int, string>|string $sql


### PR DESCRIPTION
This change is similar to #5456. It is possible to declare the method abstract as of #5457.