### PR TITLE
Deprecate fallback connection to determine platform

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ awareness about deprecated code.
 
 # Upgrade to 3.5
 
+## Deprecated fallback connection used to determine the database platform.
+
+Relying on a fallback connection used to determine the database platform while connecting to a non-existing database
+has been deprecated. Either use an existing database name in connection parameters or omit the database name
+if the platform and the server configuration allow that.
+
 ## Deprecated default PostgreSQL connection database.
 
 Relying on the DBAL connecting to the "postgres" database by default is deprecated. Unless you want to have the server

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -400,6 +400,15 @@ class Connection
                     throw $originalException;
                 }
 
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/5707',
+                    'Relying on a fallback connection used to determine the database platform while connecting'
+                        . ' to a non-existing database is deprecated. Either use an existing database name in'
+                        . ' connection parameters or omit the database name if the platform'
+                        . ' and the server configuration allow that.',
+                );
+
                 // The database to connect to might not yet exist.
                 // Retry detection without database name connection parameter.
                 $params = $this->params;


### PR DESCRIPTION
The fallback connection only allows detection of the server version but doesn't allow anything else. E.g. it cannot be used to create the database used in the configuration that doesn't yet exist (which one would think would be the intended use case).


```php
$connection = DriverManager::getConnection([
    'driver' => 'mysqli',
    'host'   => '127.0.0.1',
    'user'   => 'root',
    'dbname' => 'non_existing_database',
]);

echo get_class($connection->getDatabasePlatform()), PHP_EOL;
// Doctrine\DBAL\Platforms\MySQL80Platform

try {
    $connection->executeStatement('CREATE DATABASE non_existing_database');
} catch (Exception $e) {
    echo $e->getMessage(), PHP_EOL;
    // An exception occurred in the driver: Unknown database 'non_existing_database'
}
```

If the configured database doesn't exist, in order to create it, the user will have to use an admin connection anyway (like the test suite does). The feature seems to have worked like the above since its implementation (https://github.com/doctrine/dbal/pull/2671).

Besides having questionable value and not being fully portable and not having integration tests, this code has required quite some maintenance, most recently in https://github.com/doctrine/dbal/pull/4764#discussion_r697695742.