### PR TITLE
New driver: SQLite3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,13 +44,21 @@ jobs:
           - "8.2"
         dependencies:
           - "highest"
+        extension:
+          - "pdo_sqlite"
         include:
           - os: "ubuntu-20.04"
             php-version: "7.4"
             dependencies: "lowest"
+            extension: "pdo_sqlite"
+          - os: "ubuntu-22.04"
+            php-version: "7.4"
+            dependencies: "highest"
+            extension: "sqlite3"
           - os: "ubuntu-22.04"
             php-version: "8.1"
             dependencies: "highest"
+            extension: "sqlite3"
 
     steps:
       - name: "Checkout"
@@ -74,14 +82,20 @@ jobs:
       - name: "Print SQLite version"
         run: >
           php -r 'printf("Testing with libsqlite version %s\n", (new PDO("sqlite::memory:"))->query("select sqlite_version()")->fetch()[0]);'
+        if: "${{ matrix.extension == 'pdo_sqlite' }}"
+
+      - name: "Print SQLite version"
+        run: >
+          php -r 'printf("Testing with libsqlite version %s\n", SQLite3::version()["versionString"]);'
+        if: "${{ matrix.extension == 'sqlite3' }}"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/sqlite.xml --coverage-clover=coverage.xml"
+        run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}.xml --coverage-clover=coverage.xml"
 
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v3"
         with:
-          name: "phpunit-sqlite-${{ matrix.deps }}-${{ matrix.php-version }}.coverage"
+          name: "phpunit-${{ matrix.extension }}-${{ matrix.deps }}-${{ matrix.php-version }}.coverage"
           path: "coverage.xml"
 
   phpunit-oci8:
@@ -551,7 +565,7 @@ jobs:
           path: "coverage.xml"
 
   development-deps:
-    name: "PHPUnit with SQLite and development dependencies"
+    name: "PHPUnit with PDO_SQLite and development dependencies"
     runs-on: "ubuntu-22.04"
 
     strategy:
@@ -577,7 +591,7 @@ jobs:
           composer-options: "--prefer-dist"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/sqlite.xml"
+        run: "vendor/bin/phpunit -c ci/github/phpunit/pdo_sqlite.xml"
 
   upload_coverage:
     name: "Upload coverage to Codecov"

--- a/ci/github/phpunit/pdo_sqlite.xml
+++ b/ci/github/phpunit/pdo_sqlite.xml
@@ -10,6 +10,10 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+
+        <var name="db_driver" value="pdo_sqlite"/>
+        <var name="db_memory" value="true"/>
+        <var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\SQLiteSessionInit"/>
     </php>
 
     <testsuites>

--- a/ci/github/phpunit/sqlite3.xml
+++ b/ci/github/phpunit/sqlite3.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         convertDeprecationsToExceptions="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+
+        <var name="db_driver" value="sqlite3"/>
+        <var name="db_memory" value="true"/>
+        <var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\SQLiteSessionInit"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Doctrine DBAL Test Suite">
+            <directory>../../../tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory suffix=".php">../../../src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -113,6 +113,7 @@ interfaces to use. It can be configured in one of three ways:
    -  ``mysqli``: A MySQL driver that uses the mysqli extension.
    -  ``pdo_sqlite``: An SQLite driver that uses the pdo_sqlite PDO
       extension.
+   -  ``sqlite3``: An SQLite driver that uses the sqlite3 extension.
    -  ``pdo_pgsql``: A PostgreSQL driver that uses the pdo_pgsql PDO
       extension.
    -  ``pdo_oci``: An Oracle driver that uses the pdo_oci PDO
@@ -154,6 +155,14 @@ pdo_sqlite
 -  ``memory`` (boolean): True if the SQLite database should be
    in-memory (non-persistent). Mutually exclusive with ``path``.
    ``path`` takes precedence.
