### PR TITLE
Remove Driver::getSchemaManager()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: removed `Driver::getSchemaManager()`
+
+The `Driver::getSchemaManager()` method has been removed.
+
 ## BC BREAK: removed `AbstractSchemaManager::getDatabasePlatform()`
 
 The `AbstractSchemaManager::getDatabasePlatform()` method has been removed.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -39,10 +39,6 @@
                     See https://github.com/doctrine/dbal/pull/4317
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Driver::getSchemaManager"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1264,10 +1264,8 @@ class Connection implements ServerVersionProvider
      */
     public function createSchemaManager(): AbstractSchemaManager
     {
-        return $this->_driver->getSchemaManager(
-            $this,
-            $this->getDatabasePlatform()
-        );
+        return $this->getDatabasePlatform()
+            ->createSchemaManager($this);
     }
 
     /**

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 
 /**
  * Driver interface.
@@ -34,14 +33,6 @@ interface Driver
      * @return AbstractPlatform The database platform.
      */
     public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform;
-
-    /**
-     * Gets the SchemaManager that can be used to inspect and change the underlying
-     * database schema of the platform this driver connects to.
-     *
-     * @deprecated Use {@link AbstractPlatform::createSchemaManager()} instead.
-     */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager;
 
     /**
      * Gets the ExceptionConverter that can be used to convert driver-level exceptions into DBAL exceptions.

--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -4,16 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\IBMDB2\ExceptionConverter;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
-use Doctrine\DBAL\Schema\DB2SchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
-use Doctrine\Deprecations\Deprecation;
-
-use function assert;
 
 /**
  * Abstract base implementation of the {@see Driver} interface for IBM DB2 based drivers.
@@ -23,23 +17,6 @@ abstract class AbstractDB2Driver implements Driver
     public function getDatabasePlatform(ServerVersionProvider $versionProvider): DB2Platform
     {
         return new DB2Platform();
-    }
-
-    /**
-     * @deprecated Use {@link DB2Platform::createSchemaManager()} instead.
-     */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): DB2SchemaManager
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5458',
-            'AbstractDB2Driver::getSchemaManager() is deprecated.'
-                . ' Use DB2Platform::createSchemaManager() instead.'
-        );
-
-        assert($platform instanceof DB2Platform);
-
-        return new DB2SchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -4,21 +4,16 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\MySQL\ExceptionConverter;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Exception\InvalidPlatformVersion;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
-use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
-use Doctrine\Deprecations\Deprecation;
 
-use function assert;
 use function preg_match;
 use function stripos;
 use function version_compare;
@@ -79,23 +74,6 @@ abstract class AbstractMySQLDriver implements Driver
         }
 
         return $majorVersion . '.' . $minorVersion . '.' . $patchVersion;
-    }
-
-    /**
-     * @deprecated Use {@link AbstractMySQLPlatform::createSchemaManager()} instead.
-     */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): MySQLSchemaManager
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5458',
-            'AbstractMySQLDriver::getSchemaManager() is deprecated.'
-                . ' Use MySQLPlatform::createSchemaManager() instead.'
-        );
-
-        assert($platform instanceof AbstractMySQLPlatform);
-
-        return new MySQLSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Driver/AbstractOracleDriver.php
+++ b/src/Driver/AbstractOracleDriver.php
@@ -4,17 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\AbstractOracleDriver\EasyConnectString;
 use Doctrine\DBAL\Driver\API\OCI\ExceptionConverter;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Schema\OracleSchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
