### PR TITLE
Deprecate SchemaException codes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,25 @@ awareness about deprecated code.
 
 # Upgrade to 3.5
 
+## Deprecated `SchemaException` error codes.
+
+Relying on the error code of `SchemaException` is deprecated. In order to handle a specific type of exception,
+catch the corresponding exception class instead.
+
+| Error Code                  | Class                          |
+|-----------------------------|--------------------------------|
+| `TABLE_DOESNT_EXIST`        | `TableDoesNotExist`            |
+| `TABLE_ALREADY_EXISTS`      | `TableAlreadyExists`           |
+| `COLUMN_DOESNT_EXIST`       | `ColumnDoesNotExist`           |
+| `COLUMN_ALREADY_EXISTS`     | `ColumnAlreadyExists`          |
+| `INDEX_DOESNT_EXIST`        | `IndexDoesNotExist`            |
+| `INDEX_ALREADY_EXISTS`      | `IndexAlreadyExists`           |
+| `SEQUENCE_DOENST_EXIST`     | `SequenceDoesNotExist`         |
+| `SEQUENCE_ALREADY_EXISTS`   | `SequenceAlreadyExists`        |
+| `FOREIGNKEY_DOESNT_EXIST`   | `ForeignKeyDoesNotExist`       |
+| `CONSTRAINT_DOESNT_EXIST`   | `UniqueConstraintDoesNotExist` |
+| `NAMESPACE_ALREADY_EXISTS`  | `NamespaceAlreadyExists`       |
+
 ## Deprecated fallback connection used to determine the database platform.
 
 Relying on a fallback connection used to determine the database platform while connecting to a non-existing database

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -116,6 +116,10 @@
                 -->
                 <file name="src/Query/QueryBuilder.php"/>
                 <file name="tests/Query/QueryBuilderTest.php"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <directory name="src/Schema/Exception"/>
             </errorLevel>
         </DeprecatedConstant>
         <DeprecatedInterface>

--- a/src/Schema/Exception/ColumnAlreadyExists.php
+++ b/src/Schema/Exception/ColumnAlreadyExists.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class ColumnAlreadyExists extends SchemaException
+{
+    public static function new(string $tableName, string $columnName): self
+    {
+        return new self(
+            sprintf('The column "%s" on table "%s" already exists.', $columnName, $tableName),
+            self::COLUMN_ALREADY_EXISTS,
+        );
+    }
+}

--- a/src/Schema/Exception/ColumnDoesNotExist.php
+++ b/src/Schema/Exception/ColumnDoesNotExist.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class ColumnDoesNotExist extends SchemaException
+{
+    public static function new(string $columnName, string $table): self
+    {
+        return new self(
+            sprintf('There is no column with name "%s" on table "%s".', $columnName, $table),
+            self::COLUMN_DOESNT_EXIST,
+        );
+    }
+}

--- a/src/Schema/Exception/ForeignKeyDoesNotExist.php
+++ b/src/Schema/Exception/ForeignKeyDoesNotExist.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class ForeignKeyDoesNotExist extends SchemaException
+{
+    public static function new(string $foreignKeyName, string $table): self
+    {
+        return new self(
+            sprintf('There exists no foreign key with the name "%s" on table "%s".', $foreignKeyName, $table),
+            self::FOREIGNKEY_DOESNT_EXIST,
+        );
+    }
+}

--- a/src/Schema/Exception/IndexAlreadyExists.php
+++ b/src/Schema/Exception/IndexAlreadyExists.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class IndexAlreadyExists extends SchemaException
+{
+    public static function new(string $indexName, string $table): self
+    {
+        return new self(
+            sprintf('An index with name "%s" was already defined on table "%s".', $indexName, $table),
+            self::INDEX_ALREADY_EXISTS,
+        );
+    }
+}

--- a/src/Schema/Exception/IndexDoesNotExist.php
+++ b/src/Schema/Exception/IndexDoesNotExist.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class IndexDoesNotExist extends SchemaException
+{
+    public static function new(string $indexName, string $table): self
+    {
+        return new self(
+            sprintf('Index "%s" does not exist on table "%s".', $indexName, $table),
+            self::INDEX_DOESNT_EXIST,
+        );
+    }
+}

