### PR TITLE
Remove AbstractSchemaManager::createSchema()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -572,6 +572,7 @@ The former has also been made final.
 The following schema- and namespace-related methods have been removed:
 
 - `AbstractPlatform::getListNamespacesSQL()`,
+- `AbstractSchemaManager::createSchema()`,
 - `AbstractSchemaManager::listNamespaceNames()`,
 - `AbstractSchemaManager::getPortableNamespacesList()`,
 - `AbstractSchemaManager::getPortableNamespaceDefinition()`,

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -39,10 +39,6 @@
                     See https://github.com/doctrine/dbal/pull/4317
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\AbstractSchemaManager::createSchema"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -14,7 +14,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
 use function array_intersect;
@@ -833,21 +832,12 @@ abstract class AbstractSchemaManager
     }
 
     /**
-     * Creates a schema instance for the current database.
-     *
-     * @deprecated Use {@link introspectSchema()} instead.
+     * Returns a {@see Schema} instance representing the current database schema.
      *
      * @throws Exception
      */
-    public function createSchema(): Schema
+    public function introspectSchema(): Schema
     {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5613',
-            '%s is deprecated. Use introspectSchema() instead.',
-            __METHOD__,
-        );
-
         $schemaNames = [];
 
         if ($this->platform->supportsSchemas()) {
@@ -863,16 +853,6 @@ abstract class AbstractSchemaManager
         $tables = $this->listTables();
 
         return new Schema($tables, $sequences, $this->createSchemaConfig(), $schemaNames);
-    }
-
-    /**
-     * Returns a {@see Schema} instance representing the current database schema.
-     *
-     * @throws Exception
-     */
-    public function introspectSchema(): Schema
-    {
-        return $this->createSchema();
     }
 
     /**


### PR DESCRIPTION
The method being removed was deprecated in https://github.com/doctrine/dbal/pull/5613.