### PR TITLE
Deprecate AbstractSchemaManager::listTableDetails()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,13 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 3.5
+
+## Deprecated `AbstractSchemaManager::listTableDetails()`.
+
+The `AbstractSchemaManager::listTableDetails()` methods has been deprecated.
+Use `AbstractSchemaManager::getTable()` instead.
+
 # Upgrade to 3.4
 
 ## Deprecated wrapper- and driver-level `Statement::bindParam()` methods.

--- a/docs/en/reference/schema-manager.rst
+++ b/docs/en/reference/schema-manager.rst
@@ -82,16 +82,16 @@ Now you can loop over the array inspecting each column object:
         echo $column->getName() . ': ' . $column->getType() . "\n";
     }
 
-listTableDetails()
+getTable()
 ----------------------------
 
 Retrieve a single ``Doctrine\DBAL\Schema\Table`` instance that
-encapsulates all the details of the given table:
+encapsulates the definition of the given table:
 
 .. code-block:: php
 
     <?php
-    $table = $sm->listTableDetails('user');
+    $table = $sm->getDetails('user');
 
 Now you can call methods on the table to manipulate the in memory
 schema for that table. For example we can add a new column:
@@ -232,4 +232,3 @@ table:
       0 => 'DROP TABLE user'
     )
     */
-

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -409,6 +409,11 @@
                 <referencedMethod name="Doctrine\DBAL\Driver\PDO\Statement::bindParam"/>
                 <referencedMethod name="Doctrine\DBAL\Driver\PDO\SQLSrv\Statement::bindParam"/>
                 <referencedMethod name="Doctrine\DBAL\Statement::bindParam"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractSchemaManager::listTableDetails"/>
+                <referencedMethod name="Doctrine\DBAL\Schema\SqliteSchemaManager::listTableDetails"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -392,7 +392,7 @@ abstract class AbstractSchemaManager
 
         $tables = [];
         foreach ($tableNames as $tableName) {
-            $tables[] = $this->listTableDetails($tableName);
+            $tables[] = $this->getTable($tableName);
         }
 
         return $tables;
@@ -434,6 +434,8 @@ abstract class AbstractSchemaManager
     }
 
     /**
+     * @deprecated Use {@see getTable()} instead.
+     *
      * @param string $name
      *
      * @return Table
@@ -442,6 +444,13 @@ abstract class AbstractSchemaManager
      */
     public function listTableDetails($name)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5595',
+            '%s is deprecated. Use getTable() instead.',
+            __METHOD__
+        );
+
         $columns     = $this->listTableColumns($name);
         $foreignKeys = [];
 
@@ -595,6 +604,22 @@ abstract class AbstractSchemaManager
     protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
         throw Exception::notSupported(__METHOD__);
+    }
+
+    /**
+     * Returns the table with the given name.
+     *
+     * @throws Exception
+     */
+    public function getTable(string $name): Table
+    {
+        $table = $this->listTableDetails($name);
+
+        if ($table->getColumns() === []) {
+            throw SchemaException::tableDoesNotExist($name);
+        }
+
+        return $table;
     }
 
     /**

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_change_key_case;
 use function implode;
@@ -44,9 +45,18 @@ class DB2SchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use {@see getTable()} instead.
      */
     public function listTableDetails($name)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5595',
+            '%s is deprecated. Use getTable() instead.',
+            __METHOD__
+        );
+
         return $this->doListTableDetails($name);
     }
 

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider\CachingCollationMeta
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider\ConnectionCollationMetadataProvider;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_change_key_case;
 use function array_shift;
@@ -69,9 +70,18 @@ class MySQLSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use {@see getTable()} instead.
      */
     public function listTableDetails($name)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5595',
+            '%s is deprecated. Use getTable() instead.',
+            __METHOD__
+        );
+
         return $this->doListTableDetails($name);
     }
 

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_change_key_case;
 use function array_values;
