### PR TITLE
Update documentation on schema comparison

### DIFF
--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -47,7 +47,8 @@ foreign key, sequence and index changes.
 .. code-block:: php
 
     <?php
-    $comparator = new \Doctrine\DBAL\Schema\Comparator();
+    $schemaManager = $connection->createSchemaManager();
+    $comparator = $schemaManager->createComparator();
     $schemaDiff = $comparator->compare($fromSchema, $toSchema);
 
     $queries = $schemaDiff->toSql($myPlatform); // queries to get from one to another schema.


### PR DESCRIPTION
The issue was reported in https://github.com/doctrine/dbal/issues/5369#issuecomment-1214165867. Direct instantiation of schema comparator was deprecated in https://github.com/doctrine/dbal/pull/4746.