### PR TITLE
Do not treat deprecation level as errors

### DIFF
--- a/src/Types/ArrayType.php
+++ b/src/Types/ArrayType.php
@@ -11,6 +11,9 @@ use function set_error_handler;
 use function stream_get_contents;
 use function unserialize;
 
+use const E_DEPRECATED;
+use const E_USER_DEPRECATED;
+
 /**
  * Type that maps a PHP array to a clob SQL type.
  */
@@ -45,6 +48,10 @@ class ArrayType extends Type
         $value = is_resource($value) ? stream_get_contents($value) : $value;
 
         set_error_handler(function (int $code, string $message): bool {
+            if ($code === E_DEPRECATED || $code === E_USER_DEPRECATED) {
+                return false;
+            }
+
             throw ConversionException::conversionFailedUnserialization($this->getName(), $message);
         });
 

--- a/tests/Types/ArrayTest.php
+++ b/tests/Types/ArrayTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Tests\Types\Fixtures\UnserializeWithDeprecationObject;
 use Doctrine\DBAL\Types\ArrayType;
 use Doctrine\DBAL\Types\ConversionException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -43,6 +44,14 @@ class ArrayTest extends TestCase
         );
 
         $this->type->convertToPHPValue('abcdefg', $this->platform);
+    }
+
+    public function testDeprecationDuringConversion(): void
+    {
+        @self::assertInstanceOf(UnserializeWithDeprecationObject::class, $this->type->convertToPHPValue(
+            serialize(new UnserializeWithDeprecationObject()),
+            $this->platform
+        ));
     }
 
     public function testNullConversion(): void

--- a/tests/Types/Fixtures/UnserializeWithDeprecationObject.php
+++ b/tests/Types/Fixtures/UnserializeWithDeprecationObject.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Types\Fixtures;
+
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
+
+class UnserializeWithDeprecationObject
+{
+    public function __wakeup(): void
+    {
+        trigger_error('Deprecation triggered', E_USER_DEPRECATED);
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | -

#### Summary

When testing our application on PHP 8.1, we noticed Doctrine fails hard on the deprecation notice about `Serialization::unserialize()`. As we cannot upgrade to `__unserialize()` quickly (we returned a custom string representation), we cannot fix this deprecation at the moment (instead, we'll always serialize using the `serialize()` format, and let all entries update over time).

Doctrine treating deprecations as a hard unserialization error is blocking this process. I believe it should ignore deprecations and let the PHP handler handle them.