### PR TITLE
Fix database detection on SQLite with PORTABILITY_EMPTY_TO_NULL

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -170,14 +170,15 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      *
-     * The SQLite platform doesn't support the concept of a database, therefore, it always returns an empty string
+     * The DBAL doesn't support databases on the SQLite platform. The expression here always returns a fixed string
      * as an indicator of an implicitly selected database.
      *
-     * @see \Doctrine\DBAL\Connection::getDatabase()
+     * @link https://www.sqlite.org/lang_select.html
+     * @see Connection::getDatabase()
      */
     public function getCurrentDatabaseExpression(): string
     {
-        return "''";
+        return "'main'";
     }
 
     /**

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -139,6 +139,12 @@ class PortabilityTest extends FunctionalTestCase
         self::assertSame([null, null], $column);
     }
 
+    public function testGetDatabaseName(): void
+    {
+        $this->connectWithPortability(Connection::PORTABILITY_EMPTY_TO_NULL, 0);
+        self::assertNotNull($this->connection->getDatabase());
+    }
+
     private function connectWithPortability(int $mode, int $case): void
     {
         // closing the default connection prior to 4.0.0 to prevent connection leak


### PR DESCRIPTION
This is primarily a workaround while there are two fundamental issues:

1. The DBAL doesn't support databases on the SQLite platform but there is a wrapper-level method `Connection::getDatabase()` which is used internally. It cannot be properly implemented in a portable way by definition.
2. When performing its own queries (e.g. database detection or schema introspection), the DBAL should not use user-defined middlewares (because they can be arbitrary) but should use the wrapper-level APIs (because otherwise, it would duplicate the wrapper code). This is what makes us use other hacks like the following across the schema managers' codebase: https://github.com/doctrine/dbal/blob/279f36584796be0c9cf114ecd988fc3702541d51/src/Schema/OracleSchemaManager.php#L235-L236

Returning `main` instead of an empty string as the SQLite database name was originally proposed in https://github.com/doctrine/dbal/issues/5046.

Fixes #5615.