### PR TITLE
Deprecate AbstractSchemaManager::createSchema() in favor of introspectSchema()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,7 +15,7 @@ The `AbstractSchemaManager::_execSql()` method has been marked as internal. It w
 ## Deprecated `AbstractSchemaManager::listTableDetails()`.
 
 The `AbstractSchemaManager::listTableDetails()` methods has been deprecated.
-Use `AbstractSchemaManager::getTable()` instead.
+Use `AbstractSchemaManager::introspectTable()` instead.
 
 # Upgrade to 3.4
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,10 +12,12 @@ awareness about deprecated code.
 
 The `AbstractSchemaManager::_execSql()` method has been marked as internal. It will not be available in 4.0.
 
-## Deprecated `AbstractSchemaManager::listTableDetails()`.
+## Deprecated `AbstractSchemaManager` schema introspection methods.
 
-The `AbstractSchemaManager::listTableDetails()` methods has been deprecated.
-Use `AbstractSchemaManager::introspectTable()` instead.
+The following `AbstractSchemaManager` methods has been deprecated:
+
+1. `listTableDetails()`. Use `introspectTable()` instead,
+2. `createSchema()`. Use `introspectSchema()` instead.
 
 # Upgrade to 3.4
 

--- a/docs/en/reference/schema-manager.rst
+++ b/docs/en/reference/schema-manager.rst
@@ -188,18 +188,18 @@ Now you can loop over the array inspecting each view object:
         echo $view->getName() . ': ' . $view->getSql() . "\n";
     }
 
-createSchema()
---------------
+introspectSchema()
+------------------
 
 For a complete representation of the current database you can use
-the ``createSchema()`` method which returns an instance of
+the ``introspectSchema()`` method which returns an instance of
 ``Doctrine\DBAL\Schema\Schema``, which you can use in conjunction
 with the SchemaTool or Schema Comparator.
 
 .. code-block:: php
 
     <?php
-    $fromSchema = $sm->createSchema();
+    $fromSchema = $sm->introspectSchema();
 
 Now we can clone the ``$fromSchema`` to ``$toSchema`` and drop a
 table:

--- a/docs/en/reference/schema-manager.rst
+++ b/docs/en/reference/schema-manager.rst
@@ -82,8 +82,8 @@ Now you can loop over the array inspecting each column object:
         echo $column->getName() . ': ' . $column->getType() . "\n";
     }
 
-getTable()
-----------------------------
+introspectTable()
+-----------------
 
 Retrieve a single ``Doctrine\DBAL\Schema\Table`` instance that
 encapsulates the definition of the given table:
@@ -91,7 +91,7 @@ encapsulates the definition of the given table:
 .. code-block:: php
 
     <?php
-    $table = $sm->getDetails('user');
+    $table = $sm->introspectTable('user');
 
 Now you can call methods on the table to manipulate the in memory
 schema for that table. For example we can add a new column:

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3974,7 +3974,7 @@ abstract class AbstractPlatform
      * @deprecated
      *
      * Platforms that either support or emulate schemas don't automatically
-     * filter a schema for the namespaced elements in {@see AbstractManager::createSchema()}.
+     * filter a schema for the namespaced elements in {@see AbstractManager::introspectSchema()}.
      *
      * @return bool
      */

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -392,7 +392,7 @@ abstract class AbstractSchemaManager
 
         $tables = [];
         foreach ($tableNames as $tableName) {
-            $tables[] = $this->getTable($tableName);
+            $tables[] = $this->introspectTable($tableName);
         }
 
         return $tables;
@@ -434,7 +434,7 @@ abstract class AbstractSchemaManager
     }
 
     /**
-     * @deprecated Use {@see getTable()} instead.
+     * @deprecated Use {@see introspectTable()} instead.
      *
      * @param string $name
      *
@@ -447,7 +447,7 @@ abstract class AbstractSchemaManager
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5595',
-            '%s is deprecated. Use getTable() instead.',
+            '%s is deprecated. Use introspectTable() instead.',
             __METHOD__
         );
 
@@ -607,11 +607,11 @@ abstract class AbstractSchemaManager
     }
 
     /**
-     * Returns the table with the given name.
+     * Introspects the table with the given name.
      *
      * @throws Exception
      */
