### PR TITLE
Fix link in deprecation message

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -38,7 +38,7 @@ class Comparator
         if ($platform === null) {
             Deprecation::triggerIfCalledFromOutside(
                 'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/4659',
+                'https://github.com/doctrine/dbal/pull/4746',
                 'Not passing a $platform to %s is deprecated.'
                     . ' Use AbstractSchemaManager::createComparator() to instantiate the comparator.',
                 __METHOD__


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | documentation
| Fixed issues | N/A

#### Summary

This deprecation has been introduced in #4746 which superseded the currently documented #4659. I think we should change the link to the PR that has actually been merged.