### PR TITLE
Mark TableDiff public properties internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -66,6 +66,25 @@ The following `Comparator` methods have been marked as internal:
 
 The `diffColumn()` method has been deprecated. Use `diffTable()` instead.
 
+## Marked `TableDiff` public properties as internal.
+
+The public properties of the `TableDiff` class have been marked as internal. Use the following corresponding methods
+instead:
+
+| Property               | Method                     |
+|------------------------|----------------------------|
+| `$addedColumns`        | `getAddedColumns()`        |
+| `$changedColumns`      | `getModifiedColumns()`     |
+| `$removedColumns`      | `getDroppedColumns()`      |
+| `$renamedColumns`      | `getRenamedColumns()`      |
+| `$addedIndexes`        | `getAddedIndexes()`        |
+| `$changedIndexes`      | `getModifiedIndexes()`     |
+| `$removedIndexes`      | `getDroppedIndexes()`      |
+| `$renamedIndexes`      | `getRenamedIndexes()`      |
+| `$addedForeignKeys`    | `getAddedForeignKeys()`    |
+| `$changedForeignKeys`  | `getModifiedForeignKeys()` |
+| `$removedForeignKeys`  | `getDroppedForeignKeys()`  |
+
 ## Marked `ColumnDiff` public properties as internal.
 
 The `$fromColumn` and `$column` properties of the `ColumnDiff` class have been marked as internal. Use the

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
@@ -31,6 +32,7 @@ use function is_string;
 use function sprintf;
 use function str_replace;
 use function strcasecmp;
+use function strtolower;
 use function strtoupper;
 use function trim;
 
@@ -620,7 +622,7 @@ SQL
             $queryParts[] = 'RENAME TO ' . $newName->getQuotedName($this);
         }
 
-        foreach ($diff->addedColumns as $column) {
+        foreach ($diff->getAddedColumns() as $column) {
             if ($this->onSchemaAlterTableAddColumn($column, $diff, $columnSql)) {
                 continue;
             }
@@ -635,7 +637,7 @@ SQL
             );
         }
 
-        foreach ($diff->removedColumns as $column) {
+        foreach ($diff->getDroppedColumns() as $column) {
             if ($this->onSchemaAlterTableRemoveColumn($column, $diff, $columnSql)) {
                 continue;
             }
@@ -643,7 +645,7 @@ SQL
             $queryParts[] =  'DROP ' . $column->getQuotedName($this);
         }
 
-        foreach ($diff->changedColumns as $columnDiff) {
+        foreach ($diff->getModifiedColumns() as $columnDiff) {
             if ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
                 continue;
             }
@@ -660,7 +662,7 @@ SQL
                 . $this->getColumnDeclarationSQL($newColumn->getQuotedName($this), $newColumnProperties);
         }
 
-        foreach ($diff->renamedColumns as $oldColumnName => $column) {
+        foreach ($diff->getRenamedColumns() as $oldColumnName => $column) {
             if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $column, $diff, $columnSql)) {
                 continue;
             }
@@ -675,21 +677,47 @@ SQL
                 . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnProperties);
         }
 
-        if (isset($diff->addedIndexes['primary'])) {
-            $keyColumns   = array_unique(array_values($diff->addedIndexes['primary']->getColumns()));
+        $addedIndexes    = $this->indexAssetsByLowerCaseName($diff->getAddedIndexes());
+        $modifiedIndexes = $this->indexAssetsByLowerCaseName($diff->getModifiedIndexes());
+        $diffModified    = false;
+
+        if (isset($addedIndexes['primary'])) {
+            $keyColumns   = array_unique(array_values($addedIndexes['primary']->getColumns()));
             $queryParts[] = 'ADD PRIMARY KEY (' . implode(', ', $keyColumns) . ')';
-            unset($diff->addedIndexes['primary']);
-        } elseif (isset($diff->changedIndexes['primary'])) {
+            unset($addedIndexes['primary']);
+            $diffModified = true;
+        } elseif (isset($modifiedIndexes['primary'])) {
+            $addedColumns = $this->indexAssetsByLowerCaseName($diff->getAddedColumns());
+
             // Necessary in case the new primary key includes a new auto_increment column
-            foreach ($diff->changedIndexes['primary']->getColumns() as $columnName) {
-                if (isset($diff->addedColumns[$columnName]) && $diff->addedColumns[$columnName]->getAutoincrement()) {
-                    $keyColumns   = array_unique(array_values($diff->changedIndexes['primary']->getColumns()));
+            foreach ($modifiedIndexes['primary']->getColumns() as $columnName) {
+                if (isset($addedColumns[$columnName]) && $addedColumns[$columnName]->getAutoincrement()) {
+                    $keyColumns   = array_unique(array_values($modifiedIndexes['primary']->getColumns()));
                     $queryParts[] = 'DROP PRIMARY KEY';
                     $queryParts[] = 'ADD PRIMARY KEY (' . implode(', ', $keyColumns) . ')';
-                    unset($diff->changedIndexes['primary']);
+                    unset($modifiedIndexes['primary']);
+                    $diffModified = true;
                     break;
                 }
             }
+        }
+
+        if ($diffModified) {
+            $diff = new TableDiff(
+                $diff->name,
+                $diff->getAddedColumns(),
+                $diff->getModifiedColumns(),
+                $diff->getDroppedColumns(),
+                array_values($addedIndexes),
+                array_values($modifiedIndexes),
+                $diff->getDroppedIndexes(),
+                $diff->getOldTable(),
+                $diff->getAddedForeignKeys(),
+                $diff->getModifiedForeignKeys(),
+                $diff->getDroppedForeignKeys(),
+                $diff->getRenamedColumns(),
+                $diff->getRenamedIndexes(),
+            );
         }
 
         $sql      = [];
@@ -720,33 +748,34 @@ SQL
 
         $tableNameSQL = ($diff->getOldTable() ?? $diff->getName($this))->getQuotedName($this);
 
-        foreach ($diff->changedIndexes as $changedIndex) {
+        foreach ($diff->getModifiedIndexes() as $changedIndex) {
             $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $changedIndex));
         }
 
-        foreach ($diff->removedIndexes as $remKey => $remIndex) {
-            $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $remIndex));
+        foreach ($diff->getDroppedIndexes() as $droppedIndex) {
+            $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $droppedIndex));
 
