### PR TITLE
Remove deprecated QueryBuilder methods and constants

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -299,8 +299,12 @@ The following `QueryBuilder` methods have been removed:
 
 The following `QueryBuilder` constants have been removed:
 
-1. `STATE_DIRTY`,
-2. `STATE_CLEAN`.
+1. `SELECT`,
+2. `DELETE`,
+3. `UPDATE`,
+4. `INSERT`,
+5. `STATE_DIRTY`,
+6. `STATE_CLEAN`.
 
 ## BC BREAK: Removed the `Constraint` interface.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -289,13 +289,18 @@ DBAL is now tested only with SQL Server 2017 and newer.
 
 The `Statement::execute()` method has been marked private.
 
-## BC BREAK: Removed `QueryBuilder` methods.
+## BC BREAK: Removed `QueryBuilder` methods and contstants.
 
 The following `QueryBuilder` methods have been removed:
 
 1. `execute()`,
 2. `getState()`,
 3. `getType()`.
+
+The following `QueryBuilder` constants have been removed:
+
+1. `STATE_DIRTY`,
+2. `STATE_CLEAN`.
 
 ## BC BREAK: Removed the `Constraint` interface.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -289,9 +289,13 @@ DBAL is now tested only with SQL Server 2017 and newer.
 
 The `Statement::execute()` method has been marked private.
 
-## BC BREAK: Removed `QueryBuilder::execute()`.
+## BC BREAK: Removed `QueryBuilder` methods.
 
-The `QueryBuilder::execute()` method has been removed.
+The following `QueryBuilder` methods have been removed:
+
+1. `execute()`,
+2. `getState()`,
+3. `getType()`.
 
 ## BC BREAK: Removed the `Constraint` interface.
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -32,14 +32,6 @@
                 <file name="src/Driver/OCI8/ConvertPositionalToNamedPlaceholders.php"/>
             </errorLevel>
         </ConflictingReferenceConstraint>
-        <DeprecatedConstant>
-            <errorLevel type="suppress">
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <file name="src/Query/QueryBuilder.php"/>
-            </errorLevel>
-        </DeprecatedConstant>
         <DeprecatedMethod>
             <errorLevel type="suppress">
                 <!--

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -38,7 +38,6 @@
                     TODO: remove in 4.0.0
                 -->
                 <file name="src/Query/QueryBuilder.php"/>
-                <file name="tests/Query/QueryBuilderTest.php"/>
             </errorLevel>
         </DeprecatedConstant>
         <DeprecatedMethod>
@@ -48,11 +47,6 @@
                     See https://github.com/doctrine/dbal/pull/4317
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::getState"/>
-                <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::getType"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -58,16 +58,6 @@ class QueryBuilder
     final public const INSERT = 3;
 
     /**
-     * @deprecated
-     */
-    final public const STATE_DIRTY = 0;
-
-    /**
-     * @deprecated
-     */
-    final public const STATE_CLEAN = 1;
-
-    /**
      * The complete SQL string for this query.
      */
     private ?string $sql = null;
@@ -90,11 +80,6 @@ class QueryBuilder
      * The type of query this is. Can be select, update or delete.
      */
     private int $type = self::SELECT;
-
-    /**
-     * The state of the query object. Can be dirty or clean.
-     */
-    private int $state = self::STATE_CLEAN;
 
     /**
      * The index of the first result to retrieve.
@@ -358,7 +343,7 @@ class QueryBuilder
      */
     public function getSQL(): string
     {
-        if ($this->sql !== null && $this->state === self::STATE_CLEAN) {
+        if ($this->sql !== null) {
             return $this->sql;
         }
 
@@ -369,8 +354,7 @@ class QueryBuilder
             default => $this->getSQLForSelect(),
         };
 
-        $this->state = self::STATE_CLEAN;
-        $this->sql   = $sql;
+        $this->sql = $sql;
 
         return $sql;
     }
@@ -494,8 +478,9 @@ class QueryBuilder
      */
     public function setFirstResult(int $firstResult): self
     {
-        $this->state       = self::STATE_DIRTY;
         $this->firstResult = $firstResult;
+
+        $this->sql = null;
 
         return $this;
     }
@@ -519,8 +504,9 @@ class QueryBuilder
      */
     public function setMaxResults(?int $maxResults): self
     {
-        $this->state      = self::STATE_DIRTY;
         $this->maxResults = $maxResults;
+
+        $this->sql = null;
 
         return $this;
     }