@@ -45,9 +46,18 @@ class OracleSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use {@see getTable()} instead.
      */
     public function listTableDetails($name)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5595',
+            '%s is deprecated. Use getTable() instead.',
+            __METHOD__
+        );
+
         return $this->doListTableDetails($name);
     }
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -58,9 +58,18 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use {@see getTable()} instead.
      */
     public function listTableDetails($name)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5595',
+            '%s is deprecated. Use getTable() instead.',
+            __METHOD__
+        );
+
         return $this->doListTableDetails($name);
     }
 

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -50,9 +50,18 @@ class SQLServerSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use {@see getTable()} instead.
      */
     public function listTableDetails($name)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5595',
+            '%s is deprecated. Use getTable() instead.',
+            __METHOD__
+        );
+
         return $this->doListTableDetails($name);
     }
 

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -59,9 +59,18 @@ class SqliteSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated Use {@see getTable()} instead.
      */
     public function listTableDetails($name)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5595',
+            '%s is deprecated. Use getTable() instead.',
+            __METHOD__
+        );
+
         return $this->doListTableDetails($name);
     }
 

--- a/tests/Functional/Platform/AlterColumnTest.php
+++ b/tests/Functional/Platform/AlterColumnTest.php
@@ -25,12 +25,12 @@ class AlterColumnTest extends FunctionalTestCase
 
         $sm         = $this->connection->createSchemaManager();
         $comparator = new Comparator();
-        $diff       = $comparator->diffTable($sm->listTableDetails('test_alter'), $table);
+        $diff       = $comparator->diffTable($sm->getTable('test_alter'), $table);
 
         self::assertNotFalse($diff);
         $sm->alterTable($diff);
 
-        $table = $sm->listTableDetails('test_alter');
+        $table = $sm->getTable('test_alter');
         self::assertSame(['c1', 'c2'], array_keys($table->getColumns()));
     }
 }

--- a/tests/Functional/Platform/PlatformRestrictionsTest.php
+++ b/tests/Functional/Platform/PlatformRestrictionsTest.php
@@ -26,7 +26,7 @@ class PlatformRestrictionsTest extends FunctionalTestCase
         $table->addColumn($columnName, 'integer', ['autoincrement' => true]);
         $table->setPrimaryKey([$columnName]);
         $this->dropAndCreateTable($table);
-        $createdTable = $this->connection->getSchemaManager()->listTableDetails($tableName);
+        $createdTable = $this->connection->getSchemaManager()->getTable($tableName);
 
         $this->assertTrue($createdTable->hasColumn($columnName));
         $this->assertTrue($createdTable->hasPrimaryKey());

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -27,12 +27,12 @@ class RenameColumnTest extends FunctionalTestCase
 
         $sm         =  $this->connection->createSchemaManager();
         $comparator = new Comparator();
-        $diff       = $comparator->diffTable($sm->listTableDetails('test_rename'), $table);
+        $diff       = $comparator->diffTable($sm->getTable('test_rename'), $table);
 
         self::assertNotFalse($diff);
         $sm->alterTable($diff);
 
-        $table = $sm->listTableDetails('test_rename');
+        $table = $sm->getTable('test_rename');
         self::assertSame([strtolower($newColumnName), 'c2'], array_keys($table->getColumns()));
     }
 

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -47,7 +47,7 @@ class ComparatorTest extends FunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $onlineTable = $this->schemaManager->listTableDetails('default_value');
+        $onlineTable = $this->schemaManager->getTable('default_value');
 
         self::assertFalse($comparatorFactory($this->schemaManager)->diffTable($table, $onlineTable));
     }

--- a/tests/Functional/Schema/ComparatorTestUtils.php
+++ b/tests/Functional/Schema/ComparatorTestUtils.php
@@ -23,7 +23,7 @@ final class ComparatorTestUtils
         Table $desiredTable
     ) {
         return $comparator->diffTable(
-            $schemaManager->listTableDetails($desiredTable->getName()),
+            $schemaManager->getTable($desiredTable->getName()),
             $desiredTable
         );
     }
