### PR TITLE
Introduce property-specific ColumnDiff methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,22 @@ awareness about deprecated code.
 Relying on the default precision and scale of decimal columns provided by the DBAL is deprecated.
 When declaring decimal columns, specify the precision and scale explicitly.
 
+## Marked `ColumnDiff::hasChanged()` as internal.
+
+The `ColumnDiff::hasChanged()` method has been marked as internal. Use one of the following `ColumnDiff` methods
+in order to check if a given column property has changed:
+
+- `hasTypeChanged()`,
+- `hasLengthChanged()`,
+- `hasPrecisionChanged()`,
+- `hasScaleChanged()`,
+- `hasUnsignedChanged()`,
+- `hasFixedChanged()`,
+- `hasNotNullChanged()`,
+- `hasDefaultChanged()`,
+- `hasAutoIncrementChanged()`,
+- `hasCommentChanged()`.
+
 ## Deprecated `ColumnDiff` APIs dedicated to the old column name.
 
 The `$oldColumnName` property and the `getOldColumnName()` method of the `ColumnDiff` class have been deprecated.

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -604,7 +604,7 @@ class DB2Platform extends AbstractPlatform
                 continue;
             }
 
-            if ($columnDiff->hasChanged('comment')) {
+            if ($columnDiff->hasCommentChanged()) {
                 $commentsSQL[] = $this->getCommentOnColumnSQL(
                     $diff->getName($this)->getQuotedName($this),
                     $columnDiff->column->getQuotedName($this),
@@ -713,20 +713,20 @@ class DB2Platform extends AbstractPlatform
         $clauses = [];
 
         if (
-            $columnDiff->hasChanged('type') ||
-            $columnDiff->hasChanged('length') ||
-            $columnDiff->hasChanged('precision') ||
-            $columnDiff->hasChanged('scale') ||
-            $columnDiff->hasChanged('fixed')
+            $columnDiff->hasTypeChanged() ||
+            $columnDiff->hasLengthChanged() ||
+            $columnDiff->hasPrecisionChanged() ||
+            $columnDiff->hasScaleChanged() ||
+            $columnDiff->hasFixedChanged()
         ) {
             $clauses[] = $alterClause . ' SET DATA TYPE ' . $column['type']->getSQLDeclaration($column, $this);
         }
 
-        if ($columnDiff->hasChanged('notnull')) {
+        if ($columnDiff->hasNotNullChanged()) {
             $clauses[] = $column['notnull'] ? $alterClause . ' SET NOT NULL' : $alterClause . ' DROP NOT NULL';
         }
 
-        if ($columnDiff->hasChanged('default')) {
+        if ($columnDiff->hasDefaultChanged()) {
             if (isset($column['default'])) {
                 $defaultClause = $this->getDefaultValueDeclarationSQL($column);
 

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -907,13 +907,13 @@ SQL
             // Avoids unnecessary table alteration statements.
             if (
                 $column->getType() instanceof BinaryType &&
-                $columnDiff->hasChanged('fixed') &&
+                $columnDiff->hasFixedChanged() &&
                 count($columnDiff->changedProperties) === 1
             ) {
                 continue;
             }
 
-            $columnHasChangedComment = $columnDiff->hasChanged('comment');
+            $columnHasChangedComment = $columnDiff->hasCommentChanged();
 
             /**
              * Do not add query part if only comment has changed
@@ -921,7 +921,7 @@ SQL
             if (! ($columnHasChangedComment && count($columnDiff->changedProperties) === 1)) {
                 $columnInfo = $column->toArray();
 
-                if (! $columnDiff->hasChanged('notnull')) {
+                if (! $columnDiff->hasNotNullChanged()) {
                     unset($columnInfo['notnull']);
                 }
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -572,10 +572,10 @@ SQL
             $column = $columnDiff->column;
 
             if (
-                $columnDiff->hasChanged('type')
-                || $columnDiff->hasChanged('precision')
-                || $columnDiff->hasChanged('scale')
-                || $columnDiff->hasChanged('fixed')
+                $columnDiff->hasTypeChanged()
+                || $columnDiff->hasPrecisionChanged()
+                || $columnDiff->hasScaleChanged()
+                || $columnDiff->hasFixedChanged()
             ) {
                 $type = $column->getType();
 
@@ -588,7 +588,7 @@ SQL
                 $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ' . $query;
             }
 
-            if ($columnDiff->hasChanged('default')) {
+            if ($columnDiff->hasDefaultChanged()) {
                 $defaultClause = $column->getDefault() === null
                     ? ' DROP DEFAULT'
                     : ' SET' . $this->getDefaultValueDeclarationSQL($column->toArray());
@@ -596,12 +596,12 @@ SQL
                 $sql[]         = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ' . $query;
             }
 
-            if ($columnDiff->hasChanged('notnull')) {
+            if ($columnDiff->hasNotNullChanged()) {
                 $query = 'ALTER ' . $oldColumnName . ' ' . ($column->getNotnull() ? 'SET' : 'DROP') . ' NOT NULL';
                 $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ' . $query;
             }
 
-            if ($columnDiff->hasChanged('autoincrement')) {
+            if ($columnDiff->hasAutoIncrementChanged()) {
                 if ($column->getAutoincrement()) {
                     // add autoincrement
                     $seqName = $this->getIdentitySequenceName($diff->name, $oldColumnName);
@@ -622,7 +622,7 @@ SQL
             $oldComment = $this->getOldColumnComment($columnDiff);
 
             if (
-                $columnDiff->hasChanged('comment')
+                $columnDiff->hasCommentChanged()
                 || ($columnDiff->fromColumn !== null && $oldComment !== $newComment)
             ) {
                 $commentsSQL[] = $this->getCommentOnColumnSQL(
@@ -632,7 +632,7 @@ SQL
                 );
             }
 
-            if (! $columnDiff->hasChanged('length')) {
+            if (! $columnDiff->hasLengthChanged()) {
                 continue;
             }
 
@@ -706,7 +706,7 @@ SQL
             return count(array_diff($columnDiff->changedProperties, ['type', 'length', 'fixed'])) === 0;
         }
 
-        if ($columnDiff->hasChanged('type')) {
+        if ($columnDiff->hasTypeChanged()) {
             return false;
         }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -583,7 +583,7 @@ class SQLServerPlatform extends AbstractPlatform
             }
 
             // Do not add query part if only comment has changed.
-            if ($columnDiff->hasChanged('comment') && count($columnDiff->changedProperties) === 1) {
+            if ($columnDiff->hasCommentChanged() && count($columnDiff->changedProperties) === 1) {
                 continue;
             }
 
@@ -609,7 +609,7 @@ class SQLServerPlatform extends AbstractPlatform
 
             if (
                 ! isset($columnDef['default'])
-                || (! $requireDropDefaultConstraint && ! $columnDiff->hasChanged('default'))
+                || (! $requireDropDefaultConstraint && ! $columnDiff->hasDefaultChanged())
             ) {
                 continue;
             }
@@ -733,13 +733,13 @@ class SQLServerPlatform extends AbstractPlatform
 
         // We need to drop an existing default constraint if the column was
         // defined with a default value before and it has changed.
-        if ($columnDiff->hasChanged('default')) {
+        if ($columnDiff->hasDefaultChanged()) {
             return true;
         }
 
         // We need to drop an existing default constraint if the column was
         // defined with a default value before and the native column type has changed.
-        return $columnDiff->hasChanged('type') || $columnDiff->hasChanged('fixed');
+        return $columnDiff->hasTypeChanged() || $columnDiff->hasFixedChanged();
     }
 
     /**

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -1161,7 +1161,7 @@ class SqlitePlatform extends AbstractPlatform
                 continue;
             }
 
-            if (! $columnDiff->hasChanged('type') && $columnDiff->hasChanged('unsigned')) {
+            if (! $columnDiff->hasTypeChanged() && $columnDiff->hasUnsignedChanged()) {
                 unset($diff->changedColumns[$oldColumnName]);
 
                 continue;

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -54,7 +54,59 @@ class ColumnDiff
         $this->fromColumn        = $fromColumn;
     }
 
+    public function hasTypeChanged(): bool
+    {
+        return $this->hasChanged('type');
+    }
+
+    public function hasLengthChanged(): bool
+    {
+        return $this->hasChanged('length');
+    }
+
+    public function hasPrecisionChanged(): bool
+    {
+        return $this->hasChanged('precision');
+    }
+
+    public function hasScaleChanged(): bool
+    {
+        return $this->hasChanged('scale');
+    }
+
+    public function hasUnsignedChanged(): bool
+    {
+        return $this->hasChanged('unsigned');
+    }
+
+    public function hasFixedChanged(): bool
+    {
+        return $this->hasChanged('fixed');
+    }
+
+    public function hasNotNullChanged(): bool
+    {
+        return $this->hasChanged('notnull');
+    }
+
+    public function hasDefaultChanged(): bool
+    {
+        return $this->hasChanged('default');
+    }
+
+    public function hasAutoIncrementChanged(): bool
+    {
+        return $this->hasChanged('autoincrement');
+    }
+
+    public function hasCommentChanged(): bool
+    {
+        return $this->hasChanged('comment');
+    }
+
     /**
+     * @internal
+     *
      * @param string $propertyName
      *
      * @return bool


### PR DESCRIPTION
This patch introduces property-specific `ColumnDiff` methods which on its own allows avoiding using magic strings that the `hasChanged()` method accepts. Additionally, it will enable the following steps:

1. Move the property-specific comparison logic from the comparator to the diff.
2. Remove the `ColumnDiff::$changedProperties` property.
3. Deprecate and remove `Comparator::diffColumn()`.

At this point, the property-based schema comparison logic will be almost eradicated.

Later, we can even get rid of the methods being introduced here in favor of the approach implemented in https://github.com/doctrine/dbal/pull/5623, https://github.com/doctrine/dbal/pull/5640 and https://github.com/doctrine/dbal/pull/5641. This will make schema comparison fully driven by the platforms and simplify the comparator and the diff classes.

Besides that, this change brings us one step closer to getting rid of `Column::toArray()`, which is horrible from the type safety standpoint.