### PR TITLE
Fix unnamed FK constraints parse for Sqlite

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -21,8 +21,6 @@ use function array_merge;
 use function array_unique;
 use function array_values;
 use function count;
-use function crc32;
-use function dechex;
 use function explode;
 use function func_get_arg;
 use function func_get_args;
@@ -32,6 +30,7 @@ use function is_array;
 use function is_bool;
 use function is_numeric;
 use function is_string;
+use function md5;
 use function preg_match;
 use function preg_match_all;
 use function sprintf;
@@ -1674,7 +1673,7 @@ class SQLServerPlatform extends AbstractPlatform
         // Always generate name for unquoted identifiers to ensure consistency.
         $identifier = new Identifier($identifier);
 
-        return strtoupper(dechex(crc32($identifier->getName())));
+        return strtoupper(md5($identifier->getName()));
     }
 
     protected function getCommentOnTableSQL(string $tableName, ?string $comment): string

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -6,10 +6,9 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
-use function crc32;
-use function dechex;
 use function explode;
 use function implode;
+use function md5;
 use function str_replace;
 use function strpos;
 use function strtolower;
@@ -214,9 +213,12 @@ abstract class AbstractAsset
      */
     protected function _generateIdentifierName($columnNames, $prefix = '', $maxSize = 30)
     {
-        $hash = implode('', array_map(static function ($column): string {
-            return dechex(crc32($column));
-        }, $columnNames));
+        $hash = md5(implode("\0", array_map(static function ($column): string {
+            // Always generate name for unquoted identifiers to ensure consistency.
+            $column = new Identifier($column);
+
+            return $column->getName();
+        }, $columnNames)));
 
         return strtoupper(substr($prefix . '_' . $hash, 0, $maxSize));
     }

--- a/src/Schema/SchemaConfig.php
+++ b/src/Schema/SchemaConfig.php
@@ -17,7 +17,7 @@ class SchemaConfig
     protected $hasExplicitForeignKeyIndexes = false;
 
     /** @var int */