@@ -40,7 +40,7 @@ final class ComparatorTestUtils
     ) {
         return $comparator->diffTable(
             $desiredTable,
-            $schemaManager->listTableDetails($desiredTable->getName())
+            $schemaManager->getTable($desiredTable->getName())
         );
     }
 

--- a/tests/Functional/Schema/DefaultValueTest.php
+++ b/tests/Functional/Schema/DefaultValueTest.php
@@ -39,7 +39,7 @@ class DefaultValueTest extends FunctionalTestCase
             $expectedDefault,
             $this->connection
                 ->getSchemaManager()
-                ->listTableDetails('default_value')
+                ->getTable('default_value')
                 ->getColumn($name)
                 ->getDefault()
         );

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -32,7 +32,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableOld->addColumn('bar_id', 'integer');
 
         $this->schemaManager->createTable($tableOld);
-        $tableFetched = $this->schemaManager->listTableDetails('switch_primary_key_columns');
+        $tableFetched = $this->schemaManager->getTable('switch_primary_key_columns');
         $tableNew     = clone $tableFetched;
         $tableNew->setPrimaryKey(['bar_id', 'foo_id']);
 
@@ -42,7 +42,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $table      = $this->schemaManager->listTableDetails('switch_primary_key_columns');
+        $table      = $this->schemaManager->getTable('switch_primary_key_columns');
         $primaryKey = $table->getPrimaryKeyColumns();
 
         self::assertCount(2, $primaryKey);
@@ -65,7 +65,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addIndex(['localized_value']); // this is much more selective than the unique index
 
         $this->schemaManager->createTable($table);
-        $tableFetched = $this->schemaManager->listTableDetails('diffbug_routing_translations');
+        $tableFetched = $this->schemaManager->getTable('diffbug_routing_translations');
 
         $diff = $this->schemaManager->createComparator()
             ->diffTable($tableFetched, $table);
@@ -144,7 +144,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $table = $this->schemaManager->listTableDetails('alter_table_add_pk');
+        $table = $this->schemaManager->getTable('alter_table_add_pk');
 
         self::assertFalse($table->hasIndex('idx_id'));
         self::assertTrue($table->hasPrimaryKey());
@@ -169,7 +169,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $table = $this->schemaManager->listTableDetails('drop_primary_key');
+        $table = $this->schemaManager->getTable('drop_primary_key');
 
         self::assertFalse($table->hasPrimaryKey());
         self::assertFalse($table->getColumn('id')->getAutoincrement());
@@ -191,7 +191,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $onlineTable = $this->schemaManager->listTableDetails('text_blob_default_value');
+        $onlineTable = $this->schemaManager->getTable('text_blob_default_value');
 
         self::assertNull($onlineTable->getColumn('def_text')->getDefault());
         self::assertNull($onlineTable->getColumn('def_text_null')->getDefault());
@@ -238,7 +238,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $table = $this->schemaManager->listTableDetails($tableName);
+        $table = $this->schemaManager->getTable($tableName);
 
         self::assertEquals('ascii', $table->getColumn('col_text')->getPlatformOption('charset'));
     }
@@ -349,7 +349,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($offlineTable);
 
