### PR TITLE
Remove leftovers of renaming default contraints

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1286,12 +1286,9 @@ abstract class AbstractPlatform
      */
     abstract public function getAlterTableSQL(TableDiff $diff): array;
 
-    /** @return list<string> */
-    public function getRenameTableSQL(string $oldName, string $newName): array
+    public function getRenameTableSQL(string $oldName, string $newName): string
     {
-        return [
-            sprintf('ALTER TABLE %s RENAME TO %s', $oldName, $newName),
-        ];
+        return sprintf('ALTER TABLE %s RENAME TO %s', $oldName, $newName);
     }
 
     /** @param mixed[] $columnSql */

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -357,14 +357,9 @@ class DB2Platform extends AbstractPlatform
         return array_merge($sql, $tableSql, $columnSql);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getRenameTableSQL(string $oldName, string $newName): array
+    public function getRenameTableSQL(string $oldName, string $newName): string
     {
-        return [
-            sprintf('RENAME TABLE %s TO %s', $oldName, $newName),
-        ];
+        return sprintf('RENAME TABLE %s TO %s', $oldName, $newName);
     }
 
     /**

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -493,36 +493,13 @@ class SQLServerPlatform extends AbstractPlatform
         return array_merge($sql, $tableSql, $columnSql);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getRenameTableSQL(string $oldName, string $newName): array
+    public function getRenameTableSQL(string $oldName, string $newName): string
     {
-        return [
-            sprintf('sp_rename %s, %s', $this->quoteStringLiteral($oldName), $this->quoteStringLiteral($newName)),
-
-            /* Rename table's default constraints names
-             * to match the new table name.
-             * This is necessary to ensure that the default
-             * constraints can be referenced in future table
-             * alterations as the table name is encoded in
-             * default constraints' names. */
-            sprintf(
-                <<<'SQL'
-                DECLARE @sql NVARCHAR(MAX) = N'';
-                SELECT @sql += N'EXEC sp_rename N''' + dc.name + ''', N'''
-                    + REPLACE(dc.name, '%s', '%s') + ''', ''OBJECT'';'
-                    FROM sys.default_constraints dc
-                    JOIN sys.tables tbl
-                        ON dc.parent_object_id = tbl.object_id
-                    WHERE tbl.name = %s;
-                EXEC sp_executesql @sql
-                SQL,
-                $this->generateIdentifierName($oldName),
-                $this->generateIdentifierName($newName),
-                $this->quoteStringLiteral($newName),
-            ),
-        ];
+        return sprintf(
+            'sp_rename %s, %s',
+            $this->quoteStringLiteral($oldName),
+            $this->quoteStringLiteral($newName)
+        );
     }
 
     /**

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -633,7 +633,9 @@ abstract class AbstractSchemaManager
      */
     public function renameTable(string $name, string $newName): void
     {
-        $this->executeStatements($this->platform->getRenameTableSQL($name, $newName));
+        $this->connection->executeStatement(
+            $this->platform->getRenameTableSQL($name, $newName)
+        );
     }
 
     /**


### PR DESCRIPTION
The statement that renames the default constraints as part of renaming the table should not have been merged up from 3.5.x in https://github.com/doctrine/dbal/pull/5674.

Additionally, the return type of `AbstractPlatform::getRenameTableSQL()` is being changed from `list<string>` to `string` as the former was only necessary to support renaming the default constraints.