-    public function getTable(string $name): Table
+    public function introspectTable(string $name): Table
     {
         $table = $this->listTableDetails($name);
 

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -1232,7 +1232,7 @@ abstract class AbstractSchemaManager
     public function migrateSchema(Schema $toSchema): void
     {
         $schemaDiff = $this->createComparator()
-            ->compareSchemas($this->createSchema(), $toSchema);
+            ->compareSchemas($this->introspectSchema(), $toSchema);
 
         $this->alterSchema($schemaDiff);
     }
@@ -1617,12 +1617,21 @@ abstract class AbstractSchemaManager
     /**
      * Creates a schema instance for the current database.
      *
+     * @deprecated Use {@link introspectSchema()} instead.
+     *
      * @return Schema
      *
      * @throws Exception
      */
     public function createSchema()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5613',
+            '%s is deprecated. Use introspectSchema() instead.',
+            __METHOD__
+        );
+
         $schemaNames = [];
 
         if ($this->_platform->supportsSchemas()) {
@@ -1638,6 +1647,16 @@ abstract class AbstractSchemaManager
         $tables = $this->listTables();
 
         return new Schema($tables, $sequences, $this->createSchemaConfig(), $schemaNames);
+    }
+
+    /**
+     * Returns a {@see Schema} instance representing the current database schema.
+     *
+     * @throws Exception
+     */
+    public function introspectSchema(): Schema
+    {
+        return $this->createSchema();
     }
 
     /**

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -46,14 +46,14 @@ class DB2SchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      *
-     * @deprecated Use {@see getTable()} instead.
+     * @deprecated Use {@see introspectTable()} instead.
      */
     public function listTableDetails($name)
     {
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5595',
-            '%s is deprecated. Use getTable() instead.',
+            '%s is deprecated. Use introspectTable() instead.',
             __METHOD__
         );
 

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -71,14 +71,14 @@ class MySQLSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      *
-     * @deprecated Use {@see getTable()} instead.
+     * @deprecated Use {@see introspectTable()} instead.
      */
     public function listTableDetails($name)
     {
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5595',
-            '%s is deprecated. Use getTable() instead.',
+            '%s is deprecated. Use introspectTable() instead.',
             __METHOD__
         );
 

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -47,14 +47,14 @@ class OracleSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      *
-     * @deprecated Use {@see getTable()} instead.
+     * @deprecated Use {@see introspectTable()} instead.
      */
     public function listTableDetails($name)
     {
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5595',
-            '%s is deprecated. Use getTable() instead.',
+            '%s is deprecated. Use introspectTable() instead.',
             __METHOD__
         );
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -59,14 +59,14 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      *
-     * @deprecated Use {@see getTable()} instead.
+     * @deprecated Use {@see introspectTable()} instead.
      */
     public function listTableDetails($name)
     {
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5595',
-            '%s is deprecated. Use getTable() instead.',
+            '%s is deprecated. Use introspectTable() instead.',
             __METHOD__
         );
 

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -51,14 +51,14 @@ class SQLServerSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      *
-     * @deprecated Use {@see getTable()} instead.
+     * @deprecated Use {@see introspectTable()} instead.
      */
     public function listTableDetails($name)
     {
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5595',
-            '%s is deprecated. Use getTable() instead.',
+            '%s is deprecated. Use introspectTable() instead.',
             __METHOD__
         );
 

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -60,14 +60,14 @@ class SqliteSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      *
-     * @deprecated Use {@see getTable()} instead.
+     * @deprecated Use {@see introspectTable()} instead.
      */
     public function listTableDetails($name)
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5595',
-            '%s is deprecated. Use getTable() instead.',
+            '%s is deprecated. Use introspectTable() instead.',
             __METHOD__
         );
 

--- a/src/Tools/Console/Command/ReservedWordsCommand.php
+++ b/src/Tools/Console/Command/ReservedWordsCommand.php
@@ -184,7 +184,7 @@ EOT
             true
         );
 
-        $schema  = $conn->getSchemaManager()->createSchema();
+        $schema  = $conn->getSchemaManager()->introspectSchema();
         $visitor = new ReservedKeywordsValidator($keywords);
         $schema->visit($visitor);
 

--- a/tests/Functional/Platform/AlterColumnTest.php
+++ b/tests/Functional/Platform/AlterColumnTest.php
@@ -25,12 +25,12 @@ class AlterColumnTest extends FunctionalTestCase
 
         $sm         = $this->connection->createSchemaManager();
         $comparator = new Comparator();
-        $diff       = $comparator->diffTable($sm->getTable('test_alter'), $table);
+        $diff       = $comparator->diffTable($sm->introspectTable('test_alter'), $table);
 
         self::assertNotFalse($diff);
         $sm->alterTable($diff);
 
-        $table = $sm->getTable('test_alter');
+        $table = $sm->introspectTable('test_alter');
         self::assertSame(['c1', 'c2'], array_keys($table->getColumns()));
     }
 }

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -36,7 +36,7 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
         $this->dropTableIfExists('dbal2807');
 
         $schemaManager = $this->connection->getSchemaManager();
-        $schema        = $schemaManager->createSchema();
+        $schema        = $schemaManager->introspectSchema();
 
         $table = $schema->createTable('dbal2807');
         $table->addColumn('initial_id', 'integer');
@@ -55,7 +55,7 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
 
         $schemaManager->alterSchema($diff);
 
