### PR TITLE
Deprecate passing parameters to Statement::execute*()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated passing `$params` to `Statement::execute*()` methods.
+
+Passing `$params` to the driver-level `Statement::execute()` and the wrapper-level `Statement::executeQuery()`
+and `Statement::executeStatement()` methods has been deprecated.
+
+Bind parameters using `Statement::bindParam()` or `Statement::bindValue()` instead.
+
 ## Deprecated `QueryBuilder` methods and constants.
 
 1. The `QueryBuilder::getState()` method has been deprecated as the builder state is an internal concern.

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1021,12 +1021,10 @@ class Connection
                 }
 
                 $stmt = $connection->prepare($sql);
-                if (count($types) > 0) {
-                    $this->_bindTypedValues($stmt, $params, $types);
-                    $result = $stmt->execute();
-                } else {
-                    $result = $stmt->execute($params);
-                }
+
+                $this->bindParameters($stmt, $params, $types);
+
+                $result = $stmt->execute();
             } else {
                 $result = $connection->query($sql);
             }
@@ -1128,15 +1126,10 @@ class Connection
 
                 $stmt = $connection->prepare($sql);
 
-                if (count($types) > 0) {
-                    $this->_bindTypedValues($stmt, $params, $types);
+                $this->bindParameters($stmt, $params, $types);
 
-                    $result = $stmt->execute();
-                } else {
-                    $result = $stmt->execute($params);
-                }
-
-                return $result->rowCount();
+                return $stmt->execute()
+                    ->rowCount();
             }
 
             return $connection->exec($sql);
@@ -1668,7 +1661,7 @@ class Connection
      *
      * @throws Exception
      */
