### PR TITLE
Rework introspection of table indexes and foreign keys on Postgres

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -289,11 +289,12 @@ abstract class AbstractSchemaManager
     protected function doListTableIndexes($table): array
     {
         $database = $this->getDatabase(__METHOD__);
+        $table    = $this->normalizeName($table);
 
         return $this->_getPortableTableIndexesList(
             $this->selectIndexColumns(
                 $database,
-                $this->normalizeName($table)
+                $table
             )->fetchAllAssociative(),
             $table
         );
@@ -381,7 +382,7 @@ abstract class AbstractSchemaManager
     /**
      * Lists the tables for this connection.
      *
-     * @return Table[]
+     * @return list<Table>
      *
      * @throws Exception
      */
@@ -489,7 +490,9 @@ abstract class AbstractSchemaManager
      */
     protected function normalizeName(string $name): string
     {
-        return $name;
+        $identifier = new Identifier($name);
+
+        return $identifier->getName();
     }
 
     /**

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -199,7 +199,9 @@ class SqliteSchemaManager extends AbstractSchemaManager
      */
     public function listTableForeignKeys($table, $database = null)
     {
-        $columns = $this->selectForeignKeyColumns('', $this->normalizeName($table))
+        $table = $this->normalizeName($table);
+
+        $columns = $this->selectForeignKeyColumns('', $table)
             ->fetchAllAssociative();
 
         if (count($columns) > 0) {

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -304,34 +304,13 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertInstanceOf(BlobType::class, $table->getColumn($columnName)->getType());
     }
 
-    public function testListQuotedTable(): void
-    {
-        $offlineTable = new Table('user');
-        $offlineTable->addColumn('id', 'integer');
-        $offlineTable->addColumn('username', 'string');
-        $offlineTable->addColumn('fk', 'integer');
-        $offlineTable->setPrimaryKey(['id']);
-        $offlineTable->addForeignKeyConstraint($offlineTable, ['fk'], ['id']);
-
-        $this->dropAndCreateTable($offlineTable);
-
-        $onlineTable = $this->schemaManager->listTableDetails('"user"');
-
-        $comparator = new Comparator();
-
-        self::assertFalse($comparator->diffTable($offlineTable, $onlineTable));
-    }
-
     public function testListTableDetailsWhenCurrentSchemaNameQuoted(): void
     {
         $this->connection->executeStatement('CREATE SCHEMA "001_test"');
         $this->connection->executeStatement('SET search_path TO "001_test"');
+        $this->markConnectionNotReusable();
 
-        try {
-            $this->testListQuotedTable();
-        } finally {
-            $this->connection->close();
-        }
+        $this->testIntrospectReservedKeywordTableViaListTableDetails();
     }
 
     public function testListTablesExcludesViews(): void

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
@@ -1661,6 +1662,52 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         self::assertSame($localColumns, array_map('strtolower', $foreignKey->getLocalColumns()));
         self::assertSame($foreignColumns, array_map('strtolower', $foreignKey->getForeignColumns()));
+    }
+
+    public function testIntrospectReservedKeywordTableViaListTableDetails(): void
+    {
+        $this->createReservedKeywordTables();
+
+        $user = $this->schemaManager->listTableDetails('"user"');
+        self::assertCount(2, $user->getColumns());
+        self::assertCount(2, $user->getIndexes());
+        self::assertCount(1, $user->getForeignKeys());
+    }
+
+    public function testIntrospectReservedKeywordTableViaListTables(): void
+    {
+        $this->createReservedKeywordTables();
+
+        $tables = $this->schemaManager->listTables();
+
+        $user = $this->findTableByName($tables, 'user');
+        self::assertNotNull($user);
+        self::assertCount(2, $user->getColumns());
+        self::assertCount(2, $user->getIndexes());
+        self::assertCount(1, $user->getForeignKeys());
+    }
+
+    private function createReservedKeywordTables(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        $this->dropTableIfExists($platform->quoteIdentifier('user'));
+        $this->dropTableIfExists($platform->quoteIdentifier('group'));
+
+        $schema = new Schema();
+
+        $user = $schema->createTable('user');
+        $user->addColumn('id', 'integer');
+        $user->addColumn('group_id', 'integer');
+        $user->setPrimaryKey(['id']);
+        $user->addForeignKeyConstraint('group', ['group_id'], ['id']);
+
+        $group = $schema->createTable('group');
+        $group->addColumn('id', 'integer');
+        $group->setPrimaryKey(['id']);
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createSchemaObjects($schema);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

Fixes #5575.

The primary changes are in the PostgreSQL schema manager where instead of using `::REGCLASS` to get the table name, we join the `pg_class` relation and get the name from there.

Additionally, there are some changes about quoting identifiers in order to make the second part of the test pass across platforms: on the one hand, we need to pass the table name quoted (otherwise, the Oracle's schema manager will upper-case it before introspection); on the other hand, the abstract schema manager had to be tweaked for that to work across the platforms.

`PostgreSQLSchemaManagerTest::testListQuotedTable()` has been reworked into `SchemaManagerFunctionalTestCase::testIntrospectReservedKeywordTableViaListTableDetails()` since it covered a subset of what the new test covers and only for PostgreSQL.