### PR TITLE
Deprecate not passing $fromColumn to TableDiff

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,6 +17,13 @@ The "unique" and "check" column properties have been deprecated. Use unique cons
 Relying on the default precision and scale of decimal columns provided by the DBAL is deprecated.
 When declaring decimal columns, specify the precision and scale explicitly.
 
+## Deprecated not passing `$fromColumn` to the `TableDiff` constructor.
+
+Not passing `$fromColumn` to the `TableDiff` constructor has been deprecated.
+
+The `TableDiff::$name` property and the `TableDiff::getName()` method have been deprecated as well. In order to obtain
+the name of the table that the diff describes, use `TableDiff::getOldTable()`.
+
 ## Deprecated renaming tables via `TableDiff` and `AbstractPlatform::alterTable()`.
 
 Renaming tables via setting the `$newName` property on a `TableDiff` and passing it to `AbstractPlatform::alterTable()`

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -427,6 +427,10 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getNewName"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getName"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>
@@ -472,6 +476,10 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedProperty name="Doctrine\DBAL\Schema\TableDiff::$newName"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedProperty name="Doctrine\DBAL\Schema\TableDiff::$name"/>
             </errorLevel>
         </DeprecatedProperty>
         <DocblockTypeContradiction>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2719,7 +2719,7 @@ abstract class AbstractPlatform
     /** @return string[] */
     protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff)
     {
-        $tableName = $diff->getName($this)->getQuotedName($this);
+        $tableNameSQL = ($diff->getOldTable() ?? $diff->getName($this))->getQuotedName($this);
 
         $sql = [];
         if ($this->supportsForeignKeyConstraints()) {
@@ -2728,20 +2728,20 @@ abstract class AbstractPlatform
                     $foreignKey = $foreignKey->getQuotedName($this);
                 }
 
-                $sql[] = $this->getDropForeignKeySQL($foreignKey, $tableName);
+                $sql[] = $this->getDropForeignKeySQL($foreignKey, $tableNameSQL);
             }
 
             foreach ($diff->changedForeignKeys as $foreignKey) {
-                $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableName);
+                $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableNameSQL);
             }
         }
 
         foreach ($diff->removedIndexes as $index) {
-            $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $tableName);
+            $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $tableNameSQL);
         }
 
         foreach ($diff->changedIndexes as $index) {
-            $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $tableName);
+            $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $tableNameSQL);
         }
 
         return $sql;
@@ -2754,34 +2754,34 @@ abstract class AbstractPlatform
         $newName = $diff->getNewName();
 
         if ($newName !== false) {
-            $tableName = $newName->getQuotedName($this);
+            $tableNameSQL = $newName->getQuotedName($this);
         } else {
-            $tableName = $diff->getName($this)->getQuotedName($this);
+            $tableNameSQL = ($diff->getOldTable() ?? $diff->getName($this))->getQuotedName($this);
         }
 
         if ($this->supportsForeignKeyConstraints()) {
             foreach ($diff->addedForeignKeys as $foreignKey) {
-                $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableName);
+                $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
             }
 
             foreach ($diff->changedForeignKeys as $foreignKey) {
-                $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableName);
+                $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
             }
         }
 
         foreach ($diff->addedIndexes as $index) {
-            $sql[] = $this->getCreateIndexSQL($index, $tableName);
+            $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
         }
 
         foreach ($diff->changedIndexes as $index) {
-            $sql[] = $this->getCreateIndexSQL($index, $tableName);
+            $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
         }
 
         foreach ($diff->renamedIndexes as $oldIndexName => $index) {
             $oldIndexName = new Identifier($oldIndexName);
             $sql          = array_merge(
                 $sql,
-                $this->getRenameIndexSQL($oldIndexName->getQuotedName($this), $index, $tableName),
+                $this->getRenameIndexSQL($oldIndexName->getQuotedName($this), $index, $tableNameSQL),
             );
         }
 

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -870,6 +870,8 @@ SQL
 
         $fields = [];
 
+        $tableNameSQL = ($diff->getOldTable() ?? $diff->getName($this))->getQuotedName($this);
+
         foreach ($diff->addedColumns as $column) {
             if ($this->onSchemaAlterTableAddColumn($column, $diff, $columnSql)) {
                 continue;
@@ -883,15 +885,14 @@ SQL
             }
 
             $commentsSQL[] = $this->getCommentOnColumnSQL(
-                $diff->getName($this)->getQuotedName($this),
+                $tableNameSQL,
                 $column->getQuotedName($this),
                 $comment,
             );
         }
 
         if (count($fields) > 0) {
-            $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this)
-                . ' ADD (' . implode(', ', $fields) . ')';
+            $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ADD (' . implode(', ', $fields) . ')';
         }
 
         $fields = [];
@@ -933,15 +934,14 @@ SQL
             }
 
             $commentsSQL[] = $this->getCommentOnColumnSQL(
-                $diff->getName($this)->getQuotedName($this),
+                $tableNameSQL,
                 $newColumn->getQuotedName($this),
                 $this->getColumnComment($newColumn),
             );
         }
 
         if (count($fields) > 0) {
-            $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this)
-                . ' MODIFY (' . implode(', ', $fields) . ')';
+            $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' MODIFY (' . implode(', ', $fields) . ')';
         }
 
         foreach ($diff->renamedColumns as $oldColumnName => $column) {
@@ -951,8 +951,8 @@ SQL
 
             $oldColumnName = new Identifier($oldColumnName);
 
-            $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this) .
-                ' RENAME COLUMN ' . $oldColumnName->getQuotedName($this) . ' TO ' . $column->getQuotedName($this);
+            $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' RENAME COLUMN ' . $oldColumnName->getQuotedName($this)
+                . ' TO ' . $column->getQuotedName($this);
         }
 
         $fields = [];
