### PR TITLE
Deprecate passing assets as names

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,28 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated passing asset names as assets in `AbstractPlatform` and `AbstractSchemaManager` methods.
+
+Passing assets to the following `AbstractPlatform` methods and parameters has been deprecated:
+
+1. The `$table` parameter of `getDropTableSQL()`,
+2. The `$table` parameter of `getDropTemporaryTableSQL()`,
+3. The `$index` and `$table` parameters of `getDropIndexSQL()`,
+4. The `$constraint` and `$table` parameters of `getDropConstraintSQL()`,
+5. The `$foreignKey` and `$table` parameters of `getDropForeignKeySQL()`,
+6. The `$sequence` parameter of `getDropSequenceSQL()`,
+7. The `$table` parameter of `getCreateConstraintSQL()`,
+8. The `$table` parameter of `getCreatePrimaryKeySQL()`,
+9. The `$table` parameter of `getCreateForeignKeySQL()`.
+
+Passing assets to the following `AbstractSchemaManager` methods and parameters has been deprecated:
+
+1. The `$index` and `$table` parameters of `dropIndex()`,
+2. The `$table` parameter of `dropConstraint()`,
+3. The `$foreignKey` and `$table` parameters of `dropForeignKey()`.
+
+Pass a string representing the quoted asset name instead.
+
 ## Marked `AbstractPlatform` methods as internal.
 
 The following methods have been marked internal as they are not designed to be used from outside the platform classes:

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -847,7 +847,7 @@ SQL
                 continue;
             }
 
-            $sql[] = $this->getDropForeignKeySQL($foreignKey, $tableName);
+            $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableName);
         }
 
         return $sql;
@@ -1050,6 +1050,13 @@ SQL
     public function getDropIndexSQL($index, $table = null)
     {
         if ($index instanceof Index) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $index as an Index object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $indexName = $index->getQuotedName($this);
         } elseif (is_string($index)) {
             $indexName = $index;
@@ -1060,6 +1067,13 @@ SQL
         }
 
         if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $table = $table->getQuotedName($this);
         } elseif (! is_string($table)) {
             throw new InvalidArgumentException(
@@ -1223,6 +1237,13 @@ SQL
     public function getDropTemporaryTableSQL($table)
     {
         if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $table = $table->getQuotedName($this);
         } elseif (! is_string($table)) {
             throw new InvalidArgumentException(

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1795,6 +1795,13 @@ abstract class AbstractPlatform
         $tableArg = $table;
 
         if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $table = $table->getQuotedName($this);
         }
 
@@ -1831,6 +1838,17 @@ abstract class AbstractPlatform
      */
     public function getDropTemporaryTableSQL($table)
     {
+        if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
+            $table = $table->getQuotedName($this);
+        }
+
         return $this->getDropTableSQL($table);
     }
 
@@ -1847,6 +1865,13 @@ abstract class AbstractPlatform
     public function getDropIndexSQL($index, $table = null)
     {
         if ($index instanceof Index) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $index as an Index object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $index = $index->getQuotedName($this);
         } elseif (! is_string($index)) {
             throw new InvalidArgumentException(
@@ -1869,11 +1894,25 @@ abstract class AbstractPlatform
      */
     public function getDropConstraintSQL($constraint, $table)
     {
-        if (! $constraint instanceof Constraint) {
+        if ($constraint instanceof Constraint) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $constraint as a Constraint object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+        } else {
             $constraint = new Identifier($constraint);
         }
 
-        if (! $table instanceof Table) {
+        if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+        } else {
             $table = new Identifier($table);
         }
 
@@ -1893,11 +1932,26 @@ abstract class AbstractPlatform
      */
     public function getDropForeignKeySQL($foreignKey, $table)
     {
-        if (! $foreignKey instanceof ForeignKeyConstraint) {
+        if ($foreignKey instanceof ForeignKeyConstraint) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $foreignKey as a ForeignKeyConstraint object to %s is deprecated.'
+                    . ' Pass it as a quoted name instead.',
+                __METHOD__
+            );
+        } else {
             $foreignKey = new Identifier($foreignKey);
         }
 
-        if (! $table instanceof Table) {
+        if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+        } else {
             $table = new Identifier($table);
         }
 
@@ -2119,7 +2173,7 @@ abstract class AbstractPlatform
         }
 
         foreach ($tables as $table) {
-            $sql[] = $this->getDropTableSQL($table);
+            $sql[] = $this->getDropTableSQL($table->getQuotedName($this));
         }
 
         return $sql;
@@ -2271,6 +2325,13 @@ abstract class AbstractPlatform
         }
 
         if ($sequence instanceof Sequence) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $sequence as a Sequence object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $sequence = $sequence->getQuotedName($this);
         }
 
@@ -2292,6 +2353,13 @@ abstract class AbstractPlatform
     public function getCreateConstraintSQL(Constraint $constraint, $table)
     {
         if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $table = $table->getQuotedName($this);
         }
 
@@ -2336,6 +2404,13 @@ abstract class AbstractPlatform
     public function getCreateIndexSQL(Index $index, $table)
     {
         if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $table = $table->getQuotedName($this);
         }
 
@@ -2390,6 +2465,13 @@ abstract class AbstractPlatform
     public function getCreatePrimaryKeySQL(Index $index, $table)
     {
         if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $table = $table->getQuotedName($this);
         }
 
@@ -2485,6 +2567,13 @@ abstract class AbstractPlatform
     public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, $table)
     {
         if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $table = $table->getQuotedName($this);
         }
 
@@ -2631,20 +2720,24 @@ abstract class AbstractPlatform
         $sql = [];
         if ($this->supportsForeignKeyConstraints()) {
             foreach ($diff->removedForeignKeys as $foreignKey) {
+                if ($foreignKey instanceof ForeignKeyConstraint) {
+                    $foreignKey = $foreignKey->getQuotedName($this);
+                }
+
                 $sql[] = $this->getDropForeignKeySQL($foreignKey, $tableName);
             }
 
             foreach ($diff->changedForeignKeys as $foreignKey) {
-                $sql[] = $this->getDropForeignKeySQL($foreignKey, $tableName);
+                $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableName);
             }
         }
 
         foreach ($diff->removedIndexes as $index) {
-            $sql[] = $this->getDropIndexSQL($index, $tableName);
+            $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $tableName);
         }
 
         foreach ($diff->changedIndexes as $index) {
-            $sql[] = $this->getDropIndexSQL($index, $tableName);
+            $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $tableName);
         }
 
         return $sql;

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -185,6 +185,13 @@ class OraclePlatform extends AbstractPlatform
     public function getCreatePrimaryKeySQL(Index $index, $table): string
     {
         if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $table = $table->getQuotedName($this);
         }
 
