### PR TITLE
Remove the APIs deprecated in DBAL 3.x

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: made parameter type in driver-level `Statement::bind*()` methods required.
+
+The `$type` parameter of the driver-level `Statement::bindParam()` and `::bindValue()` has been made required.
+
 ## BC BREAK: removed support for using NULL as prepared statement parameter type.
 
 The value of parameter type used in the wrapper layer (e.g. in `Connection::executeQuery()`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: removed support for using NULL as prepared statement parameter type.
+
+The value of parameter type used in the wrapper layer (e.g. in `Connection::executeQuery()`
+or `Statement::bindValue()`) can no longer be `NULL`.
+
 ## BC BREAK: converted enum-like classes to enums
 
 The following classes have been converted to enums:

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -124,9 +124,4 @@
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName">
         <exclude-pattern>src/ParameterType.php</exclude-pattern>
     </rule>
-
-    <!-- The union types representing prepared statement parameter types are too complex -->
-    <rule ref="Generic.Files.LineLength.TooLong">
-        <exclude-pattern>src/Cache/QueryCacheProfile.php</exclude-pattern>
-    </rule>
 </ruleset>

--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -52,9 +52,9 @@ class QueryCacheProfile
     /**
      * Generates the real cache key from query, params, types and connection parameters.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
-     * @param array<string, mixed>                                                                             $connectionParams
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
+     * @param array<string, mixed>                                                                   $connectionParams
      *
      * @return string[]
      */

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -361,8 +361,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the first row of the result
      * as an associative array.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return array<string, mixed>|false False is returned if no rows are found.
      *
@@ -377,8 +377,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the first row of the result
      * as a numerically indexed array.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return list<mixed>|false False is returned if no rows are found.
      *
@@ -393,8 +393,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the value of a single column
      * of the first row of the result.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return mixed|false False is returned if no rows are found.
      *
@@ -456,8 +456,8 @@ class Connection implements ServerVersionProvider
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param array<string, mixed>                                                                             $criteria
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param array<string, mixed>                                                                   $criteria
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return int|string The number of affected rows.
      *
@@ -520,9 +520,9 @@ class Connection implements ServerVersionProvider
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param array<string, mixed>                                                                             $data
-     * @param array<string, mixed>                                                                             $criteria
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param array<string, mixed>                                                                   $data
+     * @param array<string, mixed>                                                                   $criteria
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return int|string The number of affected rows.
      *
@@ -555,8 +555,8 @@ class Connection implements ServerVersionProvider
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param array<string, mixed>                                                                             $data
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param array<string, mixed>                                                                   $data
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return int|string The number of affected rows.
      *
@@ -589,10 +589,10 @@ class Connection implements ServerVersionProvider
     /**
      * Extract ordered type list from an ordered column list and type map.
      *
-     * @param array<int, string>                                                                               $columns
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param array<int, string>                                                                     $columns
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
-     * @return array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null>
+     * @return array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type>
      */
     private function extractTypeValues(array $columns, array $types): array
     {
@@ -636,8 +636,8 @@ class Connection implements ServerVersionProvider
     /**
      * Prepares and executes an SQL query and returns the result as an array of numeric arrays.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return list<list<mixed>>
      *
@@ -651,8 +651,8 @@ class Connection implements ServerVersionProvider
     /**
      * Prepares and executes an SQL query and returns the result as an array of associative arrays.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return list<array<string,mixed>>
      *
@@ -667,8 +667,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the result as an associative array with the keys
      * mapped to the first column and the values mapped to the second column.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return array<mixed,mixed>
      *
@@ -684,8 +684,8 @@ class Connection implements ServerVersionProvider
      * to the first column and the values being an associative array representing the rest of the columns
      * and their values.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return array<mixed,array<string,mixed>>
      *
@@ -699,8 +699,8 @@ class Connection implements ServerVersionProvider
     /**
      * Prepares and executes an SQL query and returns the result as an array of the first column values.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return list<mixed>
      *
@@ -714,8 +714,8 @@ class Connection implements ServerVersionProvider
     /**
      * Prepares and executes an SQL query and returns the result as an iterator over rows represented as numeric arrays.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return Traversable<int,list<mixed>>
      *
@@ -730,8 +730,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the result as an iterator over rows represented
      * as associative arrays.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return Traversable<int,array<string,mixed>>
      *
@@ -746,8 +746,8 @@ class Connection implements ServerVersionProvider
      * Prepares and executes an SQL query and returns the result as an iterator with the keys
      * mapped to the first column and the values mapped to the second column.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return Traversable<mixed,mixed>
      *
@@ -779,8 +779,8 @@ class Connection implements ServerVersionProvider
     /**
      * Prepares and executes an SQL query and returns the result as an iterator over the first column values.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return Traversable<int,mixed>
      *
@@ -816,8 +816,8 @@ class Connection implements ServerVersionProvider
      *
      * If the query is parametrized, a prepared statement is used.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @throws Exception
      */
@@ -855,8 +855,8 @@ class Connection implements ServerVersionProvider
     /**
      * Executes a caching query.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @throws CacheException
      * @throws Exception
@@ -913,8 +913,8 @@ class Connection implements ServerVersionProvider
      *
      * This method supports PDO binding types as well as DBAL mapping types.
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @throws Exception
      */
@@ -1302,8 +1302,8 @@ class Connection implements ServerVersionProvider
      * Binds a set of parameters, some or all of which are typed with a PDO binding type
      * or DBAL mapping type, to a given statement.
      *
-     * @param list<mixed>|array<string, mixed>                                                         $params
-     * @param array<int, string|ParameterType|Type|null>|array<string, string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                               $params
+     * @param array<int, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
      *
      * @throws Exception
      */
@@ -1314,19 +1314,10 @@ class Connection implements ServerVersionProvider
             $bindIndex = 1;
 
             foreach ($params as $key => $value) {
-                if (isset($types[$key])) {
+                if (array_key_exists($key, $types)) {
                     $type                  = $types[$key];
                     [$value, $bindingType] = $this->getBindingInfo($value, $type);
                 } else {
-                    if (array_key_exists($key, $types)) {
-                        Deprecation::trigger(
-                            'doctrine/dbal',
-                            'https://github.com/doctrine/dbal/pull/5550',
-                            'Using NULL as prepared statement parameter type is deprecated.'
-                                . 'Omit or use Parameter::STRING instead'
-                        );
-                    }
-
                     $bindingType = ParameterType::STRING;
                 }
 
@@ -1337,19 +1328,10 @@ class Connection implements ServerVersionProvider
         } else {
             // Named parameters
             foreach ($params as $name => $value) {
-                if (isset($types[$name])) {
+                if (array_key_exists($name, $types)) {
                     $type                  = $types[$name];
                     [$value, $bindingType] = $this->getBindingInfo($value, $type);
                 } else {
-                    if (array_key_exists($name, $types)) {
-                        Deprecation::trigger(
-                            'doctrine/dbal',
-                            'https://github.com/doctrine/dbal/pull/5550',
-                            'Using NULL as prepared statement parameter type is deprecated.'
-                                . 'Omit or use Parameter::STRING instead'
-                        );
-                    }
-
                     $bindingType = ParameterType::STRING;
                 }
 
@@ -1361,14 +1343,14 @@ class Connection implements ServerVersionProvider
     /**
      * Gets the binding type of a given type.
      *
-     * @param mixed                          $value The value to bind.
-     * @param string|ParameterType|Type|null $type  The type to bind.
+     * @param mixed                     $value The value to bind.
+     * @param string|ParameterType|Type $type  The type to bind.
      *
      * @return array{mixed, ParameterType} [0] => the (escaped) value, [1] => the binding type.
      *
      * @throws Exception
      */
-    private function getBindingInfo(mixed $value, string|ParameterType|Type|null $type): array
+    private function getBindingInfo(mixed $value, string|ParameterType|Type $type): array
     {
         if (is_string($type)) {
             $type = Type::getType($type);
@@ -1378,7 +1360,7 @@ class Connection implements ServerVersionProvider
             $value       = $type->convertToDatabaseValue($value, $this->getDatabasePlatform());
             $bindingType = $type->getBindingType();
         } else {
-            $bindingType = $type ?? ParameterType::STRING;
+            $bindingType = $type;
         }
 
         return [$value, $bindingType];
@@ -1395,8 +1377,8 @@ class Connection implements ServerVersionProvider
     /**
      * @internal
      *
-     * @param list<mixed>|array<string,mixed>                                                                  $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string,mixed>                                                        $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      */
     final public function convertExceptionDuringQuery(
         Driver\Exception $e,
@@ -1416,13 +1398,13 @@ class Connection implements ServerVersionProvider
     }
 
     /**
-     * @param array<int, mixed>|array<string, mixed>                                                           $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param array<int, mixed>|array<string, mixed>                                                 $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return array{
      *     string,
      *     array<int, mixed>|array<string, mixed>,
-     *     array<int, string|ParameterType|Type|null>|array<string, string|ParameterType|Type|null>
+     *     array<int, string|ParameterType|Type>|array<string, string|ParameterType|Type>
      * }
      */
     private function expandArrayParameters(string $sql, array $params, array $types): array
@@ -1478,8 +1460,8 @@ class Connection implements ServerVersionProvider
      *
      * @deprecated This API is deprecated and will be removed after 2022
      *
-     * @param array<int, mixed>|array<string, mixed>                                                           $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param array<int, mixed>|array<string, mixed>                                                 $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @throws Exception
      */

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -17,7 +17,6 @@ use function db2_bind_param;
 use function db2_execute;
 use function error_get_last;
 use function fclose;
-use function func_num_args;
 use function is_int;
 use function is_resource;
 use function stream_copy_to_stream;
@@ -52,38 +51,16 @@ final class Statement implements StatementInterface
     {
     }
 
-    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type): void
     {
         assert(is_int($param));
-
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindValue() is deprecated.'
-                    . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
 
         $this->bindParam($param, $value, $type);
     }
 
-    public function bindParam(
-        int|string $param,
-        mixed &$variable,
-        ParameterType $type = ParameterType::STRING,
-        ?int $length = null
-    ): void {
+    public function bindParam(int|string $param, mixed &$variable, ParameterType $type, ?int $length = null): void
+    {
         assert(is_int($param));
-
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindParam() is deprecated.'
-                    . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
 
         switch ($type) {
             case ParameterType::INTEGER:

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Driver\IBMDB2\Exception\CannotCreateTemporaryFile;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\StatementError;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 use function db2_bind_param;
@@ -89,20 +88,11 @@ final class Statement implements StatementInterface
         }
     }
 
-    public function execute(?array $params = null): Result
+    public function execute(): Result
     {
-        if ($params !== null) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5556',
-                'Passing $params to Statement::execute() is deprecated. Bind parameters using'
-                    . ' Statement::bindParam() or Statement::bindValue() instead.'
-            );
-        }
-
         $handles = $this->bindLobs();
 
-        $result = @db2_execute($this->stmt, $params ?? $this->parameters);
+        $result = @db2_execute($this->stmt, $this->parameters);
 
         foreach ($handles as $handle) {
             fclose($handle);

--- a/src/Driver/Middleware/AbstractStatementMiddleware.php
+++ b/src/Driver/Middleware/AbstractStatementMiddleware.php
@@ -7,9 +7,6 @@ namespace Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
-
-use function func_num_args;
 
 abstract class AbstractStatementMiddleware implements Statement
 {
@@ -17,35 +14,17 @@ abstract class AbstractStatementMiddleware implements Statement
     {
     }
 
-    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type): void
     {
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindValue() is deprecated.'
-                    . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
-
         $this->wrappedStatement->bindValue($param, $value, $type);
     }
 
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        ParameterType $type = ParameterType::STRING,
+        ParameterType $type,
         ?int $length = null
     ): void {
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindParam() is deprecated.'
-                . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
-
         $this->wrappedStatement->bindParam($param, $variable, $type, $length);
     }
 

--- a/src/Driver/Middleware/AbstractStatementMiddleware.php
+++ b/src/Driver/Middleware/AbstractStatementMiddleware.php
@@ -28,8 +28,8 @@ abstract class AbstractStatementMiddleware implements Statement
         $this->wrappedStatement->bindParam($param, $variable, $type, $length);
     }
 
-    public function execute(?array $params = null): Result
+    public function execute(): Result
     {
-        return $this->wrappedStatement->execute($params);
+        return $this->wrappedStatement->execute();
     }
 }

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -19,7 +19,6 @@ use function assert;
 use function count;
 use function feof;
 use function fread;
-use function func_num_args;
 use function get_resource_type;
 use function is_int;
 use function is_resource;
@@ -56,36 +55,18 @@ final class Statement implements StatementInterface
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        ParameterType $type = ParameterType::STRING,
+        ParameterType $type,
         ?int $length = null
     ): void {
         assert(is_int($param));
-
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindParam() is deprecated.'
-                . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
 
         $this->types[$param - 1]   = $this->convertParameterType($type);
         $this->boundValues[$param] =& $variable;
     }
 
-    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type): void
     {
         assert(is_int($param));
-
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindValue() is deprecated.'
-                . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
 
         $this->types[$param - 1]   = $this->convertParameterType($type);
         $this->values[$param]      = $value;

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
 
-use function func_num_args;
 use function is_int;
 use function oci_bind_by_name;
 use function oci_execute;
@@ -41,35 +40,17 @@ final class Statement implements StatementInterface
     ) {
     }
 
-    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type): void
     {
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindValue() is deprecated.'
-                . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
-
         $this->bindParam($param, $value, $type);
     }
 
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        ParameterType $type = ParameterType::STRING,
+        ParameterType $type,
         ?int $length = null
     ): void {
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindParam() is deprecated.'
-                    . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
-
         if (is_int($param)) {
             if (! isset($this->parameterMap[$param])) {
                 throw UnknownParameterIndex::new($param);

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Driver\OCI8\Exception\Error;
 use Doctrine\DBAL\Driver\OCI8\Exception\UnknownParameterIndex;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 
 use function is_int;
 use function oci_bind_by_name;
@@ -95,27 +94,8 @@ final class Statement implements StatementInterface
         };
     }
 
-    public function execute(?array $params = null): Result
+    public function execute(): Result
     {
-        if ($params !== null) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5556',
-                'Passing $params to Statement::execute() is deprecated. Bind parameters using'
-                    . ' Statement::bindParam() or Statement::bindValue() instead.'
-            );
-
-            foreach ($params as $key => $val) {
-                if (is_int($key)) {
-                    $param = $key + 1;
-                } else {
-                    $param = $key;
-                }
-
-                $this->bindValue($param, $val, ParameterType::STRING);
-            }
-        }
-
         if ($this->executionMode->isAutoCommitEnabled()) {
             $mode = OCI_COMMIT_ON_SUCCESS;
         } else {

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -7,10 +7,7 @@ namespace Doctrine\DBAL\Driver\PDO\SQLSrv;
 use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
 use Doctrine\DBAL\Driver\PDO\Statement as PDOStatement;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 use PDO;
-
-use function func_num_args;
 
 final class Statement extends AbstractStatementMiddleware
 {
@@ -29,18 +26,9 @@ final class Statement extends AbstractStatementMiddleware
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        ParameterType $type = ParameterType::STRING,
+        ParameterType $type,
         ?int $length = null
     ): void {
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindParam() is deprecated.'
-                . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
-
         switch ($type) {
             case ParameterType::LARGE_OBJECT:
             case ParameterType::BINARY:
@@ -68,17 +56,8 @@ final class Statement extends AbstractStatementMiddleware
         }
     }
 
-    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type): void
     {
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindValue() is deprecated.'
-                . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
-
         $this->bindParam($param, $value, $type);
     }
 }

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -12,8 +12,6 @@ use PDO;
 use PDOException;
 use PDOStatement;
 
