### PR TITLE
Update JetBrains PhpStorm stubs to 2022.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,7 +48,7 @@ jobs:
           - os: "ubuntu-20.04"
             php-version: "7.4"
             dependencies: "lowest"
-          - os: "ubuntu-18.04"
+          - os: "ubuntu-20.04"
             php-version: "8.1"
             dependencies: "highest"
 
@@ -495,7 +495,7 @@ jobs:
 
   phpunit-ibm-db2:
     name: "PHPUnit with IBM DB2"
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-20.04"
     needs: "phpunit-smoke-check"
 
     strategy:

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "9.0.0",
-        "jetbrains/phpstorm-stubs": "2022.1",
+        "jetbrains/phpstorm-stubs": "2022.2",
         "phpstan/phpstan": "1.8.2",
         "phpstan/phpstan-strict-rules": "^1.3",
         "phpunit/phpunit": "9.5.21",


### PR DESCRIPTION
There don't seem to be any suppressed static analysis issues that this update would address.

Additionally, an update of Ubuntu images on CI is required to keep the builds passing. See https://github.com/actions/runner-images/issues/6002.