### PR TITLE
Fix DATE_ADD function for Sqlite db

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -134,13 +134,6 @@ class SqlitePlatform extends AbstractPlatform
     protected function getDateArithmeticIntervalExpression($date, $operator, $interval, $unit)
     {
         switch ($unit) {
-            case DateIntervalUnit::SECOND:
-            case DateIntervalUnit::MINUTE:
-            case DateIntervalUnit::HOUR:
-                return 'DATETIME(' . $date . ",'" . $operator . $interval . ' ' . $unit . "')";
-        }
-
-        switch ($unit) {
             case DateIntervalUnit::WEEK:
                 $interval *= 7;
                 $unit      = DateIntervalUnit::DAY;
@@ -154,6 +147,13 @@ class SqlitePlatform extends AbstractPlatform
 
         if (! is_numeric($interval)) {
             $interval = "' || " . $interval . " || '";
+        }
+
+        switch ($unit) {
+            case DateIntervalUnit::SECOND:
+            case DateIntervalUnit::MINUTE:
+            case DateIntervalUnit::HOUR:
+                return 'DATETIME(' . $date . ",'" . $operator . $interval . ' ' . $unit . "')";
         }
 
         return 'DATE(' . $date . ",'" . $operator . $interval . ' ' . $unit . "')";

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -782,6 +782,42 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function testDateAddStaticNumberOfTimes(): void
+    {
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+10 SECOND')",
+            $this->platform->getDateAddSecondsExpression('rentalBeginsOn', 10)
+        );
+
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+10 MINUTE')",
+            $this->platform->getDateAddMinutesExpression('rentalBeginsOn', 10)
+        );
+
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+10 HOUR')",
+            $this->platform->getDateAddHourExpression('rentalBeginsOn', 10)
+        );
+    }
+
+    public function testDateAddNumberOfTimesFromColumn(): void
+    {
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+' || duration || ' SECOND')",
+            $this->platform->getDateAddSecondsExpression('rentalBeginsOn', 'duration')
+        );
+
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+' || duration || ' MINUTE')",
+            $this->platform->getDateAddMinutesExpression('rentalBeginsOn', 'duration')
+        );
+
+        self::assertSame(
+            "DATETIME(rentalBeginsOn,'+' || duration || ' HOUR')",
+            $this->platform->getDateAddHourExpression('rentalBeginsOn', 'duration')
+        );
+    }
+
     public function testSupportsColumnCollation(): void
     {
         self::assertTrue($this->platform->supportsColumnCollation());


### PR DESCRIPTION
The DATE_ADD function was working incorrectly for sqlite when used with a column. I fixed it simply by changing the flow order of the code and added some tests.