### PR TITLE
Remove support for renaming tables via TableDiff

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -430,6 +430,10 @@ the name of the object as a separate parameter. The name of the passed index or 
 The `AbstractPlatform::canEmulateSchemas()` method and the schema emulation implemented in the SQLite platform
 have been removed.
 
+## BC BREAK: removed support for renaming tables via `TableDiff` and `AbstractPlatform::alterTable()`.
+
+The `TableDiff::$newName` property and the `TableDiff::getNewName()` method have been removed.
+
 ## BC BREAK: removed `SchemaDiff` reference to the original schema.
 
 The `SchemaDiff` class no longer accepts or exposes a reference to the original schema.
@@ -645,7 +649,6 @@ Table columns are no longer indexed by column name. Use the `name` attribute of 
 - Method `Doctrine\DBAL\Schema\AbstractSchemaManager::_getPortableViewDefinition()` no longer optionally returns false. It will always return a `Doctrine\DBAL\Schema\View` instance.
 - Method `Doctrine\DBAL\Schema\Comparator::diffTable()` now optionally returns null instead of false.
 - Property `Doctrine\DBAL\Schema\Table::$_primaryKeyName` is now optionally null instead of false.
-- Property `Doctrine\DBAL\Schema\TableDiff::$newName` is now optionally null instead of false.
 - Method `Doctrine\DBAL\Schema\AbstractSchemaManager::tablesExist()` no longer accepts a string. Use `Doctrine\DBAL\Schema\AbstractSchemaManager::tableExists()` instead.
 - Method `Doctrine\DBAL\Schema\OracleSchemaManager::createDatabase()` no longer accepts `null` for `$database` argument.
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -39,20 +39,8 @@
                     See https://github.com/doctrine/dbal/pull/4317
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getNewName"/>
             </errorLevel>
         </DeprecatedMethod>
-        <DeprecatedProperty>
-            <errorLevel type="suppress">
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedProperty name="Doctrine\DBAL\Schema\TableDiff::$newName"/>
-            </errorLevel>
-        </DeprecatedProperty>
         <DocblockTypeContradiction>
             <errorLevel type="suppress">
                 <!--

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -15,7 +15,6 @@ use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function array_unique;
@@ -311,17 +310,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     {
         $columnSql  = [];
         $queryParts = [];
-        $newName    = $diff->getNewName();
-
-        if ($newName !== null) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5663',
-                'Generation of SQL that renames a table using %s is deprecated. Use getRenameTableSQL() instead.',
-                __METHOD__,
-            );
-            $queryParts[] = 'RENAME TO ' . $newName->getQuotedName($this);
-        }
 
         foreach ($diff->addedColumns as $column) {
             if ($this->onSchemaAlterTableAddColumn($column, $diff, $columnSql)) {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1422,14 +1422,9 @@ abstract class AbstractPlatform
     /** @return string[] */
     protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff): array
     {
-        $sql     = [];
-        $newName = $diff->getNewName();
+        $sql = [];
 
-        if ($newName !== null) {
-            $tableName = $newName->getQuotedName($this);
-        } else {
-            $tableName = $diff->getName($this)->getQuotedName($this);
-        }
+        $tableName = $diff->getName($this)->getQuotedName($this);
 
         foreach ($diff->addedForeignKeys as $foreignKey) {
             $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableName);

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -15,7 +15,6 @@ use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function count;
@@ -347,27 +346,10 @@ class DB2Platform extends AbstractPlatform
                 $sql[] = "CALL SYSPROC.ADMIN_CMD ('REORG TABLE " . $diff->getName($this)->getQuotedName($this) . "')";
             }
 
-            $sql = array_merge($sql, $commentsSQL);
-
-            $newName = $diff->getNewName();
-
-            if ($newName !== null) {
-                Deprecation::trigger(
-                    'doctrine/dbal',
-                    'https://github.com/doctrine/dbal/pull/5663',
-                    'Generation of "rename table" SQL using %s is deprecated. Use getRenameTableSQL() instead.',
-                    __METHOD__,
-                );
-                $sql[] = sprintf(
-                    'RENAME TABLE %s TO %s',
-                    $diff->getName($this)->getQuotedName($this),
-                    $newName->getQuotedName($this),
-                );
-            }
-
             $sql = array_merge(
                 $this->getPreAlterTableIndexForeignKeySQL($diff),
                 $sql,
+                $commentsSQL,
                 $this->getPostAlterTableIndexForeignKeySQL($diff),
             );
         }

