### PR TITLE
Remove Statement::bindParam()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: removed wrapper- and driver-level `Statement::bindParam()` methods.
+
+The following methods have been removed:
+
+1. `Doctrine\DBAL\Statement::bindParam()`,
+2. `Doctrine\DBAL\Driver\Statement::bindParam()`.
+
 ## BC BREAK: made parameter type in driver-level `Statement::bind*()` methods required.
 
 The `$type` parameter of the driver-level `Statement::bindParam()` and `::bindValue()` has been made required.

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Driver\IBMDB2\Exception\CannotCreateTemporaryFile;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\StatementError;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 use function db2_bind_param;
@@ -55,34 +54,17 @@ final class Statement implements StatementInterface
     {
         assert(is_int($param));
 
-        $this->bindParam($param, $value, $type);
-    }
-
-    /**
-     * @deprecated Use {@see bindValue()} instead.
-     */
-    public function bindParam(int|string $param, mixed &$variable, ParameterType $type, ?int $length = null): void
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5563',
-            '%s is deprecated. Use bindValue() instead.',
-            __METHOD__
-        );
-
-        assert(is_int($param));
-
         switch ($type) {
             case ParameterType::INTEGER:
-                $this->bind($param, $variable, DB2_PARAM_IN, DB2_LONG);
+                $this->bind($param, $value, DB2_PARAM_IN, DB2_LONG);
                 break;
 
             case ParameterType::LARGE_OBJECT:
-                $this->lobs[$param] = &$variable;
+                $this->lobs[$param] = &$value;
                 break;
 
             default:
-                $this->bind($param, $variable, DB2_PARAM_IN, DB2_CHAR);
+                $this->bind($param, $value, DB2_PARAM_IN, DB2_CHAR);
                 break;
         }
     }

--- a/src/Driver/Middleware/AbstractStatementMiddleware.php
+++ b/src/Driver/Middleware/AbstractStatementMiddleware.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 
 abstract class AbstractStatementMiddleware implements Statement
 {
@@ -18,25 +17,6 @@ abstract class AbstractStatementMiddleware implements Statement
     public function bindValue(int|string $param, mixed $value, ParameterType $type): void
     {
         $this->wrappedStatement->bindValue($param, $value, $type);
-    }
-
-    /**
-     * @deprecated Use {@see bindValue()} instead.
-     */
-    public function bindParam(
-        int|string $param,
-        mixed &$variable,
-        ParameterType $type,
-        ?int $length = null
-    ): void {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5563',
-            '%s is deprecated. Use bindValue() instead.',
-            __METHOD__
-        );
-
-        $this->wrappedStatement->bindParam($param, $variable, $type, $length);
     }
 
     public function execute(): Result

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Driver\Mysqli\Exception\NonStreamResourceUsedAsLargeObject;
 use Doctrine\DBAL\Driver\Mysqli\Exception\StatementError;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 use mysqli_sql_exception;
 use mysqli_stmt;
 
@@ -50,28 +49,6 @@ final class Statement implements StatementInterface
         $paramCount        = $this->stmt->param_count;
         $this->types       = str_repeat(self::PARAMETER_TYPE_STRING, $paramCount);
         $this->boundValues = array_fill(1, $paramCount, null);
-    }
-
-    /**
-     * @deprecated Use {@see bindValue()} instead.
-     */
-    public function bindParam(
-        int|string $param,
-        mixed &$variable,
-        ParameterType $type,
-        ?int $length = null
-    ): void {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5563',
-            '%s is deprecated. Use bindValue() instead.',
-            __METHOD__
-        );
-
-        assert(is_int($param));
-
-        $this->types[$param - 1]   = $this->convertParameterType($type);
-        $this->boundValues[$param] =& $variable;
     }
 
     public function bindValue(int|string $param, mixed $value, ParameterType $type): void

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Driver\PDO\SQLSrv;
 use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
 use Doctrine\DBAL\Driver\PDO\Statement as PDOStatement;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 use PDO;
 
 final class Statement extends AbstractStatementMiddleware
