### PR TITLE
Convert Doctrine\DBAL\Exception to an interface

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: The base exception class has been converted to an interface
+
+The Doctrine\DBAL\Exception class is now an interface.
+
 ## BC BREAK: removed misspelled isFullfilledBy() method
 
 This method's name was spelled incorrectly. Use `isFulfilledBy` instead.

--- a/src/Cache/CacheException.php
+++ b/src/Cache/CacheException.php
@@ -7,6 +7,6 @@ namespace Doctrine\DBAL\Cache;
 use Doctrine\DBAL\Exception;
 
 /** @psalm-immutable */
-class CacheException extends Exception
+class CacheException extends \Exception implements Exception
 {
 }

--- a/src/ConnectionException.php
+++ b/src/ConnectionException.php
@@ -5,6 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL;
 
 /** @psalm-immutable */
-class ConnectionException extends Exception
+class ConnectionException extends \Exception implements Exception
 {
 }

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Driver\OCI8;
 use Doctrine\DBAL\Driver\PDO;
 use Doctrine\DBAL\Driver\SQLSrv;
 use Doctrine\DBAL\Exception\DriverRequired;
+use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Exception\InvalidDriverClass;
 use Doctrine\DBAL\Exception\InvalidWrapperClass;
 use Doctrine\DBAL\Exception\UnknownDriver;
