### PR TITLE
Switch to PHP 8.0 syntax via Rector

### DIFF
--- a/src/Cache/ArrayResult.php
+++ b/src/Cache/ArrayResult.php
@@ -16,18 +16,14 @@ use function reset;
  */
 final class ArrayResult implements Result
 {
-    /** @var list<array<string, mixed>> */
-    private array $data;
-
     private int $columnCount = 0;
     private int $num         = 0;
 
     /**
      * @param list<array<string, mixed>> $data
      */
-    public function __construct(array $data)
+    public function __construct(private array $data)
     {
-        $this->data = $data;
         if (count($data) === 0) {
             return;
         }

--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -19,20 +19,11 @@ use function sha1;
  */
 class QueryCacheProfile
 {
-    private ?CacheItemPoolInterface $resultCache = null;
-
-    private int $lifetime;
-
-    private ?string $cacheKey = null;
-
     public function __construct(
-        int $lifetime = 0,
-        ?string $cacheKey = null,
-        ?CacheItemPoolInterface $resultCache = null
+        private int $lifetime = 0,
+        private ?string $cacheKey = null,
+        private ?CacheItemPoolInterface $resultCache = null
     ) {
-        $this->lifetime    = $lifetime;
-        $this->cacheKey    = $cacheKey;
-        $this->resultCache = $resultCache;
     }
 
     public function getResultCache(): ?CacheItemPoolInterface

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -145,14 +145,9 @@ class Connection implements ServerVersionProvider
         ?EventManager $eventManager = null
     ) {
         $this->_driver = $driver;
-        $this->params  = $params;
 
-        // Create default config and event manager if none given
-        $config       ??= new Configuration();
-        $eventManager ??= new EventManager();
-
-        $this->_config       = $config;
-        $this->_eventManager = $eventManager;
+        $this->_config       = $config ?? new Configuration();
+        $this->_eventManager = $eventManager ?? new EventManager();
 
         if (isset($params['platform'])) {
             if (! $params['platform'] instanceof Platforms\AbstractPlatform) {
@@ -163,6 +158,7 @@ class Connection implements ServerVersionProvider
             $this->platform->setEventManager($this->_eventManager);
         }
 
+        $this->params     = $params;
         $this->autoCommit = $config->getAutoCommit();
     }
 

--- a/src/Connection/StaticServerVersionProvider.php
+++ b/src/Connection/StaticServerVersionProvider.php
@@ -8,11 +8,8 @@ use Doctrine\DBAL\ServerVersionProvider;
 
 class StaticServerVersionProvider implements ServerVersionProvider
 {
-    private string $version;
-
-    public function __construct(string $version)
+    public function __construct(private string $version)
     {
-        $this->version = $version;
     }
 
     public function getServerVersion(): string

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -235,7 +235,7 @@ class PrimaryReadReplicaConnection extends Connection
         $connectionParams = $this->chooseConnectionConfiguration($connectionName, $params);
 
         try {
-            return $this->_driver->connect($connectionParams);
+            return $this->driver->connect($connectionParams);
         } catch (DriverException $e) {
             throw $this->convertException($e);
         }

--- a/src/Driver/API/IBMDB2/ExceptionConverter.php
+++ b/src/Driver/API/IBMDB2/ExceptionConverter.php
@@ -27,39 +27,21 @@ final class ExceptionConverter implements ExceptionConverterInterface
 {
     public function convert(Exception $exception, ?Query $query): DriverException
     {
-        switch ($exception->getCode()) {
-            case -104:
-                return new SyntaxErrorException($exception, $query);
-
-            case -203:
-                return new NonUniqueFieldNameException($exception, $query);
-
-            case -204:
-                return new TableNotFoundException($exception, $query);
-
-            case -206:
-                return new InvalidFieldNameException($exception, $query);
-
-            case -407:
-                return new NotNullConstraintViolationException($exception, $query);
-
-            case -530:
-            case -531:
-            case -532:
-            case -20356:
-                return new ForeignKeyConstraintViolationException($exception, $query);
-
-            case -601:
-                return new TableExistsException($exception, $query);
-
-            case -803:
-                return new UniqueConstraintViolationException($exception, $query);
-
-            case -1336:
-            case -30082:
-                return new ConnectionException($exception, $query);
-        }
-
-        return new DriverException($exception, $query);
+        return match ($exception->getCode()) {
+            -104 => new SyntaxErrorException($exception, $query),
+            -203 => new NonUniqueFieldNameException($exception, $query),
+            -204 => new TableNotFoundException($exception, $query),
+            -206 => new InvalidFieldNameException($exception, $query),
+            -407 => new NotNullConstraintViolationException($exception, $query),
+            -530,
+            -531,
+            -532,
+            -20356 => new ForeignKeyConstraintViolationException($exception, $query),
+            -601 => new TableExistsException($exception, $query),
+            -803 => new UniqueConstraintViolationException($exception, $query),
+            -1336,
+            -30082 => new ConnectionException($exception, $query),
+            default => new DriverException($exception, $query),
+        };
     }
 }

--- a/src/Driver/API/MySQL/ExceptionConverter.php
+++ b/src/Driver/API/MySQL/ExceptionConverter.php
@@ -33,89 +33,63 @@ final class ExceptionConverter implements ExceptionConverterInterface
      */
     public function convert(Exception $exception, ?Query $query): DriverException
     {
-        switch ($exception->getCode()) {
-            case 1008:
-                return new DatabaseDoesNotExist($exception, $query);
-
-            case 1213:
-                return new DeadlockException($exception, $query);
-
-            case 1205:
-                return new LockWaitTimeoutException($exception, $query);
-
-            case 1050:
-                return new TableExistsException($exception, $query);
-
-            case 1051:
-            case 1146:
-                return new TableNotFoundException($exception, $query);
-
-            case 1216:
-            case 1217:
-            case 1451:
-            case 1452:
-            case 1701:
-                return new ForeignKeyConstraintViolationException($exception, $query);
-
-            case 1062:
-            case 1557:
-            case 1569:
-            case 1586:
-                return new UniqueConstraintViolationException($exception, $query);
-
-            case 1054:
-            case 1166:
-            case 1611:
-                return new InvalidFieldNameException($exception, $query);
-
-            case 1052:
-            case 1060:
-            case 1110:
-                return new NonUniqueFieldNameException($exception, $query);
-
-            case 1064:
-            case 1149:
-            case 1287:
-            case 1341:
-            case 1342:
-            case 1343:
-            case 1344:
-            case 1382:
-            case 1479:
-            case 1541:
-            case 1554:
-            case 1626:
-                return new SyntaxErrorException($exception, $query);
-
-            case 1044:
-            case 1045:
-            case 1046:
-            case 1049:
-            case 1095:
-            case 1142:
-            case 1143:
-            case 1227:
-            case 1370:
-            case 1429:
-            case 2002:
-            case 2005:
-            case 2054:
-                return new ConnectionException($exception, $query);
-
-            case 2006:
-                return new ConnectionLost($exception, $query);
-
-            case 1048:
-            case 1121:
-            case 1138:
-            case 1171:
-            case 1252:
-            case 1263:
-            case 1364:
-            case 1566:
-                return new NotNullConstraintViolationException($exception, $query);
-        }
-
-        return new DriverException($exception, $query);
+        return match ($exception->getCode()) {
+            1008 => new DatabaseDoesNotExist($exception, $query),
+            1213 => new DeadlockException($exception, $query),
+            1205 => new LockWaitTimeoutException($exception, $query),
+            1050 => new TableExistsException($exception, $query),
+            1051,
+            1146 => new TableNotFoundException($exception, $query),
+            1216,
+            1217,
+            1451,
+            1452,
+            1701 => new ForeignKeyConstraintViolationException($exception, $query),
+            1062,
+            1557,
+            1569,
+            1586 => new UniqueConstraintViolationException($exception, $query),
+            1054,
+            1166,
+            1611 => new InvalidFieldNameException($exception, $query),
+            1052,
+            1060,
+            1110 => new NonUniqueFieldNameException($exception, $query),
+            1064,
+            1149,
+            1287,
+            1341,
+            1342,
+            1343,
+            1344,
+            1382,
+            1479,
+            1541,
+            1554,
+            1626 => new SyntaxErrorException($exception, $query),
+            1044,
+            1045,
+            1046,
+            1049,
+            1095,
+            1142,
+            1143,
+            1227,
+            1370,
+            1429,
+            2002,
+            2005,
+            2054 => new ConnectionException($exception, $query),
+            2006 => new ConnectionLost($exception, $query),
+            1048,
+            1121,
+            1138,
+            1171,
+            1252,
+            1263,
+            1364,
+            1566 => new NotNullConstraintViolationException($exception, $query),
+            default => new DriverException($exception, $query),
+        };
     }
 }

--- a/src/Driver/API/OCI/ExceptionConverter.php
+++ b/src/Driver/API/OCI/ExceptionConverter.php
@@ -30,49 +30,27 @@ final class ExceptionConverter implements ExceptionConverterInterface
      */
     public function convert(Exception $exception, ?Query $query): DriverException
     {
-        switch ($exception->getCode()) {
-            case 1:
-            case 2299:
-            case 38911:
-                return new UniqueConstraintViolationException($exception, $query);
-
-            case 904:
-                return new InvalidFieldNameException($exception, $query);
-
-            case 918:
-            case 960:
-                return new NonUniqueFieldNameException($exception, $query);
-
-            case 923:
-                return new SyntaxErrorException($exception, $query);
-
-            case 942:
-                return new TableNotFoundException($exception, $query);
-
-            case 955:
-                return new TableExistsException($exception, $query);
-
-            case 1017:
-            case 12545:
-                return new ConnectionException($exception, $query);
-
-            case 1400:
-                return new NotNullConstraintViolationException($exception, $query);
-
-            case 1918:
-                return new DatabaseDoesNotExist($exception, $query);
-
-            case 2289:
-            case 2443:
-            case 4080:
-                return new DatabaseObjectNotFoundException($exception, $query);
-
-            case 2266:
-            case 2291:
-            case 2292:
-                return new ForeignKeyConstraintViolationException($exception, $query);
-        }
-
-        return new DriverException($exception, $query);
+        return match ($exception->getCode()) {
+            1,
+            2299,
+            38911 => new UniqueConstraintViolationException($exception, $query),
+            904 => new InvalidFieldNameException($exception, $query),
+            918,
+            960 => new NonUniqueFieldNameException($exception, $query),
+            923 => new SyntaxErrorException($exception, $query),
+            942 => new TableNotFoundException($exception, $query),
+            955 => new TableExistsException($exception, $query),
+            1017,
+            12545 => new ConnectionException($exception, $query),
+            1400 => new NotNullConstraintViolationException($exception, $query),
+            1918 => new DatabaseDoesNotExist($exception, $query),
+            2289,
+            2443,
+            4080 => new DatabaseObjectNotFoundException($exception, $query),
+            2266,
+            2291,
+            2292 => new ForeignKeyConstraintViolationException($exception, $query),
+            default => new DriverException($exception, $query),
+        };
     }
 }

--- a/src/Driver/API/SQLSrv/ExceptionConverter.php
+++ b/src/Driver/API/SQLSrv/ExceptionConverter.php
@@ -28,42 +28,22 @@ final class ExceptionConverter implements ExceptionConverterInterface
 {
     public function convert(Exception $exception, ?Query $query): DriverException
     {
-        switch ($exception->getCode()) {
-            case 102:
-                return new SyntaxErrorException($exception, $query);
-
-            case 207:
-                return new InvalidFieldNameException($exception, $query);
-
-            case 208:
-                return new TableNotFoundException($exception, $query);
-
-            case 209:
-                return new NonUniqueFieldNameException($exception, $query);
-
-            case 515:
-                return new NotNullConstraintViolationException($exception, $query);
-
-            case 547:
-            case 4712:
-                return new ForeignKeyConstraintViolationException($exception, $query);
-
-            case 2601:
-            case 2627:
-                return new UniqueConstraintViolationException($exception, $query);
-
-            case 2714:
-                return new TableExistsException($exception, $query);
-
-            case 3701:
-            case 15151:
-                return new DatabaseObjectNotFoundException($exception, $query);
-
-            case 11001:
-            case 18456:
-                return new ConnectionException($exception, $query);
-        }
-
-        return new DriverException($exception, $query);
+        return match ($exception->getCode()) {
+            102 => new SyntaxErrorException($exception, $query),
+            207 => new InvalidFieldNameException($exception, $query),
+            208 => new TableNotFoundException($exception, $query),
+            209 => new NonUniqueFieldNameException($exception, $query),
+            515 => new NotNullConstraintViolationException($exception, $query),
+            547,
+            4712 => new ForeignKeyConstraintViolationException($exception, $query),
+            2601,
+            2627 => new UniqueConstraintViolationException($exception, $query),
+            2714 => new TableExistsException($exception, $query),
+            3701,
+            15151 => new DatabaseObjectNotFoundException($exception, $query),
+            11001,
+            18456 => new ConnectionException($exception, $query),
+            default => new DriverException($exception, $query),
+        };
     }
 }

--- a/src/Driver/AbstractException.php
+++ b/src/Driver/AbstractException.php
@@ -15,21 +15,18 @@ use Throwable;
 abstract class AbstractException extends BaseException implements Exception
 {
     /**
-     * The SQLSTATE of the driver.
-     */
-    private ?string $sqlState = null;
-
-    /**
      * @param string         $message  The driver error message.
      * @param string|null    $sqlState The SQLSTATE the driver is in at the time the error occurred, if any.
      * @param int            $code     The driver specific error code if any.
      * @param Throwable|null $previous The previous throwable used for the exception chaining.
      */
-    public function __construct(string $message, ?string $sqlState = null, int $code = 0, ?Throwable $previous = null)
-    {
+    public function __construct(
+        string $message,
+        private ?string $sqlState = null,
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
         parent::__construct($message, $code, $previous);
-
-        $this->sqlState = $sqlState;
     }
 
     public function getSQLState(): ?string

--- a/src/Driver/AbstractOracleDriver/EasyConnectString.php
+++ b/src/Driver/AbstractOracleDriver/EasyConnectString.php
@@ -15,11 +15,8 @@ use function sprintf;
  */
 final class EasyConnectString
 {
-    private string $string;
-
-    private function __construct(string $string)
+    private function __construct(private string $string)
     {
-        $this->string = $string;
     }
 
     public function __toString(): string

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -28,17 +28,13 @@ use const DB2_AUTOCOMMIT_ON;
 
 final class Connection implements ConnectionInterface
 {
-    /** @var resource */
-    private $connection;
-
     /**
      * @internal The connection can be only instantiated by its driver.
      *
      * @param resource $connection
      */
-    public function __construct($connection)
+    public function __construct(private $connection)
     {
-        $this->connection = $connection;
     }
 
     public function getServerVersion(): string

--- a/src/Driver/IBMDB2/DataSourceName.php
+++ b/src/Driver/IBMDB2/DataSourceName.php
@@ -13,11 +13,8 @@ use function str_contains;
  */
 final class DataSourceName
 {
-    private string $string;
-
-    private function __construct(string $string)
+    private function __construct(private string $string)
     {
-        $this->string = $string;
     }
 
     public function toString(): string

--- a/src/Driver/IBMDB2/Result.php
+++ b/src/Driver/IBMDB2/Result.php
@@ -17,17 +17,13 @@ use function db2_stmt_error;
 
 final class Result implements ResultInterface
 {
-    /** @var resource */
-    private $statement;
-
     /**
      * @internal The result can be only instantiated by its driver connection or statement.
      *
      * @param resource $statement
      */
-    public function __construct($statement)
+    public function __construct(private $statement)
     {
-        $this->statement = $statement;
     }
 
     public function fetchNumeric(): array|false

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -30,9 +30,6 @@ use const DB2_PARAM_IN;
 
 final class Statement implements StatementInterface
 {
-    /** @var resource */
-    private $stmt;
-
     /** @var mixed[] */
     private array $parameters = [];
 
@@ -49,9 +46,8 @@ final class Statement implements StatementInterface
      *
      * @param resource $stmt
      */
-    public function __construct($stmt)
+    public function __construct(private $stmt)
     {
-        $this->stmt = $stmt;
     }
 
     public function bindValue(int|string $param, mixed $value, int $type = ParameterType::STRING): void

--- a/src/Driver/Middleware/AbstractConnectionMiddleware.php
+++ b/src/Driver/Middleware/AbstractConnectionMiddleware.php
@@ -10,11 +10,8 @@ use Doctrine\DBAL\Driver\Statement;
 
 abstract class AbstractConnectionMiddleware implements Connection
 {
-    private Connection $wrappedConnection;
-
-    public function __construct(Connection $wrappedConnection)
+    public function __construct(private Connection $wrappedConnection)
     {
-        $this->wrappedConnection = $wrappedConnection;
     }
 
     public function prepare(string $sql): Statement

--- a/src/Driver/Middleware/AbstractDriverMiddleware.php
+++ b/src/Driver/Middleware/AbstractDriverMiddleware.php
@@ -12,11 +12,8 @@ use Doctrine\DBAL\ServerVersionProvider;
 
 abstract class AbstractDriverMiddleware implements Driver
 {
-    private Driver $wrappedDriver;
-
-    public function __construct(Driver $wrappedDriver)
+    public function __construct(private Driver $wrappedDriver)
     {
-        $this->wrappedDriver = $wrappedDriver;
     }
 
     /**

--- a/src/Driver/Middleware/AbstractResultMiddleware.php
+++ b/src/Driver/Middleware/AbstractResultMiddleware.php
@@ -8,11 +8,8 @@ use Doctrine\DBAL\Driver\Result;
 
 abstract class AbstractResultMiddleware implements Result
 {
-    private Result $wrappedResult;
-
-    public function __construct(Result $result)
+    public function __construct(private Result $wrappedResult)
     {
-        $this->wrappedResult = $result;
     }
 
     public function fetchNumeric(): array|false

--- a/src/Driver/Middleware/AbstractStatementMiddleware.php
+++ b/src/Driver/Middleware/AbstractStatementMiddleware.php
@@ -10,11 +10,8 @@ use Doctrine\DBAL\ParameterType;
 
 abstract class AbstractStatementMiddleware implements Statement
 {
-    private Statement $wrappedStatement;
-
-    public function __construct(Statement $wrappedStatement)
+    public function __construct(private Statement $wrappedStatement)
     {
-        $this->wrappedStatement = $wrappedStatement;
     }
 
     public function bindValue(int|string $param, mixed $value, int $type = ParameterType::STRING): void

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -17,14 +17,11 @@ final class Connection implements ConnectionInterface
      */
     public const OPTION_FLAGS = 'flags';
 
-    private mysqli $connection;
-
     /**
      * @internal The connection can be only instantiated by its driver.
      */
-    public function __construct(mysqli $connection)
+    public function __construct(private mysqli $connection)
     {
-        $this->connection = $connection;
     }
 
     public function getServerVersion(): string

--- a/src/Driver/Mysqli/Initializer/Charset.php
+++ b/src/Driver/Mysqli/Initializer/Charset.php
@@ -11,11 +11,8 @@ use mysqli_sql_exception;
 
 final class Charset implements Initializer
 {
-    private string $charset;
-
-    public function __construct(string $charset)
+    public function __construct(private string $charset)
     {
-        $this->charset = $charset;
     }
 
     public function initialize(mysqli $connection): void

--- a/src/Driver/Mysqli/Initializer/Options.php
+++ b/src/Driver/Mysqli/Initializer/Options.php
@@ -12,15 +12,11 @@ use function mysqli_options;
 
 final class Options implements Initializer
 {
-    /** @var array<int,mixed> */
-    private array $options;
-
     /**
      * @param array<int,mixed> $options
      */
-    public function __construct(array $options)
+    public function __construct(private array $options)
     {
-        $this->options = $options;
     }
 
     public function initialize(mysqli $connection): void

--- a/src/Driver/Mysqli/Initializer/Secure.php
+++ b/src/Driver/Mysqli/Initializer/Secure.php
@@ -9,19 +9,13 @@ use mysqli;
 
 final class Secure implements Initializer
 {
-    private string $key;
-    private string $cert;
-    private string $ca;
-    private string $capath;
-    private string $cipher;
-
-    public function __construct(string $key, string $cert, string $ca, string $capath, string $cipher)
-    {
-        $this->key    = $key;
-        $this->cert   = $cert;
-        $this->ca     = $ca;
-        $this->capath = $capath;
-        $this->cipher = $cipher;
+    public function __construct(
+        private string $key,
+        private string $cert,
+        private string $ca,
+        private string $capath,
+        private string $cipher
+    ) {
     }
 
     public function initialize(mysqli $connection): void

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -18,8 +18,6 @@ use function count;
 
 final class Result implements ResultInterface
 {
-    private mysqli_stmt $statement;
-
     /**
      * Whether the statement result has columns. The property should be used only after the result metadata
      * has been fetched ({@see $metadataFetched}). Otherwise, the property value is undetermined.
@@ -42,10 +40,8 @@ final class Result implements ResultInterface
      *
      * @throws Exception
      */
-    public function __construct(mysqli_stmt $statement)
+    public function __construct(private mysqli_stmt $statement)
     {
-        $this->statement = $statement;
-
         $meta = $statement->result_metadata();
 
         if ($meta === false) {

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -37,8 +37,6 @@ final class Statement implements StatementInterface
         ParameterType::LARGE_OBJECT => 'b',
     ];
 
-    private mysqli_stmt $stmt;
-
     /** @var mixed[] */
     private array $boundValues;
 
@@ -54,10 +52,8 @@ final class Statement implements StatementInterface
     /**
      * @internal The statement can be only instantiated by its driver connection.
      */
-    public function __construct(mysqli_stmt $stmt)
+    public function __construct(private mysqli_stmt $stmt)
     {
-        $this->stmt = $stmt;
-
         $paramCount        = $this->stmt->param_count;
         $this->types       = str_repeat('s', $paramCount);
         $this->boundValues = array_fill(1, $paramCount, null);

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -22,9 +22,6 @@ use function str_replace;
 
 final class Connection implements ConnectionInterface
 {
-    /** @var resource */
-    private $connection;
-
     private Parser $parser;
     private ExecutionMode $executionMode;
 
@@ -33,9 +30,8 @@ final class Connection implements ConnectionInterface
      *
      * @param resource $connection
      */
-    public function __construct($connection)
+    public function __construct(private $connection)
     {
-        $this->connection    = $connection;
         $this->parser        = new Parser(false);
         $this->executionMode = new ExecutionMode();
     }

--- a/src/Driver/OCI8/Result.php
+++ b/src/Driver/OCI8/Result.php
@@ -25,17 +25,13 @@ use const OCI_RETURN_NULLS;
 
 final class Result implements ResultInterface
 {
-    /** @var resource */
-    private $statement;
-
     /**
      * @internal The result can be only instantiated by its driver connection or statement.
      *
      * @param resource $statement
      */
-    public function __construct($statement)
+    public function __construct(private $statement)
     {
-        $this->statement = $statement;
     }
 
     public function fetchNumeric(): array|false

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -24,17 +24,6 @@ use const SQLT_CHR;
 
 final class Statement implements StatementInterface
 {
-    /** @var resource */
-    private $connection;
-
-    /** @var resource */
-    private $statement;
-
-    /** @var array<int,string> */
-    private array $parameterMap;
-
-    private ExecutionMode $executionMode;
-
     /**
      * @internal The statement can be only instantiated by its driver connection.
      *
@@ -42,12 +31,12 @@ final class Statement implements StatementInterface
      * @param resource          $statement
      * @param array<int,string> $parameterMap
      */
-    public function __construct($connection, $statement, array $parameterMap, ExecutionMode $executionMode)
-    {
-        $this->connection    = $connection;
-        $this->statement     = $statement;
-        $this->parameterMap  = $parameterMap;
-        $this->executionMode = $executionMode;
+    public function __construct(
+        private $connection,
+        private $statement,
+        private array $parameterMap,
+        private ExecutionMode $executionMode
+    ) {
     }
 
     public function bindValue(int|string $param, mixed $value, int $type = ParameterType::STRING): void
@@ -98,16 +87,11 @@ final class Statement implements StatementInterface
      */
     private function convertParameterType(int $type): int
     {
-        switch ($type) {
-            case ParameterType::BINARY:
-                return OCI_B_BIN;
-
-            case ParameterType::LARGE_OBJECT:
-                return OCI_B_BLOB;
-
-            default:
-                return SQLT_CHR;
-        }
+        return match ($type) {
+            ParameterType::BINARY => OCI_B_BIN,
+            ParameterType::LARGE_OBJECT => OCI_B_BLOB,
+            default => SQLT_CHR,
+        };
     }
 
     public function execute(?array $params = null): Result

--- a/src/Driver/PDO/Result.php
+++ b/src/Driver/PDO/Result.php
@@ -11,14 +11,11 @@ use PDOStatement;
 
 final class Result implements ResultInterface
 {
-    private PDOStatement $statement;
-
     /**
      * @internal The result can be only instantiated by its driver connection or statement.
      */
-    public function __construct(PDOStatement $statement)
+    public function __construct(private PDOStatement $statement)
     {
-        $this->statement = $statement;
     }
 
     public function fetchNumeric(): array|false

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -24,14 +24,11 @@ final class Statement implements StatementInterface
         ParameterType::BOOLEAN      => PDO::PARAM_BOOL,
     ];
 
-    private PDOStatement $stmt;
-
     /**
      * @internal The statement can be only instantiated by its driver connection.
      */
-    public function __construct(PDOStatement $stmt)
+    public function __construct(private PDOStatement $stmt)
     {
-        $this->stmt = $stmt;
     }
 
     public function bindValue(int|string $param, mixed $value, int $type = ParameterType::STRING): void

--- a/src/Driver/SQLSrv/Connection.php
+++ b/src/Driver/SQLSrv/Connection.php
@@ -18,17 +18,13 @@ use function str_replace;
 
 final class Connection implements ConnectionInterface
 {
-    /** @var resource */
-    private $connection;
-
     /**
      * @internal The connection can be only instantiated by its driver.
      *
      * @param resource $connection
      */
-    public function __construct($connection)
+    public function __construct(private $connection)
     {
-        $this->connection = $connection;
     }
 
     public function getServerVersion(): string

--- a/src/Driver/SQLSrv/Result.php
+++ b/src/Driver/SQLSrv/Result.php
@@ -17,17 +17,13 @@ use const SQLSRV_FETCH_NUMERIC;
 
 final class Result implements ResultInterface
 {
-    /** @var resource */
-    private $statement;
-
     /**
      * @internal The result can be only instantiated by its driver connection or statement.
      *
-     * @param resource $stmt
+     * @param resource $statement
      */
-    public function __construct($stmt)
+    public function __construct(private $statement)
     {
-        $this->statement = $stmt;
     }
 
     public function fetchNumeric(): array|false

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -25,18 +25,6 @@ use const SQLSRV_PARAM_IN;
 final class Statement implements StatementInterface
 {
     /**
-     * The SQLSRV Resource.
-     *
-     * @var resource
-     */
-    private $conn;
-
-    /**
-     * The SQL statement to execute.
-     */
-    private string $sql;
-
-    /**
      * The SQLSRV statement resource.
      *
      * @var resource|null
@@ -67,11 +55,10 @@ final class Statement implements StatementInterface
      *
      * @param resource $conn
      */
-    public function __construct($conn, string $sql)
-    {
-        $this->conn = $conn;
-        $this->sql  = $sql;
-
+    public function __construct(
+        private $conn,
+        private string $sql
+    ) {
         if (stripos($sql, 'INSERT INTO ') !== 0) {
             return;
         }

--- a/src/Event/ConnectionEventArgs.php
+++ b/src/Event/ConnectionEventArgs.php
@@ -12,11 +12,8 @@ use Doctrine\DBAL\Connection;
  */
 class ConnectionEventArgs extends EventArgs
 {
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     public function getConnection(): Connection

--- a/src/Event/Listeners/SQLSessionInit.php
+++ b/src/Event/Listeners/SQLSessionInit.php
@@ -14,11 +14,8 @@ use Doctrine\DBAL\Exception;
  */
 class SQLSessionInit implements EventSubscriber
 {
-    protected string $sql;
-
-    public function __construct(string $sql)
+    public function __construct(protected string $sql)
     {
-        $this->sql = $sql;
     }
 
     /**

--- a/src/Event/SchemaAlterTableAddColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableAddColumnEventArgs.php
@@ -16,18 +16,14 @@ use function array_values;
  */
 class SchemaAlterTableAddColumnEventArgs extends SchemaEventArgs
 {
-    private Column $column;
-    private TableDiff $tableDiff;
-    private AbstractPlatform $platform;
-
     /** @var array<int, string> */
     private array $sql = [];
 
-    public function __construct(Column $column, TableDiff $tableDiff, AbstractPlatform $platform)
-    {
-        $this->column    = $column;
-        $this->tableDiff = $tableDiff;
-        $this->platform  = $platform;
+    public function __construct(
+        private Column $column,
+        private TableDiff $tableDiff,
+        private AbstractPlatform $platform
+    ) {
     }
 
     public function getColumn(): Column

--- a/src/Event/SchemaAlterTableChangeColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableChangeColumnEventArgs.php
@@ -16,18 +16,14 @@ use function array_values;
  */
 class SchemaAlterTableChangeColumnEventArgs extends SchemaEventArgs
 {
-    private ColumnDiff $columnDiff;
-    private TableDiff $tableDiff;
-    private AbstractPlatform $platform;
-
     /** @var array<int, string> */
     private array $sql = [];
 
-    public function __construct(ColumnDiff $columnDiff, TableDiff $tableDiff, AbstractPlatform $platform)
-    {
-        $this->columnDiff = $columnDiff;
-        $this->tableDiff  = $tableDiff;
-        $this->platform   = $platform;
+    public function __construct(
+        private ColumnDiff $columnDiff,
+        private TableDiff $tableDiff,
+        private AbstractPlatform $platform
+    ) {
     }
 
     public function getColumnDiff(): ColumnDiff

--- a/src/Event/SchemaAlterTableEventArgs.php
+++ b/src/Event/SchemaAlterTableEventArgs.php
@@ -15,16 +15,11 @@ use function array_values;
  */
 class SchemaAlterTableEventArgs extends SchemaEventArgs
 {
-    private TableDiff $tableDiff;
-    private AbstractPlatform $platform;
-
     /** @var array<int, string> */
     private array $sql = [];
 
-    public function __construct(TableDiff $tableDiff, AbstractPlatform $platform)
+    public function __construct(private TableDiff $tableDiff, private AbstractPlatform $platform)
     {
-        $this->tableDiff = $tableDiff;
-        $this->platform  = $platform;
     }
 
     public function getTableDiff(): TableDiff

--- a/src/Event/SchemaAlterTableRemoveColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableRemoveColumnEventArgs.php
@@ -16,18 +16,14 @@ use function array_values;
  */
 class SchemaAlterTableRemoveColumnEventArgs extends SchemaEventArgs
 {
-    private Column $column;
-    private TableDiff $tableDiff;
-    private AbstractPlatform $platform;
-
     /** @var array<int, string> */
     private array $sql = [];
 
-    public function __construct(Column $column, TableDiff $tableDiff, AbstractPlatform $platform)
-    {
-        $this->column    = $column;
-        $this->tableDiff = $tableDiff;
-        $this->platform  = $platform;
+    public function __construct(
+        private Column $column,
+        private TableDiff $tableDiff,
+        private AbstractPlatform $platform
+    ) {
     }
 
     public function getColumn(): Column

--- a/src/Event/SchemaAlterTableRenameColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableRenameColumnEventArgs.php
@@ -16,20 +16,15 @@ use function array_values;
  */
 class SchemaAlterTableRenameColumnEventArgs extends SchemaEventArgs
 {
-    private string $oldColumnName;
-    private Column $column;
-    private TableDiff $tableDiff;
-    private AbstractPlatform $platform;
-
     /** @var array<int, string> */
     private array $sql = [];
 
-    public function __construct(string $oldColumnName, Column $column, TableDiff $tableDiff, AbstractPlatform $platform)
-    {
-        $this->oldColumnName = $oldColumnName;
-        $this->column        = $column;
-        $this->tableDiff     = $tableDiff;
-        $this->platform      = $platform;
+    public function __construct(
+        private string $oldColumnName,
+        private Column $column,
+        private TableDiff $tableDiff,
+        private AbstractPlatform $platform
+    ) {
     }
 
     public function getOldColumnName(): string

--- a/src/Event/SchemaColumnDefinitionEventArgs.php
+++ b/src/Event/SchemaColumnDefinitionEventArgs.php
@@ -15,27 +15,14 @@ class SchemaColumnDefinitionEventArgs extends SchemaEventArgs
     private ?Column $column = null;
 
     /**
-     * Raw column data as fetched from the database.
-     *
-     * @var array<string, mixed>
-     */
-    private array $tableColumn;
-
-    private string $table;
-
-    private string $database;
-
-    private Connection $connection;
-
-    /**
      * @param array<string, mixed> $tableColumn
      */
-    public function __construct(array $tableColumn, string $table, string $database, Connection $connection)
-    {
-        $this->tableColumn = $tableColumn;
-        $this->table       = $table;
-        $this->database    = $database;
-        $this->connection  = $connection;
+    public function __construct(
+        private array $tableColumn,
+        private string $table,
+        private string $database,
+        private Connection $connection
+    ) {
     }
 
     /**

--- a/src/Event/SchemaCreateTableColumnEventArgs.php
+++ b/src/Event/SchemaCreateTableColumnEventArgs.php
@@ -16,18 +16,11 @@ use function array_values;
  */
 class SchemaCreateTableColumnEventArgs extends SchemaEventArgs
 {
-    private Column $column;
-    private Table $table;
-    private AbstractPlatform $platform;
-
     /** @var array<int, string> */
     private array $sql = [];
 
-    public function __construct(Column $column, Table $table, AbstractPlatform $platform)
+    public function __construct(private Column $column, private Table $table, private AbstractPlatform $platform)
     {
-        $this->column   = $column;
-        $this->table    = $table;
-        $this->platform = $platform;
     }
 
     public function getColumn(): Column

--- a/src/Event/SchemaCreateTableEventArgs.php
+++ b/src/Event/SchemaCreateTableEventArgs.php
@@ -15,16 +15,6 @@ use function array_values;
  */
 class SchemaCreateTableEventArgs extends SchemaEventArgs
 {
-    private Table $table;
-
-    /** @var array<int, array<string, mixed>> */
-    private array $columns;
-
-    /** @var array<string, mixed> */
-    private array $options;
-
-    private AbstractPlatform $platform;
-
     /** @var array<int, string> */
     private array $sql = [];
 
@@ -32,12 +22,12 @@ class SchemaCreateTableEventArgs extends SchemaEventArgs
      * @param array<int, array<string, mixed>> $columns
      * @param array<string, mixed>             $options
      */
-    public function __construct(Table $table, array $columns, array $options, AbstractPlatform $platform)
-    {
-        $this->table    = $table;
-        $this->columns  = $columns;
-        $this->options  = $options;
-        $this->platform = $platform;
+    public function __construct(
+        private Table $table,
+        private array $columns,
+        private array $options,
+        private AbstractPlatform $platform
+    ) {
     }
 
     public function getTable(): Table

--- a/src/Event/SchemaDropTableEventArgs.php
+++ b/src/Event/SchemaDropTableEventArgs.php
@@ -11,16 +11,10 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class SchemaDropTableEventArgs extends SchemaEventArgs
 {
-    private string $table;
-
-    private AbstractPlatform $platform;
-
     private ?string $sql = null;
 
-    public function __construct(string $table, AbstractPlatform $platform)
+    public function __construct(private string $table, private AbstractPlatform $platform)
     {
-        $this->table    = $table;
-        $this->platform = $platform;
     }
 
     public function getTable(): string

--- a/src/Event/SchemaIndexDefinitionEventArgs.php
+++ b/src/Event/SchemaIndexDefinitionEventArgs.php
@@ -15,24 +15,13 @@ class SchemaIndexDefinitionEventArgs extends SchemaEventArgs
     private ?Index $index = null;
 
     /**
-     * Raw index data as fetched from the database.
-     *
-     * @var array<string, mixed>
-     */
-    private array $tableIndex;
-
-    private string $table;
-
-    private Connection $connection;
-
-    /**
      * @param array<string, mixed> $tableIndex
      */
-    public function __construct(array $tableIndex, string $table, Connection $connection)
-    {
-        $this->tableIndex = $tableIndex;
-        $this->table      = $table;
-        $this->connection = $connection;
+    public function __construct(
+        private array $tableIndex,
+        private string $table,
+        private Connection $connection
+    ) {
     }
 
     /**

--- a/src/Event/TransactionEventArgs.php
+++ b/src/Event/TransactionEventArgs.php
@@ -9,11 +9,8 @@ use Doctrine\DBAL\Connection;
 
 abstract class TransactionEventArgs extends EventArgs
 {
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     public function getConnection(): Connection

--- a/src/ExpandArrayParameters.php
+++ b/src/ExpandArrayParameters.php
@@ -17,12 +17,6 @@ use function substr;
 
 final class ExpandArrayParameters implements Visitor
 {
-    /** @var array<int,mixed>|array<string,mixed> */
-    private array $originalParameters;
-
-    /** @var array<int,Type|int|string|null>|array<string,Type|int|string|null> */
-    private array $originalTypes;
-
     private int $originalParameterIndex = 0;
 
     /** @var list<string> */
@@ -35,13 +29,11 @@ final class ExpandArrayParameters implements Visitor
     private array $convertedTypes = [];
 
     /**
-     * @param array<int, mixed>|array<string, mixed>                             $parameters
-     * @param array<int,Type|int|string|null>|array<string,Type|int|string|null> $types
+     * @param array<int, mixed>|array<string, mixed>                             $originalParameters
+     * @param array<int,Type|int|string|null>|array<string,Type|int|string|null> $originalTypes
      */
-    public function __construct(array $parameters, array $types)
+    public function __construct(private array $originalParameters, private array $originalTypes)
     {
-        $this->originalParameters = $parameters;
-        $this->originalTypes      = $types;
     }
 
     public function acceptPositionalParameter(string $sql): void

--- a/src/Logging/Connection.php
+++ b/src/Logging/Connection.php
@@ -12,16 +12,12 @@ use Psr\Log\LoggerInterface;
 
 final class Connection extends AbstractConnectionMiddleware
 {
-    private LoggerInterface $logger;
-
     /**
      * @internal This connection can be only instantiated by its driver.
      */
-    public function __construct(ConnectionInterface $connection, LoggerInterface $logger)
+    public function __construct(ConnectionInterface $connection, private LoggerInterface $logger)
     {
         parent::__construct($connection);
-
-        $this->logger = $logger;
     }
 
     public function __destruct()

--- a/src/Logging/Driver.php
+++ b/src/Logging/Driver.php
@@ -10,16 +10,12 @@ use Psr\Log\LoggerInterface;
 
 final class Driver extends AbstractDriverMiddleware
 {
-    private LoggerInterface $logger;
-
     /**
      * @internal This driver can be only instantiated by its middleware.
      */
-    public function __construct(DriverInterface $driver, LoggerInterface $logger)
+    public function __construct(DriverInterface $driver, private LoggerInterface $logger)
     {
         parent::__construct($driver);
-
-        $this->logger = $logger;
     }
 
     /**

--- a/src/Logging/Middleware.php
+++ b/src/Logging/Middleware.php
@@ -10,11 +10,8 @@ use Psr\Log\LoggerInterface;
 
 final class Middleware implements MiddlewareInterface
 {
-    private LoggerInterface $logger;
-
-    public function __construct(LoggerInterface $logger)
+    public function __construct(private LoggerInterface $logger)
     {
-        $this->logger = $logger;
     }
 
     public function wrap(DriverInterface $driver): DriverInterface

--- a/src/Logging/Statement.php
+++ b/src/Logging/Statement.php
@@ -12,9 +12,6 @@ use Psr\Log\LoggerInterface;
 
 final class Statement extends AbstractStatementMiddleware
 {
-    private LoggerInterface $logger;
-    private string $sql;
-
     /** @var array<int,mixed>|array<string,mixed> */
     private array $params = [];
 
@@ -24,12 +21,9 @@ final class Statement extends AbstractStatementMiddleware
     /**
      * @internal This statement can be only instantiated by its connection.
      */
-    public function __construct(StatementInterface $statement, LoggerInterface $logger, string $sql)
+    public function __construct(StatementInterface $statement, private LoggerInterface $logger, private string $sql)
     {
         parent::__construct($statement);
-
-        $this->logger = $logger;
-        $this->sql    = $sql;
     }
 
     public function bindParam(

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -758,16 +758,13 @@ abstract class AbstractPlatform
      */
     public function appendLockHint(string $fromClause, int $lockMode): string
     {
-        switch ($lockMode) {
-            case LockMode::NONE:
-            case LockMode::OPTIMISTIC:
-            case LockMode::PESSIMISTIC_READ:
-            case LockMode::PESSIMISTIC_WRITE:
-                return $fromClause;
-
-            default:
-                throw InvalidLockMode::fromLockMode($lockMode);
-        }
+        return match ($lockMode) {
+            LockMode::NONE,
+            LockMode::OPTIMISTIC,
+            LockMode::PESSIMISTIC_READ,
+            LockMode::PESSIMISTIC_WRITE => $fromClause,
+            default => throw InvalidLockMode::fromLockMode($lockMode),
+        };
     }
 
     /**
@@ -1833,17 +1830,15 @@ abstract class AbstractPlatform
     public function getForeignKeyReferentialActionSQL(string $action): string
     {
         $upper = strtoupper($action);
-        switch ($upper) {
-            case 'CASCADE':
-            case 'SET NULL':
-            case 'NO ACTION':
-            case 'RESTRICT':
-            case 'SET DEFAULT':
-                return $upper;
 
-            default:
-                throw new InvalidArgumentException(sprintf('Invalid foreign key action "%s".', $upper));
-        }
+        return match ($upper) {
+            'CASCADE',
+            'SET NULL',
+            'NO ACTION',
+            'RESTRICT',
+            'SET DEFAULT' => $upper,
+            default => throw new InvalidArgumentException(sprintf('Invalid foreign key action "%s".', $upper)),
+        };
     }
 
     /**
@@ -2002,22 +1997,13 @@ abstract class AbstractPlatform
      */
     protected function _getTransactionIsolationLevelSQL(int $level): string
     {
-        switch ($level) {
-            case TransactionIsolationLevel::READ_UNCOMMITTED:
-                return 'READ UNCOMMITTED';
-
-            case TransactionIsolationLevel::READ_COMMITTED:
-                return 'READ COMMITTED';
-
-            case TransactionIsolationLevel::REPEATABLE_READ:
-                return 'REPEATABLE READ';
-
-            case TransactionIsolationLevel::SERIALIZABLE:
-                return 'SERIALIZABLE';
-
-            default:
-                throw new InvalidArgumentException(sprintf('Invalid isolation level "%s".', $level));
-        }
+        return match ($level) {
+            TransactionIsolationLevel::READ_UNCOMMITTED => 'READ UNCOMMITTED',
+            TransactionIsolationLevel::READ_COMMITTED => 'READ COMMITTED',
+            TransactionIsolationLevel::REPEATABLE_READ => 'REPEATABLE READ',
+            TransactionIsolationLevel::SERIALIZABLE => 'SERIALIZABLE',
+            default => throw new InvalidArgumentException(sprintf('Invalid isolation level "%s".', $level)),
+        };
     }
 
     /**

--- a/src/Platforms/MySQL/CollationMetadataProvider/CachingCollationMetadataProvider.php
+++ b/src/Platforms/MySQL/CollationMetadataProvider/CachingCollationMetadataProvider.php
@@ -13,14 +13,11 @@ use function array_key_exists;
  */
 final class CachingCollationMetadataProvider implements CollationMetadataProvider
 {
-    private CollationMetadataProvider $collationMetadataProvider;
-
     /** @var array<string,?string> */
     private array $cache = [];
 
-    public function __construct(CollationMetadataProvider $collationMetadataProvider)
+    public function __construct(private CollationMetadataProvider $collationMetadataProvider)
     {
-        $this->collationMetadataProvider = $collationMetadataProvider;
     }
 
     public function getCollationCharset(string $collation): ?string

--- a/src/Platforms/MySQL/CollationMetadataProvider/ConnectionCollationMetadataProvider.php
+++ b/src/Platforms/MySQL/CollationMetadataProvider/ConnectionCollationMetadataProvider.php
@@ -13,11 +13,8 @@ use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
  */
 final class ConnectionCollationMetadataProvider implements CollationMetadataProvider
 {
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     /**

--- a/src/Platforms/MySQL/Comparator.php
+++ b/src/Platforms/MySQL/Comparator.php
@@ -20,26 +20,16 @@ use function array_diff_assoc;
  */
 class Comparator extends BaseComparator
 {
-    private CharsetMetadataProvider $charsetMetadataProvider;
-
-    private CollationMetadataProvider $collationMetadataProvider;
-
-    private DefaultTableOptions $defaultTableOptions;
-
     /**
      * @internal The comparator can be only instantiated by a schema manager.
      */
     public function __construct(
         AbstractMySQLPlatform $platform,
-        CharsetMetadataProvider $charsetMetadataProvider,
-        CollationMetadataProvider $collationMetadataProvider,
-        DefaultTableOptions $defaultTableOptions
+        private CharsetMetadataProvider $charsetMetadataProvider,
+        private CollationMetadataProvider $collationMetadataProvider,
+        private DefaultTableOptions $defaultTableOptions
     ) {
         parent::__construct($platform);
-
-        $this->charsetMetadataProvider   = $charsetMetadataProvider;
-        $this->collationMetadataProvider = $collationMetadataProvider;
-        $this->defaultTableOptions       = $defaultTableOptions;
     }
 
     public function diffTable(Table $fromTable, Table $toTable): ?TableDiff

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -181,20 +181,12 @@ class OraclePlatform extends AbstractPlatform
 
     protected function _getTransactionIsolationLevelSQL(int $level): string
     {
-        switch ($level) {
-            case TransactionIsolationLevel::READ_UNCOMMITTED:
-                return 'READ UNCOMMITTED';
-
-            case TransactionIsolationLevel::READ_COMMITTED:
-                return 'READ COMMITTED';
-
-            case TransactionIsolationLevel::REPEATABLE_READ:
-            case TransactionIsolationLevel::SERIALIZABLE:
-                return 'SERIALIZABLE';
-
-            default:
-                return parent::_getTransactionIsolationLevelSQL($level);
-        }
+        return match ($level) {
+            TransactionIsolationLevel::READ_UNCOMMITTED => 'READ UNCOMMITTED',
+            TransactionIsolationLevel::READ_COMMITTED => 'READ COMMITTED',
+            TransactionIsolationLevel::REPEATABLE_READ, TransactionIsolationLevel::SERIALIZABLE => 'SERIALIZABLE',
+            default => parent::_getTransactionIsolationLevelSQL($level),
+        };
     }
 
     /**
@@ -510,21 +502,13 @@ END;';
     {
         $action = strtoupper($action);
 
-        switch ($action) {
-            case 'RESTRICT': // RESTRICT is not supported, therefore falling back to NO ACTION.
-            case 'NO ACTION':
-                // NO ACTION cannot be declared explicitly,
-                // therefore returning empty string to indicate to OMIT the referential clause.
-                return '';
-
-            case 'CASCADE':
-            case 'SET NULL':
-                return $action;
-
-            default:
-                // SET DEFAULT is not supported, throw exception instead.
-                throw new InvalidArgumentException(sprintf('Invalid foreign key action "%s".', $action));
-        }
+        return match ($action) {
+            'RESTRICT',
+            'NO ACTION' => '',
+            'CASCADE',
+            'SET NULL' => $action,
+            default => throw new InvalidArgumentException(sprintf('Invalid foreign key action "%s".', $action)),
+        };
     }
 
     public function getCreateDatabaseSQL(string $name): string

--- a/src/Platforms/SQLServer/Comparator.php
+++ b/src/Platforms/SQLServer/Comparator.php
@@ -16,16 +16,12 @@ use Doctrine\DBAL\Schema\TableDiff;
  */
 class Comparator extends BaseComparator
 {
-    private string $databaseCollation;
-
     /**
      * @internal The comparator can be only instantiated by a schema manager.
      */
-    public function __construct(SQLServerPlatform $platform, string $databaseCollation)
+    public function __construct(SQLServerPlatform $platform, private string $databaseCollation)
     {
         parent::__construct($platform);
-
-        $this->databaseCollation = $databaseCollation;
     }
 
     public function diffTable(Table $fromTable, Table $toTable): ?TableDiff

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -800,16 +800,11 @@ class SQLServerPlatform extends AbstractPlatform
         }
 
         if ($char === null) {
-            switch ($mode) {
-                case TrimMode::LEADING:
-                    return 'LTRIM(' . $str . ')';
-
-                case TrimMode::TRAILING:
-                    return 'RTRIM(' . $str . ')';
-
-                default:
-                    return 'LTRIM(RTRIM(' . $str . '))';
-            }
+            return match ($mode) {
+                TrimMode::LEADING => 'LTRIM(' . $str . ')',
+                TrimMode::TRAILING => 'RTRIM(' . $str . ')',
+                default => 'LTRIM(RTRIM(' . $str . '))',
+            };
         }
 
         $pattern = "'%[^' + " . $char . " + ']%'";
@@ -1132,20 +1127,13 @@ class SQLServerPlatform extends AbstractPlatform
 
     public function appendLockHint(string $fromClause, int $lockMode): string
     {
-        switch ($lockMode) {
-            case LockMode::NONE:
-            case LockMode::OPTIMISTIC:
-                return $fromClause;
-
-            case LockMode::PESSIMISTIC_READ:
-                return $fromClause . ' WITH (HOLDLOCK, ROWLOCK)';
-
-            case LockMode::PESSIMISTIC_WRITE:
-                return $fromClause . ' WITH (UPDLOCK, ROWLOCK)';
-
-            default:
-                throw InvalidLockMode::fromLockMode($lockMode);
-        }
+        return match ($lockMode) {
+            LockMode::NONE,
+            LockMode::OPTIMISTIC => $fromClause,
+            LockMode::PESSIMISTIC_READ => $fromClause . ' WITH (HOLDLOCK, ROWLOCK)',
+            LockMode::PESSIMISTIC_WRITE => $fromClause . ' WITH (UPDLOCK, ROWLOCK)',
+            default => throw InvalidLockMode::fromLockMode($lockMode),
+        };
     }
 
     public function getForUpdateSQL(): string

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -62,28 +62,18 @@ class SQLitePlatform extends AbstractPlatform
 
     public function getTrimExpression(string $str, int $mode = TrimMode::UNSPECIFIED, ?string $char = null): string
     {
-        switch ($mode) {
-            case TrimMode::UNSPECIFIED:
-            case TrimMode::BOTH:
-                $trimFn = 'TRIM';
-                break;
-
-            case TrimMode::LEADING:
-                $trimFn = 'LTRIM';
-                break;
-
-            case TrimMode::TRAILING:
-                $trimFn = 'RTRIM';
-                break;
-
-            default:
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'The value of $mode is expected to be one of the TrimMode constants, %d given.',
-                        $mode
-                    )
-                );
-        }
+        $trimFn = match ($mode) {
+            TrimMode::UNSPECIFIED,
+            TrimMode::BOTH => 'TRIM',
+            TrimMode::LEADING => 'LTRIM',
+            TrimMode::TRAILING => 'RTRIM',
+            default => throw new InvalidArgumentException(
+                sprintf(
+                    'The value of $mode is expected to be one of the TrimMode constants, %d given.',
+                    $mode
+                )
+            ),
+        };
 
         $arguments = [$str];
 
@@ -157,18 +147,13 @@ class SQLitePlatform extends AbstractPlatform
 
     protected function _getTransactionIsolationLevelSQL(int $level): string
     {
-        switch ($level) {
-            case TransactionIsolationLevel::READ_UNCOMMITTED:
-                return '0';
-
-            case TransactionIsolationLevel::READ_COMMITTED:
-            case TransactionIsolationLevel::REPEATABLE_READ:
-            case TransactionIsolationLevel::SERIALIZABLE:
-                return '1';
-
-            default:
-                return parent::_getTransactionIsolationLevelSQL($level);
-        }
+        return match ($level) {
+            TransactionIsolationLevel::READ_UNCOMMITTED => '0',
+            TransactionIsolationLevel::READ_COMMITTED,
+            TransactionIsolationLevel::REPEATABLE_READ,
+            TransactionIsolationLevel::SERIALIZABLE => '1',
+            default => parent::_getTransactionIsolationLevelSQL($level),
+        };
     }
 
     public function getSetTransactionIsolationSQL(int $level): string

--- a/src/Portability/Connection.php
+++ b/src/Portability/Connection.php
@@ -18,13 +18,9 @@ final class Connection extends AbstractConnectionMiddleware
     public const PORTABILITY_EMPTY_TO_NULL = 4;
     public const PORTABILITY_FIX_CASE      = 8;
 
-    private Converter $converter;
-
-    public function __construct(ConnectionInterface $connection, Converter $converter)
+    public function __construct(ConnectionInterface $connection, private Converter $converter)
     {
         parent::__construct($connection);
-
-        $this->converter = $converter;
     }
 
     public function prepare(string $sql): Statement

--- a/src/Portability/Driver.php
+++ b/src/Portability/Driver.php
@@ -15,16 +15,9 @@ use const CASE_UPPER;
 
 final class Driver extends AbstractDriverMiddleware
 {
-    private int $mode;
-
-    private int $case;
-
-    public function __construct(DriverInterface $driver, int $mode, int $case)
+    public function __construct(DriverInterface $driver, private int $mode, private int $case)
     {
         parent::__construct($driver);
-
-        $this->mode = $mode;
-        $this->case = $case;
     }
 
     /**

--- a/src/Portability/Middleware.php
+++ b/src/Portability/Middleware.php
@@ -9,14 +9,8 @@ use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
 
 final class Middleware implements MiddlewareInterface
 {
-    private int $mode;
-
-    private int $case;
-
-    public function __construct(int $mode, int $case)
+    public function __construct(private int $mode, private int $case)
     {
-        $this->mode = $mode;
-        $this->case = $case;
     }
 
     public function wrap(DriverInterface $driver): DriverInterface

--- a/src/Portability/Result.php
+++ b/src/Portability/Result.php
@@ -9,16 +9,12 @@ use Doctrine\DBAL\Driver\Result as ResultInterface;
 
 final class Result extends AbstractResultMiddleware
 {
-    private Converter $converter;
-
     /**
      * @internal The result can be only instantiated by the portability connection or statement.
      */
-    public function __construct(ResultInterface $result, Converter $converter)
+    public function __construct(ResultInterface $result, private Converter $converter)
     {
         parent::__construct($result);
-
-        $this->converter = $converter;
     }
 
     public function fetchNumeric(): array|false

--- a/src/Portability/Statement.php
+++ b/src/Portability/Statement.php
@@ -13,16 +13,12 @@ use Doctrine\DBAL\Driver\Statement as DriverStatement;
  */
 final class Statement extends AbstractStatementMiddleware
 {
-    private Converter $converter;
-
     /**
      * Wraps <tt>Statement</tt> and applies portability measures.
      */
-    public function __construct(DriverStatement $stmt, Converter $converter)
+    public function __construct(DriverStatement $stmt, private Converter $converter)
     {
         parent::__construct($stmt);
-
-        $this->converter = $converter;
     }
 
     public function execute(?array $params = null): ResultInterface

--- a/src/Query.php
+++ b/src/Query.php
@@ -14,35 +14,16 @@ use Doctrine\DBAL\Types\Type;
 final class Query
 {
     /**
-     * The SQL query.
-     */
-    private string $sql;
-
-    /**
-     * The parameters bound to the query.
-     *
-     * @var array<mixed>
-     */
-    private array $params;
-
-    /**
-     * The types of the parameters bound to the query.
-     *
-     * @var array<Type|int|string|null>
-     */
-    private array $types;
-
-    /**
      * @param array<mixed>                $params
      * @param array<Type|int|string|null> $types
      *
      * @psalm-suppress ImpurePropertyAssignment
      */
-    public function __construct(string $sql, array $params, array $types)
-    {
-        $this->sql    = $sql;
-        $this->params = $params;
-        $this->types  = $types;
+    public function __construct(
+        private string $sql,
+        private array $params,
+        private array $types
+    ) {
     }
 
     public function getSQL(): string

--- a/src/Query/Expression/CompositeExpression.php
+++ b/src/Query/Expression/CompositeExpression.php
@@ -29,11 +29,6 @@ class CompositeExpression implements Countable
     public const TYPE_OR = 'OR';
 
     /**
-     * The instance type of composite expression.
-     */
-    private string $type;
-
-    /**
      * Each expression part of the composite expression.
      *
      * @var array<int, self|string>
@@ -43,9 +38,11 @@ class CompositeExpression implements Countable
     /**
      * @internal Use the and() / or() factory methods.
      */
-    public function __construct(string $type, self|string $part, self|string ...$parts)
-    {
-        $this->type  = $type;
+    public function __construct(
+        private string $type,
+        self|string $part,
+        self|string ...$parts
+    ) {
         $this->parts = array_merge([$part], array_values($parts));
     }
 

--- a/src/Query/Expression/ExpressionBuilder.php
+++ b/src/Query/Expression/ExpressionBuilder.php
@@ -22,18 +22,12 @@ class ExpressionBuilder
     public const GTE = '>=';
 
     /**
-     * The DBAL Connection.
-     */
-    private Connection $connection;
-
-    /**
      * Initializes a new <tt>ExpressionBuilder</tt>.
      *
      * @param Connection $connection The DBAL Connection.
      */
-    public function __construct(Connection $connection)
+    public function __construct(private Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     /**

--- a/src/Query/From.php
+++ b/src/Query/From.php
@@ -9,13 +9,7 @@ namespace Doctrine\DBAL\Query;
  */
 final class From
 {
-    public string $table;
-
-    public ?string $alias = null;
-
-    public function __construct(string $table, ?string $alias = null)
+    public function __construct(public string $table, public ?string $alias = null)
     {
-        $this->table = $table;
-        $this->alias = $alias;
     }
 }

--- a/src/Query/Join.php
+++ b/src/Query/Join.php
@@ -9,20 +9,12 @@ namespace Doctrine\DBAL\Query;
  */
 final class Join
 {
-    public string $type;
-
-    public string $table;
-
-    public string $alias;
-
-    public ?string $condition = null;
-
-    private function __construct(string $type, string $table, string $alias, ?string $condition)
-    {
-        $this->type      = $type;
-        $this->table     = $table;
-        $this->alias     = $alias;
-        $this->condition = $condition;
+    private function __construct(
+        public string $type,
+        public string $table,
+        public string $alias,
+        public ?string $condition
+    ) {
     }
 
     public static function inner(string $table, string $alias, ?string $condition): Join

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -14,7 +14,6 @@ use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Statement;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_key_exists;
 use function array_keys;
@@ -50,11 +49,6 @@ class QueryBuilder
      */
     public const STATE_DIRTY = 0;
     public const STATE_CLEAN = 1;
-
-    /**
-     * The DBAL Connection.
-     */
-    private Connection $connection;
 
     /**
      * The complete SQL string for this query.
@@ -174,9 +168,8 @@ class QueryBuilder
      *
      * @param Connection $connection The DBAL Connection.
      */
-    public function __construct(Connection $connection)
+    public function __construct(private Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     /**
@@ -370,24 +363,12 @@ class QueryBuilder
             return $this->sql;
         }
 
-        switch ($this->type) {
-            case self::INSERT:
-                $sql = $this->getSQLForInsert();
-                break;
-
-            case self::DELETE:
-                $sql = $this->getSQLForDelete();
-                break;
-
-            case self::UPDATE:
-                $sql = $this->getSQLForUpdate();
-                break;
-
-            case self::SELECT:
-            default:
-                $sql = $this->getSQLForSelect();
-                break;
-        }
+        $sql = match ($this->type) {
+            self::INSERT => $this->getSQLForInsert(),
+            self::DELETE => $this->getSQLForDelete(),
+            self::UPDATE => $this->getSQLForUpdate(),
+            default => $this->getSQLForSelect(),
+        };
 
         $this->state = self::STATE_CLEAN;
         $this->sql   = $sql;

--- a/src/Result.php
+++ b/src/Result.php
@@ -15,16 +15,11 @@ use function func_num_args;
 
 class Result
 {
-    private DriverResult $result;
-    private Connection $connection;
-
     /**
      * @internal The result can be only instantiated by {@see Connection} or {@see Statement}.
      */
-    public function __construct(DriverResult $result, Connection $connection)
+    public function __construct(private DriverResult $result, private Connection $connection)
     {
-        $this->result     = $result;
-        $this->connection = $connection;
     }
 
     /**
@@ -34,7 +29,7 @@ class Result
      *
      * @throws Exception
      */
-    public function fetchNumeric()
+    public function fetchNumeric(): array|false
     {
         try {
             return $this->result->fetchNumeric();

--- a/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
@@ -14,11 +14,8 @@ use function array_merge;
 
 final class CreateSchemaObjectsSQLBuilder
 {
-    private AbstractPlatform $platform;
-
-    public function __construct(AbstractPlatform $platform)
+    public function __construct(private AbstractPlatform $platform)
     {
-        $this->platform = $platform;
     }
 
     /**

--- a/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
@@ -14,11 +14,8 @@ use function array_merge;
 
 final class DropSchemaObjectsSQLBuilder
 {
-    private AbstractPlatform $platform;
-
-    public function __construct(AbstractPlatform $platform)
+    public function __construct(private AbstractPlatform $platform)
     {
-        $this->platform = $platform;
     }
 
     /**

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -33,24 +33,10 @@ use function strtolower;
 abstract class AbstractSchemaManager
 {
     /**
-     * Holds instance of the Doctrine connection for this schema manager.
-     */
-    protected Connection $_conn;
-
-    /**
-     * Holds instance of the database platform used for this schema manager.
-     *
-     * @var T
-     */
-    protected AbstractPlatform $_platform;
-
-    /**
      * @param T $platform
      */
-    public function __construct(Connection $connection, AbstractPlatform $platform)
+    public function __construct(protected Connection $connection, protected AbstractPlatform $platform)
     {
-        $this->_conn     = $connection;
-        $this->_platform = $platform;
     }
 
     /**
@@ -64,8 +50,8 @@ abstract class AbstractSchemaManager
     {
         return array_map(function (array $row): string {
             return $this->_getPortableDatabaseDefinition($row);
-        }, $this->_conn->fetchAllAssociative(
-            $this->_platform->getListDatabasesSQL()
+        }, $this->connection->fetchAllAssociative(
+            $this->platform->getListDatabasesSQL()
         ));
     }
 
@@ -93,8 +79,8 @@ abstract class AbstractSchemaManager
         return $this->filterAssetNames(
             array_map(function (array $row): Sequence {
                 return $this->_getPortableSequenceDefinition($row);
-            }, $this->_conn->fetchAllAssociative(
-                $this->_platform->getListSequencesSQL(
+            }, $this->connection->fetchAllAssociative(
+                $this->platform->getListSequencesSQL(
                     $this->getDatabase(__METHOD__)
                 )
             ))
@@ -196,7 +182,7 @@ abstract class AbstractSchemaManager
      */
     private function filterAssetNames(array $assetNames): array
     {
-        $filter = $this->_conn->getConfiguration()->getSchemaAssetsFilter();
+        $filter = $this->connection->getConfiguration()->getSchemaAssetsFilter();
 
         return array_values(array_filter($assetNames, $filter));
     }
@@ -217,7 +203,7 @@ abstract class AbstractSchemaManager
         $foreignKeyColumnsByTable = $this->fetchForeignKeyColumnsByTable($database);
         $tableOptionsByTable      = $this->fetchTableOptionsByTable($database);
 
-        $filter = $this->_conn->getConfiguration()->getSchemaAssetsFilter();
+        $filter = $this->connection->getConfiguration()->getSchemaAssetsFilter();
         $tables = [];
 
         foreach ($tableColumnsByTable as $tableName => $tableColumns) {
@@ -359,8 +345,8 @@ abstract class AbstractSchemaManager
     {
         return array_map(function (array $row): View {
             return $this->_getPortableViewDefinition($row);
-        }, $this->_conn->fetchAllAssociative(
-            $this->_platform->getListViewsSQL(
+        }, $this->connection->fetchAllAssociative(
+            $this->platform->getListViewsSQL(
                 $this->getDatabase(__METHOD__)
             )
         ));
@@ -396,7 +382,7 @@ abstract class AbstractSchemaManager
      */
     public function dropDatabase(string $database): void
     {
-        $this->_execSql($this->_platform->getDropDatabaseSQL($database));
+        $this->_execSql($this->platform->getDropDatabaseSQL($database));
     }
 
     /**
@@ -406,7 +392,7 @@ abstract class AbstractSchemaManager
      */
     public function dropSchema(string $schemaName): void
     {
-        $this->_execSql($this->_platform->getDropSchemaSQL($schemaName));
+        $this->_execSql($this->platform->getDropSchemaSQL($schemaName));
     }
 
     /**
@@ -416,7 +402,7 @@ abstract class AbstractSchemaManager
      */
     public function dropTable(string $name): void
     {
-        $this->_execSql($this->_platform->getDropTableSQL($name));
+        $this->_execSql($this->platform->getDropTableSQL($name));
     }
 
     /**
@@ -426,7 +412,7 @@ abstract class AbstractSchemaManager
      */
     public function dropIndex(string $index, string $table): void
     {
-        $this->_execSql($this->_platform->getDropIndexSQL($index, $table));
+        $this->_execSql($this->platform->getDropIndexSQL($index, $table));
     }
 
     /**
@@ -436,7 +422,7 @@ abstract class AbstractSchemaManager
      */
     public function dropForeignKey(string $name, string $table): void
     {
-        $this->_execSql($this->_platform->getDropForeignKeySQL($name, $table));
+        $this->_execSql($this->platform->getDropForeignKeySQL($name, $table));
     }
 
     /**
@@ -446,7 +432,7 @@ abstract class AbstractSchemaManager
      */
     public function dropSequence(string $name): void
     {
-        $this->_execSql($this->_platform->getDropSequenceSQL($name));
+        $this->_execSql($this->platform->getDropSequenceSQL($name));
     }
 
     /**
@@ -456,7 +442,7 @@ abstract class AbstractSchemaManager
      */
     public function dropUniqueConstraint(string $name, string $tableName): void
     {
-        $this->_execSql($this->_platform->getDropUniqueConstraintSQL($name, $tableName));
+        $this->_execSql($this->platform->getDropUniqueConstraintSQL($name, $tableName));
     }
 
     /**
@@ -466,7 +452,7 @@ abstract class AbstractSchemaManager
      */
     public function dropView(string $name): void
     {
-        $this->_execSql($this->_platform->getDropViewSQL($name));
+        $this->_execSql($this->platform->getDropViewSQL($name));
     }
 
     /* create*() Methods */
@@ -476,7 +462,7 @@ abstract class AbstractSchemaManager
      */
     public function createSchemaObjects(Schema $schema): void
     {
-        $this->_execSql($schema->toSql($this->_platform));
+        $this->_execSql($schema->toSql($this->platform));
     }
 
     /**
@@ -486,7 +472,7 @@ abstract class AbstractSchemaManager
      */
     public function createDatabase(string $database): void
     {
-        $this->_execSql($this->_platform->getCreateDatabaseSQL($database));
+        $this->_execSql($this->platform->getCreateDatabaseSQL($database));
     }
 
     /**
@@ -496,7 +482,7 @@ abstract class AbstractSchemaManager
      */
     public function createTable(Table $table): void
     {
-        $this->_execSql($this->_platform->getCreateTableSQL($table));
+        $this->_execSql($this->platform->getCreateTableSQL($table));
     }
 
     /**
@@ -506,7 +492,7 @@ abstract class AbstractSchemaManager
      */
     public function createSequence(Sequence $sequence): void
     {
-        $this->_execSql($this->_platform->getCreateSequenceSQL($sequence));
+        $this->_execSql($this->platform->getCreateSequenceSQL($sequence));
     }
 
     /**
@@ -518,7 +504,7 @@ abstract class AbstractSchemaManager
      */
     public function createIndex(Index $index, string $table): void
     {
-        $this->_execSql($this->_platform->getCreateIndexSQL($index, $table));
+        $this->_execSql($this->platform->getCreateIndexSQL($index, $table));
     }
 
     /**
@@ -531,7 +517,7 @@ abstract class AbstractSchemaManager
      */
     public function createForeignKey(ForeignKeyConstraint $foreignKey, string $table): void
     {
-        $this->_execSql($this->_platform->getCreateForeignKeySQL($foreignKey, $table));
+        $this->_execSql($this->platform->getCreateForeignKeySQL($foreignKey, $table));
     }
 
     /**
@@ -541,7 +527,7 @@ abstract class AbstractSchemaManager
      */
     public function createUniqueConstraint(UniqueConstraint $uniqueConstraint, string $tableName): void
     {
-        $this->_execSql($this->_platform->getCreateUniqueConstraintSQL($uniqueConstraint, $tableName));
+        $this->_execSql($this->platform->getCreateUniqueConstraintSQL($uniqueConstraint, $tableName));
     }
 
     /**
@@ -551,7 +537,7 @@ abstract class AbstractSchemaManager
      */
     public function createView(View $view): void
     {
-        $this->_execSql($this->_platform->getCreateViewSQL($view->getQuotedName($this->_platform), $view->getSql()));
+        $this->_execSql($this->platform->getCreateViewSQL($view->getQuotedName($this->platform), $view->getSql()));
     }
 
     /**
@@ -559,7 +545,7 @@ abstract class AbstractSchemaManager
      */
     public function dropSchemaObjects(Schema $schema): void
     {
-        $this->_execSql($schema->toDropSql($this->_platform));
+        $this->_execSql($schema->toDropSql($this->platform));
     }
 
     /**
@@ -569,7 +555,7 @@ abstract class AbstractSchemaManager
      */
     public function alterSchema(SchemaDiff $schemaDiff): void
     {
-        $this->_execSql($schemaDiff->toSql($this->_platform));
+        $this->_execSql($schemaDiff->toSql($this->platform));
     }
 
     /**
@@ -594,7 +580,7 @@ abstract class AbstractSchemaManager
      */
     public function alterTable(TableDiff $tableDiff): void
     {
-        foreach ($this->_platform->getAlterTableSQL($tableDiff) as $ddlQuery) {
+        foreach ($this->platform->getAlterTableSQL($tableDiff) as $ddlQuery) {
             $this->_execSql($ddlQuery);
         }
     }
@@ -649,7 +635,7 @@ abstract class AbstractSchemaManager
      */
     protected function _getPortableTableColumnList(string $table, string $database, array $tableColumns): array
     {
-        $eventManager = $this->_platform->getEventManager();
+        $eventManager = $this->platform->getEventManager();
 
         $list = [];
         foreach ($tableColumns as $tableColumn) {
@@ -657,7 +643,7 @@ abstract class AbstractSchemaManager
             $defaultPrevented = false;
 
             if ($eventManager !== null && $eventManager->hasListeners(Events::onSchemaColumnDefinition)) {
-                $eventArgs = new SchemaColumnDefinitionEventArgs($tableColumn, $table, $database, $this->_conn);
+                $eventArgs = new SchemaColumnDefinitionEventArgs($tableColumn, $table, $database, $this->connection);
                 $eventManager->dispatchEvent(Events::onSchemaColumnDefinition, $eventArgs);
 
                 $defaultPrevented = $eventArgs->isDefaultPrevented();
@@ -672,7 +658,7 @@ abstract class AbstractSchemaManager
                 continue;
             }
 
-            $name        = strtolower($column->getQuotedName($this->_platform));
+            $name        = strtolower($column->getQuotedName($this->platform));
             $list[$name] = $column;
         }
 
@@ -731,7 +717,7 @@ abstract class AbstractSchemaManager
             $result[$keyName]['options']['lengths'][] = $tableIndex['length'] ?? null;
         }
 
-        $eventManager = $this->_platform->getEventManager();
+        $eventManager = $this->platform->getEventManager();
 
         $indexes = [];
         foreach ($result as $indexKey => $data) {
@@ -739,7 +725,7 @@ abstract class AbstractSchemaManager
             $defaultPrevented = false;
 
             if ($eventManager !== null && $eventManager->hasListeners(Events::onSchemaIndexDefinition)) {
-                $eventArgs = new SchemaIndexDefinitionEventArgs($data, $tableName, $this->_conn);
+                $eventArgs = new SchemaIndexDefinitionEventArgs($data, $tableName, $this->connection);
                 $eventManager->dispatchEvent(Events::onSchemaIndexDefinition, $eventArgs);
 
                 $defaultPrevented = $eventArgs->isDefaultPrevented();
@@ -806,7 +792,7 @@ abstract class AbstractSchemaManager
     protected function _execSql(array|string $sql): void
     {
         foreach ((array) $sql as $query) {
-            $this->_conn->executeStatement($query);
+            $this->connection->executeStatement($query);
         }
     }
 
@@ -819,13 +805,13 @@ abstract class AbstractSchemaManager
     {
         $schemaNames = [];
 
-        if ($this->_platform->supportsSchemas()) {
+        if ($this->platform->supportsSchemas()) {
             $schemaNames = $this->listSchemaNames();
         }
 
         $sequences = [];
 
-        if ($this->_platform->supportsSequences()) {
+        if ($this->platform->supportsSequences()) {
             $sequences = $this->listSequences();
         }
 
@@ -842,9 +828,9 @@ abstract class AbstractSchemaManager
     public function createSchemaConfig(): SchemaConfig
     {
         $schemaConfig = new SchemaConfig();
-        $schemaConfig->setMaxIdentifierLength($this->_platform->getMaxIdentifierLength());
+        $schemaConfig->setMaxIdentifierLength($this->platform->getMaxIdentifierLength());
 
-        $params = $this->_conn->getParams();
+        $params = $this->connection->getParams();
         if (! isset($params['defaultTableOptions'])) {
             $params['defaultTableOptions'] = [];
         }
@@ -863,7 +849,7 @@ abstract class AbstractSchemaManager
      */
     private function getDatabase(string $methodName): string
     {
-        $database = $this->_conn->getDatabase();
+        $database = $this->connection->getDatabase();
 
         if ($database === null) {
             throw DatabaseRequired::new($methodName);
@@ -874,7 +860,7 @@ abstract class AbstractSchemaManager
 
     public function createComparator(): Comparator
     {
-        return new Comparator($this->_platform);
+        return new Comparator($this->platform);
     }
 
     /**

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -11,28 +11,15 @@ use function in_array;
  */
 class ColumnDiff
 {
-    public string $oldColumnName;
-
-    public Column $column;
-
-    /** @var array<int, string> */
-    public array $changedProperties;
-
-    public Column $fromColumn;
-
     /**
      * @param array<string> $changedProperties
      */
     public function __construct(
-        string $oldColumnName,
-        Column $column,
-        array $changedProperties,
-        Column $fromColumn
+        public string $oldColumnName,
+        public Column $column,
+        public array $changedProperties,
+        public Column $fromColumn
     ) {
-        $this->oldColumnName     = $oldColumnName;
-        $this->column            = $column;
-        $this->changedProperties = $changedProperties;
-        $this->fromColumn        = $fromColumn;
     }
 
     public function hasChanged(string $propertyName): bool

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -14,7 +14,6 @@ use function array_map;
 use function array_unique;
 use function assert;
 use function count;
-use function get_class;
 use function strtolower;
 
 /**
@@ -22,14 +21,11 @@ use function strtolower;
  */
 class Comparator
 {
-    private AbstractPlatform $platform;
-
     /**
      * @internal The comparator can be only instantiated by a schema manager.
      */
-    public function __construct(AbstractPlatform $platform)
+    public function __construct(private AbstractPlatform $platform)
     {
-        $this->platform = $platform;
     }
 
     /**
@@ -440,7 +436,7 @@ class Comparator
 
         $changedProperties = [];
 
-        if (get_class($properties1['type']) !== get_class($properties2['type'])) {
+        if ($properties1['type']::class !== $properties2['type']::class) {
             $changedProperties[] = 'type';
         }
 

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -49,7 +49,7 @@ class DB2SchemaManager extends AbstractSchemaManager
             }
         }
 
-        $type = $this->_platform->getDoctrineTypeMapping($tableColumn['typename']);
+        $type = $this->platform->getDoctrineTypeMapping($tableColumn['typename']);
 
         switch (strtolower($tableColumn['typename'])) {
             case 'varchar':
@@ -203,7 +203,7 @@ WHERE TYPE = 'T'
   AND CREATOR = ?
 SQL;
 
-        return $this->_conn->executeQuery($sql, [$databaseName]);
+        return $this->connection->executeQuery($sql, [$databaseName]);
     }
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
@@ -243,7 +243,7 @@ SQL;
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY C.TABNAME, C.COLNO';
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
@@ -282,7 +282,7 @@ SQL;
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY IDX.INDNAME, IDXCOL.COLSEQ';
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
@@ -331,7 +331,7 @@ SQL;
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY R.CONSTNAME, FKCOL.COLSEQ';
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     /**
@@ -356,7 +356,7 @@ SQL;
         }
 
         /** @var array<string,array<string,mixed>> $metadata */
-        $metadata = $this->_conn->executeQuery($sql, $params)
+        $metadata = $this->connection->executeQuery($sql, $params)
             ->fetchAllAssociativeIndexed();
 
         $tableOptions = [];

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -38,13 +38,6 @@ class ForeignKeyConstraint extends AbstractAsset
     protected array $_foreignColumnNames;
 
     /**
-     * Options associated with the foreign key constraint.
-     *
-     * @var array<string, mixed>
-     */
-    protected array $_options;
-
-    /**
      * Initializes the foreign key constraint.
      *
      * @param array<int, string>   $localColumnNames   Names of the referencing table columns.
@@ -58,7 +51,7 @@ class ForeignKeyConstraint extends AbstractAsset
         string $foreignTableName,
         array $foreignColumnNames,
         string $name = '',
-        array $options = []
+        protected array $options = []
     ) {
         $this->_setName($name);
 
@@ -66,7 +59,6 @@ class ForeignKeyConstraint extends AbstractAsset
         $this->_foreignTableName = new Identifier($foreignTableName);
 
         $this->_foreignColumnNames = $this->createIdentifierMap($foreignColumnNames);
-        $this->_options            = $options;
     }
 
     /**
@@ -218,7 +210,7 @@ class ForeignKeyConstraint extends AbstractAsset
      */
     public function hasOption(string $name): bool
     {
-        return isset($this->_options[$name]);
+        return isset($this->options[$name]);
     }
 
     /**
@@ -226,7 +218,7 @@ class ForeignKeyConstraint extends AbstractAsset
      */
     public function getOption(string $name): mixed
     {
-        return $this->_options[$name];
+        return $this->options[$name];
     }
 
     /**
@@ -236,7 +228,7 @@ class ForeignKeyConstraint extends AbstractAsset
      */
     public function getOptions(): array
     {
-        return $this->_options;
+        return $this->options;
     }
 
     /**
@@ -265,8 +257,8 @@ class ForeignKeyConstraint extends AbstractAsset
      */
     private function onEvent(string $event): ?string
     {
-        if (isset($this->_options[$event])) {
-            $onEvent = strtoupper($this->_options[$event]);
+        if (isset($this->options[$event])) {
+            $onEvent = strtoupper($this->options[$event]);
 
             if ($onEvent !== 'NO ACTION' && $onEvent !== 'RESTRICT') {
                 return $onEvent;

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -35,14 +35,6 @@ class Index extends AbstractAsset
     protected array $_flags = [];
 
     /**
-     * Platform specific options
-     *
-     * @todo $_flags should eventually be refactored into options
-     * @var array<string, mixed>
-     */
-    private array $options;
-
-    /**
      * @param array<int, string>   $columns
      * @param array<int, string>   $flags
      * @param array<string, mixed> $options
@@ -53,7 +45,7 @@ class Index extends AbstractAsset
         bool $isUnique = false,
         bool $isPrimary = false,
         array $flags = [],
-        array $options = []
+        private array $options = []
     ) {
         $isUnique = $isUnique || $isPrimary;
 
@@ -63,7 +55,6 @@ class Index extends AbstractAsset
 
         $this->_isUnique  = $isUnique;
         $this->_isPrimary = $isPrimary;
-        $this->options    = $options;
 
         foreach ($columns as $column) {
             $this->_addColumn($column);

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -130,7 +130,7 @@ class OracleSchemaManager extends AbstractSchemaManager
             $scale = (int) $tableColumn['data_scale'];
         }
 
-        $type = $this->_platform->getDoctrineTypeMapping($dbType);
+        $type = $this->platform->getDoctrineTypeMapping($dbType);
 
         switch ($dbType) {
             case 'number':
@@ -252,18 +252,18 @@ class OracleSchemaManager extends AbstractSchemaManager
 
     public function createDatabase(string $database): void
     {
-        $statement = $this->_platform->getCreateDatabaseSQL($database);
+        $statement = $this->platform->getCreateDatabaseSQL($database);
 
-        $params = $this->_conn->getParams();
+        $params = $this->connection->getParams();
 
         if (isset($params['password'])) {
             $statement .= ' IDENTIFIED BY ' . $params['password'];
         }
 
-        $this->_conn->executeStatement($statement);
+        $this->connection->executeStatement($statement);
 
         $statement = 'GRANT DBA TO ' . $database;
-        $this->_conn->executeStatement($statement);
+        $this->connection->executeStatement($statement);
     }
 
     /**
@@ -271,9 +271,9 @@ class OracleSchemaManager extends AbstractSchemaManager
      */
     protected function dropAutoincrement(string $table): bool
     {
-        $sql = $this->_platform->getDropAutoincrementSql($table);
+        $sql = $this->platform->getDropAutoincrementSql($table);
         foreach ($sql as $query) {
-            $this->_conn->executeStatement($query);
+            $this->connection->executeStatement($query);
         }
 
         return true;
@@ -283,7 +283,7 @@ class OracleSchemaManager extends AbstractSchemaManager
     {
         try {
             $this->dropAutoincrement($name);
-        } catch (DatabaseObjectNotFoundException $e) {
+        } catch (DatabaseObjectNotFoundException) {
         }
 
         parent::dropTable($name);
@@ -298,7 +298,7 @@ class OracleSchemaManager extends AbstractSchemaManager
     private function getQuotedIdentifierName(string $identifier): string
     {
         if (preg_match('/[a-z]/', $identifier) === 1) {
-            return $this->_platform->quoteIdentifier($identifier);
+            return $this->platform->quoteIdentifier($identifier);
         }
 
         return $identifier;
@@ -313,7 +313,7 @@ WHERE OWNER = :OWNER
 ORDER BY TABLE_NAME
 SQL;
 
-        return $this->_conn->executeQuery($sql, ['OWNER' => $databaseName]);
+        return $this->connection->executeQuery($sql, ['OWNER' => $databaseName]);
     }
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
@@ -351,7 +351,7 @@ SQL;
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY C.COLUMN_ID';
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
@@ -389,7 +389,7 @@ SQL;
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY IND_COL.TABLE_NAME, IND_COL.INDEX_NAME'
             . ', IND_COL.COLUMN_POSITION';
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
@@ -425,7 +425,7 @@ SQL;
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY COLS.TABLE_NAME, COLS.CONSTRAINT_NAME'
             . ', COLS.POSITION';
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     /**
@@ -446,7 +446,7 @@ SQL;
         $sql .= ' FROM ALL_TAB_COMMENTS WHERE ' . implode(' AND ', $conditions);
 
         /** @var array<string,array<string,mixed>> $metadata */
-        $metadata = $this->_conn->executeQuery($sql, $params)
+        $metadata = $this->connection->executeQuery($sql, $params)
             ->fetchAllAssociativeIndexed();
 
         $tableOptions = [];

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -118,7 +118,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
         $indexBuffer = [];
 
         // fetch primary
-        $indexArray = $this->_conn->fetchAllAssociative('SELECT * FROM PRAGMA_TABLE_INFO (?)', [$tableName]);
+        $indexArray = $this->connection->fetchAllAssociative('SELECT * FROM PRAGMA_TABLE_INFO (?)', [$tableName]);
 
         usort(
             $indexArray,
@@ -161,7 +161,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             $idx['primary']    = false;
             $idx['non_unique'] = ! $tableIndex['unique'];
 
-            $indexArray = $this->_conn->fetchAllAssociative('SELECT * FROM PRAGMA_INDEX_INFO (?)', [$keyName]);
+            $indexArray = $this->connection->fetchAllAssociative('SELECT * FROM PRAGMA_INDEX_INFO (?)', [$keyName]);
 
             foreach ($indexArray as $indexColumnRow) {
                 $idx['column_name'] = $indexColumnRow['name'];
@@ -252,7 +252,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             $unsigned = true;
         }
 
-        $type    = $this->_platform->getDoctrineTypeMapping($dbType);
+        $type    = $this->platform->getDoctrineTypeMapping($dbType);
         $default = $tableColumn['dflt_value'];
         if ($default === 'NULL') {
             $default = null;
@@ -378,7 +378,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
     private function parseColumnCollationFromSQL(string $column, string $sql): ?string
     {
         $pattern = '{(?:\W' . preg_quote($column) . '\W|\W'
-            . preg_quote($this->_platform->quoteSingleIdentifier($column))
+            . preg_quote($this->platform->quoteSingleIdentifier($column))
             . '\W)[^,(]+(?:\([^()]+\)[^,]*)?(?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*COLLATE\s+["\']?([^\s,"\')]+)}is';
 
         if (preg_match($pattern, $sql, $match) !== 1) {
@@ -392,7 +392,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
     {
         $pattern = '/\s* # Allow whitespace characters at start of line
 CREATE\sTABLE # Match "CREATE TABLE"
-(?:\W"' . preg_quote($this->_platform->quoteSingleIdentifier($table), '/') . '"\W|\W' . preg_quote($table, '/')
+(?:\W"' . preg_quote($this->platform->quoteSingleIdentifier($table), '/') . '"\W|\W' . preg_quote($table, '/')
             . '\W) # Match table name (quoted and unquoted)
 ( # Start capture
    (?:\s*--[^\n]*\n?)+ # Capture anything that starts with whitespaces followed by -- until the end of the line(s)
@@ -409,7 +409,7 @@ CREATE\sTABLE # Match "CREATE TABLE"
 
     private function parseColumnCommentFromSQL(string $column, string $sql): string
     {
-        $pattern = '{[\s(,](?:\W' . preg_quote($this->_platform->quoteSingleIdentifier($column))
+        $pattern = '{[\s(,](?:\W' . preg_quote($this->platform->quoteSingleIdentifier($column))
             . '\W|\W' . preg_quote($column) . '\W)(?:\([^)]*?\)|[^,(])*?,?((?:(?!\n))(?:\s*--[^\n]*\n?)+)}i';
 
         if (preg_match($pattern, $sql, $match) !== 1) {
@@ -427,7 +427,7 @@ CREATE\sTABLE # Match "CREATE TABLE"
      */
     private function getCreateTableSQL(string $table): string
     {
-        $sql = $this->_conn->fetchOne(
+        $sql = $this->connection->fetchOne(
             <<<'SQL'
 SELECT sql
   FROM (
@@ -516,7 +516,7 @@ SQL
 
     public function createComparator(): Comparator
     {
-        return new SQLite\Comparator($this->_platform);
+        return new SQLite\Comparator($this->platform);
     }
 
     protected function selectTableNames(string $databaseName): Result
@@ -535,7 +535,7 @@ WHERE type = 'table'
 ORDER BY name
 SQL;
 
-        return $this->_conn->executeQuery($sql);
+        return $this->connection->executeQuery($sql);
     }
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
@@ -560,7 +560,7 @@ SQL;
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, c.cid';
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
@@ -585,7 +585,7 @@ SQL;
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, i.seq';
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
@@ -611,7 +611,7 @@ SQL;
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, p.id DESC, p.seq';
 
-        return $this->_conn->executeQuery($sql, $params);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     /**

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -17,8 +17,6 @@ use function array_values;
  */
 class SchemaDiff
 {
-    public ?Schema $fromSchema = null;
-
     /**
      * All added namespaces.
      *
@@ -32,27 +30,6 @@ class SchemaDiff
      * @var array<string, string>
      */
     public array $removedNamespaces = [];
-
-    /**
-     * All added tables.
-     *
-     * @var array<string, Table>
-     */
-    public array $newTables = [];
-
-    /**
-     * All changed tables.
-     *
-     * @var array<string, TableDiff>
-     */
-    public array $changedTables = [];
-
-    /**
-     * All removed tables.
-     *
-     * @var array<string, Table>
-     */
-    public array $removedTables = [];
 
     /** @var array<int, Sequence> */
     public array $newSequences = [];
@@ -78,15 +55,11 @@ class SchemaDiff
      * @param array<string, Table>     $removedTables
      */
     public function __construct(
-        array $newTables = [],
-        array $changedTables = [],
-        array $removedTables = [],
-        ?Schema $fromSchema = null
+        public array $newTables = [],
+        public array $changedTables = [],
+        public array $removedTables = [],
+        public ?Schema $fromSchema = null
     ) {
-        $this->newTables     = $newTables;
-        $this->changedTables = $changedTables;
-        $this->removedTables = $removedTables;
-        $this->fromSchema    = $fromSchema;
     }
 
     /**

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -16,14 +16,15 @@ class Sequence extends AbstractAsset
 
     protected int $initialValue = 1;
 
-    protected ?int $cache = null;
-
-    public function __construct(string $name, int $allocationSize = 1, int $initialValue = 1, ?int $cache = null)
-    {
+    public function __construct(
+        string $name,
+        int $allocationSize = 1,
+        int $initialValue = 1,
+        protected ?int $cache = null
+    ) {
         $this->_setName($name);
         $this->setAllocationSize($allocationSize);
         $this->setInitialValue($initialValue);
-        $this->cache = $cache;
     }
 
     public function getAllocationSize(): int

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -11,30 +11,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class TableDiff
 {
-    public string $name;
-
     public ?string $newName = null;
-
-    /**
-     * All added columns
-     *
-     * @var array<string, Column>
-     */
-    public array $addedColumns;
-
-    /**
-     * All changed columns
-     *
-     * @var array<string, ColumnDiff>
-     */
-    public array $changedColumns = [];
-
-    /**
-     * All removed columns
-     *
-     * @var array<string, Column>
-     */
-    public array $removedColumns = [];
 
     /**
      * Columns that are only renamed from key to column instance name.
@@ -42,27 +19,6 @@ class TableDiff
      * @var array<string, Column>
      */
     public array $renamedColumns = [];
-
-    /**
-     * All added indexes.
-     *
-     * @var array<string, Index>
-     */
-    public array $addedIndexes = [];
-
-    /**
-     * All changed indexes.
-     *
-     * @var array<string, Index>
-     */
-    public array $changedIndexes = [];
-
-    /**
-     * All removed indexes
-     *
-     * @var array<string, Index>
-     */
-    public array $removedIndexes = [];
 
     /**
      * Indexes that are only renamed but are identical otherwise.
@@ -92,8 +48,6 @@ class TableDiff
      */
     public array $removedForeignKeys = [];
 
-    public ?Table $fromTable = null;
-
     /**
      * Constructs an TableDiff object.
      *
@@ -105,23 +59,15 @@ class TableDiff
      * @param array<string, Index>      $removedIndexes
      */
     public function __construct(
-        string $tableName,
-        array $addedColumns = [],
-        array $changedColumns = [],
-        array $removedColumns = [],
-        array $addedIndexes = [],
-        array $changedIndexes = [],
-        array $removedIndexes = [],
-        ?Table $fromTable = null
+        public string $name,
+        public array $addedColumns = [],
+        public array $changedColumns = [],
+        public array $removedColumns = [],
+        public array $addedIndexes = [],
+        public array $changedIndexes = [],
+        public array $removedIndexes = [],
+        public ?Table $fromTable = null
     ) {
-        $this->name           = $tableName;
-        $this->addedColumns   = $addedColumns;
-        $this->changedColumns = $changedColumns;
-        $this->removedColumns = $removedColumns;
-        $this->addedIndexes   = $addedIndexes;
-        $this->changedIndexes = $changedIndexes;
-        $this->removedIndexes = $removedIndexes;
-        $this->fromTable      = $fromTable;
     }
 
     /**

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -30,22 +30,17 @@ class UniqueConstraint extends AbstractAsset
     protected array $flags = [];
 
     /**
-     * Platform specific options
-     *
-     * @var array<string, mixed>
-     */
-    private array $options;
-
-    /**
      * @param array<string>        $columns
      * @param array<string>        $flags
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name, array $columns, array $flags = [], array $options = [])
-    {
+    public function __construct(
+        string $name,
+        array $columns,
+        array $flags = [],
+        private array $options = []
+    ) {
         $this->_setName($name);
-
-        $this->options = $options;
 
         foreach ($columns as $column) {
             $this->addColumn($column);

--- a/src/Schema/View.php
+++ b/src/Schema/View.php
@@ -9,12 +9,9 @@ namespace Doctrine\DBAL\Schema;
  */
 class View extends AbstractAsset
 {
-    private string $sql;
-
-    public function __construct(string $name, string $sql)
+    public function __construct(string $name, private string $sql)
     {
         $this->_setName($name);
-        $this->sql = $sql;
     }
 
     public function getSql(): string

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -16,11 +16,6 @@ use function is_string;
 class Statement
 {
     /**
-     * The SQL statement.
-     */
-    protected string $sql;
-
-    /**
      * The bound parameters.
      *
      * @var mixed[]
@@ -35,36 +30,26 @@ class Statement
     protected array $types = [];
 
     /**
-     * The underlying driver statement.
-     */
-    protected Driver\Statement $stmt;
-
-    /**
      * The underlying database platform.
      */
     protected AbstractPlatform $platform;
-
-    /**
-     * The connection this statement is bound to and executed on.
-     */
-    protected Connection $conn;
 
     /**
      * Creates a new <tt>Statement</tt> for the given SQL and <tt>Connection</tt>.
      *
      * @internal The statement can be only instantiated by {@see Connection}.
      *
-     * @param Connection       $conn      The connection for handling statement errors.
-     * @param Driver\Statement $statement The underlying driver-level statement.
-     * @param string           $sql       The SQL of the statement.
+     * @param Connection       $conn The connection for handling statement errors.
+     * @param Driver\Statement $stmt The underlying driver-level statement.
+     * @param string           $sql  The SQL of the statement.
      *
      * @throws Exception
      */
-    public function __construct(Connection $conn, Driver\Statement $statement, string $sql)
-    {
-        $this->conn     = $conn;
-        $this->stmt     = $statement;
-        $this->sql      = $sql;
+    public function __construct(
+        protected Connection $conn,
+        protected Driver\Statement $stmt,
+        protected string $sql
+    ) {
         $this->platform = $conn->getDatabasePlatform();
     }
 

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -28,12 +28,9 @@ use function stripos;
  */
 class RunSqlCommand extends Command
 {
-    private ConnectionProvider $connectionProvider;
-
-    public function __construct(ConnectionProvider $connectionProvider)
+    public function __construct(private ConnectionProvider $connectionProvider)
     {
         parent::__construct();
-        $this->connectionProvider = $connectionProvider;
     }
 
     protected function configure(): void

--- a/src/Tools/Console/ConnectionProvider/SingleConnectionProvider.php
+++ b/src/Tools/Console/ConnectionProvider/SingleConnectionProvider.php
@@ -12,14 +12,8 @@ use function sprintf;
 
 class SingleConnectionProvider implements ConnectionProvider
 {
-    private Connection $connection;
-
-    private string $defaultConnectionName;
-
-    public function __construct(Connection $connection, string $defaultConnectionName = 'default')
+    public function __construct(private Connection $connection, private string $defaultConnectionName = 'default')
     {
-        $this->connection            = $connection;
-        $this->defaultConnectionName = $defaultConnectionName;
     }
 
     public function getDefaultConnection(): Connection

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -18,18 +18,10 @@ use function array_search;
 final class TypeRegistry
 {
     /**
-     * Map of type names and their corresponding objects.
-     *
-     * @var array<string, Type>
-     */
-    private array $instances;
-
-    /**
      * @param array<string, Type> $instances
      */
-    public function __construct(array $instances = [])
+    public function __construct(private array $instances = [])
     {
-        $this->instances = $instances;
     }
 
     /**

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -204,7 +204,7 @@ class ConnectionTest extends TestCase
         $conn->rollBack();
         try {
             $conn->commit();
-        } catch (ConnectionException $exception) {
+        } catch (ConnectionException) {
         }
     }
 

--- a/tests/Functional/Connection/ConnectionLostTest.php
+++ b/tests/Functional/Connection/ConnectionLostTest.php
@@ -34,7 +34,7 @@ class ConnectionLostTest extends FunctionalTestCase
             // in addition to the error, MYSQLI_REPORT_OFF will generate a warning that needs to be
             // suppressed in order to not let PHPUnit handle it before the actual error
             @$this->connection->executeQuery($query);
-        } catch (ConnectionLost $e) {
+        } catch (ConnectionLost) {
             self::assertEquals(1, $this->connection->fetchOne($query));
 
             return;

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -141,7 +141,7 @@ class ConnectionTest extends FunctionalTestCase
             self::assertFalse($this->connection->isRollbackOnly());
 
             $this->connection->commit(); // should not throw exception
-        } catch (ConnectionException $e) {
+        } catch (ConnectionException) {
             self::fail('Transaction commit after failed nested transaction should not fail when using savepoints.');
         }
     }
@@ -242,7 +242,7 @@ class ConnectionTest extends FunctionalTestCase
 
                 throw new Error('Ooops!');
             });
-        } catch (Error $expected) {
+        } catch (Error) {
         }
 
         self::assertEquals(0, $this->connection->getTransactionNestingLevel());

--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -79,7 +79,7 @@ class NoneTest extends FunctionalTestCase
         try {
             $this->connection->setTransactionIsolation(TransactionIsolationLevel::READ_COMMITTED);
             $this->connection2->setTransactionIsolation(TransactionIsolationLevel::READ_COMMITTED);
-        } catch (Exception $e) {
+        } catch (Exception) {
             self::markTestSkipped('This test must be able to set a transaction isolation level');
         }
 

--- a/tests/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Functional/PrimaryReadReplicaConnectionTest.php
@@ -33,7 +33,7 @@ class PrimaryReadReplicaConnectionTest extends FunctionalTestCase
 
             $sm = $this->connection->createSchemaManager();
             $sm->createTable($table);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
         }
 
         $this->connection->executeStatement('DELETE FROM primary_replica_table');

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -208,7 +208,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         try {
             $schemaManager->dropTable($otherTable->getName());
-        } catch (DatabaseObjectNotFoundException $e) {
+        } catch (DatabaseObjectNotFoundException) {
         }
 
         $schemaManager->createTable($otherTable);

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -46,13 +46,11 @@ use function array_shift;
 use function array_values;
 use function count;
 use function current;
-use function get_class;
 use function get_debug_type;
 use function sprintf;
+use function str_starts_with;
 use function strcasecmp;
-use function strlen;
 use function strtolower;
-use function substr;
 
 abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 {
@@ -81,7 +79,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         try {
             //sql server versions below 2016 do not support 'IF EXISTS' so we have to catch the exception here
             $this->connection->executeStatement('DROP SCHEMA testschema');
-        } catch (Exception $e) {
+        } catch (Exception) {
         }
     }
 
@@ -155,7 +153,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     {
         try {
             $this->schemaManager->dropDatabase('test_create_database');
-        } catch (DatabaseObjectNotFoundException $e) {
+        } catch (DatabaseObjectNotFoundException) {
         }
 
         $this->schemaManager->createDatabase('test_create_database');
@@ -177,7 +175,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         try {
             $this->schemaManager->dropSchema('test_create_schema');
-        } catch (DatabaseObjectNotFoundException $e) {
+        } catch (DatabaseObjectNotFoundException) {
         }
 
         self::assertNotContains('test_create_schema', $this->schemaManager->listSchemaNames());
@@ -222,7 +220,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->connection->getConfiguration()->setSchemaAssetsFilter(
             static function (string $name) use ($prefix): bool {
-                return substr(strtolower($name), 0, strlen($prefix)) === $prefix;
+                return str_starts_with(strtolower($name), $prefix);
             }
         );
 
@@ -308,7 +306,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals('baz2', strtolower($columns['baz2']->getName()));
         self::assertEquals(5, array_search('baz2', $columnsKeys, true));
         self::assertContains(
-            get_class($columns['baz2']->getType()),
+            $columns['baz2']->getType()::class,
             [TimeType::class, DateType::class, DateTimeType::class]
         );
         self::assertEquals(true, $columns['baz2']->getNotnull());
@@ -317,7 +315,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals('baz3', strtolower($columns['baz3']->getName()));
         self::assertEquals(6, array_search('baz3', $columnsKeys, true));
         self::assertContains(
-            get_class($columns['baz3']->getType()),
+            $columns['baz3']->getType()::class,
             [TimeType::class, DateType::class, DateTimeType::class]
         );
         self::assertEquals(true, $columns['baz3']->getNotnull());
@@ -1170,7 +1168,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         try {
             $this->schemaManager->dropSequence($sequence->getName());
-        } catch (DatabaseObjectNotFoundException $e) {
+        } catch (DatabaseObjectNotFoundException) {
         }
 
         $this->schemaManager->createSequence($sequence);

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -294,7 +294,7 @@ EOF
             // some drivers will trigger a PHP error here which, if not suppressed,
             // would be converted to a PHPUnit exception prior to DBAL throwing its own one
             $value = @$fetch($result);
-        } catch (Driver\Exception $e) {
+        } catch (Driver\Exception) {
             // The drivers that enforce the command sequencing internally will throw an exception
             $this->expectNotToPerformAssertions();
 

--- a/tests/Functional/TemporaryTableTest.php
+++ b/tests/Functional/TemporaryTableTest.php
@@ -92,7 +92,7 @@ class TemporaryTableTest extends FunctionalTestCase
             $this->connection->executeStatement(
                 $platform->getDropTemporaryTableSQL($tempTable)
             );
-        } catch (Throwable $e) {
+        } catch (Throwable) {
         }
 
         // In an event of an error this result has one row, because of an implicit commit
@@ -108,7 +108,7 @@ class TemporaryTableTest extends FunctionalTestCase
 
         try {
             $this->connection->executeStatement($sql);
-        } catch (Exception $e) {
+        } catch (Exception) {
         }
     }
 }

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -262,7 +262,7 @@ class WriteTest extends FunctionalTestCase
 
         try {
             $this->connection->createSchemaManager()->dropTable($table->getQuotedName($platform));
-        } catch (Throwable $e) {
+        } catch (Throwable) {
         }
 
         foreach ($platform->getCreateTableSQL($table) as $sql) {

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -86,7 +86,7 @@ abstract class FunctionalTestCase extends TestCase
 
         try {
             $schemaManager->dropTable($name);
-        } catch (DatabaseObjectNotFoundException $e) {
+        } catch (DatabaseObjectNotFoundException) {
         }
     }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -21,7 +21,6 @@ use Doctrine\DBAL\Types\Type;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-use function get_class;
 use function implode;
 use function sprintf;
 
@@ -1082,7 +1081,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testGeneratesInlineColumnCommentSQL(string $comment, string $expectedSql): void
     {
         if (! $this->platform->supportsInlineColumnComments()) {
-            self::markTestSkipped(sprintf('%s does not support inline column comments.', get_class($this->platform)));
+            self::markTestSkipped(sprintf('%s does not support inline column comments.', $this->platform::class));
         }
 
         self::assertSame($expectedSql, $this->platform->getInlineColumnCommentSQL($comment));
@@ -1129,7 +1128,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testThrowsExceptionOnGeneratingInlineColumnCommentSQLIfUnsupported(): void
     {
         if ($this->platform->supportsInlineColumnComments()) {
-            self::markTestSkipped(sprintf('%s supports inline column comments.', get_class($this->platform)));
+            self::markTestSkipped(sprintf('%s supports inline column comments.', $this->platform::class));
         }
 
         $this->expectException(Exception::class);

--- a/tests/Portability/ConverterTest.php
+++ b/tests/Portability/ConverterTest.php
@@ -17,8 +17,12 @@ class ConverterTest extends TestCase
      *
      * @dataProvider convertNumericProvider
      */
-    public function testConvertNumeric($row, bool $convertEmptyStringToNull, bool $rightTrimString, $expected): void
-    {
+    public function testConvertNumeric(
+        array|false $row,
+        bool $convertEmptyStringToNull,
+        bool $rightTrimString,
+        array|false $expected
+    ): void {
         self::assertSame(
             $expected,
             $this->createConverter($convertEmptyStringToNull, $rightTrimString, null)

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -135,7 +135,7 @@ class TestUtil
 
             try {
                 $sm->dropDatabase($dbname);
-            } catch (DatabaseObjectNotFoundException $e) {
+            } catch (DatabaseObjectNotFoundException) {
             }
 
             $sm->createDatabase($dbname);

--- a/tests/Types/DateImmutableTypeTest.php
+++ b/tests/Types/DateImmutableTypeTest.php
@@ -13,8 +13,6 @@ use Doctrine\DBAL\Types\DateImmutableType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-use function get_class;
-
 class DateImmutableTypeTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
@@ -30,7 +28,7 @@ class DateImmutableTypeTest extends TestCase
 
     public function testFactoryCreatesCorrectType(): void
     {
-        self::assertSame(DateImmutableType::class, get_class($this->type));
+        self::assertSame(DateImmutableType::class, $this->type::class);
     }
 
     public function testReturnsBindingType(): void

--- a/tests/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Types/DateTimeImmutableTypeTest.php
@@ -13,8 +13,6 @@ use Doctrine\DBAL\Types\DateTimeImmutableType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-use function get_class;
-
 class DateTimeImmutableTypeTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
@@ -30,7 +28,7 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testFactoryCreatesCorrectType(): void
     {
-        self::assertSame(DateTimeImmutableType::class, get_class($this->type));
+        self::assertSame(DateTimeImmutableType::class, $this->type::class);
     }
 
     public function testReturnsBindingType(): void

--- a/tests/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Types/DateTimeTzImmutableTypeTest.php
@@ -13,8 +13,6 @@ use Doctrine\DBAL\Types\DateTimeTzImmutableType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-use function get_class;
-
 class DateTimeTzImmutableTypeTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
@@ -30,7 +28,7 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
     public function testFactoryCreatesCorrectType(): void
     {
-        self::assertSame(DateTimeTzImmutableType::class, get_class($this->type));
+        self::assertSame(DateTimeTzImmutableType::class, $this->type::class);
     }
 
     public function testReturnsBindingType(): void

--- a/tests/Types/TimeImmutableTypeTest.php
+++ b/tests/Types/TimeImmutableTypeTest.php
@@ -13,8 +13,6 @@ use Doctrine\DBAL\Types\TimeImmutableType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-use function get_class;
-
 class TimeImmutableTypeTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
@@ -30,7 +28,7 @@ class TimeImmutableTypeTest extends TestCase
 
     public function testFactoryCreatesCorrectType(): void
     {
-        self::assertSame(TimeImmutableType::class, get_class($this->type));
+        self::assertSame(TimeImmutableType::class, $this->type::class);
     }
 
     public function testReturnsBindingType(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

The following configuration was used to make the changes:
```php
<?php

declare(strict_types=1);

use Rector\Config\RectorConfig;
use Rector\Core\ValueObject\PhpVersion;
use Rector\Set\ValueObject\SetList;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->paths([__DIR__ . '/src', __DIR__ . '/tests']);
    $rectorConfig->sets([SetList::PHP_80]);
    $rectorConfig->phpVersion(PhpVersion::PHP_80);
    $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon.dist');
};
```
I reverted the addition of `implements Stringable` as I believe that relying on `__toString()` in the cases except for logging is an anti-pattern. I'd rather get rid of these methods in the codebase.

We can enforce the above rules on CI ~~as the next step~~ once they are supported by the coding standard.