### PR TITLE
Remove deprecated API to register custom SQLite functions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,21 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC Break: Removed the `userDefinedFunctions` driver option for `pdo_sqlite`
+
+To register a custom function, use `getNativeConnection()` to access the
+wrapped PDO connection and register your custom function directly.
+
+```php
+$connection = DriverManager::getConnection([
+    'driver' => 'pdo_sqlite',
+    'path' => '/path/to/file.db',
+]);
+
+$connection->getNativeConnection()
+    ->sqliteCreateFunction('my_function', MyClass::myMethod(...), 2);
+```
+
 ## BC BREAK: Removed `Table` methods
 
 The following `Table` methods have been removed:

--- a/src/Driver/API/SQLite/UserDefinedFunctions.php
+++ b/src/Driver/API/SQLite/UserDefinedFunctions.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\API\SQLite;
 
-use function array_merge;
+use function sqrt;
 use function strpos;
 
 /**
@@ -14,29 +14,18 @@ use function strpos;
  */
 final class UserDefinedFunctions
 {
-    private const DEFAULT_FUNCTIONS = [
-        'sqrt' => ['callback' => 'sqrt', 'numArgs' => 1],
-        'mod'  => ['callback' => [self::class, 'mod'], 'numArgs' => 2],
-        'locate'  => ['callback' => [self::class, 'locate'], 'numArgs' => -1],
-    ];
-
-    /**
-     * @param callable(string, callable, int): bool                  $callback
-     * @param array<string, array{callback: callable, numArgs: int}> $additionalFunctions
-     */
-    public static function register(callable $callback, array $additionalFunctions = []): void
+    /** @param callable(string, callable, int): bool $callback */
+    public static function register(callable $callback): void
     {
-        $userDefinedFunctions = array_merge(self::DEFAULT_FUNCTIONS, $additionalFunctions);
-
-        foreach ($userDefinedFunctions as $function => $data) {
-            $callback($function, $data['callback'], $data['numArgs']);
-        }
+        $callback('sqrt', sqrt(...), 1);
+        $callback('mod', self::mod(...), 2);
+        $callback('locate', self::locate(...), -1);
     }
 
     /**
      * User-defined function that implements MOD().
      */
-    public static function mod(int $a, int $b): int
+    private static function mod(int $a, int $b): int
     {
         return $a % $b;
     }
@@ -44,7 +33,7 @@ final class UserDefinedFunctions
     /**
      * User-defined function that implements LOCATE().
      */
-    public static function locate(string $str, string $substr, int $offset = 0): int
+    private static function locate(string $str, string $substr, int $offset = 0): int
     {
         // SQL's LOCATE function works on 1-based positions, while PHP's strpos works on 0-based positions.
         // So we have to make them compatible if an offset is given.
@@ -59,5 +48,9 @@ final class UserDefinedFunctions
         }
 
         return 0;
+    }
+
+    private function __construct()
+    {
     }
 }

--- a/src/Driver/SQLite3/Driver.php
+++ b/src/Driver/SQLite3/Driver.php
@@ -41,7 +41,7 @@ final class Driver extends AbstractSQLiteDriver
 
         $connection->enableExceptions(true);
 
-        UserDefinedFunctions::register([$connection, 'createFunction']);
+        UserDefinedFunctions::register($connection->createFunction(...));
 
         return new Connection($connection);
     }

--- a/tests/Functional/Driver/PDO/SQLite/DriverTest.php
+++ b/tests/Functional/Driver/PDO/SQLite/DriverTest.php
@@ -4,18 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Driver\PDO\SQLite;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\DBAL\Tests\Functional\Driver\AbstractDriverTest;
 use Doctrine\DBAL\Tests\TestUtil;
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 
 /** @requires extension pdo_sqlite */
 class DriverTest extends AbstractDriverTest
 {
-    use VerifyDeprecations;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -35,24 +31,5 @@ class DriverTest extends AbstractDriverTest
     protected function createDriver(): DriverInterface
     {
         return new Driver();
-    }
-
-    public function testRegisterCustomFunction(): void
-    {
-        $params                                          = $this->connection->getParams();
-        $params['driverOptions']['userDefinedFunctions'] = [
-            'my_add' => ['callback' => static fn (int $a, int $b): int => $a + $b, 'numArgs' => 2],
-        ];
-
-        $connection = new Connection(
-            $params,
-            $this->connection->getDriver(),
-            $this->connection->getConfiguration(),
-            $this->connection->getEventManager(),
-        );
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/5742');
-
-        self::assertSame(42, (int) $connection->fetchOne('SELECT my_add(20, 22)'));
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follow-up to #5742

#### Summary

This PR removes the ability to register user defined SQLite function via the configuration. This also allowed me to simplify our internal `UserDefinedFunctions` class a bit: I got rid of the undocumented array structure by calling the callback method directly. By switching to first-class callable syntax I could also close down `UserDefinedFunctions` by setting all methods to private.
