### PR TITLE
Remove handling orphaned foreign keys

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## Removed `SchemaDiff::$orphanedForeignKeys`
+
+The functionality of automatically dropping the foreign keys referencing the tables being dropped has been removed.
+
 ## BC Break: Removed registration of user defined functions for SQLite
 
 DBAL does not register functions for SQLite anymore. The following functions
@@ -570,9 +574,6 @@ Reference from `ForeignKeyConstraint` to its local (referencing) `Table` is remo
 - `setLocalTable()`,
 - `getLocalTable()`,
 - `getLocalTableName()`.
-
-The type of `SchemaDiff::$orphanedForeignKeys` has changed from list of foreign keys (`list<ForeignKeyConstraint>`)
-to map of referencing tables to their list of foreign keys (`array<string,list<ForeignKeyConstraint>>`).
 
 ## BC BREAK: Removed redundant `AbstractPlatform` methods.
 

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -54,13 +54,6 @@ class SchemaDiff
     public array $removedSequences = [];
 
     /**
-     * @deprecated
-     *
-     * @var array<string,list<ForeignKeyConstraint>>
-     */
-    public array $orphanedForeignKeys = [];
-
-    /**
      * Constructs an SchemaDiff object.
      *
      * @internal The diff can be only instantiated by a {@see Comparator}.
@@ -172,17 +165,6 @@ class SchemaDiff
         if ($platform->supportsSchemas()) {
             foreach ($this->getCreatedSchemas() as $schema) {
                 $sql[] = $platform->getCreateSchemaSQL($schema);
-            }
-        }
-
-        if ($saveMode === false) {
-            foreach ($this->orphanedForeignKeys as $localTableName => $tableOrphanedForeignKey) {
-                foreach ($tableOrphanedForeignKey as $orphanedForeignKey) {
-                    $sql[] = $platform->getDropForeignKeySQL(
-                        $orphanedForeignKey->getQuotedName($platform),
-                        $localTableName,
-                    );
-                }
             }
         }
 

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -40,7 +40,7 @@ class TableDiff
         private readonly array $renamedIndexes,
         private readonly array $addedForeignKeys,
         private readonly array $modifiedForeignKeys,
-        private array $droppedForeignKeys,
+        private readonly array $droppedForeignKeys,
     ) {
     }
 
@@ -141,16 +141,5 @@ class TableDiff
     public function getDroppedForeignKeys(): array
     {
         return $this->droppedForeignKeys;
-    }
-
-    /** @internal This method exists only for compatibility with the current implementation of the schema comparator. */
-    public function unsetDroppedForeignKey(ForeignKeyConstraint $foreignKey): void
-    {
-        $this->droppedForeignKeys = array_filter(
-            $this->droppedForeignKeys,
-            static function (ForeignKeyConstraint $droppedForeignKey) use ($foreignKey): bool {
-                return $droppedForeignKey !== $foreignKey;
-            },
-        );
     }
 }


### PR DESCRIPTION
The functionality being removed was deprecated in https://github.com/doctrine/dbal/pull/5758.