@@ -561,7 +547,7 @@ class QueryBuilder
 
         $this->select = $expressions;
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -582,7 +568,7 @@ class QueryBuilder
     {
         $this->distinct = true;
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -609,7 +595,7 @@ class QueryBuilder
 
         $this->select = array_merge($this->select, [$expression], $expressions);
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -635,7 +621,7 @@ class QueryBuilder
 
         $this->table = $table;
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -661,7 +647,7 @@ class QueryBuilder
 
         $this->table = $table;
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -691,7 +677,7 @@ class QueryBuilder
 
         $this->table = $table;
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -715,7 +701,7 @@ class QueryBuilder
     {
         $this->from[] = new From($table, $alias);
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -763,7 +749,7 @@ class QueryBuilder
     {
         $this->join[$fromAlias][] = Join::inner($join, $alias, $condition);
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -789,7 +775,7 @@ class QueryBuilder
     {
         $this->join[$fromAlias][] = Join::left($join, $alias, $condition);
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -815,7 +801,7 @@ class QueryBuilder
     {
         $this->join[$fromAlias][] = Join::right($join, $alias, $condition);
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -839,7 +825,7 @@ class QueryBuilder
     {
         $this->set[] = $key . ' = ' . $value;
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -875,7 +861,7 @@ class QueryBuilder
     {
         $this->where = $this->createPredicate($predicate, ...$predicates);
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -908,7 +894,7 @@ class QueryBuilder
             ...$predicates
         );
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -936,7 +922,7 @@ class QueryBuilder
     {
         $this->where = $this->appendToPredicate($this->where, CompositeExpression::TYPE_OR, $predicate, ...$predicates);
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -961,7 +947,7 @@ class QueryBuilder
     {
         $this->groupBy = array_merge([$expression], $expressions);
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -986,7 +972,7 @@ class QueryBuilder
     {
         $this->groupBy = array_merge($this->groupBy, [$expression], $expressions);
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -1040,7 +1026,7 @@ class QueryBuilder
     {
         $this->values = $values;
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -1058,7 +1044,7 @@ class QueryBuilder
     {
         $this->having = $this->createPredicate($predicate, ...$predicates);
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -1081,7 +1067,7 @@ class QueryBuilder
             ...$predicates
         );
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -1104,7 +1090,7 @@ class QueryBuilder
             ...$predicates
         );
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -1163,7 +1149,7 @@ class QueryBuilder
 
         $this->orderBy = [$orderBy];
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }
@@ -1186,7 +1172,7 @@ class QueryBuilder
 
         $this->orderBy[] = $orderBy;
 
-        $this->state = self::STATE_DIRTY;
+        $this->sql = null;
 
         return $this;
     }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -209,46 +209,11 @@ class QueryBuilder
     }
 
     /**
-     * Gets the type of the currently built query.
-     *
-     * @deprecated If necessary, track the type of the query being built outside of the builder.
-     */
-    public function getType(): int
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5551',
-            'Relying on the type of the query being built is deprecated.'
-                . ' If necessary, track the type of the query being built outside of the builder.'
-        );
-
-        return $this->type;
-    }
-
-    /**
      * Gets the associated DBAL Connection for this query builder.
      */
     public function getConnection(): Connection
     {
         return $this->connection;
-    }
-
-    /**
-     * Gets the state of this query builder instance.
-     *
-     * @deprecated The builder state is an internal concern.
-     *
-     * @return int Either QueryBuilder::STATE_DIRTY or QueryBuilder::STATE_CLEAN.
-     */
-    public function getState(): int
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5551',
-            'Relying on the query builder state is deprecated as it is an internal concern.'
-        );
-
-        return $this->state;
     }
 
     /**

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -38,26 +38,6 @@ use function substr;
 class QueryBuilder
 {
     /**
-     * @deprecated
-     */
-    final public const SELECT = 0;
-
-    /**
-     * @deprecated
-     */
-    final public const DELETE = 1;
-
-    /**
-     * @deprecated
-     */
-    final public const UPDATE = 2;
-
-    /**
-     * @deprecated
-     */
-    final public const INSERT = 3;
-
-    /**
      * The complete SQL string for this query.
      */
     private ?string $sql = null;
@@ -79,7 +59,7 @@ class QueryBuilder
     /**
      * The type of query this is. Can be select, update or delete.
      */
-    private int $type = self::SELECT;
+    private QueryType $type = QueryType::SELECT;
 
     /**
      * The index of the first result to retrieve.
@@ -343,20 +323,12 @@ class QueryBuilder
      */
     public function getSQL(): string
     {
-        if ($this->sql !== null) {
-            return $this->sql;
-        }
-
-        $sql = match ($this->type) {
-            self::INSERT => $this->getSQLForInsert(),
-            self::DELETE => $this->getSQLForDelete(),
-            self::UPDATE => $this->getSQLForUpdate(),
-            default => $this->getSQLForSelect(),
+        return $this->sql ??= match ($this->type) {
+            QueryType::INSERT => $this->getSQLForInsert(),
+            QueryType::DELETE => $this->getSQLForDelete(),
+            QueryType::UPDATE => $this->getSQLForUpdate(),
+            QueryType::SELECT => $this->getSQLForSelect(),
         };
-
-        $this->sql = $sql;
-
-        return $sql;
     }
 
     /**
@@ -539,7 +511,7 @@ class QueryBuilder
      */
     public function select(string ...$expressions): self
     {
-        $this->type = self::SELECT;
+        $this->type = QueryType::SELECT;
 
         if (count($expressions) < 1) {
             return $this;
@@ -591,7 +563,7 @@ class QueryBuilder
      */
     public function addSelect(string $expression, string ...$expressions): self
     {
-        $this->type = self::SELECT;
+        $this->type = QueryType::SELECT;
 
         $this->select = array_merge($this->select, [$expression], $expressions);
 
@@ -617,7 +589,7 @@ class QueryBuilder
      */
     public function delete(string $table): self
     {
-        $this->type = self::DELETE;
+        $this->type = QueryType::DELETE;
 
         $this->table = $table;
 
@@ -643,7 +615,7 @@ class QueryBuilder
      */
     public function update(string $table): self
     {
-        $this->type = self::UPDATE;
+        $this->type = QueryType::UPDATE;
 
         $this->table = $table;
 
@@ -673,7 +645,7 @@ class QueryBuilder
      */
     public function insert(string $table): self
     {
-        $this->type = self::INSERT;
+        $this->type = QueryType::INSERT;
 
         $this->table = $table;
 

--- a/src/Query/QueryType.php
+++ b/src/Query/QueryType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Query;
+
+/**
+ * @internal
+ */
+enum QueryType
+{
+    case SELECT;
+    case DELETE;
+    case UPDATE;
+    case INSERT;
+}

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -351,7 +351,6 @@ class QueryBuilderTest extends TestCase
         $qb2 = $qb->select();
 
         self::assertSame($qb, $qb2);
-        self::assertEquals(QueryBuilder::SELECT, $qb->getType());
 
         $this->expectException(QueryException::class);
         $qb->getSQL();
@@ -387,7 +386,6 @@ class QueryBuilderTest extends TestCase
            ->set('foo', '?')
            ->set('bar', '?');
 
-        self::assertEquals(QueryBuilder::UPDATE, $qb->getType());
         self::assertEquals('UPDATE users SET foo = ?, bar = ?', (string) $qb);
     }
 
@@ -406,7 +404,6 @@ class QueryBuilderTest extends TestCase
         $qb = new QueryBuilder($this->conn);
         $qb->delete('users');
 
-        self::assertEquals(QueryBuilder::DELETE, $qb->getType());
         self::assertEquals('DELETE FROM users', (string) $qb);
     }
 
@@ -430,7 +427,6 @@ class QueryBuilderTest extends TestCase
                 ]
             );
 
-        self::assertEquals(QueryBuilder::INSERT, $qb->getType());
         self::assertEquals('INSERT INTO users (foo, bar) VALUES(?, ?)', (string) $qb);
     }
 
@@ -451,7 +447,6 @@ class QueryBuilderTest extends TestCase
                 ]
             );
 
-        self::assertEquals(QueryBuilder::INSERT, $qb->getType());
         self::assertEquals('INSERT INTO users (bar, foo) VALUES(?, ?)', (string) $qb);
     }
 
@@ -463,7 +458,6 @@ class QueryBuilderTest extends TestCase
             ->setValue('bar', '?')
             ->setValue('foo', '?');
 
-        self::assertEquals(QueryBuilder::INSERT, $qb->getType());
         self::assertEquals('INSERT INTO users (foo, bar) VALUES(?, ?)', (string) $qb);
     }
 
