### PR TITLE
Remove workaround for PHP bug in PostgreSQL exception handler

### DIFF
--- a/src/Driver/API/PostgreSQL/ExceptionConverter.php
+++ b/src/Driver/API/PostgreSQL/ExceptionConverter.php
@@ -77,13 +77,6 @@ final class ExceptionConverter implements ExceptionConverterInterface
                 return new ConnectionException($exception, $query);
         }
 
-        // Prior to fixing https://bugs.php.net/bug.php?id=64705 (PHP 7.4.10),
-        // in some cases (mainly connection errors) the PDO exception wouldn't provide a SQLSTATE via its code.
-        // We have to match against the SQLSTATE in the error message in these cases.
-        if ($exception->getCode() === 7 && str_contains($exception->getMessage(), 'SQLSTATE[08006]')) {
-            return new ConnectionException($exception, $query);
-        }
-
         return new DriverException($exception, $query);
     }
 }


### PR DESCRIPTION
The workaround is irrelevant as of https://github.com/doctrine/dbal/pull/5043.