### PR TITLE
Remove AbstractPlatform::hasNative*Type() methods and Type::requiresSQLCommentHint()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -209,13 +209,12 @@ Postgres 9 is not actively supported anymore. The following classes have been me
 
 ## BC BREAK: Removed Platform "commented type" API
 
-Since `Type::requiresSQLCommentTypeHint()` already allows determining whether a
-type should result in SQL columns with a type hint in their comments, the
-following methods are removed:
+The following methods are removed:
 
 - `AbstractPlatform::isCommentedDoctrineType()`
 - `AbstractPlatform::initializeCommentedDoctrineTypes()`
 - `AbstractPlatform::markDoctrineTypeCommented()`
+- `Type::requiresSQLCommentHint()`
 
 The protected property `AbstractPlatform::$doctrineTypeComments` is removed as
 well.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -211,6 +211,8 @@ Postgres 9 is not actively supported anymore. The following classes have been me
 
 The following methods are removed:
 
+- `AbstractPlatform::hasNativeJsonType()`
+- `AbstractPlatform::hasNativeGuidType()`
 - `AbstractPlatform::isCommentedDoctrineType()`
 - `AbstractPlatform::initializeCommentedDoctrineTypes()`
 - `AbstractPlatform::markDoctrineTypeCommented()`

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -39,12 +39,6 @@
                     See https://github.com/doctrine/dbal/pull/4317
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::hasNativeGuidType"/>
-                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::hasNativeJsonType"/>
-                <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::hasNativeJsonType"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -42,18 +42,6 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
-                <referencedMethod name="Doctrine\DBAL\Types\Type::requiresSQLCommentHint"/>
-                <referencedMethod name="Doctrine\DBAL\Types\DateImmutableType::requiresSQLCommentHint"/>
-                <referencedMethod name="Doctrine\DBAL\Types\DateIntervalType::requiresSQLCommentHint"/>
-                <referencedMethod name="Doctrine\DBAL\Types\DateTimeTzImmutableType::requiresSQLCommentHint"/>
-                <referencedMethod name="Doctrine\DBAL\Types\DateTimeImmutableType::requiresSQLCommentHint"/>
-                <referencedMethod name="Doctrine\DBAL\Types\GuidType::requiresSQLCommentHint"/>
-                <referencedMethod name="Doctrine\DBAL\Types\JsonType::requiresSQLCommentHint"/>
-                <referencedMethod name="Doctrine\DBAL\Types\TimeImmutableType::requiresSQLCommentHint"/>
-                <referencedMethod name="Doctrine\DBAL\Types\VarDateTimeImmutableType::requiresSQLCommentHint"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::hasNativeGuidType"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::hasNativeJsonType"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::hasNativeJsonType"/>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -37,7 +37,6 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 use UnexpectedValueException;
 
@@ -2283,40 +2282,6 @@ abstract class AbstractPlatform
      */
     public function supportsCommentOnStatement(): bool
     {
-        return false;
-    }
-
-    /**
-     * Does this platform have native guid type.
-     *
-     * @deprecated
-     */
-    public function hasNativeGuidType(): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return false;
-    }
-
-    /**
-     * Does this platform have native JSON type.
-     *
-     * @deprecated
-     */
-    public function hasNativeJsonType(): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
         return false;
     }
 

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -32,11 +32,6 @@ class MySQLPlatform extends AbstractMySQLPlatform
         return parent::getDefaultValueDeclarationSQL($column);
     }
 
-    public function hasNativeJsonType(): bool
-    {
-        return true;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -16,7 +16,6 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
-use Doctrine\Deprecations\Deprecation;
 use UnexpectedValueException;
 
 use function array_diff;
@@ -152,21 +151,6 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     public function supportsCommentOnStatement(): bool
     {
-        return true;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function hasNativeGuidType(): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
         return true;
     }
 
@@ -821,21 +805,6 @@ class PostgreSQLPlatform extends AbstractPlatform
             'year'             => 'date',
             '_varchar'         => 'string',
         ];
-    }
-
-    /**
-     * @deprecated
-     */
-    public function hasNativeJsonType(): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return true;
     }
 
     protected function createReservedKeywordsList(): KeywordList

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\DBAL\Schema\TableDiff;
-use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 use function array_merge;
@@ -153,21 +152,6 @@ class SQLServerPlatform extends AbstractPlatform
     public function getSequenceNextValSQL(string $sequence): string
     {
         return 'SELECT NEXT VALUE FOR ' . $sequence;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function hasNativeGuidType(): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return true;
     }
 
     public function getDropForeignKeySQL(string $foreignKey, string $table): string

--- a/src/Types/BooleanType.php
+++ b/src/Types/BooleanType.php
@@ -6,8 +6,6 @@ namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\DB2Platform;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * Type that maps an SQL boolean to a PHP boolean.
@@ -35,22 +33,5 @@ class BooleanType extends Type
     public function getBindingType(): int
     {
         return ParameterType::BOOLEAN;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        // We require a commented boolean type in order to distinguish between
-        // boolean and smallint as both (have to) map to the same native type.
-        return $platform instanceof DB2Platform;
     }
 }

