### PR TITLE
Deprecate Table::changeColumn()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,6 +45,7 @@ The `hasPrimaryKey()` method has been deprecated. Use `getPrimaryKey()` and chec
 The `getPrimaryKeyColumns()` method has been deprecated. Use `getPrimaryKey()` and `Index::getColumns()` instead.
 The `getForeignKeyColumns()` method has been deprecated. Use `getForeignKey()`
 and `ForeignKeyConstraint::getLocalColumns()` instead.
+The `changeColumn()` method has been deprecated. Use `modifyColumn()` instead.
 
 ## Deprecated `SchemaException` error codes.
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -438,6 +438,7 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
+                <referencedMethod name="Doctrine\DBAL\Schema\Table::changeColumn"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::getForeignKeyColumns"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::getPrimaryKeyColumns"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::hasPrimaryKey"/>

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -349,6 +349,8 @@ class Table extends AbstractAsset
     /**
      * Change Column Details.
      *
+     * @deprecated Use {@link modifyColumn()} instead.
+     *
      * @param string  $name
      * @param mixed[] $options
      *
@@ -357,6 +359,26 @@ class Table extends AbstractAsset
      * @throws SchemaException
      */
     public function changeColumn($name, array $options)
+    {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5747',
+            '%s is deprecated. Use modifyColumn() instead.',
+            __METHOD__,
+        );
+
+        return $this->modifyColumn($name, $options);
+    }
+
+    /**
+     * @param string  $name
+     * @param mixed[] $options
+     *
+     * @return self
+     *
+     * @throws SchemaException
+     */
+    public function modifyColumn($name, array $options)
     {
         $column = $this->getColumn($name);
         $column->setOptions($options);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The `Table::addColumn()` and `Table::dropColumn()` methods are named consistently with their corresponding SQL operations: `ALTER TABLE t ADD COLUMN` and `ALTER TABLE t DROP COLUMN`. Let's rename `Table::changeColumn()` to `Table::modifyColumn()` to make it consistent with `ALTER TABLE t MODIFY COLUMN`.