### PR TITLE
Deprecate AbstractPlatform::hasNative*Type() and Type::requiresSQLCommentHint()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -197,9 +197,10 @@ As a consequence, depending on the name of a type being `json` for `jsonb` to
 be used for the Postgres platform is deprecated in favor of extending
 `Doctrine\DBAL\Types\JsonType`.
 
-## Deprecated `AbstractPlatform::getColumnComment()` and `AbstractPlatform::getDoctrineTypeComment()`
+## Deprecated `AbstractPlatform::getColumnComment()`, `AbstractPlatform::getDoctrineTypeComment()` and
+`Type::requiresSQLCommentHint()`
 
-DBAL no longer needs column comments to ensure proper diffing. Note that both
+DBAL no longer needs column comments to ensure proper diffing. Note that all the
 methods should probably have been marked as internal as these comments were an
 implementation detail of the DBAL.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -197,8 +197,8 @@ As a consequence, depending on the name of a type being `json` for `jsonb` to
 be used for the Postgres platform is deprecated in favor of extending
 `Doctrine\DBAL\Types\JsonType`.
 
-## Deprecated `AbstractPlatform::getColumnComment()`, `AbstractPlatform::getDoctrineTypeComment()` and
-`Type::requiresSQLCommentHint()`
+## Deprecated `AbstractPlatform::getColumnComment()`, `AbstractPlatform::getDoctrineTypeComment()`,
+`AbstractPlatform::hasNative*Type()` and `Type::requiresSQLCommentHint()`
 
 DBAL no longer needs column comments to ensure proper diffing. Note that all the
 methods should probably have been marked as internal as these comments were an

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -350,6 +350,18 @@
                 <referencedMethod name="Doctrine\DBAL\Schema\Column::getCustomSchemaOptions"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Column::hasCustomSchemaOption"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Column::setCustomSchemaOption"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Types\Type::requiresSQLCommentHint"/>
+                <referencedMethod name="Doctrine\DBAL\Types\DateImmutableType::requiresSQLCommentHint"/>
+                <referencedMethod name="Doctrine\DBAL\Types\DateIntervalType::requiresSQLCommentHint"/>
+                <referencedMethod name="Doctrine\DBAL\Types\DateTimeTzImmutableType::requiresSQLCommentHint"/>
+                <referencedMethod name="Doctrine\DBAL\Types\DateTimeImmutableType::requiresSQLCommentHint"/>
+                <referencedMethod name="Doctrine\DBAL\Types\GuidType::requiresSQLCommentHint"/>
+                <referencedMethod name="Doctrine\DBAL\Types\JsonType::requiresSQLCommentHint"/>
+                <referencedMethod name="Doctrine\DBAL\Types\TimeImmutableType::requiresSQLCommentHint"/>
+                <referencedMethod name="Doctrine\DBAL\Types\VarDateTimeImmutableType::requiresSQLCommentHint"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -362,6 +362,12 @@
                 <referencedMethod name="Doctrine\DBAL\Types\JsonType::requiresSQLCommentHint"/>
                 <referencedMethod name="Doctrine\DBAL\Types\TimeImmutableType::requiresSQLCommentHint"/>
                 <referencedMethod name="Doctrine\DBAL\Types\VarDateTimeImmutableType::requiresSQLCommentHint"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::hasNativeGuidType"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::hasNativeJsonType"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::hasNativeJsonType"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3917,20 +3917,38 @@ abstract class AbstractPlatform
     /**
      * Does this platform have native guid type.
      *
+     * @deprecated
+     *
      * @return bool
      */
     public function hasNativeGuidType()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return false;
     }
 
     /**
      * Does this platform have native JSON type.
      *
+     * @deprecated
+     *
      * @return bool
      */
     public function hasNativeJsonType()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return false;
     }
 

