### PR TITLE
Deprecate platform parameter of wrapper Connection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.5
 
+## Deprecated the "platform" parameter of the wrapper `Connection`.
+
+The "platform" parameter of the wrapper `Connection` has been deprecated. Use a driver middleware that would instantiate
+the platform instead.
+
 ## Deprecated driver name aliases.
 
 Relying on driver name aliases in connection parameters has been deprecated. Use the actual driver names instead.

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -278,45 +278,15 @@ Automatic platform version detection
 
 Doctrine ships with different database platform implementations for some vendors
 to support version specific features, dialect and behaviour.
-As of Doctrine DBAL 2.5 the appropriate platform implementation for the underlying
-database server version can be detected at runtime automatically for nearly all drivers.
-Before 2.5 you had to configure Doctrine to use a certain platform implementation
-explicitly with the ``platform`` connection parameter (see section below).
-Otherwise Doctrine always used a default platform implementation. For example if
-your application was backed by a SQL Server 2012 database, Doctrine would still use
-the SQL Server 2008 platform implementation as it is the default, unless you told
-Doctrine explicitly to use the SQL Server 2012 implementation.
 
-The following drivers support automatic database platform detection out of the box
-without any extra configuration required:
+The drivers will automatically detect the platform version and instantiate
+the corresponding platform class.
 
--  ``pdo_mysql``
--  ``mysqli``
--  ``pdo_pgsql``
--  ``pdo_sqlsrv``
--  ``sqlsrv``
-
-Some drivers cannot provide the version of the underlying database server without
-having to query for it explicitly.
-
-If you still want to tell Doctrine which database server version you are using in
-order to choose the appropriate platform implementation, you can pass the
-``serverVersion`` option with a vendor specific version string that matches the
-database server version you are using.
-You can also pass this option if you want to disable automatic database platform
-detection for a driver that natively supports it and choose the platform version
-implementation explicitly.
+You can also pass the ``serverVersion`` option if you want to disable automatic
+database platform detection and choose the platform version implementation explicitly.
 
 If you are running a MariaDB database, you should prefix the ``serverVersion``
 with ``mariadb-`` (ex: ``mariadb-10.2.12``).
-
-Custom Platform
-~~~~~~~~~~~~~~~
-
-Each built-in driver uses a default implementation of
-``Doctrine\DBAL\Platforms\AbstractPlatform``. If you wish to use a
-customized or custom implementation, you can pass a precreated
-instance in the ``platform`` option.
 
 Custom Driver Options
 ~~~~~~~~~~~~~~~~~~~~~

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -184,6 +184,13 @@ class Connection
                 throw Exception::invalidPlatformType($params['platform']);
             }
 
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5699',
+                'The "platform" connection parameter is deprecated.'
+                    . ' Use a driver middleware that would instantiate the platform instead.',
+            );
+
             $this->platform = $params['platform'];
             $this->platform->setEventManager($this->_eventManager);
         }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

## Issues with the current API

### Unsafe from the type system standpoint #​1

Currently, each driver is responsible for making sure that the platform it instantiates is compatible with the driver itself. When a platform is overridden via the connection parameters, there's no way to statically guarantee that the platform is compatible with the driver. One can use `mysql` as the driver and pass an instance of `PostrgreSQL` platform. The mismatch will surface only at runtime and only in the scenarios when the platform logic kicks in (e.g. building `LIMIT` queries).

This becomes evident when Psalm analyses the codebase with some assertions replaced with parametrized types. The following line is reported as having this issue:

https://github.com/doctrine/dbal/blob/6bad1f284035e53fa02eed33236ced41bd4fc1f3/src/Connection.php#L187

```
ERROR: InvalidPropertyAssignmentValue - src/Connection.php:190:31 - $this->platform with declared type
'(P:Doctrine\DBAL\Connection as Doctrine\DBAL\Platforms\AbstractPlatform)|null' cannot be assigned type
'Doctrine\DBAL\Platforms\AbstractPlatform' (see https://psalm.dev/145)
```

While the connection is expected to contain a platform compatible with the driver, the connection parameters can contain any platform.

### Unsafe from the type system standpoint #​2

The type of the `platform` parameter needs to be checked at runtime:

https://github.com/doctrine/dbal/blob/eebdee3d200767b0ad058c1f7bc1fb97eba5b32b/src/Connection.php#L183-L185

### Not really a parameter

Unlike connection hostname and port, a platform is a stateful object that implements logic. It should be set programmatically via the extension points defined by the API, not via a configuration parameter.

### Requires additional code and testing

This seemingly simple feature requires additional code and tests, which proves the previous point: https://github.com/doctrine/dbal/blob/b24280d3e45788ee59bcca4b8b25f1b25800d8d4/src/Connection.php#L877 https://github.com/doctrine/dbal/blob/e652aab6bfe83a7e17d761b43069cf84e1c1f906/tests/ConnectionTest.php#L716-L811

## Proposal

Deprecate in favor of using a driver middleware like the following:
```php
class MySQLitePlatform extends SqlitePlatform {}

class MyDriver extends AbstractDriverMiddleware
{
    public function createDatabasePlatformForVersion($version)
    {
        echo 'MySQLitePlatform is used', PHP_EOL;

        return new MySQLitePlatform();
    }
}

class MyMiddleware implements Driver\Middleware
{
    public function wrap(Driver $driver): Driver
    {
        return new MyDriver($driver);
    }
}

$config = $connection->getConfiguration()
    ->setMiddlewares([new MyMiddleware()]);

$connection = DriverManager::getConnection($params, $config);
```

In the future, when the driver classes become parametrized with platform types, this type of the platform returned by the middleware will be enforced statically.

As a bonus, this approach enables instantiation of the platform on demand instead of having to instantiate it prior to instantiating the wrapper connection.