### PR TITLE
Replace Ubuntu 20.04 with 22.04 on CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - "ubuntu-20.04"
+          - "ubuntu-22.04"
         php-version:
           - "7.4"
           - "8.0"
@@ -48,7 +48,7 @@ jobs:
           - os: "ubuntu-20.04"
             php-version: "7.4"
             dependencies: "lowest"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             php-version: "8.1"
             dependencies: "highest"
 
@@ -86,7 +86,7 @@ jobs:
 
   phpunit-oci8:
     name: "PHPUnit on OCI8"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -144,7 +144,7 @@ jobs:
 
   phpunit-pdo-oci:
     name: "PHPUnit on PDO_OCI"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -202,7 +202,7 @@ jobs:
 
   phpunit-postgres:
     name: "PHPUnit with PostgreSQL"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -260,7 +260,7 @@ jobs:
 
   phpunit-mariadb:
     name: "PHPUnit with MariaDB"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -338,7 +338,7 @@ jobs:
 
   phpunit-mysql:
     name: "PHPUnit with MySQL"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -495,7 +495,7 @@ jobs:
 
   phpunit-ibm-db2:
     name: "PHPUnit with IBM DB2"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -552,7 +552,7 @@ jobs:
 
   development-deps:
     name: "PHPUnit with SQLite and development dependencies"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     strategy:
       matrix:
@@ -581,7 +581,7 @@ jobs:
 
   upload_coverage:
     name: "Upload coverage to Codecov"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs:
       - "phpunit-smoke-check"
       - "phpunit-oci8"

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   static-analysis-phpstan:
     name: "Static Analysis with PHPStan"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     strategy:
       matrix:
@@ -55,7 +55,7 @@ jobs:
 
   static-analysis-psalm:
     name: "Static Analysis with Psalm"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     strategy:
       matrix:


### PR DESCRIPTION
Update all builds except for:
1. The one that prefers the lowest versions of dependencies.
2. SQL Server builds which would [fail](https://github.com/doctrine/dbal/runs/7954920083?check_suite_focus=true#step:6:77) with the following:
   > SQLSTATE[IMSSP]: This extension requires the Microsoft ODBC Driver for SQL Server to communicate with SQL Server. Access the following URL to download the ODBC Driver for SQL Server for x64: https://go.microsoft.com/fwlink/?LinkId=163712
   
   At a glance, `shivammathur/setup-php@v2` should [install](https://github.com/shivammathur/setup-php/blob/2.21.2/src/scripts/extensions/sqlsrv.sh#L12) it as a dependency for the corresponding PHP extensions.