-use Doctrine\Deprecations\Deprecation;
-
-use function assert;
 
 /**
  * Abstract base implementation of the {@see Driver} interface for Oracle based drivers.
@@ -24,23 +18,6 @@ abstract class AbstractOracleDriver implements Driver
     public function getDatabasePlatform(ServerVersionProvider $versionProvider): OraclePlatform
     {
         return new OraclePlatform();
-    }
-
-    /**
-     * @deprecated Use {@link OraclePlatform::createSchemaManager()} instead.
-     */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): OracleSchemaManager
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5458',
-            'AbstractOracleDriver::getSchemaManager() is deprecated.'
-                . ' Use OraclePlatform::createSchemaManager() instead.'
-        );
-
-        assert($platform instanceof OraclePlatform);
-
-        return new OracleSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -4,16 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\PostgreSQL\ExceptionConverter;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
-use Doctrine\Deprecations\Deprecation;
-
-use function assert;
 
 /**
  * Abstract base implementation of the {@see Driver} interface for PostgreSQL based drivers.
@@ -23,23 +17,6 @@ abstract class AbstractPostgreSQLDriver implements Driver
     public function getDatabasePlatform(ServerVersionProvider $versionProvider): PostgreSQLPlatform
     {
         return new PostgreSQLPlatform();
-    }
-
-    /**
-     * @deprecated Use {@link PostgreSQLPlatform::createSchemaManager()} instead.
-     */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): PostgreSQLSchemaManager
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5458',
-            'AbstractPostgreSQLDriver::getSchemaManager() is deprecated.'
-                . ' Use PostgreSQLPlatform::createSchemaManager() instead.'
-        );
-
-        assert($platform instanceof PostgreSQLPlatform);
-
-        return new PostgreSQLSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Driver/AbstractSQLServerDriver.php
+++ b/src/Driver/AbstractSQLServerDriver.php
@@ -4,16 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\SQLSrv\ExceptionConverter;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
-use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
-use Doctrine\Deprecations\Deprecation;
-
-use function assert;
 
 /**
  * Abstract base implementation of the {@see Driver} interface for Microsoft SQL Server based drivers.
@@ -23,23 +17,6 @@ abstract class AbstractSQLServerDriver implements Driver
     public function getDatabasePlatform(ServerVersionProvider $versionProvider): SQLServerPlatform
     {
         return new SQLServerPlatform();
-    }
-
-    /**
-     * @deprecated Use {@link SQLServerPlatform::createSchemaManager()} instead.
-     */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): SQLServerSchemaManager
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5458',
-            'AbstractSQLServerDriver::getSchemaManager() is deprecated.'
-                . ' Use SQLServerPlatform::createSchemaManager() instead.'
-        );
-
-        assert($platform instanceof SQLServerPlatform);
-
-        return new SQLServerSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Driver/AbstractSQLiteDriver.php
+++ b/src/Driver/AbstractSQLiteDriver.php
@@ -4,16 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\SQLite\ExceptionConverter;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
-use Doctrine\Deprecations\Deprecation;
-
-use function assert;
 
 /**
  * Abstract base implementation of the {@see Driver} interface for SQLite based drivers.
@@ -23,23 +17,6 @@ abstract class AbstractSQLiteDriver implements Driver
     public function getDatabasePlatform(ServerVersionProvider $versionProvider): SqlitePlatform
     {
         return new SqlitePlatform();
-    }
-
-    /**
-     * @deprecated Use {@link SqlitePlatform::createSchemaManager()} instead.
-     */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): SqliteSchemaManager
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5458',
-            'AbstractSQLiteDriver::getSchemaManager() is deprecated.'
-                . ' Use SqlitePlatform::createSchemaManager() instead.'
-        );
-
-        assert($platform instanceof SqlitePlatform);
-
-        return new SqliteSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/src/Driver/Middleware/AbstractDriverMiddleware.php
+++ b/src/Driver/Middleware/AbstractDriverMiddleware.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\Middleware;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\ServerVersionProvider;
-use Doctrine\Deprecations\Deprecation;
 
 abstract class AbstractDriverMiddleware implements Driver
 {
@@ -33,21 +30,6 @@ abstract class AbstractDriverMiddleware implements Driver
     public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform
     {
         return $this->wrappedDriver->getDatabasePlatform($versionProvider);
-    }
-
-    /**
-     * @deprecated Use {@link AbstractPlatform::createSchemaManager()} instead.
-     */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5458',
-            'AbstractDriverMiddleware::getSchemaManager() is deprecated.'
-                . ' Use AbstractPlatform::createSchemaManager() instead.'
-        );
-
-        return $this->wrappedDriver->getSchemaManager($conn, $platform);
     }
 
     public function getExceptionConverter(): ExceptionConverter

--- a/tests/Driver/AbstractDriverTest.php
+++ b/tests/Driver/AbstractDriverTest.php
@@ -13,7 +13,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
 
 /**
  * @template P of AbstractPlatform
@@ -48,22 +47,6 @@ abstract class AbstractDriverTest extends TestCase
         $this->driver->getDatabasePlatform(
             new StaticServerVersionProvider('foo')
         );
-    }
-
-    public function testReturnsSchemaManager(): void
-    {
-        $connection    = $this->getConnectionMock();
-        $schemaManager = $this->driver->getSchemaManager(
-            $connection,
-            $this->createPlatform()
-        );
-
-        self::assertEquals($this->createSchemaManager($connection), $schemaManager);
-
-        $re = new ReflectionProperty($schemaManager, '_conn');
-        $re->setAccessible(true);
-
-        self::assertSame($connection, $re->getValue($schemaManager));
     }
 
     public function testReturnsExceptionConverter(): void


### PR DESCRIPTION
The method was deprecated in #5458.