### PR TITLE
Remove SchemaDiff::$fromSchema

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -426,6 +426,10 @@ the name of the object as a separate parameter. The name of the passed index or 
 The `AbstractPlatform::canEmulateSchemas()` method and the schema emulation implemented in the SQLite platform
 have been removed.
 
+## BC BREAK: removed `SchemaDiff` reference to the original schema.
+
+The `SchemaDiff` class no longer accepts or exposes a reference to the original schema.
+
 ## BC BREAK: Changes in the `ColumnDiff` class
 
 1. The `$fromColumn` parameter of the `ColumnDiff` constructor has been made required.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -50,10 +50,6 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
-                <referencedProperty name="Doctrine\DBAL\Schema\SchemaDiff::$fromSchema"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
                 <referencedProperty name="Doctrine\DBAL\Schema\TableDiff::$newName"/>
             </errorLevel>
         </DeprecatedProperty>

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -29,8 +29,7 @@ class Comparator
      */
     public function compareSchemas(Schema $fromSchema, Schema $toSchema): SchemaDiff
     {
-        $diff             = new SchemaDiff();
-        $diff->fromSchema = $fromSchema;
+        $diff = new SchemaDiff();
 
         /** @var array<string,list<array{ForeignKeyConstraint,string}>> $foreignKeysToTable */
         $foreignKeysToTable = [];

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -11,9 +11,6 @@ use function array_values;
 
 /**
  * Differences between two schemas.
- *
- * The object contains the operations to change the schema stored in $fromSchema
- * to a target schema.
  */
 class SchemaDiff
 {
@@ -60,10 +57,6 @@ class SchemaDiff
         public array $newTables = [],
         public array $changedTables = [],
         public array $removedTables = [],
-        /**
-         * @deprecated
-         */
-        public ?Schema $fromSchema = null,
     ) {
     }
 

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -44,9 +44,7 @@ abstract class ComparatorTest extends TestCase
             ),
         ]);
 
-        $expected             = new SchemaDiff();
-        $expected->fromSchema = $schema1;
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals(new SchemaDiff(), $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareSame2(): void
@@ -70,9 +68,7 @@ abstract class ComparatorTest extends TestCase
             ),
         ]);
 
-        $expected             = new SchemaDiff();
-        $expected->fromSchema = $schema1;
-        self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
+        self::assertEquals(new SchemaDiff(), $this->comparator->compareSchemas($schema1, $schema2));
     }
 
     public function testCompareMissingTable(): void
@@ -85,7 +81,7 @@ abstract class ComparatorTest extends TestCase
         $schema1 = new Schema([$table], [], $schemaConfig);
         $schema2 = new Schema([], [], $schemaConfig);
 
-        $expected = new SchemaDiff([], [], ['bugdb' => $table], $schema1);
+        $expected = new SchemaDiff([], [], ['bugdb' => $table]);
 
         self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
@@ -100,7 +96,7 @@ abstract class ComparatorTest extends TestCase
         $schema1 = new Schema([], [], $schemaConfig);
         $schema2 = new Schema([$table], [], $schemaConfig);
 
-        $expected = new SchemaDiff(['bugdb' => $table], [], [], $schema1);
+        $expected = new SchemaDiff(['bugdb' => $table], [], []);
 
         self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
     }
@@ -136,7 +132,7 @@ abstract class ComparatorTest extends TestCase
             ),
         ]);
 
-        $expected                                    = new SchemaDiff(
+        $expected = new SchemaDiff(
             [],
             [
                 'bugdb' => new TableDiff(
@@ -147,7 +143,7 @@ abstract class ComparatorTest extends TestCase
                 ),
             ],
         );
-        $expected->fromSchema                        = $schema1;
+
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
         self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
@@ -173,7 +169,7 @@ abstract class ComparatorTest extends TestCase
             ),
         ]);
 
-        $expected                                    = new SchemaDiff(
+        $expected = new SchemaDiff(
             [],
             [
                 'bugdb' => new TableDiff(
@@ -184,7 +180,7 @@ abstract class ComparatorTest extends TestCase
                 ),
             ],
         );
-        $expected->fromSchema                        = $schema1;
+
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
         self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
@@ -281,7 +277,7 @@ abstract class ComparatorTest extends TestCase
             ),
         ]);
 
-        $expected                                    = new SchemaDiff(
+        $expected = new SchemaDiff(
             [],
             [
                 'bugdb' => new TableDiff(
@@ -301,7 +297,7 @@ abstract class ComparatorTest extends TestCase
                 ),
             ],
         );
-        $expected->fromSchema                        = $schema1;
+
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
         self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
@@ -335,7 +331,7 @@ abstract class ComparatorTest extends TestCase
             ),
         ]);
 