-        $onlineTable = $this->schemaManager->listTableDetails('list_guid_table_column');
+        $onlineTable = $this->schemaManager->getTable('list_guid_table_column');
 
         self::assertFalse(
             $this->schemaManager->createComparator()->diffTable($onlineTable, $offlineTable),
@@ -417,7 +417,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $onlineTable = $this->schemaManager->listTableDetails('test_column_defaults_current_timestamp');
+        $onlineTable = $this->schemaManager->getTable('test_column_defaults_current_timestamp');
         self::assertSame($currentTimeStampSql, $onlineTable->getColumn('col_datetime')->getDefault());
         self::assertSame($currentTimeStampSql, $onlineTable->getColumn('col_datetime_nullable')->getDefault());
 
@@ -489,7 +489,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $onlineTable = $this->schemaManager->listTableDetails('test_column_defaults_current_time_and_date');
+        $onlineTable = $this->schemaManager->getTable('test_column_defaults_current_time_and_date');
 
         self::assertSame($currentTimestampSql, $onlineTable->getColumn('col_datetime')->getDefault());
         self::assertSame($currentDateSql, $onlineTable->getColumn('col_date')->getDefault());
@@ -516,7 +516,7 @@ PARTITION BY HASH (col1)
 SQL;
 
         $this->connection->executeStatement($sql);
-        $onlineTable = $this->schemaManager->listTableDetails('test_table_metadata');
+        $onlineTable = $this->schemaManager->getTable('test_table_metadata');
 
         self::assertEquals('InnoDB', $onlineTable->getOption('engine'));
         self::assertEquals('utf8mb4_general_ci', $onlineTable->getOption('collation'));
@@ -533,19 +533,12 @@ SQL;
         $this->connection->executeStatement('DROP TABLE IF EXISTS test_table_empty_metadata');
 
         $this->connection->executeStatement('CREATE TABLE test_table_empty_metadata(col1 INT NOT NULL)');
-        $onlineTable = $this->schemaManager->listTableDetails('test_table_empty_metadata');
+        $onlineTable = $this->schemaManager->getTable('test_table_empty_metadata');
 
         self::assertNotEmpty($onlineTable->getOption('engine'));
         // collation could be set to default or not set, information_schema indicate a possibly null value
         self::assertFalse($onlineTable->hasOption('autoincrement'));
         self::assertEquals('', $onlineTable->getOption('comment'));
         self::assertEquals([], $onlineTable->getOption('create_options'));
-    }
-
-    public function testParseNullCreateOptions(): void
-    {
-        $table = $this->schemaManager->listTableDetails('sys.processlist');
-
-        self::assertEquals([], $table->getOption('create_options'));
     }
 }

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -121,8 +121,8 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->schemaManager->createTable($offlinePrimaryTable);
         $this->schemaManager->createTable($offlineForeignTable);
 
-        $onlinePrimaryTable = $this->schemaManager->listTableDetails($primaryTableName);
-        $onlineForeignTable = $this->schemaManager->listTableDetails($foreignTableName);
+        $onlinePrimaryTable = $this->schemaManager->getTable($primaryTableName);
+        $onlineForeignTable = $this->schemaManager->getTable($foreignTableName);
 
         $platform = $this->connection->getDatabasePlatform();
 

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -65,13 +65,13 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $createTableSQL = 'CREATE TABLE domain_type_test (id INT PRIMARY KEY, value MyMoney)';
         $this->connection->executeStatement($createTableSQL);
 
-        $table = $this->connection->getSchemaManager()->listTableDetails('domain_type_test');
+        $table = $this->connection->getSchemaManager()->getTable('domain_type_test');
         self::assertInstanceOf(DecimalType::class, $table->getColumn('value')->getType());
 
         Type::addType('MyMoney', MoneyType::class);
         $this->connection->getDatabasePlatform()->registerDoctrineTypeMapping('MyMoney', 'MyMoney');
 
-        $table = $this->connection->getSchemaManager()->listTableDetails('domain_type_test');
+        $table = $this->connection->getSchemaManager()->getTable('domain_type_test');
         self::assertInstanceOf(MoneyType::class, $table->getColumn('value')->getType());
     }
 
@@ -81,7 +81,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $column       = $autoincTable->addColumn('id', 'integer');
         $column->setAutoincrement(true);
         $this->dropAndCreateTable($autoincTable);
-        $autoincTable = $this->schemaManager->listTableDetails('autoinc_table');
+        $autoincTable = $this->schemaManager->getTable('autoinc_table');
 
         self::assertTrue($autoincTable->getColumn('id')->getAutoincrement());
     }