--- a/src/Schema/Exception/IndexNameInvalid.php
+++ b/src/Schema/Exception/IndexNameInvalid.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class IndexNameInvalid extends SchemaException
+{
+    public static function new(string $indexName): self
+    {
+        return new self(
+            sprintf('Invalid index name "%s" given, has to be [a-zA-Z0-9_].', $indexName),
+            self::INDEX_INVALID_NAME,
+        );
+    }
+}

--- a/src/Schema/Exception/NamedForeignKeyRequired.php
+++ b/src/Schema/Exception/NamedForeignKeyRequired.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Schema\Table;
+
+use function implode;
+use function sprintf;
+
+/** @psalm-immutable */
+final class NamedForeignKeyRequired extends SchemaException
+{
+    public static function new(Table $localTable, ForeignKeyConstraint $foreignKey): self
+    {
+        return new self(
+            sprintf(
+                'The performed schema operation on "%s" requires a named foreign key, ' .
+                'but the given foreign key from (%s) onto foreign table "%s" (%s) is currently unnamed.',
+                $localTable->getName(),
+                implode(', ', $foreignKey->getColumns()),
+                $foreignKey->getForeignTableName(),
+                implode(', ', $foreignKey->getForeignColumns()),
+            ),
+        );
+    }
+}

--- a/src/Schema/Exception/NamespaceAlreadyExists.php
+++ b/src/Schema/Exception/NamespaceAlreadyExists.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class NamespaceAlreadyExists extends SchemaException
+{
+    public static function new(string $namespaceName): self
+    {
+        return new self(
+            sprintf('The namespace with name "%s" already exists.', $namespaceName),
+            self::NAMESPACE_ALREADY_EXISTS,
+        );
+    }
+}

--- a/src/Schema/Exception/SequenceAlreadyExists.php
+++ b/src/Schema/Exception/SequenceAlreadyExists.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class SequenceAlreadyExists extends SchemaException
+{
+    public static function new(string $sequenceName): self
+    {
+        return new self(
+            sprintf('The sequence "%s" already exists.', $sequenceName),
+            self::SEQUENCE_ALREADY_EXISTS,
+        );
+    }
+}

--- a/src/Schema/Exception/SequenceDoesNotExist.php
+++ b/src/Schema/Exception/SequenceDoesNotExist.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class SequenceDoesNotExist extends SchemaException
+{
+    public static function new(string $sequenceName): self
+    {
+        return new self(
+            sprintf('There exists no sequence with the name "%s".', $sequenceName),
+            self::SEQUENCE_DOENST_EXIST,
+        );
+    }
+}

--- a/src/Schema/Exception/TableAlreadyExists.php
+++ b/src/Schema/Exception/TableAlreadyExists.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class TableAlreadyExists extends SchemaException
+{
+    public static function new(string $tableName): self
+    {
+        return new self(
+            sprintf('The table with name "%s" already exists.', $tableName),
+            self::TABLE_ALREADY_EXISTS,
+        );
+    }
+}

--- a/src/Schema/Exception/TableDoesNotExist.php
+++ b/src/Schema/Exception/TableDoesNotExist.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class TableDoesNotExist extends SchemaException
+{
+    public static function new(string $tableName): self
+    {
+        return new self(
+            sprintf('There is no table with name "%s" in the schema.', $tableName),
+            self::TABLE_DOESNT_EXIST,
+        );
+    }
+}

--- a/src/Schema/Exception/UniqueConstraintDoesNotExist.php
+++ b/src/Schema/Exception/UniqueConstraintDoesNotExist.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class UniqueConstraintDoesNotExist extends SchemaException
+{
+    public static function new(string $constraintName, string $table): self
+    {
+        return new self(
+            sprintf('There exists no unique constraint with the name "%s" on table "%s".', $constraintName, $table),
+            self::CONSTRAINT_DOESNT_EXIST,
+        );
+    }
+}

