### PR TITLE
Reset nested transaction level on deadlock exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
         "squizlabs/php_codesniffer": "3.7.1",
         "symfony/cache": "^5.4|^6.0",
         "symfony/console": "^4.4|^5.4|^6.0",
-        "vimeo/psalm": "4.27.0"
+        "vimeo/psalm": "4.27.0",
+        "ext-pcntl": "*"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."

--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,7 @@
         "squizlabs/php_codesniffer": "3.7.1",
         "symfony/cache": "^5.4|^6.0",
         "symfony/console": "^4.4|^5.4|^6.0",
-        "vimeo/psalm": "4.27.0",
-        "ext-pcntl": "*"
+        "vimeo/psalm": "4.27.0"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Event\TransactionBeginEventArgs;
 use Doctrine\DBAL\Event\TransactionCommitEventArgs;
 use Doctrine\DBAL\Event\TransactionRollBackEventArgs;
 use Doctrine\DBAL\Exception\ConnectionLost;
+use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -1840,6 +1841,11 @@ class Connection
 
         if ($exception instanceof ConnectionLost) {
             $this->close();
+        }
+
+        if ($exception instanceof DeadlockException) {
+            //Reset transaction nesting level since deadlocks always rollback.
+            $this->transactionNestingLevel = 0;
         }
 
         return $exception;

--- a/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
+++ b/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
@@ -7,8 +7,10 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 
+use function implode;
 use function pcntl_fork;
 use function sleep;
+use function sprintf;
 
 class DeadlockTest extends FunctionalTestCase
 {
@@ -16,8 +18,9 @@ class DeadlockTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        if (TestUtil::isDriverOneOf('sqlite')) {
-            $this->markTestSkipped();
+        $supportedDrivers = ['pdo_mysql', 'mysqli', 'mssql'];
+        if (! TestUtil::isDriverOneOf(...$supportedDrivers)) {
+            self::markTestSkipped(sprintf('This supports one of %s drivers', implode(', ', $supportedDrivers)));
         }
 
         $table = new Table('test1');

--- a/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
+++ b/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
@@ -70,8 +70,8 @@ class DeadlockTest extends FunctionalTestCase
 
         $connection = TestUtil::getConnection();
         $connection->beginTransaction();
-        $connection->executeStatement('DELETE FROM `test2`');
-        $connection->executeStatement('DELETE FROM `test1`');
+        $connection->executeStatement('DELETE FROM test2');
+        $connection->executeStatement('DELETE FROM test1');
         $connection->commit();
     }
 

--- a/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
+++ b/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Driver\PDO\MySQL;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\PDO\MySQL\Driver;
+use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Tests\Functional\Driver\AbstractDriverTest;
+use Doctrine\DBAL\Tests\TestUtil;
+use ReflectionObject;
+use Throwable;
+
+use function pcntl_fork;
+use function sleep;
+
+class DeadlockTest extends AbstractDriverTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (TestUtil::isDriverOneOf('pdo_mysql')) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires the pdo_mysql driver.');
+    }
+
+    public function testNestedTransactionsDeadlockExceptionHandling(): void
+    {
+        $firstConnection = new Connection($this->connection->getParams(), $this->driver);
+        $firstConnection->setNestTransactionsWithSavepoints(true);
+        $secondConnection = new Connection($this->connection->getParams(), $this->driver);
+        $secondConnection->setNestTransactionsWithSavepoints(true);
+
+        $this->assertNotSame($firstConnection, $secondConnection);
+
+        $this->prepareDatabase($firstConnection);
+
+        $executeQueries = static function (Connection $conn, int $thread): void {
+            $conn->beginTransaction();
+            $conn->beginTransaction();
+            if ($thread === 1) {
+                $conn->executeQuery('DELETE FROM `test1`');
+                sleep(2);
+                $conn->executeQuery('DELETE FROM `test2`');
+            } else {
+                $conn->executeQuery('DELETE FROM `test2`');
+                $conn->executeQuery('DELETE FROM `test1`');
+            }
+
+            $conn->commit();
+            $conn->commit();
+        };
+
+        $pid = pcntl_fork();
+        if (! $pid) {
+            //child process
+            $executeQueries($secondConnection, 2);
+
+            return;
+        }
+
+        try {
+            $executeQueries($firstConnection, 1);
+        } catch (Throwable $ex) {
+            $this->assertInstanceOf(DeadlockException::class, $ex);
+            $reflectionObject = new ReflectionObject($firstConnection);
+
+            $transactionNestingLevel = $reflectionObject->getProperty('transactionNestingLevel');
+            $transactionNestingLevel->setAccessible(true);
+
+            $this->assertEquals(0, $transactionNestingLevel->getValue($firstConnection));
+
+            return;
+        }
+
+        $this->fail('No deadlock exception in first thread');
+    }
+
+    private function prepareDatabase(Connection $connection): void
+    {
+        $connection->executeStatement(
+            'CREATE TABLE IF NOT EXISTS `test1`
+                (
+                    `id` INT(11) NOT NULL AUTO_INCREMENT,
+                    PRIMARY KEY (`id`)
+                ) ENGINE = InnoDB
+                  DEFAULT CHARSET = `latin1`;',
+        );
+        $connection->executeStatement('INSERT INTO `test1` VALUES()');
+
+        $connection->executeStatement(
+            'CREATE TABLE IF NOT EXISTS `test2`
+                (
+                    `id` INT(11) NOT NULL AUTO_INCREMENT,
+                    PRIMARY KEY (`id`)
+                ) ENGINE = InnoDB
+                  DEFAULT CHARSET = `latin1`;',
+        );
+        $connection->executeQuery('INSERT INTO `test2` VALUES()');
+    }
+
+    protected function createDriver(): DriverInterface
+    {
+        return new Driver();
+    }
+}

