### PR TITLE
Mark remaining schema introspection platform methods as internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -289,6 +289,14 @@ The following schema introspection methods have been deprecated:
 - `AbstractPlatform::getListTableIndexesSQL()`,
 - `AbstractPlatform::getListTableForeignKeysSQL()`.
 
+## `AbstractPlatform` schema introspection methods made internal
+
+The following schema introspection methods have been marked as internal:
+
+- `AbstractPlatform::getListDatabasesSQL()`,
+- `AbstractPlatform::getListSequencesSQL()`,
+- `AbstractPlatform::getListViewsSQL()`.
+
 The queries used for schema introspection are an internal implementation detail of the DBAL.
 
 ## Deprecated `collate` option for MySQL

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -143,6 +143,8 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListDatabasesSQL()
     {
@@ -182,6 +184,8 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListViewsSQL($database)
     {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3444,6 +3444,8 @@ abstract class AbstractPlatform
     }
 
     /**
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
+     *
      * @return string
      *
      * @throws Exception If not supported on this platform.
@@ -3475,6 +3477,8 @@ abstract class AbstractPlatform
     }
 
     /**
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
+     *
      * @param string $database
      *
      * @return string
@@ -3547,6 +3551,8 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL to list all views of a database or user.
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      *
      * @param string $database
      *

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -396,6 +396,8 @@ class DB2Platform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListViewsSQL($database)
     {

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -415,6 +415,8 @@ class OraclePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListDatabasesSQL()
     {
@@ -423,6 +425,8 @@ class OraclePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListSequencesSQL($database)
     {
@@ -518,6 +522,8 @@ class OraclePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListViewsSQL($database)
     {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -266,6 +266,8 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListDatabasesSQL()
     {
@@ -294,6 +296,8 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListSequencesSQL($database)
     {
@@ -326,6 +330,8 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListViewsSQL($database)
     {

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -190,6 +190,8 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * {@inheritdoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListSequencesSQL($database)
     {
@@ -1040,6 +1042,8 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListViewsSQL($database)
     {
@@ -1137,6 +1141,8 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListDatabasesSQL()
     {

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -573,6 +573,8 @@ class SqlitePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
      */
     public function getListViewsSQL($database)
     {


### PR DESCRIPTION
This will be consistent with the deprecations implemented in https://github.com/doctrine/dbal/pull/5268 and will allow for more API cleanup within the minor releases after 4.0.