### PR TITLE
Drop PHP 8.0 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,11 +27,11 @@ environment:
   - db: mssql
     driver: sqlsrv
     db_version: sql2017
-    php: 8.0
+    php: 8.1
   - db: mssql
     driver: pdo_sqlsrv
     db_version: sql2017
-    php: 8.0
+    php: 8.1
 
 init:
   - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;C:\tools\composer;%PATH%
@@ -64,8 +64,7 @@ install:
           Add-Content php.ini "`n extension=php_sqlite3.dll"
           Add-Content php.ini "`n extension=php_curl.dll"
 
-          # Get and install the latest stable sqlsrv DLL's
-          $DLLVersion = (Invoke-WebRequest "https://pecl.php.net/rest/r/sqlsrv/stable.txt").Content
+          $DLLVersion = "5.10.0"
           cd c:\tools\php\ext
           $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vs16-x64.zip"
           $destination = "c:\tools\php\ext\php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vs16-x64.zip"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -26,3 +26,5 @@ jobs:
   coding-standards:
     name: "Coding Standards"
     uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.1.1"
+    with:
+      php-version: "8.1"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,7 +47,7 @@ jobs:
           - os: "ubuntu-20.04"
             php-version: "8.0"
             dependencies: "lowest"
-          - os: "ubuntu-18.04"
+          - os: "ubuntu-20.04"
             php-version: "8.1"
             dependencies: "highest"
 
@@ -485,7 +485,7 @@ jobs:
 
   phpunit-ibm-db2:
     name: "PHPUnit with IBM DB2"
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-20.04"
     needs: "phpunit-smoke-check"
 
     strategy:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,14 +38,13 @@ jobs:
         os:
           - "ubuntu-20.04"
         php-version:
-          - "8.0"
           - "8.1"
           - "8.2"
         dependencies:
           - "highest"
         include:
           - os: "ubuntu-20.04"
-            php-version: "8.0"
+            php-version: "8.1"
             dependencies: "lowest"
           - os: "ubuntu-20.04"
             php-version: "8.1"
@@ -201,14 +200,12 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.0"
+          - "8.1"
         postgres-version:
           - "10"
           - "13"
           - "14"
         include:
-          - php-version: "8.1"
-            postgres-version: "14"
           - php-version: "8.2"
             postgres-version: "14"
 
@@ -259,7 +256,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.0"
+          - "8.1"
         mariadb-version:
           - "10.2"
           - "10.5"
@@ -268,18 +265,6 @@ jobs:
           - "mysqli"
           - "pdo_mysql"
         include:
-          - php-version: "8.1"
-            mariadb-version: "10.5"
-            extension: "mysqli"
-          - php-version: "8.1"
-            mariadb-version: "10.5"
-            extension: "pdo_mysql"
-          - php-version: "8.1"
-            mariadb-version: "10.7"
-            extension: "mysqli"
-          - php-version: "8.1"
-            mariadb-version: "10.7"
-            extension: "pdo_mysql"
           - php-version: "8.2"
             mariadb-version: "10.7"
             extension: "mysqli"
@@ -336,7 +321,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.0"
+          - "8.1"
         mysql-version:
           - "5.7"
           - "8.0"
@@ -346,25 +331,10 @@ jobs:
         config-file-suffix:
           - ""
         include:
-          - mysql-version: "5.7"
-          - mysql-version: "8.0"
-            # https://stackoverflow.com/questions/60902904/how-to-pass-mysql-native-password-to-mysql-service-in-github-actions
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
           - config-file-suffix: "-tls"
-            php-version: "8.0"
+            php-version: "8.1"
             mysql-version: "8.0"
             extension: "mysqli"
-          - php-version: "8.1"
-            mysql-version: "8.0"
-            extension: "mysqli"
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
-          - php-version: "8.1"
-            mysql-version: "8.0"
-            extension: "pdo_mysql"
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
           - php-version: "8.2"
             mysql-version: "8.0"
             extension: "mysqli"
@@ -434,10 +404,10 @@ jobs:
           - "Latin1_General_100_CI_AS_SC_UTF8"
         include:
           - collation: "Latin1_General_100_CS_AS_SC_UTF8"
-            php-version: "8.0"
+            php-version: "8.1"
             extension: "sqlsrv"
           - collation: "Latin1_General_100_CS_AS_SC_UTF8"
-            php-version: "8.0"
+            php-version: "8.1"
             extension: "pdo_sqlsrv"
 
     services:
@@ -491,7 +461,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.0"
+          - "8.1"
 
     services:
       ibm_db2:
@@ -547,7 +517,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.0"
+          - "8.1"
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "composer-runtime-api": "^2",
         "doctrine/deprecations": "^0.5.3|^1",
         "doctrine/event-manager": "^1.0",
@@ -48,7 +48,7 @@
         "psalm/plugin-phpunit": "0.17.0",
         "squizlabs/php_codesniffer": "3.7.1",
         "symfony/cache": "^5.4|^6.0",
-        "symfony/console": "^4.4|^5.4|^6.0",
+        "symfony/console": "^4.4.30|^5.4|^6.0",
         "vimeo/psalm": "4.24.0"
     },
     "suggest": {

--- a/src/Types/DecimalType.php
+++ b/src/Types/DecimalType.php
@@ -9,8 +9,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use function is_float;
 use function is_int;
 
-use const PHP_VERSION_ID;
-
 /**
  * Type that maps an SQL DECIMAL to a PHP string.
  */
@@ -26,9 +24,9 @@ class DecimalType extends Type
 
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
     {
-        // Some drivers starting from PHP 8.1 can represent decimals as float/int
+        // Some drivers can represent decimals as float/int
         // See also: https://github.com/doctrine/dbal/pull/4818
-        if (PHP_VERSION_ID >= 80100 && (is_float($value) || is_int($value))) {
+        if (is_float($value) || is_int($value)) {
             return (string) $value;
         }
 


### PR DESCRIPTION
The current plan is to release DBAL 4.0 while PHP 8.0 is still officially supported by the community. However, dropping its support now will allow for making some improvements.

For instance, we could replace the `ParameterType` class and similar ones with an enum and introduce more enums (e.g. for the foreign key constraint actions). Since this is a breaking change, not doing it now will require us to wait for another major DBAL release.

The support for PHP 8.0 is not part of the upgrade path from earlier DBAL versions. PHP 8.1 is also supported by DBAL 3.x.