--- a/src/Platforms/MariaDBPlatform.php
+++ b/src/Platforms/MariaDBPlatform.php
@@ -62,14 +62,9 @@ class MariaDBPlatform extends AbstractMySQLPlatform
     /** @return list<string> */
     private function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff): array
     {
-        $sql     = [];
-        $newName = $diff->getNewName();
+        $sql = [];
 
-        if ($newName !== null) {
-            $tableName = $newName->getQuotedName($this);
-        } else {
-            $tableName = $diff->getName($this)->getQuotedName($this);
-        }
+        $tableName = $diff->getName($this)->getQuotedName($this);
 
         foreach ($this->getRemainingForeignKeyConstraintsRequiringRenamedIndexes($diff) as $foreignKey) {
             if (in_array($foreignKey, $diff->changedForeignKeys, true)) {

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -15,7 +15,6 @@ use Doctrine\DBAL\Schema\OracleSchemaManager;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
-use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 use function array_merge;
@@ -621,27 +620,10 @@ END;';
         $tableSql = [];
 
         if (! $this->onSchemaAlterTable($diff, $tableSql)) {
-            $sql = array_merge($sql, $commentsSQL);
-
-            $newName = $diff->getNewName();
-
-            if ($newName !== null) {
-                Deprecation::trigger(
-                    'doctrine/dbal',
-                    'https://github.com/doctrine/dbal/pull/5663',
-                    'Generation of "rename table" SQL using %s is deprecated. Use getRenameTableSQL() instead.',
-                    __METHOD__,
-                );
-                $sql[] = sprintf(
-                    'ALTER TABLE %s RENAME TO %s',
-                    $diff->getName($this)->getQuotedName($this),
-                    $newName->getQuotedName($this),
-                );
-            }
-
             $sql = array_merge(
                 $this->getPreAlterTableIndexForeignKeySQL($diff),
                 $sql,
+                $commentsSQL,
                 $this->getPostAlterTableIndexForeignKeySQL($diff),
             );
         }

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -14,7 +14,6 @@ use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
-use Doctrine\Deprecations\Deprecation;
 use UnexpectedValueException;
 
 use function array_merge;
@@ -342,27 +341,10 @@ class PostgreSQLPlatform extends AbstractPlatform
         $tableSql = [];
 
         if (! $this->onSchemaAlterTable($diff, $tableSql)) {
-            $sql = array_merge($sql, $commentsSQL);
-
-            $newName = $diff->getNewName();
-
-            if ($newName !== null) {
-                Deprecation::trigger(
-                    'doctrine/dbal',
-                    'https://github.com/doctrine/dbal/pull/5663',
-                    'Generation of "rename table" SQL using %s is deprecated. Use getRenameTableSQL() instead.',
-                    __METHOD__,
-                );
-                $sql[] = sprintf(
-                    'ALTER TABLE %s RENAME TO %s',
-                    $diff->getName($this)->getQuotedName($this),
-                    $newName->getQuotedName($this),
-                );
-            }
-
             $sql = array_merge(
                 $this->getPreAlterTableIndexForeignKeySQL($diff),
                 $sql,
+                $commentsSQL,
                 $this->getPostAlterTableIndexForeignKeySQL($diff),
             );
         }

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
-use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 use function array_merge;
@@ -484,24 +483,10 @@ class SQLServerPlatform extends AbstractPlatform
             $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) . ' ' . $query;
         }
 
-        $sql = array_merge($sql, $commentsSql);
-
-        $newName = $diff->getNewName();
-
-        if ($newName !== null) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5663',
-                'Generation of "rename table" SQL using %s is deprecated. Use getRenameTableSQL() instead.',
-                __METHOD__,
-            );
-
-            $sql = array_merge($sql, $this->getRenameTableSQL($diff->name, $newName->getName()));
-        }
-
         $sql = array_merge(
             $this->getPreAlterTableIndexForeignKeySQL($diff),
             $sql,
+            $commentsSql,
             $this->getPostAlterTableIndexForeignKeySQL($diff),
         );
 

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * Table Diff.
  */
 class TableDiff
 {
-    /** @deprecated Rename tables via {@link AbstractSchemaManager::renameTable()} instead. */
-    public ?string $newName = null;
-
     /**
      * Columns that are only renamed from key to column instance name.
      *
@@ -80,24 +76,5 @@ class TableDiff
         return new Identifier(
             $this->fromTable instanceof Table ? $this->fromTable->getQuotedName($platform) : $this->name,
         );
-    }
-
-    /**
-     * @deprecated Rename tables via {@link AbstractSchemaManager::renameTable()} instead.
-     */
-    public function getNewName(): ?Identifier
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5663',
-            '%s is deprecated. Rename tables via AbstractSchemaManager::renameTable() instead.',
-            __METHOD__,
-        );
-
-        if ($this->newName === null) {
-            return null;
-        }
-
-        return new Identifier($this->newName);
     }
 }

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -616,10 +616,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         return [
             'ALTER TABLE `foo` DROP FOREIGN KEY fk1',
             'ALTER TABLE `foo` DROP FOREIGN KEY fk2',
-            'ALTER TABLE `foo` RENAME TO `table`, ADD bloo INT NOT NULL, DROP baz, CHANGE bar bar INT DEFAULT NULL, ' .
+            'ALTER TABLE `foo` ADD bloo INT NOT NULL, DROP baz, CHANGE bar bar INT DEFAULT NULL, ' .
             'CHANGE id war INT NOT NULL',
-            'ALTER TABLE `table` ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
-            'ALTER TABLE `table` ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
+            'ALTER TABLE `foo` ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
+            'ALTER TABLE `foo` ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
         ];
     }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -1078,7 +1078,6 @@ abstract class AbstractPlatformTestCase extends TestCase
 
         $tableDiff                        = new TableDiff('"foo"');
         $tableDiff->fromTable             = $table;
