### PR TITLE
Update Doctrine Coding Standard to 10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "psr/log": "^1|^2|^3"
     },
     "require-dev": {
-        "doctrine/coding-standard": "9.0.2",
+        "doctrine/coding-standard": "10.0.0",
         "jetbrains/phpstorm-stubs": "2022.2",
         "phpstan/phpstan": "1.8.3",
         "phpstan/phpstan-phpunit": "1.1.1",

--- a/src/Exception/ColumnPrecisionRequired.php
+++ b/src/Exception/ColumnPrecisionRequired.php
@@ -6,9 +6,7 @@ namespace Doctrine\DBAL\Exception;
 
 use Doctrine\DBAL\Exception;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class ColumnPrecisionRequired extends Exception
 {
     public static function new(): self

--- a/src/Exception/ColumnScaleRequired.php
+++ b/src/Exception/ColumnScaleRequired.php
@@ -6,9 +6,7 @@ namespace Doctrine\DBAL\Exception;
 
 use Doctrine\DBAL\Exception;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class ColumnScaleRequired extends Exception
 {
     public static function new(): self

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -429,7 +429,7 @@ class SQLServerPlatform extends AbstractPlatform
                 $commentsSql[] = $this->getCreateColumnCommentSQL(
                     $tableName,
                     $newColumn->getQuotedName($this),
-                    $newComment
+                    $newComment,
                 );
             }
 
@@ -478,7 +478,7 @@ class SQLServerPlatform extends AbstractPlatform
                 "sp_rename '%s.%s', '%s', 'COLUMN'",
                 $tableNameSQL,
                 $oldColumnName->getQuotedName($this),
-                $newColumn->getQuotedName($this)
+                $newColumn->getQuotedName($this),
             );
         }
 
@@ -507,7 +507,7 @@ class SQLServerPlatform extends AbstractPlatform
         return sprintf(
             'sp_rename %s, %s',
             $this->quoteStringLiteral($oldName),
-            $this->quoteStringLiteral($newName)
+            $this->quoteStringLiteral($newName),
         );
     }
 

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -634,7 +634,7 @@ abstract class AbstractSchemaManager
     public function renameTable(string $name, string $newName): void
     {
         $this->connection->executeStatement(
-            $this->platform->getRenameTableSQL($name, $newName)
+            $this->platform->getRenameTableSQL($name, $newName),
         );
     }
 

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -9,9 +9,7 @@ namespace Doctrine\DBAL\Schema;
  */
 class ColumnDiff
 {
-    /**
-     * @internal The diff can be only instantiated by a {@see Comparator}.
-     */
+    /** @internal The diff can be only instantiated by a {@see Comparator}. */
     public function __construct(private readonly Column $oldColumn, private readonly Column $newColumn)
     {
     }

--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -31,7 +31,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $diff = $this->schemaManager->createComparator()
             ->diffTable(
                 $this->schemaManager->introspectTable('sqlsrv_drop_column'),
-                $newTable
+                $newTable,
             );
         self::assertNotNull($diff);
 
@@ -115,7 +115,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $diff = $this->schemaManager->createComparator()
             ->diffTable(
                 $this->schemaManager->introspectTable('sqlsrv_default_constraints'),
-                $newTable
+                $newTable,
             );
         self::assertNotNull($diff);
 

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -853,7 +853,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $diff = $this->schemaManager->createComparator()
             ->diffTable(
                 $this->schemaManager->introspectTable('column_def_change_type'),
-                $newTable
+                $newTable,
             );
         self::assertNotNull($diff);
 
@@ -998,7 +998,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $diff = $this->schemaManager->createComparator()
             ->diffTable(
                 $this->schemaManager->introspectTable('col_def_lifecycle'),
-                $newTable
+                $newTable,
             );
         self::assertNotNull($diff);
 


### PR DESCRIPTION
This update was implemented in https://github.com/doctrine/dbal/pull/5624 but seems to have been lost in https://github.com/doctrine/dbal/pull/5635.