### PR TITLE
Improve error message for index SQL creation

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2416,7 +2416,11 @@ abstract class AbstractPlatform
         $columns = $index->getColumns();
 
         if (count($columns) === 0) {
-            throw new InvalidArgumentException("Incomplete definition. 'columns' required.");
+            throw new InvalidArgumentException(sprintf(
+                'Incomplete or invalid index definition %s on table %s',
+                $name,
+                $table,
+            ));
         }
 
         if ($index->isPrimary()) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

When creating an index on a missing or mistyped column/field or changing the name of the column/field which has previously been indexed, attempting to create a new migration can fail with the message `Incomplete definition. 'columns' required.` This message does not identify the problematic entity.

This pull request improves the error message to identify the invalid entity/index.