### PR TITLE
Use the `%` operator instead of `MOD()` in SQLite

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -84,6 +84,14 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getModExpression($expression1, $expression2)
+    {
+        return $expression1 . ' % ' . $expression2;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getTrimExpression($str, $mode = TrimMode::UNSPECIFIED, $char = false)
     {
         $trimChar = $char !== false ? ', ' . $char : '';


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Part of #5745

#### Summary

Depending on the SQLite version and compile flags, SQLite might not have a `MOD()` function. Currently, we polyfill it.

However, SQLite does have a `%` operator that should always be available. This PR alters `getModExpression()` so that we use the operator instead of calling `MOD()`. We're doing the same thing for SQL Server already.

The operation is covered by the functional test `ModExpressionTest` which still passes.
