### PR TITLE
Deprecate not passing parameter type to bindParam() and bindValue()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated not passing parameter type to the driver-level `Statement::bind*()` methods.
+
+Not passing `$type` to the driver-level `Statement::bindParam()` and `::bindValue()` is deprecated.
+Pass the type corresponding to the parameter being bound.
+
 ## Deprecated passing `$params` to `Statement::execute*()` methods.
 
 Passing `$params` to the driver-level `Statement::execute()` and the wrapper-level `Statement::executeQuery()`

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1671,7 +1671,6 @@ class Connection
                 if (isset($types[$key])) {
                     $type                  = $types[$key];
                     [$value, $bindingType] = $this->getBindingInfo($value, $type);
-                    $stmt->bindValue($bindIndex, $value, $bindingType);
                 } else {
                     if (array_key_exists($key, $types)) {
                         Deprecation::trigger(
@@ -1682,8 +1681,10 @@ class Connection
                         );
                     }
 
-                    $stmt->bindValue($bindIndex, $value);
+                    $bindingType = ParameterType::STRING;
                 }
+
+                $stmt->bindValue($bindIndex, $value, $bindingType);
 
                 ++$bindIndex;
             }
@@ -1693,7 +1694,6 @@ class Connection
                 if (isset($types[$name])) {
                     $type                  = $types[$name];
                     [$value, $bindingType] = $this->getBindingInfo($value, $type);
-                    $stmt->bindValue($name, $value, $bindingType);
                 } else {
                     if (array_key_exists($name, $types)) {
                         Deprecation::trigger(
@@ -1704,8 +1704,10 @@ class Connection
                         );
                     }
 
-                    $stmt->bindValue($name, $value);
+                    $bindingType = ParameterType::STRING;
                 }
+
+                $stmt->bindValue($name, $value, $bindingType);
             }
         }
     }

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -16,6 +16,7 @@ use function db2_bind_param;
 use function db2_execute;
 use function error_get_last;
 use function fclose;
+use function func_num_args;
 use function is_int;
 use function is_resource;
 use function stream_copy_to_stream;
@@ -61,6 +62,15 @@ final class Statement implements StatementInterface
     {
         assert(is_int($param));
 
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindValue() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         return $this->bindParam($param, $value, $type);
     }
 
@@ -70,6 +80,15 @@ final class Statement implements StatementInterface
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
         assert(is_int($param));
