### PR TITLE
Remove Table methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: Removed `Table` methods
+
+The following `Table` methods have been removed:
+
+- `getForeignKeyColumns()`,
+- `getPrimaryKeyColumns()`,
+- `hasPrimaryKey()`.
+
 ## BC BREAK: removed `SchemaException` error code constants
 
 The following `SchemaException` class constants have been removed:

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -42,23 +42,11 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
-                <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getName"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::getForeignKeyColumns"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::getPrimaryKeyColumns"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::hasPrimaryKey"/>
             </errorLevel>
         </DeprecatedMethod>
-        <DeprecatedProperty>
-            <errorLevel type="suppress">
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedProperty name="Doctrine\DBAL\Schema\TableDiff::$name"/>
-            </errorLevel>
-        </DeprecatedProperty>
         <DocblockTypeContradiction>
             <errorLevel type="suppress">
                 <!--

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -39,12 +39,6 @@
                     See https://github.com/doctrine/dbal/pull/4317
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\Table::getForeignKeyColumns"/>
-                <referencedMethod name="Doctrine\DBAL\Schema\Table::getPrimaryKeyColumns"/>
-                <referencedMethod name="Doctrine\DBAL\Schema\Table::hasPrimaryKey"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -14,18 +14,13 @@ use Doctrine\DBAL\Schema\Exception\IndexNameInvalid;
 use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
-use function array_filter;
 use function array_merge;
 use function array_values;
 use function in_array;
 use function is_string;
 use function preg_match;
-use function sprintf;
 use function strtolower;
-
-use const ARRAY_FILTER_USE_KEY;
 
 /**
  * Object Representation of a table.
@@ -461,20 +456,6 @@ class Table extends AbstractAsset
     }
 
     /**
-     * Returns only columns that have specified names
-     *
-     * @param string[] $columnNames
-     *
-     * @return Column[]
-     */
-    private function filterColumns(array $columnNames, bool $reverse = false): array
-    {
-        return array_filter($this->_columns, static function (string $columnName) use ($columnNames, $reverse): bool {
-            return in_array($columnName, $columnNames, true) !== $reverse;
-        }, ARRAY_FILTER_USE_KEY);
-    }
-
-    /**
      * Returns whether this table has a Column with the given name.
      */
     public function hasColumn(string $name): bool
@@ -510,50 +491,6 @@ class Table extends AbstractAsset
         }
 
         return null;