-        $validationSchema = $schemaManager->createSchema();
+        $validationSchema = $schemaManager->introspectSchema();
         $validationTable  = $validationSchema->getTable($table->getName());
 
         self::assertTrue($validationTable->hasColumn('new_id'));

--- a/tests/Functional/Platform/PlatformRestrictionsTest.php
+++ b/tests/Functional/Platform/PlatformRestrictionsTest.php
@@ -26,7 +26,7 @@ class PlatformRestrictionsTest extends FunctionalTestCase
         $table->addColumn($columnName, 'integer', ['autoincrement' => true]);
         $table->setPrimaryKey([$columnName]);
         $this->dropAndCreateTable($table);
-        $createdTable = $this->connection->getSchemaManager()->getTable($tableName);
+        $createdTable = $this->connection->getSchemaManager()->introspectTable($tableName);
 
         $this->assertTrue($createdTable->hasColumn($columnName));
         $this->assertTrue($createdTable->hasPrimaryKey());

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -27,12 +27,12 @@ class RenameColumnTest extends FunctionalTestCase
 
         $sm         =  $this->connection->createSchemaManager();
         $comparator = new Comparator();
-        $diff       = $comparator->diffTable($sm->getTable('test_rename'), $table);
+        $diff       = $comparator->diffTable($sm->introspectTable('test_rename'), $table);
 
         self::assertNotFalse($diff);
         $sm->alterTable($diff);
 
-        $table = $sm->getTable('test_rename');
+        $table = $sm->introspectTable('test_rename');
         self::assertSame([strtolower($newColumnName), 'c2'], array_keys($table->getColumns()));
     }
 

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -47,7 +47,7 @@ class ComparatorTest extends FunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $onlineTable = $this->schemaManager->getTable('default_value');
+        $onlineTable = $this->schemaManager->introspectTable('default_value');
 
         self::assertFalse($comparatorFactory($this->schemaManager)->diffTable($table, $onlineTable));
     }

--- a/tests/Functional/Schema/ComparatorTestUtils.php
+++ b/tests/Functional/Schema/ComparatorTestUtils.php
@@ -23,7 +23,7 @@ final class ComparatorTestUtils
         Table $desiredTable
     ) {
         return $comparator->diffTable(
-            $schemaManager->getTable($desiredTable->getName()),
+            $schemaManager->introspectTable($desiredTable->getName()),
             $desiredTable
         );
     }
@@ -40,7 +40,7 @@ final class ComparatorTestUtils
     ) {
         return $comparator->diffTable(
             $desiredTable,
-            $schemaManager->getTable($desiredTable->getName())
+            $schemaManager->introspectTable($desiredTable->getName())
         );
     }
 

--- a/tests/Functional/Schema/DefaultValueTest.php
+++ b/tests/Functional/Schema/DefaultValueTest.php
@@ -39,7 +39,7 @@ class DefaultValueTest extends FunctionalTestCase
             $expectedDefault,
             $this->connection
                 ->getSchemaManager()
-                ->getTable('default_value')
+                ->introspectTable('default_value')
                 ->getColumn($name)
                 ->getDefault()
         );

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -32,7 +32,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableOld->addColumn('bar_id', 'integer');
 
         $this->schemaManager->createTable($tableOld);
-        $tableFetched = $this->schemaManager->getTable('switch_primary_key_columns');
+        $tableFetched = $this->schemaManager->introspectTable('switch_primary_key_columns');
         $tableNew     = clone $tableFetched;
         $tableNew->setPrimaryKey(['bar_id', 'foo_id']);
 
@@ -42,7 +42,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $table      = $this->schemaManager->getTable('switch_primary_key_columns');
+        $table      = $this->schemaManager->introspectTable('switch_primary_key_columns');
         $primaryKey = $table->getPrimaryKeyColumns();
 
         self::assertCount(2, $primaryKey);
@@ -65,7 +65,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addIndex(['localized_value']); // this is much more selective than the unique index
 
         $this->schemaManager->createTable($table);
-        $tableFetched = $this->schemaManager->getTable('diffbug_routing_translations');
+        $tableFetched = $this->schemaManager->introspectTable('diffbug_routing_translations');
 
         $diff = $this->schemaManager->createComparator()
             ->diffTable($tableFetched, $table);
@@ -144,7 +144,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $table = $this->schemaManager->getTable('alter_table_add_pk');
+        $table = $this->schemaManager->introspectTable('alter_table_add_pk');
 
         self::assertFalse($table->hasIndex('idx_id'));
         self::assertTrue($table->hasPrimaryKey());
@@ -169,7 +169,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $table = $this->schemaManager->getTable('drop_primary_key');
+        $table = $this->schemaManager->introspectTable('drop_primary_key');
 
         self::assertFalse($table->hasPrimaryKey());
         self::assertFalse($table->getColumn('id')->getAutoincrement());
