### PR TITLE
Lock closed issues in 30 days

### DIFF
--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -1,0 +1,18 @@
+name: Lock Closed Issues
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          github-token: '${{ github.token }}'
+          issue-inactive-days: 30
+          issue-comment: >
+            This thread has been automatically locked since there has not been
+            any recent activity after it was closed. Please open a new issue for
+            related bugs.


### PR DESCRIPTION
This workflow will prevent necrobumping old issues and pull requests and encourage users to file new ones. The comments in old issues are easy to miss.