### PR TITLE
Remove support for the NULL value of schema asset filter

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: removed support for the `NULL` value of schema asset filter.
+
+The argument of `Configuration::setSchemaAssetsFilter()` is now required and non-nullable.
+
 ## BC BREAK: removed support for custom schema options.
 
 The following `Column` class properties and methods have been removed:

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL;
 
 use Doctrine\DBAL\Driver\Middleware;
-use Doctrine\Deprecations\Deprecation;
 use Psr\Cache\CacheItemPoolInterface;
-
-use function func_num_args;
 
 /**
  * Configuration container for the Doctrine DBAL.
@@ -26,7 +23,7 @@ class Configuration
     /**
      * The callable to use to filter schema assets.
      *
-     * @var callable|null
+     * @var callable
      */
     protected $schemaAssetsFilter;
 
@@ -61,31 +58,15 @@ class Configuration
     /**
      * Sets the callable to use to filter schema assets.
      */
-    public function setSchemaAssetsFilter(?callable $callable = null): void
+    public function setSchemaAssetsFilter(callable $schemaAssetsFilter): void
     {
-        if (func_num_args() < 1) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5483',
-                'Not passing an argument to %s is deprecated.',
-                __METHOD__
-            );
-        } elseif ($callable === null) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5483',
-                'Using NULL as a schema asset filter is deprecated.'
-                    . ' Use a callable that always returns true instead.',
-            );
-        }
-
-        $this->schemaAssetsFilter = $callable;
+        $this->schemaAssetsFilter = $schemaAssetsFilter;
     }
 
     /**
      * Returns the callable to use to filter schema assets.
      */
-    public function getSchemaAssetsFilter(): ?callable
+    public function getSchemaAssetsFilter(): callable
     {
         return $this->schemaAssetsFilter;
     }

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -197,9 +197,6 @@ abstract class AbstractSchemaManager
     private function filterAssetNames(array $assetNames): array
     {
         $filter = $this->_conn->getConfiguration()->getSchemaAssetsFilter();
-        if ($filter === null) {
-            return $assetNames;
-        }
 
         return array_values(array_filter($assetNames, $filter));
     }
@@ -224,7 +221,7 @@ abstract class AbstractSchemaManager
         $tables = [];
 
         foreach ($tableColumnsByTable as $tableName => $tableColumns) {
-            if ($filter !== null && ! $filter($tableName)) {
+            if (! $filter($tableName)) {
                 continue;
             }
 


### PR DESCRIPTION
This API was deprecated in https://github.com/doctrine/dbal/pull/5483.