@@ -191,7 +191,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $onlineTable = $this->schemaManager->getTable('text_blob_default_value');
+        $onlineTable = $this->schemaManager->introspectTable('text_blob_default_value');
 
         self::assertNull($onlineTable->getColumn('def_text')->getDefault());
         self::assertNull($onlineTable->getColumn('def_text_null')->getDefault());
@@ -238,7 +238,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $table = $this->schemaManager->getTable($tableName);
+        $table = $this->schemaManager->introspectTable($tableName);
 
         self::assertEquals('ascii', $table->getColumn('col_text')->getPlatformOption('charset'));
     }
@@ -349,7 +349,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($offlineTable);
 
-        $onlineTable = $this->schemaManager->getTable('list_guid_table_column');
+        $onlineTable = $this->schemaManager->introspectTable('list_guid_table_column');
 
         self::assertFalse(
             $this->schemaManager->createComparator()->diffTable($onlineTable, $offlineTable),
@@ -417,7 +417,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $onlineTable = $this->schemaManager->getTable('test_column_defaults_current_timestamp');
+        $onlineTable = $this->schemaManager->introspectTable('test_column_defaults_current_timestamp');
         self::assertSame($currentTimeStampSql, $onlineTable->getColumn('col_datetime')->getDefault());
         self::assertSame($currentTimeStampSql, $onlineTable->getColumn('col_datetime_nullable')->getDefault());
 
@@ -489,7 +489,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $onlineTable = $this->schemaManager->getTable('test_column_defaults_current_time_and_date');
+        $onlineTable = $this->schemaManager->introspectTable('test_column_defaults_current_time_and_date');
 
         self::assertSame($currentTimestampSql, $onlineTable->getColumn('col_datetime')->getDefault());
         self::assertSame($currentDateSql, $onlineTable->getColumn('col_date')->getDefault());
@@ -516,7 +516,7 @@ PARTITION BY HASH (col1)
 SQL;
 
         $this->connection->executeStatement($sql);
-        $onlineTable = $this->schemaManager->getTable('test_table_metadata');
+        $onlineTable = $this->schemaManager->introspectTable('test_table_metadata');
 
         self::assertEquals('InnoDB', $onlineTable->getOption('engine'));
         self::assertEquals('utf8mb4_general_ci', $onlineTable->getOption('collation'));
@@ -533,7 +533,7 @@ SQL;
         $this->connection->executeStatement('DROP TABLE IF EXISTS test_table_empty_metadata');
 
         $this->connection->executeStatement('CREATE TABLE test_table_empty_metadata(col1 INT NOT NULL)');
-        $onlineTable = $this->schemaManager->getTable('test_table_empty_metadata');
+        $onlineTable = $this->schemaManager->introspectTable('test_table_empty_metadata');
 
         self::assertNotEmpty($onlineTable->getOption('engine'));
         // collation could be set to default or not set, information_schema indicate a possibly null value

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -121,8 +121,8 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->schemaManager->createTable($offlinePrimaryTable);
         $this->schemaManager->createTable($offlineForeignTable);
 
-        $onlinePrimaryTable = $this->schemaManager->getTable($primaryTableName);
-        $onlineForeignTable = $this->schemaManager->getTable($foreignTableName);
+        $onlinePrimaryTable = $this->schemaManager->introspectTable($primaryTableName);
+        $onlineForeignTable = $this->schemaManager->introspectTable($foreignTableName);
 
         $platform = $this->connection->getDatabasePlatform();
 

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -275,7 +275,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $schemaManager = $this->connection->createSchemaManager();
 
-        $fromSchema = $schemaManager->createSchema();
+        $fromSchema = $schemaManager->introspectSchema();
         $toSchema   = clone $fromSchema;
 
         $toSchema->getTable('"tester"')->dropColumn('"name"');

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -310,7 +310,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
      *
      * 1. The DBAL currently doesn't properly drop tables in the namespaces that need to be quoted
      *    (@see testListTableDetailsWhenCurrentSchemaNameQuoted()).
-     * 2. The schema returned by {@see AbstractSchemaManager::createSchema()} doesn't contain views, so
+     * 2. The schema returned by {@see AbstractSchemaManager::introspectSchema()} doesn't contain views, so
      *    {@see AbstractSchemaManager::dropSchemaObjects()} cannot drop the tables that have dependent views
      *    (@see testListTablesExcludesViews()).
      * 3. In the case of inheritance, PHPUnit runs the tests declared immediately in the test class
@@ -333,7 +333,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $schemaManager = $this->connection->createSchemaManager();
         $schemaManager->createSchemaObjects($schema);
 
-        $schema = $schemaManager->createSchema();
+        $schema = $schemaManager->introspectSchema();
         $schemaManager->dropSchemaObjects($schema);
 
         self::assertFalse($schemaManager->tablesExist(['test_autoincrement']));

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -66,13 +66,13 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $createTableSQL = 'CREATE TABLE domain_type_test (id INT PRIMARY KEY, value MyMoney)';
         $this->connection->executeStatement($createTableSQL);
 
-        $table = $this->connection->getSchemaManager()->getTable('domain_type_test');
+        $table = $this->connection->getSchemaManager()->introspectTable('domain_type_test');
         self::assertInstanceOf(DecimalType::class, $table->getColumn('value')->getType());
 
         Type::addType('MyMoney', MoneyType::class);
         $this->connection->getDatabasePlatform()->registerDoctrineTypeMapping('MyMoney', 'MyMoney');
 
-        $table = $this->connection->getSchemaManager()->getTable('domain_type_test');
+        $table = $this->connection->getSchemaManager()->introspectTable('domain_type_test');
         self::assertInstanceOf(MoneyType::class, $table->getColumn('value')->getType());
     }
 
