### PR TITLE
Removing deprecated `isFullfilledBy()` method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: removed misspelled isFullfilledBy() method
+
+This method's name was spelled incorrectly. Use `isFulfilledBy` instead.
+
 ## BC BREAK: removed default PostgreSQL connection database.
 
 When connecting to a PostgreSQL server, the driver will no longer connect to the "postgres" database by default.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -43,7 +43,6 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getName"/>
-                <referencedMethod name="Doctrine\DBAL\Schema\Index::isFullFilledBy"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -162,17 +162,6 @@ class Index extends AbstractAsset
 
     /**
      * Checks if the other index already fulfills all the indexing and constraint needs of the current one.
-     * Keeping misspelled function name for backwards compatibility
-     *
-     * @deprecated Use {@see isFulfilledBy()} instead.
-     */
-    public function isFullfilledBy(Index $other): bool
-    {
-        return $this->isFulfilledBy($other);
-    }
-
-    /**
-     * Checks if the other index already fulfills all the indexing and constraint needs of the current one.
      */
     public function isFulfilledBy(Index $other): bool
     {

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -708,7 +708,7 @@ class Table extends AbstractAsset
         $indexCandidate = $this->_createIndex($constraint->getColumns(), $indexName, true, false);
 
         foreach ($this->_indexes as $existingIndex) {
-            if ($indexCandidate->isFullfilledBy($existingIndex)) {
+            if ($indexCandidate->isFulfilledBy($existingIndex)) {
                 return $this;
             }
         }
@@ -745,7 +745,7 @@ class Table extends AbstractAsset
         $indexCandidate = $this->_createIndex($constraint->getLocalColumns(), $indexName, false, false);
 
         foreach ($this->_indexes as $existingIndex) {
-            if ($indexCandidate->isFullfilledBy($existingIndex)) {
+            if ($indexCandidate->isFulfilledBy($existingIndex)) {
                 return $this;
             }
         }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #5722 

#### Summary

Removing deprecated `isFullfilledBy()` method