--- a/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
+++ b/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
@@ -16,6 +16,10 @@ class DeadlockTest extends FunctionalTestCase
     {
         parent::setUp();
 
+        if (TestUtil::isDriverOneOf('sqlite')) {
+            $this->markTestSkipped();
+        }
+
         $table = new Table('test1');
         $table->addColumn('id', 'integer');
         $this->dropAndCreateTable($table);

--- a/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
+++ b/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
@@ -24,8 +24,8 @@ class DeadlockTest extends FunctionalTestCase
         $table->addColumn('id', 'integer');
         $this->dropAndCreateTable($table);
 
-        $this->connection->executeStatement('INSERT INTO `test1` VALUES(1)');
-        $this->connection->executeStatement('INSERT INTO `test2` VALUES(1)');
+        $this->connection->executeStatement('INSERT INTO test1 VALUES(1)');
+        $this->connection->executeStatement('INSERT INTO test2 VALUES(1)');
     }
 
     public function testNestedTransactionsDeadlockExceptionHandling(): void
@@ -35,11 +35,11 @@ class DeadlockTest extends FunctionalTestCase
         try {
             $this->connection->beginTransaction();
             $this->connection->beginTransaction();
-            $this->connection->executeStatement('DELETE FROM `test1`;');
+            $this->connection->executeStatement('DELETE FROM test1');
 
             $this->forceTableLockState();
 
-            $this->connection->executeStatement('DELETE FROM `test2`;');
+            $this->connection->executeStatement('DELETE FROM test2');
             $this->connection->commit();
             $this->connection->commit();
         } catch (DeadlockException $ex) {

--- a/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
+++ b/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
@@ -12,6 +12,7 @@ use function pcntl_fork;
 use function sleep;
 use function sprintf;
 
+/** @require extension pcntl */
 class DeadlockTest extends FunctionalTestCase
 {
     protected function setUp(): void

--- a/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
+++ b/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
@@ -18,7 +18,7 @@ class DeadlockTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $supportedDrivers = ['pdo_mysql', 'mysqli', 'mssql'];
+        $supportedDrivers = ['pdo_mysql', 'mysqli', 'pdo_pgsql'];
         if (! TestUtil::isDriverOneOf(...$supportedDrivers)) {
             self::markTestSkipped(sprintf('This supports one of %s drivers', implode(', ', $supportedDrivers)));
         }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

Fixes #4279.

#### Summary
The code resets transactions' nested level to zero on deadlock exceptions.
Also, add a functional/integration test to validate that it works as expected.

Probably should be ported to 4.x and 2.x
