### PR TITLE
Set properties to readonly if possible

### DIFF
--- a/src/Cache/ArrayResult.php
+++ b/src/Cache/ArrayResult.php
@@ -16,19 +16,15 @@ use function reset;
  */
 final class ArrayResult implements Result
 {
-    private int $columnCount = 0;
-    private int $num         = 0;
+    private readonly int $columnCount;
+    private int $num = 0;
 
     /**
      * @param list<array<string, mixed>> $data
      */
     public function __construct(private array $data)
     {
-        if (count($data) === 0) {
-            return;
-        }
-
-        $this->columnCount = count($data[0]);
+        $this->columnCount = $data === [] ? 0 : count($data[0]);
     }
 
     public function fetchNumeric(): array|false

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -33,7 +33,7 @@ final class Connection implements ConnectionInterface
      *
      * @param resource $connection
      */
-    public function __construct(private $connection)
+    public function __construct(private readonly mixed $connection)
     {
     }
 

--- a/src/Driver/IBMDB2/Result.php
+++ b/src/Driver/IBMDB2/Result.php
@@ -22,7 +22,7 @@ final class Result implements ResultInterface
      *
      * @param resource $statement
      */
-    public function __construct(private $statement)
+    public function __construct(private readonly mixed $statement)
     {
     }
 

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -46,7 +46,7 @@ final class Statement implements StatementInterface
      *
      * @param resource $stmt
      */
-    public function __construct(private $stmt)
+    public function __construct(private readonly mixed $stmt)
     {
     }
 

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -22,7 +22,7 @@ final class Result implements ResultInterface
      * Whether the statement result has columns. The property should be used only after the result metadata
      * has been fetched ({@see $metadataFetched}). Otherwise, the property value is undetermined.
      */
-    private bool $hasColumns = false;
+    private readonly bool $hasColumns;
 
     /**
      * Mapping of statement result column indexes to their names. The property should be used only
@@ -30,7 +30,7 @@ final class Result implements ResultInterface
      *
      * @var array<int,string>
      */
-    private array $columnNames = [];
+    private readonly array $columnNames;
 
     /** @var mixed[] */
     private array $boundValues = [];
@@ -42,15 +42,13 @@ final class Result implements ResultInterface
      */
     public function __construct(private readonly mysqli_stmt $statement)
     {
-        $meta = $statement->result_metadata();
+        $meta              = $statement->result_metadata();
+        $this->hasColumns  = $meta !== false;
+        $this->columnNames = $meta !== false ? array_column($meta->fetch_fields(), 'name') : [];
 
         if ($meta === false) {
             return;
         }
-
-        $this->hasColumns = true;
-
-        $this->columnNames = array_column($meta->fetch_fields(), 'name');
 
         $meta->free();
 

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -30,7 +30,7 @@ final class Connection implements ConnectionInterface
      *
      * @param resource $connection
      */
-    public function __construct(private $connection)
+    public function __construct(private readonly mixed $connection)
     {
         $this->parser        = new Parser(false);
         $this->executionMode = new ExecutionMode();

--- a/src/Driver/OCI8/Result.php
+++ b/src/Driver/OCI8/Result.php
@@ -30,7 +30,7 @@ final class Result implements ResultInterface
      *
      * @param resource $statement
      */
-    public function __construct(private $statement)
+    public function __construct(private readonly mixed $statement)
     {
     }
 

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -32,8 +32,8 @@ final class Statement implements StatementInterface
      * @param array<int,string> $parameterMap
      */
     public function __construct(
-        private $connection,
-        private $statement,
+        private readonly mixed $connection,
+        private readonly mixed $statement,
         private readonly array $parameterMap,
         private readonly ExecutionMode $executionMode
     ) {

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -15,16 +15,12 @@ use function assert;
 
 final class Connection implements ConnectionInterface
 {
-    private readonly PDO $connection;
-
     /**
      * @internal The connection can be only instantiated by its driver.
      */
-    public function __construct(PDO $connection)
+    public function __construct(private readonly PDO $connection)
     {
         $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
-        $this->connection = $connection;
     }
 
     public function exec(string $sql): int|string

--- a/src/Driver/SQLSrv/Connection.php
+++ b/src/Driver/SQLSrv/Connection.php
@@ -23,7 +23,7 @@ final class Connection implements ConnectionInterface
      *
      * @param resource $connection
      */
-    public function __construct(private $connection)
+    public function __construct(private readonly mixed $connection)
     {
     }
 

--- a/src/Driver/SQLSrv/Result.php
+++ b/src/Driver/SQLSrv/Result.php
@@ -22,7 +22,7 @@ final class Result implements ResultInterface
      *
      * @param resource $statement
      */
-    public function __construct(private $statement)
+    public function __construct(private readonly mixed $statement)
     {
     }
 

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -56,7 +56,7 @@ final class Statement implements StatementInterface
      * @param resource $conn
      */
     public function __construct(
-        private $conn,
+        private readonly mixed $conn,
         private string $sql
     ) {
         if (stripos($sql, 'INSERT INTO ') !== 0) {

--- a/src/Exception/DriverException.php
+++ b/src/Exception/DriverException.php
@@ -18,18 +18,15 @@ use function assert;
 class DriverException extends Exception implements Driver\Exception
 {
     /**
-     * The query that triggered the exception, if any.
-     */
-    private readonly ?Query $query;
-
-    /**
      * @internal
      *
      * @param Driver\Exception $driverException The DBAL driver exception to chain.
      * @param Query|null       $query           The SQL query that triggered the exception, if any.
      */
-    public function __construct(Driver\Exception $driverException, ?Query $query)
-    {
+    public function __construct(
+        Driver\Exception $driverException,
+        private readonly ?Query $query,
+    ) {
         if ($query !== null) {
             $message = 'An exception occurred while executing a query: ' . $driverException->getMessage();
         } else {
@@ -37,8 +34,6 @@ class DriverException extends Exception implements Driver\Exception
         }
 
         parent::__construct($message, $driverException->getCode(), $driverException);
-
-        $this->query = $query;
     }
 
     public function getSQLState(): ?string

--- a/src/Query/From.php
+++ b/src/Query/From.php
@@ -9,7 +9,9 @@ namespace Doctrine\DBAL\Query;
  */
 final class From
 {
-    public function __construct(public string $table, public ?string $alias = null)
-    {
+    public function __construct(
+        public readonly string $table,
+        public readonly ?string $alias = null,
+    ) {
     }
 }

--- a/src/Query/Join.php
+++ b/src/Query/Join.php
@@ -10,10 +10,10 @@ namespace Doctrine\DBAL\Query;
 final class Join
 {
     private function __construct(
-        public string $type,
-        public string $table,
-        public string $alias,
-        public ?string $condition
+        public readonly string $type,
+        public readonly string $table,
+        public readonly string $alias,
+        public readonly ?string $condition,
     ) {
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

This PR flags all properties as `readonly` when I found it safe to do so:

* The property is written once in the constructor and only read afterwards and
* the property is `private` or it or its class is flagged as `@internal`.

My main motivation is to make clear that we consider those properties as immutable. My expectation is that this makes the code easier to comprehend and analyze.