@@ -24,30 +23,15 @@ final class Statement extends AbstractStatementMiddleware
         $this->statement = $statement;
     }
 
-    /**
-     * @deprecated Use {@see bindValue()} instead.
-     */
-    public function bindParam(
-        int|string $param,
-        mixed &$variable,
-        ParameterType $type,
-        ?int $length = null
-    ): void {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5563',
-            '%s is deprecated. Use bindValue() instead.',
-            __METHOD__
-        );
-
+    public function bindValue(int|string $param, mixed $value, ParameterType $type): void
+    {
         switch ($type) {
             case ParameterType::LARGE_OBJECT:
             case ParameterType::BINARY:
                 $this->statement->bindParamWithDriverOptions(
                     $param,
-                    $variable,
+                    $value,
                     $type,
-                    $length ?? 0,
                     PDO::SQLSRV_ENCODING_BINARY
                 );
                 break;
@@ -55,20 +39,14 @@ final class Statement extends AbstractStatementMiddleware
             case ParameterType::ASCII:
                 $this->statement->bindParamWithDriverOptions(
                     $param,
-                    $variable,
+                    $value,
                     ParameterType::STRING,
-                    $length ?? 0,
                     PDO::SQLSRV_ENCODING_SYSTEM
                 );
                 break;
 
             default:
-                $this->statement->bindParam($param, $variable, $type, $length ?? 0);
+                $this->statement->bindValue($param, $value, $type);
         }
-    }
-
-    public function bindValue(int|string $param, mixed $value, ParameterType $type): void
-    {
-        $this->bindParam($param, $value, $type);
     }
 }

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\Driver\Exception as ExceptionInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -33,33 +32,6 @@ final class Statement implements StatementInterface
     }
 
     /**
-     * @deprecated Use {@see bindValue()} instead.
-     */
-    public function bindParam(
-        string|int $param,
-        mixed &$variable,
-        ParameterType $type,
-        ?int $length = null
-    ): void {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5563',
-            '%s is deprecated. Use bindValue() instead.',
-            __METHOD__
-        );
-
-        try {
-            if ($length === null) {
-                $this->stmt->bindParam($param, $variable, $this->convertParamType($type));
-            } else {
-                $this->stmt->bindParam($param, $variable, $this->convertParamType($type), $length);
-            }
-        } catch (PDOException $exception) {
-            throw Exception::new($exception);
-        }
-    }
-
-    /**
      * @internal Driver options can be only specified by a PDO-based driver.
      *
      * @throws ExceptionInterface
@@ -68,11 +40,10 @@ final class Statement implements StatementInterface
         string|int $param,
         mixed &$variable,
         ParameterType $type,
-        int $length,
         mixed $driverOptions
     ): void {
         try {
-            $this->stmt->bindParam($param, $variable, $this->convertParamType($type), $length, $driverOptions);
+            $this->stmt->bindParam($param, $variable, $this->convertParamType($type), 0, $driverOptions);
         } catch (PDOException $exception) {
             throw Exception::new($exception);
         }

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 
 use function assert;
 use function is_int;
@@ -73,31 +72,6 @@ final class Statement implements StatementInterface
 
         $this->variables[$param] = $value;
         $this->types[$param]     = $type;
-    }
-
-    /**
-     * @deprecated Use {@see bindValue()} instead.
-     */
-    public function bindParam(
-        int|string $param,
-        mixed &$variable,
-        ParameterType $type,
-        ?int $length = null
-    ): void {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5563',
-            '%s is deprecated. Use bindValue() instead.',
-            __METHOD__
-        );
-
-        assert(is_int($param));
-
-        $this->variables[$param] =& $variable;
-        $this->types[$param]     = $type;
-
-        // unset the statement resource if it exists as the new one will need to be bound to the new variable
-        $this->stmt = null;
     }
 
     public function execute(): Result