-use function func_num_args;
-
 final class Statement implements StatementInterface
 {
     /**
@@ -23,17 +21,8 @@ final class Statement implements StatementInterface
     {
     }
 
-    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type): void
     {
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindValue() is deprecated.'
-                    . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
-
         $type = $this->convertParamType($type);
 
         try {
@@ -46,18 +35,9 @@ final class Statement implements StatementInterface
     public function bindParam(
         string|int $param,
         mixed &$variable,
-        ParameterType $type = ParameterType::STRING,
+        ParameterType $type,
         ?int $length = null
     ): void {
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindParam() is deprecated.'
-                . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
-
         try {
             if ($length === null) {
                 $this->stmt->bindParam($param, $variable, $this->convertParamType($type));

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\Driver\Exception as ExceptionInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -68,19 +67,10 @@ final class Statement implements StatementInterface
         }
     }
 
-    public function execute(?array $params = null): Result
+    public function execute(): Result
     {
-        if ($params !== null) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5556',
-                'Passing $params to Statement::execute() is deprecated. Bind parameters using'
-                    . ' Statement::bindParam() or Statement::bindValue() instead.'
-            );
-        }
-
         try {
-            $this->stmt->execute($params);
+            $this->stmt->execute();
         } catch (PDOException $exception) {
             throw Exception::new($exception);
         }

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 use function is_int;
@@ -90,25 +89,8 @@ final class Statement implements StatementInterface
         $this->stmt = null;
     }
 
-    public function execute(?array $params = null): Result
+    public function execute(): Result
     {
-        if ($params !== null) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5556',
-                'Passing $params to Statement::execute() is deprecated. Bind parameters using'
-                    . ' Statement::bindParam() or Statement::bindValue() instead.'
-            );
-
-            foreach ($params as $key => $val) {
-                if (is_int($key)) {
-                    $this->bindValue($key + 1, $val, ParameterType::STRING);
-                } else {
-                    $this->bindValue($key, $val, ParameterType::STRING);
-                }
-            }
-        }
-
         $this->stmt ??= $this->prepare();
 
         if (! sqlsrv_execute($this->stmt)) {

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
 
 use function assert;
-use function func_num_args;
 use function is_int;
 use function sqlsrv_execute;
 use function SQLSRV_PHPTYPE_STREAM;
@@ -68,18 +67,9 @@ final class Statement implements StatementInterface
         $this->sql .= self::LAST_INSERT_ID_SQL;
     }
 
-    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type): void
     {
         assert(is_int($param));
-
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindValue() is deprecated.'
-                    . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
 
         $this->variables[$param] = $value;
         $this->types[$param]     = $type;
@@ -88,19 +78,10 @@ final class Statement implements StatementInterface
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        ParameterType $type = ParameterType::STRING,
+        ParameterType $type,
         ?int $length = null
     ): void {
         assert(is_int($param));
-
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindParam() is deprecated.'
-                    . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
 
         $this->variables[$param] =& $variable;
         $this->types[$param]     = $type;

--- a/src/Driver/Statement.php
+++ b/src/Driver/Statement.php
@@ -28,7 +28,7 @@ interface Statement
      *
      * @throws Exception
      */
-    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void;
+    public function bindValue(int|string $param, mixed $value, ParameterType $type): void;
 
     /**
      * Binds a PHP variable to a corresponding named (not supported by mysqli driver, see comment below) or question
@@ -49,7 +49,7 @@ interface Statement
      *                                question mark placeholders, this will be the 1-indexed position of the parameter.
      * @param mixed         $variable The variable to bind to the parameter.
      * @param ParameterType $type     Explicit data type for the parameter using the {@see ParameterType}
-     *                             constants.
+     *                                constants.
      * @param int|null      $length   You must specify maxlength when using an OUT bind
      *                                so that PHP allocates enough memory to hold the returned value.
      *
@@ -58,7 +58,7 @@ interface Statement
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        ParameterType $type = ParameterType::STRING,
+        ParameterType $type,
         ?int $length = null
     ): void;
 

--- a/src/Driver/Statement.php
+++ b/src/Driver/Statement.php
@@ -65,16 +65,7 @@ interface Statement
     /**
      * Executes a prepared statement
      *
-     * If the prepared statement included parameter markers, you must either:
-     * call {@see bindParam()} to bind PHP variables to the parameter markers:
-     * bound variables pass their value as input and receive the output value,
-     * if any, of their associated parameter markers or pass an array of input-only
-     * parameter values.
-     *
-     * @param mixed[]|null $params A numeric array of values with as many elements as there are
-     *                             bound parameters in the SQL statement being executed.
-     *
      * @throws Exception
      */
-    public function execute(?array $params = null): Result;
+    public function execute(): Result;
 }

