### PR TITLE
Mark SchemaDiff public properties internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -139,6 +139,22 @@ The following `Comparator` methods have been marked as internal:
 
 The `diffColumn()` method has been deprecated. Use `diffTable()` instead.
 
+## Marked `SchemaDiff` public properties as internal.
+
+The public properties of the `SchemaDiff` class have been marked as internal. Use the following corresponding methods
+instead:
+
+| Property             | Method                  |
+|----------------------|-------------------------|
+| `$newNamespaces`     | `getCreatedSchemas()`   |
+| `$removedNamespaces` | `getDroppedSchemas()`   |
+| `$newTables`         | `getCreatedTables()`    |
+| `$changedTables`     | `getAlteredTables()`    |
+| `$removedTables`     | `getDroppedTables()`    |
+| `$newSequences`      | `getCreatedSequences()` |
+| `$changedSequences`  | `getAlteredSequence()`  |
+| `$removedSequences`  | `getDroppedSequences()` |
+
 ## Marked `TableDiff` public properties as internal.
 
 The public properties of the `TableDiff` class have been marked as internal. Use the following corresponding methods

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,11 @@ Relying on the availability of the `LOCATE()` on SQLite deprecated. SQLite does 
 but the function `INSTR()` can be a drop-in replacement in most situations. Use
 `AbstractPlatform::getLocateExpression()` if you need a portable solution.
 
+## Deprecated `SchemaDiff::$orphanedForeignKeys`
+
+Relying on the schema diff tracking foreign keys referencing the tables that have been dropped is deprecated.
+Before dropping a table referenced by foreign keys, drop the foreign keys first.
+
 ## Deprecated the `userDefinedFunctions` driver option for `pdo_sqlite`
 
 Instead of funneling custom functions through the `userDefinedFunctions` option, use `getNativeConnection()`

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -491,6 +491,10 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedProperty name="Doctrine\DBAL\Schema\TableDiff::$name"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedProperty name="Doctrine\DBAL\Schema\SchemaDiff::$orphanedForeignKeys"/>
             </errorLevel>
         </DeprecatedProperty>
         <DocblockTypeContradiction>

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -65,7 +65,11 @@ class SchemaDiff
     /** @var Sequence[] */
     public $removedSequences = [];
 
-    /** @var ForeignKeyConstraint[] */
+    /**
+     * @deprecated
+     *
+     * @var ForeignKeyConstraint[]
+     */
     public $orphanedForeignKeys = [];
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

This patch continues the API refactoring previously done in #5657 and #5717.

Additionally, it deprecates the functionality of tracking orphaned foreign keys in the schema diff. This functionality was introduced in https://github.com/doctrine/dbal/commit/bf0ef0d0a767ec7040fd878a5b8cd077e019dbae without any tests or description of the problem that it was meant to solve. It implements dropping foreign keys referencing the table when the table is dropped. There's no reason why it should be done automatically. Besides enforcing data integrity at the row level, a foreign key enforces it at the table level. If this enforcement is no longer necessary, the constraint should be dropped explicitly.