@@ -82,7 +82,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $column       = $autoincTable->addColumn('id', 'integer');
         $column->setAutoincrement(true);
         $this->dropAndCreateTable($autoincTable);
-        $autoincTable = $this->schemaManager->getTable('autoinc_table');
+        $autoincTable = $this->schemaManager->introspectTable('autoinc_table');
 
         self::assertTrue($autoincTable->getColumn('id')->getAutoincrement());
     }
@@ -103,7 +103,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableFrom = new Table('autoinc_table_add');
         $tableFrom->addColumn('id', 'integer');
         $this->dropAndCreateTable($tableFrom);
-        $tableFrom = $this->schemaManager->getTable('autoinc_table_add');
+        $tableFrom = $this->schemaManager->introspectTable('autoinc_table_add');
         self::assertFalse($tableFrom->getColumn('id')->getAutoincrement());
 
         $tableTo = new Table('autoinc_table_add');
@@ -122,7 +122,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         ], $sql);
 
         $this->schemaManager->alterTable($diff);
-        $tableFinal = $this->schemaManager->getTable('autoinc_table_add');
+        $tableFinal = $this->schemaManager->introspectTable('autoinc_table_add');
         self::assertTrue($tableFinal->getColumn('id')->getAutoincrement());
     }
 
@@ -137,7 +137,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $column    = $tableFrom->addColumn('id', 'integer');
         $column->setAutoincrement(true);
         $this->dropAndCreateTable($tableFrom);
-        $tableFrom = $this->schemaManager->getTable('autoinc_table_drop');
+        $tableFrom = $this->schemaManager->introspectTable('autoinc_table_drop');
         self::assertTrue($tableFrom->getColumn('id')->getAutoincrement());
 
         $tableTo = new Table('autoinc_table_drop');
@@ -153,7 +153,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         );
 
         $this->schemaManager->alterTable($diff);
-        $tableFinal = $this->schemaManager->getTable('autoinc_table_drop');
+        $tableFinal = $this->schemaManager->introspectTable('autoinc_table_drop');
         self::assertFalse($tableFinal->getColumn('id')->getAutoincrement());
     }
 
@@ -181,7 +181,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tables = $this->schemaManager->listTables();
         self::assertNotNull($this->findTableByName($tables, 'nested.schematable'));
 
-        $nestedSchemaTable = $this->schemaManager->getTable('nested.schematable');
+        $nestedSchemaTable = $this->schemaManager->introspectTable('nested.schematable');
         self::assertTrue($nestedSchemaTable->hasColumn('id'));
 
         $primaryKey = $nestedSchemaTable->getPrimaryKey();
@@ -207,7 +207,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
             . ' FOREIGN KEY( "table" ) REFERENCES dbal91_something ON UPDATE CASCADE;';
         $this->connection->executeStatement($sql);
 
-        $table = $this->schemaManager->getTable('dbal91_something');
+        $table = $this->schemaManager->introspectTable('dbal91_something');
 
         self::assertEquals(
             [
@@ -264,7 +264,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $testTable->setPrimaryKey(['id']);
         $this->dropAndCreateTable($testTable);
 
-        $databaseTable = $this->schemaManager->getTable($testTable->getName());
+        $databaseTable = $this->schemaManager->introspectTable($testTable->getName());
 
         self::assertEquals('foo', $databaseTable->getColumn('def')->getDefault());
     }
@@ -282,7 +282,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $databaseTable = $this->schemaManager->getTable($table->getName());
+        $databaseTable = $this->schemaManager->introspectTable($table->getName());
 
         $diff = $comparatorFactory($this->schemaManager)->diffTable($table, $databaseTable);
 
@@ -384,7 +384,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($offlineTable);
 
-        $onlineTable = $this->schemaManager->getTable('person');
+        $onlineTable = $this->schemaManager->introspectTable('person');
 
         $comparator = new Comparator();
 
@@ -520,7 +520,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $column    = $tableFrom->addColumn('id', $from);
         $column->setAutoincrement(true);
         $this->dropAndCreateTable($tableFrom);
-        $tableFrom = $this->schemaManager->getTable('autoinc_type_modification');
+        $tableFrom = $this->schemaManager->introspectTable('autoinc_type_modification');
         self::assertTrue($tableFrom->getColumn('id')->getAutoincrement());
 
         $tableTo = new Table('autoinc_type_modification');
@@ -535,7 +535,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         );
 
         $this->schemaManager->alterTable($diff);