-    private function _bindTypedValues(DriverStatement $stmt, array $params, array $types): void
+    private function bindParameters(DriverStatement $stmt, array $params, array $types): void
     {
         // Check whether parameters are positional or named. Mixing is not allowed.
         if (is_int(key($params))) {

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\IBMDB2\Exception\StatementError;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 use function db2_bind_param;
@@ -107,6 +108,15 @@ final class Statement implements StatementInterface
      */
     public function execute($params = null): ResultInterface
     {
+        if ($params !== null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5556',
+                'Passing $params to Statement::execute() is deprecated. Bind parameters using'
+                    . ' Statement::bindParam() or Statement::bindValue() instead.'
+            );
+        }
+
         $handles = $this->bindLobs();
 
         $result = @db2_execute($this->stmt, $params ?? $this->parameters);

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Driver\Mysqli\Exception\StatementError;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use mysqli_sql_exception;
 use mysqli_stmt;
 
@@ -102,6 +103,15 @@ final class Statement implements StatementInterface
      */
     public function execute($params = null): ResultInterface
     {
+        if ($params !== null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5556',
+                'Passing $params to Statement::execute() is deprecated. Bind parameters using'
+                    . ' Statement::bindParam() or Statement::bindValue() instead.'
+            );
+        }
+
         if ($params !== null && count($params) > 0) {
             if (! $this->bindUntypedValues($params)) {
                 throw StatementError::new($this->stmt);

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\OCI8\Exception\UnknownParameterIndex;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 
 use function is_int;
 use function oci_bind_by_name;
@@ -113,6 +114,13 @@ final class Statement implements StatementInterface
     public function execute($params = null): ResultInterface
     {
         if ($params !== null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5556',
+                'Passing $params to Statement::execute() is deprecated. Bind parameters using'
+                    . ' Statement::bindParam() or Statement::bindValue() instead.'
+            );
+
             foreach ($params as $key => $val) {
                 if (is_int($key)) {
                     $this->bindValue($key + 1, $val);

--- a/src/Driver/PDO/SQLSrv/Connection.php
+++ b/src/Driver/PDO/SQLSrv/Connection.php
@@ -41,8 +41,12 @@ final class Connection extends AbstractConnectionMiddleware
             'The usage of Connection::lastInsertId() with a sequence name is deprecated.'
         );
 
-        return $this->prepare('SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?')
-            ->execute([$name])
+        $statement = $this->prepare(
+            'SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?'
+        );
+        $statement->bindValue(1, $name);
+
+        return $statement->execute()
             ->fetchOne();
     }
 

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -96,6 +96,15 @@ final class Statement implements StatementInterface
      */
     public function execute($params = null): ResultInterface
     {
+        if ($params !== null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5556',
+                'Passing $params to Statement::execute() is deprecated. Bind parameters using'
+                    . ' Statement::bindParam() or Statement::bindValue() instead.'
+            );
+        }
+
         try {
             $this->stmt->execute($params);
         } catch (PDOException $exception) {

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 use function is_int;
@@ -114,6 +115,13 @@ final class Statement implements StatementInterface
     public function execute($params = null): ResultInterface
     {
         if ($params !== null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5556',
+                'Passing $params to Statement::execute() is deprecated. Bind parameters using'
+                    . ' Statement::bindParam() or Statement::bindValue() instead.'
+            );
+
             foreach ($params as $key => $val) {
                 if (is_int($key)) {
                     $this->bindValue($key + 1, $val);

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -198,6 +198,15 @@ class Statement
      */
     public function executeQuery(array $params = []): Result
     {
+        if (func_num_args() > 0) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5556',
+                'Passing $params to Statement::executeQuery() is deprecated. Bind parameters using'
+                    . ' Statement::bindParam() or Statement::bindValue() instead.'
+            );
+        }
+
         if ($params === []) {
             $params = null; // Workaround as long execute() exists and used internally.
         }
@@ -214,6 +223,15 @@ class Statement
      */
     public function executeStatement(array $params = []): int
     {
+        if (func_num_args() > 0) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5556',
+                'Passing $params to Statement::executeStatement() is deprecated. Bind parameters using'
+                    . ' Statement::bindParam() or Statement::bindValue() instead.'
+            );
+        }
+
         if ($params === []) {
             $params = null; // Workaround as long execute() exists and used internally.
         }

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -22,6 +22,8 @@ use function sys_get_temp_dir;
 use function touch;
 use function unlink;
 
+use const E_ALL;
+use const E_WARNING;
 use const PHP_OS_FAMILY;
 
 /**
@@ -201,6 +203,9 @@ class ExceptionTest extends FunctionalTestCase
         $table = new Table('bad_columnname_table');
         $table->addColumn('id', 'integer', []);
         $this->dropAndCreateTable($table);
+
+        // prevent the PHPUnit error handler from handling the warning that db2_bind_param() may trigger
+        $this->iniSet('error_reporting', (string) (E_ALL & ~E_WARNING));
 
         $this->expectException(Exception\InvalidFieldNameException::class);
         $this->connection->insert('bad_columnname_table', ['name' => 5]);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

Being able to bind parameters to the statements via `execute($params)` is a PDO legacy and has the following downsides:

1. Unlike the `Statement::bindParam()` and `::bindValue()` methods which accept 1-based numeric parameter positions, `execute($params)` expects 0-based indexes for positional parameters. This results in the inconsistency in logging statement parameters as reported in https://github.com/doctrine/dbal/issues/5525.
2. No way to tell statically whether the `$params` in a given call to `Statement::execute()` should have integer or string keys since it depends on how parameters were declared in the SQL used to prepare the statement.
3. The behavior of passing `$params` to `execute()` of a statement that already has parameters bound via `bindParam()` or `bindValue()` is undefined. Do parameters get merged or the previously bound parameters get ignored?
4. The side effect of passing `$params` to `execute()` is undefined. Do the corresponding values remain bound to the statement or they are used only for this call? For reference, they remain bound to the wrapper statement but the driver-level behavior is undefined and is defined by the DBAL-level or the underlying driver.
5. Not all underlying drivers support this API, so the DBAL has to emulate it by calling "bind" internally (e.g. for oci8).

The even bigger problem is that the wrapper level uses the same API for binding positional and named parameters that results in ugly and incorrect types like `list<...>|array<string,...>`. Whether the statement parameters are positional or named is decided at runtime. Deprecating this feature is the first step toward introducing separate APIs for positional and named parameters.

**Affected API consumers**:

1. The ORM will not be affected since it minds the parameter types and uses `Statement::bindValue()` for binding parameters to the statement.
2. The users of the DBAL will be barely affected since the wrapper-level API will still allow using the "shortcut" methods like `executeQuery($sql, $params, $types)`.