### PR TITLE
Deprecate driver name aliases

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 3.5
 
+## Deprecated driver name aliases.
+
+Relying on driver name aliases in connection parameters has been deprecated. Use the actual driver names instead.
+
 ## Deprecated "unique" and "check" column properties.
 
 The "unique" and "check" column properties have been deprecated. Use unique constraints to define unique columns.

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -49,25 +49,13 @@ The path after the authority part represents the name of the
 database, sans the leading slash. Any query parameters are used as
 additional connection parameters.
 
-The scheme names representing the drivers are either the regular
-driver names (see below) with any underscores in their name replaced
-with a hyphen (to make them legal in URL scheme names), or one of the
-following simplified driver names that serve as aliases:
+The scheme names representing the drivers are the driver names
+with any underscores in their name replaced with a hyphen
+(to make them legal in URL scheme names).
 
--  ``db2``: alias for ``ibm_db2``
--  ``mssql``: alias for ``pdo_sqlsrv``
--  ``mysql``/``mysql2``: alias for ``pdo_mysql``
--  ``pgsql``/``postgres``/``postgresql``: alias for ``pdo_pgsql``
--  ``sqlite``/``sqlite3``: alias for ``pdo_sqlite``
-
-For example, to connect to a "foo" MySQL DB using the ``pdo_mysql``
+For example, to connect to a "foo" MySQL database using the ``pdo_mysql``
 driver on localhost port 4486 with the "charset" option set to ``utf8mb4``,
 you would use the following URL::
-
-    mysql://localhost:4486/foo?charset=utf8mb4
-
-This is identical to the following connection string using the
-full driver name::
 
     pdo-mysql://localhost:4486/foo?charset=utf8mb4
 
@@ -79,28 +67,28 @@ URL is obviously irrelevant and thus can be omitted. The path part
 of the URL is, like for all other drivers, stripped of its leading
 slash, resulting in a relative file name for the database::
 
-    sqlite:///somedb.sqlite
+    pdo-sqlite:///somedb.sqlite
 
 This would access ``somedb.sqlite`` in the current working directory
 and is identical to the following::
 
-    sqlite://ignored:ignored@ignored:1234/somedb.sqlite
+    pdo-sqlite://ignored:ignored@ignored:1234/somedb.sqlite
 
 To specify an absolute file path, e.g. ``/usr/local/var/db.sqlite``,
 simply use that as the database name, which results in two leading
 slashes for the path part of the URL, and four slashes in total after
 the URL scheme name and its following colon::
 
-    sqlite:////usr/local/var/db.sqlite
+    pdo-sqlite:////usr/local/var/db.sqlite
 
 Which is, again, identical to supplying ignored user/pass/authority::
 
-    sqlite://notused:inthis@case//usr/local/var/db.sqlite
+    pdo-sqlite://notused:inthis@case//usr/local/var/db.sqlite
 
 To connect to an in-memory SQLite instance, use ``:memory:`` as the
 database name::
 
-    sqlite:///:memory:
+    pdo-sqlite:///:memory:
 
 .. note::
 


### PR DESCRIPTION
The aliases were initially implemented in https://github.com/doctrine/dbal/pull/729 as part of the support for connection URLs but there wasn't any public discussion about their design and purpose.

The existing set of aliases is quite illogical and raises questions:
1. The `mysql` alias prefers the `pdo_mysql` driver over `mysqli`. Why?
2. The "MS SQL" and "SQL Server" terms are quite interchangeable but using `sqlsrv` in the schema will make the `sqlsrv` driver used while `mssql` is mapped to `pdo_sqlsrv`. Why?
3. The `mysql2` alias was introduced for https://github.com/doctrine/dbal/blob/2ab785585ed257717760eb6ddcd12bfb96f97639/src/DriverManager.php#L101 Why should the DBAL support the schema used by AWS RDS?
4. If the aliases are needed for compatibility with the driver naming of other database-related APIs, how do we validate and maintain the compatibility, and which APIs should the DBAL be compatible with?

Judging by the documentation, the only purpose of using an alias is to avoid using dashes or underscores in connection URLs. Even if that's the case, why do we need more than one alias per driver name? Being able to do one thing in four different ways (`pgsql`, `postgres`, `postgresql`, `pdo-pgsql`) has rarely been a good idea.

Given that the requirement for using dashes has been documented since the very beginning, I don't believe that this is a problem that requires support for aliases.