-        $expected                                    = new SchemaDiff(
+        $expected = new SchemaDiff(
             [],
             [
                 'bugdb' => new TableDiff(
@@ -353,7 +349,7 @@ abstract class ComparatorTest extends TestCase
                 ),
             ],
         );
-        $expected->fromSchema                        = $schema1;
+
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
         self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
@@ -394,7 +390,7 @@ abstract class ComparatorTest extends TestCase
             ),
         ]);
 
-        $expected                                    = new SchemaDiff(
+        $expected = new SchemaDiff(
             [],
             [
                 'bugdb' => new TableDiff(
@@ -416,7 +412,7 @@ abstract class ComparatorTest extends TestCase
                 ),
             ],
         );
-        $expected->fromSchema                        = $schema1;
+
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
         self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
@@ -449,7 +445,7 @@ abstract class ComparatorTest extends TestCase
             ),
         ]);
 
-        $expected                                    = new SchemaDiff(
+        $expected = new SchemaDiff(
             [],
             [
                 'bugdb' => new TableDiff(
@@ -464,7 +460,7 @@ abstract class ComparatorTest extends TestCase
                 ),
             ],
         );
-        $expected->fromSchema                        = $schema1;
+
         $expected->changedTables['bugdb']->fromTable = $schema1->getTable('bugdb');
 
         self::assertEquals($expected, $this->comparator->compareSchemas($schema1, $schema2));
@@ -820,8 +816,7 @@ abstract class ComparatorTest extends TestCase
         $newSchema = new Schema([], [], $config);
         $newSchema->createTable('foo.bar');
 
-        $expected             = new SchemaDiff();
-        $expected->fromSchema = $oldSchema;
+        $expected = new SchemaDiff();
 
         self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
     }
@@ -841,7 +836,6 @@ abstract class ComparatorTest extends TestCase
         $newSchema->createTable('war.tab');
 
         $expected                = new SchemaDiff();
-        $expected->fromSchema    = $oldSchema;
         $expected->newNamespaces = ['bar' => 'bar', 'baz' => 'baz'];
 
         $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
@@ -861,10 +855,7 @@ abstract class ComparatorTest extends TestCase
         $newSchema = new Schema();
         $newSchema->createTable('bar');
 
-        $expected             = new SchemaDiff();
-        $expected->fromSchema = $oldSchema;
-
-        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
+        self::assertEquals(new SchemaDiff(), $this->comparator->compareSchemas($oldSchema, $newSchema));
     }
 
     public function testFqnSchemaComparisonNoSchemaSame(): void
@@ -877,10 +868,7 @@ abstract class ComparatorTest extends TestCase
         $newSchema = new Schema();
         $newSchema->createTable('bar');
 
-        $expected             = new SchemaDiff();
-        $expected->fromSchema = $oldSchema;
-
-        self::assertEquals($expected, $this->comparator->compareSchemas($oldSchema, $newSchema));
+        self::assertEquals(new SchemaDiff(), $this->comparator->compareSchemas($oldSchema, $newSchema));
     }
 
     public function testAutoIncrementSequences(): void
@@ -971,8 +959,7 @@ abstract class ComparatorTest extends TestCase
         $table     = $newSchema->createTable('foo');
         $table->addColumn('id', 'string', ['length' => 32]);
 
-        $expected             = new SchemaDiff();
-        $expected->fromSchema = $oldSchema;
+        $expected = new SchemaDiff();
 
         $tableDiff            = $expected->changedTables['foo'] = new TableDiff('foo');
         $tableDiff->fromTable = $tableFoo;
@@ -996,8 +983,7 @@ abstract class ComparatorTest extends TestCase
         $table     = $newSchema->createTable('foo');
         $table->addColumn('id', 'binary', ['length' => 42, 'fixed' => true]);
 
-        $expected             = new SchemaDiff();
-        $expected->fromSchema = $oldSchema;
+        $expected = new SchemaDiff();
 
         $tableDiff            = $expected->changedTables['foo'] = new TableDiff('foo');
         $tableDiff->fromTable = $tableFoo;
@@ -1058,7 +1044,6 @@ abstract class ComparatorTest extends TestCase
             ->willReturnOnConsecutiveCalls(false, true);
 
         $expected                    = new SchemaDiff();
-        $expected->fromSchema        = $fromSchema;
         $expected->newNamespaces     = ['baz' => 'baz'];
         $expected->removedNamespaces = ['foo' => 'foo'];
 


### PR DESCRIPTION
The property being removed was deprecated in https://github.com/doctrine/dbal/pull/5666.