### PR TITLE
Deprecate array and object column types

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,20 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `array` and `object` column types.
+
+The `array` and `object` column types have been deprecated since they use PHP built-in serialization. Without additional
+configuration, which the API of these types doesn't allow, the usage of built-in serialization may lead to
+security issues.
+
+The following classes and constants have been deprecated:
+- `ArrayType`,
+- `ObjectType`,
+- `Types::ARRAY`,
+- `Types::OBJECT`.
+
+Use JSON for storing unstructured data.
+
 ## Deprecated `Driver::getSchemaManager()`.
 
 The `Driver::getSchemaManager()` method has been deprecated. Use `AbstractPlatform::createSchemaManager()` instead.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -95,8 +95,24 @@
                 -->
                 <referencedClass name="Doctrine\DBAL\Schema\Visitor\AbstractVisitor"/>
                 <referencedClass name="Doctrine\DBAL\Schema\Visitor\Visitor"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedClass name="Doctrine\DBAL\Types\ArrayType"/>
+                <referencedClass name="Doctrine\DBAL\Types\ObjectType"/>
             </errorLevel>
         </DeprecatedClass>
+        <DeprecatedConstant>
+            <errorLevel type="suppress">
+            <!--
+                TODO: remove in 4.0.0
+            -->
+                <file name="src/Types/ArrayType.php"/>
+                <file name="src/Types/ObjectType.php"/>
+                <file name="src/Types/Type.php"/>
+                <file name="tests/Schema/ComparatorTest.php"/>
+            </errorLevel>
+        </DeprecatedConstant>
         <DeprecatedInterface>
             <errorLevel type="suppress">
                 <!--

--- a/src/Types/ArrayType.php
+++ b/src/Types/ArrayType.php
@@ -13,6 +13,8 @@ use function unserialize;
 
 /**
  * Type that maps a PHP array to a clob SQL type.
+ *
+ * @deprecated Use {@link JsonType} instead.
  */
 class ArrayType extends Type
 {

--- a/src/Types/ObjectType.php
+++ b/src/Types/ObjectType.php
@@ -13,6 +13,8 @@ use function unserialize;
 
 /**
  * Type that maps a PHP object to a clob SQL type.
+ *
+ * @deprecated Use {@link JsonType} instead.
  */
 class ObjectType extends Type
 {

--- a/src/Types/Types.php
+++ b/src/Types/Types.php
@@ -9,7 +9,11 @@ namespace Doctrine\DBAL\Types;
  */
 final class Types
 {
-    public const ARRAY                = 'array';
+    /**
+     * @deprecated Use {@link Types::JSON} instead.
+     */
+    public const ARRAY = 'array';
+
     public const ASCII_STRING         = 'ascii_string';
     public const BIGINT               = 'bigint';
     public const BINARY               = 'binary';
@@ -27,13 +31,18 @@ final class Types
     public const GUID                 = 'guid';
     public const INTEGER              = 'integer';
     public const JSON                 = 'json';
-    public const OBJECT               = 'object';
-    public const SIMPLE_ARRAY         = 'simple_array';
-    public const SMALLINT             = 'smallint';
-    public const STRING               = 'string';
-    public const TEXT                 = 'text';
-    public const TIME_MUTABLE         = 'time';
-    public const TIME_IMMUTABLE       = 'time_immutable';
+
+    /**
+     * @deprecated Use {@link Types::JSON} instead.
+     */
+    public const OBJECT = 'object';
+
+    public const SIMPLE_ARRAY   = 'simple_array';
+    public const SMALLINT       = 'smallint';
+    public const STRING         = 'string';
+    public const TEXT           = 'text';
+    public const TIME_MUTABLE   = 'time';
+    public const TIME_IMMUTABLE = 'time_immutable';
 
     /**
      * @codeCoverageIgnore


### PR DESCRIPTION
The `array` and `object` column types use PHP built-in serialization. Without additional configuration (specifically, the `allowed_classes` option), which the API of these types doesn't allow, the usage of built-in serialization may lead to security issues (see [object injection](https://owasp.org/www-community/vulnerabilities/PHP_Object_Injection)).