### PR TITLE
Improve MySQL charset and collation comparison

### DIFF
--- a/src/Platforms/MySQL/CharsetMetadataProvider.php
+++ b/src/Platforms/MySQL/CharsetMetadataProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms\MySQL;
+
+/**
+ * @internal
+ */
+interface CharsetMetadataProvider
+{
+    public function getDefaultCharsetCollation(string $charset): ?string;
+}

--- a/src/Platforms/MySQL/CharsetMetadataProvider/CachingCharsetMetadataProvider.php
+++ b/src/Platforms/MySQL/CharsetMetadataProvider/CachingCharsetMetadataProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
+
+use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
+
+use function array_key_exists;
+
+/**
+ * @internal
+ */
+final class CachingCharsetMetadataProvider implements CharsetMetadataProvider
+{
+    /** @var array<string,?string> */
+    private array $cache = [];
+
+    public function __construct(private CharsetMetadataProvider $charsetMetadataProvider)
+    {
+    }
+
+    public function getDefaultCharsetCollation(string $charset): ?string
+    {
+        if (array_key_exists($charset, $this->cache)) {
+            return $this->cache[$charset];
+        }
+
+        return $this->cache[$charset] = $this->charsetMetadataProvider->getDefaultCharsetCollation($charset);
+    }
+}

--- a/src/Platforms/MySQL/CharsetMetadataProvider/ConnectionCharsetMetadataProvider.php
+++ b/src/Platforms/MySQL/CharsetMetadataProvider/ConnectionCharsetMetadataProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
+
+/**
+ * @internal
+ */
+final class ConnectionCharsetMetadataProvider implements CharsetMetadataProvider
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getDefaultCharsetCollation(string $charset): ?string
+    {
+        $collation = $this->connection->fetchOne(
+            <<<'SQL'
+            SELECT DEFAULT_COLLATE_NAME
+            FROM information_schema.CHARACTER_SETS
+            WHERE CHARACTER_SET_NAME = ?;
+            SQL
+            ,
+            [$charset]
+        );
+
+        if ($collation !== false) {
+            return $collation;
+        }
+
+        return null;
+    }
+}

--- a/src/Platforms/MySQL/DefaultTableOptions.php
+++ b/src/Platforms/MySQL/DefaultTableOptions.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms\MySQL;
+
+/**
+ * @internal
+ */
+final class DefaultTableOptions
+{
+    public function __construct(private string $charset, private string $collation)
+    {
+    }
+
+    public function getCharset(): string
+    {
+        return $this->charset;
+    }
+
+    public function getCollation(): string
+    {
+        return $this->collation;
+    }
+}

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -598,7 +598,7 @@ class Table extends AbstractAsset
 
     public function getOption(string $name): mixed
     {
-        return $this->_options[$name];
+        return $this->_options[$name] ?? null;
     }
 
     /**

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -7,7 +7,9 @@ namespace Doctrine\DBAL\Tests\Platforms;
 use Doctrine\DBAL\Exception\ColumnLengthRequired;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\MySQL;
+use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
+use Doctrine\DBAL\Platforms\MySQL\DefaultTableOptions;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
@@ -808,7 +810,9 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         return new MySQL\Comparator(
             $this->platform,
-            $this->createStub(CollationMetadataProvider::class)
+            $this->createStub(CharsetMetadataProvider::class),
+            $this->createStub(CollationMetadataProvider::class),
+            new DefaultTableOptions('utf8mb4', 'utf8mb4_general_ci')
         );
     }
 }

--- a/tests/Platforms/MySQL/ComparatorTest.php
+++ b/tests/Platforms/MySQL/ComparatorTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Platforms\MySQL;
 
+use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\Comparator;
+use Doctrine\DBAL\Platforms\MySQL\DefaultTableOptions;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Tests\Schema\ComparatorTest as BaseComparatorTest;
 
@@ -15,7 +17,9 @@ class ComparatorTest extends BaseComparatorTest
     {
         $this->comparator = new Comparator(
             new MySQLPlatform(),
-            $this->createStub(CollationMetadataProvider::class)
+            $this->createStub(CharsetMetadataProvider::class),
+            $this->createStub(CollationMetadataProvider::class),
+            new DefaultTableOptions('utf8mb4', 'utf8mb4_general_ci')
         );
     }
 }

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -6,7 +6,9 @@ namespace Doctrine\DBAL\Tests\Schema\Platforms;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQL;
+use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
+use Doctrine\DBAL\Platforms\MySQL\DefaultTableOptions;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
@@ -91,7 +93,9 @@ class MySQLSchemaTest extends TestCase
     {
         return new MySQL\Comparator(
             new MySQLPlatform(),
-            $this->createStub(CollationMetadataProvider::class)
+            $this->createStub(CharsetMetadataProvider::class),
+            $this->createStub(CollationMetadataProvider::class),
+            new DefaultTableOptions('utf8mb4', 'utf8mb4_general_ci')
         );
     }
 }


### PR DESCRIPTION
Closes #5338.

This is an improvement of the logic implemented in https://github.com/doctrine/dbal/pull/5471. Up until this patch, the comparator didn't work correctly if the column definition contained some options that would eventually match the table options but the table options weren't explicitly specified (i.e. they defaulted to the database defaults).

In order to address the issue, we need to normalize the table and column definitions and make all the default options explicit. Then compare the normalized definitions.

Backporting the fix to 3.x would require additional effort due to the MySQL platform there enforcing made-up defaults for table collation but not for column collation: https://github.com/doctrine/dbal/blob/8532d4942c2b1565ad27a211966ede334d68d5f1/src/Platforms/AbstractMySQLPlatform.php#L460-L462

In order to support this logic, we'd need to use two implementations of the charset metadata provider: one for columns that would detect the default charset based on the information schema; and one for tables that mimicks the behavior implemented in the platform.