### PR TITLE
Deprecate NULL schema asset filter

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `NULL` schema asset filter.
+
+Not passing an argument to `Configuration::setSchemaAssetsFilter()` and passing `NULL` as the value of `$callable`
+has been deprecated. In order to disable filtering, pass a callable that always returns true.
+
 ## Deprecated custom schema options.
 
 Custom schema options have been deprecated since they effectively duplicate the functionality of platform options.

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\Deprecations\Deprecation;
 use Psr\Cache\CacheItemPoolInterface;
 
+use function func_num_args;
+
 /**
  * Configuration container for the Doctrine DBAL.
  */
@@ -52,6 +54,13 @@ class Configuration
      * @var bool
      */
     protected $autoCommit = true;
+
+    public function __construct()
+    {
+        $this->schemaAssetsFilter = static function (): bool {
+            return true;
+        };
+    }
 
     /**
      * Sets the SQL logger to use. Defaults to NULL which means SQL logging is disabled.
@@ -144,6 +153,22 @@ class Configuration
      */
     public function setSchemaAssetsFilter(?callable $callable = null): void
     {
+        if (func_num_args() < 1) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5483',
+                'Not passing an argument to %s is deprecated.',
+                __METHOD__
+            );
+        } elseif ($callable === null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5483',
+                'Using NULL as a schema asset filter is deprecated.'
+                    . ' Use a callable that always returns true instead.',
+            );
+        }
+
         $this->schemaAssetsFilter = $callable;
     }
 


### PR DESCRIPTION
Having the filter nullable requires checking for null every time when the configuration needs to be enforced. Instead, we can default the filter to a function that always returns true.