### PR TITLE
Do not add artificial name to anonymous SQLite constraint

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -443,8 +443,8 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $list = [];
         foreach ($tableForeignKeys as $value) {
             $value = array_change_key_case($value, CASE_LOWER);
-            $name  = $value['constraint_name'];
-            if (! isset($list[$name])) {
+            $id    = $value['id'];
+            if (! isset($list[$id])) {
                 if (! isset($value['on_delete']) || $value['on_delete'] === 'RESTRICT') {
                     $value['on_delete'] = null;
                 }
@@ -453,8 +453,8 @@ class SqliteSchemaManager extends AbstractSchemaManager
                     $value['on_update'] = null;
                 }
 
-                $list[$name] = [
-                    'name' => $name,
+                $list[$id] = [
+                    'name' => $value['constraint_name'],
                     'local' => [],
                     'foreign' => [],
                     'foreignTable' => $value['table'],
@@ -465,13 +465,13 @@ class SqliteSchemaManager extends AbstractSchemaManager
                 ];
             }
 
-            $list[$name]['local'][] = $value['from'];
+            $list[$id]['local'][] = $value['from'];
 
             if ($value['to'] === null) {
                 continue;
             }
 
-            $list[$name]['foreign'][] = $value['to'];
+            $list[$id]['foreign'][] = $value['to'];
         }
 
         return parent::_getPortableTableForeignKeysList($list);
@@ -644,7 +644,7 @@ SQL
 
         for ($i = 0, $count = count($match[0]); $i < $count; $i++) {
             $details[] = [
-                'constraint_name' => isset($names[$i]) && $names[$i] !== '' ? $names[$i] : $i,
+                'constraint_name' => isset($names[$i]) && $names[$i] !== '' ? $names[$i] : null,
                 'deferrable'      => isset($deferrable[$i]) && strcasecmp($deferrable[$i], 'deferrable') === 0,
                 'deferred'        => isset($deferred[$i]) && strcasecmp($deferred[$i], 'deferred') === 0,
             ];

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
+use function array_shift;
 use function dirname;
 
 class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
@@ -83,7 +84,7 @@ EOS
                 ['parent'],
                 'user',
                 ['id'],
-                '1',
+                null,
                 ['onUpdate' => 'NO ACTION', 'onDelete' => 'CASCADE', 'deferrable' => false, 'deferred' => false]
             ),
             new ForeignKeyConstraint(
@@ -191,5 +192,86 @@ SQL;
         self::assertNull($sm->listTableDetails('own_column_comment')
             ->getColumn('col1')
             ->getComment());
+    }
+
+    public function testNonSimpleAlterTableCreatedFromDDL(): void
+    {
+        $this->dropTableIfExists('nodes');
+
+        $ddl = <<<'DDL'
+        CREATE TABLE nodes (
+            id        INTEGER NOT NULL,
+            parent_id INTEGER,
+            name      TEXT,
+            PRIMARY KEY (id),
+            FOREIGN KEY (parent_id) REFERENCES nodes (id)
+        )
+        DDL;
+
+        $this->connection->executeStatement($ddl);
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $table1 = $schemaManager->listTableDetails('nodes');
+        $table2 = clone $table1;
+        $table2->addIndex(['name'], 'idx_name');
+
+        $comparator = $schemaManager->createComparator();
+        $diff       = $comparator->diffTable($table1, $table2);
+        self::assertNotFalse($diff);
+
+        $schemaManager->alterTable($diff);
+
+        $table = $schemaManager->listTableDetails('nodes');
+        $index = $table->getIndex('idx_name');
+        self::assertSame(['name'], $index->getColumns());
+    }
+
+    public function testIntrospectMultipleAnonymousForeignKeyConstraints(): void
+    {
+        $this->dropTableIfExists('album');
+        $this->dropTableIfExists('song');
+
+        $ddl = <<<'DDL'
+        CREATE TABLE artist(
+          id INTEGER,
+          name TEXT,
+          PRIMARY KEY(id)
+        );
+
+        CREATE TABLE album(
+          id INTEGER,
+          name TEXT,
+          PRIMARY KEY(id)
+        );
+
+        CREATE TABLE song(
+          id     INTEGER,
+          album_id INTEGER,
+          artist_id INTEGER,
+          FOREIGN KEY(album_id) REFERENCES album(id),
+          FOREIGN KEY(artist_id) REFERENCES artist(id)
+        );
+        DDL;
+
+        $this->connection->executeStatement($ddl);
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $song        = $schemaManager->listTableDetails('song');
+        $foreignKeys = $song->getForeignKeys();
+        self::assertCount(2, $foreignKeys);
+
+        $foreignKey1 = array_shift($foreignKeys);
+        self::assertEmpty($foreignKey1->getName());
+
+        self::assertSame(['album_id'], $foreignKey1->getLocalColumns());
+        self::assertSame(['id'], $foreignKey1->getForeignColumns());
+
+        $foreignKey2 = array_shift($foreignKeys);
+        self::assertEmpty($foreignKey2->getName());
+
+        self::assertSame(['artist_id'], $foreignKey2->getLocalColumns());
+        self::assertSame(['id'], $foreignKey2->getForeignColumns());
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

Fixes #5572.

1. As originally implemented in https://github.com/doctrine/dbal/pull/4246, do not add an artificial name to anonymous SQLite constraints.
2. In order to avoid the dependency on the foreign key name for grouping columns, group columns by `id`.

The first test reproduces the regression, the second ensures that multiple anonymous foreign keys on a single table are still properly introspected.