### PR TITLE
Add citext mapping to DBAL text type for PostgreSQL

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -1088,6 +1088,7 @@ SQL
             'bpchar'           => 'string',
             'bytea'            => 'blob',
             'char'             => 'string',
+            'citext'           => 'text',
             'date'             => 'date',
             'datetime'         => 'datetime',
             'decimal'          => 'decimal',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

citing: https://www.postgresql.org/docs/current/citext.html

> The citext module provides a case-insensitive character string type, citext. Essentially, it internally calls lower when comparing values. Otherwise, it behaves almost exactly like text.