### PR TITLE
Enable testReturnsDatabaseNameWithoutDatabaseNameParameter for SQLite

### DIFF
--- a/tests/Functional/Driver/PDO/SQLite/DriverTest.php
+++ b/tests/Functional/Driver/PDO/SQLite/DriverTest.php
@@ -21,9 +21,9 @@ class DriverTest extends AbstractDriverTest
         self::markTestSkipped('This test requires the pdo_sqlite driver.');
     }
 
-    public function testReturnsDatabaseNameWithoutDatabaseNameParameter(): void
+    protected static function getDatabaseNameForConnectionWithoutDatabaseNameParameter(): ?string
     {
-        self::markTestSkipped('SQLite does not support the concept of a database.');
+        return 'main';
     }
 
     protected function createDriver(): DriverInterface


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

Backport from #5737. Our SQLite driver does understand "the concept of a database" now, so we don't need to skip that test anymore.
