### PR TITLE
Update PHPStan to 1.8.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,8 @@
     "require-dev": {
         "doctrine/coding-standard": "10.0.0",
         "jetbrains/phpstorm-stubs": "2022.2",
-        "phpstan/phpstan": "1.8.3",
-        "phpstan/phpstan-strict-rules": "^1.3",
+        "phpstan/phpstan": "1.8.6",
+        "phpstan/phpstan-strict-rules": "^1.4",
         "phpunit/phpunit": "9.5.24",
         "psalm/plugin-phpunit": "0.17.0",
         "squizlabs/php_codesniffer": "3.7.1",


### PR DESCRIPTION
There are quite some `composer install` failures related to the `phpstan/phpstan` package ([example](https://github.com/doctrine/dbal/actions/runs/3156312930/jobs/5135893991)), also reported in https://github.com/phpstan/phpstan/issues/7967.

While it looks like a broken zip archive somewhere on the GitHub CDN, let's try updating PHPStan to see if the issue is caused by a specific archive. If it doesn't address the failure, we will at least have a new data point.