-        $tableDiff->newName               = 'table';
         $tableDiff->addedColumns['bloo']  = new Column('bloo', Type::getType('integer'));
         $tableDiff->changedColumns['bar'] = new ColumnDiff(
             new Column('bar', Type::getType('integer'), ['notnull' => false]),

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -477,9 +477,8 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             'ALTER COLUMN bar DROP NOT NULL ' .
             'RENAME COLUMN id TO war',
             'CALL SYSPROC.ADMIN_CMD (\'REORG TABLE "foo"\')',
-            'RENAME TABLE "foo" TO "table"',
-            'ALTER TABLE "table" ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
-            'ALTER TABLE "table" ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
+            'ALTER TABLE "foo" ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
+            'ALTER TABLE "foo" ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
         ];
     }
 

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -528,9 +528,8 @@ SQL
             'ALTER TABLE "foo" MODIFY (bar NUMBER(10) DEFAULT NULL NULL)',
             'ALTER TABLE "foo" RENAME COLUMN id TO war',
             'ALTER TABLE "foo" DROP (baz)',
-            'ALTER TABLE "foo" RENAME TO "table"',
-            'ALTER TABLE "table" ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
-            'ALTER TABLE "table" ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
+            'ALTER TABLE "foo" ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
+            'ALTER TABLE "foo" ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
         ];
     }
 

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -646,10 +646,9 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE "foo" DROP baz',
             'ALTER TABLE "foo" ALTER bar DROP NOT NULL',
             'ALTER TABLE "foo" RENAME COLUMN id TO war',
-            'ALTER TABLE "foo" RENAME TO "table"',
-            'ALTER TABLE "table" ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id) NOT DEFERRABLE ' .
+            'ALTER TABLE "foo" ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id) NOT DEFERRABLE ' .
             'INITIALLY IMMEDIATE',
-            'ALTER TABLE "table" ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id) NOT DEFERRABLE ' .
+            'ALTER TABLE "foo" ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id) NOT DEFERRABLE ' .
             'INITIALLY IMMEDIATE',
         ];
     }

