### PR TITLE
Fix implicit/generated unique index name typo

### DIFF
--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -523,7 +523,7 @@ class Table extends AbstractAsset
         $mergedNames = array_merge([$this->getName()], $constraint->getColumns());
         $name        = strlen($constraint->getName()) > 0
             ? $constraint->getName()
-            : $this->_generateIdentifierName($mergedNames, 'fk', $this->_getMaxIdentifierLength());
+            : $this->_generateIdentifierName($mergedNames, 'uniq', $this->_getMaxIdentifierLength());
 
         $name = $this->normalizeIdentifier($name);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

In `Table::addUniqueConstraint()` it was/is correct, but in `Table::_addUniqueConstraint()` it was wrong.