### PR TITLE
Deprecate using NULL as prepared statement parameter type

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated using NULL as prepared statement parameter type.
+
+Omit the type or use `Parameter::STRING` instead.
+
 ## Deprecated passing asset names as assets in `AbstractPlatform` and `AbstractSchemaManager` methods.
 
 Passing assets to the following `AbstractPlatform` methods and parameters has been deprecated:

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -28,6 +28,7 @@ use LogicException;
 use Throwable;
 use Traversable;
 
+use function array_key_exists;
 use function assert;
 use function count;
 use function get_class;
@@ -1677,6 +1678,15 @@ class Connection
                     [$value, $bindingType] = $this->getBindingInfo($value, $type);
                     $stmt->bindValue($bindIndex, $value, $bindingType);
                 } else {
+                    if (array_key_exists($key, $types)) {
+                        Deprecation::trigger(
+                            'doctrine/dbal',
+                            'https://github.com/doctrine/dbal/pull/5550',
+                            'Using NULL as prepared statement parameter type is deprecated.'
+                                . 'Omit or use Parameter::STRING instead'
+                        );
+                    }
+
                     $stmt->bindValue($bindIndex, $value);
                 }
 
@@ -1690,6 +1700,15 @@ class Connection
                     [$value, $bindingType] = $this->getBindingInfo($value, $type);
                     $stmt->bindValue($name, $value, $bindingType);
                 } else {
+                    if (array_key_exists($name, $types)) {
+                        Deprecation::trigger(
+                            'doctrine/dbal',
+                            'https://github.com/doctrine/dbal/pull/5550',
+                            'Using NULL as prepared statement parameter type is deprecated.'
+                                . 'Omit or use Parameter::STRING instead'
+                        );
+                    }
+
                     $stmt->bindValue($name, $value);
                 }
             }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -400,10 +400,17 @@ class QueryBuilder
      *
      * @return $this This QueryBuilder instance.
      */
-    public function setParameter($key, $value, $type = null)
+    public function setParameter($key, $value, $type = ParameterType::STRING)
     {
         if ($type !== null) {
             $this->paramTypes[$key] = $type;
+        } else {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5550',
+                'Using NULL as prepared statement parameter type is deprecated.'
+                    . 'Omit or use Parameter::STRING instead'
+            );
         }
 
         $this->params[$key] = $value;
@@ -476,11 +483,11 @@ class QueryBuilder
      *
      * @param int|string $key The key of the bound parameter type
      *
-     * @return int|string|Type|null The value of the bound parameter type
+     * @return int|string|Type The value of the bound parameter type
      */
     public function getParameterType($key)
     {
-        return $this->paramTypes[$key] ?? null;
+        return $this->paramTypes[$key] ?? ParameterType::STRING;
     }
 
     /**

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -882,16 +882,16 @@ class QueryBuilderTest extends TestCase
 
         $qb->select('*')->from('users');
 
-        self::assertNull($qb->getParameterType('name'));
+        self::assertSame(ParameterType::STRING, $qb->getParameterType('name'));
 
         $qb->where('name = :name');
         $qb->setParameter('name', 'foo');
 
-        self::assertNull($qb->getParameterType('name'));
-
-        $qb->setParameter('name', 'foo', ParameterType::STRING);
-
         self::assertSame(ParameterType::STRING, $qb->getParameterType('name'));
+
+        $qb->setParameter('name', 'foo', ParameterType::INTEGER);
+
+        self::assertSame(ParameterType::INTEGER, $qb->getParameterType('name'));
     }
 
     public function testGetParameterTypes(): void
@@ -905,9 +905,9 @@ class QueryBuilderTest extends TestCase
         $qb->where('name = :name');
         $qb->setParameter('name', 'foo');
 
-        self::assertSame([], $qb->getParameterTypes());
-
-        $qb->setParameter('name', 'foo', ParameterType::STRING);
+        self::assertSame([
+            'name' => ParameterType::STRING,
+        ], $qb->getParameterTypes());
 
         $qb->where('is_active = :isActive');
         $qb->setParameter('isActive', true, ParameterType::BOOLEAN);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

Semantically, the NULL value of the parameter type is identical to `ParameterType::STRING` which is the default in most of the methods. Given that the parameter type is optional in all APIs, there's no point in supporting NULL. Dropping the support for NULL will make the PHP types representing prepared statement parameter types a bit simpler (see https://github.com/doctrine/dbal/pull/5548).