### PR TITLE
Do not drop table indexes before dropping SQLite table

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -803,22 +803,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff)
     {
-        if (! $diff->fromTable instanceof Table) {
-            throw new Exception(
-                'Sqlite platform requires for alter table the table diff with reference to original table schema'
-            );
-        }
-
-        $sql = [];
-        foreach ($diff->fromTable->getIndexes() as $index) {
-            if ($index->isPrimary()) {
-                continue;
-            }
-
-            $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $diff->name);
-        }
-
-        return $sql;
+        return [];
     }
 
     /**

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -579,6 +579,32 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals('CASCADE', $fkeys[0]->getOption('onDelete'));
     }
 
+    public function testCreateForeignKeyWithTableObject(): void
+    {
+        $this->createTestTable('test_create_fk1');
+        $this->createTestTable('test_create_fk2');
+
+        $table = $this->schemaManager->listTableDetails('test_create_fk1');
+        $table->addForeignKeyConstraint(
+            'test_create_fk2',
+            ['foreign_key_test'],
+            ['id'],
+            [],
+            'i'
+        );
+        $foreignKey = $table->getForeignKeys()['i'];
+        $this->schemaManager->createForeignKey($foreignKey, $table);
+
+        $fkeys = $this->schemaManager->listTableForeignKeys('test_create_fk1');
+
+        self::assertCount(1, $fkeys, "Table 'test_create_fk1' has to have one foreign key.");
+
+        self::assertInstanceOf(ForeignKeyConstraint::class, $fkeys[0]);
+        self::assertEquals(['foreign_key_test'], array_map('strtolower', $fkeys[0]->getLocalColumns()));
+        self::assertEquals(['id'], array_map('strtolower', $fkeys[0]->getForeignColumns()));
+        self::assertEquals('test_create_fk2', strtolower($fkeys[0]->getForeignTableName()));
+    }
+
     protected function getCreateExampleViewSql(): void
     {
         self::markTestSkipped('No Create Example View SQL was defined for this SchemaManager');

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -430,10 +430,6 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $diff->removedIndexes['index1'] = $table->getIndex('index1');
 
         $sql = [
-            'DROP INDEX IDX_8D93D64923A0E66',
-            'DROP INDEX IDX_8D93D6495A8A6C8D',
-            'DROP INDEX IDX_8D93D6493D8E604F',
-            'DROP INDEX index1',
             'CREATE TEMPORARY TABLE __temp__user AS SELECT id, article, post FROM user',
             'DROP TABLE user',
             'CREATE TABLE user ('
@@ -644,8 +640,6 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     protected function getQuotesTableIdentifiersInAlterTableSQL(): array
     {
         return [
-            'DROP INDEX IDX_8C736521A81E660E',
-            'DROP INDEX IDX_8C736521FDC58D6C',
             'CREATE TEMPORARY TABLE __temp__foo AS SELECT fk, fk2, id, fk3, bar FROM "foo"',
             'DROP TABLE "foo"',
             'CREATE TABLE "foo" (fk2 INTEGER NOT NULL, fk3 INTEGER NOT NULL, fk INTEGER NOT NULL, ' .
@@ -727,8 +721,6 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL(): array
     {
         return [
-            'DROP INDEX idx_foo',
-            'DROP INDEX idx_bar',
             'CREATE TEMPORARY TABLE __temp__mytable AS SELECT foo, bar, baz FROM mytable',
             'DROP TABLE mytable',
             'CREATE TABLE mytable (foo INTEGER NOT NULL, bar INTEGER NOT NULL, baz INTEGER NOT NULL, '


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #5485

#### Summary

There are two possible solutions to the issue.

a) use `DROP INDEX IF EXISTS xxx`, but it `IF EXISTS` is currently not supported by DBAL for indexes
b) simply drop the `DROP INDEX xxx` before `DROP TABLE` completely, it is not needed, as the `DROP TABLE` will drop the indexes automatically, citing from https://sqlite.org/lang_droptable.html:

> All indices and triggers associated with the table are also deleted.

So the b) solution should not impose any side effects, will execute faster and I implemented it.