--- a/src/ExpandArrayParameters.php
+++ b/src/ExpandArrayParameters.php
@@ -27,12 +27,12 @@ final class ExpandArrayParameters implements Visitor
     /** @var list<mixed> */
     private array $convertedParameters = [];
 
-    /** @var array<int,string|ParameterType|Type|null> */
+    /** @var array<int,string|ParameterType|Type> */
     private array $convertedTypes = [];
 
     /**
-     * @param array<int, mixed>|array<string, mixed>                                                         $parameters
-     * @param array<int,int|string|ParameterType|Type|null>|array<string,int|string|ParameterType|Type|null> $types
+     * @param array<int, mixed>|array<string, mixed>                                               $parameters
+     * @param array<int,int|string|ParameterType|Type>|array<string,int|string|ParameterType|Type> $types
      */
     public function __construct(private readonly array $parameters, private readonly array $types)
     {
@@ -115,7 +115,7 @@ final class ExpandArrayParameters implements Visitor
     }
 
     /**
-     * @return array<int,string|ParameterType|Type|null>
+     * @return array<int,string|ParameterType|Type>
      */
     public function getTypes(): array
     {
@@ -125,7 +125,7 @@ final class ExpandArrayParameters implements Visitor
     /**
      * @param list<mixed> $values
      */
-    private function appendTypedParameter(array $values, string|ParameterType|Type|null $type): void
+    private function appendTypedParameter(array $values, string|ParameterType|Type $type): void
     {
         $this->convertedSQL[] = implode(', ', array_fill(0, count($values), '?'));
 

--- a/src/Logging/Statement.php
+++ b/src/Logging/Statement.php
@@ -8,10 +8,7 @@ use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 use Psr\Log\LoggerInterface;
-
-use function func_num_args;
 
 final class Statement extends AbstractStatementMiddleware
 {
@@ -35,35 +32,17 @@ final class Statement extends AbstractStatementMiddleware
     public function bindParam(
         int|string $param,
         mixed &$variable,
-        ParameterType $type = ParameterType::STRING,
+        ParameterType $type,
         ?int $length = null
     ): void {
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindParam() is deprecated.'
-                    . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
-
         $this->params[$param] = &$variable;
         $this->types[$param]  = $type;
 
         parent::bindParam($param, $variable, $type, $length);
     }
 
-    public function bindValue(int|string $param, mixed $value, ParameterType $type = ParameterType::STRING): void
+    public function bindValue(int|string $param, mixed $value, ParameterType $type): void
     {
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindValue() is deprecated.'
-                    . ' Pass the type corresponding to the parameter being bound.'
-            );
-        }
-
         $this->params[$param] = $value;
         $this->types[$param]  = $type;
 

--- a/src/Logging/Statement.php
+++ b/src/Logging/Statement.php
@@ -49,14 +49,14 @@ final class Statement extends AbstractStatementMiddleware
         parent::bindValue($param, $value, $type);
     }
 
-    public function execute(?array $params = null): ResultInterface
+    public function execute(): ResultInterface
     {
         $this->logger->debug('Executing statement: {sql} (parameters: {params}, types: {types})', [
             'sql'    => $this->sql,
-            'params' => $params ?? $this->params,
+            'params' => $this->params,
             'types'  => $this->types,
         ]);
 
-        return parent::execute($params);
+        return parent::execute();
     }
 }

