### PR TITLE
Fix tests on Windows

### DIFF
--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -290,6 +290,7 @@ class ExceptionTest extends FunctionalTestCase
                 $conn->executeStatement($sql);
             }
         } finally {
+            $conn->close();
             $this->cleanupReadOnlyFile($filename);
         }
     }

--- a/tests/Types/BinaryTest.php
+++ b/tests/Types/BinaryTest.php
@@ -10,8 +10,9 @@ use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-use function base64_encode;
 use function fopen;
+use function fwrite;
+use function rewind;
 use function stream_get_contents;
 
 class BinaryTest extends TestCase
@@ -62,8 +63,10 @@ class BinaryTest extends TestCase
 
     public function testBinaryResourceConvertsToPHPValue(): void
     {
-        $databaseValue = fopen('data://text/plain;base64,' . base64_encode('binary string'), 'r');
-        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
+        $databaseValue = fopen('php://memory', 'r+');
+        fwrite($databaseValue, 'binary string');
+        rewind($databaseValue);
+        $phpValue = $this->type->convertToPHPValue($databaseValue, $this->platform);
 
         self::assertSame($databaseValue, $phpValue);
     }

--- a/tests/Types/BlobTest.php
+++ b/tests/Types/BlobTest.php
@@ -7,9 +7,10 @@ use Doctrine\DBAL\Types\BlobType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-use function base64_encode;
 use function chr;
 use function fopen;
+use function fwrite;
+use function rewind;
 use function stream_get_contents;
 
 class BlobTest extends TestCase
@@ -41,8 +42,10 @@ class BlobTest extends TestCase
 
     public function testBinaryResourceConvertsToPHPValue(): void
     {
-        $databaseValue = fopen('data://text/plain;base64,' . base64_encode($this->getBinaryString()), 'r');
-        $phpValue      = $this->type->convertToPHPValue($databaseValue, $this->platform);
+        $databaseValue = fopen('php://memory', 'r+');
+        fwrite($databaseValue, $this->getBinaryString());
+        rewind($databaseValue);
+        $phpValue = $this->type->convertToPHPValue($databaseValue, $this->platform);
 
         self::assertSame($databaseValue, $phpValue);
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

a) on Windows, Sqlite file cannot be unlinked before the connection is closed, it is Windows/NTFS FS behaviour
b) `/tmp` dir is not available, use `sys_get_temp_dir()` instead
c) `data://` URL read may be blocked by `allow_url_open=Off` php.ini, use `php://memory` instead, the `data://` is older way how to convert string to stream - https://evertpot.com/222/, in src already converted in https://github.com/doctrine/dbal/pull/555