--- a/src/Platforms/MySQL57Platform.php
+++ b/src/Platforms/MySQL57Platform.php
@@ -18,9 +18,18 @@ class MySQL57Platform extends MySQLPlatform
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function hasNativeJsonType()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -218,9 +218,18 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function hasNativeGuidType()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 
@@ -1185,9 +1194,18 @@ SQL
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function hasNativeJsonType()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -202,9 +202,18 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function hasNativeGuidType()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 

--- a/src/Types/ArrayType.php
+++ b/src/Types/ArrayType.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 use function is_resource;
 use function restore_error_handler;
@@ -67,9 +68,18 @@ class ArrayType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 }

--- a/src/Types/BooleanType.php
+++ b/src/Types/BooleanType.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Types;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Type that maps an SQL boolean to a PHP boolean.
@@ -52,10 +53,19 @@ class BooleanType extends Type
     }
 
     /**
+     * @deprecated
+     *
      * @return bool
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         // We require a commented boolean type in order to distinguish between
         // boolean and smallint as both (have to) map to the same native type.
         return $platform instanceof DB2Platform;

--- a/src/Types/DateImmutableType.php
+++ b/src/Types/DateImmutableType.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Types;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Immutable type of {@see DateType}.
@@ -62,9 +63,18 @@ class DateImmutableType extends DateType
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 }

--- a/src/Types/DateIntervalType.php
+++ b/src/Types/DateIntervalType.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Types;
 
 use DateInterval;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 use Throwable;
 
 use function substr;
@@ -80,9 +81,18 @@ class DateIntervalType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 }

--- a/src/Types/DateTimeImmutableType.php
+++ b/src/Types/DateTimeImmutableType.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Types;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 use function date_create_immutable;
 
@@ -68,9 +69,18 @@ class DateTimeImmutableType extends DateTimeType
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 }

--- a/src/Types/DateTimeTzImmutableType.php
+++ b/src/Types/DateTimeTzImmutableType.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Types;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Immutable type of {@see DateTimeTzType}.
@@ -62,9 +63,18 @@ class DateTimeTzImmutableType extends DateTimeTzType
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 }

--- a/src/Types/GuidType.php
+++ b/src/Types/GuidType.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Represents a GUID/UUID datatype (both are actually synonyms) in the database.
@@ -27,9 +28,18 @@ class GuidType extends StringType
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return ! $platform->hasNativeGuidType();
     }
 }

--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 use JsonException;
 
 use function is_resource;
@@ -72,9 +73,18 @@ class JsonType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return ! $platform->hasNativeJsonType();
     }
 }

--- a/src/Types/ObjectType.php
+++ b/src/Types/ObjectType.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 use function is_resource;
 use function restore_error_handler;
@@ -66,9 +67,18 @@ class ObjectType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 }

--- a/src/Types/SimpleArrayType.php
+++ b/src/Types/SimpleArrayType.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 use function count;
 use function explode;
@@ -62,9 +63,18 @@ class SimpleArrayType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 }

--- a/src/Types/TimeImmutableType.php
+++ b/src/Types/TimeImmutableType.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Types;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Immutable type of {@see TimeType}.
@@ -62,9 +63,18 @@ class TimeImmutableType extends TimeType
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 }

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Types;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
 use function get_class;
@@ -268,10 +269,19 @@ abstract class Type
      * one of those types as commented, which will have Doctrine use an SQL
      * comment to typehint the actual Doctrine Type.
      *
+     * @deprecated
+     *
      * @return bool
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return false;
     }
 }

--- a/src/Types/VarDateTimeImmutableType.php
+++ b/src/Types/VarDateTimeImmutableType.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Types;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 use function date_create_immutable;
 
@@ -60,9 +61,18 @@ class VarDateTimeImmutableType extends VarDateTimeType
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 }


### PR DESCRIPTION
`Type::requiresSQLCommentHint()` is not needed as of https://github.com/doctrine/dbal/pull/5107. `AbstractPlatform::hasNative*Type()` is only used to implement `Type::requiresSQLCommentHint()`. 