### PR TITLE
Bump Symfony components to supported version ranges

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,8 @@
         "phpunit/phpunit": "9.5.21",
         "psalm/plugin-phpunit": "0.17.0",
         "squizlabs/php_codesniffer": "3.7.1",
-        "symfony/cache": "^5.2|^6.0",
-        "symfony/console": "^2.7|^3.0|^4.0|^5.0|^6.0",
+        "symfony/cache": "^5.4|^6.0",
+        "symfony/console": "^4.4|^5.4|^6.0",
         "vimeo/psalm": "4.24.0"
     },
     "suggest": {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

We haven't tested with Symfony Console 2.7 for quite a while in our low-deps run and I doubt that we want to maintain compatibility with it. This PR bumps all Symfony components to branches that are still supported upstream.
