### PR TITLE
Deprecate Statement::bindParam()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,15 @@ awareness about deprecated code.
 
 # Upgrade to 3.4
 
+## Deprecated wrapper- and driver-level `Statement::bindParam()` methods.
+
+The following methods have been deprecated:
+
+1. `Doctrine\DBAL\Statement::bindParam()`,
+2. `Doctrine\DBAL\Driver\Statement::bindParam()`.
+
+Use the corresponding `bindValue()` instead.
+
 ## Deprecated not passing parameter type to the driver-level `Statement::bind*()` methods.
 
 Not passing `$type` to the driver-level `Statement::bindParam()` and `::bindValue()` is deprecated.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -399,6 +399,16 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::getState"/>
                 <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::getType"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Driver\Statement::bindParam"/>
+                <referencedMethod name="Doctrine\DBAL\Driver\IBMDB2\Statement::bindParam"/>
+                <referencedMethod name="Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware::bindParam"/>
+                <referencedMethod name="Doctrine\DBAL\Driver\OCI8\Statement::bindParam"/>
+                <referencedMethod name="Doctrine\DBAL\Driver\PDO\Statement::bindParam"/>
+                <referencedMethod name="Doctrine\DBAL\Driver\PDO\SQLSrv\Statement::bindParam"/>
+                <referencedMethod name="Doctrine\DBAL\Statement::bindParam"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -76,9 +76,18 @@ final class Statement implements StatementInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@see bindValue()} instead.
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5563',
+            '%s is deprecated. Use bindValue() instead.',
+            __METHOD__
+        );
+
         assert(is_int($param));
 
         if (func_num_args() < 3) {

--- a/src/Driver/Middleware/AbstractStatementMiddleware.php
+++ b/src/Driver/Middleware/AbstractStatementMiddleware.php
@@ -37,9 +37,18 @@ abstract class AbstractStatementMiddleware implements Statement
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@see bindValue()} instead.
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5563',
+            '%s is deprecated. Use bindValue() instead.',
+            __METHOD__
+        );
+
         if (func_num_args() < 3) {
             Deprecation::trigger(
                 'doctrine/dbal',

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -66,9 +66,18 @@ final class Statement implements StatementInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@see bindValue()} instead.
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5563',
+            '%s is deprecated. Use bindValue() instead.',
+            __METHOD__
+        );
+
         assert(is_int($param));
 
         if (func_num_args() < 3) {

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -70,9 +70,18 @@ final class Statement implements StatementInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@see bindValue()} instead.
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5563',
+            '%s is deprecated. Use bindValue() instead.',
+            __METHOD__
+        );
+
         if (func_num_args() < 3) {
             Deprecation::trigger(
                 'doctrine/dbal',

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -27,6 +27,8 @@ final class Statement extends AbstractStatementMiddleware
     /**
      * {@inheritdoc}
      *
+     * @deprecated Use {@see bindValue()} instead.
+     *
      * @param string|int $param
      * @param mixed      $variable
      * @param int        $type
@@ -40,6 +42,13 @@ final class Statement extends AbstractStatementMiddleware
         $length = null,
         $driverOptions = null
     ): bool {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5563',
+            '%s is deprecated. Use bindValue() instead.',
+            __METHOD__
+        );
+
         if (func_num_args() < 3) {
             Deprecation::trigger(
                 'doctrine/dbal',

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -64,6 +64,8 @@ final class Statement implements StatementInterface
     /**
      * {@inheritDoc}
      *
+     * @deprecated Use {@see bindValue()} instead.
+     *
      * @param mixed    $param
      * @param mixed    $variable
      * @param int      $type
@@ -77,6 +79,13 @@ final class Statement implements StatementInterface
         $length = null,
         $driverOptions = null
     ): bool {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5563',
+            '%s is deprecated. Use bindValue() instead.',
+            __METHOD__
+        );
+
         if (func_num_args() < 3) {
             Deprecation::trigger(
                 'doctrine/dbal',

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -105,9 +105,18 @@ final class Statement implements StatementInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@see bindValue()} instead.
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5563',
+            '%s is deprecated. Use bindValue() instead.',
+            __METHOD__
+        );
+
         assert(is_int($param));
 
         if (func_num_args() < 3) {

--- a/src/Driver/Statement.php
+++ b/src/Driver/Statement.php
@@ -43,6 +43,8 @@ interface Statement
      * of stored procedures that return data as output parameters, and some also as input/output
      * parameters that both send in data and are updated to receive it.
      *
+     * @deprecated Use {@see bindValue()} instead.
+     *
      * @param string|int $param    Parameter identifier. For a prepared statement using named placeholders,
      *                             this will be a parameter name of the form :name. For a prepared statement using
      *                             question mark placeholders, this will be the 1-indexed position of the parameter.

--- a/src/Logging/Statement.php
+++ b/src/Logging/Statement.php
@@ -39,9 +39,18 @@ final class Statement extends AbstractStatementMiddleware
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use {@see bindValue()} instead.
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5563',
+            '%s is deprecated. Use bindValue() instead.',
+            __METHOD__
+        );
+
         if (func_num_args() < 3) {
             Deprecation::trigger(
                 'doctrine/dbal',

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -123,6 +123,8 @@ class Statement
      *
      * Binding a parameter by reference does not support DBAL mapping types.
      *
+     * @deprecated Use {@see bindValue()} instead.
+     *
      * @param string|int $param    The name or position of the parameter.
      * @param mixed      $variable The reference to the variable to bind.
      * @param int        $type     The binding type.
@@ -135,6 +137,13 @@ class Statement
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5563',
+            '%s is deprecated. Use bindValue() instead.',
+            __METHOD__
+        );
+
         $this->params[$param] = $variable;
         $this->types[$param]  = $type;
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

This API is a legacy of PDO and was mostly supposed to be used in two cases:

1. Binding out parameters (e.g. to be used with stored procedures) which the DBAL doesn’t and will not support because it’s not portable.
2. Binding variables by reference like in the following example: https://github.com/doctrine/dbal/blob/bf648df34d489a06439ced71f9130f1625fb4204/tests/Functional/StatementTest.php#L187-L195 This is too low-level, archaic and error-prone. Depending on the driver, one may need to maintain a proper parameter `$length` in order to avoid truncation of string values (see the documentation on [`oci_bind_by_name()`](https://www.php.net/manual/en/function.oci-bind-by-name.php) for more details). I don’t see a reason why anyone would want to do that (e.g. the ORM doesn’t).

Deprecating this API will simplify the improvements of type safety of the Statement API.

The only problem it may create is that `bindParam()` might be used to migrate to a better identity generation API in the ORM for Oracle (see https://github.com/doctrine/dbal/pull/5443#issuecomment-1153308159 for more details). It’s a low-priority/high-effort project, and I’m sure that if we ever get to it, we’ll find a better-localized solution.