### PR TITLE
Declare internal properties of TableDiff as private

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -398,14 +398,14 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
                 $diff->getAddedColumns(),
                 $diff->getModifiedColumns(),
                 $diff->getDroppedColumns(),
+                $diff->getRenamedColumns(),
                 array_values($addedIndexes),
                 array_values($modifiedIndexes),
                 $diff->getDroppedIndexes(),
+                $diff->getRenamedIndexes(),
                 $diff->getAddedForeignKeys(),
                 $diff->getModifiedForeignKeys(),
                 $diff->getDroppedForeignKeys(),
-                $diff->getRenamedColumns(),
-                $diff->getRenamedIndexes(),
             );
         }
 

--- a/src/Platforms/MariaDBPlatform.php
+++ b/src/Platforms/MariaDBPlatform.php
@@ -37,8 +37,10 @@ class MariaDBPlatform extends AbstractMySQLPlatform
         $sql       = [];
         $tableName = $diff->getOldTable()->getQuotedName($this);
 
+        $modifiedForeignKeys = $diff->getModifiedForeignKeys();
+
         foreach ($this->getRemainingForeignKeyConstraintsRequiringRenamedIndexes($diff) as $foreignKey) {
-            if (in_array($foreignKey, $diff->changedForeignKeys, true)) {
+            if (in_array($foreignKey, $modifiedForeignKeys, true)) {
                 continue;
             }
 
@@ -66,8 +68,10 @@ class MariaDBPlatform extends AbstractMySQLPlatform
 
         $tableName = $diff->getOldTable()->getQuotedName($this);
 
+        $modifiedForeignKeys = $diff->getModifiedForeignKeys();
+
         foreach ($this->getRemainingForeignKeyConstraintsRequiringRenamedIndexes($diff) as $foreignKey) {
-            if (in_array($foreignKey, $diff->changedForeignKeys, true)) {
+            if (in_array($foreignKey, $modifiedForeignKeys, true)) {
                 continue;
             }
 
@@ -89,7 +93,9 @@ class MariaDBPlatform extends AbstractMySQLPlatform
      */
     private function getRemainingForeignKeyConstraintsRequiringRenamedIndexes(TableDiff $diff): array
     {
-        if (count($diff->renamedIndexes) === 0) {
+        $renamedIndexes = $diff->getRenamedIndexes();
+
+        if (count($renamedIndexes) === 0) {
             return [];
         }
 
@@ -97,11 +103,11 @@ class MariaDBPlatform extends AbstractMySQLPlatform
 
         $remainingForeignKeys = array_diff_key(
             $diff->getOldTable()->getForeignKeys(),
-            $diff->removedForeignKeys,
+            $diff->getDroppedForeignKeys(),
         );
 
         foreach ($remainingForeignKeys as $foreignKey) {
-            foreach ($diff->renamedIndexes as $index) {
+            foreach ($renamedIndexes as $index) {
                 if ($foreignKey->intersectsIndexColumns($index)) {
                     $foreignKeys[] = $foreignKey;
 

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -221,10 +221,7 @@ class Comparator
                 continue;
             }
 
-            $modifiedColumns[$column->getName()] = new ColumnDiff(
-                $column,
-                $toColumn,
-            );
+            $modifiedColumns[] = new ColumnDiff($column, $toColumn);
 
             $hasChanges = true;
         }
@@ -266,7 +263,7 @@ class Comparator
                 continue;
             }
 
-            $modifiedIndexes[$indexName] = $toTableIndex;
+            $modifiedIndexes[] = $toTableIndex;
 
             $hasChanges = true;
         }
@@ -312,14 +309,14 @@ class Comparator
             $addedColumns,
             $modifiedColumns,
             $droppedColumns,
+            $renamedColumns,
             $addedIndexes,
             $modifiedIndexes,
             $droppedIndexes,
+            $renamedIndexes,
             $addedForeignKeys,
             $modifiedForeignKeys,
             $droppedForeignKeys,
-            $renamedColumns,
-            $renamedIndexes,
         );
     }
 

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -60,7 +60,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
     {
         $table = $this->introspectTable($table);
 
-        $this->alterTable(new TableDiff($table, [], [], [], [], [], [], [$foreignKey]));
+        $this->alterTable(new TableDiff($table, [], [], [], [], [], [], [], [], [$foreignKey], [], []));
     }
 
     public function dropForeignKey(string $name, string $table): void
@@ -69,7 +69,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
 
         $foreignKey = $table->getForeignKey($name);
 
-        $this->alterTable(new TableDiff($table, [], [], [], [], [], [], [], [], [$foreignKey]));
+        $this->alterTable(new TableDiff($table, [], [], [], [], [], [], [], [], [], [], [$foreignKey]));
     }
 
     /**

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -500,8 +500,9 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         Column $newColumn,
         ?string $expectedSQLClause,
     ): void {
-        $tableDiff                        = new TableDiff(new Table('foo'));
-        $tableDiff->changedColumns['bar'] = new ColumnDiff($oldColumn, $newColumn);
+        $tableDiff = new TableDiff(new Table('foo'), [], [
+            new ColumnDiff($oldColumn, $newColumn),
+        ], [], [], [], [], [], [], [], [], []);
 
         $expectedSQL = [];
 

--- a/tests/Platforms/SQLitePlatformTest.php
+++ b/tests/Platforms/SQLitePlatformTest.php
@@ -221,13 +221,14 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
     public function testAlterTableAddColumns(): void
     {
         $table = new Table('user');
-        $diff  = new TableDiff($table);
 
-        $diff->addedColumns['foo']   = new Column('foo', Type::getType('string'));
-        $diff->addedColumns['count'] = new Column('count', Type::getType('integer'), [
-            'notnull' => false,
-            'default' => 1,
-        ]);
+        $diff = new TableDiff($table, [
+            new Column('foo', Type::getType('string')),
+            new Column('count', Type::getType('integer'), [
+                'notnull' => false,
+                'default' => 1,
+            ]),
+        ], [], [], [], [], [], [], [], [], [], []);
 
         $expected = [
             'ALTER TABLE user ADD COLUMN foo VARCHAR NOT NULL',
@@ -242,8 +243,9 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
         $table = new Table('test');
         $table->addColumn('id', 'integer');
 
-        $tableDiff                          = new TableDiff($table);
-        $tableDiff->renamedColumns['value'] = new Column('data', Type::getType('string'));
+        $tableDiff = new TableDiff($table, [], [], [], [
+            'value' => new Column('data', Type::getType('string')),
+        ], [], [], [], [], [], [], []);
 
         $this->expectException(Exception::class);
         $this->platform->getAlterTableSQL($tableDiff);
@@ -293,11 +295,14 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
         $table->addForeignKeyConstraint('user', ['parent'], ['id'], ['deferrable' => true, 'deferred' => true]);
         $table->addIndex(['article', 'post'], 'index1');
 
-        $diff                           = new TableDiff($table);
-        $diff->renamedColumns['id']     = new Column('key', Type::getType('integer'), []);
-        $diff->renamedColumns['post']   = new Column('comment', Type::getType('integer'), []);
-        $diff->removedColumns['parent'] = new Column('parent', Type::getType('integer'), []);
-        $diff->removedIndexes['index1'] = $table->getIndex('index1');
+        $diff = new TableDiff($table, [], [], [
+            new Column('parent', Type::getType('integer'), []),
+        ], [
+            'id' => new Column('key', Type::getType('integer'), []),
+            'post' => new Column('comment', Type::getType('integer'), []),
+        ], [], [], [
+            $table->getIndex('index1'),
+        ], [], [], [], []);
 
         $sql = [
             'CREATE TEMPORARY TABLE __temp__user AS SELECT id, article, post FROM user',


### PR DESCRIPTION
**Change summary**:
1. `TableDiff` constructor parameters reordered by asset type: columns, indexes, foreign keys.
2. The return types of all methods except for `getRenamed*()` have been relaxed from `list<T>` to `array<T>`. The former implies that the elements of the list can be accessed by index and their order matters while this is not intended (those are just sets).
3. Instead of being reworked, some of the tests have been removed as they cover very basic use cases which are most likely still covered by integration tests.