### PR TITLE
Deprecate default precision and scale for decimal columns

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.5
 
+## Deprecated relying on the default precision and scale of decimal columns.
+
+Relying on the default precision and scale of decimal columns provided by the DBAL is deprecated.
+When declaring decimal columns, specify the precision and scale explicitly.
+
 ## Deprecated `ColumnDiff` APIs dedicated to the old column name.
 
 The `$oldColumnName` property and the `getOldColumnName()` method of the `ColumnDiff` class have been deprecated.

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2912,12 +2912,37 @@ abstract class AbstractPlatform
      */
     public function getDecimalTypeDeclarationSQL(array $column)
     {
-        $column['precision'] = ! isset($column['precision']) || empty($column['precision'])
-            ? 10 : $column['precision'];
-        $column['scale']     = ! isset($column['scale']) || empty($column['scale'])
-            ? 0 : $column['scale'];
+        if (empty($column['precision'])) {
+            if (! isset($column['precision'])) {
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/5637',
+                    'Relying on the default decimal column precision is deprecated'
+                        . ', specify the precision explicitly.',
+                );
+            }
 
-        return 'NUMERIC(' . $column['precision'] . ', ' . $column['scale'] . ')';
+            $precision = 10;
+        } else {
+            $precision = $column['precision'];
+        }
+
+        if (empty($column['scale'])) {
+            if (! isset($column['scale'])) {
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/5637',
+                    'Relying on the default decimal column scale is deprecated'
+                        . ', specify the scale explicitly.',
+                );
+            }
+
+            $scale = 0;
+        } else {
+            $scale = $column['scale'];
+        }
+
+        return 'NUMERIC(' . $precision . ', ' . $scale . ')';
     }
 
     /**


### PR DESCRIPTION
Similar to the string columns (https://github.com/doctrine/dbal/issues/3263), having the DBAL define the precision and scale of decimal columns doesn't make much sense. The values of precision and scale should reflect the properties of the model represented by the schema.