### PR TITLE
Deprecate Table methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 3.5
 
+## Deprecated `Table` methods.
+
+The `hasPrimaryKey()` method has been deprecated. Use `getPrimaryKey()` and check if the return value is not null.
+The `getPrimaryKeyColumns()` method has been deprecated. Use `getPrimaryKey()` and `Index::getColumns()` instead.
+The `getForeignKeyColumns()` method has been deprecated. Use `getForeignKey()`
+and `ForeignKeyConstraint::getLocalColumns()` instead.
+
 ## Deprecated `SchemaException` error codes.
 
 Relying on the error code of `SchemaException` is deprecated. In order to handle a specific type of exception,

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -435,6 +435,12 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getName"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\Table::getForeignKeyColumns"/>
+                <referencedMethod name="Doctrine\DBAL\Schema\Table::getPrimaryKeyColumns"/>
+                <referencedMethod name="Doctrine\DBAL\Schema\Table::hasPrimaryKey"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -866,6 +866,26 @@ SQL
             return [];
         }
 
+        $primaryKey = $table->getPrimaryKey();
+
+        if ($primaryKey === null) {
+            return [];
+        }
+
+        $primaryKeyColumns = [];
+
+        foreach ($primaryKey->getColumns() as $columnName) {
+            if (! $table->hasColumn($columnName)) {
+                continue;
+            }
+
+            $primaryKeyColumns[] = $table->getColumn($columnName);
+        }
+
+        if (count($primaryKeyColumns) === 0) {
+            return [];
+        }
+
         $sql = [];
 
         $tableNameSQL = $table->getQuotedName($this);
@@ -876,9 +896,9 @@ SQL
                 continue;
             }
 
-            foreach ($table->getPrimaryKeyColumns() as $columnName => $column) {
+            foreach ($primaryKeyColumns as $column) {
                 // Check if an autoincrement column was dropped from the primary key.
-                if (! $column->getAutoincrement() || in_array($columnName, $changedIndex->getColumns(), true)) {
+                if (! $column->getAutoincrement() || in_array($column->getName(), $changedIndex->getColumns(), true)) {
                     continue;
                 }
 

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -330,7 +330,7 @@ class Comparator
 
         /* See if all the indexes in "from" table exist in "to" table */
         foreach ($toTableIndexes as $indexName => $index) {
-            if (($index->isPrimary() && $fromTable->hasPrimaryKey()) || $fromTable->hasIndex($indexName)) {
+            if (($index->isPrimary() && $fromTable->getPrimaryKey() !== null) || $fromTable->hasIndex($indexName)) {
                 continue;
             }
 
@@ -343,7 +343,7 @@ class Comparator
         foreach ($fromTableIndexes as $indexName => $index) {
             // See if index is removed in "to" table.
             if (
-                ($index->isPrimary() && ! $toTable->hasPrimaryKey()) ||
+                ($index->isPrimary() && $toTable->getPrimaryKey() === null) ||
                 ! $index->isPrimary() && ! $toTable->hasIndex($indexName)
             ) {
                 $droppedIndexes[$indexName] = $index;

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -683,7 +683,7 @@ class Table extends AbstractAsset
      */
     public function getColumns()
     {
-        $primaryKeyColumns = $this->hasPrimaryKey() ? $this->getPrimaryKeyColumns() : [];
+        $primaryKeyColumns = $this->getPrimaryKey() !== null ? $this->getPrimaryKeyColumns() : [];
         $foreignKeyColumns = $this->getForeignKeyColumns();
         $remainderColumns  = $this->filterColumns(
             array_merge(array_keys($primaryKeyColumns), array_keys($foreignKeyColumns)),
@@ -696,10 +696,19 @@ class Table extends AbstractAsset
     /**
      * Returns the foreign key columns
      *
+     * @deprecated Use {@see getForeignKey()} and {@see ForeignKeyConstraint::getLocalColumns()} instead.
+     *
      * @return Column[]
      */
     public function getForeignKeyColumns()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5731',
+            '%s is deprecated. Use getForeignKey() and ForeignKeyConstraint::getLocalColumns() instead.',
+            __METHOD__,
+        );
+
         $foreignKeyColumns = [];
 
         foreach ($this->getForeignKeys() as $foreignKey) {
@@ -774,12 +783,21 @@ class Table extends AbstractAsset
     /**
      * Returns the primary key columns.
      *
+     * @deprecated Use {@see getPrimaryKey()} and {@see Index::getColumns()} instead.
+     *
      * @return Column[]
      *
      * @throws Exception
      */
     public function getPrimaryKeyColumns()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5731',
+            '%s is deprecated. Use getPrimaryKey() and Index::getColumns() instead.',
+            __METHOD__,
+        );
+
         $primaryKey = $this->getPrimaryKey();
 
         if ($primaryKey === null) {
@@ -792,10 +810,19 @@ class Table extends AbstractAsset
     /**
      * Returns whether this table has a primary key.
      *
+     * @deprecated Use {@see getPrimaryKey()} instead.
+     *
      * @return bool
      */
     public function hasPrimaryKey()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5731',
+            '%s is deprecated. Use getPrimaryKey() instead.',
+            __METHOD__,
+        );
+
         return $this->_primaryKeyName !== null && $this->hasIndex($this->_primaryKeyName);
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

1. `Table::getForeignKeyColumns()` was removed from 4.0.x around 36522aa4562293c9df54497444992f0a89f1d0f5 without having been deprecated first.
2. The logic of `Table::getPrimaryKeyColumns()` is non-obvious and not documented. If the primary key declares a column but it doesn't exist in the table, the column will be silently skipped. This may lead to a situation where a table has the primary key with no columns, which is not valid.

   This behavior is relied upon by `AbstractMySQLPlatform::getPreAlterTableAlterIndexForeignKeySQL()` and may make sense but then it should be implemented there.
   
   Additionally, using this method requires checking whether the primary key exists first which makes it not as convenient as it may look.
3. The implementation of `Table::hasPrimaryKey()` is almost identical to`Table::getPrimaryKey()`. Normally, the consumer of the `Table` API will need not only to know whether the primary key exists but get its columns, so they will end up calling `Table::getPrimaryKey()` anyways.

   From the static analysis point of view, a call to `getPrimaryKey()` will return a nullable value even if a prior call to `hasPrimaryKey()` returned true. Making them work together would require additional annotations. See https://github.com/doctrine/dbal/pull/3932 and https://github.com/doctrine/dbal/pull/4348 for example.