### PR TITLE
Mark Connection::ARRAY_PARAM_OFFSET internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Marked `Connection::ARRAY_PARAM_OFFSET` as internal.
+
+The `Connection::ARRAY_PARAM_OFFSET` constant has been marked as internal. It will be removed in 4.0.
+
 ## Deprecated using NULL as prepared statement parameter type.
 
 Omit the type or use `Parameter::STRING` instead.

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -65,6 +65,8 @@ class Connection
 
     /**
      * Offset by which PARAM_* constants are detected as arrays of the param type.
+     *
+     * @internal Should be used only within the wrapper layer.
      */
     public const ARRAY_PARAM_OFFSET = 100;
 


### PR DESCRIPTION
This constant is used only internally in order to derive the values of `Connection::PARAM_*_ARRAY` constants from the `ParameterType::*` of the corresponding type.

It will be removed in `4.0.x` as part of https://github.com/doctrine/dbal/pull/5548.