### PR TITLE
Remove historical TODO comment, SqliteXxx is consistent naming

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -36,8 +36,6 @@ use function trim;
 /**
  * The SqlitePlatform class describes the specifics and dialects of the SQLite
  * database platform.
- *
- * @todo   Rename: SQLitePlatform
  */
 class SqlitePlatform extends AbstractPlatform
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

I belive this TODO is historical and the change should never be done, as it will imply autoloading BC break.