@@ -755,11 +762,26 @@ SQL
      */
     public function getDropForeignKeySQL($foreignKey, $table)
     {
-        if (! $foreignKey instanceof ForeignKeyConstraint) {
+        if ($foreignKey instanceof ForeignKeyConstraint) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $foreignKey as a ForeignKeyConstraint object to %s is deprecated.'
+                . ' Pass it as a quoted name instead.',
+                __METHOD__
+            );
+        } else {
             $foreignKey = new Identifier($foreignKey);
         }
 
-        if (! $table instanceof Table) {
+        if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+        } else {
             $table = new Identifier($table);
         }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -253,6 +253,13 @@ class SQLServerPlatform extends AbstractPlatform
     public function getDropIndexSQL($index, $table = null)
     {
         if ($index instanceof Index) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $index as an Index object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $index = $index->getQuotedName($this);
         } elseif (! is_string($index)) {
             throw new InvalidArgumentException(
@@ -261,6 +268,13 @@ class SQLServerPlatform extends AbstractPlatform
         }
 
         if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as an Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $table = $table->getQuotedName($this);
         } elseif (! is_string($table)) {
             throw new InvalidArgumentException(
@@ -354,6 +368,13 @@ class SQLServerPlatform extends AbstractPlatform
     public function getCreatePrimaryKeySQL(Index $index, $table)
     {
         if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $identifier = $table->getQuotedName($this);
         } else {
             $identifier = $table;

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -815,7 +815,7 @@ class SqlitePlatform extends AbstractPlatform
                 continue;
             }
 
-            $sql[] = $this->getDropIndexSQL($index, $diff->name);
+            $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $diff->name);
         }
 
         return $sql;
@@ -926,7 +926,7 @@ class SqlitePlatform extends AbstractPlatform
         $sql = [];
 
         foreach ($tables as $table) {
-            $sql[] = $this->getDropTableSQL($table);
+            $sql[] = $this->getDropTableSQL($table->getQuotedName($this));
         }
 
         return $sql;
@@ -1110,7 +1110,7 @@ class SqlitePlatform extends AbstractPlatform
                 implode(', ', $oldColumnNames),
                 $dataTable->getQuotedName($this)
             );
-            $sql[] = $this->getDropTableSQL($dataTable);
+            $sql[] = $this->getDropTableSQL($dataTable->getQuotedName($this));
 
             $newName = $diff->getNewName();
 

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -722,7 +722,25 @@ abstract class AbstractSchemaManager
     public function dropIndex($index, $table)
     {
         if ($index instanceof Index) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $index as an Index object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
             $index = $index->getQuotedName($this->_platform);
+        }
+
+        if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as an Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
+            $table = $table->getQuotedName($this->_platform);
         }
 
         $this->_execSql($this->_platform->getDropIndexSQL($index, $table));
@@ -741,7 +759,21 @@ abstract class AbstractSchemaManager
      */
     public function dropConstraint(Constraint $constraint, $table)
     {
-        $this->_execSql($this->_platform->getDropConstraintSQL($constraint, $table));
+        if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
+            $table = $table->getQuotedName($this->_platform);
+        }
+
+        $this->_execSql($this->_platform->getDropConstraintSQL(
+            $constraint->getQuotedName($this->_platform),
+            $table
+        ));
     }
 
     /**
@@ -756,6 +788,29 @@ abstract class AbstractSchemaManager
      */
     public function dropForeignKey($foreignKey, $table)
     {
+        if ($foreignKey instanceof ForeignKeyConstraint) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $foreignKey as a ForeignKeyConstraint object to %s is deprecated.'
+                . ' Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
+            $foreignKey = $foreignKey->getQuotedName($this->_platform);
+        }
+
+        if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__
+            );
+
+            $table = $table->getQuotedName($this->_platform);
+        }
+
         $this->_execSql($this->_platform->getDropForeignKeySQL($foreignKey, $table));
     }
 

