### PR TITLE
Fix SQLite current DB detection

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -208,7 +208,7 @@ class Connection
      *
      * @return string|null The name of the database or NULL if a database is not selected.
      *                     The platforms which don't support the concept of a database (e.g. embedded databases)
-     *                     must always return a string as an indicator of an implicitly selected database.
+     *                     must always return an empty string as an indicator of an implicitly selected database.
      *
      * @throws Exception
      */

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -165,17 +165,9 @@ class SqlitePlatform extends AbstractPlatform
         return sprintf("JULIANDAY(%s, 'start of day') - JULIANDAY(%s, 'start of day')", $date1, $date2);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * The SQLite platform doesn't support the concept of a database, therefore, it always returns an empty string
-     * as an indicator of an implicitly selected database.
-     *
-     * @see \Doctrine\DBAL\Connection::getDatabase()
-     */
     public function getCurrentDatabaseExpression(): string
     {
-        return "''";
+        return "'main'";
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #5046

#### Summary

SQLite support schemas concept. There is a main schema named `main` and other schemas can be attached with the `ATTACH` SQL statement.

Citing https://www.sqlite.org/pragma.html:
> A pragma may have an optional schema-name before the pragma name. The schema-name is the name of an [ATTACH](https://www.sqlite.org/lang_attach.html)-ed database or "main" or "temp" for the main and the TEMP databases. If the optional schema name is omitted, "main" is assumed. In some pragmas, the schema name is meaningless and is simply ignored. In the documentation below, pragmas for which the schema name is meaningful are shown with a "schema." prefix.

This PR fixes the current DB detection which is always `main`. All tests pass. Later I plan to provide a PR to adjust the `SQLitePlatform` to support working with the attached/different databases.