### PR TITLE
Remove redundant condition from DB2 platform

### DIFF
--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -610,10 +610,6 @@ class DB2Platform extends AbstractPlatform
                     $columnDiff->column->getQuotedName($this),
                     $this->getColumnComment($columnDiff->column)
                 );
-
-                if (count($columnDiff->changedProperties) === 1) {
-                    continue;
-                }
             }
 
             $this->gatherAlterColumnSQL($diff->getName($this), $columnDiff, $sql, $queryParts);


### PR DESCRIPTION
Effectively, it (poorly) duplicates the following one: https://github.com/doctrine/dbal/blob/5f8378855a59610722a3e11499c5ceee1e448259/src/Platforms/DB2Platform.php#L719-L725

If the provided set of changed properties doesn't warrant a certain schema change, `DB2Platform::getAlterColumnClausesSQL()` will produce an empty array of SQL statements.