+
+sqlite3
+^^^^^^^
+
+-  ``path`` (string): The filesystem path to the database file.
+   Mutually exclusive with ``memory``.
+-  ``memory`` (boolean): True if the SQLite database should be
+   in-memory (non-persistent). Mutually exclusive with ``path``.
 
 pdo_mysql
 ^^^^^^^^^

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -56,6 +56,12 @@
         <exclude-pattern>*/src/*</exclude-pattern>
     </rule>
 
+    <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly">
+        <!-- ext-sqlite3 throws generic exceptions. -->
+        <!-- Catching \Exception is legit here, and we don't want to widen types to \Throwable. -->
+        <exclude-pattern>src/Driver/SQLite3/*</exclude-pattern>
+    </rule>
+
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>

--- a/src/Driver/API/SQLite/UserDefinedFunctions.php
+++ b/src/Driver/API/SQLite/UserDefinedFunctions.php
@@ -2,6 +2,9 @@
 
 namespace Doctrine\DBAL\Driver\API\SQLite;
 
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+
+use function array_merge;
 use function strpos;
 
 /**
@@ -11,6 +14,25 @@ use function strpos;
  */
 final class UserDefinedFunctions
 {
+    private const DEFAULT_FUNCTIONS = [
+        'sqrt' => ['callback' => [SqlitePlatform::class, 'udfSqrt'], 'numArgs' => 1],
+        'mod'  => ['callback' => [SqlitePlatform::class, 'udfMod'], 'numArgs' => 2],
+        'locate'  => ['callback' => [SqlitePlatform::class, 'udfLocate'], 'numArgs' => -1],
+    ];
+
+    /**
+     * @param callable(string, callable, int): bool                  $callback
+     * @param array<string, array{callback: callable, numArgs: int}> $additionalFunctions
+     */
+    public static function register(callable $callback, array $additionalFunctions = []): void
+    {
+        $userDefinedFunctions = array_merge(self::DEFAULT_FUNCTIONS, $additionalFunctions);
+
+        foreach ($userDefinedFunctions as $function => $data) {
+            $callback($function, $data['callback'], $data['numArgs']);
+        }
+    }
+
     /**
      * User-defined function that implements MOD().
      *

--- a/src/Driver/PDO/SQLite/Driver.php
+++ b/src/Driver/PDO/SQLite/Driver.php
@@ -3,24 +3,15 @@
 namespace Doctrine\DBAL\Driver\PDO\SQLite;
 
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
+use Doctrine\DBAL\Driver\API\SQLite\UserDefinedFunctions;
 use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDO\Exception;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
 
-use function array_merge;
-
 final class Driver extends AbstractSQLiteDriver
 {
-    /** @var mixed[] */
-    private array $userDefinedFunctions = [
-        'sqrt' => ['callback' => [SqlitePlatform::class, 'udfSqrt'], 'numArgs' => 1],
-        'mod'  => ['callback' => [SqlitePlatform::class, 'udfMod'], 'numArgs' => 2],
-        'locate'  => ['callback' => [SqlitePlatform::class, 'udfLocate'], 'numArgs' => -1],
-    ];
-
     /**
      * {@inheritdoc}
      *
@@ -28,7 +19,8 @@ final class Driver extends AbstractSQLiteDriver
      */
     public function connect(array $params)
     {
-        $driverOptions = $params['driverOptions'] ?? [];
+        $driverOptions        = $params['driverOptions'] ?? [];
+        $userDefinedFunctions = [];
 
         if (isset($driverOptions['userDefinedFunctions'])) {
             Deprecation::trigger(
@@ -38,10 +30,7 @@ final class Driver extends AbstractSQLiteDriver
                     . ' Register function directly on the native connection instead.',
             );
 
-            $this->userDefinedFunctions = array_merge(
-                $this->userDefinedFunctions,
-                $driverOptions['userDefinedFunctions'],
-            );
+            $userDefinedFunctions = $driverOptions['userDefinedFunctions'];
             unset($driverOptions['userDefinedFunctions']);
         }
 
@@ -56,9 +45,10 @@ final class Driver extends AbstractSQLiteDriver
             throw Exception::new($exception);
         }
 
-        foreach ($this->userDefinedFunctions as $fn => $data) {
-            $pdo->sqliteCreateFunction($fn, $data['callback'], $data['numArgs']);
-        }
+        UserDefinedFunctions::register(
+            [$pdo, 'sqliteCreateFunction'],
+            $userDefinedFunctions,
+        );
 
         return new Connection($pdo);
     }