@@ -280,7 +281,7 @@ final class DriverManager
         $url = parse_url($url);
 
         if ($url === false) {
-            throw new Exception('Malformed parameter "url".');
+            throw new InvalidArgumentException('Malformed parameter "url".');
         }
 
         foreach ($url as $param => $value) {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL;
 
+use Throwable;
+
 /** @psalm-immutable */
-class Exception extends \Exception
+interface Exception extends Throwable
 {
 }

--- a/src/Exception/DatabaseRequired.php
+++ b/src/Exception/DatabaseRequired.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Exception;
 use function sprintf;
 
 /** @psalm-immutable */
-class DatabaseRequired extends Exception
+class DatabaseRequired extends \Exception implements Exception
 {
     public static function new(string $methodName): self
     {

--- a/src/Exception/DriverException.php
+++ b/src/Exception/DriverException.php
@@ -15,7 +15,7 @@ use function assert;
  *
  * @psalm-immutable
  */
-class DriverException extends Exception implements Driver\Exception
+class DriverException extends \Exception implements Exception, Driver\Exception
 {
     /**
      * @internal

--- a/src/Exception/DriverRequired.php
+++ b/src/Exception/DriverRequired.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Exception;
 use function sprintf;
 
 /** @psalm-immutable */
-final class DriverRequired extends Exception
+final class DriverRequired extends \Exception implements Exception
 {
     /** @param string|null $url The URL that was provided in the connection parameters (if any). */
     public static function new(?string $url = null): self

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -11,6 +11,6 @@ use Doctrine\DBAL\Exception;
  *
  * @psalm-immutable
  */
-class InvalidArgumentException extends Exception
+class InvalidArgumentException extends \InvalidArgumentException implements Exception
 {
 }

--- a/src/Exception/InvalidColumnDeclaration.php
+++ b/src/Exception/InvalidColumnDeclaration.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Exception;
 use function sprintf;
 
 /** @psalm-immutable */
-final class InvalidColumnDeclaration extends Exception
+final class InvalidColumnDeclaration extends \Exception implements Exception
 {
     public static function fromInvalidColumnType(string $columnName, InvalidColumnType $e): self
     {

--- a/src/Exception/InvalidColumnType.php
+++ b/src/Exception/InvalidColumnType.php
@@ -7,6 +7,6 @@ namespace Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception;
 
 /** @psalm-immutable */
-abstract class InvalidColumnType extends Exception
+abstract class InvalidColumnType extends \Exception implements Exception
 {
 }

--- a/src/Exception/InvalidDriverClass.php
+++ b/src/Exception/InvalidDriverClass.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Exception;
 use function sprintf;
 
 /** @psalm-immutable */
-final class InvalidDriverClass extends Exception
+final class InvalidDriverClass extends \Exception implements Exception
 {
     public static function new(string $driverClass): self
     {

--- a/src/Exception/InvalidWrapperClass.php
+++ b/src/Exception/InvalidWrapperClass.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Exception;
 use function sprintf;
 
 /** @psalm-immutable */
-final class InvalidWrapperClass extends Exception
+final class InvalidWrapperClass extends \Exception implements Exception
 {
     public static function new(string $wrapperClass): self
     {

--- a/src/Exception/NoKeyValue.php
+++ b/src/Exception/NoKeyValue.php
@@ -13,7 +13,7 @@ use function sprintf;
  *
  * @psalm-immutable
  */
-final class NoKeyValue extends Exception
+final class NoKeyValue extends \Exception implements Exception
 {
     public static function fromColumnCount(int $columnCount): self
     {

--- a/src/Exception/UnknownDriver.php
+++ b/src/Exception/UnknownDriver.php
@@ -10,7 +10,7 @@ use function implode;
 use function sprintf;
 
 /** @psalm-immutable */
-final class UnknownDriver extends Exception
+final class UnknownDriver extends \Exception implements Exception
 {
     /** @param string[] $knownDrivers */
     public static function new(string $unknownDriverName, array $knownDrivers): self

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Event\SchemaCreateTableEventArgs;
 use Doctrine\DBAL\Event\SchemaDropTableEventArgs;
 use Doctrine\DBAL\Events;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Exception\InvalidColumnDeclaration;
 use Doctrine\DBAL\Exception\InvalidColumnType;
 use Doctrine\DBAL\Exception\InvalidColumnType\ColumnLengthRequired;
@@ -40,7 +41,6 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Type;
-use InvalidArgumentException;
 use UnexpectedValueException;
 
 use function addcslashes;
@@ -364,7 +364,7 @@ abstract class AbstractPlatform
         $dbType = strtolower($dbType);
 
         if (! isset($this->doctrineTypeMapping[$dbType])) {
-            throw new Exception(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'Unknown database type "%s" requested, %s may not support it.',
                 $dbType,
                 static::class,
@@ -2235,7 +2235,7 @@ abstract class AbstractPlatform
     final public function modifyLimitQuery(string $query, ?int $limit, int $offset = 0): string
     {
         if ($offset < 0) {
-            throw new Exception(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'Offset must be a positive integer or zero, %d given.',
                 $offset,
             ));

--- a/src/Platforms/Exception/InvalidPlatformVersion.php
+++ b/src/Platforms/Exception/InvalidPlatformVersion.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\Exception;
 
-use Doctrine\DBAL\Exception;
+use Exception;
 
 use function sprintf;
 

--- a/src/Platforms/Exception/NoColumnsSpecifiedForTable.php
+++ b/src/Platforms/Exception/NoColumnsSpecifiedForTable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\Exception;
 
-use Doctrine\DBAL\Exception;
+use Exception;
 
 use function sprintf;
 

--- a/src/Platforms/Exception/NotSupported.php
+++ b/src/Platforms/Exception/NotSupported.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\Exception;
 
-use Doctrine\DBAL\Exception;
+use Exception;
 
 use function sprintf;
 

--- a/src/Platforms/Exception/PlatformException.php
+++ b/src/Platforms/Exception/PlatformException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\Exception;
 
-interface PlatformException
+use Doctrine\DBAL\Exception;
+
+interface PlatformException extends Exception
 {
 }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -543,17 +543,17 @@ class SQLitePlatform extends AbstractPlatform
 
     public function getCreatePrimaryKeySQL(Index $index, string $table): string
     {
-        throw new Exception('Sqlite platform does not support alter primary key.');
+        throw NotSupported::new(__METHOD__);
     }
 
     public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, string $table): string
     {
-        throw new Exception('Sqlite platform does not support alter foreign key.');
+        throw NotSupported::new(__METHOD__);
     }
 
     public function getDropForeignKeySQL(string $foreignKey, string $table): string
     {
-        throw new Exception('Sqlite platform does not support alter foreign key.');
+        throw NotSupported::new(__METHOD__);
     }
 
     /**

--- a/src/Query/QueryException.php
+++ b/src/Query/QueryException.php
@@ -7,6 +7,6 @@ namespace Doctrine\DBAL\Query;
 use Doctrine\DBAL\Exception;
 
 /** @psalm-immutable */
-class QueryException extends Exception
+class QueryException extends \Exception implements Exception
 {
 }

--- a/src/Schema/SchemaException.php
+++ b/src/Schema/SchemaException.php
@@ -7,7 +7,7 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Exception;
 
 /** @psalm-immutable */
-class SchemaException extends Exception
+class SchemaException extends \Exception implements Exception
 {
     public const TABLE_DOESNT_EXIST       = 10;
     public const TABLE_ALREADY_EXISTS     = 20;

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -516,14 +516,14 @@ class Table extends AbstractAsset
      *
      * @return array<string, Column>
      *
-     * @throws Exception
+     * @throws SchemaException
      */
     public function getPrimaryKeyColumns(): array
     {
         $primaryKey = $this->getPrimaryKey();
 
         if ($primaryKey === null) {
-            throw new Exception(sprintf('Table "%s" has no primary key.', $this->getName()));
+            throw new SchemaException(sprintf('Table "%s" has no primary key.', $this->getName()));
         }
 
         return $this->filterColumns($primaryKey->getColumns());

--- a/src/Types/ConversionException.php
+++ b/src/Types/ConversionException.php
@@ -11,6 +11,6 @@ use Doctrine\DBAL\Exception;
  *
  * @psalm-immutable
  */
-class ConversionException extends Exception
+class ConversionException extends \Exception implements Exception
 {
 }

--- a/src/Types/Exception/TypeNotFound.php
+++ b/src/Types/Exception/TypeNotFound.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Types\Exception;
 
-use Doctrine\DBAL\Exception;
+use Exception;
 
 use function sprintf;
 

--- a/src/Types/Exception/TypeNotRegistered.php
+++ b/src/Types/Exception/TypeNotRegistered.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Types\Exception;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Types\Type;
+use Exception;
 
 use function get_debug_type;
 use function spl_object_hash;

--- a/src/Types/Exception/TypesAlreadyExists.php
+++ b/src/Types/Exception/TypesAlreadyExists.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Types\Exception;
 
-use Doctrine\DBAL\Exception;
+use Exception;
 
 use function sprintf;
 

--- a/src/Types/Exception/TypesException.php
+++ b/src/Types/Exception/TypesException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Types\Exception;
 
-interface TypesException
+use Doctrine\DBAL\Exception;
+
+interface TypesException extends Exception
 {
 }

--- a/src/Types/Exception/UnknownColumnType.php
+++ b/src/Types/Exception/UnknownColumnType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Types\Exception;
 
-use Doctrine\DBAL\Exception;
+use Exception;
 
 use function sprintf;
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

Currently, the base exception being a class doesn't allow to reuse of the semantics of the SPL exception classes. For instance, distinguish between logic and runtime exceptions.

Not being able to reuse the semantics defined in SPL causes the following issue about documenting exceptions. For example, take the `NotSupported` exception which has the following ancestry: `NotSupported → \Doctrine\DBAL\Exception → \Exception`. As static analyzers see it, semantically, it's just a generic exception as it extends the generic `\Exception` class. But in fact, it identifies an error in the logic of the code that consumes the API and thereby should not be handled by the caller (an unchecked exception).

Now, take this use case for example:

https://github.com/doctrine/dbal/blob/4bd24c858b246ddfa133bc85f1deee336f2b31b5/src/Platforms/AbstractPlatform.php#L2012-L2016

The method is declared as throwing an exception with unknown semantics. As a result, static analyzers like [PhpStorm](https://blog.jetbrains.com/phpstorm/2018/04/configurable-unchecked-exceptions/) flag the calls that don't handle this exception as incorrect. If we remove the `@throws` annotation, then the `throw` statement is flagged as incorrect. The only way to write statically correct code against this API is to catch the exception and do nothing with it, which is still wrong.

Converting the class to an interface allows retaining the relation of the exception to the DBAL and at the same time reusing the semantics defined in SPL. For example: https://github.com/doctrine/dbal/blob/4bd24c858b246ddfa133bc85f1deee336f2b31b5/src/Exception/InvalidArgumentException.php#L7-L14

In subsequent patches, we can fine-tune the semantics of other exceptions (firstly, `NotSupported`) by changing their parent from `\Exception` to something more specific.