### PR TITLE
Declare internal properties of SchemaDiff as private

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -41,7 +41,7 @@ class Comparator
                 continue;
             }
 
-            $createdSchemas[$namespace] = $namespace;
+            $createdSchemas[] = $namespace;
         }
 
         foreach ($fromSchema->getNamespaces() as $namespace) {
@@ -49,13 +49,13 @@ class Comparator
                 continue;
             }
 
-            $droppedSchemas[$namespace] = $namespace;
+            $droppedSchemas[] = $namespace;
         }
 
         foreach ($toSchema->getTables() as $table) {
             $tableName = $table->getShortestName($toSchema->getName());
             if (! $fromSchema->hasTable($tableName)) {
-                $createdTables[$tableName] = $toSchema->getTable($tableName);
+                $createdTables[] = $toSchema->getTable($tableName);
             } else {
                 $tableDifferences = $this->diffTable(
                     $fromSchema->getTable($tableName),
@@ -63,7 +63,7 @@ class Comparator
                 );
 
                 if ($tableDifferences !== null) {
-                    $alteredTables[$tableName] = $tableDifferences;
+                    $alteredTables[] = $tableDifferences;
                 }
             }
         }
@@ -77,7 +77,7 @@ class Comparator
                 continue;
             }
 
-            $droppedTables[$tableName] = $table;
+            $droppedTables[] = $table;
         }
 
         foreach ($toSchema->getSequences() as $sequence) {
@@ -108,11 +108,11 @@ class Comparator
         }
 
         return new SchemaDiff(
+            $createdSchemas,
+            $droppedSchemas,
             $createdTables,
             $alteredTables,
             $droppedTables,
-            $createdSchemas,
-            $droppedSchemas,
             $createdSequences,
             $alteredSequences,
             $droppedSequences,

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -15,124 +15,77 @@ use function array_values;
 class SchemaDiff
 {
     /**
-     * All added namespaces.
-     *
-     * @internal Use {@link getCreatedSchemas()} instead.
-     *
-     * @var array<string, string>
-     */
-    public array $newNamespaces = [];
-
-    /**
-     * All removed namespaces.
-     *
-     * @internal Use {@link getDroppedSchemas()} instead.
-     *
-     * @var array<string, string>
-     */
-    public array $removedNamespaces = [];
-
-    /**
-     * @internal Use {@link getCreatedSequences()} instead.
-     *
-     * @var array<int, Sequence>
-     */
-    public array $newSequences = [];
-
-    /**
-     * @internal Use {@link getAlteredSequences()} instead.
-     *
-     * @var array<int, Sequence>
-     */
-    public array $changedSequences = [];
-
-    /**
-     * @internal Use {@link getDroppedSequences()} instead.
-     *
-     * @var array<int, Sequence>
-     */
-    public array $removedSequences = [];
-
-    /**
      * Constructs an SchemaDiff object.
      *
      * @internal The diff can be only instantiated by a {@see Comparator}.
      *
-     * @param array<string, Table>     $newTables
-     * @param array<string, TableDiff> $changedTables
-     * @param array<string, Table>     $removedTables
-     * @param array<string>            $createdSchemas
-     * @param array<string>            $droppedSchemas
-     * @param array<Sequence>          $createdSequences
-     * @param array<Sequence>          $alteredSequences
-     * @param array<Sequence>          $droppedSequences
+     * @param array<string>    $createdSchemas
+     * @param array<string>    $droppedSchemas
+     * @param array<Table>     $createdTables
+     * @param array<TableDiff> $alteredTables
+     * @param array<Table>     $droppedTables
+     * @param array<Sequence>  $createdSequences
+     * @param array<Sequence>  $alteredSequences
+     * @param array<Sequence>  $droppedSequences
      */
     public function __construct(
-        /** @internal Use {@link getCreatedTables()} instead. */
-        public array $newTables = [],
-        /** @internal Use {@link getAlteredTables()} instead. */
-        public array $changedTables = [],
-        /** @internal Use {@link getDroppedTables()} instead. */
-        public array $removedTables = [],
-        array $createdSchemas = [],
-        array $droppedSchemas = [],
-        array $createdSequences = [],
-        array $alteredSequences = [],
-        array $droppedSequences = [],
+        private readonly array $createdSchemas,
+        private readonly array $droppedSchemas,
+        private readonly array $createdTables,
+        private readonly array $alteredTables,
+        private readonly array $droppedTables,
+        private readonly array $createdSequences,
+        private readonly array $alteredSequences,
+        private readonly array $droppedSequences,
     ) {
-        $this->newNamespaces     = $createdSchemas;
-        $this->removedNamespaces = $droppedSchemas;
-        $this->newSequences      = $createdSequences;
-        $this->changedSequences  = $alteredSequences;
-        $this->removedSequences  = $droppedSequences;
     }
 
     /** @return array<string> */
     public function getCreatedSchemas(): array
     {
-        return $this->newNamespaces;
+        return $this->createdSchemas;
     }
 
     /** @return array<string> */
     public function getDroppedSchemas(): array
     {
-        return $this->removedNamespaces;
+        return $this->droppedSchemas;
     }
 
     /** @return array<Table> */
     public function getCreatedTables(): array
     {
-        return $this->newTables;
+        return $this->createdTables;
     }
 
     /** @return array<TableDiff> */
     public function getAlteredTables(): array
     {
-        return $this->changedTables;
+        return $this->alteredTables;
     }
 
     /** @return array<Table> */
     public function getDroppedTables(): array
     {
-        return $this->removedTables;
+        return $this->droppedTables;
     }
 
     /** @return array<Sequence> */
     public function getCreatedSequences(): array
     {
-        return $this->newSequences;
+        return $this->createdSequences;
     }
 
     /** @return array<Sequence> */
     public function getAlteredSequences(): array
     {
-        return $this->changedSequences;
+        return $this->alteredSequences;
     }
 
     /** @return array<Sequence> */
     public function getDroppedSequences(): array
     {
-        return $this->removedSequences;
+        return $this->droppedSequences;
     }
 
     /**

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -684,9 +684,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             self::markTestSkipped('Schema definition is not supported by this platform.');
         }
 
-        //create schema
-        $diff                              = new SchemaDiff();
-        $diff->newNamespaces['testschema'] = 'testschema';
+        $diff = new SchemaDiff(['testschema'], [], [], [], [], [], [], []);
 
         foreach ($diff->toSql($this->connection->getDatabasePlatform()) as $sql) {
             $this->connection->executeStatement($sql);


### PR DESCRIPTION
The changes here complement the ones implemented in https://github.com/doctrine/dbal/pull/5753.