--- a/src/Schema/Visitor/DropSchemaSqlCollector.php
+++ b/src/Schema/Visitor/DropSchemaSqlCollector.php
@@ -83,17 +83,20 @@ class DropSchemaSqlCollector extends AbstractVisitor
         foreach ($this->constraints as $fkConstraint) {
             assert($fkConstraint instanceof ForeignKeyConstraint);
             $localTable = $this->constraints[$fkConstraint];
-            $sql[]      = $this->platform->getDropForeignKeySQL($fkConstraint, $localTable);
+            $sql[]      = $this->platform->getDropForeignKeySQL(
+                $fkConstraint->getQuotedName($this->platform),
+                $localTable->getQuotedName($this->platform)
+            );
         }
 
         foreach ($this->sequences as $sequence) {
             assert($sequence instanceof Sequence);
-            $sql[] = $this->platform->getDropSequenceSQL($sequence);
+            $sql[] = $this->platform->getDropSequenceSQL($sequence->getQuotedName($this->platform));
         }
 
         foreach ($this->tables as $table) {
             assert($table instanceof Table);
-            $sql[] = $this->platform->getDropTableSQL($table);
+            $sql[] = $this->platform->getDropTableSQL($table->getQuotedName($this->platform));
         }
 
         return $sql;

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -428,7 +428,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertEquals(
             [
                 'ALTER TABLE alter_primary_key MODIFY id INT NOT NULL',
-                'ALTER TABLE alter_primary_key DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON alter_primary_key',
                 'ALTER TABLE alter_primary_key ADD PRIMARY KEY (foo)',
             ],
             $this->platform->getAlterTableSQL($diff)
@@ -456,7 +456,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertEquals(
             [
                 'ALTER TABLE drop_primary_key MODIFY id INT NOT NULL',
-                'ALTER TABLE drop_primary_key DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON drop_primary_key',
             ],
             $this->platform->getAlterTableSQL($diff)
         );
@@ -485,7 +485,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertSame(
             [
                 'ALTER TABLE tbl MODIFY id INT NOT NULL',
-                'ALTER TABLE tbl DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON tbl',
                 'ALTER TABLE tbl ADD PRIMARY KEY (id)',
             ],
             $this->platform->getAlterTableSQL($diff)
@@ -514,7 +514,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertSame(
             [
                 'ALTER TABLE tbl MODIFY id INT NOT NULL',
-                'ALTER TABLE tbl DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON tbl',
                 'ALTER TABLE tbl ADD PRIMARY KEY (id, foo)',
             ],
             $this->platform->getAlterTableSQL($diff)
@@ -550,7 +550,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $sql = $this->platform->getAlterTableSQL($diff);
 
         self::assertEquals([
-            'ALTER TABLE mytable DROP PRIMARY KEY',
+            'DROP INDEX foo_index ON mytable',
             'ALTER TABLE mytable ADD PRIMARY KEY (foo)',
         ], $sql);
     }
@@ -576,7 +576,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
         self::assertSame(
             [
-                'ALTER TABLE yolo DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON yolo',
                 'ALTER TABLE yolo ADD pkc2 INT NOT NULL',
                 'ALTER TABLE yolo ADD PRIMARY KEY (pkc1, pkc2)',
             ],

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -39,7 +39,7 @@ class MySQLSchemaTest extends TestCase
 
         self::assertEquals(
             [
-                'ALTER TABLE test DROP PRIMARY KEY',
+                'DROP INDEX `primary` ON test',
                 'ALTER TABLE test ADD PRIMARY KEY (bar_id, foo_id)',
             ],
             $sql

--- a/tests/Schema/Visitor/DropSchemaSqlCollectorTest.php
+++ b/tests/Schema/Visitor/DropSchemaSqlCollectorTest.php
@@ -31,8 +31,8 @@ class DropSchemaSqlCollectorTest extends TestCase
         $platform->expects(self::exactly(2))
             ->method('getDropForeignKeySQL')
             ->withConsecutive(
-                [$keyConstraintOne, $tableOne],
-                [$keyConstraintTwo, $tableTwo]
+                [$keyConstraintOne->getQuotedName($platform), $tableOne->getQuotedName($platform)],
+                [$keyConstraintTwo->getQuotedName($platform), $tableTwo->getQuotedName($platform)]
             );
 
         $collector->acceptForeignKey($tableOne, $keyConstraintOne);


### PR DESCRIPTION
The support for passing assets as names was removed in https://github.com/doctrine/dbal/pull/4797. It is unlikely that #4772 will be implemented by the 4.0.0 release. Therefore, let's deprecate passing names as assets in favor of passing them as quoted names (strings) as it's already implemented in 4.0.x.

Closes #4798.