-            foreach ($diff->addedIndexes as $addKey => $addIndex) {
-                if ($remIndex->getColumns() !== $addIndex->getColumns()) {
+            foreach ($diff->getAddedIndexes() as $addedIndex) {
+                if ($droppedIndex->getColumns() !== $addedIndex->getColumns()) {
                     continue;
                 }
 
-                $indexClause = 'INDEX ' . $addIndex->getName();
+                $indexClause = 'INDEX ' . $addedIndex->getName();
 
-                if ($addIndex->isPrimary()) {
+                if ($addedIndex->isPrimary()) {
                     $indexClause = 'PRIMARY KEY';
-                } elseif ($addIndex->isUnique()) {
-                    $indexClause = 'UNIQUE INDEX ' . $addIndex->getName();
+                } elseif ($addedIndex->isUnique()) {
+                    $indexClause = 'UNIQUE INDEX ' . $addedIndex->getName();
                 }
 
-                $query  = 'ALTER TABLE ' . $tableNameSQL . ' DROP INDEX ' . $remIndex->getName() . ', ';
+                $query  = 'ALTER TABLE ' . $tableNameSQL . ' DROP INDEX ' . $droppedIndex->getName() . ', ';
                 $query .= 'ADD ' . $indexClause;
-                $query .= ' (' . $this->getIndexFieldDeclarationListSQL($addIndex) . ')';
+                $query .= ' (' . $this->getIndexFieldDeclarationListSQL($addedIndex) . ')';
 
                 $sql[] = $query;
 
-                unset($diff->removedIndexes[$remKey], $diff->addedIndexes[$addKey]);
+                $diff->unsetAddedIndex($addedIndex);
+                $diff->unsetDroppedIndex($droppedIndex);
 
                 break;
             }
@@ -841,7 +870,7 @@ SQL
 
         $tableNameSQL = $table->getQuotedName($this);
 
-        foreach ($diff->changedIndexes as $changedIndex) {
+        foreach ($diff->getModifiedIndexes() as $changedIndex) {
             // Changed primary key
             if (! $changedIndex->isPrimary()) {
                 continue;
@@ -881,7 +910,7 @@ SQL
         $tableNameSQL = ($diff->getOldTable() ?? $diff->getName($this))->getQuotedName($this);
 
         foreach ($this->getRemainingForeignKeyConstraintsRequiringRenamedIndexes($diff) as $foreignKey) {
-            if (in_array($foreignKey, $diff->changedForeignKeys, true)) {
+            if (in_array($foreignKey, $diff->getModifiedForeignKeys(), true)) {
                 continue;
             }
 
@@ -903,7 +932,7 @@ SQL
      */
     private function getRemainingForeignKeyConstraintsRequiringRenamedIndexes(TableDiff $diff): array
     {
-        if (count($diff->renamedIndexes) === 0) {
+        if (count($diff->getRenamedIndexes()) === 0) {
             return [];
         }
 
@@ -917,11 +946,11 @@ SQL
         /** @var ForeignKeyConstraint[] $remainingForeignKeys */
         $remainingForeignKeys = array_diff_key(
             $table->getForeignKeys(),
-            $diff->removedForeignKeys,
+            $diff->getDroppedForeignKeys(),
         );
 
         foreach ($remainingForeignKeys as $foreignKey) {
-            foreach ($diff->renamedIndexes as $index) {
+            foreach ($diff->getRenamedIndexes() as $index) {
                 if ($foreignKey->intersectsIndexColumns($index)) {
                     $foreignKeys[] = $foreignKey;
 
@@ -961,7 +990,7 @@ SQL
         }
 
         foreach ($this->getRemainingForeignKeyConstraintsRequiringRenamedIndexes($diff) as $foreignKey) {
-            if (in_array($foreignKey, $diff->changedForeignKeys, true)) {
+            if (in_array($foreignKey, $diff->getModifiedForeignKeys(), true)) {
                 continue;
             }
 
@@ -1353,5 +1382,23 @@ SQL
     public function createSchemaManager(Connection $connection): MySQLSchemaManager
     {
         return new MySQLSchemaManager($connection, $this);
+    }
+
+    /**
+     * @param list<T> $assets
+     *
+     * @return array<string,T>
+     *
+     * @template T of AbstractAsset
+     */
+    private function indexAssetsByLowerCaseName(array $assets): array
+    {
+        $result = [];
+
+        foreach ($assets as $asset) {
+            $result[strtolower($asset->getName())] = $asset;
+        }
+
+        return $result;
     }
 }

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -903,7 +903,7 @@ SQL
      */
     private function getRemainingForeignKeyConstraintsRequiringRenamedIndexes(TableDiff $diff): array
     {
-        if (empty($diff->renamedIndexes)) {
+        if (count($diff->renamedIndexes) === 0) {
             return [];
         }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2723,7 +2723,7 @@ abstract class AbstractPlatform
 
         $sql = [];
         if ($this->supportsForeignKeyConstraints()) {
-            foreach ($diff->removedForeignKeys as $foreignKey) {
+            foreach ($diff->getDroppedForeignKeys() as $foreignKey) {
                 if ($foreignKey instanceof ForeignKeyConstraint) {
                     $foreignKey = $foreignKey->getQuotedName($this);
                 }
@@ -2731,16 +2731,16 @@ abstract class AbstractPlatform
                 $sql[] = $this->getDropForeignKeySQL($foreignKey, $tableNameSQL);
             }
 
-            foreach ($diff->changedForeignKeys as $foreignKey) {
+            foreach ($diff->getModifiedForeignKeys() as $foreignKey) {
                 $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableNameSQL);
             }
         }
 
-        foreach ($diff->removedIndexes as $index) {
+        foreach ($diff->getDroppedIndexes() as $index) {
             $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $tableNameSQL);
         }
 
-        foreach ($diff->changedIndexes as $index) {
+        foreach ($diff->getModifiedIndexes() as $index) {
             $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $tableNameSQL);
         }
 
@@ -2760,24 +2760,24 @@ abstract class AbstractPlatform
         }
 
         if ($this->supportsForeignKeyConstraints()) {
-            foreach ($diff->addedForeignKeys as $foreignKey) {
+            foreach ($diff->getAddedForeignKeys() as $foreignKey) {
                 $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
             }
 
-            foreach ($diff->changedForeignKeys as $foreignKey) {
+            foreach ($diff->getModifiedForeignKeys() as $foreignKey) {
                 $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
             }
         }
 
-        foreach ($diff->addedIndexes as $index) {
+        foreach ($diff->getAddedIndexes() as $index) {
             $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
         }
 
-        foreach ($diff->changedIndexes as $index) {
+        foreach ($diff->getModifiedIndexes() as $index) {
             $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
         }
 
-        foreach ($diff->renamedIndexes as $oldIndexName => $index) {
+        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
             $oldIndexName = new Identifier($oldIndexName);
             $sql          = array_merge(
                 $sql,

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -561,7 +561,7 @@ class DB2Platform extends AbstractPlatform
         $tableNameSQL = ($diff->getOldTable() ?? $diff->getName($this))->getQuotedName($this);
 
         $queryParts = [];
-        foreach ($diff->addedColumns as $column) {
+        foreach ($diff->getAddedColumns() as $column) {
             if ($this->onSchemaAlterTableAddColumn($column, $diff, $columnSql)) {
                 continue;
             }
@@ -593,7 +593,7 @@ class DB2Platform extends AbstractPlatform
             );
         }
 
-        foreach ($diff->removedColumns as $column) {
+        foreach ($diff->getDroppedColumns() as $column) {
             if ($this->onSchemaAlterTableRemoveColumn($column, $diff, $columnSql)) {
                 continue;
             }
@@ -601,7 +601,7 @@ class DB2Platform extends AbstractPlatform
             $queryParts[] =  'DROP COLUMN ' . $column->getQuotedName($this);
         }
 
-        foreach ($diff->changedColumns as $columnDiff) {
+        foreach ($diff->getModifiedColumns() as $columnDiff) {
             if ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
                 continue;
             }
@@ -622,7 +622,7 @@ class DB2Platform extends AbstractPlatform
             );
         }
 
-        foreach ($diff->renamedColumns as $oldColumnName => $column) {
+        foreach ($diff->getRenamedColumns() as $oldColumnName => $column) {
             if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $column, $diff, $columnSql)) {
                 continue;
             }
@@ -641,7 +641,7 @@ class DB2Platform extends AbstractPlatform
             }
 
             // Some table alteration operations require a table reorganization.
-            if (count($diff->removedColumns) > 0 || count($diff->changedColumns) > 0) {
+            if (count($diff->getDroppedColumns()) > 0 || count($diff->getModifiedColumns()) > 0) {
                 $sql[] = "CALL SYSPROC.ADMIN_CMD ('REORG TABLE " . $tableNameSQL . "')";
             }
 
@@ -774,31 +774,30 @@ class DB2Platform extends AbstractPlatform
 
         $tableNameSQL = ($diff->getOldTable() ?? $diff->getName($this))->getQuotedName($this);
 
-        foreach ($diff->removedIndexes as $remKey => $remIndex) {
-            foreach ($diff->addedIndexes as $addKey => $addIndex) {
-                if ($remIndex->getColumns() !== $addIndex->getColumns()) {
+        foreach ($diff->getDroppedIndexes() as $droppedIndex) {
+            foreach ($diff->getAddedIndexes() as $addedIndex) {
+                if ($droppedIndex->getColumns() !== $addedIndex->getColumns()) {
                     continue;
                 }
 
-                if ($remIndex->isPrimary()) {
+                if ($droppedIndex->isPrimary()) {
                     $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' DROP PRIMARY KEY';
-                } elseif ($remIndex->isUnique()) {
-                    $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' DROP UNIQUE ' . $remIndex->getQuotedName($this);
+                } elseif ($droppedIndex->isUnique()) {
+                    $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' DROP UNIQUE ' . $droppedIndex->getQuotedName($this);
                 } else {
-                    $sql[] = $this->getDropIndexSQL($remIndex, $tableNameSQL);
+                    $sql[] = $this->getDropIndexSQL($droppedIndex, $tableNameSQL);
                 }
 
-                $sql[] = $this->getCreateIndexSQL($addIndex, $tableNameSQL);
+                $sql[] = $this->getCreateIndexSQL($addedIndex, $tableNameSQL);
 
-                unset($diff->removedIndexes[$remKey], $diff->addedIndexes[$addKey]);
+                $diff->unsetAddedIndex($addedIndex);
+                $diff->unsetDroppedIndex($droppedIndex);
 
                 break;
             }
         }
 
-        $sql = array_merge($sql, parent::getPreAlterTableIndexForeignKeySQL($diff));
-
-        return $sql;
+        return array_merge($sql, parent::getPreAlterTableIndexForeignKeySQL($diff));
     }
 
     /**

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -641,7 +641,7 @@ class DB2Platform extends AbstractPlatform
             }
 
             // Some table alteration operations require a table reorganization.
-            if (! empty($diff->removedColumns) || ! empty($diff->changedColumns)) {
+            if (count($diff->removedColumns) > 0 || count($diff->changedColumns) > 0) {
                 $sql[] = "CALL SYSPROC.ADMIN_CMD ('REORG TABLE " . $tableNameSQL . "')";
             }
 

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -872,7 +872,7 @@ SQL
 
         $tableNameSQL = ($diff->getOldTable() ?? $diff->getName($this))->getQuotedName($this);
 
-        foreach ($diff->addedColumns as $column) {
+        foreach ($diff->getAddedColumns() as $column) {
             if ($this->onSchemaAlterTableAddColumn($column, $diff, $columnSql)) {
                 continue;
             }
@@ -896,7 +896,7 @@ SQL
         }
 
         $fields = [];
-        foreach ($diff->changedColumns as $columnDiff) {
+        foreach ($diff->getModifiedColumns() as $columnDiff) {
             if ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
                 continue;
             }
@@ -944,7 +944,7 @@ SQL
             $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' MODIFY (' . implode(', ', $fields) . ')';
         }
 
-        foreach ($diff->renamedColumns as $oldColumnName => $column) {
+        foreach ($diff->getRenamedColumns() as $oldColumnName => $column) {
             if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $column, $diff, $columnSql)) {
                 continue;
             }
@@ -956,7 +956,7 @@ SQL
         }
 
         $fields = [];
-        foreach ($diff->removedColumns as $column) {
+        foreach ($diff->getDroppedColumns() as $column) {
             if ($this->onSchemaAlterTableRemoveColumn($column, $diff, $columnSql)) {
                 continue;
             }

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -526,7 +526,7 @@ SQL
 
         $tableNameSQL = $table->getQuotedName($this);
 
-        foreach ($diff->addedColumns as $addedColumn) {
+        foreach ($diff->getAddedColumns() as $addedColumn) {
             if ($this->onSchemaAlterTableAddColumn($addedColumn, $diff, $columnSql)) {
                 continue;
             }
@@ -551,16 +551,16 @@ SQL
             );
         }
 
-        foreach ($diff->removedColumns as $removedColumn) {
-            if ($this->onSchemaAlterTableRemoveColumn($removedColumn, $diff, $columnSql)) {
+        foreach ($diff->getDroppedColumns() as $droppedColumn) {
+            if ($this->onSchemaAlterTableRemoveColumn($droppedColumn, $diff, $columnSql)) {
                 continue;
             }
 
-            $query = 'DROP ' . $removedColumn->getQuotedName($this);
+            $query = 'DROP ' . $droppedColumn->getQuotedName($this);
             $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ' . $query;
         }
 
-        foreach ($diff->changedColumns as $columnDiff) {
+        foreach ($diff->getModifiedColumns() as $columnDiff) {
             if ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
                 continue;
             }
@@ -648,7 +648,7 @@ SQL
             $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ' . $query;
         }
 
-        foreach ($diff->renamedColumns as $oldColumnName => $column) {
+        foreach ($diff->getRenamedColumns() as $oldColumnName => $column) {
             if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $column, $diff, $columnSql)) {
                 continue;
             }

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -526,15 +526,19 @@ SQL
 
         $tableNameSQL = $table->getQuotedName($this);
 
-        foreach ($diff->addedColumns as $newColumn) {
-            if ($this->onSchemaAlterTableAddColumn($newColumn, $diff, $columnSql)) {
+        foreach ($diff->addedColumns as $addedColumn) {
+            if ($this->onSchemaAlterTableAddColumn($addedColumn, $diff, $columnSql)) {
                 continue;
             }
 
-            $query = 'ADD ' . $this->getColumnDeclarationSQL($newColumn->getQuotedName($this), $newColumn->toArray());
+            $query = 'ADD ' . $this->getColumnDeclarationSQL(
+                $addedColumn->getQuotedName($this),
+                $addedColumn->toArray(),
+            );
+
             $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ' . $query;
 
-            $comment = $this->getColumnComment($newColumn);
+            $comment = $this->getColumnComment($addedColumn);
 
             if ($comment === null || $comment === '') {
                 continue;
@@ -542,17 +546,17 @@ SQL
 
             $commentsSQL[] = $this->getCommentOnColumnSQL(
                 $tableNameSQL,
-                $newColumn->getQuotedName($this),
+                $addedColumn->getQuotedName($this),
                 $comment,
             );
         }
 
-        foreach ($diff->removedColumns as $newColumn) {
-            if ($this->onSchemaAlterTableRemoveColumn($newColumn, $diff, $columnSql)) {
+        foreach ($diff->removedColumns as $removedColumn) {
+            if ($this->onSchemaAlterTableRemoveColumn($removedColumn, $diff, $columnSql)) {
                 continue;
             }
 
-            $query = 'DROP ' . $newColumn->getQuotedName($this);
+            $query = 'DROP ' . $removedColumn->getQuotedName($this);
             $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ' . $query;
         }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -520,7 +520,7 @@ class SQLServerPlatform extends AbstractPlatform
 
         $tableName = $table->getName();
 
-        foreach ($diff->addedColumns as $column) {
+        foreach ($diff->getAddedColumns() as $column) {
             if ($this->onSchemaAlterTableAddColumn($column, $diff, $columnSql)) {
                 continue;
             }
@@ -551,7 +551,7 @@ class SQLServerPlatform extends AbstractPlatform
             );
         }
 
-        foreach ($diff->removedColumns as $column) {
+        foreach ($diff->getDroppedColumns() as $column) {
             if ($this->onSchemaAlterTableRemoveColumn($column, $diff, $columnSql)) {
                 continue;
             }
@@ -559,7 +559,7 @@ class SQLServerPlatform extends AbstractPlatform
             $queryParts[] = 'DROP COLUMN ' . $column->getQuotedName($this);
         }
 
-        foreach ($diff->changedColumns as $columnDiff) {
+        foreach ($diff->getModifiedColumns() as $columnDiff) {
             if ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
                 continue;
             }
@@ -630,7 +630,7 @@ class SQLServerPlatform extends AbstractPlatform
 
         $tableNameSQL = $table->getQuotedName($this);
 
-        foreach ($diff->renamedColumns as $oldColumnName => $newColumn) {
+        foreach ($diff->getRenamedColumns() as $oldColumnName => $newColumn) {
             if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $newColumn, $diff, $columnSql)) {
                 continue;
             }

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -25,6 +25,7 @@ use function array_merge;
 use function array_search;
 use function array_unique;
 use function array_values;
+use function count;
 use function implode;
 use function is_numeric;
 use function sprintf;
@@ -1202,16 +1203,16 @@ class SqlitePlatform extends AbstractPlatform
         }
 
         if (
-            ! empty($diff->renamedColumns)
-            || ! empty($diff->addedForeignKeys)
-            || ! empty($diff->addedIndexes)
-            || ! empty($diff->changedColumns)
-            || ! empty($diff->changedForeignKeys)
-            || ! empty($diff->changedIndexes)
-            || ! empty($diff->removedColumns)
-            || ! empty($diff->removedForeignKeys)
-            || ! empty($diff->removedIndexes)
-            || ! empty($diff->renamedIndexes)
+            count($diff->renamedColumns) > 0
+            || count($diff->addedForeignKeys) > 0
+            || count($diff->addedIndexes) > 0
+            || count($diff->changedColumns) > 0
+            || count($diff->changedForeignKeys) > 0
+            || count($diff->changedIndexes) > 0
+            || count($diff->removedColumns) > 0
+            || count($diff->removedForeignKeys) > 0
+            || count($diff->removedIndexes) > 0
+            || count($diff->renamedIndexes) > 0
         ) {
             return false;
         }

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -1013,12 +1013,12 @@ class SqlitePlatform extends AbstractPlatform
             $oldColumnNames[$columnName] = $newColumnNames[$columnName] = $column->getQuotedName($this);
         }
 
-        foreach ($diff->removedColumns as $columnName => $column) {
+        foreach ($diff->getDroppedColumns() as $column) {
             if ($this->onSchemaAlterTableRemoveColumn($column, $diff, $columnSql)) {
                 continue;
             }
 
-            $columnName = strtolower($columnName);
+            $columnName = strtolower($column->getName());
             if (! isset($columns[$columnName])) {
                 continue;
             }
@@ -1030,7 +1030,7 @@ class SqlitePlatform extends AbstractPlatform
             );
         }
 
-        foreach ($diff->renamedColumns as $oldColumnName => $column) {
+        foreach ($diff->getRenamedColumns() as $oldColumnName => $column) {
             if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $column, $diff, $columnSql)) {
                 continue;
             }
@@ -1051,12 +1051,14 @@ class SqlitePlatform extends AbstractPlatform
             $newColumnNames[$oldColumnName] = $column->getQuotedName($this);
         }
 
-        foreach ($diff->changedColumns as $oldColumnName => $columnDiff) {
+        foreach ($diff->getModifiedColumns() as $columnDiff) {
             if ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
                 continue;
             }
 
-            $oldColumnName = strtolower($oldColumnName);
+            $oldColumn = $columnDiff->getOldColumn() ?? $columnDiff->getOldColumnName();
+
+            $oldColumnName = strtolower($oldColumn->getName());
 
             $columns = $this->replaceColumn(
                 $table->getName(),
@@ -1072,12 +1074,12 @@ class SqlitePlatform extends AbstractPlatform
             $newColumnNames[$oldColumnName] = $columnDiff->getNewColumn()->getQuotedName($this);
         }
 
-        foreach ($diff->addedColumns as $columnName => $column) {
+        foreach ($diff->getAddedColumns() as $column) {
             if ($this->onSchemaAlterTableAddColumn($column, $diff, $columnSql)) {
                 continue;
             }
 
-            $columns[strtolower($columnName)] = $column;
+            $columns[strtolower($column->getName())] = $column;
         }
 
         $sql      = [];
@@ -1174,7 +1176,7 @@ class SqlitePlatform extends AbstractPlatform
     private function getSimpleAlterTableSQL(TableDiff $diff)
     {
         // Suppress changes on integer type autoincrement columns.
-        foreach ($diff->changedColumns as $oldColumnName => $columnDiff) {
+        foreach ($diff->getModifiedColumns() as $columnDiff) {
             $oldColumn = $columnDiff->getOldColumn();
 
             if ($oldColumn === null) {
@@ -1186,6 +1188,8 @@ class SqlitePlatform extends AbstractPlatform
             if (! $newColumn->getAutoincrement() || ! $newColumn->getType() instanceof IntegerType) {
                 continue;
             }
+
+            $oldColumnName = $oldColumn->getName();
 
             if (! $columnDiff->hasTypeChanged() && $columnDiff->hasUnsignedChanged()) {
                 unset($diff->changedColumns[$oldColumnName]);
@@ -1203,16 +1207,16 @@ class SqlitePlatform extends AbstractPlatform
         }
 
         if (
-            count($diff->renamedColumns) > 0
-            || count($diff->addedForeignKeys) > 0
-            || count($diff->addedIndexes) > 0
-            || count($diff->changedColumns) > 0
-            || count($diff->changedForeignKeys) > 0
-            || count($diff->changedIndexes) > 0
-            || count($diff->removedColumns) > 0
-            || count($diff->removedForeignKeys) > 0
-            || count($diff->removedIndexes) > 0
-            || count($diff->renamedIndexes) > 0
+            count($diff->getModifiedColumns()) > 0
+            || count($diff->getDroppedColumns()) > 0
+            || count($diff->getRenamedColumns()) > 0
+            || count($diff->getAddedIndexes()) > 0
+            || count($diff->getModifiedIndexes()) > 0
+            || count($diff->getDroppedIndexes()) > 0
+            || count($diff->getRenamedIndexes()) > 0
+            || count($diff->getAddedForeignKeys()) > 0
+            || count($diff->getModifiedForeignKeys()) > 0
+            || count($diff->getDroppedForeignKeys()) > 0
         ) {
             return false;
         }
@@ -1223,7 +1227,7 @@ class SqlitePlatform extends AbstractPlatform
         $tableSql  = [];
         $columnSql = [];
 
-        foreach ($diff->addedColumns as $column) {
+        foreach ($diff->getAddedColumns() as $column) {
             if ($this->onSchemaAlterTableAddColumn($column, $diff, $columnSql)) {
                 continue;
             }
@@ -1282,8 +1286,8 @@ class SqlitePlatform extends AbstractPlatform
             $columns[strtolower($columnName)] = $column->getName();
         }
 
-        foreach ($diff->removedColumns as $columnName => $column) {
-            $columnName = strtolower($columnName);
+        foreach ($diff->getDroppedColumns() as $column) {
+            $columnName = strtolower($column->getName());
             if (! isset($columns[$columnName])) {
                 continue;
             }
@@ -1291,19 +1295,22 @@ class SqlitePlatform extends AbstractPlatform
             unset($columns[$columnName]);
         }
 
-        foreach ($diff->renamedColumns as $oldColumnName => $column) {
+        foreach ($diff->getRenamedColumns() as $oldColumnName => $column) {
             $columnName                          = $column->getName();
             $columns[strtolower($oldColumnName)] = $columnName;
             $columns[strtolower($columnName)]    = $columnName;
         }
 
-        foreach ($diff->changedColumns as $oldColumnName => $columnDiff) {
+        foreach ($diff->getModifiedColumns() as $columnDiff) {
+            $oldColumn = $columnDiff->getOldColumn() ?? $columnDiff->getOldColumnName();
+
+            $oldColumnName                       = $oldColumn->getName();
             $newColumnName                       = $columnDiff->getNewColumn()->getName();
             $columns[strtolower($oldColumnName)] = $newColumnName;
             $columns[strtolower($newColumnName)] = $newColumnName;
         }
 
-        foreach ($diff->addedColumns as $column) {
+        foreach ($diff->getAddedColumns() as $column) {
             $columnName                       = $column->getName();
             $columns[strtolower($columnName)] = $columnName;
         }
@@ -1318,7 +1325,7 @@ class SqlitePlatform extends AbstractPlatform
         $columnNames = $this->getColumnNamesInAlteredTable($diff, $fromTable);
 
         foreach ($indexes as $key => $index) {
-            foreach ($diff->renamedIndexes as $oldIndexName => $renamedIndex) {
+            foreach ($diff->getRenamedIndexes() as $oldIndexName => $renamedIndex) {
                 if (strtolower($key) !== strtolower($oldIndexName)) {
                     continue;
                 }
@@ -1356,7 +1363,7 @@ class SqlitePlatform extends AbstractPlatform
             );
         }
 
-        foreach ($diff->removedIndexes as $index) {
+        foreach ($diff->getDroppedIndexes() as $index) {
             $indexName = strtolower($index->getName());
             if (strlen($indexName) === 0 || ! isset($indexes[$indexName])) {
                 continue;
@@ -1365,7 +1372,13 @@ class SqlitePlatform extends AbstractPlatform
             unset($indexes[$indexName]);
         }
 
-        foreach (array_merge($diff->changedIndexes, $diff->addedIndexes, $diff->renamedIndexes) as $index) {
+        foreach (
+            array_merge(
+                $diff->getModifiedIndexes(),
+                $diff->getAddedIndexes(),
+                $diff->getRenamedIndexes(),
+            ) as $index
+        ) {
             $indexName = strtolower($index->getName());
             if (strlen($indexName) > 0) {
                 $indexes[$indexName] = $index;
@@ -1414,7 +1427,7 @@ class SqlitePlatform extends AbstractPlatform
             );
         }
 
-        foreach ($diff->removedForeignKeys as $constraint) {
+        foreach ($diff->getDroppedForeignKeys() as $constraint) {
             if (! $constraint instanceof ForeignKeyConstraint) {
                 $constraint = new Identifier($constraint);
             }
@@ -1427,7 +1440,7 @@ class SqlitePlatform extends AbstractPlatform
             unset($foreignKeys[$constraintName]);
         }
 
-        foreach (array_merge($diff->changedForeignKeys, $diff->addedForeignKeys) as $constraint) {
+        foreach (array_merge($diff->getModifiedForeignKeys(), $diff->getAddedForeignKeys()) as $constraint) {
             $constraintName = strtolower($constraint->getName());
             if (strlen($constraintName) > 0) {
                 $foreignKeys[$constraintName] = $constraint;

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -167,15 +167,15 @@ class Comparator
                     continue;
                 }
 
-                foreach ($diff->changedTables[$localTableName]->removedForeignKeys as $key => $removedForeignKey) {
-                    assert($removedForeignKey instanceof ForeignKeyConstraint);
+                foreach ($diff->changedTables[$localTableName]->getDroppedForeignKeys() as $droppedForeignKey) {
+                    assert($droppedForeignKey instanceof ForeignKeyConstraint);
 
                     // We check if the key is from the removed table if not we skip.
-                    if ($tableName !== strtolower($removedForeignKey->getForeignTableName())) {
+                    if ($tableName !== strtolower($droppedForeignKey->getForeignTableName())) {
                         continue;
                     }
 
-                    unset($diff->changedTables[$localTableName]->removedForeignKeys[$key]);
+                    $diff->changedTables[$localTableName]->unsetDroppedForeignKey($droppedForeignKey);
                 }
             }
         }
@@ -266,7 +266,15 @@ class Comparator
     {
         $hasChanges = false;
 
-        $tableDifferences = new TableDiff($fromTable->getName(), [], [], [], [], [], [], $fromTable);
+        $addedColumns        = [];
+        $modifiedColumns     = [];
+        $droppedColumns      = [];
+        $addedIndexes        = [];
+        $modifiedIndexes     = [];
+        $droppedIndexes      = [];
+        $addedForeignKeys    = [];
+        $modifiedForeignKeys = [];
+        $droppedForeignKeys  = [];
 
         $fromTableColumns = $fromTable->getColumns();
         $toTableColumns   = $toTable->getColumns();
@@ -277,7 +285,7 @@ class Comparator
                 continue;
             }
 
-            $tableDifferences->addedColumns[$columnName] = $column;
+            $addedColumns[$columnName] = $column;
 
             $hasChanges = true;
         }
@@ -286,7 +294,7 @@ class Comparator
         foreach ($fromTableColumns as $columnName => $column) {
             // See if column is removed in "to" table.
             if (! $toTable->hasColumn($columnName)) {
-                $tableDifferences->removedColumns[$columnName] = $column;
+                $droppedColumns[$columnName] = $column;
 
                 $hasChanges = true;
                 continue;
@@ -305,7 +313,7 @@ class Comparator
                 continue;
             }
 
-            $tableDifferences->changedColumns[$column->getName()] = new ColumnDiff(
+            $modifiedColumns[$column->getName()] = new ColumnDiff(
                 $column->getName(),
                 $toColumn,
                 $changedProperties,
@@ -315,7 +323,7 @@ class Comparator
             $hasChanges = true;
         }
 
-        $this->detectColumnRenamings($tableDifferences);
+        $renamedColumns = $this->detectRenamedColumns($addedColumns, $droppedColumns);
 
         $fromTableIndexes = $fromTable->getIndexes();
         $toTableIndexes   = $toTable->getIndexes();
@@ -326,7 +334,7 @@ class Comparator
                 continue;
             }
 
-            $tableDifferences->addedIndexes[$indexName] = $index;
+            $addedIndexes[$indexName] = $index;
 
             $hasChanges = true;
         }
@@ -338,7 +346,7 @@ class Comparator
                 ($index->isPrimary() && ! $toTable->hasPrimaryKey()) ||
                 ! $index->isPrimary() && ! $toTable->hasIndex($indexName)
             ) {
-                $tableDifferences->removedIndexes[$indexName] = $index;
+                $droppedIndexes[$indexName] = $index;
 
                 $hasChanges = true;
                 continue;
@@ -352,12 +360,12 @@ class Comparator
                 continue;
             }
 
-            $tableDifferences->changedIndexes[$indexName] = $toTableIndex;
+            $modifiedIndexes[$indexName] = $toTableIndex;
 
             $hasChanges = true;
         }
 
-        $this->detectIndexRenamings($tableDifferences);
+        $renamedIndexes = $this->detectRenamedIndexes($addedIndexes, $droppedIndexes);
 
         $fromForeignKeys = $fromTable->getForeignKeys();
         $toForeignKeys   = $toTable->getForeignKeys();
@@ -368,7 +376,7 @@ class Comparator
                     unset($fromForeignKeys[$fromKey], $toForeignKeys[$toKey]);
                 } else {
                     if (strtolower($fromConstraint->getName()) === strtolower($toConstraint->getName())) {
-                        $tableDifferences->changedForeignKeys[] = $toConstraint;
+                        $modifiedForeignKeys[] = $toConstraint;
 
                         $hasChanges = true;
                         unset($fromForeignKeys[$fromKey], $toForeignKeys[$toKey]);
@@ -378,101 +386,140 @@ class Comparator
         }
 
         foreach ($fromForeignKeys as $fromConstraint) {
-            $tableDifferences->removedForeignKeys[] = $fromConstraint;
+            $droppedForeignKeys[] = $fromConstraint;
 
             $hasChanges = true;
         }
 
         foreach ($toForeignKeys as $toConstraint) {
-            $tableDifferences->addedForeignKeys[] = $toConstraint;
+            $addedForeignKeys[] = $toConstraint;
 
             $hasChanges = true;
         }
 
-        return $hasChanges ? $tableDifferences : false;
+        if (! $hasChanges) {
+            return false;
+        }
+
+        return new TableDiff(
+            $toTable->getName(),
+            $addedColumns,
+            $modifiedColumns,
+            $droppedColumns,
+            $addedIndexes,
+            $modifiedIndexes,
+            $droppedIndexes,
+            $fromTable,
+            $addedForeignKeys,
+            $modifiedForeignKeys,
+            $droppedForeignKeys,
+            $renamedColumns,
+            $renamedIndexes,
+        );
     }
 
     /**
      * Try to find columns that only changed their name, rename operations maybe cheaper than add/drop
      * however ambiguities between different possibilities should not lead to renaming at all.
+     *
+     * @param array<string,Column> $addedColumns
+     * @param array<string,Column> $removedColumns
+     *
+     * @return array<string,Column>
+     *
+     * @throws Exception
      */
-    private function detectColumnRenamings(TableDiff $tableDifferences): void
+    private function detectRenamedColumns(array &$addedColumns, array &$removedColumns): array
     {
-        $renameCandidates = [];
-        foreach ($tableDifferences->addedColumns as $addedColumnName => $addedColumn) {
-            foreach ($tableDifferences->removedColumns as $removedColumn) {
+        $candidatesByName = [];
+
+        foreach ($addedColumns as $addedColumnName => $addedColumn) {
+            foreach ($removedColumns as $removedColumn) {
                 if (! $this->columnsEqual($addedColumn, $removedColumn)) {
                     continue;
                 }
 
-                $renameCandidates[$addedColumn->getName()][] = [$removedColumn, $addedColumn, $addedColumnName];
+                $candidatesByName[$addedColumn->getName()][] = [$removedColumn, $addedColumn, $addedColumnName];
             }
         }
 
-        foreach ($renameCandidates as $candidateColumns) {
-            if (count($candidateColumns) !== 1) {
+        $renamedColumns = [];
+
+        foreach ($candidatesByName as $candidates) {
+            if (count($candidates) !== 1) {
                 continue;
             }
 
-            [$removedColumn, $addedColumn] = $candidateColumns[0];
+            [$removedColumn, $addedColumn] = $candidates[0];
             $removedColumnName             = $removedColumn->getName();
             $addedColumnName               = strtolower($addedColumn->getName());
 
-            if (isset($tableDifferences->renamedColumns[$removedColumnName])) {
+            if (isset($renamedColumns[$removedColumnName])) {
                 continue;
             }
 
-            $tableDifferences->renamedColumns[$removedColumnName] = $addedColumn;
+            $renamedColumns[$removedColumnName] = $addedColumn;
             unset(
-                $tableDifferences->addedColumns[$addedColumnName],
-                $tableDifferences->removedColumns[strtolower($removedColumnName)],
+                $addedColumns[$addedColumnName],
+                $removedColumns[strtolower($removedColumnName)],
             );
         }
+
+        return $renamedColumns;
     }
 
     /**
      * Try to find indexes that only changed their name, rename operations maybe cheaper than add/drop
      * however ambiguities between different possibilities should not lead to renaming at all.
+     *
+     * @param array<string,Index> $addedIndexes
+     * @param array<string,Index> $removedIndexes
+     *
+     * @return array<string,Index>
      */
-    private function detectIndexRenamings(TableDiff $tableDifferences): void
+    private function detectRenamedIndexes(array &$addedIndexes, array &$removedIndexes): array
     {
-        $renameCandidates = [];
+        $candidatesByName = [];
 
         // Gather possible rename candidates by comparing each added and removed index based on semantics.
-        foreach ($tableDifferences->addedIndexes as $addedIndexName => $addedIndex) {
-            foreach ($tableDifferences->removedIndexes as $removedIndex) {
+        foreach ($addedIndexes as $addedIndexName => $addedIndex) {
+            foreach ($removedIndexes as $removedIndex) {
                 if ($this->diffIndex($addedIndex, $removedIndex)) {
                     continue;
                 }
 
-                $renameCandidates[$addedIndex->getName()][] = [$removedIndex, $addedIndex, $addedIndexName];
+                $candidatesByName[$addedIndex->getName()][] = [$removedIndex, $addedIndex, $addedIndexName];
             }
         }
 
-        foreach ($renameCandidates as $candidateIndexes) {
+        $renamedIndexes = [];
+
+        foreach ($candidatesByName as $candidates) {
             // If the current rename candidate contains exactly one semantically equal index,
             // we can safely rename it.
-            // Otherwise it is unclear if a rename action is really intended,
+            // Otherwise, it is unclear if a rename action is really intended,
             // therefore we let those ambiguous indexes be added/dropped.
-            if (count($candidateIndexes) !== 1) {
+            if (count($candidates) !== 1) {
                 continue;
             }
 
-            [$removedIndex, $addedIndex] = $candidateIndexes[0];
+            [$removedIndex, $addedIndex] = $candidates[0];
 
             $removedIndexName = strtolower($removedIndex->getName());
             $addedIndexName   = strtolower($addedIndex->getName());
 
-            if (isset($tableDifferences->renamedIndexes[$removedIndexName])) {
+            if (isset($renamedIndexes[$removedIndexName])) {
                 continue;
             }
 
-            $tableDifferences->renamedIndexes[$removedIndexName] = $addedIndex;
+            $renamedIndexes[$removedIndexName] = $addedIndex;
             unset(
-                $tableDifferences->addedIndexes[$addedIndexName],
-                $tableDifferences->removedIndexes[$removedIndexName],
+                $addedIndexes[$addedIndexName],
+                $removedIndexes[$removedIndexName],
             );
         }
+
+        return $renamedIndexes;
     }
 
     /**

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -264,7 +264,8 @@ class Comparator
      */
     public function diffTable(Table $fromTable, Table $toTable)
     {
-        $changes          = 0;
+        $hasChanges = false;
+
         $tableDifferences = new TableDiff($fromTable->getName(), [], [], [], [], [], [], $fromTable);
 
         $fromTableColumns = $fromTable->getColumns();
@@ -277,7 +278,8 @@ class Comparator
             }
 
             $tableDifferences->addedColumns[$columnName] = $column;
-            $changes++;
+
+            $hasChanges = true;
         }
 
         /* See if there are any removed columns in "to" table */
@@ -285,7 +287,8 @@ class Comparator
             // See if column is removed in "to" table.
             if (! $toTable->hasColumn($columnName)) {
                 $tableDifferences->removedColumns[$columnName] = $column;
-                $changes++;
+
+                $hasChanges = true;
                 continue;
             }
 
@@ -309,7 +312,7 @@ class Comparator
                 $column,
             );
 
-            $changes++;
+            $hasChanges = true;
         }
 
         $this->detectColumnRenamings($tableDifferences);
@@ -324,7 +327,8 @@ class Comparator
             }
 
             $tableDifferences->addedIndexes[$indexName] = $index;
-            $changes++;
+
+            $hasChanges = true;
         }
 
         /* See if there are any removed indexes in "to" table */
@@ -335,7 +339,8 @@ class Comparator
                 ! $index->isPrimary() && ! $toTable->hasIndex($indexName)
             ) {
                 $tableDifferences->removedIndexes[$indexName] = $index;
-                $changes++;
+
+                $hasChanges = true;
                 continue;
             }
 
@@ -348,7 +353,8 @@ class Comparator
             }
 
             $tableDifferences->changedIndexes[$indexName] = $toTableIndex;
-            $changes++;
+
+            $hasChanges = true;
         }
 
         $this->detectIndexRenamings($tableDifferences);
@@ -363,7 +369,8 @@ class Comparator
                 } else {
                     if (strtolower($fromConstraint->getName()) === strtolower($toConstraint->getName())) {
                         $tableDifferences->changedForeignKeys[] = $toConstraint;
-                        $changes++;
+
+                        $hasChanges = true;
                         unset($fromForeignKeys[$fromKey], $toForeignKeys[$toKey]);
                     }
                 }
@@ -372,15 +379,17 @@ class Comparator
 
         foreach ($fromForeignKeys as $fromConstraint) {
             $tableDifferences->removedForeignKeys[] = $fromConstraint;
-            $changes++;
+
+            $hasChanges = true;
         }
 
         foreach ($toForeignKeys as $toConstraint) {
             $tableDifferences->addedForeignKeys[] = $toConstraint;
-            $changes++;
+
+            $hasChanges = true;
         }
 
-        return $changes > 0 ? $tableDifferences : false;
+        return $hasChanges ? $tableDifferences : false;
     }
 
     /**

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -317,10 +317,12 @@ SQL,
      */
     public function alterTable(TableDiff $tableDiff)
     {
-        if (count($tableDiff->removedColumns) > 0) {
+        $droppedColumns = $tableDiff->getDroppedColumns();
+
+        if (count($droppedColumns) > 0) {
             $tableName = ($tableDiff->getOldTable() ?? $tableDiff->getName($this->_platform))->getName();
 
-            foreach ($tableDiff->removedColumns as $col) {
+            foreach ($droppedColumns as $col) {
                 foreach ($this->getColumnConstraints($tableName, $col->getName()) as $constraint) {
                     $this->_conn->executeStatement(
                         sprintf(

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -155,10 +155,11 @@ class SqliteSchemaManager extends AbstractSchemaManager
      */
     public function createForeignKey(ForeignKeyConstraint $foreignKey, $table)
     {
-        $tableDiff                     = $this->getTableDiffForAlterForeignKey($table);
-        $tableDiff->addedForeignKeys[] = $foreignKey;
+        if (! $table instanceof Table) {
+            $table = $this->listTableDetails($table);
+        }
 
-        $this->alterTable($tableDiff);
+        $this->alterTable(new TableDiff($table->getName(), [], [], [], [], [], [], $table, [$foreignKey]));
     }
 
     /**
@@ -175,10 +176,11 @@ class SqliteSchemaManager extends AbstractSchemaManager
                 . ' Use SqliteSchemaManager::dropForeignKey() and SqliteSchemaManager::createForeignKey() instead.',
         );
 
-        $tableDiff                       = $this->getTableDiffForAlterForeignKey($table);
-        $tableDiff->changedForeignKeys[] = $foreignKey;
+        if (! $table instanceof Table) {
+            $table = $this->listTableDetails($table);
+        }
 
-        $this->alterTable($tableDiff);
+        $this->alterTable(new TableDiff($table->getName(), [], [], [], [], [], [], $table, [], [$foreignKey]));
     }
 
     /**
@@ -186,10 +188,11 @@ class SqliteSchemaManager extends AbstractSchemaManager
      */
     public function dropForeignKey($foreignKey, $table)
     {
-        $tableDiff                       = $this->getTableDiffForAlterForeignKey($table);
-        $tableDiff->removedForeignKeys[] = $foreignKey;
+        if (! $table instanceof Table) {
+            $table = $this->listTableDetails($table);
+        }
 
-        $this->alterTable($tableDiff);
+        $this->alterTable(new TableDiff($table->getName(), [], [], [], [], [], [], $table, [], [], [$foreignKey]));
     }
 
     /**
@@ -494,20 +497,6 @@ class SqliteSchemaManager extends AbstractSchemaManager
                 'deferred' => $tableForeignKey['deferred'],
             ],
         );
-    }
-
-    /**
-     * @param Table|string $table
-     *
-     * @throws Exception
-     */
-    private function getTableDiffForAlterForeignKey($table): TableDiff
-    {
-        if (! $table instanceof Table) {
-            $table = $this->listTableDetails($table);
-        }
-
-        return new TableDiff($table->getName(), [], [], [], [], [], [], $table);
     }
 
     private function parseColumnCollationFromSQL(string $column, string $sql): ?string

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -420,7 +420,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $diff->newName                  = 'client';
         $diff->renamedColumns['id']     = new Column('key', Type::getType('integer'), []);
         $diff->renamedColumns['post']   = new Column('comment', Type::getType('integer'), []);
-        $diff->removedColumns['parent'] = new Column('comment', Type::getType('integer'), []);
+        $diff->removedColumns['parent'] = new Column('parent', Type::getType('integer'), []);
         $diff->removedIndexes['index1'] = $table->getIndex('index1');
 
         $sql = [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The goals are:

1. Improve encapsulation by forbidding uncontrolled access to the object state (properties) in favor of exchanging messages (calling methods).
2. Simplify the underlying data structures by removing redundant information. Currently, the collections like `$addedColumns` contain column names twice: once as the array key and once as a property of the column under the key. The consistency between the keys and the values is not enforced: https://github.com/doctrine/dbal/blob/120be86ed14673dbe90c4ea0991b3007fa358670/tests/Platforms/SqlitePlatformTest.php#L423 Having the objects indexed by the lower-case name at the abstraction level is prone to errors where object names are case-sensitive (always true for Oracle and IBM DB2, depends on the configuration for SQL Server,).

Change summary:
1. Aim at building the diff once and accessing its state via methods.
2. Change the wording in the names of the methods: changed → modified, removed → dropped, which is closer to the SQL terminology.
3. Where it's hard to get rid of the diff modification but is possible to create a new instance, do that. Note, we don't want to have any `with*()` methods within the diff itself since all these cases are invalid and exist only for historical reasons.
4. The diff constructor accepts most of the collections as `array<T>` (as the keys don't matter) and assigns them to the corresponding properties as is. The corresponding methods return the collection as `list<T>` by converting them via `array_values()`. This way, by opting into using the methods, the API consumer has to stop using the keys. In 4.0, the constructor will accept most of the collections as `list<T>`, so the `array_values()` conversion will be no longer necessary.

Rough edges:

1. The MySQL schema manager still needs some indexes and columns to be indexed by name to handle some edge cases related to the primary key.
2. DB2 does something similar.
3. MySQL "optimizes" handling of some changes in indexes and removes the ones that it has already handled from the diff.
4. The comparator modifies table diffs right after creation.

In order to keep the support for the edge cases where a diff needs to be modified, we introduce internal methods which can be removed in the future. Right now, it looks like getting rid of each of them is a complex project that needs additional research.