### PR TITLE
Filter 'public' schema from listSchemaNames

### DIFF
--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -120,6 +120,7 @@ SELECT schema_name
 FROM   information_schema.schemata
 WHERE  schema_name NOT LIKE 'pg\_%'
 AND    schema_name != 'information_schema'
+AND    schema_name != 'public'
 SQL
         );
     }

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -50,11 +50,14 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testGetSchemaNames(): void
     {
+        $createSchemaSQL = 'CREATE SCHEMA schema_retrieval_test';
+        $this->connection->executeStatement($createSchemaSQL);
+
         assert($this->schemaManager instanceof PostgreSQLSchemaManager);
 
         $names = $this->schemaManager->getSchemaNames();
 
-        self::assertContains('public', $names, 'The public schema should be found.');
+        self::assertContains('schema_retrieval_test', $names, 'The schema_retrieval_test schema should be found.');
     }
 
     public function testSupportDomainTypeFallback(): void


### PR DESCRIPTION


Fixes #5596

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #5596

#### Summary
Filter 'public' schema from listSchemaNames

As postgresql expects public to be existing as it is the default schema
https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-CATALOG
Application code is not supposed to play with, the same way as we don't
return other system-related schemas