--- a/src/Driver/SQLite3/Connection.php
+++ b/src/Driver/SQLite3/Connection.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\SQLite3;
+
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\ParameterType;
+use SQLite3;
+
+use function assert;
+use function sprintf;
+
+final class Connection implements ServerInfoAwareConnection
+{
+    private SQLite3 $connection;
+
+    /** @internal The connection can be only instantiated by its driver. */
+    public function __construct(SQLite3 $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function prepare(string $sql): Statement
+    {
+        try {
+            $statement = $this->connection->prepare($sql);
+        } catch (\Exception $e) {
+            throw Exception::new($e);
+        }
+
+        assert($statement !== false);
+
+        return new Statement($this->connection, $statement);
+    }
+
+    public function query(string $sql): Result
+    {
+        try {
+            $result = $this->connection->query($sql);
+        } catch (\Exception $e) {
+            throw Exception::new($e);
+        }
+
+        assert($result !== false);
+
+        return new Result($result, $this->connection->changes());
+    }
+
+    /** @inheritdoc */
+    public function quote($value, $type = ParameterType::STRING): string
+    {
+        return sprintf('\'%s\'', SQLite3::escapeString($value));
+    }
+
+    public function exec(string $sql): int
+    {
+        try {
+            $this->connection->exec($sql);
+        } catch (\Exception $e) {
+            throw Exception::new($e);
+        }
+
+        return $this->connection->changes();
+    }
+
+    /** @inheritdoc */
+    public function lastInsertId($name = null): int
+    {
+        return $this->connection->lastInsertRowID();
+    }
+
+    public function beginTransaction(): bool
+    {
+        try {
+            return $this->connection->exec('BEGIN');
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    public function commit(): bool
+    {
+        try {
+            return $this->connection->exec('COMMIT');
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    public function rollBack(): bool
+    {
+        try {
+            return $this->connection->exec('ROLLBACK');
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    public function getNativeConnection(): SQLite3
+    {
+        return $this->connection;
+    }
+
+    public function getServerVersion(): string
+    {
+        return SQLite3::version()['versionString'];
+    }
+}

--- a/src/Driver/SQLite3/Driver.php
+++ b/src/Driver/SQLite3/Driver.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\SQLite3;
+
+use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
+use Doctrine\DBAL\Driver\API\SQLite\UserDefinedFunctions;
+use SQLite3;
+
+final class Driver extends AbstractSQLiteDriver
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function connect(array $params): Connection
+    {
+        $isMemory = (bool) ($params['memory'] ?? false);
+
+        if (isset($params['path'])) {
+            if ($isMemory) {
+                throw new Exception(
+                    'Invalid connection settings: specifying both parameters "path" and "memory" ambiguous.',
+                );
+            }
+
+            $filename = $params['path'];
+        } elseif ($isMemory) {
+            $filename = ':memory:';
+        } else {
+            throw new Exception(
+                'Invalid connection settings: specify either the "path" or the "memory" parameter for SQLite3.',
+            );
+        }
+
+        try {
+            $connection = new SQLite3($filename);
+        } catch (\Exception $e) {
+            throw Exception::new($e);
+        }
+
+        $connection->enableExceptions(true);
+
+        UserDefinedFunctions::register([$connection, 'createFunction']);
+
+        return new Connection($connection);
+    }
+}

--- a/src/Driver/SQLite3/Exception.php
+++ b/src/Driver/SQLite3/Exception.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\SQLite3;
+
+use Doctrine\DBAL\Driver\AbstractException;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class Exception extends AbstractException
+{
+    public static function new(\Exception $exception): self
+    {
+        return new self($exception->getMessage(), null, (int) $exception->getCode(), $exception);
+    }
+}

--- a/src/Driver/SQLite3/Result.php
+++ b/src/Driver/SQLite3/Result.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\SQLite3;
+
+use Doctrine\DBAL\Driver\FetchUtils;
+use Doctrine\DBAL\Driver\Result as ResultInterface;
+use SQLite3Result;
+
+use const SQLITE3_ASSOC;
+use const SQLITE3_NUM;
+
+final class Result implements ResultInterface
+{
+    private ?SQLite3Result $result;
+    private int $changes;
+
+    /** @internal The result can be only instantiated by its driver connection or statement. */
+    public function __construct(SQLite3Result $result, int $changes)
+    {
+        $this->result  = $result;
+        $this->changes = $changes;
+    }
+
+    /** @inheritdoc */
+    public function fetchNumeric()
+    {
+        if ($this->result === null) {
+            return false;
+        }
+
+        return $this->result->fetchArray(SQLITE3_NUM);
+    }
+
+    /** @inheritdoc */
+    public function fetchAssociative()
+    {
+        if ($this->result === null) {
+            return false;
+        }
+
+        return $this->result->fetchArray(SQLITE3_ASSOC);
+    }
+
+    /** @inheritdoc */
+    public function fetchOne()
+    {
+        return FetchUtils::fetchOne($this);
+    }
+
+    /** @inheritdoc */
+    public function fetchAllNumeric(): array
+    {
+        return FetchUtils::fetchAllNumeric($this);
+    }
+
+    /** @inheritdoc */
+    public function fetchAllAssociative(): array
+    {
+        return FetchUtils::fetchAllAssociative($this);
+    }
+
+    /** @inheritdoc */
+    public function fetchFirstColumn(): array
+    {
+        return FetchUtils::fetchFirstColumn($this);
+    }
+
+    public function rowCount(): int
+    {
+        return $this->changes;
+    }
+
+    public function columnCount(): int
+    {
+        if ($this->result === null) {
+            return 0;
+        }
+
+        return $this->result->numColumns();
+    }
+
+    public function free(): void
+    {
+        if ($this->result === null) {
+            return;
+        }
+
+        $this->result->finalize();
+        $this->result = null;
+    }
+}

--- a/src/Driver/SQLite3/Statement.php
+++ b/src/Driver/SQLite3/Statement.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\SQLite3;
+
+use Doctrine\DBAL\Driver\Exception\UnknownParameterType;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
+use SQLite3;
+use SQLite3Stmt;
+
+use function assert;
+use function func_num_args;
+use function is_int;
+
+use const SQLITE3_BLOB;
+use const SQLITE3_INTEGER;
+use const SQLITE3_NULL;
+use const SQLITE3_TEXT;
+
+final class Statement implements StatementInterface
+{
+    private const PARAM_TYPE_MAP = [
+        ParameterType::NULL => SQLITE3_NULL,
+        ParameterType::INTEGER => SQLITE3_INTEGER,
+        ParameterType::STRING => SQLITE3_TEXT,
+        ParameterType::ASCII => SQLITE3_TEXT,
+        ParameterType::BINARY => SQLITE3_BLOB,
+        ParameterType::LARGE_OBJECT => SQLITE3_BLOB,
+        ParameterType::BOOLEAN => SQLITE3_INTEGER,
+    ];
+
+    private SQLite3 $connection;
+    private SQLite3Stmt $statement;
+
+    /** @internal The statement can be only instantiated by its driver connection. */
+    public function __construct(SQLite3 $connection, SQLite3Stmt $statement)
+    {
+        $this->connection = $connection;
+        $this->statement  = $statement;
+    }
+
+    /** @inheritdoc */
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
+    {
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindValue() is deprecated.'
+                . ' Pass the type corresponding to the parameter being bound.',
+            );
+        }
+
+        return $this->statement->bindValue($param, $value, $this->convertParamType($type));
+    }
+
+    /** @inheritdoc */
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
+    {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5563',
+            '%s is deprecated. Use bindValue() instead.',
+            __METHOD__,
+        );
+
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindParam() is deprecated.'
+                . ' Pass the type corresponding to the parameter being bound.',
+            );
+        }
+
+        return $this->statement->bindParam($param, $variable, $this->convertParamType($type));
+    }
+
+    /** @inheritdoc */
+    public function execute($params = null): Result
+    {
+        if ($params !== null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5556',
+                'Passing $params to Statement::execute() is deprecated. Bind parameters using'
+                . ' Statement::bindParam() or Statement::bindValue() instead.',
+            );
+
+            foreach ($params as $param => $value) {
+                if (is_int($param)) {
+                    $this->bindValue($param + 1, $value, ParameterType::STRING);
+                } else {
+                    $this->bindValue($param, $value, ParameterType::STRING);
+                }
+            }
+        }
+
+        try {
+            $result = $this->statement->execute();
+        } catch (\Exception $e) {
+            throw Exception::new($e);
+        }
+
+        assert($result !== false);
+
+        return new Result($result, $this->connection->changes());
+    }
+
+    private function convertParamType(int $type): int
+    {
+        if (! isset(self::PARAM_TYPE_MAP[$type])) {
+            throw UnknownParameterType::new($type);
+        }
+
+        return self::PARAM_TYPE_MAP[$type];
+    }
+}

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\Mysqli;
 use Doctrine\DBAL\Driver\OCI8;
 use Doctrine\DBAL\Driver\PDO;
