### PR TITLE
Deprecate internal and non-portable AbstractPlatform methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,6 +12,7 @@ awareness about deprecated code.
 
 1. `usesSequenceEmulatedIdentityColumns()` and `getIdentitySequenceName()` have been deprecated since the fact of
    emulation of identity columns and the underlying sequence name are internal platform-specific implementation details.
+2. `getDefaultSchemaName()` has been deprecated since it's not used to implement any of the portable APIs.
 
 ## Deprecated `SqlitePlatform::getTinyIntTypeDeclarationSQL()` and `::getMediumIntTypeDeclarationSQL()` methods.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,8 +10,8 @@ awareness about deprecated code.
 
 ## Deprecated `AbstractPlatform` methods.
 
-1. `getIdentitySequenceName()` has been deprecated since the underlying sequence name is an internal platform-specific
-   implementation detail.
+1. `usesSequenceEmulatedIdentityColumns()` and `getIdentitySequenceName()` have been deprecated since the fact of
+   emulation of identity columns and the underlying sequence name are internal platform-specific implementation details.
 
 ## Deprecated `SqlitePlatform::getTinyIntTypeDeclarationSQL()` and `::getMediumIntTypeDeclarationSQL()` methods.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,9 @@ awareness about deprecated code.
 1. `usesSequenceEmulatedIdentityColumns()` and `getIdentitySequenceName()` have been deprecated since the fact of
    emulation of identity columns and the underlying sequence name are internal platform-specific implementation details.
 2. `getDefaultSchemaName()` has been deprecated since it's not used to implement any of the portable APIs.
+3. `supportsCreateDropDatabase()` has been deprecated. Try calling `AbstractSchemaManager::createDatabase`
+    and/or `::dropDatabase()` to see if the corresponding operations are supported by the current database platform
+    or implement conditional logic based on the platform class name.
 
 ## Deprecated `SqlitePlatform::getTinyIntTypeDeclarationSQL()` and `::getMediumIntTypeDeclarationSQL()` methods.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated `AbstractPlatform` methods.
+
+1. `getIdentitySequenceName()` has been deprecated since the underlying sequence name is an internal platform-specific
+   implementation detail.
+
 ## Deprecated `SqlitePlatform::getTinyIntTypeDeclarationSQL()` and `::getMediumIntTypeDeclarationSQL()` methods.
 
 The methods have been deprecated since they are implemented only by the SQLite platform, and the column types

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -376,6 +376,7 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getDefaultSchemaName"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getIdentitySequenceName"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::usesSequenceEmulatedIdentityColumns"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\OraclePlatform::usesSequenceEmulatedIdentityColumns"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -377,7 +377,10 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getIdentitySequenceName"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::usesSequenceEmulatedIdentityColumns"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\OraclePlatform::usesSequenceEmulatedIdentityColumns"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::getIdentitySequenceName"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::usesSequenceEmulatedIdentityColumns"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -378,7 +378,9 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getDefaultSchemaName"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getIdentitySequenceName"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::supportsCreateDropDatabase"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::usesSequenceEmulatedIdentityColumns"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\DB2Platform::supportsCreateDropDatabase"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\OraclePlatform::usesSequenceEmulatedIdentityColumns"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::getIdentitySequenceName"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::usesSequenceEmulatedIdentityColumns"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -373,6 +373,11 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::getTinyIntTypeDeclarationSQL"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::getMediumIntTypeDeclarationSQL"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getIdentitySequenceName"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::getIdentitySequenceName"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3669,10 +3669,19 @@ abstract class AbstractPlatform
      * but support sequences can emulate identity columns by using
      * sequences.
      *
+     * @deprecated
+     *
      * @return bool
      */
     public function usesSequenceEmulatedIdentityColumns()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5513',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return false;
     }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3866,6 +3866,8 @@ abstract class AbstractPlatform
     /**
      * Returns the default schema name.
      *
+     * @deprecated
+     *
      * @return string
      *
      * @throws Exception If not supported on this platform.

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3679,6 +3679,8 @@ abstract class AbstractPlatform
     /**
      * Returns the name of the sequence for a particular identity column in a particular table.
      *
+     * @deprecated
+     *
      * @see usesSequenceEmulatedIdentityColumns
      *
      * @param string $tableName  The name of the table to return the sequence name for.

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3882,10 +3882,19 @@ abstract class AbstractPlatform
      *
      * Some databases don't allow to create and drop databases at all or only with certain tools.
      *
+     * @deprecated
+     *
      * @return bool
      */
     public function supportsCreateDropDatabase()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5513',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -466,9 +466,18 @@ class DB2Platform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function supportsCreateDropDatabase()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5513',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return false;
     }
 

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -1006,9 +1006,18 @@ SQL
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function usesSequenceEmulatedIdentityColumns()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5513',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -1014,6 +1014,8 @@ SQL
 
     /**
      * {@inheritdoc}
+     *
+     * @internal The method should be only used from within the OraclePlatform class hierarchy.
      */
     public function getIdentitySequenceName($tableName, $columnName)
     {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -170,9 +170,18 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getDefaultSchemaName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5513',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return 'public';
     }
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -202,9 +202,18 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getIdentitySequenceName($tableName, $columnName)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5513',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return $tableName . '_' . $columnName . '_seq';
     }
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -194,9 +194,18 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function usesSequenceEmulatedIdentityColumns()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5513',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return true;
     }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -144,9 +144,18 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getDefaultSchemaName()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5513',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return 'dbo';
     }
 

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -580,9 +580,18 @@ class SqlitePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated
      */
     public function supportsCreateDropDatabase()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5513',
+            '%s is deprecated.',
+            __METHOD__
+        );
+
         return false;
     }
 


### PR DESCRIPTION
1. `usesSequenceEmulatedIdentityColumns()` and `getIdentitySequenceName()` expose internal platform-specific implementation details.
2. `getDefaultSchemaName()` returns static values like `dbo` or `public` while the actual default schema may depend on the current user. It is only used in tests.
3. `supportsCreateDropDatabase()` is used only in tests. Since not all platforms support creating and dropping databases, a portable solution requires identifying the platform by its class name anyways (see `TestUtil`).