--- a/src/Portability/Statement.php
+++ b/src/Portability/Statement.php
@@ -21,10 +21,10 @@ final class Statement extends AbstractStatementMiddleware
         parent::__construct($stmt);
     }
 
-    public function execute(?array $params = null): ResultInterface
+    public function execute(): ResultInterface
     {
         return new Result(
-            parent::execute($params),
+            parent::execute(),
             $this->converter
         );
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -14,8 +14,8 @@ use Doctrine\DBAL\Types\Type;
 final class Query
 {
     /**
-     * @param array<mixed>                              $params
-     * @param array<int|string|ParameterType|Type|null> $types
+     * @param array<mixed>                         $params
+     * @param array<int|string|ParameterType|Type> $types
      *
      * @psalm-suppress ImpurePropertyAssignment
      */
@@ -40,7 +40,7 @@ final class Query
     }
 
     /**
-     * @return array<int|string|ParameterType|Type|null>
+     * @return array<int|string|ParameterType|Type>
      */
     public function getTypes(): array
     {

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -53,7 +53,7 @@ class QueryBuilder
     /**
      * The parameter type map of this query.
      *
-     * @var array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null>
+     * @var array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type>
      */
     private array $types = [];
 
@@ -353,29 +353,19 @@ class QueryBuilder
      *         ->setParameter('user_id', 1);
      * </code>
      *
-     * @param int|string                     $key   Parameter position or name
-     * @param mixed                          $value Parameter value
-     * @param string|ParameterType|Type|null $type  Parameter type
+     * @param int|string                $key   Parameter position or name
+     * @param mixed                     $value Parameter value
+     * @param string|ParameterType|Type $type  Parameter type
      *
      * @return $this This QueryBuilder instance.
      */
     public function setParameter(
         int|string $key,
         mixed $value,
-        string|ParameterType|Type|null $type = ParameterType::STRING
+        string|ParameterType|Type $type = ParameterType::STRING
     ): self {
-        if ($type !== null) {
-            $this->types[$key] = $type;
-        } else {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5550',
-                'Using NULL as prepared statement parameter type is deprecated.'
-                    . 'Omit or use Parameter::STRING instead'
-            );
-        }
-
         $this->params[$key] = $value;
+        $this->types[$key]  = $type;
 
         return $this;
     }
@@ -394,8 +384,8 @@ class QueryBuilder
      *         ));
      * </code>
      *
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @return $this This QueryBuilder instance.
      */
