### PR TITLE
Reduce duplication of collation declaration code

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -1033,16 +1033,6 @@ SQL
      *
      * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
-    public function getColumnCollationDeclarationSQL($collation)
-    {
-        return 'COLLATE ' . $this->quoteSingleIdentifier($collation);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     */
     public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey)
     {
         $query = '';

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3321,7 +3321,7 @@ abstract class AbstractPlatform
      */
     public function getColumnCollationDeclarationSQL($collation)
     {
-        return $this->supportsColumnCollation() ? 'COLLATE ' . $collation : '';
+        return $this->supportsColumnCollation() ? 'COLLATE ' . $this->quoteSingleIdentifier($collation) : '';
     }
 
     /**

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -1304,16 +1304,6 @@ SQL
 
     /**
      * {@inheritdoc}
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     */
-    public function getColumnCollationDeclarationSQL($collation)
-    {
-        return 'COLLATE ' . $this->quoteSingleIdentifier($collation);
-    }
-
-    /**
-     * {@inheritdoc}
      */
     public function getJsonTypeDeclarationSQL(array $column)
     {

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1650,6 +1650,16 @@ class SQLServerPlatform extends AbstractPlatform
         return $name . ' ' . $columnDef;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * SQL Server does not support quoting collation identifiers.
+     */
+    public function getColumnCollationDeclarationSQL($collation)
+    {
+        return 'COLLATE ' . $collation;
+    }
+
     public function columnsEqual(Column $column1, Column $column2): bool
     {
         if (! parent::columnsEqual($column1, $column2)) {

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -787,14 +787,6 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         self::assertTrue($this->platform->supportsColumnCollation());
     }
 
-    public function testColumnCollationDeclarationSQL(): void
-    {
-        self::assertSame(
-            'COLLATE NOCASE',
-            $this->platform->getColumnCollationDeclarationSQL('NOCASE'),
-        );
-    }
-
     public function testGetCreateTableSQLWithColumnCollation(): void
     {
         $table = new Table('foo');
@@ -804,7 +796,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         self::assertSame(
             [
                 'CREATE TABLE foo (no_collation VARCHAR(255) NOT NULL, '
-                    . 'column_collation VARCHAR(255) NOT NULL COLLATE NOCASE)',
+                    . 'column_collation VARCHAR(255) NOT NULL COLLATE "NOCASE")',
             ],
             $this->platform->getCreateTableSQL($table),
         );


### PR DESCRIPTION
It is safe to quote collation in the default implementation of `getColumnCollationDeclarationSQL()` since those platforms where the case sensitivity of an identifier depends on whether it's quoted (Oracle, IBM DB2) do not support column collation anyways.

SQL Server does not support quoting collation identifiers, so we'll handle it as a special case.