### PR TITLE
Fix SqlitePlatform FK compare for quoted columns

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -1264,7 +1264,7 @@ class SqlitePlatform extends AbstractPlatform
         foreach ($foreignKeys as $key => $constraint) {
             $changed      = false;
             $localColumns = [];
-            foreach ($constraint->getLocalColumns() as $columnName) {
+            foreach ($constraint->getUnquotedLocalColumns() as $columnName) {
                 $normalizedColumnName = strtolower($columnName);
                 if (! isset($columnNames[$normalizedColumnName])) {
                     unset($foreignKeys[$key]);

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -1033,7 +1033,7 @@ class SqlitePlatform extends AbstractPlatform
      *
      * @throws Exception
      */
-    private function replaceColumn($tableName, array $columns, $columnName, Column $column): array
+    protected function replaceColumn($tableName, array $columns, $columnName, Column $column): array
     {
         $keys  = array_keys($columns);
         $index = array_search($columnName, $keys, true);
@@ -1055,7 +1055,7 @@ class SqlitePlatform extends AbstractPlatform
      *
      * @throws Exception
      */
-    private function getSimpleAlterTableSQL(TableDiff $diff)
+    protected function getSimpleAlterTableSQL(TableDiff $diff)
     {
         // Suppress changes on integer type autoincrement columns.
         foreach ($diff->changedColumns as $oldColumnName => $columnDiff) {
@@ -1148,7 +1148,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * @return string[]
      */
-    private function getColumnNamesInAlteredTable(TableDiff $diff, Table $fromTable): array
+    protected function getColumnNamesInAlteredTable(TableDiff $diff, Table $fromTable): array
     {
         $columns = [];
 
@@ -1188,7 +1188,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * @return Index[]
      */
-    private function getIndexesInAlteredTable(TableDiff $diff, Table $fromTable): array
+    protected function getIndexesInAlteredTable(TableDiff $diff, Table $fromTable): array
     {
         $indexes     = $fromTable->getIndexes();
         $columnNames = $this->getColumnNamesInAlteredTable($diff, $fromTable);
@@ -1256,7 +1256,7 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * @return ForeignKeyConstraint[]
      */
-    private function getForeignKeysInAlteredTable(TableDiff $diff, Table $fromTable): array
+    protected function getForeignKeysInAlteredTable(TableDiff $diff, Table $fromTable): array
     {
         $foreignKeys = $fromTable->getForeignKeys();
         $columnNames = $this->getColumnNamesInAlteredTable($diff, $fromTable);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

The previous FKs are dropped if the `$fromTable` has quoted columns - https://github.com/doctrine/dbal/blob/3.3.7/src/Platforms/SqlitePlatform.php#L1261

all other column names are unquoted, thus the columns from `$fromTable` must be as well

also make some SqlitePlatform methods protected, so (hot)fixing issues like these is possible on the dependent packages