### PR TITLE
Fix filtering tables according to the configuration

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -412,9 +412,14 @@ abstract class AbstractSchemaManager
         $foreignKeyColumnsByTable = $this->fetchForeignKeyColumnsByTable($database);
         $tableOptionsByTable      = $this->fetchTableOptionsByTable($database);
 
+        $filter = $this->_conn->getConfiguration()->getSchemaAssetsFilter();
         $tables = [];
 
         foreach ($tableColumnsByTable as $tableName => $tableColumns) {
+            if ($filter !== null && ! $filter($tableName)) {
+                continue;
+            }
+
             $tables[] = new Table(
                 $tableName,
                 $this->_getPortableTableColumnList($tableName, $database, $tableColumns),

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -24,7 +24,6 @@ use function array_pop;
 use function array_unshift;
 use function assert;
 use function count;
-use function preg_match;
 use function strtolower;
 
 class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
@@ -213,31 +212,6 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
             ],
             $this->connection->getDatabasePlatform()->getCreateTableSQL($table)
         );
-    }
-
-    public function testFilterSchemaExpression(): void
-    {
-        $testTable = new Table('dbal204_test_prefix');
-        $testTable->addColumn('id', 'integer');
-        $this->dropAndCreateTable($testTable);
-
-        $testTable = new Table('dbal204_without_prefix');
-        $testTable->addColumn('id', 'integer');
-        $this->dropAndCreateTable($testTable);
-
-        $this->markConnectionNotReusable();
-
-        $this->connection->getConfiguration()->setSchemaAssetsFilter(static function (string $name): bool {
-            return preg_match('#^dbal204_#', $name) === 1;
-        });
-        $names = $this->schemaManager->listTableNames();
-        self::assertCount(2, $names);
-
-        $this->connection->getConfiguration()->setSchemaAssetsFilter(static function (string $name): bool {
-            return preg_match('#^dbal204_test#', $name) === 1;
-        });
-        $names = $this->schemaManager->listTableNames();
-        self::assertCount(1, $names);
     }
 
     public function testListForeignKeys(): void


### PR DESCRIPTION
Prior to https://github.com/doctrine/dbal/pull/5268, `listTables()` called `listTableNames()` internally which in turn implemented filtering table names according to the configuration. After this change, `listTables()` no longer calls `listTableNames()`, so the configuration is no longer respected.

This scenario wasn't covered by the test suite.