### PR TITLE
Fix DropSchemaObjectsSQLBuilder issues

### DIFF
--- a/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
@@ -27,8 +27,8 @@ final class DropSchemaObjectsSQLBuilder
     public function buildSQL(Schema $schema): array
     {
         return array_merge(
-            $this->buildTableStatements($schema->getTables()),
             $this->buildSequenceStatements($schema->getSequences()),
+            $this->buildTableStatements($schema->getTables()),
         );
     }
 

--- a/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
@@ -29,7 +29,6 @@ final class DropSchemaObjectsSQLBuilder
         return array_merge(
             $this->buildTableStatements($schema->getTables()),
             $this->buildSequenceStatements($schema->getSequences()),
-            $this->buildNamespaceStatements($schema->getNamespaces()),
         );
     }
 
@@ -56,26 +55,6 @@ final class DropSchemaObjectsSQLBuilder
 
         foreach ($sequences as $sequence) {
             $statements[] = $this->platform->getDropSequenceSQL($sequence);
-        }
-
-        return $statements;
-    }
-
-    /**
-     * @param list<string> $namespaces
-     *
-     * @return list<string>
-     *
-     * @throws Exception
-     */
-    private function buildNamespaceStatements(array $namespaces): array
-    {
-        $statements = [];
-
-        if ($this->platform->supportsSchemas()) {
-            foreach ($namespaces as $namespace) {
-                $statements[] = $this->platform->getDropSchemaSQL($namespace);
-            }
         }
 
         return $statements;

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
+use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\View;
@@ -302,6 +303,40 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     protected function assertVarBinaryColumnIsValid(Table $table, string $columnName, int $expectedLength): void
     {
         self::assertInstanceOf(BlobType::class, $table->getColumn($columnName)->getType());
+    }
+
+    /**
+     * Although this test would pass in isolation on any platform, we keep it here for the following reasons:
+     *
+     * 1. The DBAL currently doesn't properly drop tables in the namespaces that need to be quoted
+     *    (@see testListTableDetailsWhenCurrentSchemaNameQuoted()).
+     * 2. The schema returned by {@see AbstractSchemaManager::createSchema()} doesn't contain views, so
+     *    {@see AbstractSchemaManager::dropSchemaObjects()} cannot drop the tables that have dependent views
+     *    (@see testListTablesExcludesViews()).
+     * 3. In the case of inheritance, PHPUnit runs the tests declared immediately in the test class
+     *    and then runs the tests declared in the parent.
+     *
+     * This test needs to be executed before the ones it conflicts with, so it has to be declared in the same class.
+     */
+    public function testDropWithAutoincrement(): void
+    {
+        $this->dropTableIfExists('test_autoincrement');
+
+        $schema = new Schema();
+        $table  = $schema->createTable('test_autoincrement');
+        $table->addColumn('id', 'integer', [
+            'notnull' => true,
+            'autoincrement' => true,
+        ]);
+        $table->setPrimaryKey(['id']);
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createSchemaObjects($schema);
+
+        $schema = $schemaManager->createSchema();
+        $schemaManager->dropSchemaObjects($schema);
+
+        self::assertFalse($schemaManager->tablesExist(['test_autoincrement']));
     }
 
     public function testListTableDetailsWhenCurrentSchemaNameQuoted(): void


### PR DESCRIPTION
1. Although `CreateSchemaSqlCollector` creates the namespaces declared in the schema, `DropSchemaObjectsSQLBuilder` does not drop them. We will keep it the same in `DropSchemaObjectsSQLBuilder` for backward compatibility.
2. When dropping a schema, the DBAL explicitly drops all schema sequences, even if they are owned by one of the tables being dropped. As a workaround for the regression, we will drop sequences first, which is how it is implemented in `DropSchemaSqlCollector`.

The newly added `testDropWithAutoincrement()` is intended to test the second issue but covers the first one as well. It would fail without the corresponding fix if run as part of the test suite.

Fixes #5598.
Closes #5600.