-        $tableFinal = $this->schemaManager->getTable('autoinc_type_modification');
+        $tableFinal = $this->schemaManager->introspectTable('autoinc_type_modification');
         self::assertTrue($tableFinal->getColumn('id')->getAutoincrement());
     }
 

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -617,11 +617,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::markTestSkipped('No Create Example View SQL was defined for this SchemaManager');
     }
 
-    public function testCreateSchema(): void
+    public function testSchemaIntrospection(): void
     {
         $this->createTestTable('test_table');
 
-        $schema = $this->schemaManager->createSchema();
+        $schema = $this->schemaManager->introspectSchema();
         self::assertTrue($schema->hasTable('test_table'));
     }
 
@@ -630,7 +630,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->createTestTable('table_to_alter');
         $this->createTestTable('table_to_drop');
 
-        $schema = $this->schemaManager->createSchema();
+        $schema = $this->schemaManager->introspectSchema();
 
         $tableToAlter = $schema->getTable('table_to_alter');
         $tableToAlter->dropColumn('foreign_key_test');
@@ -644,7 +644,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->migrateSchema($schema);
 
-        $schema = $this->schemaManager->createSchema();
+        $schema = $this->schemaManager->introspectSchema();
 
         self::assertTrue($schema->hasTable('table_to_alter'));
         self::assertFalse($schema->getTable('table_to_alter')->hasColumn('foreign_key_test'));

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -451,7 +451,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $offlineTable = $this->createListTableColumns();
         $this->dropAndCreateTable($offlineTable);
-        $onlineTable = $this->schemaManager->getTable('list_table_columns');
+        $onlineTable = $this->schemaManager->introspectTable('list_table_columns');
 
         $diff = $comparatorFactory($this->schemaManager)->diffTable($onlineTable, $offlineTable);
 
@@ -542,7 +542,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->dropAndCreateTable($tableA);
 
-        $fkTable       = $this->schemaManager->getTable('test_create_fk');
+        $fkTable       = $this->schemaManager->introspectTable('test_create_fk');
         $fkConstraints = $fkTable->getForeignKeys();
         self::assertCount(1, $fkConstraints, "Table 'test_create_fk' has to have one foreign key.");
 
@@ -591,7 +591,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->createTestTable('test_create_fk1');
         $this->createTestTable('test_create_fk2');
 
-        $table = $this->schemaManager->getTable('test_create_fk1');
+        $table = $this->schemaManager->introspectTable('test_create_fk1');
         $table->addForeignKeyConstraint(
             'test_create_fk2',
             ['foreign_key_test'],
@@ -662,7 +662,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $alterTable = $this->createTestTable('alter_table');
         $this->createTestTable('alter_table_foreign');
 
-        $table = $this->schemaManager->getTable('alter_table');
+        $table = $this->schemaManager->introspectTable('alter_table');
         self::assertTrue($table->hasColumn('id'));
         self::assertTrue($table->hasColumn('test'));
         self::assertTrue($table->hasColumn('foreign_key_test'));
@@ -676,7 +676,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->alterTable($tableDiff);
 
-        $table = $this->schemaManager->getTable('alter_table');
+        $table = $this->schemaManager->introspectTable('alter_table');
         self::assertFalse($table->hasColumn('test'));
         self::assertTrue($table->hasColumn('foo'));
 
@@ -686,7 +686,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->alterTable($tableDiff);
 
-        $table = $this->schemaManager->getTable('alter_table');
+        $table = $this->schemaManager->introspectTable('alter_table');
         self::assertCount(2, $table->getIndexes());
         self::assertTrue($table->hasIndex('foo_idx'));
         self::assertEquals(['foo'], array_map('strtolower', $table->getIndex('foo_idx')->getColumns()));
@@ -699,7 +699,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->alterTable($tableDiff);
 
-        $table = $this->schemaManager->getTable('alter_table');
+        $table = $this->schemaManager->introspectTable('alter_table');
         self::assertCount(2, $table->getIndexes());
         self::assertTrue($table->hasIndex('foo_idx'));
         self::assertEquals(
@@ -713,7 +713,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->alterTable($tableDiff);
 
-        $table = $this->schemaManager->getTable('alter_table');
+        $table = $this->schemaManager->introspectTable('alter_table');
         self::assertCount(2, $table->getIndexes());
         self::assertTrue($table->hasIndex('bar_idx'));
         self::assertFalse($table->hasIndex('foo_idx'));
@@ -731,7 +731,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $tableDiff->addedForeignKeys[] = $fk;
 
         $this->schemaManager->alterTable($tableDiff);
-        $table = $this->schemaManager->getTable('alter_table');
+        $table = $this->schemaManager->introspectTable('alter_table');
 
         // dont check for index size here, some platforms automatically add indexes for foreign keys.
         self::assertFalse($table->hasIndex('bar_idx'));
@@ -805,7 +805,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->createTable($table);
 
-        $inferredTable = $this->schemaManager->getTable('test_autoincrement');
+        $inferredTable = $this->schemaManager->introspectTable('test_autoincrement');
         self::assertTrue($inferredTable->hasColumn('id'));
         self::assertTrue($inferredTable->getColumn('id')->getAutoincrement());
     }
@@ -824,7 +824,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->createTable($table);
 
-        $inferredTable = $this->schemaManager->getTable('test_not_autoincrement');
+        $inferredTable = $this->schemaManager->introspectTable('test_not_autoincrement');
         self::assertTrue($inferredTable->hasColumn('id'));
         self::assertFalse($inferredTable->getColumn('id')->getAutoincrement());
     }
