### PR TITLE
Remove implementation of alterTable() for SQLite

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -153,17 +153,6 @@ class SqliteSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritdoc}
      */
-    public function renameTable($name, $newName)
-    {
-        $tableDiff            = new TableDiff($name);
-        $tableDiff->fromTable = $this->listTableDetails($name);
-        $tableDiff->newName   = $newName;
-        $this->alterTable($tableDiff);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function createForeignKey(ForeignKeyConstraint $foreignKey, $table)
     {
         $tableDiff                     = $this->getTableDiffForAlterForeignKey($table);

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -22,17 +22,6 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         return $platform instanceof OraclePlatform;
     }
 
-    public function testRenameTable(): void
-    {
-        $this->createTestTable('list_tables_test');
-        $this->dropTableIfExists('list_tables_test_new_name');
-        $this->schemaManager->renameTable('list_tables_test', 'list_tables_test_new_name');
-
-        $tables = $this->schemaManager->listTables();
-
-        self::assertHasTable($tables);
-    }
-
     /**
      * Oracle currently stores VARBINARY columns as RAW (fixed-size)
      */

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -261,6 +261,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         yield 'Two tables' => ['filter_test_', 2];
     }
 
+    public function testRenameTable(): void
+    {
+        $this->createTestTable('old_name');
+        $this->schemaManager->renameTable('old_name', 'new_name');
+
+        self::assertFalse($this->schemaManager->tablesExist(['old_name']));
+        self::assertTrue($this->schemaManager->tablesExist(['new_name']));
+    }
+
     public function createListTableColumns(): Table
     {
         $table = new Table('list_table_columns');

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -41,16 +41,6 @@ class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertFileDoesNotExist($path);
     }
 
-    public function testRenameTable(): void
-    {
-        $this->createTestTable('oldname');
-        $this->schemaManager->renameTable('oldname', 'newname');
-
-        $tables = $this->schemaManager->listTableNames();
-        self::assertContains('newname', $tables);
-        self::assertNotContains('oldname', $tables);
-    }
-
     public function createListTableColumns(): Table
     {
         $table = parent::createListTableColumns();


### PR DESCRIPTION
The SQLite schema manager doesn't need to override the default implementation of `renameTable()` because its `alterTable()` doesn't use the `$fromTable` property of the diff being passed down the line.

Additionally, `renameTableTest()` has been moved to the base schema manager test class to cover the same scenario across all supported platforms. 