### PR TITLE
Split migration SQL into phases to allow changes to columns used by foreign keys

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2593,6 +2593,24 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Gets the SQL statements for altering an existing table.
+     *
+     * For systems with foreign key constraints, we may need to:
+     * 1) drop all foreign keys
+     * 2) alter all tables/columns
+     * 3) create all foreign keys
+     *
+     * @return string[][]
+     *
+     * @throws Exception If not supported on this platform.
+     */
+    public function getAlterTableSQLInPhases(TableDiff $diff)
+    {
+        // Default behaviour is only one phase
+        return [$this->getAlterTableSQL($diff)];
+    }
+
+    /**
      * @param mixed[] $columnSql
      *
      * @return bool

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -144,10 +144,14 @@ class SchemaDiff
             $sql = array_merge($sql, $platform->getDropTablesSQL($this->removedTables));
         }
 
+        $phases = [];
+
         foreach ($this->changedTables as $tableDiff) {
-            $sql = array_merge($sql, $platform->getAlterTableSQL($tableDiff));
+            foreach ($platform->getAlterTableSQLInPhases($tableDiff) as $phaseId => $phaseSql) {
+                $phases[$phaseId] = array_merge($phases[$phaseId] ?? [], $phaseSql);
+            }
         }
 
-        return $sql;
+        return array_merge($sql, ...$phases);
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

This change allows DBAL to modify the types of columns used in foreign key constraints.
Typically one might do this to change `INT` to `BIGINT`, `SIGNED` to `UNSIGNED`, or the size/collation of a `VARCHAR`.

The current `SchemaDiff` logic applies all the changes for each table to be changed in table-order:
https://github.com/doctrine/dbal/blob/3.4.5/src/Schema/SchemaDiff.php#L147-L149

This results in
* TABLE1 - drop FKs
* TABLE1 - alter columns
* TABLE1 - recreate FKs
* TABLE2 - drop FKs
* TABLE2 - alter columns
* TABLE2 - recreate FKs

However, when modifying a column used in a foreign key, we need the following order:

* TABLE1 - drop FKs
* TABLE2 - drop FKs
* TABLE1 - alter columns
* TABLE2 - alter columns
* TABLE1 - recreate FKs
* TABLE2 - recreate FKs

Otherwise MySQL complains of a type mismatch in the FK column types.

I implemented this by adding public function `getAlterTableSQLInPhases()` alongside the existing `getAlterTableSQL()`.

Note that platforms only need to define one of these two functions - the output from one can be generated automatically from the output of the other.

Platforms can now choose to generate a single list of SQL statements, or multiple lists of statements.  i.e. instead of this:

```php
[
    'ALTER TABLE t DROP FOREIGN KEY f',
    'ALTER TABLE t CHANGE c c ...',
    'ALTER TABLE t ADD CONSTRAINT f ...'
]
```

they can generate

```php
[
    [
        'ALTER TABLE t DROP FOREIGN KEY f',
    ],
    [
        'ALTER TABLE t CHANGE c c ...',
    ],
    [
        'ALTER TABLE t ADD CONSTRAINT f ...'
    ],
]
```

Note that this change would have been much cleaner if I could simply change the signature of `getAlterTableSQL`.  However this would be a BC break.

Now, with this change, `SchemaDiff` is able to process all the SQL for each phase in turn, thus giving the correct sequence.

I have only updated the MySQL platform, as this is the only one I am able to test at present.
Talking of testing, I am only able to test when connected to a live MySQL database and read the existing schema from there.  If I create old/new schemas programatically, then `SchemaDiff` doesn't attempt to drop/re-create the FKs.  