@@ -867,7 +867,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $table       = $this->schemaManager->getTable('test_fk_rename');
+        $table       = $this->schemaManager->introspectTable('test_fk_rename');
         $foreignKeys = $table->getForeignKeys();
 
         self::assertTrue($table->hasColumn('rename_fk_id'));
@@ -911,7 +911,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $foreignTable = $this->schemaManager->getTable('test_rename_index_foreign');
+        $foreignTable = $this->schemaManager->introspectTable('test_rename_index_foreign');
 
         self::assertFalse($foreignTable->hasIndex('rename_index_fk_idx'));
         self::assertTrue($foreignTable->hasIndex('renamed_index_fk_idx'));
@@ -1062,7 +1062,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->createTable($table);
 
-        $created = $this->schemaManager->getTable('test_blob_table');
+        $created = $this->schemaManager->introspectTable('test_blob_table');
 
         self::assertTrue($created->hasColumn('binarydata'));
         self::assertInstanceOf(BlobType::class, $created->getColumn('binarydata')->getType());
@@ -1217,7 +1217,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->createTable($table);
 
-        $table = $this->schemaManager->getTable($tableName);
+        $table = $this->schemaManager->introspectTable($tableName);
         $this->assertBinaryColumnIsValid($table, 'column_binary', 16);
         $this->assertVarBinaryColumnIsValid($table, 'column_varbinary', 32);
     }
@@ -1241,7 +1241,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testGetNonExistingTable(): void
     {
         $this->expectException(SchemaException::class);
-        $this->schemaManager->getTable('non_existing');
+        $this->schemaManager->introspectTable('non_existing');
     }
 
     public function testListTableDetailsWithFullQualifiedTableName(): void
@@ -1369,7 +1369,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $offlineTable->addColumn('no_comment2', 'integer');
         $this->dropAndCreateTable($offlineTable);
 
-        $onlineTable = $this->schemaManager->getTable('alter_column_comment_test');
+        $onlineTable = $this->schemaManager->introspectTable('alter_column_comment_test');
 
         self::assertSame($expectedComment1, $onlineTable->getColumn('comment1')->getComment());
         self::assertSame($expectedComment2, $onlineTable->getColumn('comment2')->getComment());
@@ -1387,7 +1387,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->alterTable($tableDiff);
 
-        $onlineTable = $this->schemaManager->getTable('alter_column_comment_test');
+        $onlineTable = $this->schemaManager->introspectTable('alter_column_comment_test');
 
         self::assertSame($expectedComment2, $onlineTable->getColumn('comment1')->getComment());
         self::assertSame($expectedComment1, $onlineTable->getColumn('comment2')->getComment());
@@ -1465,7 +1465,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table->addColumn('parameters', 'json');
 
         $tableDiff = $comparatorFactory($this->schemaManager)
-            ->diffTable($this->schemaManager->getTable('json_test'), $table);
+            ->diffTable($this->schemaManager->introspectTable('json_test'), $table);
 
         self::assertFalse($tableDiff);
     }
@@ -1617,7 +1617,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $onlineTable = $this->schemaManager->getTable('test_partial_column_index');
+        $onlineTable = $this->schemaManager->introspectTable('test_partial_column_index');
         self::assertEquals($expected, $onlineTable->getIndexes());
     }
 
@@ -1628,7 +1628,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table->setComment('Foo with control characters \'\\');
         $this->dropAndCreateTable($table);
 