-    }
-
-    /**
-     * Returns the primary key columns.
-     *
-     * @deprecated Use {@see getPrimaryKey()} and {@see Index::getColumns()} instead.
-     *
-     * @return array<string, Column>
-     *
-     * @throws SchemaException
-     */
-    public function getPrimaryKeyColumns(): array
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5731',
-            '%s is deprecated. Use getPrimaryKey() and Index::getColumns() instead.',
-            __METHOD__,
-        );
-
-        $primaryKey = $this->getPrimaryKey();
-
-        if ($primaryKey === null) {
-            throw new SchemaException(sprintf('Table "%s" has no primary key.', $this->getName()));
-        }
-
-        return $this->filterColumns($primaryKey->getColumns());
-    }
-
-    /**
-     * Returns whether this table has a primary key.
-     *
-     * @deprecated Use {@see getPrimaryKey()} instead.
-     */
-    public function hasPrimaryKey(): bool
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5731',
-            '%s is deprecated. Use getPrimaryKey() instead.',
-            __METHOD__,
-        );
-
-        return $this->_primaryKeyName !== null && $this->hasIndex($this->_primaryKeyName);
     }
 
     /**

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -56,9 +56,10 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
 
         self::assertTrue($validationTable->hasColumn('new_id'));
         self::assertTrue($validationTable->getColumn('new_id')->getAutoincrement());
-        self::assertTrue($validationTable->hasPrimaryKey());
-        self::assertCount(1, $validationTable->getPrimaryKeyColumns());
-        self::assertArrayHasKey('new_id', $validationTable->getPrimaryKeyColumns());
+
+        $primaryKey = $validationTable->getPrimaryKey();
+        self::assertNotNull($primaryKey);
+        self::assertSame(['new_id'], $primaryKey->getColumns());
     }
 
     private function getPlatform(): AbstractPlatform

--- a/tests/Functional/Platform/PlatformRestrictionsTest.php
+++ b/tests/Functional/Platform/PlatformRestrictionsTest.php
@@ -31,6 +31,6 @@ class PlatformRestrictionsTest extends FunctionalTestCase
         $createdTable = $this->connection->createSchemaManager()->introspectTable($tableName);
 
         self::assertTrue($createdTable->hasColumn($columnName));
-        self::assertTrue($createdTable->hasPrimaryKey());
+        self::assertNotNull($createdTable->getPrimaryKey());
     }
 }

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -45,12 +45,11 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $table      = $this->schemaManager->introspectTable('switch_primary_key_columns');
-        $primaryKey = $table->getPrimaryKeyColumns();
+        $table = $this->schemaManager->introspectTable('switch_primary_key_columns');
 
-        self::assertCount(2, $primaryKey);
-        self::assertArrayHasKey('bar_id', $primaryKey);
-        self::assertArrayHasKey('foo_id', $primaryKey);
+        $primaryKey = $table->getPrimaryKey();
+        self::assertNotNull($primaryKey);
+        self::assertSame(['bar_id', 'foo_id'], $primaryKey->getColumns());
     }
 
     public function testFulltextIndex(): void
@@ -127,7 +126,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table = $this->schemaManager->introspectTable('alter_table_add_pk');
 
         self::assertFalse($table->hasIndex('idx_id'));
-        self::assertTrue($table->hasPrimaryKey());
+        self::assertNotNull($table->getPrimaryKey());
     }
 
     public function testDropPrimaryKeyWithAutoincrementColumn(): void
@@ -151,7 +150,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $table = $this->schemaManager->introspectTable('drop_primary_key');
 
-        self::assertFalse($table->hasPrimaryKey());
+        self::assertNull($table->getPrimaryKey());
         self::assertFalse($table->getColumn('id')->getAutoincrement());
     }
 

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -119,7 +119,6 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         self::assertTrue($onlinePrimaryTable->hasColumn('"Id"'));
         self::assertSame('"Id"', $onlinePrimaryTable->getColumn('"Id"')->getQuotedName($platform));
-        self::assertTrue($onlinePrimaryTable->hasPrimaryKey());
 
         $onlinePrimaryTablePrimaryKey = $onlinePrimaryTable->getPrimaryKey();
         self::assertNotNull($onlinePrimaryTablePrimaryKey);
@@ -156,7 +155,6 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         // Foreign table assertions
         self::assertTrue($onlineForeignTable->hasColumn('id'));
         self::assertSame('ID', $onlineForeignTable->getColumn('id')->getQuotedName($platform));
-        self::assertTrue($onlineForeignTable->hasPrimaryKey());
 
         $onlineForeignTablePrimaryKey = $onlineForeignTable->getPrimaryKey();
         self::assertNotNull($onlineForeignTablePrimaryKey);

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -469,7 +469,7 @@ class TableTest extends TestCase
         // Table should only contain both the primary key table index and the unique one, even though it was overruled
         self::assertCount(2, $indexes);
 
-        self::assertTrue($table->hasPrimaryKey());
+        self::assertNotNull($table->getPrimaryKey());
         self::assertTrue($table->hasIndex('idx_unique'));
     }
 
@@ -561,12 +561,12 @@ class TableTest extends TestCase
     {
         $table = new Table('test');
 
-        self::assertFalse($table->hasPrimaryKey());
+        self::assertNull($table->getPrimaryKey());
 
         $table->addColumn('foo', 'integer');
         $table->setPrimaryKey(['foo']);
 
-        self::assertTrue($table->hasPrimaryKey());
+        self::assertNotNull($table->getPrimaryKey());
     }
 
     public function testAddIndexWithQuotedColumns(): void
@@ -614,10 +614,10 @@ class TableTest extends TestCase
         $table->addColumn('id', 'integer');
         $table->setPrimaryKey(['id']);
 
-        self::assertTrue($table->hasPrimaryKey());
+        self::assertNotNull($table->getPrimaryKey());
 
         $table->dropPrimaryKey();
-        self::assertFalse($table->hasPrimaryKey());
+        self::assertNull($table->getPrimaryKey());
     }
 
     public function testRenameIndex(): void
@@ -636,7 +636,7 @@ class TableTest extends TestCase
         self::assertSame($table, $table->renameIndex('idx', 'idx_new'));
         self::assertSame($table, $table->renameIndex('uniq', 'uniq_new'));
 
-        self::assertTrue($table->hasPrimaryKey());
+        self::assertNotNull($table->getPrimaryKey());
         self::assertTrue($table->hasIndex('pk_new'));
         self::assertTrue($table->hasIndex('idx_new'));
         self::assertTrue($table->hasIndex('uniq_new'));
@@ -658,7 +658,7 @@ class TableTest extends TestCase
         self::assertSame($table, $table->renameIndex('idx_new', null));
         self::assertSame($table, $table->renameIndex('uniq_new', null));
 
-        self::assertTrue($table->hasPrimaryKey());
+        self::assertNotNull($table->getPrimaryKey());
         self::assertTrue($table->hasIndex('primary'));
         self::assertTrue($table->hasIndex('IDX_D87F7E0C8C736521'));
         self::assertTrue($table->hasIndex('UNIQ_D87F7E0C76FF8CAA78240498'));
@@ -683,7 +683,7 @@ class TableTest extends TestCase
         self::assertSame($table, $table->renameIndex('IDX_D87F7E0C8C736521', 'idx_D87F7E0C8C736521'));
         self::assertSame($table, $table->renameIndex('UNIQ_D87F7E0C76FF8CAA78240498', 'uniq_D87F7E0C76FF8CAA78240498'));
 
-        self::assertTrue($table->hasPrimaryKey());
+        self::assertNotNull($table->getPrimaryKey());
         self::assertTrue($table->hasIndex('primary'));
         self::assertTrue($table->hasIndex('IDX_D87F7E0C8C736521'));
         self::assertTrue($table->hasIndex('UNIQ_D87F7E0C76FF8CAA78240498'));


### PR DESCRIPTION
The methods being removed were deprecated in https://github.com/doctrine/dbal/pull/5731.