--- a/src/Schema/SchemaException.php
+++ b/src/Schema/SchemaException.php
@@ -22,17 +22,40 @@ use function sprintf;
 /** @psalm-immutable */
 class SchemaException extends Exception
 {
-    public const TABLE_DOESNT_EXIST       = 10;
-    public const TABLE_ALREADY_EXISTS     = 20;
-    public const COLUMN_DOESNT_EXIST      = 30;
-    public const COLUMN_ALREADY_EXISTS    = 40;
-    public const INDEX_DOESNT_EXIST       = 50;
-    public const INDEX_ALREADY_EXISTS     = 60;
-    public const SEQUENCE_DOENST_EXIST    = 70;
-    public const SEQUENCE_ALREADY_EXISTS  = 80;
-    public const INDEX_INVALID_NAME       = 90;
-    public const FOREIGNKEY_DOESNT_EXIST  = 100;
-    public const CONSTRAINT_DOESNT_EXIST  = 110;
+    /** @deprecated Use {@see TableDoesNotExist} instead. */
+    public const TABLE_DOESNT_EXIST = 10;
+
+    /** @deprecated Use {@see TableAlreadyExists} instead. */
+    public const TABLE_ALREADY_EXISTS = 20;
+
+    /** @deprecated Use {@see ColumnDoesNotExist} instead. */
+    public const COLUMN_DOESNT_EXIST = 30;
+
+    /** @deprecated Use {@see ColumnAlreadyExists} instead. */
+    public const COLUMN_ALREADY_EXISTS = 40;
+
+    /** @deprecated Use {@see IndexDoesNotExist} instead. */
+    public const INDEX_DOESNT_EXIST = 50;
+
+    /** @deprecated Use {@see IndexAlreadyExists} instead. */
+    public const INDEX_ALREADY_EXISTS = 60;
+
+    /** @deprecated Use {@see SequenceDoesNotExist} instead. */
+    public const SEQUENCE_DOENST_EXIST = 70;
+
+    /** @deprecated Use {@see SequenceAlreadyExists} instead. */
+    public const SEQUENCE_ALREADY_EXISTS = 80;
+
+    /** @deprecated Use {@see IndexNameInvalid} instead. */
+    public const INDEX_INVALID_NAME = 90;
+
+    /** @deprecated Use {@see ForeignKeyDoesNotExist} instead. */
+    public const FOREIGNKEY_DOESNT_EXIST = 100;
+
+    /** @deprecated Use {@see UniqueConstraintDoesNotExist} instead. */
+    public const CONSTRAINT_DOESNT_EXIST = 110;
+
+    /** @deprecated Use {@see NamespaceAlreadyExists} instead. */
     public const NAMESPACE_ALREADY_EXISTS = 120;
 
     /**

--- a/src/Schema/SchemaException.php
+++ b/src/Schema/SchemaException.php
@@ -3,8 +3,20 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Exception\ColumnAlreadyExists;
+use Doctrine\DBAL\Schema\Exception\ColumnDoesNotExist;
+use Doctrine\DBAL\Schema\Exception\ForeignKeyDoesNotExist;
+use Doctrine\DBAL\Schema\Exception\IndexAlreadyExists;
+use Doctrine\DBAL\Schema\Exception\IndexDoesNotExist;
+use Doctrine\DBAL\Schema\Exception\IndexNameInvalid;
+use Doctrine\DBAL\Schema\Exception\NamedForeignKeyRequired;
+use Doctrine\DBAL\Schema\Exception\NamespaceAlreadyExists;
+use Doctrine\DBAL\Schema\Exception\SequenceAlreadyExists;
+use Doctrine\DBAL\Schema\Exception\SequenceDoesNotExist;
+use Doctrine\DBAL\Schema\Exception\TableAlreadyExists;
+use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
+use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
 
-use function implode;
 use function sprintf;
 
 /** @psalm-immutable */
@@ -30,7 +42,7 @@ class SchemaException extends Exception
      */
     public static function tableDoesNotExist($tableName)
     {
-        return new self("There is no table with name '" . $tableName . "' in the schema.", self::TABLE_DOESNT_EXIST);
+        return TableDoesNotExist::new($tableName);
     }
 
     /**
@@ -40,10 +52,7 @@ class SchemaException extends Exception
      */
     public static function indexNameInvalid($indexName)
     {
-        return new self(
-            sprintf('Invalid index-name %s given, has to be [a-zA-Z0-9_]', $indexName),
-            self::INDEX_INVALID_NAME,
-        );
+        return IndexNameInvalid::new($indexName);
     }
 
     /**
@@ -54,10 +63,7 @@ class SchemaException extends Exception
      */
     public static function indexDoesNotExist($indexName, $table)
     {
-        return new self(
-            sprintf("Index '%s' does not exist on table '%s'.", $indexName, $table),
-            self::INDEX_DOESNT_EXIST,
-        );
+        return IndexDoesNotExist::new($indexName, $table);
     }
 
     /**
@@ -68,10 +74,7 @@ class SchemaException extends Exception
      */
     public static function indexAlreadyExists($indexName, $table)
     {
-        return new self(
-            sprintf("An index with name '%s' was already defined on table '%s'.", $indexName, $table),
-            self::INDEX_ALREADY_EXISTS,
-        );
+        return IndexAlreadyExists::new($indexName, $table);
     }
 
     /**
@@ -82,10 +85,7 @@ class SchemaException extends Exception
      */
     public static function columnDoesNotExist($columnName, $table)
     {
-        return new self(
-            sprintf("There is no column with name '%s' on table '%s'.", $columnName, $table),
-            self::COLUMN_DOESNT_EXIST,
-        );
+        return ColumnDoesNotExist::new($columnName, $table);
     }
 
     /**
@@ -95,10 +95,7 @@ class SchemaException extends Exception
      */
     public static function namespaceAlreadyExists($namespaceName)
     {
-        return new self(
-            sprintf("The namespace with name '%s' already exists.", $namespaceName),
-            self::NAMESPACE_ALREADY_EXISTS,
-        );
+        return NamespaceAlreadyExists::new($namespaceName);
     }
 
     /**
@@ -108,7 +105,7 @@ class SchemaException extends Exception
      */
     public static function tableAlreadyExists($tableName)
     {
-        return new self("The table with name '" . $tableName . "' already exists.", self::TABLE_ALREADY_EXISTS);
+        return TableAlreadyExists::new($tableName);
     }
 
     /**
@@ -119,10 +116,7 @@ class SchemaException extends Exception
      */
     public static function columnAlreadyExists($tableName, $columnName)
     {
-        return new self(
-            "The column '" . $columnName . "' on table '" . $tableName . "' already exists.",
-            self::COLUMN_ALREADY_EXISTS,
-        );
+        return ColumnAlreadyExists::new($tableName, $columnName);
     }
 
     /**
@@ -132,7 +126,7 @@ class SchemaException extends Exception
      */
     public static function sequenceAlreadyExists($name)
     {
-        return new self("The sequence '" . $name . "' already exists.", self::SEQUENCE_ALREADY_EXISTS);
+        return SequenceAlreadyExists::new($name);
     }
 
     /**
@@ -142,7 +136,7 @@ class SchemaException extends Exception
      */
     public static function sequenceDoesNotExist($name)
     {
-        return new self("There exists no sequence with the name '" . $name . "'.", self::SEQUENCE_DOENST_EXIST);
+        return SequenceDoesNotExist::new($name);
     }
 
     /**
@@ -153,10 +147,7 @@ class SchemaException extends Exception
      */
     public static function uniqueConstraintDoesNotExist($constraintName, $table)
     {
-        return new self(
-            sprintf('There exists no unique constraint with the name "%s" on table "%s".', $constraintName, $table),
-            self::CONSTRAINT_DOESNT_EXIST,
-        );
+        return UniqueConstraintDoesNotExist::new($constraintName, $table);
     }
 
     /**
@@ -167,21 +158,13 @@ class SchemaException extends Exception
      */
     public static function foreignKeyDoesNotExist($fkName, $table)
     {
-        return new self(
-            sprintf("There exists no foreign key with the name '%s' on table '%s'.", $fkName, $table),
-            self::FOREIGNKEY_DOESNT_EXIST,
-        );
+        return ForeignKeyDoesNotExist::new($fkName, $table);
     }
 
     /** @return SchemaException */
     public static function namedForeignKeyRequired(Table $localTable, ForeignKeyConstraint $foreignKey)
     {
-        return new self(
-            'The performed schema operation on ' . $localTable->getName() . ' requires a named foreign key, ' .
-            'but the given foreign key from (' . implode(', ', $foreignKey->getColumns()) . ') onto foreign table ' .
-            "'" . $foreignKey->getForeignTableName() . "' (" . implode(', ', $foreignKey->getForeignColumns()) . ')' .
-            ' is currently unnamed.',
-        );
+        return NamedForeignKeyRequired::new($localTable, $foreignKey);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

Similar to https://github.com/doctrine/dbal/pull/5726 and https://github.com/doctrine/dbal/pull/5727, I want to convert `SchemaException` to an interface and declare some of its subclasses as `LogicException`. The problem with that is that `SchemaException` defines constants.

As of https://github.com/doctrine/dbal/pull/3525, each of the constants has a corresponding class, so as an API, these constants are redundant.

In order to provide an upgrade path, we need to backport the introduction of `SchemaException` subclasses from 4.0.x.