### PR TITLE
Index components for listTables() by portable table definition

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -16,7 +16,6 @@ use Throwable;
 use function array_filter;
 use function array_intersect;
 use function array_map;
-use function array_shift;
 use function array_values;
 use function assert;
 use function call_user_func_array;
@@ -1708,9 +1707,8 @@ abstract class AbstractSchemaManager
         $data = [];
 
         foreach ($result->fetchAllAssociative() as $row) {
-            $group = array_shift($row);
-            assert(is_string($group));
-            $data[$group][] = $row;
+            $tableName          = $this->_getPortableTableDefinition($row);
+            $data[$tableName][] = $row;
         }
 
         return $data;

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -285,7 +285,7 @@ SQL;
         $sql = 'SELECT';
 
         if ($tableName === null) {
-            $sql .= ' C.TABNAME,';
+            $sql .= ' C.TABNAME AS NAME,';
         }
 
         $sql .= <<<'SQL'
@@ -325,7 +325,7 @@ SQL;
         $sql = 'SELECT';
 
         if ($tableName === null) {
-            $sql .= ' IDX.TABNAME,';
+            $sql .= ' IDX.TABNAME AS NAME,';
         }
 
         $sql .= <<<'SQL'
@@ -364,7 +364,7 @@ SQL;
         $sql = 'SELECT';
 
         if ($tableName === null) {
-            $sql .= ' R.TABNAME,';
+            $sql .= ' R.TABNAME AS NAME,';
         }
 
         $sql .= <<<'SQL'

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -263,10 +263,10 @@ SQL
     protected function _getPortableTableDefinition($table)
     {
         if ($table['schema_name'] !== 'dbo') {
-            return $table['schema_name'] . '.' . $table['name'];
+            return $table['schema_name'] . '.' . $table['table_name'];
         }
 
-        return $table['name'];
+        return $table['table_name'];
     }
 
     /**
@@ -386,7 +386,7 @@ SQL
     {
         // The "sysdiagrams" table must be ignored as it's internal SQL Server table for Database Diagrams
         $sql = <<<'SQL'
-SELECT name,
+SELECT name AS table_name,
        SCHEMA_NAME(schema_id) AS schema_name
 FROM sys.objects
 WHERE type = 'U'
@@ -402,7 +402,7 @@ SQL;
         $sql = 'SELECT';
 
         if ($tableName === null) {
-            $sql .= ' obj.name AS tablename,';
+            $sql .= ' obj.name AS table_name, scm.name AS schema_name,';
         }
 
         $sql .= <<<'SQL'
@@ -451,7 +451,7 @@ SQL;
         $sql = 'SELECT';
 
         if ($tableName === null) {
-            $sql .= ' tbl.name AS tablename,';
+            $sql .= ' tbl.name AS table_name, scm.name AS schema_name,';
         }
 
         $sql .= <<<'SQL'
@@ -495,7 +495,7 @@ SQL;
         $sql = 'SELECT';
 
         if ($tableName === null) {
-            $sql .= ' OBJECT_NAME (f.parent_object_id),';
+            $sql .= ' OBJECT_NAME (f.parent_object_id) AS table_name, SCHEMA_NAME(f.schema_id) AS schema_name,';
         }
 
         $sql .= <<<'SQL'

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -214,7 +214,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
      */
     protected function _getPortableTableDefinition($table)
     {
-        return $table['name'];
+        return $table['table_name'];
     }
 
     /**
@@ -678,7 +678,7 @@ SQL
     protected function selectTableNames(string $databaseName): Result
     {
         $sql = <<<'SQL'
-SELECT name
+SELECT name AS table_name
 FROM sqlite_master
 WHERE type = 'table'
   AND name != 'sqlite_sequence'

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -174,8 +174,11 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->schemaManager->createTable($nestedRelatedTable);
         $this->schemaManager->createTable($nestedSchemaTable);
 
-        $tables = $this->schemaManager->listTableNames();
-        self::assertContains('nested.schematable', $tables, 'The table should be detected with its non-public schema.');
+        $tableNames = $this->schemaManager->listTableNames();
+        self::assertContains('nested.schematable', $tableNames);
+
+        $tables = $this->schemaManager->listTables();
+        self::assertNotNull($this->findTableByName($tables, 'nested.schematable'));
 
         $nestedSchemaTable = $this->schemaManager->listTableDetails('nested.schematable');
         self::assertTrue($nestedSchemaTable->hasColumn('id'));

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1662,6 +1662,20 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertSame($localColumns, array_map('strtolower', $foreignKey->getLocalColumns()));
         self::assertSame($foreignColumns, array_map('strtolower', $foreignKey->getForeignColumns()));
     }
+
+    /**
+     * @param list<Table> $tables
+     */
+    protected function findTableByName(array $tables, string $name): ?Table
+    {
+        foreach ($tables as $table) {
+            if (strtolower($table->getName()) === $name) {
+                return $table;
+            }
+        }
+
+        return null;
+    }
 }
 
 interface ListTableColumnsDispatchEventListener


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

Table columns and other table components returned by `fetchTableColumnsByTable()` and other similar methods are currently grouped by the pure table name (the first column returned by `selectTableColumns()` or the corresponding method): https://github.com/doctrine/dbal/blob/6dea08effe93f9baccc19c862f190f4dda7d7edd/src/Schema/AbstractSchemaManager.php#L1711-L1713

It works in simple cases where the table name expressed in the DBAL syntax matches the actual name but it doesn't work in special cases like:

1. The table name is namespace (see #5573).
2. The table name needs to be quoted (see #5582).

The solution is, instead of using the first column as the key, to use the return value of `_getPortableTableDefinition()`. This requires the following changes:
1. Select the schema name in the queries performed by the `select*()` methods of the PostgreSQL and SQL Server schema managers since the DBAL treats schemas on PostgreSQL and SQL Server as namespaces for table names.
2. Change the aliases of the first column returned by the `select*()` methods to match the expectations of `_getPortableTableDefinition()` or, on the contrary, adjust the column name expected by `_getPortableTableDefinition()` since it would conflict with another column selected by some of the `select*()`  methods (see SQL Server for example). This should be acceptable since this is a protected API.

Fixes #5573.