### PR TITLE
Deprecate SqlitePlatform::getTinyIntTypeDeclarationSQL() and ::getMediumIntTypeDeclarationSQL()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `SqlitePlatform::getTinyIntTypeDeclarationSQL()` and `::getMediumIntTypeDeclarationSQL()` methods.
+
+The methods have been deprecated since they are implemented only by the SQLite platform, and the column types
+they implement are not portable across the rest of the supported platforms.
+
+Use `SqlitePlatform::getSmallIntTypeDeclarationSQL()` and `::getIntegerTypeDeclarationSQL()` respectively instead.
+
 ## Deprecated `NULL` schema asset filter.
 
 Not passing an argument to `Configuration::setSchemaAssetsFilter()` and passing `NULL` as the value of `$callable`

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -368,6 +368,11 @@
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::hasNativeGuidType"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::hasNativeJsonType"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::hasNativeJsonType"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::getTinyIntTypeDeclarationSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::getMediumIntTypeDeclarationSQL"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -251,12 +251,21 @@ class SqlitePlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated Use {@see getSmallIntTypeDeclarationSQL()} instead.
+     *
      * @param array<string, mixed> $column
      *
      * @return string
      */
     public function getTinyIntTypeDeclarationSQL(array $column)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5511',
+            '%s is deprecated. Use getSmallIntTypeDeclarationSQL() instead.',
+            __METHOD__
+        );
+
         // SQLite autoincrement is implicit for INTEGER PKs, but not for TINYINT columns
         if (! empty($column['autoincrement'])) {
             return $this->getIntegerTypeDeclarationSQL($column);
@@ -279,12 +288,21 @@ class SqlitePlatform extends AbstractPlatform
     }
 
     /**
+     * @deprecated Use {@see getIntegerTypeDeclarationSQL()} instead.
+     *
      * @param array<string, mixed> $column
      *
      * @return string
      */
     public function getMediumIntTypeDeclarationSQL(array $column)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5511',
+            '%s is deprecated. Use getIntegerTypeDeclarationSQL() instead.',
+            __METHOD__
+        );
+
         // SQLite autoincrement is implicit for INTEGER PKs, but not for MEDIUMINT columns
         if (! empty($column['autoincrement'])) {
             return $this->getIntegerTypeDeclarationSQL($column);


### PR DESCRIPTION
The methods are implemented only by the SQLite platform, and the column types they implement are not portable across the rest of the supported platforms. The methods are used only in unit tests.