### PR TITLE
Rework some tests that instantiate TableDiff

### DIFF
--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -19,21 +19,6 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         return $platform instanceof SQLServerPlatform;
     }
 
-    public function testDropColumnConstraints(): void
-    {
-        $table = new Table('sqlsrv_drop_column');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('todrop', 'decimal', ['default' => 10.2]);
-
-        $this->schemaManager->createTable($table);
-
-        $diff = new TableDiff('sqlsrv_drop_column', [], [], [new Column('todrop', Type::getType('decimal'))]);
-        $this->schemaManager->alterTable($diff);
-
-        $columns = $this->schemaManager->listTableColumns('sqlsrv_drop_column');
-        self::assertCount(1, $columns);
-    }
-
     public function testColumnCollation(): void
     {
         $table  = new Table($tableName = 'test_collation');

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -247,20 +247,6 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         ];
     }
 
-    public function testChangeIndexWithForeignKeys(): void
-    {
-        $index  = new Index('idx', ['col'], false);
-        $unique = new Index('uniq', ['col'], true);
-
-        $diff = new TableDiff('test', [], [], [], [$unique], [], [$index]);
-        $sql  = $this->platform->getAlterTableSQL($diff);
-        self::assertEquals(['ALTER TABLE test DROP INDEX idx, ADD UNIQUE INDEX uniq (col)'], $sql);
-
-        $diff = new TableDiff('test', [], [], [], [$index], [], [$unique]);
-        $sql  = $this->platform->getAlterTableSQL($diff);
-        self::assertEquals(['ALTER TABLE test DROP INDEX uniq, ADD INDEX idx (col)'], $sql);
-    }
-
     /** @return string[] */
     protected function getQuotedColumnInPrimaryKeySQL(): array
     {

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -19,31 +19,6 @@ class MySQLSchemaTest extends TestCase
         $this->platform = new MySQLPlatform();
     }
 
-    /** @dataProvider comparatorProvider */
-    public function testSwitchPrimaryKeyOrder(Comparator $comparator): void
-    {
-        $tableOld = new Table('test');
-        $tableOld->addColumn('foo_id', 'integer');
-        $tableOld->addColumn('bar_id', 'integer');
-        $tableNew = clone $tableOld;
-
-        $tableOld->setPrimaryKey(['foo_id', 'bar_id']);
-        $tableNew->setPrimaryKey(['bar_id', 'foo_id']);
-
-        $diff = $comparator->diffTable($tableOld, $tableNew);
-        self::assertNotFalse($diff);
-
-        $sql = $this->platform->getAlterTableSQL($diff);
-
-        self::assertEquals(
-            [
-                'DROP INDEX `primary` ON test',
-                'ALTER TABLE test ADD PRIMARY KEY (bar_id, foo_id)',
-            ],
-            $sql,
-        );
-    }
-
     public function testGenerateForeignKeySQL(): void
     {
         $tableOld = new Table('test');


### PR DESCRIPTION
The diff should be instantiated by the comparator, not by a third party which the tests represent. See the [testing guidelines](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/testing.html) for more details.