### PR TITLE
Deprecate Configuration::getSQLLogger() and setSQLLogger()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -301,6 +301,8 @@ an exception. The characters are the following: `{}()/\@`.
 The `SQLLogger` and its implementations `DebugStack` and `LoggerChain` have been deprecated.
 For logging purposes, use `Doctrine\DBAL\Logging\Middleware` instead. No replacement for `DebugStack` is provided.
 
+The `Configuration` methods `getSQLLogger()` and `setSQLLogger()` have been deprecated as well.
+
 ## Deprecated `SqliteSchemaManager::createDatabase()` and `dropDatabase()` methods.
 
 The `SqliteSchemaManager::createDatabase()` and `dropDatabase()` methods have been deprecated. The SQLite engine

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -295,6 +295,12 @@
                 <referencedMethod name="Doctrine\DBAL\Types\Type::canRequireSQLConversion"/>
                 <!--
                     TODO: remove in 4.0.0
+                    See https://github.com/doctrine/dbal/pull/4967
+                -->
+                <referencedMethod name="Doctrine\DBAL\Configuration::getSQLLogger"/>
+                <referencedMethod name="Doctrine\DBAL\Configuration::setSQLLogger"/>
+                <!--
+                    TODO: remove in 4.0.0
                     See https://github.com/doctrine/dbal/pull/5204
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getColumnComment"/>

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -55,17 +55,35 @@ class Configuration
 
     /**
      * Sets the SQL logger to use. Defaults to NULL which means SQL logging is disabled.
+     *
+     * @deprecated Use {@see setMiddlewares()} and {@see \Doctrine\DBAL\Logging\Middleware} instead.
      */
     public function setSQLLogger(?SQLLogger $logger = null): void
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4967',
+            '%s is deprecated, use setMiddlewares() and Logging\\Middleware instead.',
+            __METHOD__
+        );
+
         $this->sqlLogger = $logger;
     }
 
     /**
      * Gets the SQL logger that is used.
+     *
+     * @deprecated
      */
     public function getSQLLogger(): ?SQLLogger
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4967',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return $this->sqlLogger;
     }
 


### PR DESCRIPTION
These methods should have been deprecated as part of https://github.com/doctrine/dbal/pull/4967.