### PR TITLE
Convert ParameterType to enum

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,9 +14,10 @@ The following classes have been converted to enums:
 
 1. `Doctrine\DBAL\ColumnCase`,
 2. `Doctrine\DBAL\LockMode`,
-3. `Doctrine\DBAL\TransactionIsolationLevel`,
-4. `Doctrine\DBAL\Platforms\DateIntervalUnit`,
-5. `Doctrine\DBAL\Platforms\TrimMode`.
+3. `Doctrine\DBAL\ParameterType`,
+4. `Doctrine\DBAL\TransactionIsolationLevel`,
+5. `Doctrine\DBAL\Platforms\DateIntervalUnit`,
+6. `Doctrine\DBAL\Platforms\TrimMode`.
 
 The corresponding class constants are now instances of their enum type.
 

--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -187,13 +187,13 @@ on the Connection, which are all described in the API section below.
 Binding Types
 -------------
 
-Besides ``Doctrine\DBAL\ParameterType`` constants, you
+Besides the values of ``Doctrine\DBAL\ParameterType``, you
 can make use of two very powerful additional features.
 
 Doctrine\DBAL\Types Conversion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you don't specify an integer (through one of ``Doctrine\DBAL\ParameterType`` constants) to
+If you don't specify a value of the type ``Doctrine\DBAL\ParameterType`` to
 any of the parameter binding methods but a string, Doctrine DBAL will
 ask the type abstraction layer to convert the passed value from
 its PHP to a database representation. This way you can pass ``\DateTime``

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -119,4 +119,14 @@
         <exclude-pattern>src/Platforms/SQLitePlatform.php</exclude-pattern>
         <exclude-pattern>src/Platforms/*/Comparator.php</exclude-pattern>
     </rule>
+
+    <!-- This issue is likely fixed in Slevomat Coding Standard 8.0.0 -->
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName">
+        <exclude-pattern>src/ParameterType.php</exclude-pattern>
+    </rule>
+
+    <!-- The union types representing prepared statement parameter types are too complex -->
+    <rule ref="Generic.Files.LineLength.TooLong">
+        <exclude-pattern>src/Cache/QueryCacheProfile.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/ArrayParameters/Exception/InvalidParameterType.php
+++ b/src/ArrayParameters/Exception/InvalidParameterType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\DBAL\Driver\Exception;
+namespace Doctrine\DBAL\ArrayParameters\Exception;
 
 use Doctrine\DBAL\Driver\AbstractException;
 
@@ -13,10 +13,10 @@ use function sprintf;
  *
  * @psalm-immutable
  */
-final class UnknownParameterType extends AbstractException
+final class InvalidParameterType extends AbstractException
 {
     public static function new(int $type): self
     {
-        return new self(sprintf('Unknown parameter type, %d given.', $type));
+        return new self(sprintf('Invalid parameter type, %d given.', $type));
     }
 }

