### PR TITLE
Require precision and scale for decimal columns

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: removed default precision and scale of decimal columns.
+
+The DBAL no longer provides default values for precision and scale of decimal columns.
+
 ## BC BREAK: a non-empty WHERE clause is not enforced in data manipulation `Connection` methods.
 
 The `Connection::update()` and `::delete()` methods no longer enforce a non-empty WHERE clause. If modification

--- a/src/Exception/ColumnPrecisionRequired.php
+++ b/src/Exception/ColumnPrecisionRequired.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Exception;
+
+use Doctrine\DBAL\Exception;
+
+/**
+ * @psalm-immutable
+ */
+final class ColumnPrecisionRequired extends Exception
+{
+    public static function new(): self
+    {
+        return new self('Column precision is not specified');
+    }
+}

--- a/src/Exception/ColumnScaleRequired.php
+++ b/src/Exception/ColumnScaleRequired.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Exception;
+
+use Doctrine\DBAL\Exception;
+
+/**
+ * @psalm-immutable
+ */
+final class ColumnScaleRequired extends Exception
+{
+    public static function new(): self
+    {
+        return new self('Column scale is not specified');
+    }
+}

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -471,7 +471,7 @@ class Comparator
                 $changedProperties[] = 'fixed';
             }
         } elseif ($properties1['type'] instanceof Types\DecimalType) {
-            if (($properties1['precision'] ?? 10) !== ($properties2['precision'] ?? 10)) {
+            if ($properties1['precision'] !== $properties2['precision']) {
                 $changedProperties[] = 'precision';
             }
 

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -344,8 +344,16 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableName = 'test_list_decimal_columns';
         $table     = new Table($tableName);
 
-        $table->addColumn('col', 'decimal');
-        $table->addColumn('col_unsigned', 'decimal', ['unsigned' => true]);
+        $table->addColumn('col', 'decimal', [
+            'precision' => 10,
+            'scale' => 6,
+        ]);
+
+        $table->addColumn('col_unsigned', 'decimal', [
+            'precision' => 10,
+            'scale' => 6,
+            'unsigned' => true,
+        ]);
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -370,7 +370,11 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('col_integer', 'integer', ['default' => -1]);
         $table->addColumn('col_bigint', 'bigint', ['default' => -1]);
         $table->addColumn('col_float', 'float', ['default' => -1.1]);
-        $table->addColumn('col_decimal', 'decimal', ['default' => -1.1]);
+        $table->addColumn('col_decimal', 'decimal', [
+            'precision' => 2,
+            'scale' => 1,
+            'default' => -1.1,
+        ]);
         $table->addColumn('col_string', 'string', ['default' => '(-1)']);
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -25,7 +25,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $table = new Table('sqlsrv_drop_column');
         $table->addColumn('id', 'integer');
-        $table->addColumn('todrop', 'decimal', ['default' => 10.2]);
+        $table->addColumn('todrop', 'integer', ['default' => 10]);
 
         $this->schemaManager->createTable($table);
 
@@ -33,7 +33,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
             'sqlsrv_drop_column',
             [],
             [],
-            ['todrop' => new Column('todrop', Type::getType('decimal'))],
+            ['todrop' => new Column('todrop', Type::getType('integer'))],
         );
 
         $this->schemaManager->alterTable($diff);

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -688,14 +688,9 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
      */
     public static function getGeneratesDecimalTypeDeclarationSQL(): iterable
     {
-        return [
-            [[], 'NUMERIC(10, 0)'],
-            [['unsigned' => true], 'NUMERIC(10, 0) UNSIGNED'],
-            [['unsigned' => false], 'NUMERIC(10, 0)'],
-            [['precision' => 5], 'NUMERIC(5, 0)'],
-            [['scale' => 5], 'NUMERIC(10, 5)'],
-            [['precision' => 8, 'scale' => 2], 'NUMERIC(8, 2)'],
-        ];
+        yield [['precision' => 10, 'scale' => 8, 'unsigned' => true], 'NUMERIC(10, 8) UNSIGNED'];
+
+        yield from parent::getGeneratesDecimalTypeDeclarationSQL();
     }
 
     /**


### PR DESCRIPTION
Similar to the string columns (https://github.com/doctrine/dbal/issues/3263), having the DBAL define the precision and scale of decimal columns doesn't make much sense. The values of precision and scale should reflect the properties of the model represented by the schema.

**TODO**:
- [x] https://github.com/doctrine/dbal/pull/5637.