@@ -102,7 +102,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableFrom = new Table('autoinc_table_add');
         $tableFrom->addColumn('id', 'integer');
         $this->dropAndCreateTable($tableFrom);
-        $tableFrom = $this->schemaManager->listTableDetails('autoinc_table_add');
+        $tableFrom = $this->schemaManager->getTable('autoinc_table_add');
         self::assertFalse($tableFrom->getColumn('id')->getAutoincrement());
 
         $tableTo = new Table('autoinc_table_add');
@@ -121,7 +121,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         ], $sql);
 
         $this->schemaManager->alterTable($diff);
-        $tableFinal = $this->schemaManager->listTableDetails('autoinc_table_add');
+        $tableFinal = $this->schemaManager->getTable('autoinc_table_add');
         self::assertTrue($tableFinal->getColumn('id')->getAutoincrement());
     }
 
@@ -136,7 +136,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $column    = $tableFrom->addColumn('id', 'integer');
         $column->setAutoincrement(true);
         $this->dropAndCreateTable($tableFrom);
-        $tableFrom = $this->schemaManager->listTableDetails('autoinc_table_drop');
+        $tableFrom = $this->schemaManager->getTable('autoinc_table_drop');
         self::assertTrue($tableFrom->getColumn('id')->getAutoincrement());
 
         $tableTo = new Table('autoinc_table_drop');
@@ -152,7 +152,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         );
 
         $this->schemaManager->alterTable($diff);
-        $tableFinal = $this->schemaManager->listTableDetails('autoinc_table_drop');
+        $tableFinal = $this->schemaManager->getTable('autoinc_table_drop');
         self::assertFalse($tableFinal->getColumn('id')->getAutoincrement());
     }
 
@@ -180,7 +180,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tables = $this->schemaManager->listTables();
         self::assertNotNull($this->findTableByName($tables, 'nested.schematable'));
 
-        $nestedSchemaTable = $this->schemaManager->listTableDetails('nested.schematable');
+        $nestedSchemaTable = $this->schemaManager->getTable('nested.schematable');
         self::assertTrue($nestedSchemaTable->hasColumn('id'));
 
         $primaryKey = $nestedSchemaTable->getPrimaryKey();
@@ -206,7 +206,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
             . ' FOREIGN KEY( "table" ) REFERENCES dbal91_something ON UPDATE CASCADE;';
         $this->connection->executeStatement($sql);
 
-        $table = $this->schemaManager->listTableDetails('dbal91_something');
+        $table = $this->schemaManager->getTable('dbal91_something');
 
         self::assertEquals(
             [
@@ -263,7 +263,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $testTable->setPrimaryKey(['id']);
         $this->dropAndCreateTable($testTable);
 
-        $databaseTable = $this->schemaManager->listTableDetails($testTable->getName());
+        $databaseTable = $this->schemaManager->getTable($testTable->getName());
 
         self::assertEquals('foo', $databaseTable->getColumn('def')->getDefault());
     }
@@ -281,7 +281,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $databaseTable = $this->schemaManager->listTableDetails($table->getName());
+        $databaseTable = $this->schemaManager->getTable($table->getName());
 
         $diff = $comparatorFactory($this->schemaManager)->diffTable($table, $databaseTable);
 
@@ -349,7 +349,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($offlineTable);
 
-        $onlineTable = $this->schemaManager->listTableDetails('person');
+        $onlineTable = $this->schemaManager->getTable('person');
 
         $comparator = new Comparator();
 
@@ -485,7 +485,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $column    = $tableFrom->addColumn('id', $from);
         $column->setAutoincrement(true);
         $this->dropAndCreateTable($tableFrom);
-        $tableFrom = $this->schemaManager->listTableDetails('autoinc_type_modification');
+        $tableFrom = $this->schemaManager->getTable('autoinc_type_modification');
         self::assertTrue($tableFrom->getColumn('id')->getAutoincrement());
 
         $tableTo = new Table('autoinc_type_modification');
@@ -500,7 +500,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         );
 
         $this->schemaManager->alterTable($diff);
