### PR TITLE
Fix table not found exception conversion for MSSQL

### DIFF
--- a/src/Driver/API/SQLSrv/ExceptionConverter.php
+++ b/src/Driver/API/SQLSrv/ExceptionConverter.php
@@ -19,6 +19,8 @@ use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Query;
 
+use function strpos;
+
 /**
  * @internal
  *
@@ -57,6 +59,10 @@ final class ExceptionConverter implements ExceptionConverterInterface
 
             case 3701:
             case 15151:
+                if (strpos($exception->getMessage(), 'annot drop the table') !== false) {
+                    return new TableNotFoundException($exception, $query);
+                }
+
                 return new DatabaseObjectNotFoundException($exception, $query);
 
             case 11001:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

The error code itself is not enough to detect the error is about a table, so the error message needs to be matched - https://dbfiddle.uk/?rdbms=sqlserver_2019&fiddle=99f47b0266ebefc15fa6079525523491

Here is an example why the correct exception class is needed:

```
    public function dropIfExists(): self
    {
        try {
            $this->drop();
        } catch (TableNotFoundException $e) {
        }
    }
```

Full stacktrace before fix:

```
Doctrine\DBAL\Exception\DatabaseObjectNotFoundException: An exception occurred while executing a query: SQLSTATE[42S02]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Cannot drop the table 'user', because it does not exist or you do not have permission.

vendor\doctrine\dbal\src\Driver\API\SQLSrv\ExceptionConverter.php:64
vendor\doctrine\dbal\src\Connection.php:1815
vendor\doctrine\dbal\src\Connection.php:1750
vendor\doctrine\dbal\src\Connection.php:1164
vendor\doctrine\dbal\src\Schema\AbstractSchemaManager.php:1204
vendor\doctrine\dbal\src\Schema\AbstractSchemaManager.php:410
vendor\atk4\data\src\Schema\Migrator.php:114
vendor\atk4\data\src\Schema\Migrator.php:133
vendor\atk4\data\tests\Schema\MigratorTest.php:90

Caused by
Doctrine\DBAL\Driver\PDO\Exception: SQLSTATE[42S02]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Cannot drop the table 'user', because it does not exist or you do not have permission.

vendor\doctrine\dbal\src\Driver\PDO\Exception.php:26
vendor\doctrine\dbal\src\Driver\PDO\Connection.php:40
vendor\doctrine\dbal\src\Driver\Middleware\AbstractConnectionMiddleware.php:47
vendor\doctrine\dbal\src\Connection.php:1162
vendor\doctrine\dbal\src\Schema\AbstractSchemaManager.php:1204
vendor\doctrine\dbal\src\Schema\AbstractSchemaManager.php:410
vendor\atk4\data\src\Schema\Migrator.php:114
vendor\atk4\data\src\Schema\Migrator.php:133
vendor\atk4\data\tests\Schema\MigratorTest.php:90

Caused by
PDOException: SQLSTATE[42S02]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Cannot drop the table 'user', because it does not exist or you do not have permission.

vendor\doctrine\dbal\src\Driver\PDO\Connection.php:34
vendor\doctrine\dbal\src\Driver\Middleware\AbstractConnectionMiddleware.php:47
vendor\doctrine\dbal\src\Connection.php:1162
vendor\doctrine\dbal\src\Schema\AbstractSchemaManager.php:1204
vendor\doctrine\dbal\src\Schema\AbstractSchemaManager.php:410
vendor\atk4\data\src\Schema\Migrator.php:114
vendor\atk4\data\src\Schema\Migrator.php:133
vendor\atk4\data\tests\Schema\MigratorTest.php:90
```