--- a/src/Driver/Statement.php
+++ b/src/Driver/Statement.php
@@ -31,40 +31,6 @@ interface Statement
     public function bindValue(int|string $param, mixed $value, ParameterType $type): void;
 
     /**
-     * Binds a PHP variable to a corresponding named (not supported by mysqli driver, see comment below) or question
-     * mark placeholder in the SQL statement that was use to prepare the statement. Unlike {@see bindValue()},
-     * the variable is bound as a reference and will only be evaluated at the time
-     * that PDOStatement->execute() is called.
-     *
-     * As mentioned above, the named parameters are not natively supported by the mysqli driver, use executeQuery(),
-     * fetchAll(), fetchArray(), fetchColumn(), fetchAssoc() methods to have the named parameter emulated by doctrine.
-     *
-     * Most parameters are input parameters, that is, parameters that are
-     * used in a read-only fashion to build up the query. Some drivers support the invocation
-     * of stored procedures that return data as output parameters, and some also as input/output
-     * parameters that both send in data and are updated to receive it.
-     *
-     * @deprecated Use {@see bindValue()} instead.
-     *
-     * @param int|string    $param    Parameter identifier. For a prepared statement using named placeholders,
-     *                                this will be a parameter name of the form :name. For a prepared statement using
-     *                                question mark placeholders, this will be the 1-indexed position of the parameter.
-     * @param mixed         $variable The variable to bind to the parameter.
-     * @param ParameterType $type     Explicit data type for the parameter using the {@see ParameterType}
-     *                                constants.
-     * @param int|null      $length   You must specify maxlength when using an OUT bind
-     *                                so that PHP allocates enough memory to hold the returned value.
-     *
-     * @throws Exception
-     */
-    public function bindParam(
-        int|string $param,
-        mixed &$variable,
-        ParameterType $type,
-        ?int $length = null
-    ): void;
-
-    /**
      * Executes a prepared statement
      *
      * @throws Exception

--- a/src/Logging/Statement.php
+++ b/src/Logging/Statement.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 use Psr\Log\LoggerInterface;
 
 final class Statement extends AbstractStatementMiddleware
@@ -28,28 +27,6 @@ final class Statement extends AbstractStatementMiddleware
         private readonly string $sql
     ) {
         parent::__construct($statement);
-    }
-
-    /**
-     * @deprecated Use {@see bindValue()} instead.
-     */
-    public function bindParam(
-        int|string $param,
-        mixed &$variable,
-        ParameterType $type,
-        ?int $length = null
-    ): void {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5563',
-            '%s is deprecated. Use bindValue() instead.',
-            __METHOD__
-        );
-
-        $this->params[$param] = &$variable;
-        $this->types[$param]  = $type;
-
-        parent::bindParam($param, $variable, $type, $length);
     }
 
     public function bindValue(int|string $param, mixed $value, ParameterType $type): void

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -6,9 +6,7 @@ namespace Doctrine\DBAL;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
-use function func_num_args;
 use function is_string;
 
 /**
@@ -93,51 +91,6 @@ class Statement
 
         try {
             $this->stmt->bindValue($param, $value, $bindingType);
-        } catch (Driver\Exception $e) {
-            throw $this->conn->convertException($e);
-        }
-    }
-
-    /**
-     * Binds a parameter to a value by reference.
-     *
-     * Binding a parameter by reference does not support DBAL mapping types.
-     *
-     * @deprecated Use {@see bindValue()} instead.
-     *
-     * @param string|int    $param    Parameter identifier. For a prepared statement using named placeholders,
-     *                                this will be a parameter name of the form :name. For a prepared statement
-     *                                using question mark placeholders, this will be the 1-indexed position
-     *                                of the parameter.
-     * @param mixed         $variable The variable to bind to the parameter.
-     * @param ParameterType $type     The binding type.
-     * @param int|null      $length   Must be specified when using an OUT bind
-     *                                so that PHP allocates enough memory to hold the returned value.
-     *
-     * @throws Exception
-     */
-    public function bindParam(
-        string|int $param,
-        mixed &$variable,
-        ParameterType $type = ParameterType::STRING,
-        ?int $length = null
-    ): void {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5563',
-            '%s is deprecated. Use bindValue() instead.',
-            __METHOD__
-        );
-
-        $this->params[$param] = $variable;
-        $this->types[$param]  = $type;
-
-        try {
-            if (func_num_args() > 3) {
-                $this->stmt->bindParam($param, $variable, $type, $length);
-            } else {
-                $this->stmt->bindParam($param, $variable, $type);
-            }
         } catch (Driver\Exception $e) {
             throw $this->conn->convertException($e);
         }

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -161,10 +161,8 @@ class BlobTest extends FunctionalTestCase
             "INSERT INTO blob_table(id, clobcolumn, blobcolumn) VALUES (1, 'ignored', ?)"
         );
 
