### PR TITLE
Do not use ColumnDiff::$changedProperties in OraclePlatform::getAlterTableSQL()

### DIFF
--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -572,22 +572,20 @@ END;';
 
             $column = $columnDiff->column;
 
-            $columnHasChangedComment = $columnDiff->hasChanged('comment');
+            $columnInfo = $column->toArray();
+            $fromSQL    = $this->getColumnDeclarationSQL('', $columnDiff->fromColumn->toArray());
+            $currentSQL = $this->getColumnDeclarationSQL('', $columnInfo);
 
-            /**
-             * Do not add query part if only comment has changed
-             */
-            if (! ($columnHasChangedComment && count($columnDiff->changedProperties) === 1)) {
-                $columnInfo = $column->toArray();
-
+            if ($currentSQL !== $fromSQL) {
                 if (! $columnDiff->hasChanged('notnull')) {
                     unset($columnInfo['notnull']);
+                    $currentSQL = $this->getColumnDeclarationSQL('', $columnInfo);
                 }
 
                 $modifyColumnSQL[] = $column->getQuotedName($this) . $currentSQL;
             }
 
-            if (! $columnHasChangedComment) {
+            if (! $columnDiff->hasChanged('comment')) {
                 continue;
             }
 

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -538,15 +538,15 @@ END;';
         $commentsSQL = [];
         $columnSql   = [];
 
-        $fields = [];
+        $addColumnSQL = [];
 
         foreach ($diff->addedColumns as $column) {
             if ($this->onSchemaAlterTableAddColumn($column, $diff, $columnSql)) {
                 continue;
             }
 
-            $fields[] = $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray());
-            $comment  = $column->getComment();
+            $addColumnSQL[] = $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray());
+            $comment        = $column->getComment();
 
             if ($comment === '') {
                 continue;
@@ -559,12 +559,12 @@ END;';
             );
         }
 
-        if (count($fields) > 0) {
+        if (count($addColumnSQL) > 0) {
             $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this)
-                . ' ADD (' . implode(', ', $fields) . ')';
+                . ' ADD (' . implode(', ', $addColumnSQL) . ')';
         }
 
-        $fields = [];
+        $modifyColumnSQL = [];
         foreach ($diff->changedColumns as $columnDiff) {
             if ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
                 continue;
@@ -584,7 +584,7 @@ END;';
                     unset($columnInfo['notnull']);
                 }
 
-                $fields[] = $column->getQuotedName($this) . $this->getColumnDeclarationSQL('', $columnInfo);
+                $modifyColumnSQL[] = $column->getQuotedName($this) . $currentSQL;
             }
 
             if (! $columnHasChangedComment) {
@@ -598,9 +598,9 @@ END;';
             );
         }
 
-        if (count($fields) > 0) {
+        if (count($modifyColumnSQL) > 0) {
             $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this)
-                . ' MODIFY (' . implode(', ', $fields) . ')';
+                . ' MODIFY (' . implode(', ', $modifyColumnSQL) . ')';
         }
 
         foreach ($diff->renamedColumns as $oldColumnName => $column) {
@@ -614,18 +614,18 @@ END;';
                 ' RENAME COLUMN ' . $oldColumnName->getQuotedName($this) . ' TO ' . $column->getQuotedName($this);
         }
 
-        $fields = [];
+        $dropColumnSQL = [];
         foreach ($diff->removedColumns as $column) {
             if ($this->onSchemaAlterTableRemoveColumn($column, $diff, $columnSql)) {
                 continue;
             }
 
-            $fields[] = $column->getQuotedName($this);
+            $dropColumnSQL[] = $column->getQuotedName($this);
         }
 
-        if (count($fields) > 0) {
+        if (count($dropColumnSQL) > 0) {
             $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this)
-                . ' DROP (' . implode(', ', $fields) . ')';
+                . ' DROP (' . implode(', ', $dropColumnSQL) . ')';
         }
 
         $tableSql = [];

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -249,7 +249,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         $table = new Table('mytable');
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
         $table->addColumn('foo', 'integer');
-        $table->addColumn('bar', 'string');
+        $table->addColumn('bar', 'string', ['length' => 32]);
         $table->addColumn('bloo', 'boolean');
         $table->setPrimaryKey(['id']);
 

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -9,11 +9,9 @@ use Doctrine\DBAL\Exception\ColumnLengthRequired;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Type;
 
@@ -353,73 +351,6 @@ SQL
                 . ' REFERENCES "foo-bar" ("create", bar, "foo-bar")',
             'CREATE INDEX IDX_22660D028FD6E0FB8C736521D79164E3 ON "quoted" ("create", foo, "bar")',
         ];
-    }
-
-    public function testAlterTableNotNULL(): void
-    {
-        $tableDiff = new TableDiff('mytable');
-
-        $foo = new Column(
-            'foo',
-            Type::getType('string'),
-            [
-                'length' => 255,
-                'default' => 'bla',
-                'notnull' => true,
-            ]
-        );
-
-        $bar = new Column(
-            'baz',
-            Type::getType('string'),
-            [
-                'length' => 255,
-                'default' => 'bla',
-                'notnull' => true,
-            ]
-        );
-
-        $baz = new Column(
-            'baz',
-            Type::getType('string'),
-            [
-                'length' => 255,
-                'default' => 'bla',
-                'notnull' => true,
-            ]
-        );
-
-        $metar = new Column(
-            'metar',
-            Type::getType('string'),
-            [
-                'length' => 2000,
-                'notnull' => false,
-            ]
-        );
-
-        $tableDiff->changedColumns['foo'] = new ColumnDiff(
-            'foo',
-            $foo,
-            ['type'],
-            $foo
-        );
-
-        $tableDiff->changedColumns['bar'] = new ColumnDiff('bar', $bar, ['type', 'notnull'], $baz);
-
-        $tableDiff->changedColumns['metar'] = new ColumnDiff(
-            'metar',
-            $metar,
-            ['notnull'],
-            $metar
-        );
-
-        $expectedSql = [
-            "ALTER TABLE mytable MODIFY (foo VARCHAR2(255) DEFAULT 'bla', baz VARCHAR2(255) DEFAULT 'bla' NOT NULL, "
-                . 'metar VARCHAR2(2000) DEFAULT NULL NULL)',
-        ];
-
-        self::assertEquals($expectedSql, $this->platform->getAlterTableSQL($tableDiff));
     }
 
     public function testInitializesDoctrineTypeMappings(): void


### PR DESCRIPTION
Instead of counting changed properties, the code should check whether the resulting column declaration has changed.

This renders the test being removed invalid because it uses the diff that declares changed properties but the from and the to columns are the same. The original test implementation introduced in https://github.com/doctrine/dbal/pull/360 was correct but it was incorrectly updated in https://github.com/doctrine/dbal/pull/4786. It is not worth fixing the test since there is a functional test that covers the same logic (`OracleSchemaManagerTest::testAlterTableColumnNotNull()`).