### PR TITLE
Clarify semantics of logic exceptions

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -122,8 +122,6 @@ class Connection implements ServerVersionProvider
      * @param EventManager|null    $eventManager The event manager, optional.
      * @psalm-param Params $params
      * @phpstan-param array<string,mixed> $params
-     *
-     * @throws Exception
      */
     public function __construct(
         array $params,

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -98,9 +98,6 @@ class PrimaryReadReplicaConnection extends Connection
      * @param array<string, mixed> $params
      * @psalm-param Params $params
      * @phpstan-param array<string,mixed> $params
-     *
-     * @throws Exception
-     * @throws InvalidArgumentException
      */
     public function __construct(
         array $params,

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -158,8 +158,6 @@ final class DriverManager
      *
      * @psalm-return ($params is array{wrapperClass:mixed} ? T : Connection)
      *
-     * @throws Exception
-     *
      * @template T of Connection
      */
     public static function getConnection(
@@ -216,8 +214,6 @@ final class DriverManager
      * @param array<string,mixed> $params
      * @psalm-param Params $params
      * @phpstan-param array<string,mixed> $params
-     *
-     * @throws Exception
      */
     private static function createDriver(array $params): Driver
     {
@@ -267,8 +263,6 @@ final class DriverManager
      *                 URL extracted into indidivual parameter parts.
      * @psalm-return Params
      * @phpstan-return array<string,mixed>
-     *
-     * @throws Exception
      */
     private static function parseDatabaseUrl(array $params): array
     {
@@ -422,8 +416,6 @@ final class DriverManager
      * @param mixed[]     $params The connection parameters to resolve.
      *
      * @return mixed[] The resolved connection parameters.
-     *
-     * @throws Exception If parsing failed or resolution is not possible.
      */
     private static function parseDatabaseUrlScheme(?string $scheme, array $params): array
     {

--- a/src/Exception/DriverRequired.php
+++ b/src/Exception/DriverRequired.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Exception;
 
-use Doctrine\DBAL\Exception;
-
 use function sprintf;
 
 /** @psalm-immutable */
-final class DriverRequired extends \Exception implements Exception
+final class DriverRequired extends InvalidArgumentException
 {
     /** @param string|null $url The URL that was provided in the connection parameters (if any). */
     public static function new(?string $url = null): self

--- a/src/Exception/InvalidColumnDeclaration.php
+++ b/src/Exception/InvalidColumnDeclaration.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Exception;
 
 use Doctrine\DBAL\Exception;
+use LogicException;
 
 use function sprintf;
 
 /** @psalm-immutable */
-final class InvalidColumnDeclaration extends \Exception implements Exception
+final class InvalidColumnDeclaration extends LogicException implements Exception
 {
     public static function fromInvalidColumnType(string $columnName, InvalidColumnType $e): self
     {

--- a/src/Exception/InvalidColumnType.php
+++ b/src/Exception/InvalidColumnType.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Exception;
 
 use Doctrine\DBAL\Exception;
+use LogicException;
 
 /** @psalm-immutable */
-abstract class InvalidColumnType extends \Exception implements Exception
+abstract class InvalidColumnType extends LogicException implements Exception
 {
 }

--- a/src/Exception/InvalidDriverClass.php
+++ b/src/Exception/InvalidDriverClass.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Exception;
 
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Exception;
 
 use function sprintf;
 
 /** @psalm-immutable */
-final class InvalidDriverClass extends \Exception implements Exception
+final class InvalidDriverClass extends InvalidArgumentException
 {
     public static function new(string $driverClass): self
     {

--- a/src/Exception/InvalidWrapperClass.php
+++ b/src/Exception/InvalidWrapperClass.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Exception;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception;
 
 use function sprintf;
 
 /** @psalm-immutable */
-final class InvalidWrapperClass extends \Exception implements Exception
+final class InvalidWrapperClass extends InvalidArgumentException
 {
     public static function new(string $wrapperClass): self
     {

--- a/src/Exception/UnknownDriver.php
+++ b/src/Exception/UnknownDriver.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Exception;
 
-use Doctrine\DBAL\Exception;
-
 use function implode;
 use function sprintf;
 
 /** @psalm-immutable */
-final class UnknownDriver extends \Exception implements Exception
+final class UnknownDriver extends InvalidArgumentException
 {
     /** @param string[] $knownDrivers */
     public static function new(string $unknownDriverName, array $knownDrivers): self

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1127,8 +1127,6 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL to create an index on a table on this platform.
-     *
-     * @throws InvalidArgumentException
      */
     public function getCreateIndexSQL(Index $index, string $table): string
     {
@@ -1648,8 +1646,6 @@ abstract class AbstractPlatform
      * @param UniqueConstraint $constraint The unique constraint definition.
      *
      * @return string DBMS specific SQL code portion needed to set a constraint.
-     *
-     * @throws InvalidArgumentException
      */
     public function getUniqueConstraintDeclarationSQL(UniqueConstraint $constraint): string
     {
@@ -1695,8 +1691,6 @@ abstract class AbstractPlatform
      * @param Index $index The index definition.
      *
      * @return string DBMS specific SQL code portion needed to set an index.
-     *
-     * @throws InvalidArgumentException
      */
     public function getIndexDeclarationSQL(Index $index): string
     {
@@ -1763,8 +1757,6 @@ abstract class AbstractPlatform
      * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      *
      * @param string $action The foreign key referential action.
-     *
-     * @throws InvalidArgumentException If unknown referential action given.
      */
     public function getForeignKeyReferentialActionSQL(string $action): string
     {
@@ -1783,8 +1775,6 @@ abstract class AbstractPlatform
     /**
      * Obtains DBMS specific SQL code portion needed to set the FOREIGN KEY constraint
      * of a column declaration to be used in statements like CREATE TABLE.
-     *
-     * @throws InvalidArgumentException
      */
     public function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey): string
     {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -168,8 +168,6 @@ abstract class AbstractPlatform
      * store characters in the ASCII character set
      *
      * @param array<string, mixed> $column The column definition.
-     *
-     * @throws ColumnLengthRequired
      */
     public function getAsciiStringTypeDeclarationSQL(array $column): string
     {
@@ -180,8 +178,6 @@ abstract class AbstractPlatform
      * Returns the SQL snippet used to declare a string column type.
      *
      * @param array<string, mixed> $column The column definition.
-     *
-     * @throws InvalidColumnDeclaration
      */
     public function getStringTypeDeclarationSQL(array $column): string
     {
@@ -202,8 +198,6 @@ abstract class AbstractPlatform
      * Returns the SQL snippet used to declare a binary string column type.
      *
      * @param array<string, mixed> $column The column definition.
-     *
-     * @throws InvalidColumnDeclaration
      */
     public function getBinaryTypeDeclarationSQL(array $column): string
     {
@@ -227,8 +221,6 @@ abstract class AbstractPlatform
      * special datatypes when the underlying databases support this datatype.
      *
      * @param array<string, mixed> $column The column definition.
-     *
-     * @throws Exception
      */
     public function getGuidTypeDeclarationSQL(array $column): string
     {
@@ -269,8 +261,6 @@ abstract class AbstractPlatform
     /**
      * @param int|null $length The length of the column in characters
      *                         or NULL if the length should be omitted.
-     *
-     * @throws ColumnLengthRequired
      */
     protected function getVarcharTypeDeclarationSQLSnippet(?int $length): string
     {
@@ -286,8 +276,6 @@ abstract class AbstractPlatform
      *
      * @param int|null $length The length of the column in bytes
      *                         or NULL if the length should be omitted.
-     *
-     * @throws ColumnLengthRequired
      */
     protected function getBinaryTypeDeclarationSQLSnippet(?int $length): string
     {
@@ -305,8 +293,6 @@ abstract class AbstractPlatform
      *
      * @param int|null $length The length of the column in bytes
      *                         or NULL if the length should be omitted.
-     *
-     * @throws ColumnLengthRequired
      */
     protected function getVarbinaryTypeDeclarationSQLSnippet(?int $length): string
     {
@@ -1556,8 +1542,6 @@ abstract class AbstractPlatform
      * Returns the SQL snippet that declares a floating point column of arbitrary precision.
      *
      * @param mixed[] $column
-     *
-     * @throws InvalidColumnDeclaration
      */
     public function getDecimalTypeDeclarationSQL(array $column): string
     {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -390,8 +390,6 @@ abstract class AbstractPlatform
 
     /**
      * Returns the regular expression operator.
-     *
-     * @throws Exception If not supported on this platform.
      */
     public function getRegexpExpression(): string
     {
@@ -1050,8 +1048,6 @@ abstract class AbstractPlatform
      * Returns the SQL to create inline comment on a column.
      *
      * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     *
-     * @throws Exception If not supported on this platform.
      */
     public function getInlineColumnCommentSQL(string $comment): string
     {
@@ -1117,8 +1113,6 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL to create a sequence on this platform.
-     *
-     * @throws Exception If not supported on this platform.
      */
     public function getCreateSequenceSQL(Sequence $sequence): string
     {
@@ -1127,8 +1121,6 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL to change a sequence on this platform.
-     *
-     * @throws Exception If not supported on this platform.
      */
     public function getAlterSequenceSQL(Sequence $sequence): string
     {
@@ -1137,8 +1129,6 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL snippet to drop an existing sequence.
-     *
-     * @throws Exception If not supported on this platform.
      */
     public function getDropSequenceSQL(string $name): string
     {
@@ -1203,8 +1193,6 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL to create a named schema.
-     *
-     * @throws Exception If not supported on this platform.
      */
     public function getCreateSchemaSQL(string $schemaName): string
     {
@@ -1226,8 +1214,6 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL snippet to drop a schema.
-     *
-     * @throws Exception If not supported on this platform.
      */
     public function getDropSchemaSQL(string $schemaName): string
     {
@@ -1972,21 +1958,13 @@ abstract class AbstractPlatform
         };
     }
 
-    /**
-     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
-     *
-     * @throws Exception If not supported on this platform.
-     */
+    /** @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy. */
     public function getListDatabasesSQL(): string
     {
         throw NotSupported::new(__METHOD__);
     }
 
-    /**
-     * @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy.
-     *
-     * @throws Exception If not supported on this platform.
-     */
+    /** @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy. */
     public function getListSequencesSQL(string $database): string
     {
         throw NotSupported::new(__METHOD__);
@@ -2009,7 +1987,6 @@ abstract class AbstractPlatform
         return 'DROP VIEW ' . $name;
     }
 
-    /** @throws Exception If not supported on this platform. */
     public function getSequenceNextValSQL(string $sequence): string
     {
         throw NotSupported::new(__METHOD__);

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\Keywords\DB2Keywords;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
@@ -191,11 +190,6 @@ class DB2Platform extends AbstractPlatform
         return 'TRUNCATE ' . $tableIdentifier->getQuotedName($this) . ' IMMEDIATE';
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws Exception
-     */
     public function getSetTransactionIsolationSQL(TransactionIsolationLevel $level): string
     {
         throw NotSupported::new(__METHOD__);

--- a/src/Platforms/Exception/NotSupported.php
+++ b/src/Platforms/Exception/NotSupported.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\Exception;
 
-use Exception;
+use LogicException;
 
 use function sprintf;
 
 /** @psalm-immutable */
-final class NotSupported extends Exception implements PlatformException
+final class NotSupported extends LogicException implements PlatformException
 {
     public static function new(string $method): self
     {

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -292,8 +292,6 @@ class SQLServerPlatform extends AbstractPlatform
      * Returns the SQL snippet for declaring a default constraint.
      *
      * @param mixed[] $column Column definition.
-     *
-     * @throws InvalidArgumentException
      */
     protected function getDefaultConstraintDeclarationSQL(array $column): string
     {

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -39,13 +39,11 @@ use function trim;
  */
 class SQLitePlatform extends AbstractPlatform
 {
-    /** @throws NotSupported */
     public function getCreateDatabaseSQL(string $name): string
     {
         throw NotSupported::new(__METHOD__);
     }
 
-    /** @throws NotSupported */
     public function getDropDatabaseSQL(string $name): string
     {
         throw NotSupported::new(__METHOD__);

--- a/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
@@ -36,8 +36,6 @@ final class CreateSchemaObjectsSQLBuilder
      * @param list<string> $namespaces
      *
      * @return list<string>
-     *
-     * @throws Exception
      */
     private function buildNamespaceStatements(array $namespaces): array
     {
@@ -68,8 +66,6 @@ final class CreateSchemaObjectsSQLBuilder
      * @param list<Sequence> $sequences
      *
      * @return list<string>
-     *
-     * @throws Exception
      */
     private function buildSequenceStatements(array $sequences): array
     {

--- a/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\SQL\Builder;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
@@ -18,11 +17,7 @@ final class DropSchemaObjectsSQLBuilder
     {
     }
 
-    /**
-     * @return list<string>
-     *
-     * @throws Exception
-     */
+    /** @return list<string> */
     public function buildSQL(Schema $schema): array
     {
         return array_merge(
@@ -45,8 +40,6 @@ final class DropSchemaObjectsSQLBuilder
      * @param list<Sequence> $sequences
      *
      * @return list<string>
-     *
-     * @throws Exception
      */
     private function buildSequenceStatements(array $sequences): array
     {

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -643,24 +643,16 @@ abstract class AbstractSchemaManager
      * the native DBMS data definition to a portable Doctrine definition
      */
 
-    /**
-     * @param array<string, string> $database
-     *
-     * @throws Exception
-     */
+    /** @param array<string, string> $database */
     protected function _getPortableDatabaseDefinition(array $database): string
     {
         throw NotSupported::new(__METHOD__);
     }
 
-    /**
-     * @param array<string, mixed> $sequence
-     *
-     * @throws Exception
-     */
+    /** @param array<string, mixed> $sequence */
     protected function _getPortableSequenceDefinition(array $sequence): Sequence
     {
-        throw NotSupported::new('Sequences');
+        throw NotSupported::new(__METHOD__);
     }
 
     /**

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -90,8 +90,6 @@ abstract class Type
      *
      * @param array<string, mixed> $column   The column definition
      * @param AbstractPlatform     $platform The currently used database platform.
-     *
-     * @throws Exception
      */
     abstract public function getSQLDeclaration(array $column, AbstractPlatform $platform): string;
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

Declaring certain exceptions as subclasses of the SPL `LogicException` allows removing `@throws` annotations from the methods that throw them since logic exceptions are not supposed to be handled at runtime (unchecked).