-        $tableFinal = $this->schemaManager->listTableDetails('autoinc_type_modification');
+        $tableFinal = $this->schemaManager->getTable('autoinc_type_modification');
         self::assertTrue($tableFinal->getColumn('id')->getAutoincrement());
     }
 

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -189,7 +189,7 @@ SQL;
         $sm = $this->connection->getSchemaManager();
         $sm->createTable($table);
 
-        self::assertNull($sm->listTableDetails('own_column_comment')
+        self::assertNull($sm->getTable('own_column_comment')
             ->getColumn('col1')
             ->getComment());
     }
@@ -212,7 +212,7 @@ SQL;
 
         $schemaManager = $this->connection->createSchemaManager();
 
-        $table1 = $schemaManager->listTableDetails('nodes');
+        $table1 = $schemaManager->getTable('nodes');
         $table2 = clone $table1;
         $table2->addIndex(['name'], 'idx_name');
 
@@ -222,7 +222,7 @@ SQL;
 
         $schemaManager->alterTable($diff);
 
-        $table = $schemaManager->listTableDetails('nodes');
+        $table = $schemaManager->getTable('nodes');
         $index = $table->getIndex('idx_name');
         self::assertSame(['name'], $index->getColumns());
     }
@@ -258,7 +258,7 @@ SQL;
 
         $schemaManager = $this->connection->createSchemaManager();
 
-        $song        = $schemaManager->listTableDetails('song');
+        $song        = $schemaManager->getTable('song');
         $foreignKeys = $song->getForeignKeys();
         self::assertCount(2, $foreignKeys);
 

--- a/tests/Functional/Ticket/DBAL168Test.php
+++ b/tests/Functional/Ticket/DBAL168Test.php
@@ -21,7 +21,7 @@ class DBAL168Test extends FunctionalTestCase
         $table->addForeignKeyConstraint('domains', ['parent_id'], ['id']);
 
         $this->connection->getSchemaManager()->createTable($table);
-        $table = $this->connection->getSchemaManager()->listTableDetails('domains');
+        $table = $this->connection->getSchemaManager()->getTable('domains');
 
         self::assertEquals('domains', $table->getName());
     }

--- a/tests/Functional/Ticket/DBAL510Test.php
+++ b/tests/Functional/Ticket/DBAL510Test.php
@@ -33,7 +33,7 @@ class DBAL510Test extends FunctionalTestCase
         $this->dropAndCreateTable($table);
 
         $schemaManager = $this->connection->createSchemaManager();
-        $onlineTable   = $schemaManager->listTableDetails('dbal510tbl');
+        $onlineTable   = $schemaManager->getTable('dbal510tbl');
 
         $comparator = $comparatorFactory($schemaManager);
         $diff       = $comparator->diffTable($onlineTable, $table);

--- a/tests/Functional/Ticket/DBAL752Test.php
+++ b/tests/Functional/Ticket/DBAL752Test.php
@@ -34,7 +34,7 @@ SQL
 
         $schemaManager = $this->connection->getSchemaManager();
 
-        $fetchedTable = $schemaManager->listTableDetails('dbal752_unsigneds');
+        $fetchedTable = $schemaManager->getTable('dbal752_unsigneds');
 
         self::assertEquals('smallint', $fetchedTable->getColumn('small')->getType()->getName());
         self::assertEquals('smallint', $fetchedTable->getColumn('small_unsigned')->getType()->getName());


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The `AbstractSchemaManager::listTableDetails()` method has the following issues:
1. The "list" in the name implies that it returns a list (e.g. similar to `listViews()`) but it returns a single object.
2. If the method is invoked with a name of a non-existing table, it still returns a `Table` instance as if this table did exist.
3. The "details" part of the name doesn't refer to any existing entity in the DBAL API, it doesn’t convey any meaning.