-        $table = $this->schemaManager->getTable('table_with_comment');
+        $table = $this->schemaManager->introspectTable('table_with_comment');
         self::assertSame('Foo with control characters \'\\', $table->getComment());
     }
 
@@ -1668,7 +1668,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->schemaManager->createTable($table);
 
-        $table = $this->schemaManager->getTable($foreignTable);
+        $table = $this->schemaManager->introspectTable($foreignTable);
 
         $foreignKey = $table->getForeignKey($foreignKey);
 
@@ -1680,7 +1680,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     {
         $this->createReservedKeywordTables();
 
-        $user = $this->schemaManager->getTable('"user"');
+        $user = $this->schemaManager->introspectTable('"user"');
         self::assertCount(2, $user->getColumns());
         self::assertCount(2, $user->getIndexes());
         self::assertCount(1, $user->getForeignKeys());

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -189,7 +189,7 @@ SQL;
         $sm = $this->connection->getSchemaManager();
         $sm->createTable($table);
 
-        self::assertNull($sm->getTable('own_column_comment')
+        self::assertNull($sm->introspectTable('own_column_comment')
             ->getColumn('col1')
             ->getComment());
     }
@@ -212,7 +212,7 @@ SQL;
 
         $schemaManager = $this->connection->createSchemaManager();
 
-        $table1 = $schemaManager->getTable('nodes');
+        $table1 = $schemaManager->introspectTable('nodes');
         $table2 = clone $table1;
         $table2->addIndex(['name'], 'idx_name');
 
@@ -222,7 +222,7 @@ SQL;
 
         $schemaManager->alterTable($diff);
 
-        $table = $schemaManager->getTable('nodes');
+        $table = $schemaManager->introspectTable('nodes');
         $index = $table->getIndex('idx_name');
         self::assertSame(['name'], $index->getColumns());
     }
@@ -258,7 +258,7 @@ SQL;
 
         $schemaManager = $this->connection->createSchemaManager();
 
-        $song        = $schemaManager->getTable('song');
+        $song        = $schemaManager->introspectTable('song');
         $foreignKeys = $song->getForeignKeys();
         self::assertCount(2, $foreignKeys);
 

--- a/tests/Functional/Ticket/DBAL168Test.php
+++ b/tests/Functional/Ticket/DBAL168Test.php
@@ -16,7 +16,7 @@ class DBAL168Test extends FunctionalTestCase
         $table->addForeignKeyConstraint('domains', ['parent_id'], ['id']);
 
         $this->connection->getSchemaManager()->createTable($table);
-        $table = $this->connection->getSchemaManager()->getTable('domains');
+        $table = $this->connection->getSchemaManager()->introspectTable('domains');
 
         self::assertEquals('domains', $table->getName());
     }

--- a/tests/Functional/Ticket/DBAL510Test.php
+++ b/tests/Functional/Ticket/DBAL510Test.php
@@ -33,7 +33,7 @@ class DBAL510Test extends FunctionalTestCase
         $this->dropAndCreateTable($table);
 
         $schemaManager = $this->connection->createSchemaManager();
-        $onlineTable   = $schemaManager->getTable('dbal510tbl');
+        $onlineTable   = $schemaManager->introspectTable('dbal510tbl');
 
         $comparator = $comparatorFactory($schemaManager);
         $diff       = $comparator->diffTable($onlineTable, $table);

--- a/tests/Functional/Ticket/DBAL752Test.php
+++ b/tests/Functional/Ticket/DBAL752Test.php
@@ -34,7 +34,7 @@ SQL
 
         $schemaManager = $this->connection->getSchemaManager();
 
-        $fetchedTable = $schemaManager->getTable('dbal752_unsigneds');
+        $fetchedTable = $schemaManager->introspectTable('dbal752_unsigneds');
 
         self::assertEquals('smallint', $fetchedTable->getColumn('small')->getType()->getName());
         self::assertEquals('smallint', $fetchedTable->getColumn('small_unsigned')->getType()->getName());

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -111,7 +111,7 @@ class TestUtil
 
             $sm = $testConn->createSchemaManager();
 
-            $schema = $sm->createSchema();
+            $schema = $sm->introspectSchema();
             $sm->dropSchemaObjects($schema);
 
             $testConn->close();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The current API has the following problems:
1. The `createSchema()` name is misleading since unlike other `create*()` methods (e.g. `createTable()`) which create an object in the database, `createSchema()` creates an internal representation of the schema by introspecting it.
2. The fact that this method existed didn't allow to introduce a method that would actually create the schema in #5416.

This pull request proposes to deprecate `AbstractSchemaManager::createSchema()` in favor of `introspectSchema()`.

The name of the `introspectSchema()` method being introduced is slightly inconsistent with `AbstractSchemaManager::getTable()` recently introduced in #5595. However, instead of naming it `getSchema()` for consistency, I believe it's not too late to rename `getTable()` to `introspectTable()`. That would be more precise.