-    protected $maxIdentifierLength = 63;
+    protected $maxIdentifierLength = 30;
 
     /** @var string|null */
     protected $name;

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -443,8 +443,10 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $list = [];
         foreach ($tableForeignKeys as $value) {
             $value = array_change_key_case($value, CASE_LOWER);
-            $name  = $value['constraint_name'];
-            if (! isset($list[$name])) {
+            $i     = $value['constraint_name'] !== ''
+                ? $value['constraint_name']
+                : '##unnamed_gh028hvwlfuhzhgn##' . count($list);
+            if (! isset($list[$i])) {
                 if (! isset($value['on_delete']) || $value['on_delete'] === 'RESTRICT') {
                     $value['on_delete'] = null;
                 }
@@ -453,8 +455,8 @@ class SqliteSchemaManager extends AbstractSchemaManager
                     $value['on_update'] = null;
                 }
 
-                $list[$name] = [
-                    'name' => $name,
+                $list[$i] = [
+                    'name' => $value['constraint_name'],
                     'local' => [],
                     'foreign' => [],
                     'foreignTable' => $value['table'],
@@ -465,13 +467,13 @@ class SqliteSchemaManager extends AbstractSchemaManager
                 ];
             }
 
-            $list[$name]['local'][] = $value['from'];
+            $list[$i]['local'][] = $value['from'];
 
             if ($value['to'] === null) {
                 continue;
             }
 
-            $list[$name]['foreign'][] = $value['to'];
+            $list[$i]['foreign'][] = $value['to'];
         }
 
         return parent::_getPortableTableForeignKeysList($list);
@@ -644,7 +646,7 @@ SQL
 
         for ($i = 0, $count = count($match[0]); $i < $count; $i++) {
             $details[] = [
-                'constraint_name' => isset($names[$i]) && $names[$i] !== '' ? $names[$i] : $i,
+                'constraint_name' => $names[$i] ?? '',
                 'deferrable'      => isset($deferrable[$i]) && strcasecmp($deferrable[$i], 'deferrable') === 0,
                 'deferred'        => isset($deferred[$i]) && strcasecmp($deferred[$i], 'deferred') === 0,
             ];

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -109,7 +109,7 @@ class Table extends AbstractAsset
             return $this->_schemaConfig->getMaxIdentifierLength();
         }
 
-        return 63;
+        return 30;
     }
 
     /**

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -407,7 +407,12 @@ class Table extends AbstractAsset
         $name = null
     ) {
         $name ??= $this->_generateIdentifierName(
-            array_merge([$this->getName()], $localColumnNames),
+            array_merge(
+                [$this->getName()],
+                $localColumnNames,
+                [$foreignTable instanceof Table ? $foreignTable->getName() : $foreignTable],
+                $foreignColumnNames
+            ),
             'fk',
             $this->_getMaxIdentifierLength()
         );
@@ -551,7 +556,12 @@ class Table extends AbstractAsset
             $name = $constraint->getName();
         } else {
             $name = $this->_generateIdentifierName(
-                array_merge([$this->getName()], $constraint->getLocalColumns()),
+                array_merge(
+                    [$this->getName()],
+                    $constraint->getLocalColumns(),
+                    [$constraint->getForeignTableName()],
+                    $constraint->getForeignColumns()
+                ),
                 'fk',
                 $this->_getMaxIdentifierLength()
             );

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -208,7 +208,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals(
             [
                 'CREATE TABLE dbal91_something (id INT NOT NULL, "table" INT DEFAULT NULL, PRIMARY KEY(id))',
-                'CREATE INDEX IDX_A9401304ECA7352B ON dbal91_something ("table")',
+                'CREATE INDEX IDX_62BCB2560889B82B4CE565A3A9 ON dbal91_something ("table")',
             ],
             $this->connection->getDatabasePlatform()->getCreateTableSQL($table)
         );

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1429,7 +1429,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         self::assertCount(2, $indexes);
         self::assertArrayHasKey('explicit_fk1_idx', $indexes);
-        self::assertArrayHasKey('idx_3d6c147fdc58d6c', $indexes);
+        self::assertArrayHasKey('idx_73b039498fad39d43d97f0fedf', $indexes);
     }
 
     /**

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -83,7 +83,7 @@ EOS
                 ['parent'],
                 'user',
                 ['id'],
-                '1',
+                '',
                 ['onUpdate' => 'NO ACTION', 'onDelete' => 'CASCADE', 'deferrable' => false, 'deferred' => false]
             ),
             new ForeignKeyConstraint(

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -307,7 +307,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE `quoted` (`create` VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, '
-                . '`bar` VARCHAR(255) NOT NULL, INDEX IDX_22660D028FD6E0FB8C736521D79164E3 (`create`, foo, `bar`)) '
+                . '`bar` VARCHAR(255) NOT NULL, INDEX IDX_22660D028FD6E0FB8C736521D7 (`create`, foo, `bar`)) '
                 . 'DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB',
             'ALTER TABLE `quoted` ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY (`create`, foo, `bar`)'
                 . ' REFERENCES `foreign` (`create`, bar, `foo-bar`)',
@@ -664,7 +664,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
                 'CREATE TABLE foreign_table (id INT NOT NULL, fk_id INT NOT NULL, '
                     . 'INDEX IDX_5690FFE2A57719D0 (fk_id), PRIMARY KEY(id)) '
                     . 'DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB',
-                'ALTER TABLE foreign_table ADD CONSTRAINT FK_5690FFE2A57719D05690FFE2BF396750 FOREIGN KEY (fk_id)'
+                'ALTER TABLE foreign_table ADD CONSTRAINT FK_5690FFE2A57719D05690FFE2BF3 FOREIGN KEY (fk_id)'
                     . ' REFERENCES foreign_table (id)',
             ],
             $this->platform->getCreateTableSQL(

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -664,7 +664,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
                 'CREATE TABLE foreign_table (id INT NOT NULL, fk_id INT NOT NULL, '
                     . 'INDEX IDX_5690FFE2A57719D0 (fk_id), PRIMARY KEY(id)) '
                     . 'DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB',
-                'ALTER TABLE foreign_table ADD CONSTRAINT FK_5690FFE2A57719D0 FOREIGN KEY (fk_id)'
+                'ALTER TABLE foreign_table ADD CONSTRAINT FK_5690FFE2A57719D05690FFE2BF396750 FOREIGN KEY (fk_id)'
                     . ' REFERENCES foreign_table (id)',
             ],
             $this->platform->getCreateTableSQL(

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -51,7 +51,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE test (foo VARCHAR(255) DEFAULT NULL, bar VARCHAR(255) DEFAULT NULL, '
-                . 'UNIQUE INDEX UNIQ_D87F7E0C8C73652176FF8CAA (foo, bar))'
+                . 'UNIQUE INDEX UNIQ_619043F8DC53577B71BC678FF (foo, bar))'
                 . ' DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB',
         ];
     }
@@ -196,7 +196,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
         self::assertEquals([
             'ALTER TABLE foo ADD PRIMARY KEY (bar)',
-            'CREATE UNIQUE INDEX UNIQ_8C73652178240498 ON foo (baz)',
+            'CREATE UNIQUE INDEX UNIQ_8A7B98B5B720055A8916A6F76 ON foo (baz)',
         ], $sql);
     }
 
@@ -284,7 +284,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE `quoted` (`create` VARCHAR(255) NOT NULL, '
-                . 'INDEX IDX_22660D028FD6E0FB (`create`)) '
+                . 'INDEX IDX_CF36C4B1E8E549425821CC4EA0 (`create`)) '
                 . 'DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB',
         ];
     }
@@ -307,7 +307,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE `quoted` (`create` VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, '
-                . '`bar` VARCHAR(255) NOT NULL, INDEX IDX_22660D028FD6E0FB8C736521D7 (`create`, foo, `bar`)) '
+                . '`bar` VARCHAR(255) NOT NULL, INDEX IDX_3A6D53DB88755747E8576E8FF4 (`create`, foo, `bar`)) '
                 . 'DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB',
             'ALTER TABLE `quoted` ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY (`create`, foo, `bar`)'
                 . ' REFERENCES `foreign` (`create`, bar, `foo-bar`)',
@@ -647,7 +647,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertSame(
             [
                 'CREATE TABLE foreign_table (id INT NOT NULL, fk_id INT NOT NULL, '
-                    . 'INDEX IDX_5690FFE2A57719D0 (fk_id), PRIMARY KEY(id)) '
+                    . 'INDEX IDX_1BAF4D7E2B8B0A482E6DBD4A2C (fk_id), PRIMARY KEY(id)) '
                     . 'DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = MyISAM',
             ],
             $this->platform->getCreateTableSQL(
@@ -662,9 +662,9 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertSame(
             [
                 'CREATE TABLE foreign_table (id INT NOT NULL, fk_id INT NOT NULL, '
-                    . 'INDEX IDX_5690FFE2A57719D0 (fk_id), PRIMARY KEY(id)) '
+                    . 'INDEX IDX_1BAF4D7E2B8B0A482E6DBD4A2C (fk_id), PRIMARY KEY(id)) '
                     . 'DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB',
-                'ALTER TABLE foreign_table ADD CONSTRAINT FK_5690FFE2A57719D05690FFE2BF3 FOREIGN KEY (fk_id)'
+                'ALTER TABLE foreign_table ADD CONSTRAINT FK_0177BF8D40F2AFCBCE887844A16 FOREIGN KEY (fk_id)'
                     . ' REFERENCES foreign_table (id)',
             ],
             $this->platform->getCreateTableSQL(

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -88,7 +88,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
                 . ' REFERENCES foo ("create", bar, "foo-bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar")'
                 . ' REFERENCES "foo-bar" ("create", bar, "foo-bar")',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D79164E3 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D7 ON "quoted" ("create", foo, "bar")',
         ];
     }
 
@@ -213,8 +213,8 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             [
                 'CREATE TABLE test (id INTEGER NOT NULL, fk_1 INTEGER NOT NULL, fk_2 INTEGER NOT NULL'
                     . ', PRIMARY KEY(id))',
-                'ALTER TABLE test ADD CONSTRAINT FK_D87F7E0C177612A38E7F43195690FFE262041AE0FB0D4B5A'
-                    . ' FOREIGN KEY (fk_1, fk_2) REFERENCES foreign_table (pk_1, pk_2)',
+                'ALTER TABLE test ADD CONSTRAINT FK_D87F7E0C177612A38E7F4319569 FOREIGN KEY (fk_1, fk_2)'
+                    . ' REFERENCES foreign_table (pk_1, pk_2)',
                 'ALTER TABLE test ADD CONSTRAINT named_fk FOREIGN KEY (fk_1, fk_2)'
                     . ' REFERENCES foreign_table2 (pk_1, pk_2)',
                 'CREATE INDEX IDX_D87F7E0C177612A38E7F4319 ON test (fk_1, fk_2)',

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -65,7 +65,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE test (foo VARCHAR(255) DEFAULT NULL, bar VARCHAR(255) DEFAULT NULL)',
-            'CREATE UNIQUE INDEX UNIQ_D87F7E0C8C73652176FF8CAA ON test (foo, bar)',
+            'CREATE UNIQUE INDEX UNIQ_619043F8DC53577B71BC678FF ON test (foo, bar)',
         ];
     }
 
@@ -88,7 +88,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
                 . ' REFERENCES foo ("create", bar, "foo-bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar")'
                 . ' REFERENCES "foo-bar" ("create", bar, "foo-bar")',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D7 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_3A6D53DB88755747E8576E8FF4 ON "quoted" ("create", foo, "bar")',
         ];
     }
 
@@ -99,7 +99,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL)',
-            'CREATE INDEX IDX_22660D028FD6E0FB ON "quoted" ("create")',
+            'CREATE INDEX IDX_CF36C4B1E8E549425821CC4EA0 ON "quoted" ("create")',
         ];
     }
 
@@ -186,7 +186,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         self::assertEquals(
             [
                 'CREATE TABLE test (id INTEGER NOT NULL, name VARCHAR(50) NOT NULL, PRIMARY KEY(id))',
-                'CREATE INDEX IDX_D87F7E0C5E237E06 ON test (name)',
+                'CREATE INDEX IDX_9D7F57B4367F70D42050F321F8 ON test (name)',
                 'CREATE INDEX composite_idx ON test (id, name)',
             ],
             $this->platform->getCreateTableSQL($table)
@@ -213,11 +213,11 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             [
                 'CREATE TABLE test (id INTEGER NOT NULL, fk_1 INTEGER NOT NULL, fk_2 INTEGER NOT NULL'
                     . ', PRIMARY KEY(id))',
-                'ALTER TABLE test ADD CONSTRAINT FK_D87F7E0C177612A38E7F4319569 FOREIGN KEY (fk_1, fk_2)'
+                'ALTER TABLE test ADD CONSTRAINT FK_4737136AACC59BFA6AD90831D48 FOREIGN KEY (fk_1, fk_2)'
                     . ' REFERENCES foreign_table (pk_1, pk_2)',
                 'ALTER TABLE test ADD CONSTRAINT named_fk FOREIGN KEY (fk_1, fk_2)'
                     . ' REFERENCES foreign_table2 (pk_1, pk_2)',
-                'CREATE INDEX IDX_D87F7E0C177612A38E7F4319 ON test (fk_1, fk_2)',
+                'CREATE INDEX IDX_5A3D07B0C9CDD6D0F776956820 ON test (fk_1, fk_2)',
             ],
             $this->platform->getCreateTableSQL(
                 $table,

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -213,8 +213,8 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             [
                 'CREATE TABLE test (id INTEGER NOT NULL, fk_1 INTEGER NOT NULL, fk_2 INTEGER NOT NULL'
                     . ', PRIMARY KEY(id))',
-                'ALTER TABLE test ADD CONSTRAINT FK_D87F7E0C177612A38E7F4319 FOREIGN KEY (fk_1, fk_2)'
-                    . ' REFERENCES foreign_table (pk_1, pk_2)',
+                'ALTER TABLE test ADD CONSTRAINT FK_D87F7E0C177612A38E7F43195690FFE262041AE0FB0D4B5A'
+                    . ' FOREIGN KEY (fk_1, fk_2) REFERENCES foreign_table (pk_1, pk_2)',
                 'ALTER TABLE test ADD CONSTRAINT named_fk FOREIGN KEY (fk_1, fk_2)'
                     . ' REFERENCES foreign_table2 (pk_1, pk_2)',
                 'CREATE INDEX IDX_D87F7E0C177612A38E7F4319 ON test (fk_1, fk_2)',

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -485,7 +485,7 @@ SQL
                 . ' REFERENCES foo ("create", bar, "foo-bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar")'
                 . ' REFERENCES "foo-bar" ("create", bar, "foo-bar")',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D79164E3 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D7 ON "quoted" ("create", foo, "bar")',
         ];
     }
 

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -95,7 +95,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE test (foo VARCHAR2(255) DEFAULT NULL NULL, bar VARCHAR2(255) DEFAULT NULL NULL)',
-            'CREATE UNIQUE INDEX UNIQ_D87F7E0C8C73652176FF8CAA ON test (foo, bar)',
+            'CREATE UNIQUE INDEX UNIQ_619043F8DC53577B71BC678FF ON test (foo, bar)',
         ];
     }
 
@@ -456,7 +456,7 @@ SQL
     {
         return [
             'CREATE TABLE "quoted" ("create" VARCHAR2(255) NOT NULL)',
-            'CREATE INDEX IDX_22660D028FD6E0FB ON "quoted" ("create")',
+            'CREATE INDEX IDX_CF36C4B1E8E549425821CC4EA0 ON "quoted" ("create")',
         ];
     }
 
@@ -485,7 +485,7 @@ SQL
                 . ' REFERENCES foo ("create", bar, "foo-bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar")'
                 . ' REFERENCES "foo-bar" ("create", bar, "foo-bar")',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D7 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_3A6D53DB88755747E8576E8FF4 ON "quoted" ("create", foo, "bar")',
         ];
     }
 

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -432,7 +432,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         return [
             'CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, '
             . 'foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL)',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D79164E3 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D7 ON "quoted" ("create", foo, "bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar")'
                 . ' REFERENCES "foreign" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar")'
@@ -601,7 +601,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         $sql = $this->platform->getAlterTableSQL($diff);
 
         $expectedSql = [
-            'ALTER TABLE mytable DROP CONSTRAINT FK_6B2BD609727ACA706B2BD609BF396750',
+            'ALTER TABLE mytable DROP CONSTRAINT FK_6B2BD609727ACA706B2BD609BF3',
             'DROP INDEX IDX_6B2BD609727ACA70',
             'ALTER TABLE mytable DROP parent_id',
         ];

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -601,7 +601,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         $sql = $this->platform->getAlterTableSQL($diff);
 
         $expectedSql = [
-            'ALTER TABLE mytable DROP CONSTRAINT FK_6B2BD609727ACA70',
+            'ALTER TABLE mytable DROP CONSTRAINT FK_6B2BD609727ACA706B2BD609BF396750',
             'DROP INDEX IDX_6B2BD609727ACA70',
             'ALTER TABLE mytable DROP parent_id',
         ];

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -40,7 +40,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE test (foo VARCHAR(255) DEFAULT NULL, bar VARCHAR(255) DEFAULT NULL)',
-            'CREATE UNIQUE INDEX UNIQ_D87F7E0C8C73652176FF8CAA ON test (foo, bar)',
+            'CREATE UNIQUE INDEX UNIQ_619043F8DC53577B71BC678FF ON test (foo, bar)',
         ];
     }
 
@@ -409,7 +409,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL)',
-            'CREATE INDEX IDX_22660D028FD6E0FB ON "quoted" ("create")',
+            'CREATE INDEX IDX_CF36C4B1E8E549425821CC4EA0 ON "quoted" ("create")',
         ];
     }
 
@@ -432,7 +432,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         return [
             'CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, '
             . 'foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL)',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D7 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_3A6D53DB88755747E8576E8FF4 ON "quoted" ("create", foo, "bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar")'
                 . ' REFERENCES "foreign" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar")'
@@ -601,8 +601,8 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         $sql = $this->platform->getAlterTableSQL($diff);
 
         $expectedSql = [
-            'ALTER TABLE mytable DROP CONSTRAINT FK_6B2BD609727ACA706B2BD609BF3',
-            'DROP INDEX IDX_6B2BD609727ACA70',
+            'ALTER TABLE mytable DROP CONSTRAINT FK_ACE3D33C6EE2079DB0BC79A2AE3',
+            'DROP INDEX IDX_C8FA05661F035BDB9B986322C6',
             'ALTER TABLE mytable DROP parent_id',
         ];
 

--- a/tests/Platforms/SQLServerPlatformTestCase.php
+++ b/tests/Platforms/SQLServerPlatformTestCase.php
@@ -39,7 +39,7 @@ class SQLServerPlatformTestCase extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE test (foo NVARCHAR(255), bar NVARCHAR(255))',
-            'CREATE UNIQUE INDEX UNIQ_D87F7E0C8C73652176FF8CAA ON test (foo, bar)'
+            'CREATE UNIQUE INDEX UNIQ_619043F8DC53577B71BC678FF ON test (foo, bar)'
                 . ' WHERE foo IS NOT NULL AND bar IS NOT NULL',
         ];
     }
@@ -638,7 +638,7 @@ class SQLServerPlatformTestCase extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE [quoted] ([create] NVARCHAR(255) NOT NULL)',
-            'CREATE INDEX IDX_22660D028FD6E0FB ON [quoted] ([create])',
+            'CREATE INDEX IDX_CF36C4B1E8E549425821CC4EA0 ON [quoted] ([create])',
         ];
     }
 

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -393,11 +393,11 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'CREATE TABLE user ('
                 . 'id INTEGER NOT NULL, article INTEGER NOT NULL, post INTEGER NOT NULL, parent INTEGER NOT NULL'
                 . ', PRIMARY KEY(id)'
-                . ', CONSTRAINT FK_8D93D64923A0E6623A0E66BF396750 FOREIGN KEY (article)'
+                . ', CONSTRAINT FK_8D93D64923A0E6623A0E66BF396 FOREIGN KEY (article)'
                 . ' REFERENCES article (id) DEFERRABLE INITIALLY IMMEDIATE'
-                . ', CONSTRAINT FK_8D93D6495A8A6C8D5A8A6C8DBF396750 FOREIGN KEY (post)'
+                . ', CONSTRAINT FK_8D93D6495A8A6C8D5A8A6C8DBF3 FOREIGN KEY (post)'
                 . ' REFERENCES post (id) NOT DEFERRABLE INITIALLY DEFERRED'
-                . ', CONSTRAINT FK_8D93D6493D8E604F8D93D649BF396750 FOREIGN KEY (parent)'
+                . ', CONSTRAINT FK_8D93D6493D8E604F8D93D649BF3 FOREIGN KEY (parent)'
                 . ' REFERENCES user (id) DEFERRABLE INITIALLY DEFERRED'
                 . ')',
             'CREATE INDEX IDX_8D93D64923A0E66 ON user (article)',
@@ -435,9 +435,9 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'CREATE TABLE user ('
                 . '"key" INTEGER NOT NULL, article INTEGER NOT NULL, comment INTEGER NOT NULL'
                 . ', PRIMARY KEY("key")'
-                . ', CONSTRAINT FK_8D93D64923A0E6623A0E66BF396750 FOREIGN KEY (article)'
+                . ', CONSTRAINT FK_8D93D64923A0E6623A0E66BF396 FOREIGN KEY (article)'
                 . ' REFERENCES article (id) DEFERRABLE INITIALLY IMMEDIATE'
-                . ', CONSTRAINT FK_8D93D6495A8A6C8D5A8A6C8DBF396750 FOREIGN KEY (comment)'
+                . ', CONSTRAINT FK_8D93D6495A8A6C8D5A8A6C8DBF3 FOREIGN KEY (comment)'
                 . ' REFERENCES post (id) NOT DEFERRABLE INITIALLY DEFERRED'
                 . ')',
             'INSERT INTO user ("key", article, comment) SELECT id, article, post FROM __temp__user',
@@ -494,7 +494,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'REFERENCES foo ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE, ' .
             'CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") ' .
             'REFERENCES "foo-bar" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE)',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D79164E3 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D7 ON "quoted" ("create", foo, "bar")',
         ];
     }
 

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -393,11 +393,11 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'CREATE TABLE user ('
                 . 'id INTEGER NOT NULL, article INTEGER NOT NULL, post INTEGER NOT NULL, parent INTEGER NOT NULL'
                 . ', PRIMARY KEY(id)'
-                . ', CONSTRAINT FK_8D93D64923A0E66 FOREIGN KEY (article)'
+                . ', CONSTRAINT FK_8D93D64923A0E6623A0E66BF396750 FOREIGN KEY (article)'
                 . ' REFERENCES article (id) DEFERRABLE INITIALLY IMMEDIATE'
-                . ', CONSTRAINT FK_8D93D6495A8A6C8D FOREIGN KEY (post)'
+                . ', CONSTRAINT FK_8D93D6495A8A6C8D5A8A6C8DBF396750 FOREIGN KEY (post)'
                 . ' REFERENCES post (id) NOT DEFERRABLE INITIALLY DEFERRED'
-                . ', CONSTRAINT FK_8D93D6493D8E604F FOREIGN KEY (parent)'
+                . ', CONSTRAINT FK_8D93D6493D8E604F8D93D649BF396750 FOREIGN KEY (parent)'
                 . ' REFERENCES user (id) DEFERRABLE INITIALLY DEFERRED'
                 . ')',
             'CREATE INDEX IDX_8D93D64923A0E66 ON user (article)',
@@ -435,9 +435,9 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'CREATE TABLE user ('
                 . '"key" INTEGER NOT NULL, article INTEGER NOT NULL, comment INTEGER NOT NULL'
                 . ', PRIMARY KEY("key")'
-                . ', CONSTRAINT FK_8D93D64923A0E66 FOREIGN KEY (article)'
+                . ', CONSTRAINT FK_8D93D64923A0E6623A0E66BF396750 FOREIGN KEY (article)'
                 . ' REFERENCES article (id) DEFERRABLE INITIALLY IMMEDIATE'
-                . ', CONSTRAINT FK_8D93D6495A8A6C8D FOREIGN KEY (comment)'
+                . ', CONSTRAINT FK_8D93D6495A8A6C8D5A8A6C8DBF396750 FOREIGN KEY (comment)'
                 . ' REFERENCES post (id) NOT DEFERRABLE INITIALLY DEFERRED'
                 . ')',
             'INSERT INTO user ("key", article, comment) SELECT id, article, post FROM __temp__user',

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -33,7 +33,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE test (foo VARCHAR(255) DEFAULT NULL, bar VARCHAR(255) DEFAULT NULL)',
-            'CREATE UNIQUE INDEX UNIQ_D87F7E0C8C73652176FF8CAA ON test (foo, bar)',
+            'CREATE UNIQUE INDEX UNIQ_619043F8DC53577B71BC678FF ON test (foo, bar)',
         ];
     }
 
@@ -393,16 +393,16 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'CREATE TABLE user ('
                 . 'id INTEGER NOT NULL, article INTEGER NOT NULL, post INTEGER NOT NULL, parent INTEGER NOT NULL'
                 . ', PRIMARY KEY(id)'
-                . ', CONSTRAINT FK_8D93D64923A0E6623A0E66BF396 FOREIGN KEY (article)'
+                . ', CONSTRAINT FK_2E3E837BA0ED4870A4EBDEF501F FOREIGN KEY (article)'
                 . ' REFERENCES article (id) DEFERRABLE INITIALLY IMMEDIATE'
-                . ', CONSTRAINT FK_8D93D6495A8A6C8D5A8A6C8DBF3 FOREIGN KEY (post)'
+                . ', CONSTRAINT FK_9DD374C012BF24C10C07745B3C6 FOREIGN KEY (post)'
                 . ' REFERENCES post (id) NOT DEFERRABLE INITIALLY DEFERRED'
-                . ', CONSTRAINT FK_8D93D6493D8E604F8D93D649BF3 FOREIGN KEY (parent)'
+                . ', CONSTRAINT FK_B81E882FC08BCECE445F53C27ED FOREIGN KEY (parent)'
                 . ' REFERENCES user (id) DEFERRABLE INITIALLY DEFERRED'
                 . ')',
-            'CREATE INDEX IDX_8D93D64923A0E66 ON user (article)',
-            'CREATE INDEX IDX_8D93D6495A8A6C8D ON user (post)',
-            'CREATE INDEX IDX_8D93D6493D8E604F ON user (parent)',
+            'CREATE INDEX IDX_0D3DBF4B036CCAE9636E30A100 ON user (article)',
+            'CREATE INDEX IDX_E806623150143792426B998417 ON user (post)',
+            'CREATE INDEX IDX_98C2B6A085F733F30320015DA5 ON user (parent)',
         ];
 
         self::assertEquals($sql, $this->platform->getCreateTableSQL($table));
@@ -435,16 +435,16 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'CREATE TABLE user ('
                 . '"key" INTEGER NOT NULL, article INTEGER NOT NULL, comment INTEGER NOT NULL'
                 . ', PRIMARY KEY("key")'
-                . ', CONSTRAINT FK_8D93D64923A0E6623A0E66BF396 FOREIGN KEY (article)'
+                . ', CONSTRAINT FK_2E3E837BA0ED4870A4EBDEF501F FOREIGN KEY (article)'
                 . ' REFERENCES article (id) DEFERRABLE INITIALLY IMMEDIATE'
-                . ', CONSTRAINT FK_8D93D6495A8A6C8D5A8A6C8DBF3 FOREIGN KEY (comment)'
+                . ', CONSTRAINT FK_9DD374C012BF24C10C07745B3C6 FOREIGN KEY (comment)'
                 . ' REFERENCES post (id) NOT DEFERRABLE INITIALLY DEFERRED'
                 . ')',
             'INSERT INTO user ("key", article, comment) SELECT id, article, post FROM __temp__user',
             'DROP TABLE __temp__user',
             'ALTER TABLE user RENAME TO client',
-            'CREATE INDEX IDX_8D93D64923A0E66 ON client (article)',
-            'CREATE INDEX IDX_8D93D6495A8A6C8D ON client (comment)',
+            'CREATE INDEX IDX_0D3DBF4B036CCAE9636E30A100 ON client (article)',
+            'CREATE INDEX IDX_E806623150143792426B998417 ON client (comment)',
         ];
 
         self::assertEquals($sql, $this->platform->getAlterTableSQL($diff));
@@ -465,7 +465,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL)',
-            'CREATE INDEX IDX_22660D028FD6E0FB ON "quoted" ("create")',
+            'CREATE INDEX IDX_CF36C4B1E8E549425821CC4EA0 ON "quoted" ("create")',
         ];
     }
 
@@ -494,7 +494,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'REFERENCES foo ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE, ' .
             'CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") ' .
             'REFERENCES "foo-bar" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE)',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D7 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_3A6D53DB88755747E8576E8FF4 ON "quoted" ("create", foo, "bar")',
         ];
     }
 
@@ -649,8 +649,8 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             'INSERT INTO "foo" (fk, fk2, war, fk3, bar) SELECT fk, fk2, id, fk3, bar FROM __temp__foo',
             'DROP TABLE __temp__foo',
             'ALTER TABLE "foo" RENAME TO "table"',
-            'CREATE INDEX IDX_8C736521A81E660E ON "table" (fk)',
-            'CREATE INDEX IDX_8C736521FDC58D6C ON "table" (fk2)',
+            'CREATE INDEX IDX_20C639AACE34AECF1BE2556F95 ON "table" (fk)',
+            'CREATE INDEX IDX_46283D0BCDE71C459B9112D4C5 ON "table" (fk2)',
         ];
     }
 

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -598,7 +598,9 @@ class ComparatorTest extends TestCase
         $tableDiff = $this->comparator->diffTable($table1, $table2);
 
         self::assertInstanceOf(TableDiff::class, $tableDiff);
-        self::assertCount(1, $tableDiff->changedForeignKeys);
+        self::assertCount(1, $tableDiff->removedForeignKeys);
+        self::assertCount(1, $tableDiff->addedForeignKeys);
+        self::assertCount(0, $tableDiff->changedForeignKeys);
     }
 
     public function testTablesCaseInsensitive(): void

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -59,7 +59,7 @@ class MySQLSchemaTest extends TestCase
 
         self::assertEquals(
             [
-                'ALTER TABLE test ADD CONSTRAINT FK_D87F7E0C8E48560F18B33AE88E48560F FOREIGN KEY (foo_id)'
+                'ALTER TABLE test ADD CONSTRAINT FK_D87F7E0C8E48560F18B33AE88E4 FOREIGN KEY (foo_id)'
                     . ' REFERENCES test_foreign (foo_id)',
             ],
             $sqls

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -59,7 +59,7 @@ class MySQLSchemaTest extends TestCase
 
         self::assertEquals(
             [
-                'ALTER TABLE test ADD CONSTRAINT FK_D87F7E0C8E48560F18B33AE88E4 FOREIGN KEY (foo_id)'
+                'ALTER TABLE test ADD CONSTRAINT FK_5C121F116BF1E3195BB7E13B130 FOREIGN KEY (foo_id)'
                     . ' REFERENCES test_foreign (foo_id)',
             ],
             $sqls

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -59,7 +59,7 @@ class MySQLSchemaTest extends TestCase
 
         self::assertEquals(
             [
-                'ALTER TABLE test ADD CONSTRAINT FK_D87F7E0C8E48560F FOREIGN KEY (foo_id)'
+                'ALTER TABLE test ADD CONSTRAINT FK_D87F7E0C8E48560F18B33AE88E48560F FOREIGN KEY (foo_id)'
                     . ' REFERENCES test_foreign (foo_id)',
             ],
             $sqls

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -409,10 +409,10 @@ class TableTest extends TestCase
         self::assertCount(3, $table->getIndexes());
         self::assertTrue($table->hasIndex('composite_idx'));
         self::assertTrue($table->hasIndex('full_idx'));
-        self::assertTrue($table->hasIndex('idx_8c73652176ff8caa78240498'));
+        self::assertTrue($table->hasIndex('idx_caee8a578bbbbf9d63306488dd'));
         self::assertSame(['baz', 'bar'], $table->getIndex('composite_idx')->getColumns());
         self::assertSame(['bar', 'baz', 'bloo'], $table->getIndex('full_idx')->getColumns());
-        self::assertSame(['bar', 'baz'], $table->getIndex('idx_8c73652176ff8caa78240498')->getColumns());
+        self::assertSame(['bar', 'baz'], $table->getIndex('idx_caee8a578bbbbf9d63306488dd')->getColumns());
     }
 
     public function testOverrulingIndexDoesNotDropOverruledIndex(): void
@@ -537,15 +537,15 @@ class TableTest extends TestCase
         $localTable->addForeignKeyConstraint($foreignTable, ['id'], ['id']);
 
         self::assertCount(1, $localTable->getIndexes());
-        self::assertTrue($localTable->hasIndex('IDX_8BD688E8BF396750'));
+        self::assertTrue($localTable->hasIndex('IDX_5E32205233580BE27163E0737C'));
 
-        $implicitIndex = $localTable->getIndex('IDX_8BD688E8BF396750');
+        $implicitIndex = $localTable->getIndex('IDX_5E32205233580BE27163E0737C');
 
-        $localTable->addIndex(['id'], 'IDX_8BD688E8BF396750');
+        $localTable->addIndex(['id'], 'IDX_5E32205233580BE27163E0737C');
 
         self::assertCount(1, $localTable->getIndexes());
-        self::assertTrue($localTable->hasIndex('IDX_8BD688E8BF396750'));
-        self::assertNotSame($implicitIndex, $localTable->getIndex('IDX_8BD688E8BF396750'));
+        self::assertTrue($localTable->hasIndex('IDX_5E32205233580BE27163E0737C'));
+        self::assertNotSame($implicitIndex, $localTable->getIndex('IDX_5E32205233580BE27163E0737C'));
     }
 
     public function testQuotedTableName(): void
@@ -674,8 +674,8 @@ class TableTest extends TestCase
 
         self::assertTrue($table->hasPrimaryKey());
         self::assertTrue($table->hasIndex('primary'));
-        self::assertTrue($table->hasIndex('IDX_D87F7E0C8C736521'));
-        self::assertTrue($table->hasIndex('UNIQ_D87F7E0C76FF8CAA78240498'));
+        self::assertTrue($table->hasIndex('IDX_AF422564835B2722E53D867AEA'));
+        self::assertTrue($table->hasIndex('UNIQ_AF5C0B1CE23DCAC98C0F986C5'));
 
         self::assertFalse($table->hasIndex('pk_new'));
         self::assertFalse($table->hasIndex('idx_new'));
@@ -684,23 +684,29 @@ class TableTest extends TestCase
         self::assertEquals(new Index('primary', ['id'], true, true), $table->getPrimaryKey());
         self::assertEquals(new Index('primary', ['id'], true, true), $table->getIndex('primary'));
         self::assertEquals(
-            new Index('IDX_D87F7E0C8C736521', ['foo'], false, false, ['flag']),
-            $table->getIndex('IDX_D87F7E0C8C736521')
+            new Index('IDX_AF422564835B2722E53D867AEA', ['foo'], false, false, ['flag']),
+            $table->getIndex('IDX_AF422564835B2722E53D867AEA')
         );
         self::assertEquals(
-            new Index('UNIQ_D87F7E0C76FF8CAA78240498', ['bar', 'baz'], true),
-            $table->getIndex('UNIQ_D87F7E0C76FF8CAA78240498')
+            new Index('UNIQ_AF5C0B1CE23DCAC98C0F986C5', ['bar', 'baz'], true),
+            $table->getIndex('UNIQ_AF5C0B1CE23DCAC98C0F986C5')
         );
 
         // Rename to same name (changed case).
         self::assertSame($table, $table->renameIndex('primary', 'PRIMARY'));
-        self::assertSame($table, $table->renameIndex('IDX_D87F7E0C8C736521', 'idx_D87F7E0C8C736521'));
-        self::assertSame($table, $table->renameIndex('UNIQ_D87F7E0C76FF8CAA78240498', 'uniq_D87F7E0C76FF8CAA78240498'));
+        self::assertSame(
+            $table,
+            $table->renameIndex('IDX_AF422564835B2722E53D867AEA', 'idx_Af422564835b2722e53d867aea')
+        );
+        self::assertSame(
+            $table,
+            $table->renameIndex('UNIQ_AF5C0B1CE23DCAC98C0F986C5', 'uniq_Af5c0b1ce23dcac98c0f986c5')
+        );
 
         self::assertTrue($table->hasPrimaryKey());
         self::assertTrue($table->hasIndex('primary'));
-        self::assertTrue($table->hasIndex('IDX_D87F7E0C8C736521'));
-        self::assertTrue($table->hasIndex('UNIQ_D87F7E0C76FF8CAA78240498'));
+        self::assertTrue($table->hasIndex('IDX_AF422564835B2722E53D867AEA'));
+        self::assertTrue($table->hasIndex('UNIQ_AF5C0B1CE23DCAC98C0F986C5'));
     }
 
     public function testKeepsIndexOptionsOnRenamingRegularIndex(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

https://github.com/doctrine/dbal/pull/5490 must be merged first, this PR depends on it

fixes https://dbfiddle.uk/?rdbms=sqlite_3.27&fiddle=4651f0cc575a2f2df11856003d2e0af8

`$i` as a fallback name in
https://github.com/doctrine/dbal/blob/d8fdd45b3a1e6b8d5eb9fa5a565c69d8de2cfda8/src/Schema/SqliteSchemaManager.php#L647
is wrong, as Sqlite constraint name cannot start with a number.

Empty string (`''`) as a fallback name must be used, so `CONSTRAINT <numerical_name> FOREIGN KEY...` is not generated for `CREATE TABLE`

https://www.sqlite.org/syntax/table-constraint.html