### PR TITLE
Expect an SQLServerPlatform instance in AbstractSQLServerDriver

### DIFF
--- a/src/Driver/AbstractSQLServerDriver.php
+++ b/src/Driver/AbstractSQLServerDriver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\API\SQLSrv\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\Deprecations\Deprecation;
 
@@ -40,7 +41,7 @@ abstract class AbstractSQLServerDriver implements Driver
                 . ' Use SQLServerPlatform::createSchemaManager() instead.'
         );
 
-        assert($platform instanceof SQLServer2012Platform);
+        assert($platform instanceof SQLServerPlatform);
 
         return new SQLServerSchemaManager($conn, $platform);
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

The `SQLServerPlatform` class was reinstated in https://github.com/doctrine/dbal/pull/4755 (`3.2.0`). The driver should allow using the most low-level of the corresponding platform classes. This would be consistent with the expectation of its schema manager (which is what this assertion is used for): https://github.com/doctrine/dbal/blob/2191acb4dd2d9c07223e363e306245f381cea372/src/Schema/SQLServerSchemaManager.php#L29

Fixes #5583.