-        $stmt->bindParam(1, $stream, ParameterType::LARGE_OBJECT);
-
-        // Bind param does late binding (bind by reference), so create the stream only now:
         $stream = fopen('data://text/plain,test', 'r');
+        $stmt->bindValue(1, $stream, ParameterType::LARGE_OBJECT);
 
         $stmt->executeStatement();
 

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -56,24 +56,6 @@ class DataAccessTest extends FunctionalTestCase
         self::assertEquals(['test_int' => 1, 'test_string' => 'foo'], $row);
     }
 
-    public function testPrepareWithBindParam(): void
-    {
-        $paramInt = 1;
-        $paramStr = 'foo';
-
-        $sql  = 'SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?';
-        $stmt = $this->connection->prepare($sql);
-
-        $stmt->bindParam(1, $paramInt);
-        $stmt->bindParam(2, $paramStr);
-
-        $row = $stmt->executeQuery()->fetchAssociative();
-
-        self::assertIsArray($row);
-        $row = array_change_key_case($row, CASE_LOWER);
-        self::assertEquals(['test_int' => 1, 'test_string' => 'foo'], $row);
-    }
-
     public function testPrepareWithFetchAllAssociative(): void
     {
         $paramInt = 1;
@@ -82,8 +64,8 @@ class DataAccessTest extends FunctionalTestCase
         $sql  = 'SELECT test_int, test_string FROM fetch_table WHERE test_int = ? AND test_string = ?';
         $stmt = $this->connection->prepare($sql);
 
-        $stmt->bindParam(1, $paramInt);
-        $stmt->bindParam(2, $paramStr);
+        $stmt->bindValue(1, $paramInt);
+        $stmt->bindValue(2, $paramStr);
 
         $rows    = $stmt->executeQuery()->fetchAllAssociative();
         $rows[0] = array_change_key_case($rows[0], CASE_LOWER);
@@ -98,8 +80,8 @@ class DataAccessTest extends FunctionalTestCase
         $sql  = 'SELECT test_int FROM fetch_table WHERE test_int = ? AND test_string = ?';
         $stmt = $this->connection->prepare($sql);
 
-        $stmt->bindParam(1, $paramInt);
-        $stmt->bindParam(2, $paramStr);
+        $stmt->bindValue(1, $paramInt);
+        $stmt->bindValue(2, $paramStr);
 
         $column = $stmt->executeQuery()->fetchOne();
         self::assertEquals(1, $column);
@@ -666,7 +648,7 @@ class DataAccessTest extends FunctionalTestCase
                     return '?';
                 },
                 static function (Statement $stmt, int $interval): void {
-                    $stmt->bindParam(1, $interval, ParameterType::INTEGER);
+                    $stmt->bindValue(1, $interval, ParameterType::INTEGER);
                 },
             ],
             'literal' => [

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -182,25 +182,6 @@ EOF
         self::assertEquals(2, $id);
     }
 
