### PR TITLE
Deprecate SchemaDiff::toSql() and SchemaDiff::toSaveSql()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,13 @@ Relying on the availability of the `LOCATE()` on SQLite deprecated. SQLite does 
 but the function `INSTR()` can be a drop-in replacement in most situations. Use
 `AbstractPlatform::getLocateExpression()` if you need a portable solution.
 
+## Deprecated `SchemaDiff::toSql()` and `SchemaDiff::toSaveSql()`
+
+Using `SchemaDiff::toSql()` to generate SQL representing the diff has been deprecated.
+Use `AbstractPlatform::getAlterSchemaSQL()` instead.
+
+`SchemaDiff::toSaveSql()` has been deprecated without a replacement.
+
 ## Deprecated `SchemaDiff::$orphanedForeignKeys`
 
 Relying on the schema diff tracking foreign keys referencing the tables that have been dropped is deprecated.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -442,6 +442,10 @@
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::getForeignKeyColumns"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::getPrimaryKeyColumns"/>
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::hasPrimaryKey"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\SchemaDiff::toSql"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Schema\Constraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -2281,6 +2282,16 @@ abstract class AbstractPlatform
     public function getCreateTemporaryTableSnippetSQL()
     {
         return 'CREATE TEMPORARY TABLE';
+    }
+
+    /**
+     * Generates SQL statements that can be used to apply the diff.
+     *
+     * @return list<string>
+     */
+    public function getAlterSchemaSQL(SchemaDiff $diff): array
+    {
+        return $diff->toSql($this);
     }
 
     /**

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -1213,7 +1213,7 @@ abstract class AbstractSchemaManager
      */
     public function alterSchema(SchemaDiff $schemaDiff): void
     {
-        $this->_execSql($schemaDiff->toSql($this->_platform));
+        $this->_execSql($this->_platform->getAlterSchemaSQL($schemaDiff));
     }
 
     /**

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 
@@ -187,16 +188,36 @@ class SchemaDiff
      *
      * This way it is ensured that assets are deleted which might not be relevant to the metadata schema at all.
      *
+     * @deprecated
+     *
      * @return list<string>
      */
     public function toSaveSql(AbstractPlatform $platform)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5766',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return $this->_toSql($platform, true);
     }
 
-    /** @return list<string> */
+    /**
+     * @deprecated Use {@link AbstractPlatform::getAlterSchemaSQL()} instead.
+     *
+     * @return list<string>
+     */
     public function toSql(AbstractPlatform $platform)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5766',
+            '%s is deprecated. Use AbstractPlatform::getAlterSchemaSQL() instead.',
+            __METHOD__,
+        );
+
         return $this->_toSql($platform, false);
     }
 

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -757,7 +757,9 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testTableInNamespace(): void
     {
-        if (! $this->connection->getDatabasePlatform()->supportsSchemas()) {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $platform->supportsSchemas()) {
             self::markTestSkipped('Schema definition is not supported by this platform.');
         }
 
@@ -765,7 +767,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $diff                  = new SchemaDiff();
         $diff->newNamespaces[] = 'testschema';
 
-        foreach ($diff->toSql($this->connection->getDatabasePlatform()) as $sql) {
+        foreach ($platform->getAlterSchemaSQL($diff) as $sql) {
             $this->connection->executeStatement($sql);
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

1. Similar to `TableDiff::getName()` (https://github.com/doctrine/dbal/pull/5678), implementing the SQL-related methods makes the diff (which is a value object) depend on the infrastructure. It should be the other way around.
2. Being able to discard all `DROP` statements from the generated schema migration SQL is a poor-man solution to dealing with the objects not owned by the DBAL. It has the following downsides:
   1. The DBAL still can choke during introspection of those objects (e.g. https://github.com/doctrine/dbal/issues/4470, https://github.com/doctrine/dbal/issues/5306).
   2. The objects that are owned by the DBAL still need to be dropped manually.
3. The `toSaveSql()` method and the corresponding `$saveMode` parameter names make absolute no sense.
4. Neither the DBAL nor Migrations use `SchemaDiff::toSaveSql()`. This method is absolutely untested, and I'm not talking about a unit test that confirms that the flag is respected. I'm talking about the integration testing of the scenarios for which the method was implemented in the first place.

Instead of using `SchemaDiff::toSaveSql()` for discarding schema changes in 3rd-party database objects (if that's the case), it is recommended to use asset filtering.