### PR TITLE
Mark ColumnDiff public properties as internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -23,6 +23,11 @@ The following `Comparator` methods have been marked as internal:
 
 The `diffColumn()` method has been deprecated. Use `diffTable()` instead.
 
+## Marked `ColumnDiff` public properties as internal.
+
+The `$fromColumn` and `$column` properties of the `ColumnDiff` class have been marked as internal. Use the
+`getOldColumn()` and `getNewColumn()` methods instead.
+
 ## Deprecated `ColumnDiff::$changedProperties` and `::hasChanged()`.
 
 The `ColumnDiff::$changedProperties` property and the `hasChanged()` method have been deprecated. Use one of the

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -607,8 +607,8 @@ class DB2Platform extends AbstractPlatform
             if ($columnDiff->hasCommentChanged()) {
                 $commentsSQL[] = $this->getCommentOnColumnSQL(
                     $diff->getName($this)->getQuotedName($this),
-                    $columnDiff->column->getQuotedName($this),
-                    $this->getColumnComment($columnDiff->column),
+                    $columnDiff->getNewColumn()->getQuotedName($this),
+                    $this->getColumnComment($columnDiff->getNewColumn()),
                 );
             }
 
@@ -702,12 +702,12 @@ class DB2Platform extends AbstractPlatform
      */
     private function getAlterColumnClausesSQL(ColumnDiff $columnDiff): array
     {
-        $column = $columnDiff->column->toArray();
+        $newColumn = $columnDiff->getNewColumn()->toArray();
 
-        $alterClause = 'ALTER COLUMN ' . $columnDiff->column->getQuotedName($this);
+        $alterClause = 'ALTER COLUMN ' . $columnDiff->getNewColumn()->getQuotedName($this);
 
-        if ($column['columnDefinition'] !== null) {
-            return [$alterClause . ' ' . $column['columnDefinition']];
+        if ($newColumn['columnDefinition'] !== null) {
+            return [$alterClause . ' ' . $newColumn['columnDefinition']];
         }
 
         $clauses = [];
@@ -719,16 +719,16 @@ class DB2Platform extends AbstractPlatform
             $columnDiff->hasScaleChanged() ||
             $columnDiff->hasFixedChanged()
         ) {
-            $clauses[] = $alterClause . ' SET DATA TYPE ' . $column['type']->getSQLDeclaration($column, $this);
+            $clauses[] = $alterClause . ' SET DATA TYPE ' . $newColumn['type']->getSQLDeclaration($newColumn, $this);
         }
 
         if ($columnDiff->hasNotNullChanged()) {
-            $clauses[] = $column['notnull'] ? $alterClause . ' SET NOT NULL' : $alterClause . ' DROP NOT NULL';
+            $clauses[] = $newColumn['notnull'] ? $alterClause . ' SET NOT NULL' : $alterClause . ' DROP NOT NULL';
         }
 
         if ($columnDiff->hasDefaultChanged()) {
-            if (isset($column['default'])) {
-                $defaultClause = $this->getDefaultValueDeclarationSQL($column);
+            if (isset($newColumn['default'])) {
+                $defaultClause = $this->getDefaultValueDeclarationSQL($newColumn);
 
                 if ($defaultClause !== '') {
                     $clauses[] = $alterClause . ' SET' . $defaultClause;

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -900,13 +900,13 @@ SQL
                 continue;
             }
 
-            $column = $columnDiff->column;
+            $newColumn = $columnDiff->getNewColumn();
 
             // Do not generate column alteration clause if type is binary and only fixed property has changed.
             // Oracle only supports binary type columns with variable length.
             // Avoids unnecessary table alteration statements.
             if (
-                $column->getType() instanceof BinaryType &&
+                $newColumn->getType() instanceof BinaryType &&
                 $columnDiff->hasFixedChanged() &&
                 count($columnDiff->changedProperties) === 1
             ) {
@@ -919,13 +919,13 @@ SQL
              * Do not add query part if only comment has changed
              */
             if (! ($columnHasChangedComment && count($columnDiff->changedProperties) === 1)) {
-                $columnInfo = $column->toArray();
+                $newColumnProperties = $newColumn->toArray();
 
                 if (! $columnDiff->hasNotNullChanged()) {
-                    unset($columnInfo['notnull']);
+                    unset($newColumnProperties['notnull']);
                 }
 
-                $fields[] = $column->getQuotedName($this) . $this->getColumnDeclarationSQL('', $columnInfo);
+                $fields[] = $newColumn->getQuotedName($this) . $this->getColumnDeclarationSQL('', $newColumnProperties);
             }
 
             if (! $columnHasChangedComment) {
@@ -934,8 +934,8 @@ SQL
 
             $commentsSQL[] = $this->getCommentOnColumnSQL(
                 $diff->getName($this)->getQuotedName($this),
-                $column->getQuotedName($this),
-                $this->getColumnComment($column),
+                $newColumn->getQuotedName($this),
+                $this->getColumnComment($newColumn),
             );
         }
 

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -18,7 +18,11 @@ class ColumnDiff
      */
     public $oldColumnName;
 
-    /** @var Column */
+    /**
+     * @internal Use {@see getNewColumn()} instead.
+     *
+     * @var Column
+     */
     public $column;
 
     /**
@@ -30,7 +34,11 @@ class ColumnDiff
      */
     public $changedProperties = [];
 
-    /** @var Column|null */
+    /**
+     * @internal Use {@see getOldColumn()} instead.
+     *
+     * @var Column|null
+     */
     public $fromColumn;
 
     /**
@@ -58,6 +66,16 @@ class ColumnDiff
         $this->column            = $column;
         $this->changedProperties = $changedProperties;
         $this->fromColumn        = $fromColumn;
+    }
+
+    public function getOldColumn(): ?Column
+    {
+        return $this->fromColumn;
+    }
+
+    public function getNewColumn(): Column
+    {
+        return $this->column;
     }
 
     public function hasTypeChanged(): bool


### PR DESCRIPTION
The current property names `$fromColumn` and `$column` are clumsy. The API expressed via properties is harder to evolve compared to an API expressed in methods. Let's replace properties with getters. We can do the same with the other diff classes later.