### PR TITLE
Change max identifier length

### DIFF
--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -1086,7 +1086,7 @@ SQL
      */
     public function getMaxIdentifierLength()
     {
-        return 30;
+        return 128;
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

In version 12.2 changed "Max Identifier length" [from 30 to 128 bytes
](https://docs.oracle.com/en/database/oracle/oracle-database/21/odpnt/EFCoreIdentifier.html#GUID-FA43F1A1-EDA2-462F-8844-45D49EF67607)

<!-- Provide a summary of your change. -->
