### PR TITLE
Remove calls to setAccessible()

### DIFF
--- a/src/Driver/Mysqli/Exception/ConnectionError.php
+++ b/src/Driver/Mysqli/Exception/ConnectionError.php
@@ -24,7 +24,6 @@ final class ConnectionError extends AbstractException
     public static function upcast(mysqli_sql_exception $exception): self
     {
         $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
-        $p->setAccessible(true);
 
         return new self($exception->getMessage(), $p->getValue($exception), (int) $exception->getCode(), $exception);
     }

--- a/src/Driver/Mysqli/Exception/ConnectionFailed.php
+++ b/src/Driver/Mysqli/Exception/ConnectionFailed.php
@@ -29,7 +29,6 @@ final class ConnectionFailed extends AbstractException
     public static function upcast(mysqli_sql_exception $exception): self
     {
         $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
-        $p->setAccessible(true);
 
         return new self($exception->getMessage(), $p->getValue($exception), (int) $exception->getCode(), $exception);
     }

--- a/src/Driver/Mysqli/Exception/InvalidCharset.php
+++ b/src/Driver/Mysqli/Exception/InvalidCharset.php
@@ -30,7 +30,6 @@ final class InvalidCharset extends AbstractException
     public static function upcast(mysqli_sql_exception $exception, string $charset): self
     {
         $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
-        $p->setAccessible(true);
 
         return new self(
             sprintf('Failed to set charset "%s": %s', $charset, $exception->getMessage()),

--- a/src/Driver/Mysqli/Exception/StatementError.php
+++ b/src/Driver/Mysqli/Exception/StatementError.php
@@ -24,7 +24,6 @@ final class StatementError extends AbstractException
     public static function upcast(mysqli_sql_exception $exception): self
     {
         $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
-        $p->setAccessible(true);
 
         return new self($exception->getMessage(), $p->getValue($exception), (int) $exception->getCode(), $exception);
     }

--- a/tests/Functional/Ticket/DBAL461Test.php
+++ b/tests/Functional/Ticket/DBAL461Test.php
@@ -22,8 +22,7 @@ class DBAL461Test extends TestCase
         $schemaManager = new SQLServerSchemaManager($conn, $platform);
 
         $reflectionMethod = new ReflectionMethod($schemaManager, '_getPortableTableColumnDefinition');
-        $reflectionMethod->setAccessible(true);
-        $column = $reflectionMethod->invoke($schemaManager, [
+        $column           = $reflectionMethod->invoke($schemaManager, [
             'type' => 'numeric(18,0)',
             'length' => null,
             'default' => null,

--- a/tests/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Schema/SQLiteSchemaManagerTest.php
@@ -21,7 +21,6 @@ class SQLiteSchemaManagerTest extends TestCase
 
         $manager = new SQLiteSchemaManager($conn, new SQLitePlatform());
         $ref     = new ReflectionMethod($manager, 'parseColumnCollationFromSQL');
-        $ref->setAccessible(true);
 
         self::assertSame($collation, $ref->invoke($manager, $column, $sql));
     }
@@ -137,7 +136,6 @@ class SQLiteSchemaManagerTest extends TestCase
 
         $manager = new SQLiteSchemaManager($conn, new SQLitePlatform());
         $ref     = new ReflectionMethod($manager, 'parseColumnCommentFromSQL');
-        $ref->setAccessible(true);
 
         self::assertSame($comment, $ref->invoke($manager, $column, $sql));
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

`setAccessible()` on reflection objects is a no-op since PHP 8.1. We can drop all calls since we don't need to support PHP 8.0 anymore.