--- a/src/Types/DateImmutableType.php
+++ b/src/Types/DateImmutableType.php
@@ -8,7 +8,6 @@ use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * Immutable type of {@see DateType}.
@@ -49,20 +48,5 @@ class DateImmutableType extends DateType
         }
 
         return $dateTime;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return true;
     }
 }

--- a/src/Types/DateIntervalType.php
+++ b/src/Types/DateIntervalType.php
@@ -8,7 +8,6 @@ use DateInterval;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
-use Doctrine\Deprecations\Deprecation;
 use Throwable;
 
 use function substr;
@@ -67,20 +66,5 @@ class DateIntervalType extends Type
         } catch (Throwable $exception) {
             throw InvalidFormat::new($value, static::class, self::FORMAT, $exception);
         }
-    }
-
-    /**
-     * @deprecated
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return true;
     }
 }

--- a/src/Types/DateTimeImmutableType.php
+++ b/src/Types/DateTimeImmutableType.php
@@ -8,7 +8,6 @@ use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
-use Doctrine\Deprecations\Deprecation;
 
 use function date_create_immutable;
 
@@ -55,20 +54,5 @@ class DateTimeImmutableType extends DateTimeType
         }
 
         return $dateTime;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return true;
     }
 }

--- a/src/Types/DateTimeTzImmutableType.php
+++ b/src/Types/DateTimeTzImmutableType.php
@@ -8,7 +8,6 @@ use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * Immutable type of {@see DateTimeTzType}.
@@ -49,20 +48,5 @@ class DateTimeTzImmutableType extends DateTimeTzType
         }
 
         return $dateTime;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return true;
     }
 }

--- a/src/Types/GuidType.php
+++ b/src/Types/GuidType.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * Represents a GUID/UUID datatype (both are actually synonyms) in the database.
@@ -18,20 +17,5 @@ class GuidType extends StringType
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return $platform->getGuidTypeDeclarationSQL($column);
-    }
-
-    /**
-     * @deprecated
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return ! $platform->hasNativeGuidType();
     }
 }

--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Types;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\SerializationFailed;
 use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
-use Doctrine\Deprecations\Deprecation;
 use JsonException;
 
 use function is_resource;
@@ -59,20 +58,5 @@ class JsonType extends Type
         } catch (JsonException $e) {
             throw ValueNotConvertible::new($value, 'json', $e->getMessage(), $e);
         }
-    }
-
-    /**
-     * @deprecated
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return ! $platform->hasNativeJsonType();
     }
 }

--- a/src/Types/SimpleArrayType.php
+++ b/src/Types/SimpleArrayType.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\Deprecations\Deprecation;
 
 use function count;
 use function explode;
@@ -50,20 +49,5 @@ class SimpleArrayType extends Type
         $value = is_resource($value) ? stream_get_contents($value) : $value;
 
         return explode(',', $value);
-    }
-
-    /**
-     * @deprecated
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return true;
     }
 }

--- a/src/Types/TimeImmutableType.php
+++ b/src/Types/TimeImmutableType.php
@@ -8,7 +8,6 @@ use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * Immutable type of {@see TimeType}.
@@ -49,20 +48,5 @@ class TimeImmutableType extends TimeType
         }
 
         return $dateTime;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return true;
     }
 }

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Types;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
 
@@ -214,25 +213,5 @@ abstract class Type
     public function getMappedDatabaseTypes(AbstractPlatform $platform): array
     {
         return [];
-    }
-
-    /**
-     * If this Doctrine Type maps to an already mapped database type,
-     * reverse schema engineering can't tell them apart. You need to mark
-     * one of those types as commented, which will have Doctrine use an SQL
-     * comment to typehint the actual Doctrine Type.
-     *
-     * @deprecated
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return false;
     }
 }

--- a/src/Types/VarDateTimeImmutableType.php
+++ b/src/Types/VarDateTimeImmutableType.php
@@ -8,7 +8,6 @@ use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidType;
 use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
-use Doctrine\Deprecations\Deprecation;
 
 use function date_create_immutable;
 
@@ -47,20 +46,5 @@ class VarDateTimeImmutableType extends VarDateTimeType
         }
 
         return $dateTime;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
-        return true;
     }
 }

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1116,26 +1116,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertArrayHasKey('idx_3d6c147fdc58d6c', $indexes);
     }
 
-    public function testComparatorShouldNotAddCommentToJsonTypeSinceItIsTheDefaultNow(): void
-    {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if (! $platform->hasNativeJsonType()) {
-            self::markTestSkipped('This test is only supported on platforms that have native JSON type.');
-        }
-
-        $this->dropTableIfExists('json_test');
-        $this->connection->executeQuery('CREATE TABLE json_test (parameters JSON NOT NULL)');
-
-        $table = new Table('json_test');
-        $table->addColumn('parameters', 'json');
-
-        $tableDiff = $this->schemaManager->createComparator()
-            ->diffTable($this->schemaManager->listTableDetails('json_test'), $table);
-
-        self::assertNull($tableDiff);
-    }
-
     public function testCreateAndListSequences(): void
     {
         if (! $this->connection->getDatabasePlatform()->supportsSequences()) {

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -817,11 +817,6 @@ abstract class AbstractPlatformTestCase extends TestCase
         return 'VARBINARY(16)';
     }
 
-    public function hasNativeJsonType(): void
-    {
-        self::assertFalse($this->platform->hasNativeJsonType());
-    }
-
     public function testReturnsJsonTypeDeclarationSQL(): void
     {
         $column = [

--- a/tests/Platforms/MariaDBPlatformTest.php
+++ b/tests/Platforms/MariaDBPlatformTest.php
@@ -15,11 +15,6 @@ class MariaDBPlatformTest extends AbstractMySQLPlatformTestCase
         return new MariaDBPlatform();
     }
 
-    public function testHasNativeJsonType(): void
-    {
-        self::assertFalse($this->platform->hasNativeJsonType());
-    }
-
     /**
      * From MariaDB 10.2.7, JSON type is an alias to LONGTEXT
      *

--- a/tests/Platforms/MySQLPlatformTest.php
+++ b/tests/Platforms/MySQLPlatformTest.php
@@ -20,11 +20,6 @@ class MySQLPlatformTest extends AbstractMySQLPlatformTestCase
         return new MySQLPlatform();
     }
 
-    public function testHasNativeJsonType(): void
-    {
-        self::assertTrue($this->platform->hasNativeJsonType());
-    }
-
     public function testReturnsJsonTypeDeclarationSQL(): void
     {
         self::assertSame('JSON', $this->platform->getJsonTypeDeclarationSQL([]));

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -897,11 +897,6 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         );
     }
 
-    public function testHasNativeJsonType(): void
-    {
-        self::assertTrue($this->platform->hasNativeJsonType());
-    }
-
     public function testReturnsJsonTypeDeclarationSQL(): void
     {
         self::assertSame('JSON', $this->platform->getJsonTypeDeclarationSQL([]));

--- a/tests/Types/DateImmutableTypeTest.php
+++ b/tests/Types/DateImmutableTypeTest.php
@@ -110,9 +110,4 @@ class DateImmutableTypeTest extends TestCase
 
         $this->type->convertToPHPValue('invalid date string', $this->platform);
     }
-
-    public function testRequiresSQLCommentHint(): void
-    {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
-    }
 }

--- a/tests/Types/DateIntervalTest.php
+++ b/tests/Types/DateIntervalTest.php
@@ -89,11 +89,6 @@ final class DateIntervalTest extends TestCase
         $this->type->convertToPHPValue('', $this->platform);
     }
 
-    public function testRequiresSQLCommentHint(): void
-    {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
-    }
-
     /**
      * @dataProvider invalidPHPValuesProvider
      */

