### PR TITLE
Deprecate SchemaDiff::$fromSchema

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -62,6 +62,10 @@ The constructors of the following classes have been marked as internal:
 These classes can be instantiated only by schema comparators. The signatures of the constructors may change in future
 versions.
 
+## Deprecated `SchemaDiff` reference to the original schema.
+
+The `SchemaDiff::$fromSchema` property has been deprecated.
+
 ## Marked `AbstractSchemaManager::_execSql()` as internal.
 
 The `AbstractSchemaManager::_execSql()` method has been marked as internal. It will not be available in 4.0.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -455,6 +455,10 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
+                <referencedProperty name="Doctrine\DBAL\Schema\SchemaDiff::$fromSchema"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
                 <referencedProperty name="Doctrine\DBAL\Schema\ColumnDiff::$oldColumnName"/>
                 <!--
                     TODO: remove in 4.0.0

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -14,7 +14,11 @@ use function array_merge;
  */
 class SchemaDiff
 {
-    /** @var Schema|null */
+    /**
+     * @deprecated
+     *
+     * @var Schema|null
+     */
     public $fromSchema;
 
     /**


### PR DESCRIPTION
This reference is optional (i.e. the consumers cannot rely on its presence) and is unused anywhere since its introduction in [#220](https://github.com/doctrine/dbal/pull/220/commits/95522656fde1c4a940f8ee22bc9b0c53790dea35).