### PR TITLE
Revert deprecation of `AbstractPlatform#hasNativeGuidType()`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -214,7 +214,7 @@ be used for the Postgres platform is deprecated in favor of extending
 `Doctrine\DBAL\Types\JsonType`.
 
 ## Deprecated `AbstractPlatform::getColumnComment()`, `AbstractPlatform::getDoctrineTypeComment()`,
-`AbstractPlatform::hasNative*Type()` and `Type::requiresSQLCommentHint()`
+`AbstractPlatform::hasNativeJsonType()` and `Type::requiresSQLCommentHint()`
 
 DBAL no longer needs column comments to ensure proper diffing. Note that all the
 methods should probably have been marked as internal as these comments were an

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -365,7 +365,6 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
-                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::hasNativeGuidType"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::hasNativeJsonType"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\PostgreSQLPlatform::hasNativeJsonType"/>
                 <!--

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3939,19 +3939,10 @@ abstract class AbstractPlatform
     /**
      * Does this platform have native guid type.
      *
-     * @deprecated
-     *
      * @return bool
      */
     public function hasNativeGuidType()
     {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
         return false;
     }
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -245,18 +245,9 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
-     *
-     * @deprecated
      */
     public function hasNativeGuidType()
     {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
         return true;
     }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -211,18 +211,9 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
-     *
-     * @deprecated
      */
     public function hasNativeGuidType()
     {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5509',
-            '%s is deprecated.',
-            __METHOD__
-        );
-
         return true;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | -

#### Summary

The hasNativeGuidType method deprecated in https://github.com/doctrine/dbal/pull/5509 is actually [used by symfony/uid](https://github.com/symfony/symfony/blob/5bc5827010902dd19deb30a649ebc0da650d5642/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php#L67) to determine how uids should be stored.
Since there is no replacement and this method has valid usages from the outside, I propose to revert that deprecation.