@@ -965,8 +965,7 @@ SQL
         }
 
         if (count($fields) > 0) {
-            $sql[] = 'ALTER TABLE ' . $diff->getName($this)->getQuotedName($this)
-                . ' DROP (' . implode(', ', $fields) . ')';
+            $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' DROP (' . implode(', ', $fields) . ')';
         }
 
         $tableSql = [];
@@ -986,7 +985,7 @@ SQL
 
                 $sql[] = sprintf(
                     'ALTER TABLE %s RENAME TO %s',
-                    $diff->getName($this)->getQuotedName($this),
+                    $tableNameSQL,
                     $newName->getQuotedName($this),
                 );
             }

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -27,7 +27,7 @@ use function strtolower;
  */
 class Comparator
 {
-    private ?AbstractPlatform $platform = null;
+    private ?AbstractPlatform $platform;
 
     /** @internal The comparator can be only instantiated by a schema manager. */
     public function __construct(?AbstractPlatform $platform = null)
@@ -264,9 +264,8 @@ class Comparator
      */
     public function diffTable(Table $fromTable, Table $toTable)
     {
-        $changes                     = 0;
-        $tableDifferences            = new TableDiff($fromTable->getName());
-        $tableDifferences->fromTable = $fromTable;
+        $changes          = 0;
+        $tableDifferences = new TableDiff($fromTable->getName(), [], [], [], [], [], [], $fromTable);
 
         $fromTableColumns = $fromTable->getColumns();
         $toTableColumns   = $toTable->getColumns();

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -318,12 +318,14 @@ SQL,
     public function alterTable(TableDiff $tableDiff)
     {
         if (count($tableDiff->removedColumns) > 0) {
+            $tableName = ($tableDiff->getOldTable() ?? $tableDiff->getName($this->_platform))->getName();
+
             foreach ($tableDiff->removedColumns as $col) {
-                foreach ($this->getColumnConstraints($tableDiff->name, $col->getName()) as $constraint) {
+                foreach ($this->getColumnConstraints($tableName, $col->getName()) as $constraint) {
                     $this->_conn->executeStatement(
                         sprintf(
                             'ALTER TABLE %s DROP CONSTRAINT %s',
-                            $tableDiff->name,
+                            $tableName,
                             $constraint,
                         ),
                     );

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -507,10 +507,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
             $table = $this->listTableDetails($table);
         }
 
-        $tableDiff            = new TableDiff($table->getName());
-        $tableDiff->fromTable = $table;
-
-        return $tableDiff;
+        return new TableDiff($table->getName(), [], [], [], [], [], [], $table);
     }
 
     private function parseColumnCollationFromSQL(string $column, string $sql): ?string

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -10,7 +10,11 @@ use Doctrine\Deprecations\Deprecation;
  */
 class TableDiff
 {
-    /** @var string */
+    /**
+     * @deprecated Use {@see getOldTable()} instead.
+     *
+     * @var string
+     */
     public $name;
 
     /**
@@ -97,7 +101,11 @@ class TableDiff
      */
     public $removedForeignKeys = [];
 
-    /** @var Table|null */
+    /**
+     * @internal Use {@see getOldTable()} instead.
+     *
+     * @var Table|null
+     */
     public $fromTable;
 
     /**
@@ -131,9 +139,22 @@ class TableDiff
         $this->changedIndexes = $changedIndexes;
         $this->removedIndexes = $removedIndexes;
         $this->fromTable      = $fromTable;
+
+        if ($fromTable !== null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5678',
+                'Not passing the $fromColumn to %s is deprecated.',
+                __METHOD__,
+            );
+        }
+
+        $this->fromTable = $fromTable;
     }
 
     /**
+     * @deprecated Use {@see getOldTable()} instead.
+     *
      * @param AbstractPlatform $platform The platform to use for retrieving this table diff's name.
      *
      * @return Identifier
@@ -164,5 +185,10 @@ class TableDiff
         }
 
         return new Identifier($this->newName);
+    }
+
+    public function getOldTable(): ?Table
+    {
+        return $this->fromTable;
     }
 }


### PR DESCRIPTION
The reference from `TableDiff` to the old table should be required as it is required by the SQLite platform: https://github.com/doctrine/dbal/blob/0361d33d942f0dfd82bf568799aa68bff13399e2/src/Platforms/SqlitePlatform.php#L996-L1001

Using the diff itself as a source of the old table name is a hack that should have been deprecated with the introduction of the reference to the old table. It makes the diff (which is a value object) depend on the platform API (which is infrastructure): https://github.com/doctrine/dbal/blob/0361d33d942f0dfd82bf568799aa68bff13399e2/src/Schema/TableDiff.php#L141-L146

Additionally, it loses the information about the table name being quoted: https://github.com/doctrine/dbal/blob/0361d33d942f0dfd82bf568799aa68bff13399e2/src/Schema/Comparator.php#L268