+
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindParam() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
 
         switch ($type) {
             case ParameterType::INTEGER:

--- a/src/Driver/Middleware/AbstractStatementMiddleware.php
+++ b/src/Driver/Middleware/AbstractStatementMiddleware.php
@@ -5,6 +5,9 @@ namespace Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
+
+use function func_num_args;
 
 abstract class AbstractStatementMiddleware implements Statement
 {
@@ -20,6 +23,15 @@ abstract class AbstractStatementMiddleware implements Statement
      */
     public function bindValue($param, $value, $type = ParameterType::STRING)
     {
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindValue() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         return $this->wrappedStatement->bindValue($param, $value, $type);
     }
 
@@ -28,6 +40,15 @@ abstract class AbstractStatementMiddleware implements Statement
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
     {
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindParam() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         return $this->wrappedStatement->bindParam($param, $variable, $type, $length);
     }
 

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -19,6 +19,7 @@ use function assert;
 use function count;
 use function feof;
 use function fread;
+use function func_num_args;
 use function get_resource_type;
 use function is_int;
 use function is_resource;
@@ -70,6 +71,15 @@ final class Statement implements StatementInterface
     {
         assert(is_int($param));
 
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindParam() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         if (! isset(self::$paramTypeMap[$type])) {
             throw UnknownParameterType::new($type);
         }
@@ -86,6 +96,15 @@ final class Statement implements StatementInterface
     public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
         assert(is_int($param));
+
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindValue() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
 
         if (! isset(self::$paramTypeMap[$type])) {
             throw UnknownParameterType::new($type);

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
 
+use function func_num_args;
 use function is_int;
 use function oci_bind_by_name;
 use function oci_execute;
@@ -55,6 +56,15 @@ final class Statement implements StatementInterface
      */
     public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindValue() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         return $this->bindParam($param, $value, $type);
     }
 
@@ -63,6 +73,15 @@ final class Statement implements StatementInterface
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindParam() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         if (is_int($param)) {
             if (! isset($this->parameterMap[$param])) {
                 throw UnknownParameterIndex::new($param);
@@ -123,9 +142,9 @@ final class Statement implements StatementInterface
 
             foreach ($params as $key => $val) {
                 if (is_int($key)) {
-                    $this->bindValue($key + 1, $val);
+                    $this->bindValue($key + 1, $val, ParameterType::STRING);
                 } else {
-                    $this->bindValue($key, $val);
+                    $this->bindValue($key, $val, ParameterType::STRING);
                 }
             }
         }

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -40,6 +40,15 @@ final class Statement extends AbstractStatementMiddleware
         $length = null,
         $driverOptions = null
     ): bool {
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindParam() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         if (func_num_args() > 4) {
             Deprecation::triggerIfCalledFromOutside(
                 'doctrine/dbal',
@@ -70,6 +79,15 @@ final class Statement extends AbstractStatementMiddleware
      */
     public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindValue() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         return $this->bindParam($param, $value, $type);
     }
 }

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -43,6 +43,15 @@ final class Statement implements StatementInterface
      */
     public function bindValue($param, $value, $type = ParameterType::STRING)
     {
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindValue() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         $type = $this->convertParamType($type);
 
         try {
@@ -68,6 +77,15 @@ final class Statement implements StatementInterface
         $length = null,
         $driverOptions = null
     ): bool {
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindParam() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         if (func_num_args() > 4) {
             Deprecation::triggerIfCalledFromOutside(
                 'doctrine/dbal',

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
 
 use function assert;
+use function func_num_args;
 use function is_int;
 use function sqlsrv_execute;
 use function SQLSRV_PHPTYPE_STREAM;
@@ -87,6 +88,15 @@ final class Statement implements StatementInterface
     {
         assert(is_int($param));
 
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindValue() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         $this->variables[$param] = $value;
         $this->types[$param]     = $type;
 
@@ -99,6 +109,15 @@ final class Statement implements StatementInterface
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
         assert(is_int($param));
+
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindParam() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
 
         $this->variables[$param] =& $variable;
         $this->types[$param]     = $type;
@@ -124,9 +143,9 @@ final class Statement implements StatementInterface
 
             foreach ($params as $key => $val) {
                 if (is_int($key)) {
-                    $this->bindValue($key + 1, $val);
+                    $this->bindValue($key + 1, $val, ParameterType::STRING);
                 } else {
-                    $this->bindValue($key, $val);
+                    $this->bindValue($key, $val, ParameterType::STRING);
                 }
             }
         }

--- a/src/Logging/Statement.php
+++ b/src/Logging/Statement.php
@@ -8,10 +8,12 @@ use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
 use Psr\Log\LoggerInterface;
 
 use function array_slice;
 use function func_get_args;
+use function func_num_args;
 
 final class Statement extends AbstractStatementMiddleware
 {
@@ -40,6 +42,15 @@ final class Statement extends AbstractStatementMiddleware
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
     {
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindParam() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         $this->params[$param] = &$variable;
         $this->types[$param]  = $type;
 
@@ -51,6 +62,15 @@ final class Statement extends AbstractStatementMiddleware
      */
     public function bindValue($param, $value, $type = ParameterType::STRING)
     {
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindValue() is deprecated.'
+                    . ' Pass the type corresponding to the parameter being bound.'
+            );
+        }
+
         $this->params[$param] = $value;
         $this->types[$param]  = $type;
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The default for the parameter type primarily exists to save keystrokes for end users and works because in most cases binding an integer as a sting is okay for the underlying database platform and/or driver. It is fine to have such defaults in the wrapper-level "shortcut" methods like `executeQuery($sql, $params)` but they shouldn't be spread across different APIs at multiple architecture levels.

The ability to omit parameter binding type at the driver level is a PDO legacy which is a user-facing API as such but is a driver in the context of the DBAL.

Similar to https://github.com/doctrine/dbal/pull/5556, this should have a minimal impact on the ORM and immediate users of the DBAL.