--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Cache;
 
 use Doctrine\DBAL\Cache\Exception\NoCacheKey;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -51,9 +52,9 @@ class QueryCacheProfile
     /**
      * Generates the real cache key from query, params, types and connection parameters.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params
-     * @param array<int, Type|int|string|null>|array<string, Type|int|string|null> $types
-     * @param array<string, mixed>                                                 $connectionParams
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param array<string, mixed>                                                                             $connectionParams
      *
      * @return string[]
      */

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -54,26 +54,19 @@ use function sprintf;
 class Connection implements ServerVersionProvider
 {
     /**
-     * Represents an array of ints to be expanded by Doctrine SQL parsing.
+     * Represents an array of integers to be expanded by Doctrine SQL parsing.
      */
-    final public const PARAM_INT_ARRAY = ParameterType::INTEGER + self::ARRAY_PARAM_OFFSET;
+    final public const PARAM_INT_ARRAY = 101;
 
     /**
      * Represents an array of strings to be expanded by Doctrine SQL parsing.
      */
-    final public const PARAM_STR_ARRAY = ParameterType::STRING + self::ARRAY_PARAM_OFFSET;
+    final public const PARAM_STR_ARRAY = 102;
 
     /**
      * Represents an array of ascii strings to be expanded by Doctrine SQL parsing.
      */
-    final public const PARAM_ASCII_STR_ARRAY = ParameterType::ASCII + self::ARRAY_PARAM_OFFSET;
-
-    /**
-     * Offset by which PARAM_* constants are detected as arrays of the param type.
-     *
-     * @internal Should be used only within the wrapper layer.
-     */
-    final public const ARRAY_PARAM_OFFSET = 100;
+    final public const PARAM_ASCII_STR_ARRAY = 117;
 
     /**
      * The wrapped driver connection.
@@ -368,8 +361,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the first row of the result
      * as an associative array.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return array<string, mixed>|false False is returned if no rows are found.
      *
@@ -384,8 +377,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the first row of the result
      * as a numerically indexed array.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return list<mixed>|false False is returned if no rows are found.
      *
@@ -400,8 +393,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the value of a single column
      * of the first row of the result.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return mixed|false False is returned if no rows are found.
      *
@@ -463,8 +456,8 @@ class Connection implements ServerVersionProvider
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param array<string, mixed>                                                 $criteria Deletion criteria
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
+     * @param array<string, mixed>                                                                             $criteria
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return int|string The number of affected rows.
      *
@@ -527,9 +520,9 @@ class Connection implements ServerVersionProvider
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param array<string, mixed>                                                 $data     Column-value pairs
-     * @param array<string, mixed>                                                 $criteria Update criteria
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
+     * @param array<string, mixed>                                                                             $data
+     * @param array<string, mixed>                                                                             $criteria
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return int|string The number of affected rows.
      *
@@ -562,8 +555,8 @@ class Connection implements ServerVersionProvider
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param array<string, mixed>                                                 $data  Column-value pairs
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types Parameter types
+     * @param array<string, mixed>                                                                             $data
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return int|string The number of affected rows.
      *
@@ -596,16 +589,16 @@ class Connection implements ServerVersionProvider
     /**
      * Extract ordered type list from an ordered column list and type map.
      *
-     * @param array<int, string>                                                   $columnList
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     * @param array<int, string>                                                                               $columns
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
-     * @return array<int, int|string|Type|null>|array<string, int|string|Type|null>
+     * @return array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null>
      */
-    private function extractTypeValues(array $columnList, array $types): array
+    private function extractTypeValues(array $columns, array $types): array
     {
         $typeValues = [];
 
-        foreach ($columnList as $columnName) {
+        foreach ($columns as $columnName) {
             $typeValues[] = $types[$columnName] ?? ParameterType::STRING;
         }
 
@@ -643,8 +636,8 @@ class Connection implements ServerVersionProvider
     /**
      * Prepares and executes an SQL query and returns the result as an array of numeric arrays.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return list<list<mixed>>
      *
@@ -658,8 +651,8 @@ class Connection implements ServerVersionProvider
     /**
      * Prepares and executes an SQL query and returns the result as an array of associative arrays.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return list<array<string,mixed>>
      *
@@ -674,8 +667,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the result as an associative array with the keys
      * mapped to the first column and the values mapped to the second column.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return array<mixed,mixed>
      *
@@ -691,9 +684,8 @@ class Connection implements ServerVersionProvider
      * to the first column and the values being an associative array representing the rest of the columns
      * and their values.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return array<mixed,array<string,mixed>>
      *
@@ -707,8 +699,8 @@ class Connection implements ServerVersionProvider
     /**
      * Prepares and executes an SQL query and returns the result as an array of the first column values.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return list<mixed>
      *
@@ -722,8 +714,8 @@ class Connection implements ServerVersionProvider
     /**
      * Prepares and executes an SQL query and returns the result as an iterator over rows represented as numeric arrays.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return Traversable<int,list<mixed>>
      *
@@ -738,8 +730,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the result as an iterator over rows represented
      * as associative arrays.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return Traversable<int,array<string,mixed>>
      *
@@ -754,8 +746,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the result as an iterator with the keys
      * mapped to the first column and the values mapped to the second column.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return Traversable<mixed,mixed>
      *
@@ -771,9 +763,9 @@ class Connection implements ServerVersionProvider
      * to the first column and the values being an associative array representing the rest of the columns
      * and their values.
      *
-     * @param string                                           $query  SQL query
-     * @param list<mixed>|array<string, mixed>                 $params Query parameters
-     * @param array<int, int|string>|array<string, int|string> $types  Parameter types
+     * @param string                                                               $query  SQL query
+     * @param list<mixed>|array<string, mixed>                                     $params
+     * @param array<int, ParameterType|string>|array<string, ParameterType|string> $types
      *
      * @return Traversable<mixed,array<string,mixed>>
      *
@@ -787,8 +779,8 @@ class Connection implements ServerVersionProvider
     /**
      * Prepares and executes an SQL query and returns the result as an iterator over the first column values.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return Traversable<int,mixed>
      *
@@ -824,8 +816,8 @@ class Connection implements ServerVersionProvider
      *
      * If the query is parametrized, a prepared statement is used.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @throws Exception
      */
@@ -843,9 +835,7 @@ class Connection implements ServerVersionProvider
 
         try {
             if (count($params) > 0) {
-                if ($this->needsArrayParameterConversion($params, $types)) {
-                    [$sql, $params, $types] = $this->expandArrayParameters($sql, $params, $types);
-                }
+                [$sql, $params, $types] = $this->expandArrayParameters($sql, $params, $types);
 
                 $stmt = $connection->prepare($sql);
                 if (count($types) > 0) {
@@ -867,8 +857,8 @@ class Connection implements ServerVersionProvider
     /**
      * Executes a caching query.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @throws CacheException
      * @throws Exception
@@ -925,8 +915,8 @@ class Connection implements ServerVersionProvider
      *
      * This method supports PDO binding types as well as DBAL mapping types.
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Statement parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @throws Exception
      */
@@ -936,9 +926,7 @@ class Connection implements ServerVersionProvider
 
         try {
             if (count($params) > 0) {
-                if ($this->needsArrayParameterConversion($params, $types)) {
-                    [$sql, $params, $types] = $this->expandArrayParameters($sql, $params, $types);
-                }
+                [$sql, $params, $types] = $this->expandArrayParameters($sql, $params, $types);
 
                 $stmt = $connection->prepare($sql);
 
@@ -1321,9 +1309,8 @@ class Connection implements ServerVersionProvider
      * Binds a set of parameters, some or all of which are typed with a PDO binding type
      * or DBAL mapping type, to a given statement.
      *
-     * @param DriverStatement                                                      $stmt   Prepared statement
-     * @param list<mixed>|array<string, mixed>                                     $params Statement parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                         $params
+     * @param array<int, string|ParameterType|Type|null>|array<string, string|ParameterType|Type|null> $types
      *
      * @throws Exception
      */
@@ -1379,14 +1366,14 @@ class Connection implements ServerVersionProvider
     /**
      * Gets the binding type of a given type.
      *
-     * @param mixed                $value The value to bind.
-     * @param int|string|Type|null $type  The type to bind (PDO or DBAL).
+     * @param mixed                          $value The value to bind.
+     * @param string|ParameterType|Type|null $type  The type to bind.
      *
-     * @return array{mixed, int} [0] => the (escaped) value, [1] => the binding type.
+     * @return array{mixed, ParameterType} [0] => the (escaped) value, [1] => the binding type.
      *
      * @throws Exception
      */
-    private function getBindingInfo(mixed $value, int|string|Type|null $type): array
+    private function getBindingInfo(mixed $value, string|ParameterType|Type|null $type): array
     {
         if (is_string($type)) {
             $type = Type::getType($type);
@@ -1413,8 +1400,8 @@ class Connection implements ServerVersionProvider
     /**
      * @internal
      *
-     * @param list<mixed>|array<string,mixed>                                      $params
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     * @param list<mixed>|array<string,mixed>                                                                  $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      */
     final public function convertExceptionDuringQuery(
         Driver\Exception $e,
@@ -1434,13 +1421,37 @@ class Connection implements ServerVersionProvider
     }
 
     /**
-     * @param array<int, mixed>|array<string, mixed>                               $params
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     * @param array<int, mixed>|array<string, mixed>                                                           $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
-     * @return array{string, list<mixed>, array<int,Type|int|string|null>}
+     * @return array{
+     *     string,
+     *     array<int, mixed>|array<string, mixed>,
+     *     array<int, string|ParameterType|Type|null>|array<string, string|ParameterType|Type|null>
+     * }
      */
     private function expandArrayParameters(string $sql, array $params, array $types): array
     {
+        $needsConversion = false;
+        $nonArrayTypes   = [];
+
+        if (is_string(key($params))) {
+            $needsConversion = true;
+        } else {
+            foreach ($types as $key => $type) {
+                if (is_int($type)) {
+                    $needsConversion = true;
+                    break;
+                }
+
+                $nonArrayTypes[$key] = $type;
+            }
+        }
+
+        if (! $needsConversion) {
+            return [$sql, $params, $nonArrayTypes];
+        }
+
         $this->parser ??= $this->getDatabasePlatform()->createSQLParser();
         $visitor        = new ExpandArrayParameters($params, $types);
 
@@ -1451,29 +1462,6 @@ class Connection implements ServerVersionProvider
             $visitor->getParameters(),
             $visitor->getTypes(),
         ];
-    }
-
-    /**
-     * @param array<int, mixed>|array<string, mixed>                               $params
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
-     */
-    private function needsArrayParameterConversion(array $params, array $types): bool
-    {
-        if (is_string(key($params))) {
-            return true;
-        }
-
-        foreach ($types as $type) {
-            if (
-                $type === self::PARAM_INT_ARRAY
-                || $type === self::PARAM_STR_ARRAY
-                || $type === self::PARAM_ASCII_STR_ARRAY
-            ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private function handleDriverException(
@@ -1495,8 +1483,8 @@ class Connection implements ServerVersionProvider
      *
      * @deprecated This API is deprecated and will be removed after 2022
      *
-     * @param array<int, mixed>|array<string, mixed>                               $params Query parameters
-     * @param array<int, Type|int|string|null>|array<string, Type|int|string|null> $types  Parameter types
+     * @param array<int, mixed>|array<string, mixed>                                                           $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @throws Exception
      */

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -50,7 +50,7 @@ final class Statement implements StatementInterface
     {
     }
 
-    public function bindValue(int|string $param, mixed $value, int $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
     {
         assert(is_int($param));
 
@@ -60,7 +60,7 @@ final class Statement implements StatementInterface
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        int $type = ParameterType::STRING,
+        ParameterType $type = ParameterType::STRING,
         ?int $length = null
     ): void {
         assert(is_int($param));

--- a/src/Driver/Middleware/AbstractStatementMiddleware.php
+++ b/src/Driver/Middleware/AbstractStatementMiddleware.php
@@ -14,7 +14,7 @@ abstract class AbstractStatementMiddleware implements Statement
     {
     }
 
-    public function bindValue(int|string $param, mixed $value, int $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
     {
         $this->wrappedStatement->bindValue($param, $value, $type);
     }
@@ -22,7 +22,7 @@ abstract class AbstractStatementMiddleware implements Statement
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        int $type = ParameterType::STRING,
+        ParameterType $type = ParameterType::STRING,
         ?int $length = null
     ): void {
         $this->wrappedStatement->bindParam($param, $variable, $type, $length);

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -39,7 +39,7 @@ final class Statement implements StatementInterface
     ) {
     }
 
-    public function bindValue(int|string $param, mixed $value, int $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
     {
         $this->bindParam($param, $value, $type);
     }
@@ -47,7 +47,7 @@ final class Statement implements StatementInterface
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        int $type = ParameterType::STRING,
+        ParameterType $type = ParameterType::STRING,
         ?int $length = null
     ): void {
         if (is_int($param)) {
@@ -85,7 +85,7 @@ final class Statement implements StatementInterface
     /**
      * Converts DBAL parameter type to oci8 parameter type
      */
-    private function convertParameterType(int $type): int
+    private function convertParameterType(ParameterType $type): int
     {
         return match ($type) {
             ParameterType::BINARY => OCI_B_BIN,

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -26,7 +26,7 @@ final class Statement extends AbstractStatementMiddleware
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        int $type = ParameterType::STRING,
+        ParameterType $type = ParameterType::STRING,
         ?int $length = null
     ): void {
         switch ($type) {
@@ -56,7 +56,7 @@ final class Statement extends AbstractStatementMiddleware
         }
     }
 
-    public function bindValue(int|string $param, mixed $value, int $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
     {
         $this->bindParam($param, $value, $type);
     }

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -41,7 +41,7 @@ final class Statement implements StatementInterface
     /**
      * Bound parameter types.
      *
-     * @var array<int, int>
+     * @var array<int, ParameterType>
      */
     private array $types = [];
 
@@ -66,7 +66,7 @@ final class Statement implements StatementInterface
         $this->sql .= self::LAST_INSERT_ID_SQL;
     }
 
-    public function bindValue(int|string $param, mixed $value, int $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
     {
         assert(is_int($param));
 
@@ -77,7 +77,7 @@ final class Statement implements StatementInterface
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        int $type = ParameterType::STRING,
+        ParameterType $type = ParameterType::STRING,
         ?int $length = null
     ): void {
         assert(is_int($param));

--- a/src/Driver/Statement.php
+++ b/src/Driver/Statement.php
@@ -18,16 +18,17 @@ interface Statement
      * As mentioned above, the named parameters are not natively supported by the mysqli driver, use executeQuery(),
      * fetchAll(), fetchArray(), fetchColumn(), fetchAssoc() methods to have the named parameter emulated by doctrine.
      *
-     * @param int|string $param Parameter identifier. For a prepared statement using named placeholders,
-     *                          this will be a parameter name of the form :name. For a prepared statement
-     *                          using question mark placeholders, this will be the 1-indexed position of the parameter.
-     * @param mixed      $value The value to bind to the parameter.
-     * @param int        $type  Explicit data type for the parameter using the {@see ParameterType}
-     *                          constants.
+     * @param int|string    $param Parameter identifier. For a prepared statement using named placeholders,
+     *                             this will be a parameter name of the form :name. For a prepared statement
+     *                             using question mark placeholders, this will be the 1-indexed position
+     *                             of the parameter.
+     * @param mixed         $value The value to bind to the parameter.
+     * @param ParameterType $type  Explicit data type for the parameter using the {@see ParameterType}
+     *                             constants.
      *
      * @throws Exception
      */
-    public function bindValue(int|string $param, mixed $value, int $type = ParameterType::STRING): void;
+    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void;
 
     /**
      * Binds a PHP variable to a corresponding named (not supported by mysqli driver, see comment below) or question
@@ -43,21 +44,21 @@ interface Statement
      * of stored procedures that return data as output parameters, and some also as input/output
      * parameters that both send in data and are updated to receive it.
      *
-     * @param int|string $param    Parameter identifier. For a prepared statement using named placeholders,
-     *                             this will be a parameter name of the form :name. For a prepared statement using
-     *                             question mark placeholders, this will be the 1-indexed position of the parameter.
-     * @param mixed      $variable The variable to bind to the parameter.
-     * @param int        $type     Explicit data type for the parameter using the {@see ParameterType}
+     * @param int|string    $param    Parameter identifier. For a prepared statement using named placeholders,
+     *                                this will be a parameter name of the form :name. For a prepared statement using
+     *                                question mark placeholders, this will be the 1-indexed position of the parameter.
+     * @param mixed         $variable The variable to bind to the parameter.
+     * @param ParameterType $type     Explicit data type for the parameter using the {@see ParameterType}
      *                             constants.
-     * @param int|null   $length   You must specify maxlength when using an OUT bind
-     *                             so that PHP allocates enough memory to hold the returned value.
+     * @param int|null      $length   You must specify maxlength when using an OUT bind
+     *                                so that PHP allocates enough memory to hold the returned value.
      *
      * @throws Exception
      */
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        int $type = ParameterType::STRING,
+        ParameterType $type = ParameterType::STRING,
         ?int $length = null
     ): void;
 

--- a/src/Logging/Statement.php
+++ b/src/Logging/Statement.php
@@ -15,7 +15,7 @@ final class Statement extends AbstractStatementMiddleware
     /** @var array<int,mixed>|array<string,mixed> */
     private array $params = [];
 
-    /** @var array<int,int>|array<string,int> */
+    /** @var array<int,ParameterType>|array<string,ParameterType> */
     private array $types = [];
 
     /**
@@ -32,7 +32,7 @@ final class Statement extends AbstractStatementMiddleware
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        int $type = ParameterType::STRING,
+        ParameterType $type = ParameterType::STRING,
         ?int $length = null
     ): void {
         $this->params[$param] = &$variable;
@@ -41,7 +41,7 @@ final class Statement extends AbstractStatementMiddleware
         parent::bindParam($param, $variable, $type, $length);
     }
 
-    public function bindValue(int|string $param, mixed $value, int $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
     {
         $this->params[$param] = $value;
         $this->types[$param]  = $type;

--- a/src/ParameterType.php
+++ b/src/ParameterType.php
@@ -5,55 +5,42 @@ declare(strict_types=1);
 namespace Doctrine\DBAL;
 
 /**
- * Contains statement parameter types.
+ * Statement parameter type.
  */
-final class ParameterType
+enum ParameterType
 {
     /**
      * Represents the SQL NULL data type.
      */
-    public const NULL = 0;
+    case NULL;
 
     /**
      * Represents the SQL INTEGER data type.
      */
-    public const INTEGER = 1;
+    case INTEGER;
 
     /**
      * Represents the SQL CHAR, VARCHAR, or other string data type.
-     *
-     * @see \PDO::PARAM_STR
      */
-    public const STRING = 2;
+    case STRING;
 
     /**
      * Represents the SQL large object data type.
      */
-    public const LARGE_OBJECT = 3;
+    case LARGE_OBJECT;
 
     /**
      * Represents a boolean data type.
-     *
-     * @see \PDO::PARAM_BOOL
      */
-    public const BOOLEAN = 5;
+    case BOOLEAN;
 
     /**
      * Represents a binary string data type.
      */
-    public const BINARY = 16;
+    case BINARY;
 
     /**
      * Represents an ASCII string data type
      */
-    public const ASCII = 17;
-
-    /**
-     * This class cannot be instantiated.
-     *
-     * @codeCoverageIgnore
-     */
-    private function __construct()
-    {
-    }
+    case ASCII;
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -14,8 +14,8 @@ use Doctrine\DBAL\Types\Type;
 final class Query
 {
     /**
-     * @param array<mixed>                $params
-     * @param array<Type|int|string|null> $types
+     * @param array<mixed>                              $params
+     * @param array<int|string|ParameterType|Type|null> $types
      *
      * @psalm-suppress ImpurePropertyAssignment
      */
@@ -40,7 +40,7 @@ final class Query
     }
 
     /**
-     * @return array<Type|int|string|null>
+     * @return array<int|string|ParameterType|Type|null>
      */
     public function getTypes(): array
     {

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -52,9 +52,9 @@ class QueryBuilder
     /**
      * The parameter type map of this query.
      *
-     * @var array<int, int|string|Type|null>|array<string, int|string|Type|null>
+     * @var array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null>
      */
-    private array $paramTypes = [];
+    private array $types = [];
 
     /**
      * The type of query this is. Can be select, update or delete.
@@ -191,7 +191,7 @@ class QueryBuilder
      */
     public function fetchAssociative(): array|false
     {
-        return $this->connection->fetchAssociative($this->getSQL(), $this->params, $this->paramTypes);
+        return $this->connection->fetchAssociative($this->getSQL(), $this->params, $this->types);
     }
 
     /**
@@ -204,7 +204,7 @@ class QueryBuilder
      */
     public function fetchNumeric(): array|false
     {
-        return $this->connection->fetchNumeric($this->getSQL(), $this->params, $this->paramTypes);
+        return $this->connection->fetchNumeric($this->getSQL(), $this->params, $this->types);
     }
 
     /**
@@ -217,7 +217,7 @@ class QueryBuilder
      */
     public function fetchOne(): mixed
     {
-        return $this->connection->fetchOne($this->getSQL(), $this->params, $this->paramTypes);
+        return $this->connection->fetchOne($this->getSQL(), $this->params, $this->types);
     }
 
     /**
@@ -229,7 +229,7 @@ class QueryBuilder
      */
     public function fetchAllNumeric(): array
     {
-        return $this->connection->fetchAllNumeric($this->getSQL(), $this->params, $this->paramTypes);
+        return $this->connection->fetchAllNumeric($this->getSQL(), $this->params, $this->types);
     }
 
     /**
@@ -241,7 +241,7 @@ class QueryBuilder
      */
     public function fetchAllAssociative(): array
     {
-        return $this->connection->fetchAllAssociative($this->getSQL(), $this->params, $this->paramTypes);
+        return $this->connection->fetchAllAssociative($this->getSQL(), $this->params, $this->types);
     }
 
     /**
@@ -254,7 +254,7 @@ class QueryBuilder
      */
     public function fetchAllKeyValue(): array
     {
-        return $this->connection->fetchAllKeyValue($this->getSQL(), $this->params, $this->paramTypes);
+        return $this->connection->fetchAllKeyValue($this->getSQL(), $this->params, $this->types);
     }
 
     /**
@@ -268,7 +268,7 @@ class QueryBuilder
      */
     public function fetchAllAssociativeIndexed(): array
     {
-        return $this->connection->fetchAllAssociativeIndexed($this->getSQL(), $this->params, $this->paramTypes);
+        return $this->connection->fetchAllAssociativeIndexed($this->getSQL(), $this->params, $this->types);
     }
 
     /**
@@ -280,7 +280,7 @@ class QueryBuilder
      */
     public function fetchFirstColumn(): array
     {
-        return $this->connection->fetchFirstColumn($this->getSQL(), $this->params, $this->paramTypes);
+        return $this->connection->fetchFirstColumn($this->getSQL(), $this->params, $this->types);
     }
 
     /**
@@ -290,7 +290,7 @@ class QueryBuilder
      */
     public function executeQuery(): Result
     {
-        return $this->connection->executeQuery($this->getSQL(), $this->params, $this->paramTypes);
+        return $this->connection->executeQuery($this->getSQL(), $this->params, $this->types);
     }
 
     /**
@@ -304,7 +304,7 @@ class QueryBuilder
      */
     public function executeStatement(): int|string
     {
-        return $this->connection->executeStatement($this->getSQL(), $this->params, $this->paramTypes);
+        return $this->connection->executeStatement($this->getSQL(), $this->params, $this->types);
     }
 
     /**
@@ -342,19 +342,19 @@ class QueryBuilder
      *         ->setParameter('user_id', 1);
      * </code>
      *
-     * @param int|string           $key   Parameter position or name
-     * @param mixed                $value Parameter value
-     * @param int|string|Type|null $type  Parameter type
+     * @param int|string                     $key   Parameter position or name
+     * @param mixed                          $value Parameter value
+     * @param string|ParameterType|Type|null $type  Parameter type
      *
      * @return $this This QueryBuilder instance.
      */
     public function setParameter(
         int|string $key,
         mixed $value,
-        int|string|Type|null $type = ParameterType::STRING
+        string|ParameterType|Type|null $type = ParameterType::STRING
     ): self {
         if ($type !== null) {
-            $this->paramTypes[$key] = $type;
+            $this->types[$key] = $type;
         } else {
             Deprecation::trigger(
                 'doctrine/dbal',
@@ -383,15 +383,15 @@ class QueryBuilder
      *         ));
      * </code>
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Parameters to set
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @return $this This QueryBuilder instance.
      */
     public function setParameters(array $params, array $types = []): self
     {
-        $this->paramTypes = $types;
-        $this->params     = $params;
+        $this->params = $params;
+        $this->types  = $types;
 
         return $this;
     }
@@ -421,12 +421,11 @@ class QueryBuilder
     /**
      * Gets all defined query parameter types for the query being constructed indexed by parameter index or name.
      *
-     * @return array<int, int|string|Type|null>|array<string, int|string|Type|null> The currently defined
-     *                                                                              query parameter types
+     * @return array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null>
      */
     public function getParameterTypes(): array
     {
-        return $this->paramTypes;
+        return $this->types;
     }
 
     /**
@@ -434,11 +433,11 @@ class QueryBuilder
      *
      * @param int|string $key The key of the bound parameter type
      *
-     * @return int|string|Type The value of the bound parameter type
+     * @return int|string|ParameterType|Type The value of the bound parameter type
      */
-    public function getParameterType(int|string $key): int|string|Type|null
+    public function getParameterType(int|string $key): int|string|ParameterType|Type|null
     {
-        return $this->paramTypes[$key] ?? ParameterType::STRING;
+        return $this->types[$key] ?? ParameterType::STRING;
     }
 
     /**
@@ -1321,7 +1320,7 @@ class QueryBuilder
      */
     public function createNamedParameter(
         mixed $value,
-        int|string|Type|null $type = ParameterType::STRING,
+        string|ParameterType|Type|null $type = ParameterType::STRING,
         ?string $placeHolder = null
     ): string {
         if ($placeHolder === null) {
@@ -1351,8 +1350,10 @@ class QueryBuilder
      *     ->orWhere('u.username = ' . $qb->createPositionalParameter('Bar', ParameterType::STRING))
      * </code>
      */
-    public function createPositionalParameter(mixed $value, int|string|Type|null $type = ParameterType::STRING): string
-    {
+    public function createPositionalParameter(
+        mixed $value,
+        string|ParameterType|Type|null $type = ParameterType::STRING
+    ): string {
         $this->setParameter($this->boundCounter, $value, $type);
         $this->boundCounter++;
 

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -25,7 +25,7 @@ class Statement
     /**
      * The parameter types.
      *
-     * @var int[]|string[]|Type[]
+     * @var ParameterType[]|string[]|Type[]
      */
     protected array $types = [];
 
@@ -61,18 +61,21 @@ class Statement
      * type and the value undergoes the conversion routines of the mapping type before
      * being bound.
      *
-     * @param string|int      $param Parameter identifier. For a prepared statement using named placeholders,
-     *                               this will be a parameter name of the form :name. For a prepared statement
-     *                               using question mark placeholders, this will be the 1-indexed position
-     *                               of the parameter.
-     * @param mixed           $value The value to bind to the parameter.
-     * @param string|int|Type $type  Either one of the constants defined in {@see \Doctrine\DBAL\ParameterType}
-     *                               or a DBAL mapping type name or instance.
+     * @param string|int                $param Parameter identifier. For a prepared statement using named placeholders,
+     *                                         this will be a parameter name of the form :name. For a prepared statement
+     *                                         using question mark placeholders, this will be the 1-indexed position
+     *                                         of the parameter.
+     * @param mixed                     $value The value to bind to the parameter.
+     * @param ParameterType|string|Type $type  Either a {@see \Doctrine\DBAL\ParameterType} or a DBAL mapping type name
+     *                                or instance.
      *
      * @throws Exception
      */
-    public function bindValue(string|int $param, mixed $value, string|int|Type $type = ParameterType::STRING): void
-    {
+    public function bindValue(
+        string|int $param,
+        mixed $value,
+        string|ParameterType|Type $type = ParameterType::STRING
+    ): void {
         $this->params[$param] = $value;
         $this->types[$param]  = $type;
 
@@ -99,21 +102,21 @@ class Statement
      *
      * Binding a parameter by reference does not support DBAL mapping types.
      *
-     * @param string|int $param    Parameter identifier. For a prepared statement using named placeholders,
-     *                             this will be a parameter name of the form :name. For a prepared statement
-     *                             using question mark placeholders, this will be the 1-indexed position
-     *                             of the parameter.
-     * @param mixed      $variable The variable to bind to the parameter.
-     * @param int        $type     The binding type.
-     * @param int|null   $length   Must be specified when using an OUT bind
-     *                             so that PHP allocates enough memory to hold the returned value.
+     * @param string|int    $param    Parameter identifier. For a prepared statement using named placeholders,
+     *                                this will be a parameter name of the form :name. For a prepared statement
+     *                                using question mark placeholders, this will be the 1-indexed position
+     *                                of the parameter.
+     * @param mixed         $variable The variable to bind to the parameter.
+     * @param ParameterType $type     The binding type.
+     * @param int|null      $length   Must be specified when using an OUT bind
+     *                                so that PHP allocates enough memory to hold the returned value.
      *
      * @throws Exception
      */
     public function bindParam(
         string|int $param,
         mixed &$variable,
-        int $type = ParameterType::STRING,
+        ParameterType $type = ParameterType::STRING,
         ?int $length = null
     ): void {
         $this->params[$param] = $variable;

--- a/src/Types/AsciiStringType.php
+++ b/src/Types/AsciiStringType.php
@@ -17,7 +17,7 @@ final class AsciiStringType extends StringType
         return $platform->getAsciiStringTypeDeclarationSQL($column);
     }
 
-    public function getBindingType(): int
+    public function getBindingType(): ParameterType
     {
         return ParameterType::ASCII;
     }

--- a/src/Types/BigIntType.php
+++ b/src/Types/BigIntType.php
@@ -20,7 +20,7 @@ class BigIntType extends Type implements PhpIntegerMappingType
         return $platform->getBigIntTypeDeclarationSQL($column);
     }
 
-    public function getBindingType(): int
+    public function getBindingType(): ParameterType
     {
         return ParameterType::STRING;
     }

--- a/src/Types/BinaryType.php
+++ b/src/Types/BinaryType.php
@@ -42,7 +42,7 @@ class BinaryType extends Type
         return $value;
     }
 
-    public function getBindingType(): int
+    public function getBindingType(): ParameterType
     {
         return ParameterType::BINARY;
     }

--- a/src/Types/BlobType.php
+++ b/src/Types/BlobType.php
@@ -49,7 +49,7 @@ class BlobType extends Type
         return $value;
     }
 
-    public function getBindingType(): int
+    public function getBindingType(): ParameterType
     {
         return ParameterType::LARGE_OBJECT;
     }

--- a/src/Types/BooleanType.php
+++ b/src/Types/BooleanType.php
@@ -30,7 +30,7 @@ class BooleanType extends Type
         return $platform->convertFromBoolean($value);
     }
 
-    public function getBindingType(): int
+    public function getBindingType(): ParameterType
     {
         return ParameterType::BOOLEAN;
     }

--- a/src/Types/IntegerType.php
+++ b/src/Types/IntegerType.php
@@ -25,7 +25,7 @@ class IntegerType extends Type implements PhpIntegerMappingType
         return $value === null ? null : (int) $value;
     }
 
-    public function getBindingType(): int
+    public function getBindingType(): ParameterType
     {
         return ParameterType::INTEGER;
     }

--- a/src/Types/SmallIntType.php
+++ b/src/Types/SmallIntType.php
@@ -25,7 +25,7 @@ class SmallIntType extends Type implements PhpIntegerMappingType
         return $value === null ? null : (int) $value;
     }
 
-    public function getBindingType(): int
+    public function getBindingType(): ParameterType
     {
         return ParameterType::INTEGER;
     }

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -165,10 +165,8 @@ abstract class Type
     /**
      * Gets the (preferred) binding type for values of this type that
      * can be used when binding parameters to prepared statements.
-     *
-     * This method should return one of the {@see ParameterType} constants.
      */
-    public function getBindingType(): int
+    public function getBindingType(): ParameterType
     {
         return ParameterType::STRING;
     }

--- a/tests/Cache/QueryCacheProfileTest.php
+++ b/tests/Cache/QueryCacheProfileTest.php
@@ -18,13 +18,13 @@ class QueryCacheProfileTest extends TestCase
     private QueryCacheProfile $queryCacheProfile;
     private string $query = 'SELECT * FROM foo WHERE bar = ?';
 
-    /** @var int[] */
+    /** @var list<mixed> */
     private array $params = [666];
 
-    /** @var int[] */
+    /** @var list<ParameterType::INTEGER> */
     private array $types = [ParameterType::INTEGER];
 
-    /** @var string[] */
+    /** @var array<string, mixed> */
     private array $connectionParams = [
         'dbname'   => 'database_name',
         'user'     => 'database_user',

--- a/tests/Connection/ExpandArrayParametersTest.php
+++ b/tests/Connection/ExpandArrayParametersTest.php
@@ -415,7 +415,7 @@ class ExpandArrayParametersTest extends TestCase
      * @param array<int, mixed>|array<string, mixed>                               $params
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
      *
-     * @return array{0: string, 1: list<mixed>, 2: array<int,Type|int|string|null>}
+     * @return array{string, list<mixed>, array<int,string|ParameterType|Type|null>}
      */
     private function expandArrayParameters(string $sql, array $params, array $types): array
     {

--- a/tests/Functional/Platform/ColumnTest.php
+++ b/tests/Functional/Platform/ColumnTest.php
@@ -103,7 +103,7 @@ abstract class ColumnTest extends FunctionalTestCase
     /**
      * @param array<string, mixed> $column
      */
-    protected function assertColumn(string $type, array $column, string $value, int $bindType): void
+    protected function assertColumn(string $type, array $column, string $value, ParameterType $bindType): void
     {
         $table = new Table('column_test');
         $table->addColumn('val', $type, $column);

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -1175,8 +1175,8 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * @param list<mixed>|array<string, mixed>                                     $parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     * @param list<mixed>|array<string, mixed>                                                                 $params
+     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
      *
      * @dataProvider fetchProvider
      */
@@ -1184,8 +1184,8 @@ class QueryBuilderTest extends TestCase
         string $select,
         string $from,
         string $where,
-        array $parameters,
-        array $parameterTypes,
+        array $params,
+        array $types,
         string $expectedSql
     ): void {
         $qb           = new QueryBuilder($this->conn);
@@ -1193,13 +1193,13 @@ class QueryBuilderTest extends TestCase
 
         $this->conn->expects(self::once())
             ->method('executeQuery')
-            ->with($expectedSql, $parameters, $parameterTypes)
+            ->with($expectedSql, $params, $types)
             ->willReturn($mockedResult);
 
         $results = $qb->select($select)
             ->from($from)
             ->where($where)
-            ->setParameters($parameters, $parameterTypes)
+            ->setParameters($params, $types)
             ->executeQuery();
 
         self::assertSame(


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

Positive outcomes:
1. The driver-level statement API is now more robust. The `UnknownParameterType` exception is no longer possible since all possible values of the parameter type are constrained by the enum.
2. The driver-level parameter types and the wrapper-level array types which were previously described by a single `int` type are now distinct (`ParameterType` and `int` respectively). This is important since the wrapper-level array types have non-obviously limited support. For instance, they can be used in `Connection::executeQuery()` but not in `Statement::bindValue()`.

Negative outcomes:
1. The PHP types describing parameter types became more complex (which reflects how complex they really are).

As the next step, we can simplify the type of parameter types by making them non-nullable. There is already a default of "string" (see https://github.com/doctrine/dbal/pull/5550).

**TODO**:
- [x] https://github.com/doctrine/dbal/pull/5549.