+use Doctrine\DBAL\Driver\SQLite3;
 use Doctrine\DBAL\Driver\SQLSrv;
 use Doctrine\Deprecations\Deprecation;
 
@@ -88,6 +89,7 @@ final class DriverManager
         'pdo_sqlsrv'         => PDO\SQLSrv\Driver::class,
         'mysqli'             => Mysqli\Driver::class,
         'sqlsrv'             => SQLSrv\Driver::class,
+        'sqlite3'            => SQLite3\Driver::class,
     ];
 
     /**

--- a/src/Types/DecimalType.php
+++ b/src/Types/DecimalType.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 
 use function is_float;
 use function is_int;
@@ -37,7 +38,7 @@ class DecimalType extends Type
     {
         // Some drivers starting from PHP 8.1 can represent decimals as float/int
         // See also: https://github.com/doctrine/dbal/pull/4818
-        if (PHP_VERSION_ID >= 80100 && (is_float($value) || is_int($value))) {
+        if ((PHP_VERSION_ID >= 80100 || $platform instanceof SqlitePlatform) && (is_float($value) || is_int($value))) {
             return (string) $value;
         }
 

--- a/tests/Functional/Driver/SQLite3/DriverTest.php
+++ b/tests/Functional/Driver/SQLite3/DriverTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Driver\SQLite3;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\SQLite3\Driver;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Tests\Functional\Driver\AbstractDriverTest;
+use Doctrine\DBAL\Tests\TestUtil;
+
+/** @requires extension sqlite3 */
+class DriverTest extends AbstractDriverTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (TestUtil::isDriverOneOf('sqlite3')) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires the sqlite3 driver.');
+    }
+
+    protected static function getDatabaseNameForConnectionWithoutDatabaseNameParameter(): ?string
+    {
+        return 'main';
+    }
+
+    protected function createDriver(): DriverInterface
+    {
+        return new Driver();
+    }
+
+    public function testMissingMandatoryParams(): void
+    {
+        $params = $this->connection->getParams();
+        unset($params['path'], $params['memory']);
+
+        $this->expectException(DriverException::class);
+        $this->expectExceptionMessage(
+            'An exception occurred in the driver: '
+                . 'Invalid connection settings: specify either the "path" or the "memory" parameter for SQLite3.',
+        );
+
+        $connection = new Connection(
+            $params,
+            $this->connection->getDriver(),
+            $this->connection->getConfiguration(),
+            $this->connection->getEventManager(),
+        );
+
+        $connection->fetchOne('SELECT 1');
+    }
+
+    public function testAmbiguousParams(): void
+    {
+        $params           = $this->connection->getParams();
+        $params['path']   = __DIR__ . '/dont-create-me.db';
+        $params['memory'] = true;
+
+        $this->expectException(DriverException::class);
+        $this->expectExceptionMessage(
+            'An exception occurred in the driver: '
+                . 'Invalid connection settings: specifying both parameters "path" and "memory" ambiguous.',
+        );
+
+        $connection = new Connection(
+            $params,
+            $this->connection->getDriver(),
+            $this->connection->getConfiguration(),
+            $this->connection->getEventManager(),
+        );
+
+        $connection->fetchOne('SELECT 1');
+    }
+}

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -247,6 +247,10 @@ EOF
             self::markTestSkipped('The driver does not support named statement parameters');
         }
 
+        if (TestUtil::isDriverOneOf('sqlite3')) {
+            self::markTestSkipped('SQLite3 does not report this error');
+        }
+
         if (PHP_VERSION_ID < 80000 && TestUtil::isDriverOneOf('pdo_oci')) {
             self::markTestSkipped('pdo_oci on PHP 7 does not report this error');
         }

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -200,6 +200,7 @@ class TestUtil
                 'password',
                 'host',
                 'dbname',
+                'memory',
                 'port',
                 'server',
                 'ssl_key',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | N/A

#### Summary

Replaces #840, #2264.

This PR adds a driver for `ext-sqlite3`, allowing us to use SQLite without PDO.

It is a bit unfortunate that we've mapped the URL scheme `sqlite3://` to the PDO_SQLite driver via an alias. ~~This is why I've introduced a new scheme `ext-sqlite3://`. On DBAL 4 where we've removed the aliases, we can change this back to `sqlite3://`. But I'm open for a better solution.~~ As discussed, the `sqlite3://` URL scheme will work in DBAL 4, in DBAL 3 the `driverClass` parameter has to be used for now.
