### PR TITLE
Schema Diff API cleanup

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,17 @@ awareness about deprecated code.
 
 # Upgrade to 3.5
 
+## Marked schema diff constructors as internal.
+
+The constructors of the following classes have been marked as internal:
+
+1. `SchemaDiff`,
+2. `TableDiff`,
+3. `ColumnDiff`.
+
+These classes can be instantiated only by schema comparators. The signatures of the constructors may change in future
+versions.
+
 ## Marked `AbstractSchemaManager::_execSql()` as internal.
 
 The `AbstractSchemaManager::_execSql()` method has been marked as internal. It will not be available in 4.0.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 3.5
 
+## Deprecated `ColumnDiff` APIs dedicated to the old column name.
+
+The `$oldColumnName` property and the `getOldColumnName()` method of the `ColumnDiff` class have been deprecated.
+
+Make sure the `$fromColumn` argument is passed to the `ColumnDiff` constructor and use the `$fromColumn` property
+instead.
+
 ## Marked schema diff constructors as internal.
 
 The constructors of the following classes have been marked as internal:

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -414,6 +414,10 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractSchemaManager::listTableDetails"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\SqliteSchemaManager::listTableDetails"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\ColumnDiff::getOldColumnName"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>
@@ -443,6 +447,10 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedProperty name="Doctrine\DBAL\Schema\Column::$_customSchemaOptions"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedProperty name="Doctrine\DBAL\Schema\ColumnDiff::$oldColumnName"/>
             </errorLevel>
         </DeprecatedProperty>
         <DocblockTypeContradiction>

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -642,8 +642,15 @@ SQL
             $columnArray = $column->toArray();
 
             $columnArray['comment'] = $this->getColumnComment($column);
-            $queryParts[]           =  'CHANGE ' . ($columnDiff->getOldColumnName()->getQuotedName($this)) . ' '
-                    . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnArray);
+
+            if ($columnDiff->fromColumn !== null) {
+                $fromColumn = $columnDiff->fromColumn;
+            } else {
+                $fromColumn = $columnDiff->getOldColumnName();
+            }
+
+            $queryParts[] =  'CHANGE ' . $fromColumn->getQuotedName($this) . ' '
+                . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnArray);
         }
 
         foreach ($diff->renamedColumns as $oldColumnName => $column) {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -561,8 +561,15 @@ SQL
                 continue;
             }
 
-            $oldColumnName = $columnDiff->getOldColumnName()->getQuotedName($this);
-            $column        = $columnDiff->column;
+            if ($columnDiff->fromColumn !== null) {
+                $fromColumn = $columnDiff->fromColumn;
+            } else {
+                $fromColumn = $columnDiff->getOldColumnName();
+            }
+
+            $oldColumnName = $fromColumn->getQuotedName($this);
+
+            $column = $columnDiff->column;
 
             if (
                 $columnDiff->hasChanged('type')

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -11,7 +11,11 @@ use function in_array;
  */
 class ColumnDiff
 {
-    /** @var string */
+    /**
+     * @deprecated Use {@see $fromColumn} and {@see Column::getName()} instead.
+     *
+     * @var string
+     */
     public $oldColumnName;
 
     /** @var Column */
@@ -61,12 +65,27 @@ class ColumnDiff
     }
 
     /**
+     * @deprecated Use {@see $fromColumn} instead.
+     *
      * @return Identifier
      */
     public function getOldColumnName()
     {
-        $quote = $this->fromColumn !== null && $this->fromColumn->isQuoted();
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5622',
+            '%s is deprecated. Use $fromColumn instead.',
+            __METHOD__
+        );
 
-        return new Identifier($this->oldColumnName, $quote);
+        if ($this->fromColumn !== null) {
+            $name  = $this->fromColumn->getName();
+            $quote = $this->fromColumn->isQuoted();
+        } else {
+            $name  = $this->oldColumnName;
+            $quote = false;
+        }
+
+        return new Identifier($name, $quote);
     }
 }

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -24,6 +24,8 @@ class ColumnDiff
     public $fromColumn;
 
     /**
+     * @internal The diff can be only instantiated by a {@see Comparator}.
+     *
      * @param string   $oldColumnName
      * @param string[] $changedProperties
      */

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -67,6 +67,8 @@ class SchemaDiff
     /**
      * Constructs an SchemaDiff object.
      *
+     * @internal The diff can be only instantiated by a {@see Comparator}.
+     *
      * @param Table[]     $newTables
      * @param TableDiff[] $changedTables
      * @param Table[]     $removedTables

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -96,7 +96,9 @@ class TableDiff
     public $fromTable;
 
     /**
-     * Constructs an TableDiff object.
+     * Constructs a TableDiff object.
+     *
+     * @internal The diff can be only instantiated by a {@see Comparator}.
      *
      * @param string       $tableName
      * @param Column[]     $addedColumns


### PR DESCRIPTION
1. Mark schema diff constructors as internal. Schema diff objects are meant to be instantiated only by schema
comparators. As a cleanup of the old property-based schema comparison logic, we will eventually remove the `$changedProperties` parameter of the `ColumnDiff` class.
2. The `$oldColumnName` property and the corresponding constructor parameter were relevant until https://github.com/doctrine/dbal/pull/220 (`2.4.0`) which introduced the `$fromColumn` property and the corresponding constructor parameter. Now they are redundant. The same applies to `getOldColumnName()`. The `$fromColumn` property contains all the properties of the old column including the name.