### PR TITLE
Enforce property types in tests

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,7 +20,6 @@
 
     <rule ref="Doctrine">
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants.DisallowedLateStaticBindingForConstant"/>
@@ -46,6 +45,10 @@
     </rule>
 
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
+        <exclude-pattern>*/src/*</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint">
         <exclude-pattern>*/src/*</exclude-pattern>
     </rule>
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -39,7 +39,7 @@ class ConnectionTest extends TestCase
     private Connection $connection;
 
     /** @var array{wrapperClass?: class-string<Connection>} */
-    protected $params = [
+    protected array $params = [
         'driver' => 'pdo_mysql',
         'host' => 'localhost',
         'user' => 'root',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

On the 3.4.x branch, it should be safe to enforce native property types via PHPCS, the same way we already do this for parameter and return types.