--- a/tests/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Types/DateTimeImmutableTypeTest.php
@@ -114,9 +114,4 @@ class DateTimeImmutableTypeTest extends TestCase
 
         $this->type->convertToPHPValue('invalid datetime string', $this->platform);
     }
-
-    public function testRequiresSQLCommentHint(): void
-    {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
-    }
 }

--- a/tests/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Types/DateTimeTzImmutableTypeTest.php
@@ -102,9 +102,4 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
         $this->type->convertToPHPValue('invalid datetime with timezone string', $this->platform);
     }
-
-    public function testRequiresSQLCommentHint(): void
-    {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
-    }
 }

--- a/tests/Types/GuidTypeTest.php
+++ b/tests/Types/GuidTypeTest.php
@@ -32,15 +32,4 @@ class GuidTypeTest extends TestCase
     {
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
-
-    public function testNativeGuidSupport(): void
-    {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
-
-        $this->platform->expects(self::any())
-             ->method('hasNativeGuidType')
-             ->willReturn(true);
-
-        self::assertFalse($this->type->requiresSQLCommentHint($this->platform));
-    }
 }

--- a/tests/Types/JsonTest.php
+++ b/tests/Types/JsonTest.php
@@ -89,11 +89,6 @@ class JsonTest extends TestCase
         self::assertSame($value, $phpValue);
     }
 
-    public function testRequiresSQLCommentHint(): void
-    {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
-    }
-
     public function testPHPNullValueConvertsToJsonNull(): void
     {
         self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));

--- a/tests/Types/TimeImmutableTypeTest.php
+++ b/tests/Types/TimeImmutableTypeTest.php
@@ -110,9 +110,4 @@ class TimeImmutableTypeTest extends TestCase
 
         $this->type->convertToPHPValue('invalid time string', $this->platform);
     }
-
-    public function testRequiresSQLCommentHint(): void
-    {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
-    }
 }

--- a/tests/Types/VarDateTimeImmutableTypeTest.php
+++ b/tests/Types/VarDateTimeImmutableTypeTest.php
@@ -88,9 +88,4 @@ class VarDateTimeImmutableTypeTest extends TestCase
 
         $this->type->convertToPHPValue('invalid date-ish string', $this->platform);
     }
-
-    public function testRequiresSQLCommentHint(): void
-    {
-        self::assertTrue($this->type->requiresSQLCommentHint($this->platform));
-    }
 }


### PR DESCRIPTION
These methods were deprecated in https://github.com/doctrine/dbal/pull/5509.