### PR TITLE
Deprecating misspelled isFullfilledBy() method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,6 +15,7 @@ has been deprecated. Either use an existing database name in connection paramete
 if the platform and the server configuration allow that.
 
 ## Deprecated misspelled isFullfilledBy() method
+
 This method's name was spelled incorrectly. Use `isFulfilledBy` instead.
 
 ## Deprecated default PostgreSQL connection database.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,9 @@ Relying on a fallback connection used to determine the database platform while c
 has been deprecated. Either use an existing database name in connection parameters or omit the database name
 if the platform and the server configuration allow that.
 
+## Deprecated misspelled isFullfilledBy() method
+This method's name was spelled incorrectly. Use `isFulfilledBy` instead.
+
 ## Deprecated default PostgreSQL connection database.
 
 Relying on the DBAL connecting to the "postgres" database by default is deprecated. Unless you want to have the server

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -188,6 +188,8 @@ class Index extends AbstractAsset implements Constraint
     /**
      * Keeping misspelled function name for backwards compatibility
      *
+     * @deprecated Use {@see isFulfilledBy()} instead.
+     *
      * @return bool
      */
     public function isFullfilledBy(Index $other)


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #5716 

#### Summary

As per the request from @greg0ire and @morozov in #5716, deprecating the misspelled function and updated the upgrade guide.