@@ -432,7 +422,7 @@ class QueryBuilder
     /**
      * Gets all defined query parameter types for the query being constructed indexed by parameter index or name.
      *
-     * @return array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null>
+     * @return array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type>
      */
     public function getParameterTypes(): array
     {
@@ -446,7 +436,7 @@ class QueryBuilder
      *
      * @return int|string|ParameterType|Type The value of the bound parameter type
      */
-    public function getParameterType(int|string $key): int|string|ParameterType|Type|null
+    public function getParameterType(int|string $key): int|string|ParameterType|Type
     {
         return $this->types[$key] ?? ParameterType::STRING;
     }
@@ -1331,7 +1321,7 @@ class QueryBuilder
      */
     public function createNamedParameter(
         mixed $value,
-        string|ParameterType|Type|null $type = ParameterType::STRING,
+        string|ParameterType|Type $type = ParameterType::STRING,
         ?string $placeHolder = null
     ): string {
         if ($placeHolder === null) {
@@ -1363,7 +1353,7 @@ class QueryBuilder
      */
     public function createPositionalParameter(
         mixed $value,
-        string|ParameterType|Type|null $type = ParameterType::STRING
+        string|ParameterType|Type $type = ParameterType::STRING
     ): string {
         $this->setParameter($this->boundCounter, $value, $type);
         $this->boundCounter++;

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
 use function func_num_args;
 use function is_string;
@@ -135,19 +134,13 @@ class Statement
     }
 
     /**
-     * @param mixed[] $params
-     *
      * @throws Exception
      */
-    private function execute(array $params): Result
+    private function execute(): Result
     {
-        if ($params !== []) {
-            $this->params = $params;
-        }
-
         try {
             return new Result(
-                $this->stmt->execute($params === [] ? null : $params),
+                $this->stmt->execute(),
                 $this->conn
             );
         } catch (Driver\Exception $ex) {
@@ -158,43 +151,21 @@ class Statement
     /**
      * Executes the statement with the currently bound parameters and return result.
      *
-     * @param mixed[] $params
-     *
      * @throws Exception
      */
-    public function executeQuery(array $params = []): Result
+    public function executeQuery(): Result
     {
-        if (func_num_args() > 0) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5556',
-                'Passing $params to Statement::executeQuery() is deprecated. Bind parameters using'
-                . ' Statement::bindParam() or Statement::bindValue() instead.'
-            );
-        }
-
-        return $this->execute($params);
+        return $this->execute();
     }
 
     /**
      * Executes the statement with the currently bound parameters and return affected rows.
      *
-     * @param mixed[] $params
-     *
      * @throws Exception
      */
-    public function executeStatement(array $params = []): int
+    public function executeStatement(): int
     {
-        if (func_num_args() > 0) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5556',
-                'Passing $params to Statement::executeStatement() is deprecated. Bind parameters using'
-                . ' Statement::bindParam() or Statement::bindValue() instead.'
-            );
-        }
-
-        return $this->execute($params)->rowCount();
+        return $this->execute()->rowCount();
     }
 
     /**

--- a/tests/Connection/ExpandArrayParametersTest.php
+++ b/tests/Connection/ExpandArrayParametersTest.php
@@ -318,10 +318,10 @@ class ExpandArrayParametersTest extends TestCase
     }
 
     /**
-     * @param array<int, mixed>|array<string, mixed>                               $params
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
-     * @param list<mixed>                                                          $expectedParams
-     * @param array<int,Type|int|string|null>                                      $expectedTypes
+     * @param array<int, mixed>|array<string, mixed>                     $params
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $types
+     * @param list<mixed>                                                $expectedParams
+     * @param array<int,Type|int|string>                                 $expectedTypes
      *
      * @dataProvider dataExpandListParameters
      */
@@ -370,8 +370,8 @@ class ExpandArrayParametersTest extends TestCase
     }
 
     /**
-     * @param array<int, mixed>|array<string, mixed>                               $params
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     * @param array<int, mixed>|array<string, mixed>                     $params
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $types
      *
      * @dataProvider missingNamedParameterProvider
      */
