### PR TITLE
Introspect default constraint name

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -46,6 +46,11 @@ The following classes have been converted to enums:
 
 The corresponding class constants are now instances of their enum type.
 
+## BC BREAK: dropped naming convention for default constraints on SQL Server
+
+The DBAL no longer generates default constraint names using the table name and column name. The name is now generated
+by the database.
+
 ## BC BREAK: renamed SQLite platform classes
 
 1. `SqlitePlatform` => `SQLitePlatform`


### PR DESCRIPTION
The current approach to managing default column values on SQL Server has a few significant downsides:

1. The schema manager manages the schema with the assumption that the foreign key constraints are named in a certain way: https://github.com/doctrine/dbal/blob/171759e4c49dea823754fece88db0cd031189bc6/src/Platforms/SQLServerPlatform.php#L1216-L1219
   It makes it unable to manage the schema that was not created by the DBAL.
2. In order to maintain the naming of the default constraints with the above convention, the schema manager has to rename the affected default constraints if the table or the column that it belongs to is renamed:
   1. Renaming column: https://github.com/doctrine/dbal/blob/171759e4c49dea823754fece88db0cd031189bc6/src/Platforms/SQLServerPlatform.php#L463-L463
   2. Renaming table: https://github.com/doctrine/dbal/blob/171759e4c49dea823754fece88db0cd031189bc6/src/Platforms/SQLServerPlatform.php#L492-L499

The proposed approach eliminates the dependency on the naming convention and instead introspects the default constraints.