### PR TITLE
Fix Sqlite Schema: getForeignKeyDetails

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -617,7 +617,7 @@ SQL
      */
     private function getForeignKeyDetails($table)
     {
-        $createSql = $this->getCreateTableSQL($table);
+        $createSql = $this->getCreateTableSQL($table).PHP_EOL;
 
         if (
             preg_match_all(


### PR DESCRIPTION
if $createSql without "\n", the regex  can't parse the sql ,it will be return empty .
so when i want to get a foreign_key, it throws an error
```
   ErrorException 

  Undefined array key -1

  at vendor/doctrine/dbal/src/Schema/SqliteSchemaManager.php:607
    603▕         $foreignKeyCount   = count($foreignKeyDetails);
    604▕ 
    605▕         foreach ($columns as $i => $column) {
    606▕             // SQLite identifies foreign keys in reverse order of appearance in SQL
  ➜ 607▕             $columns[$i] = array_merge($column, $foreignKeyDetails[$foreignKeyCount - $column['id'] - 1]);
    608▕         }
    609▕ 
    610▕         return $columns;
    611▕     }
```

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
