### PR TITLE
Fix AbstractAsset name split for 2+ parts namespaces

### DIFF
--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -11,7 +11,7 @@ use function dechex;
 use function explode;
 use function implode;
 use function str_replace;
-use function strpos;
+use function strrpos;
 use function strtolower;
 use function strtoupper;
 use function substr;
@@ -51,10 +51,10 @@ abstract class AbstractAsset
             $name          = $this->trimQuotes($name);
         }
 
-        if (strpos($name, '.') !== false) {
-            $parts            = explode('.', $name);
-            $this->_namespace = $parts[0];
-            $name             = $parts[1];
+        $lastDotPos = strrpos($name, '.');
+        if ($lastDotPos !== false) {
+            $this->_namespace = substr($name, 0, $lastDotPos);
+            $name             = substr($name, $lastDotPos + 1);
         }
 
         $this->_name = $name;

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -610,6 +610,21 @@ class TableTest extends TestCase
         self::assertEquals('other.test', $table->getFullQualifiedName('other'));
     }
 
+    public function testTableNameWithDatabaseAndSchema(): void
+    {
+        $table = new Table('foo.bar.test');
+        self::assertEquals('foo.bar.test', $table->getName());
+        self::assertEquals('foo.bar', $table->getNamespaceName());
+        self::assertEquals('test', $table->getShortestName('foo.bar'));
+        self::assertEquals('foo.bar.test', $table->getFullQualifiedName('test'));
+
+        $table = new Table('`foo`.`bar`.`test`');
+        self::assertEquals('foo.bar.test', $table->getName());
+        self::assertEquals('foo.bar', $table->getNamespaceName());
+        self::assertEquals('test', $table->getShortestName('foo.bar'));
+        self::assertEquals('foo.bar.test', $table->getFullQualifiedName('test'));
+    }
+
     public function testDropIndex(): void
     {
         $table = new Table('test');


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

For DB vendors like SQL Server or PostgreSQL, the namespace can consist of 2 parts - database name and schema.

This PR fixes parsing of table names like `mydb.dbo.mytable`.

2 part namespace PostgreSQL demo https://dbfiddle.uk/?rdbms=postgres_12&fiddle=9076e8aec94c779dddf6b87935c0d2d7