### PR TITLE
Remove AbstractSchemaManager::listTableDetails()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -89,9 +89,9 @@ The following classes and constants have been removed:
 
 The `Driver::getSchemaManager()` method has been removed.
 
-## BC BREAK: removed `AbstractSchemaManager::getDatabasePlatform()`
+## BC BREAK: removed `AbstractSchemaManager` methods
 
-The `AbstractSchemaManager::getDatabasePlatform()` method has been removed.
+The `AbstractSchemaManager::getDatabasePlatform()` and `::listTableDetails()` methods have been removed.
 
 ## BC BREAK: removed Schema Visitor API.
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -39,10 +39,6 @@
                     See https://github.com/doctrine/dbal/pull/4317
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\AbstractSchemaManager::listTableDetails"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -42,16 +42,6 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
-                <referencedMethod name="Doctrine\DBAL\Driver\Statement::bindParam"/>
-                <referencedMethod name="Doctrine\DBAL\Driver\IBMDB2\Statement::bindParam"/>
-                <referencedMethod name="Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware::bindParam"/>
-                <referencedMethod name="Doctrine\DBAL\Driver\OCI8\Statement::bindParam"/>
-                <referencedMethod name="Doctrine\DBAL\Driver\PDO\Statement::bindParam"/>
-                <referencedMethod name="Doctrine\DBAL\Driver\PDO\SQLSrv\Statement::bindParam"/>
-                <referencedMethod name="Doctrine\DBAL\Statement::bindParam"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractSchemaManager::listTableDetails"/>
             </errorLevel>
         </DeprecatedMethod>

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -59,14 +59,14 @@ class SQLiteSchemaManager extends AbstractSchemaManager
     public function renameTable(string $name, string $newName): void
     {
         $tableDiff            = new TableDiff($name);
-        $tableDiff->fromTable = $this->listTableDetails($name);
+        $tableDiff->fromTable = $this->getTable($name);
         $tableDiff->newName   = $newName;
         $this->alterTable($tableDiff);
     }
 
     public function createForeignKey(ForeignKeyConstraint $foreignKey, string $table): void
     {
-        $table = $this->ensureTable($table);
+        $table = $this->getTable($table);
 
         $tableDiff = $this->getTableDiffForAlterForeignKey($table);
 
@@ -77,7 +77,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
 
     public function dropForeignKey(string $name, string $table): void
     {
-        $table = $this->ensureTable($table);
+        $table = $this->getTable($table);
 
         $tableDiff                       = $this->getTableDiffForAlterForeignKey($table);
         $tableDiff->removedForeignKeys[] = $table->getForeignKey($name);
@@ -366,15 +366,6 @@ class SQLiteSchemaManager extends AbstractSchemaManager
         $tableDiff->fromTable = $table;
 
         return $tableDiff;
-    }
-
-    private function ensureTable(string|Table $table): Table
-    {
-        if (is_string($table)) {
-            $table = $this->listTableDetails($table);
-        }
-
-        return $table;
     }
 
     private function parseColumnCollationFromSQL(string $column, string $sql): ?string

--- a/tests/Functional/Schema/ColumnCommentTest.php
+++ b/tests/Functional/Schema/ColumnCommentTest.php
@@ -124,7 +124,7 @@ class ColumnCommentTest extends FunctionalTestCase
         self::assertSame(
             $expectedComment,
             $this->connection->createSchemaManager()
-                ->listTableDetails($table)
+                ->getTable($table)
                 ->getColumn($column)
                 ->getComment()
         );

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -242,7 +242,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         self::assertEquals(
             'ascii',
-            $this->schemaManager->listTableDetails('test_column_charset_change')
+            $this->schemaManager->getTable('test_column_charset_change')
                 ->getColumn('col_string')
                 ->getPlatformOption('charset')
         );


### PR DESCRIPTION
The method being removed was deprecated in https://github.com/doctrine/dbal/pull/5595.