### PR TITLE
Clean up test scenarios related to altering columns

### DIFF
--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -205,18 +205,6 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         ];
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getAlterTableColumnCommentsSQL(): array
-    {
-        return [
-            "ALTER TABLE mytable ADD quota INT NOT NULL COMMENT 'A comment', "
-                . 'CHANGE foo foo VARCHAR(255) NOT NULL, '
-                . "CHANGE bar baz VARCHAR(255) NOT NULL COMMENT 'B comment'",
-        ];
-    }
-
     public function testChangeIndexWithForeignKeys(): void
     {
         $index  = new Index('idx', ['col'], false);

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -194,17 +194,6 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertEquals('DATETIME', $this->platform->getDateTimeTypeDeclarationSQL([]));
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getCreateTableColumnCommentsSQL(): array
-    {
-        return [
-            "CREATE TABLE test (id INT NOT NULL COMMENT 'This is a comment', "
-                . 'PRIMARY KEY(id))',
-        ];
-    }
-
     public function testChangeIndexWithForeignKeys(): void
     {
         $index  = new Index('idx', ['col'], false);

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -404,14 +404,6 @@ abstract class AbstractPlatformTestCase extends TestCase
         self::markTestSkipped('Platform does not support Column comments.');
     }
 
-    /**
-     * @return string[]
-     */
-    public function getAlterTableColumnCommentsSQL(): array
-    {
-        self::markTestSkipped('Platform does not support Column comments.');
-    }
-
     public function testGetDefaultValueDeclarationSQL(): void
     {
         // non-timestamp value will get single quotes

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -387,23 +387,6 @@ abstract class AbstractPlatformTestCase extends TestCase
         $this->platform->getAlterTableSQL($tableDiff);
     }
 
-    public function testCreateTableColumnComments(): void
-    {
-        $table = new Table('test');
-        $table->addColumn('id', 'integer', ['comment' => 'This is a comment']);
-        $table->setPrimaryKey(['id']);
-
-        self::assertEquals($this->getCreateTableColumnCommentsSQL(), $this->platform->getCreateTableSQL($table));
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getCreateTableColumnCommentsSQL(): array
-    {
-        self::markTestSkipped('Platform does not support Column comments.');
-    }
-
     public function testGetDefaultValueDeclarationSQL(): void
     {
         // non-timestamp value will get single quotes

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -134,17 +134,6 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         return 'BITOR(' . $value1 . ', ' . $value2 . ')';
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getCreateTableColumnCommentsSQL(): array
-    {
-        return [
-            'CREATE TABLE test (id INTEGER NOT NULL, PRIMARY KEY(id))',
-            "COMMENT ON COLUMN test.id IS 'This is a comment'",
-        ];
-    }
-
     public function testGeneratesCreateTableSQLWithCommonIndexes(): void
     {
         $table = new Table('test');

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -145,21 +145,6 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         ];
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getAlterTableColumnCommentsSQL(): array
-    {
-        return [
-            'ALTER TABLE mytable ' .
-            'ADD COLUMN quota INTEGER NOT NULL WITH DEFAULT',
-            "CALL SYSPROC.ADMIN_CMD ('REORG TABLE mytable')",
-            "COMMENT ON COLUMN mytable.quota IS 'A comment'",
-            "COMMENT ON COLUMN mytable.foo IS ''",
-            "COMMENT ON COLUMN mytable.baz IS 'B comment'",
-        ];
-    }
-
     public function testGeneratesCreateTableSQLWithCommonIndexes(): void
     {
         $table = new Table('test');

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -269,17 +269,6 @@ SQL
         ], $this->platform->getCreateTableSQL($table));
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getCreateTableColumnCommentsSQL(): array
-    {
-        return [
-            'CREATE TABLE test (id NUMBER(10) NOT NULL, PRIMARY KEY(id))',
-            "COMMENT ON COLUMN test.id IS 'This is a comment'",
-        ];
-    }
-
     public function getBitAndComparisonExpressionSql(string $value1, string $value2): string
     {
         return 'BITAND(' . $value1 . ', ' . $value2 . ')';

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -280,19 +280,6 @@ SQL
         ];
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getAlterTableColumnCommentsSQL(): array
-    {
-        return [
-            'ALTER TABLE mytable ADD (quota NUMBER(10) NOT NULL)',
-            "COMMENT ON COLUMN mytable.quota IS 'A comment'",
-            "COMMENT ON COLUMN mytable.foo IS ''",
-            "COMMENT ON COLUMN mytable.baz IS 'B comment'",
-        ];
-    }
-
     public function getBitAndComparisonExpressionSql(string $value1, string $value2): string
     {
         return 'BITAND(' . $value1 . ', ' . $value2 . ')';

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -354,19 +354,6 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritDoc}
      */
-    public function getAlterTableColumnCommentsSQL(): array
-    {
-        return [
-            'ALTER TABLE mytable ADD quota INT NOT NULL',
-            "COMMENT ON COLUMN mytable.quota IS 'A comment'",
-            "COMMENT ON COLUMN mytable.foo IS ''",
-            "COMMENT ON COLUMN mytable.baz IS 'B comment'",
-        ];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     protected function getQuotedColumnInPrimaryKeySQL(): array
     {
         return ['CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, PRIMARY KEY("create"))'];

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -343,17 +343,6 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     /**
      * {@inheritDoc}
      */
-    public function getCreateTableColumnCommentsSQL(): array
-    {
-        return [
-            'CREATE TABLE test (id INT NOT NULL, PRIMARY KEY(id))',
-            "COMMENT ON COLUMN test.id IS 'This is a comment'",
-        ];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     protected function getQuotedColumnInPrimaryKeySQL(): array
     {
         return ['CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, PRIMARY KEY("create"))'];

--- a/tests/Platforms/SQLServerPlatformTestCase.php
+++ b/tests/Platforms/SQLServerPlatformTestCase.php
@@ -714,18 +714,6 @@ class SQLServerPlatformTestCase extends AbstractPlatformTestCase
         self::assertEquals($expectedSql, $this->platform->getAlterTableSQL($tableDiff));
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getCreateTableColumnCommentsSQL(): array
-    {
-        return [
-            'CREATE TABLE test (id INT NOT NULL, PRIMARY KEY (id))',
-            "EXEC sp_addextendedproperty N'MS_Description', N'This is a comment', "
-                . "N'SCHEMA', 'dbo', N'TABLE', 'test', N'COLUMN', id",
-        ];
-    }
-
     public function testGeneratesCreateTableSQLWithColumnComments(): void
     {
         $table = new Table('mytable');

--- a/tests/Platforms/SQLServerPlatformTestCase.php
+++ b/tests/Platforms/SQLServerPlatformTestCase.php
@@ -726,18 +726,6 @@ class SQLServerPlatformTestCase extends AbstractPlatformTestCase
         ];
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getAlterTableColumnCommentsSQL(): array
-    {
-        return [
-            'ALTER TABLE mytable ADD quota INT NOT NULL',
-            "EXEC sp_addextendedproperty N'MS_Description', N'A comment', "
-                . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', quota",
-        ];
-    }
-
     public function testGeneratesCreateTableSQLWithColumnComments(): void
     {
         $table = new Table('mytable');


### PR DESCRIPTION
1. Remove leftovers of `AbstractPlatformTestCase::testAlterTableColumnComments()` removed in #5626.
2. Remove `AbstractPlatformTestCase::testCreateTableColumnComments()`. The corresponding functionality is covered in greater detail in the functional `ColumnCommentTest`.
3. Add a functional replacement for `PostgreSQLPlatformTest::testAlterDecimalPrecisionScale()` removed in #5626. Now altering decimal columns is covered with a single test across all supported platforms.

Closes #5627.