### PR TITLE
Deprecate `LOCATE()` emulation on SQLite

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ awareness about deprecated code.
 
 # Upgrade to 3.5
 
+## Deprecated the emulation of the `LOCATE()` function for SQLite
+
+Relying on the availability of the `LOCATE()` on SQLite deprecated. SQLite does not provide that function natively,
+but the function `INSTR()` can be a drop-in replacement in most situations. Use
+`AbstractPlatform::getLocateExpression()` if you need a portable solution.
+
 ## Deprecated the `userDefinedFunctions` driver option for `pdo_sqlite`
 
 Instead of funneling custom functions through the `userDefinedFunctions` option, use `getNativeConnection()`

--- a/src/Driver/API/SQLite/UserDefinedFunctions.php
+++ b/src/Driver/API/SQLite/UserDefinedFunctions.php
@@ -2,7 +2,9 @@
 
 namespace Doctrine\DBAL\Driver\API\SQLite;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function strpos;
@@ -53,6 +55,14 @@ final class UserDefinedFunctions
      */
     public static function locate($str, $substr, $offset = 0): int
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5749',
+            'Relying on DBAL\'s emulated LOCATE() function is deprecated. '
+                . 'Use INSTR() or %s::getLocateExpression() instead.',
+            AbstractPlatform::class,
+        );
+
         // SQL's LOCATE function works on 1-based positions, while PHP's strpos works on 0-based positions.
         // So we have to make them compatible if an offset is given.
         if ($offset > 0) {

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -123,11 +123,13 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function getLocateExpression($str, $substr, $startPos = false)
     {
-        if ($startPos === false) {
-            return 'LOCATE(' . $str . ', ' . $substr . ')';
+        if ($startPos === false || $startPos === 1 || $startPos === '1') {
+            return 'INSTR(' . $str . ', ' . $substr . ')';
         }
 
-        return 'LOCATE(' . $str . ', ' . $substr . ', ' . $startPos . ')';
+        return 'CASE WHEN INSTR(SUBSTR(' . $str . ', ' . $startPos . '), ' . $substr
+            . ') > 0 THEN INSTR(SUBSTR(' . $str . ', ' . $startPos . '), ' . $substr . ') + ' . $startPos
+            . ' - 1 ELSE 0 END';
     }
 
     /**

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -9,7 +9,9 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\TrimMode;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 
 use function array_change_key_case;
 use function date;
@@ -19,6 +21,8 @@ use const CASE_LOWER;
 
 class DataAccessTest extends FunctionalTestCase
 {
+    use VerifyDeprecations;
+
     protected function setUp(): void
     {
         $table = new Table('fetch_table');
@@ -465,22 +469,67 @@ class DataAccessTest extends FunctionalTestCase
         $sql .= $platform->getLocateExpression("'barfoobaz'", 'test_string') . ' AS locate6, ';
         $sql .= $platform->getLocateExpression("'bar'", 'test_string') . ' AS locate7, ';
         $sql .= $platform->getLocateExpression('test_string', "'oo'", 2) . ' AS locate8, ';
-        $sql .= $platform->getLocateExpression('test_string', "'oo'", 3) . ' AS locate9 ';
+        $sql .= $platform->getLocateExpression('test_string', "'oo'", 3) . ' AS locate9, ';
+        $sql .= $platform->getLocateExpression('test_string', "'foo'", 1) . ' AS locate10, ';
+        $sql .= $platform->getLocateExpression('test_string', "'oo'", '1 + 1') . ' AS locate11 ';
         $sql .= 'FROM fetch_table';
 
         $row = $this->connection->fetchAssociative($sql);
         self::assertNotFalse($row);
         $row = array_change_key_case($row, CASE_LOWER);
 
-        self::assertEquals(2, $row['locate1']);
-        self::assertEquals(1, $row['locate2']);
-        self::assertEquals(0, $row['locate3']);
-        self::assertEquals(1, $row['locate4']);
-        self::assertEquals(1, $row['locate5']);
-        self::assertEquals(4, $row['locate6']);
-        self::assertEquals(0, $row['locate7']);
-        self::assertEquals(2, $row['locate8']);
-        self::assertEquals(0, $row['locate9']);
+        self::assertEquals([
+            'locate1' => 2,
+            'locate2' => 1,
+            'locate3' => 0,
+            'locate4' => 1,
+            'locate5' => 1,
+            'locate6' => 4,
+            'locate7' => 0,
+            'locate8' => 2,
+            'locate9' => 0,
+            'locate10' => 1,
+            'locate11' => 2,
+        ], $row);
+    }
+
+    public function testSqliteLocateEmulation(): void
+    {
+        if (! TestUtil::isDriverOneOf('pdo_sqlite', 'sqlite3')) {
+            self::markTestSkipped('test is for SQLite only');
+        }
+
+        $sql = <<< 'SQL'
+            SELECT
+                LOCATE(test_string, 'oo') AS locate1,
+                LOCATE(test_string, 'foo') AS locate2,
+                LOCATE(test_string, 'bar') AS locate3,
+                LOCATE(test_string, test_string) AS locate4,
+                LOCATE('foo', test_string) AS locate5,
+                LOCATE('barfoobaz', test_string) AS locate6,
+                LOCATE('bar', test_string) AS locate7,
+                LOCATE(test_string, 'oo', 2) AS locate8,
+                LOCATE(test_string, 'oo', 3) AS locate9,
+                LOCATE(test_string, 'foo', 1) AS locate10,
+                LOCATE(test_string, 'oo', 1 + 1) AS locate11
+            FROM fetch_table
+            SQL;
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/5749');
+
+        self::assertEquals([
+            'locate1' => 2,
+            'locate2' => 1,
+            'locate3' => 0,
+            'locate4' => 1,
+            'locate5' => 1,
+            'locate6' => 4,
+            'locate7' => 0,
+            'locate8' => 2,
+            'locate9' => 0,
+            'locate10' => 1,
+            'locate11' => 2,
+        ], $this->connection->fetchAssociative($sql));
     }
 
     public function testQuoteSQLInjection(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Part of #5745

#### Summary

We currently emulate the `LOCATE()` function on SQLite in order to provide an implementation for `AbstractPlatform::getLocateExpression()`. However, SQLite ships a function called `INSTR()` which does the same except that it does not support offsets.

This PR changes `SqlitePlatform::getLocateExpression()` to use `INSTR()` instead. If `LOCATE()` is used in a SQLite query, a deprecation is triggered.