@@ -412,10 +412,10 @@ class ExpandArrayParametersTest extends TestCase
     }
 
     /**
-     * @param array<int, mixed>|array<string, mixed>                               $params
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     * @param array<int, mixed>|array<string, mixed>                     $params
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $types
      *
-     * @return array{string, list<mixed>, array<int,string|ParameterType|Type|null>}
+     * @return array{string, list<mixed>, array<int,string|ParameterType|Type>}
      */
     private function expandArrayParameters(string $sql, array $params, array $types): array
     {

--- a/tests/Driver/Middleware/AbstractStatementMiddlewareTest.php
+++ b/tests/Driver/Middleware/AbstractStatementMiddlewareTest.php
@@ -17,10 +17,9 @@ final class AbstractStatementMiddlewareTest extends TestCase
         $statement = $this->createMock(Statement::class);
         $statement->expects(self::once())
             ->method('execute')
-            ->with(['foo' => 'bar'])
             ->willReturn($result);
 
-        self::assertSame($result, $this->createMiddleware($statement)->execute(['foo' => 'bar']));
+        self::assertSame($result, $this->createMiddleware($statement)->execute());
     }
 
     private function createMiddleware(Statement $statement): AbstractStatementMiddleware

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -105,21 +105,6 @@ class DataAccessTest extends FunctionalTestCase
         self::assertEquals(1, $column);
     }
 
