### PR TITLE
Remove exception handling in server version detection

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -259,11 +259,7 @@ class Connection implements ServerVersionProvider
      */
     public function getServerVersion(): string
     {
-        try {
-            return $this->connect()->getServerVersion();
-        } catch (Driver\Exception $e) {
-            throw $this->convertException($e);
-        }
+        return $this->connect()->getServerVersion();
     }
 
     /**

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -39,10 +39,7 @@ final class Connection implements ConnectionInterface
     public function getServerVersion(): string
     {
         $version = oci_server_version($this->connection);
-
-        if ($version === false) {
-            throw Error::new($this->connection);
-        }
+        assert($version !== false);
 
         $result = preg_match('/\s+(\d+\.\d+\.\d+\.\d+\.\d+)\s+/', $version, $matches);
         assert($result === 1);


### PR DESCRIPTION
The reasons are:
1. `ServerVersionProvider::getServerVersion()` doesn't declare any thrown exceptions, so the exception being caught is flagged as never thrown by PhpStorm.
2. There is no known way to reproduce a failure to detect the server version on an already established connection (past the call to `Connection::connect()`). Furthermore, for some connection protocols (e.g. [MySQL](https://dev.mysql.com/doc/internals/en/capability-negotiation.html)), the server version is known to the driver before the connection is considered successfully established, so such a failure is impossible for MySQL by design. This is most likely the same for all other drivers.