### PR TITLE
Remove PostgreSQL-specific connection parameters and behavior

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: removed support for the "default_dbname" parameter of the wrapper `Connection`.
+
+The "default_dbname" parameter of the wrapper `Connection` is no longer supported.
+
 ## BC BREAK: removed fallback connection used to determine the database platform.
 
 When determining the database platform, if an attempt to connect using the provided configuration fails,

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: removed default PostgreSQL connection database.
+
+When connecting to a PostgreSQL server, the driver will no longer connect to the "postgres" database by default.
+
 ## BC BREAK: removed support for the "default_dbname" parameter of the wrapper `Connection`.
 
 The "default_dbname" parameter of the wrapper `Connection` is no longer supported.

--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -81,19 +81,6 @@ final class Driver extends AbstractPostgreSQLDriver
             );
 
             $dsn .= 'dbname=' . $params['default_dbname'] . ';';
-        } else {
-            if (isset($params['user']) && $params['user'] !== 'postgres') {
-                Deprecation::trigger(
-                    'doctrine/dbal',
-                    'https://github.com/doctrine/dbal/pull/5705',
-                    'Relying on the DBAL connecting to the "postgres" database by default is deprecated.'
-                        . ' Unless you want to have the server determine the default database for the connection,'
-                        . ' specify the database name explicitly.',
-                );
-            }
-
-            // Used for temporary connections to allow operations like dropping the database currently connected to.
-            $dsn .= 'dbname=postgres;';
         }
 
         if (isset($params['sslmode'])) {

--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Driver\PDO\PgSQL;
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
 use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDO\Exception;
-use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
 
@@ -73,14 +72,6 @@ final class Driver extends AbstractPostgreSQLDriver
 
         if (isset($params['dbname'])) {
             $dsn .= 'dbname=' . $params['dbname'] . ';';
-        } elseif (isset($params['default_dbname'])) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5705',
-                'The "default_dbname" connection parameter is deprecated. Use "dbname" instead.',
-            );
-
-            $dsn .= 'dbname=' . $params['default_dbname'] . ';';
         }
 
         if (isset($params['sslmode'])) {

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -35,7 +35,6 @@ use function substr;
  * @psalm-type OverrideParams = array{
  *     charset?: string,
  *     dbname?: string,
- *     default_dbname?: string,
  *     driver?: key-of<self::DRIVER_MAP>,
  *     driverClass?: class-string<Driver>,
  *     driverOptions?: array<mixed>,
@@ -51,7 +50,6 @@ use function substr;
  *     charset?: string,
  *     dbname?: string,
  *     defaultTableOptions?: array<string, mixed>,
- *     default_dbname?: string,
  *     driver?: key-of<self::DRIVER_MAP>,
  *     driverClass?: class-string<Driver>,
  *     driverOptions?: array<mixed>,
@@ -137,7 +135,6 @@ final class DriverManager
      * @psalm-param array{
      *     charset?: string,
      *     dbname?: string,
-     *     default_dbname?: string,
      *     driver?: key-of<self::DRIVER_MAP>,
      *     driverClass?: class-string<Driver>,
      *     driverOptions?: array<mixed>,

--- a/tests/Functional/Driver/PDO/PgSQL/DriverTest.php
+++ b/tests/Functional/Driver/PDO/PgSQL/DriverTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Driver\PDO\PgSQL;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\PDO\PgSQL\Driver;
 use Doctrine\DBAL\Tests\Functional\Driver\AbstractDriverTest;
@@ -26,53 +25,6 @@ class DriverTest extends AbstractDriverTest
         }
 
         self::markTestSkipped('This test requires the pdo_pgsql driver.');
-    }
-
-    /** @dataProvider getDatabaseParameter */
-    public function testDatabaseParameters(
-        ?string $databaseName,
-        ?string $defaultDatabaseName,
-        ?string $expectedDatabaseName,
-    ): void {
-        $params = $this->connection->getParams();
-
-        if ($databaseName !== null) {
-            $params['dbname'] = $databaseName;
-        } else {
-            unset($params['dbname']);
-        }
-
-        if ($defaultDatabaseName !== null) {
-            $params['default_dbname'] = $defaultDatabaseName;
-        }
-
-        $connection = new Connection(
-            $params,
-            $this->connection->getDriver(),
-            $this->connection->getConfiguration(),
-            $this->connection->getEventManager(),
-        );
-
-        self::assertSame(
-            $expectedDatabaseName,
-            $connection->getDatabase(),
-        );
-    }
-
-    /** @return mixed[][] */
-    public static function getDatabaseParameter(): iterable
-    {
-        $params            = TestUtil::getConnectionParams();
-        $realDatabaseName  = $params['dbname'] ?? '';
-        $dummyDatabaseName = $realDatabaseName . 'a';
-
-        return [
-            // dbname, default_dbname, expected
-            [$realDatabaseName, null, $realDatabaseName],
-            [$realDatabaseName, $dummyDatabaseName, $realDatabaseName],
-            [null, $realDatabaseName, $realDatabaseName],
-            [null, null, static::getDatabaseNameForConnectionWithoutDatabaseNameParameter()],
-        ];
     }
 
     public function testConnectsWithApplicationNameParameter(): void


### PR DESCRIPTION
The features being removed were deprecated in https://github.com/doctrine/dbal/pull/5705.