### PR TITLE
Deprecate PostgreSQL-specific connection parameters and behavior

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.5
 
+## Deprecated default PostgreSQL connection database.
+
+Relying on the DBAL connecting to the "postgres" database by default is deprecated. Unless you want to have the server
+determine the default database for the connection, specify the database name explicitly.
+
 ## Deprecated the "default_dbname" parameter of the wrapper `Connection`.
 
 The "default_dbname" parameter of the wrapper `Connection` has been deprecated. Use "dbname" instead.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 3.5
 
+## Deprecated the "default_dbname" parameter of the wrapper `Connection`.
+
+The "default_dbname" parameter of the wrapper `Connection` has been deprecated. Use "dbname" instead.
+
 ## Deprecated the "platform" parameter of the wrapper `Connection`.
 
 The "platform" parameter of the wrapper `Connection` has been deprecated. Use a driver middleware that would instantiate

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -203,8 +203,6 @@ pdo_pgsql
 -  ``dbname`` (string): Name of the database/schema to connect to.
 -  ``charset`` (string): The charset used when connecting to the
    database.
--  ``default_dbname`` (string): Override the default database (postgres)
-   to connect to.
 -  ``sslmode`` (string): Determines whether or with what priority
    a SSL TCP/IP connection will be negotiated with the server.
    See the list of available modes:

--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Driver\PDO\PgSQL;
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
 use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
 
@@ -73,6 +74,12 @@ final class Driver extends AbstractPostgreSQLDriver
         if (isset($params['dbname'])) {
             $dsn .= 'dbname=' . $params['dbname'] . ';';
         } elseif (isset($params['default_dbname'])) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5705',
+                'The "default_dbname" connection parameter is deprecated. Use "dbname" instead.',
+            );
+
             $dsn .= 'dbname=' . $params['default_dbname'] . ';';
         } else {
             // Used for temporary connections to allow operations like dropping the database currently connected to.

--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -82,9 +82,17 @@ final class Driver extends AbstractPostgreSQLDriver
 
             $dsn .= 'dbname=' . $params['default_dbname'] . ';';
         } else {
+            if (isset($params['user']) && $params['user'] !== 'postgres') {
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/5705',
+                    'Relying on the DBAL connecting to the "postgres" database by default is deprecated.'
+                        . ' Unless you want to have the server determine the default database for the connection,'
+                        . ' specify the database name explicitly.',
+                );
+            }
+
             // Used for temporary connections to allow operations like dropping the database currently connected to.
-            // Connecting without an explicit database does not work, therefore "postgres" database is used
-            // as it is mostly present in every server setup.
             $dsn .= 'dbname=postgres;';
         }
 


### PR DESCRIPTION
The `default_dbname` parameter was introduced in #2284 as a hack that was supposed to address https://github.com/doctrine/DoctrineBundle/issues/402.

My understanding of the hack is that it would force the connection to return the database currently connected to instead of the database specified in the configuration: https://github.com/doctrine/dbal/blob/253b602c14d2c45904f1713a7f067f4c041a1cbd/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php#L134-L136

This hack is irrelevant as of https://github.com/doctrine/dbal/pull/3606. Since 3.0.0, the connection will always return the name of the database currently connected to. Therefore, this parameter is no longer necessary.

---

The reason to hardcode `postgres` as the default database doesn't seem valid: https://github.com/doctrine/dbal/blob/d5da8b47c7f48e4b149d579d51d9f06fb4ec62d0/src/Driver/PDO/PgSQL/Driver.php#L79

According to this [article](https://www.enterprisedb.com/postgres-tutorials/connecting-postgresql-using-psql-and-pgadmin),
> The default name of the database is the same as that of the user.

This could be reproduced with the following script:
```php
<?php

$conn = new PDO('pgsql:host=localhost;port=5432;user=postgres;password=Passw0rd');

if (!$conn) {
    exit(1);
}

echo $conn->query('SELECT CURRENT_DATABASE()')
    ->fetch(PDO::FETCH_COLUMN), PHP_EOL;
// postgres
```

In any event, it is not the job of the DBAL to provide such defaults. If the user is not happy with the defaults provided by the driver, they should provide the database name explicitly.