@@ -476,7 +470,6 @@ class QueryBuilderTest extends TestCase
             )
             ->setValue('bar', '?');
 
-        self::assertEquals(QueryBuilder::INSERT, $qb->getType());
         self::assertEquals('INSERT INTO users (foo, bar) VALUES(?, ?)', (string) $qb);
     }
 
@@ -484,22 +477,6 @@ class QueryBuilderTest extends TestCase
     {
         $qb = new QueryBuilder($this->conn);
         self::assertSame($this->conn, $qb->getConnection());
-    }
-
-    public function testGetState(): void
-    {
-        $qb = new QueryBuilder($this->conn);
-
-        self::assertEquals(QueryBuilder::STATE_CLEAN, $qb->getState());
-
-        $qb->select('u.*')->from('users', 'u');
-
-        self::assertEquals(QueryBuilder::STATE_DIRTY, $qb->getState());
-
-        $sql1 = $qb->getSQL();
-
-        self::assertEquals(QueryBuilder::STATE_CLEAN, $qb->getState());
-        self::assertEquals($sql1, $qb->getSQL());
     }
 
     /**
@@ -510,7 +487,6 @@ class QueryBuilderTest extends TestCase
         $qb = new QueryBuilder($this->conn);
         $qb->setMaxResults($maxResults);
 
-        self::assertEquals(QueryBuilder::STATE_DIRTY, $qb->getState());
         self::assertEquals($maxResults, $qb->getMaxResults());
     }
 
@@ -530,7 +506,6 @@ class QueryBuilderTest extends TestCase
         $qb = new QueryBuilder($this->conn);
         $qb->setFirstResult(10);
 
-        self::assertEquals(QueryBuilder::STATE_DIRTY, $qb->getState());
         self::assertEquals(10, $qb->getFirstResult());
     }
 


### PR DESCRIPTION
1. Simplify handling query builder state by getting rid of the `$state` property and the corresponding constants.
2. Represent query type as `@internal` enum.

The removed method and constants were deprecated in https://github.com/doctrine/dbal/pull/5551.