-    public function testReuseStatementWithParameterBoundByReference(): void
-    {
-        $this->connection->insert('stmt_test', ['id' => 1]);
-        $this->connection->insert('stmt_test', ['id' => 2]);
-
-        $stmt = $this->connection->prepare('SELECT id FROM stmt_test WHERE id = ?');
-        $stmt->bindParam(1, $id);
-
-        $id = 1;
-
-        $result = $stmt->executeQuery();
-        self::assertEquals(1, $result->fetchOne());
-
-        $id = 2;
-
-        $result = $stmt->executeQuery();
-        self::assertEquals(2, $result->fetchOne());
-    }
-
     public function testReuseStatementWithReboundValue(): void
     {
         $this->connection->insert('stmt_test', ['id' => 1]);
@@ -215,36 +196,6 @@ EOF
         $stmt->bindValue(1, 2);
         $result = $stmt->executeQuery();
         self::assertEquals(2, $result->fetchOne());
-    }
-
-    public function testReuseStatementWithReboundParam(): void
-    {
-        $this->connection->insert('stmt_test', ['id' => 1]);
-        $this->connection->insert('stmt_test', ['id' => 2]);
-
-        $stmt = $this->connection->prepare('SELECT id FROM stmt_test WHERE id = ?');
-
-        $x = 1;
-        $stmt->bindParam(1, $x);
-        $result = $stmt->executeQuery();
-        self::assertEquals(1, $result->fetchOne());
-
-        $y = 2;
-        $stmt->bindParam(1, $y);
-        $result = $stmt->executeQuery();
-        self::assertEquals(2, $result->fetchOne());
-    }
-
-    public function testBindParamWithNullLength(): void
-    {
-        $this->connection->insert('stmt_test', ['id' => 1]);
-
-        $stmt = $this->connection->prepare('SELECT id FROM stmt_test WHERE id = ?');
-
-        $value = 1;
-        $stmt->bindParam(1, $value, ParameterType::INTEGER, null);
-
-        self::assertEquals(1, $stmt->executeQuery()->fetchOne());
     }
 
     public function testBindInvalidNamedParameter(): void

--- a/tests/Logging/MiddlewareTest.php
+++ b/tests/Logging/MiddlewareTest.php
@@ -100,16 +100,14 @@ class MiddlewareTest extends TestCase
             ->method('debug')
             ->with('Executing statement: {sql} (parameters: {params}, types: {types})', [
                 'sql' => 'SELECT ?, ?',
-                'params' => [1 => 42, 2 => 'Test'],
-                'types' => [1 => ParameterType::INTEGER, 2 => ParameterType::STRING],
+                'params' => [1 => 42],
+                'types' => [1 => ParameterType::INTEGER],
             ]);
 
         $connection = $this->driver->connect([]);
         $statement  = $connection->prepare('SELECT ?, ?');
         $statement->bindValue(1, 42, ParameterType::INTEGER);
-        $statement->bindParam(2, $byRef, ParameterType::STRING);
 
-        $byRef = 'Test';
         $statement->execute();
     }
 

--- a/tests/Portability/StatementTest.php
+++ b/tests/Portability/StatementTest.php
@@ -25,20 +25,6 @@ class StatementTest extends TestCase
         $this->stmt        = new Statement($this->wrappedStmt, $converter);
     }
 
-    public function testBindParam(): void
-    {
-        $column   = 'mycolumn';
-        $variable = 'myvalue';
-        $type     = ParameterType::STRING;
-        $length   = 666;
-
-        $this->wrappedStmt->expects(self::once())
-            ->method('bindParam')
-            ->with($column, $variable, $type, $length);
-
-        $this->stmt->bindParam($column, $variable, $type, $length);
-    }
-
     public function testBindValue(): void
     {
         $param = 'myparam';


### PR DESCRIPTION
The method being removed was deprecated in https://github.com/doctrine/dbal/pull/5563.