### PR TITLE
Fix order of binding parameters on ibm_db2

### DIFF
--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -263,6 +263,25 @@ EOF
         $statement->executeQuery(['bar' => 'baz']);
     }
 
+    public function testParameterBindingOrder(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        // some supported drivers don't support selecting an untyped literal
+        // from a dummy table, so we wrap it into a function that assumes its type
+        $query = $platform->getDummySelectSQL(
+            $platform->getLengthExpression('?')
+                . ', '
+                . $platform->getLengthExpression('?')
+        );
+
+        $stmt = $this->connection->prepare($query);
+        $stmt->bindValue(2, 'banana');
+        $stmt->bindValue(1, 'apple');
+
+        self::assertEquals([5, 6], $stmt->executeQuery()->fetchNumeric());
+    }
+
     /**
      * @param mixed $expected
      *


### PR DESCRIPTION
The current implementation of `IBMDB2\Statement::execute()` messes up the order of parameters if they were bound out of order (see the test).