### PR TITLE
Use default schema if `$tableName` has no namespace.

### DIFF
--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -744,22 +744,20 @@ SQL;
     private function buildQueryConditions($tableName): array
     {
         $conditions = [];
-        $schemaName = null;
 
         if ($tableName !== null) {
             if (strpos($tableName, '.') !== false) {
                 [$schemaName, $tableName] = explode('.', $tableName);
+                $conditions[]             = 'n.nspname = ' . $this->_platform->quoteStringLiteral($schemaName);
+            } else {
+                $conditions[] = 'n.nspname = ANY(current_schemas(false))';
             }
 
             $identifier   = new Identifier($tableName);
             $conditions[] = 'c.relname = ' . $this->_platform->quoteStringLiteral($identifier->getName());
         }
 
-        if ($schemaName !== null) {
-            $conditions[] = 'n.nspname = ' . $this->_platform->quoteStringLiteral($schemaName);
-        } else {
-            $conditions[] = "n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')";
-        }
+        $conditions[] = "n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')";
 
         return $conditions;
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug

#### Summary

When 2 same name tables exist in difference schema, eg: `public.table` and `another.table`, `$this->schemaManager->listTableColumns('table')` will list and mix columns from both tables.

I have confirmed `listTableColumns` is working correctly before #5586. 
This PR fixes the column issue while respecting #5586 `listTables` fix.

##### Steps to reproduce

```sql
create table public."table"
(
    id   integer not null,
    name text    not null
);

create table another."table"
(
    id    text not null,
    email text not null
);
```

Run `$this->schemaManager->listTableColumns('table')`

##### Actual

List `table` columns mixed from `public` and `another` schema.

```php
[
   'id', // text, override by another."table"
   'name', // text
   'email', // text, merged from another."table"
]
```

##### Expected

List `table` columns from the `public` schema only. 

```php
[
   'id', // integer
   'name', // text
]
```