### PR TITLE
Added result caching for QueryBuilder

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -369,3 +369,25 @@ in your query as a return value:
         ->where('email = ' .  $queryBuilder->createPositionalParameter($userInputEmail))
     ;
     // SELECT id, name FROM users WHERE email = ?
+
+Caching
+-------
+
+To use the result cache, it is necessary to call the method
+``enableResultCache($cacheProfile)`` and pass a instance of
+``Doctrine\DBAL\Cache\QueryCacheProfile`` with a cache lifetime
+value in seconds. A cache key can optionally be added if needed.
+
+.. code-block:: php
+
+    <?php
+
+    $queryBuilder
+        ->select('id', 'name')
+        ->from('users')
+        ->enableResultCache(new QueryCacheProfile(300, 'some-key'))
+    ;
+
+.. note::
+
+    See the :ref:`Caching <caching>` section for more information.

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Query;
 
+use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
@@ -965,11 +966,16 @@ class QueryBuilderTest extends TestCase
         array $parameterTypes,
         string $expectedSql
     ): void {
-        $qb = new QueryBuilder($this->conn);
+        $qb           = new QueryBuilder($this->conn);
+        $mockedResult = $this->createMock(Result::class);
 
         $this->conn->expects(self::once())
+            ->method('executeQuery')
+            ->with($expectedSql, $parameters, $parameterTypes, null)
+            ->willReturn($mockedResult);
+
+        $mockedResult->expects(self::once())
             ->method('fetchAssociative')
-            ->with($expectedSql, $parameters, $parameterTypes)
             ->willReturn(['username' => 'jwage', 'password' => 'changeme']);
 
         $row = $qb->select($select)
@@ -995,11 +1001,16 @@ class QueryBuilderTest extends TestCase
         array $parameterTypes,
         string $expectedSql
     ): void {
-        $qb = new QueryBuilder($this->conn);
+        $qb           = new QueryBuilder($this->conn);
+        $mockedResult = $this->createMock(Result::class);
 
         $this->conn->expects(self::once())
+            ->method('executeQuery')
+            ->with($expectedSql, $parameters, $parameterTypes, null)
+            ->willReturn($mockedResult);
+
+        $mockedResult->expects(self::once())
             ->method('fetchNumeric')
-            ->with($expectedSql, $parameters, $parameterTypes)
             ->willReturn(['jwage', 'changeme']);
 
         $row = $qb->select($select)
@@ -1025,11 +1036,16 @@ class QueryBuilderTest extends TestCase
         array $parameterTypes,
         string $expectedSql
     ): void {
-        $qb = new QueryBuilder($this->conn);
+        $qb           = new QueryBuilder($this->conn);
+        $mockedResult = $this->createMock(Result::class);
 
         $this->conn->expects(self::once())
+            ->method('executeQuery')
+            ->with($expectedSql, $parameters, $parameterTypes, null)
+            ->willReturn($mockedResult);
+
+        $mockedResult->expects(self::once())
             ->method('fetchOne')
-            ->with($expectedSql, $parameters, $parameterTypes)
             ->willReturn('jwage');
 
         $username = $qb->select($select)
@@ -1055,11 +1071,16 @@ class QueryBuilderTest extends TestCase
         array $parameterTypes,
         string $expectedSql
     ): void {
-        $qb = new QueryBuilder($this->conn);
+        $qb           = new QueryBuilder($this->conn);
+        $mockedResult = $this->createMock(Result::class);
 
         $this->conn->expects(self::once())
+            ->method('executeQuery')
+            ->with($expectedSql, $parameters, $parameterTypes, null)
+            ->willReturn($mockedResult);
+
+        $mockedResult->expects(self::once())
             ->method('fetchAllAssociative')
-            ->with($expectedSql, $parameters, $parameterTypes)
             ->willReturn(
                 [
                     ['username' => 'jwage', 'password' => 'changeme'],
@@ -1096,11 +1117,16 @@ class QueryBuilderTest extends TestCase
         array $parameterTypes,
         string $expectedSql
     ): void {
-        $qb = new QueryBuilder($this->conn);
+        $qb           = new QueryBuilder($this->conn);
+        $mockedResult = $this->createMock(Result::class);
 
         $this->conn->expects(self::once())
+            ->method('executeQuery')
+            ->with($expectedSql, $parameters, $parameterTypes, null)
+            ->willReturn($mockedResult);
+
+        $mockedResult->expects(self::once())
             ->method('fetchAllNumeric')
-            ->with($expectedSql, $parameters, $parameterTypes)
             ->willReturn(
                 [
                     ['jwage', 'changeme'],
@@ -1137,11 +1163,16 @@ class QueryBuilderTest extends TestCase
         array $parameterTypes,
         string $expectedSql
     ): void {
-        $qb = new QueryBuilder($this->conn);
+        $qb           = new QueryBuilder($this->conn);
+        $mockedResult = $this->createMock(Result::class);
 
         $this->conn->expects(self::once())
+            ->method('executeQuery')
+            ->with($expectedSql, $parameters, $parameterTypes, null)
+            ->willReturn($mockedResult);
+
+        $mockedResult->expects(self::once())
             ->method('fetchAllKeyValue')
-            ->with($expectedSql, $parameters, $parameterTypes)
             ->willReturn(
                 [
                     'jwage' => 'changeme',
@@ -1178,11 +1209,16 @@ class QueryBuilderTest extends TestCase
         array $parameterTypes,
         string $expectedSql
     ): void {
-        $qb = new QueryBuilder($this->conn);
+        $qb           = new QueryBuilder($this->conn);
+        $mockedResult = $this->createMock(Result::class);
 
         $this->conn->expects(self::once())
+            ->method('executeQuery')
+            ->with($expectedSql, $parameters, $parameterTypes, null)
+            ->willReturn($mockedResult);
+
+        $mockedResult->expects(self::once())
             ->method('fetchAllAssociativeIndexed')
-            ->with($expectedSql, $parameters, $parameterTypes)
             ->willReturn(
                 [
                     1 => [
@@ -1223,11 +1259,16 @@ class QueryBuilderTest extends TestCase
         array $parameterTypes,
         string $expectedSql
     ): void {
-        $qb = new QueryBuilder($this->conn);
+        $qb           = new QueryBuilder($this->conn);
+        $mockedResult = $this->createMock(Result::class);
 
         $this->conn->expects(self::once())
+            ->method('executeQuery')
+            ->with($expectedSql, $parameters, $parameterTypes, null)
+            ->willReturn($mockedResult);
+
+        $mockedResult->expects(self::once())
             ->method('fetchFirstColumn')
-            ->with($expectedSql, $parameters, $parameterTypes)
             ->willReturn(
                 [
                     'jwage',
@@ -1320,13 +1361,49 @@ class QueryBuilderTest extends TestCase
 
         $this->conn->expects(self::once())
             ->method('executeQuery')
-            ->with($expectedSql, $parameters, $parameterTypes)
+            ->with($expectedSql, $parameters, $parameterTypes, null)
             ->willReturn($mockedResult);
 
         $results = $qb->select($select)
             ->from($from)
             ->where($where)
             ->setParameters($parameters, $parameterTypes)
+            ->executeQuery();
+
+        self::assertSame(
+            $mockedResult,
+            $results
+        );
+    }
+
+    /**
+     * @param list<mixed>|array<string, mixed>                                     $parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     *
+     * @dataProvider fetchProvider
+     */
+    public function testExecuteQueryWithResultCaching(
+        string $select,
+        string $from,
+        string $where,
+        array $parameters,
+        array $parameterTypes,
+        string $expectedSql
+    ): void {
+        $qb           = new QueryBuilder($this->conn);
+        $qcp          = new QueryCacheProfile(300);
+        $mockedResult = $this->createMock(Result::class);
+
+        $this->conn->expects(self::once())
+            ->method('executeQuery')
+            ->with($expectedSql, $parameters, $parameterTypes, $qcp)
+            ->willReturn($mockedResult);
+
+        $results = $qb->select($select)
+            ->from($from)
+            ->where($where)
+            ->setParameters($parameters, $parameterTypes)
+            ->enableResultCache($qcp)
             ->executeQuery();
 
         self::assertSame(


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | 

#### Summary

Added `enable/disableResultCache` method in QueryBuilder for result caching.

I use `doctrine/dbal` in several projects and the result caching is annoying. Only way I can use result caching is calling `executeCacheQuery` method in `Connection`. I cannot use `fetch*` methods in `QueryBuilder`.

I repeat this piece of code:
```php
$builder = $connection->createQueryBuilder();
// ....
$result = $connection->executeCacheQuery(
    $builder->getSQL(),
    $builder->getParameters(),
    [],
    new \Doctrine\DBAL\Cache\QueryCacheProfile($cacheLifetime)
)->fetchAllAssociative();
```

With this improvement it will be:
```php
$builder = $connection->createQueryBuilder();
// ....
$builder->enableResultCache(300)->fetchAllAssociative();
```

What do you think about it? Is it possible to implement something like that?
