### PR TITLE
Exclude "Database role" type schema names from listing schemas

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1162,8 +1162,8 @@ class SQLServerPlatform extends AbstractPlatform
             'SQLServerPlatform::getListNamespacesSQL() is deprecated,'
                 . ' use SQLServerSchemaManager::listSchemaNames() instead.',
         );
-
-        return "SELECT name FROM sys.schemas WHERE name NOT IN('guest', 'INFORMATION_SCHEMA', 'sys') AND name NOT IN(SELECT name FROM sys.database_principals WHERE type='R')";
+        // Exclude internal (<5) and backward compatibility existed schemas (>16383)
+        return "SELECT name FROM sys.schemas WHERE schema_id BETWEEN 5 AND 16383";
     }
 
     /**

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1163,7 +1163,7 @@ class SQLServerPlatform extends AbstractPlatform
                 . ' use SQLServerSchemaManager::listSchemaNames() instead.',
         );
 
-        return "SELECT name FROM sys.schemas WHERE name NOT IN('guest', 'INFORMATION_SCHEMA', 'sys')";
+        return "SELECT name FROM sys.schemas WHERE name NOT IN('guest', 'INFORMATION_SCHEMA', 'sys') AND name NOT IN(SELECT name FROM sys.database_principals WHERE type='R')";
     }
 
     /**

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -85,12 +85,12 @@ class SQLServerSchemaManager extends AbstractSchemaManager
      */
     public function listSchemaNames(): array
     {
+        // Exclude internal (<5) and backward compatibility existed schemas (>16383)
         return $this->_conn->fetchFirstColumn(
             <<<'SQL'
 SELECT name
 FROM   sys.schemas
-WHERE  name NOT IN('guest', 'INFORMATION_SCHEMA', 'sys')
-AND    name NOT IN(SELECT name FROM sys.database_principals WHERE type='R')
+WHERE  schema_id BETWEEN 5 AND 16383
 SQL,
         );
     }

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -90,6 +90,7 @@ class SQLServerSchemaManager extends AbstractSchemaManager
 SELECT name
 FROM   sys.schemas
 WHERE  name NOT IN('guest', 'INFORMATION_SCHEMA', 'sys')
+AND    name NOT IN(SELECT name FROM sys.database_principals WHERE type='R')
 SQL,
         );
     }

--- a/tests/Platforms/SQLServerPlatformTestCase.php
+++ b/tests/Platforms/SQLServerPlatformTestCase.php
@@ -1847,4 +1847,9 @@ class SQLServerPlatformTestCase extends AbstractPlatformTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->platform->getDropIndexSQL('foo');
     }
+
+    public function testListNamespacesSQL(): void
+    {
+        self::assertEquals('SELECT name FROM sys.schemas WHERE schema_id BETWEEN 5 AND 16383', $this->platform->getListNamespacesSQL());
+    }
 }


### PR DESCRIPTION
Exclude "Database role" type schema names to prevent unnecessary generate migration-down entries for database-role schemas like: db_accessadmin, db_backupoperator, db_datareader, db_datawriter, db_ddladmin, db_denydatareader, db_denydatawriter, db_owner, db_securityadmin

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #5734

#### Summary

"Database role" type schema names ([type='R'](https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-database-principals-transact-sql?view=sql-server-ver16)) should be excluded from query to prevent unnecessary generate migration-down entries for database-role schemas.