--- a/tests/Platforms/SQLServerPlatformTestCase.php
+++ b/tests/Platforms/SQLServerPlatformTestCase.php
@@ -1367,14 +1367,8 @@ class SQLServerPlatformTestCase extends AbstractPlatformTestCase
             'ALTER TABLE [foo] ADD bloo INT NOT NULL',
             'ALTER TABLE [foo] DROP COLUMN baz',
             'ALTER TABLE [foo] ALTER COLUMN bar INT',
-            "sp_rename '[foo]', 'table'",
-            "DECLARE @sql NVARCHAR(MAX) = N''; " .
-            "SELECT @sql += N'EXEC sp_rename N''' + dc.name + ''', " .
-            "N''' + REPLACE(dc.name, '8C736521', 'F6298F46') + ''', ''json'';' " .
-            'FROM sys.default_constraints dc JOIN sys.tables tbl ON dc.parent_object_id = tbl.object_id ' .
-            "WHERE tbl.name = 'table';EXEC sp_executesql @sql",
-            'ALTER TABLE [table] ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
-            'ALTER TABLE [table] ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
+            'ALTER TABLE [foo] ADD CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id)',
+            'ALTER TABLE [foo] ADD CONSTRAINT fk2 FOREIGN KEY (fk2) REFERENCES fk_table2 (id)',
         ];
     }
 

--- a/tests/Platforms/SQLitePlatformTest.php
+++ b/tests/Platforms/SQLitePlatformTest.php
@@ -318,7 +318,6 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
 
         $diff                           = new TableDiff('user');
         $diff->fromTable                = $table;
-        $diff->newName                  = 'client';
         $diff->renamedColumns['id']     = new Column('key', Type::getType('integer'), []);
         $diff->renamedColumns['post']   = new Column('comment', Type::getType('integer'), []);
         $diff->removedColumns['parent'] = new Column('comment', Type::getType('integer'), []);
@@ -337,9 +336,8 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
                 . ')',
             'INSERT INTO user ("key", article, comment) SELECT id, article, post FROM __temp__user',
             'DROP TABLE __temp__user',
-            'ALTER TABLE user RENAME TO client',
-            'CREATE INDEX IDX_8D93D64923A0E66 ON client (article)',
-            'CREATE INDEX IDX_8D93D6495A8A6C8D ON client (comment)',
+            'CREATE INDEX IDX_8D93D64923A0E66 ON user (article)',
+            'CREATE INDEX IDX_8D93D6495A8A6C8D ON user (comment)',
         ];
 
         self::assertEquals($sql, $this->platform->getAlterTableSQL($diff));
@@ -542,9 +540,8 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
             'CONSTRAINT fk_add FOREIGN KEY (fk3) REFERENCES fk_table (id) NOT DEFERRABLE INITIALLY IMMEDIATE)',
             'INSERT INTO "foo" (war, fk, fk2, fk3, bar) SELECT id, fk, fk2, fk3, bar FROM __temp__foo',
             'DROP TABLE __temp__foo',
-            'ALTER TABLE "foo" RENAME TO "table"',
-            'CREATE INDEX IDX_8C736521A81E660E ON "table" (fk)',
-            'CREATE INDEX IDX_8C736521FDC58D6C ON "table" (fk2)',
+            'CREATE INDEX IDX_8C736521A81E660E ON "foo" (fk)',
+            'CREATE INDEX IDX_8C736521FDC58D6C ON "foo" (fk2)',
         ];
     }
 

--- a/tests/Schema/TableDiffTest.php
+++ b/tests/Schema/TableDiffTest.php
@@ -44,15 +44,4 @@ class TableDiffTest extends TestCase
 
         self::assertEquals(new Identifier('foo'), $tableDiff->getName($this->platform));
     }
-
-    public function testReturnsNewName(): void
-    {
-        $tableDiff = new TableDiff('foo');
-
-        self::assertNull($tableDiff->getNewName());
-
-        $tableDiff->newName = 'bar';
-
-        self::assertEquals(new Identifier('bar'), $tableDiff->getNewName());
-    }
 }


### PR DESCRIPTION
The API being removed was deprecated in #5663.