### PR TITLE
Switch to PHP 8.1 syntax via Rector

### DIFF
--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -20,9 +20,9 @@ use function sha1;
 class QueryCacheProfile
 {
     public function __construct(
-        private int $lifetime = 0,
-        private ?string $cacheKey = null,
-        private ?CacheItemPoolInterface $resultCache = null
+        private readonly int $lifetime = 0,
+        private readonly ?string $cacheKey = null,
+        private readonly ?CacheItemPoolInterface $resultCache = null
     ) {
     }
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -55,22 +55,22 @@ class Connection implements ServerVersionProvider
     /**
      * Represents an array of ints to be expanded by Doctrine SQL parsing.
      */
-    public const PARAM_INT_ARRAY = ParameterType::INTEGER + self::ARRAY_PARAM_OFFSET;
+    final public const PARAM_INT_ARRAY = ParameterType::INTEGER + self::ARRAY_PARAM_OFFSET;
 
     /**
      * Represents an array of strings to be expanded by Doctrine SQL parsing.
      */
-    public const PARAM_STR_ARRAY = ParameterType::STRING + self::ARRAY_PARAM_OFFSET;
+    final public const PARAM_STR_ARRAY = ParameterType::STRING + self::ARRAY_PARAM_OFFSET;
 
     /**
      * Represents an array of ascii strings to be expanded by Doctrine SQL parsing.
      */
-    public const PARAM_ASCII_STR_ARRAY = ParameterType::ASCII + self::ARRAY_PARAM_OFFSET;
+    final public const PARAM_ASCII_STR_ARRAY = ParameterType::ASCII + self::ARRAY_PARAM_OFFSET;
 
     /**
      * Offset by which PARAM_* constants are detected as arrays of the param type.
      */
-    public const ARRAY_PARAM_OFFSET = 100;
+    final public const ARRAY_PARAM_OFFSET = 100;
 
     /**
      * The wrapped driver connection.

--- a/src/Connection/StaticServerVersionProvider.php
+++ b/src/Connection/StaticServerVersionProvider.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\ServerVersionProvider;
 
 class StaticServerVersionProvider implements ServerVersionProvider
 {
-    public function __construct(private string $version)
+    public function __construct(private readonly string $version)
     {
     }
 

--- a/src/Driver/AbstractException.php
+++ b/src/Driver/AbstractException.php
@@ -22,7 +22,7 @@ abstract class AbstractException extends BaseException implements Exception
      */
     public function __construct(
         string $message,
-        private ?string $sqlState = null,
+        private readonly ?string $sqlState = null,
         int $code = 0,
         ?Throwable $previous = null
     ) {

--- a/src/Driver/AbstractOracleDriver/EasyConnectString.php
+++ b/src/Driver/AbstractOracleDriver/EasyConnectString.php
@@ -15,7 +15,7 @@ use function sprintf;
  */
 final class EasyConnectString
 {
-    private function __construct(private string $string)
+    private function __construct(private readonly string $string)
     {
     }
 

--- a/src/Driver/IBMDB2/DataSourceName.php
+++ b/src/Driver/IBMDB2/DataSourceName.php
@@ -13,7 +13,7 @@ use function str_contains;
  */
 final class DataSourceName
 {
-    private function __construct(private string $string)
+    private function __construct(private readonly string $string)
     {
     }
 

--- a/src/Driver/Middleware/AbstractConnectionMiddleware.php
+++ b/src/Driver/Middleware/AbstractConnectionMiddleware.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Driver\Statement;
 
 abstract class AbstractConnectionMiddleware implements Connection
 {
-    public function __construct(private Connection $wrappedConnection)
+    public function __construct(private readonly Connection $wrappedConnection)
     {
     }
 

--- a/src/Driver/Middleware/AbstractDriverMiddleware.php
+++ b/src/Driver/Middleware/AbstractDriverMiddleware.php
@@ -12,7 +12,7 @@ use Doctrine\DBAL\ServerVersionProvider;
 
 abstract class AbstractDriverMiddleware implements Driver
 {
-    public function __construct(private Driver $wrappedDriver)
+    public function __construct(private readonly Driver $wrappedDriver)
     {
     }
 

--- a/src/Driver/Middleware/AbstractResultMiddleware.php
+++ b/src/Driver/Middleware/AbstractResultMiddleware.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Driver\Result;
 
 abstract class AbstractResultMiddleware implements Result
 {
-    public function __construct(private Result $wrappedResult)
+    public function __construct(private readonly Result $wrappedResult)
     {
     }
 

--- a/src/Driver/Middleware/AbstractStatementMiddleware.php
+++ b/src/Driver/Middleware/AbstractStatementMiddleware.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\ParameterType;
 
 abstract class AbstractStatementMiddleware implements Statement
 {
-    public function __construct(private Statement $wrappedStatement)
+    public function __construct(private readonly Statement $wrappedStatement)
     {
     }
 

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -20,7 +20,7 @@ final class Connection implements ConnectionInterface
     /**
      * @internal The connection can be only instantiated by its driver.
      */
-    public function __construct(private mysqli $connection)
+    public function __construct(private readonly mysqli $connection)
     {
     }
 

--- a/src/Driver/Mysqli/Initializer/Charset.php
+++ b/src/Driver/Mysqli/Initializer/Charset.php
@@ -11,7 +11,7 @@ use mysqli_sql_exception;
 
 final class Charset implements Initializer
 {
-    public function __construct(private string $charset)
+    public function __construct(private readonly string $charset)
     {
     }
 

--- a/src/Driver/Mysqli/Initializer/Options.php
+++ b/src/Driver/Mysqli/Initializer/Options.php
@@ -15,7 +15,7 @@ final class Options implements Initializer
     /**
      * @param array<int,mixed> $options
      */
-    public function __construct(private array $options)
+    public function __construct(private readonly array $options)
     {
     }
 

--- a/src/Driver/Mysqli/Initializer/Secure.php
+++ b/src/Driver/Mysqli/Initializer/Secure.php
@@ -10,11 +10,11 @@ use mysqli;
 final class Secure implements Initializer
 {
     public function __construct(
-        private string $key,
-        private string $cert,
-        private string $ca,
-        private string $capath,
-        private string $cipher
+        private readonly string $key,
+        private readonly string $cert,
+        private readonly string $ca,
+        private readonly string $capath,
+        private readonly string $cipher
     ) {
     }
 

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -40,7 +40,7 @@ final class Result implements ResultInterface
      *
      * @throws Exception
      */
-    public function __construct(private mysqli_stmt $statement)
+    public function __construct(private readonly mysqli_stmt $statement)
     {
         $meta = $statement->result_metadata();
 

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -52,7 +52,7 @@ final class Statement implements StatementInterface
     /**
      * @internal The statement can be only instantiated by its driver connection.
      */
-    public function __construct(private mysqli_stmt $stmt)
+    public function __construct(private readonly mysqli_stmt $stmt)
     {
         $paramCount        = $this->stmt->param_count;
         $this->types       = str_repeat('s', $paramCount);

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -22,8 +22,8 @@ use function str_replace;
 
 final class Connection implements ConnectionInterface
 {
-    private Parser $parser;
-    private ExecutionMode $executionMode;
+    private readonly Parser $parser;
+    private readonly ExecutionMode $executionMode;
 
     /**
      * @internal The connection can be only instantiated by its driver.

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -34,8 +34,8 @@ final class Statement implements StatementInterface
     public function __construct(
         private $connection,
         private $statement,
-        private array $parameterMap,
-        private ExecutionMode $executionMode
+        private readonly array $parameterMap,
+        private readonly ExecutionMode $executionMode
     ) {
     }
 

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -15,7 +15,7 @@ use function assert;
 
 final class Connection implements ConnectionInterface
 {
-    private PDO $connection;
+    private readonly PDO $connection;
 
     /**
      * @internal The connection can be only instantiated by its driver.

--- a/src/Driver/PDO/Result.php
+++ b/src/Driver/PDO/Result.php
@@ -14,7 +14,7 @@ final class Result implements ResultInterface
     /**
      * @internal The result can be only instantiated by its driver connection or statement.
      */
-    public function __construct(private PDOStatement $statement)
+    public function __construct(private readonly PDOStatement $statement)
     {
     }
 

--- a/src/Driver/PDO/SQLSrv/Connection.php
+++ b/src/Driver/PDO/SQLSrv/Connection.php
@@ -10,7 +10,7 @@ use PDO;
 
 final class Connection extends AbstractConnectionMiddleware
 {
-    private PDOConnection $connection;
+    private readonly PDOConnection $connection;
 
     public function __construct(PDOConnection $connection)
     {

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -11,7 +11,7 @@ use PDO;
 
 final class Statement extends AbstractStatementMiddleware
 {
-    private PDOStatement $statement;
+    private readonly PDOStatement $statement;
 
     /**
      * @internal The statement can be only instantiated by its driver connection.

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -27,7 +27,7 @@ final class Statement implements StatementInterface
     /**
      * @internal The statement can be only instantiated by its driver connection.
      */
-    public function __construct(private PDOStatement $stmt)
+    public function __construct(private readonly PDOStatement $stmt)
     {
     }
 

--- a/src/Event/ConnectionEventArgs.php
+++ b/src/Event/ConnectionEventArgs.php
@@ -12,7 +12,7 @@ use Doctrine\DBAL\Connection;
  */
 class ConnectionEventArgs extends EventArgs
 {
-    public function __construct(private Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
     }
 

--- a/src/Event/SchemaAlterTableAddColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableAddColumnEventArgs.php
@@ -20,9 +20,9 @@ class SchemaAlterTableAddColumnEventArgs extends SchemaEventArgs
     private array $sql = [];
 
     public function __construct(
-        private Column $column,
-        private TableDiff $tableDiff,
-        private AbstractPlatform $platform
+        private readonly Column $column,
+        private readonly TableDiff $tableDiff,
+        private readonly AbstractPlatform $platform
     ) {
     }
 

--- a/src/Event/SchemaAlterTableChangeColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableChangeColumnEventArgs.php
@@ -20,9 +20,9 @@ class SchemaAlterTableChangeColumnEventArgs extends SchemaEventArgs
     private array $sql = [];
 
     public function __construct(
-        private ColumnDiff $columnDiff,
-        private TableDiff $tableDiff,
-        private AbstractPlatform $platform
+        private readonly ColumnDiff $columnDiff,
+        private readonly TableDiff $tableDiff,
+        private readonly AbstractPlatform $platform
     ) {
     }
 

--- a/src/Event/SchemaAlterTableEventArgs.php
+++ b/src/Event/SchemaAlterTableEventArgs.php
@@ -18,7 +18,7 @@ class SchemaAlterTableEventArgs extends SchemaEventArgs
     /** @var array<int, string> */
     private array $sql = [];
 
-    public function __construct(private TableDiff $tableDiff, private AbstractPlatform $platform)
+    public function __construct(private readonly TableDiff $tableDiff, private readonly AbstractPlatform $platform)
     {
     }
 

--- a/src/Event/SchemaAlterTableRemoveColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableRemoveColumnEventArgs.php
@@ -20,9 +20,9 @@ class SchemaAlterTableRemoveColumnEventArgs extends SchemaEventArgs
     private array $sql = [];
 
     public function __construct(
-        private Column $column,
-        private TableDiff $tableDiff,
-        private AbstractPlatform $platform
+        private readonly Column $column,
+        private readonly TableDiff $tableDiff,
+        private readonly AbstractPlatform $platform
     ) {
     }
 

--- a/src/Event/SchemaAlterTableRenameColumnEventArgs.php
+++ b/src/Event/SchemaAlterTableRenameColumnEventArgs.php
@@ -20,10 +20,10 @@ class SchemaAlterTableRenameColumnEventArgs extends SchemaEventArgs
     private array $sql = [];
 
     public function __construct(
-        private string $oldColumnName,
-        private Column $column,
-        private TableDiff $tableDiff,
-        private AbstractPlatform $platform
+        private readonly string $oldColumnName,
+        private readonly Column $column,
+        private readonly TableDiff $tableDiff,
+        private readonly AbstractPlatform $platform
     ) {
     }
 

--- a/src/Event/SchemaColumnDefinitionEventArgs.php
+++ b/src/Event/SchemaColumnDefinitionEventArgs.php
@@ -18,10 +18,10 @@ class SchemaColumnDefinitionEventArgs extends SchemaEventArgs
      * @param array<string, mixed> $tableColumn
      */
     public function __construct(
-        private array $tableColumn,
-        private string $table,
-        private string $database,
-        private Connection $connection
+        private readonly array $tableColumn,
+        private readonly string $table,
+        private readonly string $database,
+        private readonly Connection $connection
     ) {
     }
 

--- a/src/Event/SchemaCreateTableColumnEventArgs.php
+++ b/src/Event/SchemaCreateTableColumnEventArgs.php
@@ -19,8 +19,11 @@ class SchemaCreateTableColumnEventArgs extends SchemaEventArgs
     /** @var array<int, string> */
     private array $sql = [];
 
-    public function __construct(private Column $column, private Table $table, private AbstractPlatform $platform)
-    {
+    public function __construct(
+        private readonly Column $column,
+        private readonly Table $table,
+        private readonly AbstractPlatform $platform
+    ) {
     }
 
     public function getColumn(): Column

--- a/src/Event/SchemaCreateTableEventArgs.php
+++ b/src/Event/SchemaCreateTableEventArgs.php
@@ -23,10 +23,10 @@ class SchemaCreateTableEventArgs extends SchemaEventArgs
      * @param array<string, mixed>             $options
      */
     public function __construct(
-        private Table $table,
-        private array $columns,
-        private array $options,
-        private AbstractPlatform $platform
+        private readonly Table $table,
+        private readonly array $columns,
+        private readonly array $options,
+        private readonly AbstractPlatform $platform
     ) {
     }
 

--- a/src/Event/SchemaDropTableEventArgs.php
+++ b/src/Event/SchemaDropTableEventArgs.php
@@ -13,7 +13,7 @@ class SchemaDropTableEventArgs extends SchemaEventArgs
 {
     private ?string $sql = null;
 
-    public function __construct(private string $table, private AbstractPlatform $platform)
+    public function __construct(private readonly string $table, private readonly AbstractPlatform $platform)
     {
     }
 

--- a/src/Event/SchemaIndexDefinitionEventArgs.php
+++ b/src/Event/SchemaIndexDefinitionEventArgs.php
@@ -18,9 +18,9 @@ class SchemaIndexDefinitionEventArgs extends SchemaEventArgs
      * @param array<string, mixed> $tableIndex
      */
     public function __construct(
-        private array $tableIndex,
-        private string $table,
-        private Connection $connection
+        private readonly array $tableIndex,
+        private readonly string $table,
+        private readonly Connection $connection
     ) {
     }
 

--- a/src/Event/TransactionEventArgs.php
+++ b/src/Event/TransactionEventArgs.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Connection;
 
 abstract class TransactionEventArgs extends EventArgs
 {
-    public function __construct(private Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
     }
 

--- a/src/Exception/DriverException.php
+++ b/src/Exception/DriverException.php
@@ -20,7 +20,7 @@ class DriverException extends Exception implements Driver\Exception
     /**
      * The query that triggered the exception, if any.
      */
-    private ?Query $query;
+    private readonly ?Query $query;
 
     /**
      * @internal

--- a/src/ExpandArrayParameters.php
+++ b/src/ExpandArrayParameters.php
@@ -32,7 +32,7 @@ final class ExpandArrayParameters implements Visitor
      * @param array<int, mixed>|array<string, mixed>                             $originalParameters
      * @param array<int,Type|int|string|null>|array<string,Type|int|string|null> $originalTypes
      */
-    public function __construct(private array $originalParameters, private array $originalTypes)
+    public function __construct(private readonly array $originalParameters, private readonly array $originalTypes)
     {
     }
 

--- a/src/FetchMode.php
+++ b/src/FetchMode.php
@@ -10,9 +10,9 @@ namespace Doctrine\DBAL;
 class FetchMode
 {
     /** @link PDO::FETCH_ASSOC */
-    public const ASSOCIATIVE = 2;
+    final public const ASSOCIATIVE = 2;
     /** @link PDO::FETCH_NUM */
-    public const NUMERIC = 3;
+    final public const NUMERIC = 3;
     /** @link PDO::FETCH_COLUMN */
-    public const COLUMN = 7;
+    final public const COLUMN = 7;
 }

--- a/src/LockMode.php
+++ b/src/LockMode.php
@@ -9,10 +9,10 @@ namespace Doctrine\DBAL;
  */
 class LockMode
 {
-    public const NONE              = 0;
-    public const OPTIMISTIC        = 1;
-    public const PESSIMISTIC_READ  = 2;
-    public const PESSIMISTIC_WRITE = 4;
+    final public const NONE              = 0;
+    final public const OPTIMISTIC        = 1;
+    final public const PESSIMISTIC_READ  = 2;
+    final public const PESSIMISTIC_WRITE = 4;
 
     /**
      * Private constructor. This class cannot be instantiated.

--- a/src/Logging/Connection.php
+++ b/src/Logging/Connection.php
@@ -15,7 +15,7 @@ final class Connection extends AbstractConnectionMiddleware
     /**
      * @internal This connection can be only instantiated by its driver.
      */
-    public function __construct(ConnectionInterface $connection, private LoggerInterface $logger)
+    public function __construct(ConnectionInterface $connection, private readonly LoggerInterface $logger)
     {
         parent::__construct($connection);
     }

--- a/src/Logging/Driver.php
+++ b/src/Logging/Driver.php
@@ -13,7 +13,7 @@ final class Driver extends AbstractDriverMiddleware
     /**
      * @internal This driver can be only instantiated by its middleware.
      */
-    public function __construct(DriverInterface $driver, private LoggerInterface $logger)
+    public function __construct(DriverInterface $driver, private readonly LoggerInterface $logger)
     {
         parent::__construct($driver);
     }

--- a/src/Logging/Middleware.php
+++ b/src/Logging/Middleware.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerInterface;
 
 final class Middleware implements MiddlewareInterface
 {
-    public function __construct(private LoggerInterface $logger)
+    public function __construct(private readonly LoggerInterface $logger)
     {
     }
 

--- a/src/Logging/Statement.php
+++ b/src/Logging/Statement.php
@@ -21,8 +21,11 @@ final class Statement extends AbstractStatementMiddleware
     /**
      * @internal This statement can be only instantiated by its connection.
      */
-    public function __construct(StatementInterface $statement, private LoggerInterface $logger, private string $sql)
-    {
+    public function __construct(
+        StatementInterface $statement,
+        private readonly LoggerInterface $logger,
+        private readonly string $sql
+    ) {
         parent::__construct($statement);
     }
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -33,13 +33,13 @@ use function trim;
  */
 abstract class AbstractMySQLPlatform extends AbstractPlatform
 {
-    public const LENGTH_LIMIT_TINYTEXT   = 255;
-    public const LENGTH_LIMIT_TEXT       = 65535;
-    public const LENGTH_LIMIT_MEDIUMTEXT = 16777215;
+    final public const LENGTH_LIMIT_TINYTEXT   = 255;
+    final public const LENGTH_LIMIT_TEXT       = 65535;
+    final public const LENGTH_LIMIT_MEDIUMTEXT = 16777215;
 
-    public const LENGTH_LIMIT_TINYBLOB   = 255;
-    public const LENGTH_LIMIT_BLOB       = 65535;
-    public const LENGTH_LIMIT_MEDIUMBLOB = 16777215;
+    final public const LENGTH_LIMIT_TINYBLOB   = 255;
+    final public const LENGTH_LIMIT_BLOB       = 65535;
+    final public const LENGTH_LIMIT_MEDIUMBLOB = 16777215;
 
     protected function doModifyLimitQuery(string $query, ?int $limit, int $offset): string
     {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1266,7 +1266,7 @@ abstract class AbstractPlatform
     public function quoteIdentifier(string $identifier): string
     {
         if (str_contains($identifier, '.')) {
-            $parts = array_map([$this, 'quoteSingleIdentifier'], explode('.', $identifier));
+            $parts = array_map($this->quoteSingleIdentifier(...), explode('.', $identifier));
 
             return implode('.', $parts);
         }

--- a/src/Platforms/MySQL/CharsetMetadataProvider/CachingCharsetMetadataProvider.php
+++ b/src/Platforms/MySQL/CharsetMetadataProvider/CachingCharsetMetadataProvider.php
@@ -16,7 +16,7 @@ final class CachingCharsetMetadataProvider implements CharsetMetadataProvider
     /** @var array<string,?string> */
     private array $cache = [];
 
-    public function __construct(private CharsetMetadataProvider $charsetMetadataProvider)
+    public function __construct(private readonly CharsetMetadataProvider $charsetMetadataProvider)
     {
     }
 

--- a/src/Platforms/MySQL/CharsetMetadataProvider/ConnectionCharsetMetadataProvider.php
+++ b/src/Platforms/MySQL/CharsetMetadataProvider/ConnectionCharsetMetadataProvider.php
@@ -13,7 +13,7 @@ use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
  */
 final class ConnectionCharsetMetadataProvider implements CharsetMetadataProvider
 {
-    public function __construct(private Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
     }
 

--- a/src/Platforms/MySQL/CollationMetadataProvider/CachingCollationMetadataProvider.php
+++ b/src/Platforms/MySQL/CollationMetadataProvider/CachingCollationMetadataProvider.php
@@ -16,7 +16,7 @@ final class CachingCollationMetadataProvider implements CollationMetadataProvide
     /** @var array<string,?string> */
     private array $cache = [];
 
-    public function __construct(private CollationMetadataProvider $collationMetadataProvider)
+    public function __construct(private readonly CollationMetadataProvider $collationMetadataProvider)
     {
     }
 

--- a/src/Platforms/MySQL/CollationMetadataProvider/ConnectionCollationMetadataProvider.php
+++ b/src/Platforms/MySQL/CollationMetadataProvider/ConnectionCollationMetadataProvider.php
@@ -13,7 +13,7 @@ use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
  */
 final class ConnectionCollationMetadataProvider implements CollationMetadataProvider
 {
-    public function __construct(private Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
     }
 

--- a/src/Platforms/MySQL/Comparator.php
+++ b/src/Platforms/MySQL/Comparator.php
@@ -25,9 +25,9 @@ class Comparator extends BaseComparator
      */
     public function __construct(
         AbstractMySQLPlatform $platform,
-        private CharsetMetadataProvider $charsetMetadataProvider,
-        private CollationMetadataProvider $collationMetadataProvider,
-        private DefaultTableOptions $defaultTableOptions
+        private readonly CharsetMetadataProvider $charsetMetadataProvider,
+        private readonly CollationMetadataProvider $collationMetadataProvider,
+        private readonly DefaultTableOptions $defaultTableOptions
     ) {
         parent::__construct($platform);
     }

--- a/src/Platforms/MySQL/DefaultTableOptions.php
+++ b/src/Platforms/MySQL/DefaultTableOptions.php
@@ -9,7 +9,7 @@ namespace Doctrine\DBAL\Platforms\MySQL;
  */
 final class DefaultTableOptions
 {
-    public function __construct(private string $charset, private string $collation)
+    public function __construct(private readonly string $charset, private readonly string $collation)
     {
     }
 

--- a/src/Platforms/SQLServer/Comparator.php
+++ b/src/Platforms/SQLServer/Comparator.php
@@ -19,7 +19,7 @@ class Comparator extends BaseComparator
     /**
      * @internal The comparator can be only instantiated by a schema manager.
      */
-    public function __construct(SQLServerPlatform $platform, private string $databaseCollation)
+    public function __construct(SQLServerPlatform $platform, private readonly string $databaseCollation)
     {
         parent::__construct($platform);
     }

--- a/src/Portability/Connection.php
+++ b/src/Portability/Connection.php
@@ -18,7 +18,7 @@ final class Connection extends AbstractConnectionMiddleware
     public const PORTABILITY_EMPTY_TO_NULL = 4;
     public const PORTABILITY_FIX_CASE      = 8;
 
-    public function __construct(ConnectionInterface $connection, private Converter $converter)
+    public function __construct(ConnectionInterface $connection, private readonly Converter $converter)
     {
         parent::__construct($connection);
     }

--- a/src/Portability/Driver.php
+++ b/src/Portability/Driver.php
@@ -15,7 +15,7 @@ use const CASE_UPPER;
 
 final class Driver extends AbstractDriverMiddleware
 {
-    public function __construct(DriverInterface $driver, private int $mode, private int $case)
+    public function __construct(DriverInterface $driver, private readonly int $mode, private readonly int $case)
     {
         parent::__construct($driver);
     }

--- a/src/Portability/Middleware.php
+++ b/src/Portability/Middleware.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
 
 final class Middleware implements MiddlewareInterface
 {
-    public function __construct(private int $mode, private int $case)
+    public function __construct(private readonly int $mode, private readonly int $case)
     {
     }
 

--- a/src/Portability/Result.php
+++ b/src/Portability/Result.php
@@ -12,7 +12,7 @@ final class Result extends AbstractResultMiddleware
     /**
      * @internal The result can be only instantiated by the portability connection or statement.
      */
-    public function __construct(ResultInterface $result, private Converter $converter)
+    public function __construct(ResultInterface $result, private readonly Converter $converter)
     {
         parent::__construct($result);
     }

--- a/src/Portability/Statement.php
+++ b/src/Portability/Statement.php
@@ -16,7 +16,7 @@ final class Statement extends AbstractStatementMiddleware
     /**
      * Wraps <tt>Statement</tt> and applies portability measures.
      */
-    public function __construct(DriverStatement $stmt, private Converter $converter)
+    public function __construct(DriverStatement $stmt, private readonly Converter $converter)
     {
         parent::__construct($stmt);
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -20,9 +20,9 @@ final class Query
      * @psalm-suppress ImpurePropertyAssignment
      */
     public function __construct(
-        private string $sql,
-        private array $params,
-        private array $types
+        private readonly string $sql,
+        private readonly array $params,
+        private readonly array $types
     ) {
     }
 

--- a/src/Query/Expression/CompositeExpression.php
+++ b/src/Query/Expression/CompositeExpression.php
@@ -21,12 +21,12 @@ class CompositeExpression implements Countable
     /**
      * Constant that represents an AND composite expression.
      */
-    public const TYPE_AND = 'AND';
+    final public const TYPE_AND = 'AND';
 
     /**
      * Constant that represents an OR composite expression.
      */
-    public const TYPE_OR = 'OR';
+    final public const TYPE_OR = 'OR';
 
     /**
      * Each expression part of the composite expression.
@@ -39,7 +39,7 @@ class CompositeExpression implements Countable
      * @internal Use the and() / or() factory methods.
      */
     public function __construct(
-        private string $type,
+        private readonly string $type,
         self|string $part,
         self|string ...$parts
     ) {

--- a/src/Query/Expression/ExpressionBuilder.php
+++ b/src/Query/Expression/ExpressionBuilder.php
@@ -14,19 +14,19 @@ use function sprintf;
  */
 class ExpressionBuilder
 {
-    public const EQ  = '=';
-    public const NEQ = '<>';
-    public const LT  = '<';
-    public const LTE = '<=';
-    public const GT  = '>';
-    public const GTE = '>=';
+    final public const EQ  = '=';
+    final public const NEQ = '<>';
+    final public const LT  = '<';
+    final public const LTE = '<=';
+    final public const GT  = '>';
+    final public const GTE = '>=';
 
     /**
      * Initializes a new <tt>ExpressionBuilder</tt>.
      *
      * @param Connection $connection The DBAL Connection.
      */
-    public function __construct(private Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
     }
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -39,16 +39,16 @@ class QueryBuilder
     /*
      * The query types.
      */
-    public const SELECT = 0;
-    public const DELETE = 1;
-    public const UPDATE = 2;
-    public const INSERT = 3;
+    final public const SELECT = 0;
+    final public const DELETE = 1;
+    final public const UPDATE = 2;
+    final public const INSERT = 3;
 
     /*
      * The builder states.
      */
-    public const STATE_DIRTY = 0;
-    public const STATE_CLEAN = 1;
+    final public const STATE_DIRTY = 0;
+    final public const STATE_CLEAN = 1;
 
     /**
      * The complete SQL string for this query.
@@ -168,7 +168,7 @@ class QueryBuilder
      *
      * @param Connection $connection The DBAL Connection.
      */
-    public function __construct(private Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
     }
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -18,7 +18,7 @@ class Result
     /**
      * @internal The result can be only instantiated by {@see Connection} or {@see Statement}.
      */
-    public function __construct(private DriverResult $result, private Connection $connection)
+    public function __construct(private readonly DriverResult $result, private readonly Connection $connection)
     {
     }
 

--- a/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
@@ -14,7 +14,7 @@ use function array_merge;
 
 final class CreateSchemaObjectsSQLBuilder
 {
-    public function __construct(private AbstractPlatform $platform)
+    public function __construct(private readonly AbstractPlatform $platform)
     {
     }
 

--- a/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
@@ -14,7 +14,7 @@ use function array_merge;
 
 final class DropSchemaObjectsSQLBuilder
 {
-    public function __construct(private AbstractPlatform $platform)
+    public function __construct(private readonly AbstractPlatform $platform)
     {
     }
 

--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -46,7 +46,7 @@ final class Parser
     private const SPECIAL              = '[' . self::SPECIAL_CHARS . ']';
     private const OTHER                = '[^' . self::SPECIAL_CHARS . ']+';
 
-    private string $sqlPattern;
+    private readonly string $sqlPattern;
 
     public function __construct(bool $mySQLStringEscaping)
     {

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -24,7 +24,7 @@ class Comparator
     /**
      * @internal The comparator can be only instantiated by a schema manager.
      */
-    public function __construct(private AbstractPlatform $platform)
+    public function __construct(private readonly AbstractPlatform $platform)
     {
     }
 

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -118,7 +118,7 @@ class ForeignKeyConstraint extends AbstractAsset
      */
     public function getUnquotedLocalColumns(): array
     {
-        return array_map([$this, 'trimQuotes'], $this->getLocalColumns());
+        return array_map($this->trimQuotes(...), $this->getLocalColumns());
     }
 
     /**
@@ -128,7 +128,7 @@ class ForeignKeyConstraint extends AbstractAsset
      */
     public function getUnquotedForeignColumns(): array
     {
-        return array_map([$this, 'trimQuotes'], $this->getForeignColumns());
+        return array_map($this->trimQuotes(...), $this->getForeignColumns());
     }
 
     /**

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -45,7 +45,7 @@ class Index extends AbstractAsset
         bool $isUnique = false,
         bool $isPrimary = false,
         array $flags = [],
-        private array $options = []
+        private readonly array $options = []
     ) {
         $isUnique = $isUnique || $isPrimary;
 
@@ -108,7 +108,7 @@ class Index extends AbstractAsset
      */
     public function getUnquotedColumns(): array
     {
-        return array_map([$this, 'trimQuotes'], $this->getColumns());
+        return array_map($this->trimQuotes(...), $this->getColumns());
     }
 
     /**

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -38,7 +38,7 @@ class UniqueConstraint extends AbstractAsset
         string $name,
         array $columns,
         array $flags = [],
-        private array $options = []
+        private readonly array $options = []
     ) {
         $this->_setName($name);
 
@@ -78,7 +78,7 @@ class UniqueConstraint extends AbstractAsset
      */
     public function getUnquotedColumns(): array
     {
-        return array_map([$this, 'trimQuotes'], $this->getColumns());
+        return array_map($this->trimQuotes(...), $this->getColumns());
     }
 
     /**

--- a/src/Schema/View.php
+++ b/src/Schema/View.php
@@ -9,7 +9,7 @@ namespace Doctrine\DBAL\Schema;
  */
 class View extends AbstractAsset
 {
-    public function __construct(string $name, private string $sql)
+    public function __construct(string $name, private readonly string $sql)
     {
         $this->_setName($name);
     }

--- a/src/Tools/Console/Command/RunSqlCommand.php
+++ b/src/Tools/Console/Command/RunSqlCommand.php
@@ -28,7 +28,7 @@ use function stripos;
  */
 class RunSqlCommand extends Command
 {
-    public function __construct(private ConnectionProvider $connectionProvider)
+    public function __construct(private readonly ConnectionProvider $connectionProvider)
     {
         parent::__construct();
     }

--- a/src/Tools/Console/ConnectionProvider/SingleConnectionProvider.php
+++ b/src/Tools/Console/ConnectionProvider/SingleConnectionProvider.php
@@ -12,8 +12,10 @@ use function sprintf;
 
 class SingleConnectionProvider implements ConnectionProvider
 {
-    public function __construct(private Connection $connection, private string $defaultConnectionName = 'default')
-    {
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly string $defaultConnectionName = 'default'
+    ) {
     }
 
     public function getDefaultConnection(): Connection

--- a/src/Types/DateIntervalType.php
+++ b/src/Types/DateIntervalType.php
@@ -17,7 +17,7 @@ use function substr;
  */
 class DateIntervalType extends Type
 {
-    public const FORMAT = '%RP%YY%MM%DDT%HH%IM%SS';
+    final public const FORMAT = '%RP%YY%MM%DDT%HH%IM%SS';
 
     /**
      * {@inheritDoc}

--- a/tests/Driver/PDO/ExceptionTest.php
+++ b/tests/Driver/PDO/ExceptionTest.php
@@ -13,11 +13,11 @@ use PHPUnit\Framework\TestCase;
  */
 class ExceptionTest extends TestCase
 {
-    public const ERROR_CODE = 666;
+    private const ERROR_CODE = 666;
 
-    public const MESSAGE = 'PDO Exception';
+    private const MESSAGE = 'PDO Exception';
 
-    public const SQLSTATE = 'HY000';
+    private const SQLSTATE = 'HY000';
 
     /**
      * The PDO exception wrapper under test.


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

The following configuration was used to make the changes:
```php
<?php

declare(strict_types=1);

use Rector\Config\RectorConfig;
use Rector\Core\ValueObject\PhpVersion;
use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
use Rector\Set\ValueObject\SetList;
use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->paths([__DIR__ . '/src', __DIR__ . '/tests']);
    $rectorConfig->sets([SetList::PHP_81]);
    $rectorConfig->skip([
        # this one adds a ton of (string) conversions that seem unnecessary
        NullToStrictStringFuncCallArgRector::class,
        # this one generates the never return types that are incompatible in the inheritance chain
        ReturnNeverTypeRector::class,
    ]);
    $rectorConfig->phpVersion(PhpVersion::PHP_81);
    $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon.dist');
};
```