-    public function testPrepareWithExecuteParams(): void
-    {
-        $paramInt = 1;
-        $paramStr = 'foo';
-
-        $sql    = 'SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?';
-        $stmt   = $this->connection->prepare($sql);
-        $result = $stmt->executeQuery([$paramInt, $paramStr]);
-
-        $row = $result->fetchAssociative();
-        self::assertNotFalse($row);
-        $row = array_change_key_case($row, CASE_LOWER);
-        self::assertEquals(['test_int' => 1, 'test_string' => 'foo'], $row);
-    }
-
     public function testFetchAllAssociative(): void
     {
         $sql  = 'SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?';

--- a/tests/Functional/Driver/OCI8/StatementTest.php
+++ b/tests/Functional/Driver/OCI8/StatementTest.php
@@ -36,24 +36,6 @@ class StatementTest extends FunctionalTestCase
     }
 
     /**
-     * Low-level approach to working with parameter binding
-     *
-     * @param mixed[] $params
-     * @param mixed[] $expected
-     *
-     * @dataProvider queryConversionProvider
-     */
-    public function testStatementBindParameters(string $query, array $params, array $expected): void
-    {
-        self::assertEquals(
-            $expected,
-            $this->connection->prepare($query)
-                ->executeQuery($params)
-                ->fetchAssociative()
-        );
-    }
-
-    /**
      * @return array<string, array<int, mixed>>
      */
     public static function queryConversionProvider(): iterable
@@ -105,5 +87,17 @@ World?!',
                 ['COL1' => ''],
             ],
         ];
+    }
+
+    public function testBindPositionalParameter(): void
+    {
+        $statement = $this->connection->prepare('SELECT ? COL1 FROM DUAL');
+        $statement->bindValue(1, 1);
+
+        self::assertEquals(
+            ['COL1' => 1],
+            $statement->executeQuery()
+                ->fetchAssociative()
+        );
     }
 }

--- a/tests/Logging/MiddlewareTest.php
+++ b/tests/Logging/MiddlewareTest.php
@@ -94,22 +94,7 @@ class MiddlewareTest extends TestCase
         $connection->rollBack();
     }
 
