### PR TITLE
Use double quotes for strings containing contractions

### DIFF
--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -54,7 +54,7 @@ class StatementTest extends FunctionalTestCase
     public function testReuseStatementWithLongerResults(): void
     {
         if (TestUtil::isDriverOneOf('pdo_oci')) {
-            self::markTestIncomplete('PDO_OCI doesn\'t support fetching blobs via PDOStatement::fetchAll()');
+            self::markTestIncomplete("PDO_OCI doesn't support fetching blobs via PDOStatement::fetchAll()");
         }
 
         $table = new Table('stmt_longer_results');
@@ -92,7 +92,7 @@ class StatementTest extends FunctionalTestCase
         if (TestUtil::isDriverOneOf('pdo_oci')) {
             // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
             // see http://php.net/manual/en/pdo.lobs.php#example-1035
-            self::markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');
+            self::markTestSkipped("DBAL doesn't support storing LOBs represented as streams using PDO_OCI");
         }
 
         // make sure memory limit is large enough to not cause false positives,

--- a/tests/Functional/TypeConversionTest.php
+++ b/tests/Functional/TypeConversionTest.php
@@ -119,7 +119,7 @@ class TypeConversionTest extends FunctionalTestCase
         if ($type === 'text' && TestUtil::isDriverOneOf('pdo_oci')) {
             // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
             // see http://php.net/manual/en/pdo.lobs.php#example-1035
-            self::markTestSkipped('DBAL doesn\'t support storing LOBs represented as streams using PDO_OCI');
+            self::markTestSkipped("DBAL doesn't support storing LOBs represented as streams using PDO_OCI");
         }
 
         $dbValue = $this->processValue($type, $originalValue);

--- a/tests/Functional/Types/BinaryTest.php
+++ b/tests/Functional/Types/BinaryTest.php
@@ -19,7 +19,7 @@ class BinaryTest extends FunctionalTestCase
     protected function setUp(): void
     {
         if (TestUtil::isDriverOneOf('pdo_oci')) {
-            self::markTestSkipped('PDO_OCI doesn\'t support binding binary values');
+            self::markTestSkipped("PDO_OCI doesn't support binding binary values");
         }
 
         $table = new Table('binary_table');


### PR DESCRIPTION
IntelliJ IDEA's spellchecker reports `'doesn\'t'` as a typo.