### PR TITLE
Optimize MySQLSchemaManager::selectForeignKeyColumns()

### DIFF
--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -481,8 +481,7 @@ SQL;
 FROM information_schema.key_column_usage k /*!50116
 INNER JOIN information_schema.referential_constraints c
 ON c.CONSTRAINT_NAME = k.CONSTRAINT_NAME
-AND c.TABLE_NAME = k.TABLE_NAME
-AND c.CONSTRAINT_SCHEMA = k.TABLE_SCHEMA */
+AND c.TABLE_NAME = k.TABLE_NAME */
 SQL;
 
         $conditions = ['k.TABLE_SCHEMA = ?'];
@@ -495,7 +494,14 @@ SQL;
 
         $conditions[] = 'k.REFERENCED_COLUMN_NAME IS NOT NULL';
 
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY k.ORDINAL_POSITION';
+        $sql .= ' WHERE ' . implode(' AND ', $conditions)
+            // The schema name is passed multiple times in the WHERE clause instead of using a JOIN condition
+            // in order to avoid performance issues on MySQL older than 8.0 and the corresponding MariaDB versions
+            // caused by https://bugs.mysql.com/bug.php?id=81347.
+            // Use a string literal for the database name since the internal PDO SQL parser
+            // cannot recognize parameter placeholders inside conditional comments
+            . ' /*!50116 AND c.CONSTRAINT_SCHEMA = ' . $this->_conn->quote($databaseName) . ' */'
+            . ' ORDER BY k.ORDINAL_POSITION';
 
         return $this->_conn->executeQuery($sql, $params);
     }


### PR DESCRIPTION
This patch implements the same approach as #5202 and #5638 did.