-    public function testExecuteStatementWithUntypedParameters(): void
-    {
-        $this->logger->expects(self::once())
-            ->method('debug')
-            ->with('Executing statement: {sql} (parameters: {params}, types: {types})', [
-                'sql' => 'SELECT ?',
-                'params' => [42],
-                'types' => [],
-            ]);
-
-        $connection = $this->driver->connect([]);
-        $statement  = $connection->prepare('SELECT ?');
-        $statement->execute([42]);
-    }
-
-    public function testExecuteStatementWithTypedParameters(): void
+    public function testExecuteStatementWithParameters(): void
     {
         $this->logger->expects(self::once())
             ->method('debug')

--- a/tests/Logging/MiddlewareTest.php
+++ b/tests/Logging/MiddlewareTest.php
@@ -140,7 +140,7 @@ class MiddlewareTest extends TestCase
 
         $connection = $this->driver->connect([]);
         $statement  = $connection->prepare('SELECT :value');
-        $statement->bindValue('value', 'Test');
+        $statement->bindValue('value', 'Test', ParameterType::STRING);
 
         $statement->execute();
     }

--- a/tests/Portability/StatementTest.php
+++ b/tests/Portability/StatementTest.php
@@ -54,15 +54,9 @@ class StatementTest extends TestCase
 
     public function testExecute(): void
     {
-        $params = [
-            'foo',
-            'bar',
-        ];
-
         $this->wrappedStmt->expects(self::once())
-            ->method('execute')
-            ->with($params);
+            ->method('execute');
 
-        $this->stmt->execute($params);
+        $this->stmt->execute();
     }
 }

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -826,8 +826,8 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * @param list<mixed>|array<string, mixed>                                     $parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     * @param list<mixed>|array<string, mixed>                           $parameters
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $parameterTypes
      *
      * @dataProvider fetchProvider
      */
@@ -861,8 +861,8 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * @param list<mixed>|array<string, mixed>                                     $parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     * @param list<mixed>|array<string, mixed>                           $parameters
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $parameterTypes
      *
      * @dataProvider fetchProvider
      */
@@ -896,8 +896,8 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * @param list<mixed>|array<string, mixed>                                     $parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     * @param list<mixed>|array<string, mixed>                           $parameters
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $parameterTypes
      *
      * @dataProvider fetchProvider
      */
@@ -931,8 +931,8 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * @param list<mixed>|array<string, mixed>                                     $parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     * @param list<mixed>|array<string, mixed>                           $parameters
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $parameterTypes
      *
      * @dataProvider fetchProvider
      */
@@ -977,8 +977,8 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * @param list<mixed>|array<string, mixed>                                     $parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     * @param list<mixed>|array<string, mixed>                           $parameters
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $parameterTypes
      *
      * @dataProvider fetchProvider
      */
@@ -1023,8 +1023,8 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * @param list<mixed>|array<string, mixed>                                     $parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     * @param list<mixed>|array<string, mixed>                           $parameters
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $parameterTypes
      *
      * @dataProvider fetchProvider
      */
@@ -1069,8 +1069,8 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * @param list<mixed>|array<string, mixed>                                     $parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     * @param list<mixed>|array<string, mixed>                           $parameters
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $parameterTypes
      *
      * @dataProvider fetchProvider
      */
@@ -1119,8 +1119,8 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * @param list<mixed>|array<string, mixed>                                     $parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     * @param list<mixed>|array<string, mixed>                           $parameters
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $parameterTypes
      *
      * @dataProvider fetchProvider
      */
@@ -1172,7 +1172,7 @@ class QueryBuilderTest extends TestCase
      *          string,
      *          string,
      *          list<mixed>|array<string, mixed>,
-     *          array<int, int|string|Type|null>|array<string, int|string|Type|null>,
+     *          array<int, int|string|Type>|array<string, int|string|Type>,
      *          string
      *  }>
      */
@@ -1216,8 +1216,8 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * @param list<mixed>|array<string, mixed>                                                                 $params
-     * @param array<int, int|string|ParameterType|Type|null>|array<string, int|string|ParameterType|Type|null> $types
+     * @param list<mixed>|array<string, mixed>                                                       $params
+     * @param array<int, int|string|ParameterType|Type>|array<string, int|string|ParameterType|Type> $types
      *
      * @dataProvider fetchProvider
      */
@@ -1250,8 +1250,8 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * @param list<mixed>|array<string, mixed>                                     $parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $parameterTypes
+     * @param list<mixed>|array<string, mixed>                           $parameters
+     * @param array<int, int|string|Type>|array<string, int|string|Type> $parameterTypes
      *
      * @dataProvider fetchProvider
      */


### PR DESCRIPTION
See the following pull requests for reference:

1. https://github.com/doctrine/dbal/pull/5550
2. https://github.com/doctrine/dbal/pull/5556
3. https://github.com/doctrine/dbal/pull/5558
