### PR TITLE
Rename parameters of the diff-related methods

### DIFF
--- a/src/Platforms/MySQL/Comparator.php
+++ b/src/Platforms/MySQL/Comparator.php
@@ -30,11 +30,11 @@ class Comparator extends BaseComparator
         parent::__construct($platform);
     }
 
-    public function diffTable(Table $fromTable, Table $toTable): ?TableDiff
+    public function diffTable(Table $oldTable, Table $newTable): ?TableDiff
     {
         return parent::diffTable(
-            $this->normalizeTable($fromTable),
-            $this->normalizeTable($toTable),
+            $this->normalizeTable($oldTable),
+            $this->normalizeTable($newTable),
         );
     }
 

--- a/src/Platforms/SQLServer/Comparator.php
+++ b/src/Platforms/SQLServer/Comparator.php
@@ -22,15 +22,15 @@ class Comparator extends BaseComparator
         parent::__construct($platform);
     }
 
-    public function diffTable(Table $fromTable, Table $toTable): ?TableDiff
+    public function diffTable(Table $oldTable, Table $newTable): ?TableDiff
     {
-        $fromTable = clone $fromTable;
-        $toTable   = clone $toTable;
+        $oldTable = clone $oldTable;
+        $newTable = clone $newTable;
 
-        $this->normalizeColumns($fromTable);
-        $this->normalizeColumns($toTable);
+        $this->normalizeColumns($oldTable);
+        $this->normalizeColumns($newTable);
 
-        return parent::diffTable($fromTable, $toTable);
+        return parent::diffTable($oldTable, $newTable);
     }
 
     private function normalizeColumns(Table $table): void

--- a/src/Platforms/SQLite/Comparator.php
+++ b/src/Platforms/SQLite/Comparator.php
@@ -24,15 +24,15 @@ class Comparator extends BaseComparator
         parent::__construct($platform);
     }
 
-    public function diffTable(Table $fromTable, Table $toTable): ?TableDiff
+    public function diffTable(Table $oldTable, Table $newTable): ?TableDiff
     {
-        $fromTable = clone $fromTable;
-        $toTable   = clone $toTable;
+        $oldTable = clone $oldTable;
+        $newTable = clone $newTable;
 
-        $this->normalizeColumns($fromTable);
-        $this->normalizeColumns($toTable);
+        $this->normalizeColumns($oldTable);
+        $this->normalizeColumns($newTable);
 
-        return parent::diffTable($fromTable, $toTable);
+        return parent::diffTable($oldTable, $newTable);
     }
 
     private function normalizeColumns(Table $table): void

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -785,11 +785,11 @@ class SQLitePlatform extends AbstractPlatform
     }
 
     /** @return string[] */
-    private function getColumnNamesInAlteredTable(TableDiff $diff, Table $fromTable): array
+    private function getColumnNamesInAlteredTable(TableDiff $diff, Table $oldTable): array
     {
         $columns = [];
 
-        foreach ($fromTable->getColumns() as $column) {
+        foreach ($oldTable->getColumns() as $column) {
             $columnName                       = $column->getName();
             $columns[strtolower($columnName)] = $columnName;
         }
@@ -825,10 +825,10 @@ class SQLitePlatform extends AbstractPlatform
     }
 
     /** @return Index[] */
-    private function getIndexesInAlteredTable(TableDiff $diff, Table $fromTable): array
+    private function getIndexesInAlteredTable(TableDiff $diff, Table $oldTable): array
     {
-        $indexes     = $fromTable->getIndexes();
-        $columnNames = $this->getColumnNamesInAlteredTable($diff, $fromTable);
+        $indexes     = $oldTable->getIndexes();
+        $columnNames = $this->getColumnNamesInAlteredTable($diff, $oldTable);
 
         foreach ($indexes as $key => $index) {
             foreach ($diff->getRenamedIndexes() as $oldIndexName => $renamedIndex) {
@@ -899,10 +899,10 @@ class SQLitePlatform extends AbstractPlatform
     }
 
     /** @return ForeignKeyConstraint[] */
-    private function getForeignKeysInAlteredTable(TableDiff $diff, Table $fromTable): array
+    private function getForeignKeysInAlteredTable(TableDiff $diff, Table $oldTable): array
     {
-        $foreignKeys = $fromTable->getForeignKeys();
-        $columnNames = $this->getColumnNamesInAlteredTable($diff, $fromTable);
+        $foreignKeys = $oldTable->getForeignKeys();
+        $columnNames = $this->getColumnNamesInAlteredTable($diff, $oldTable);
 
         foreach ($foreignKeys as $key => $constraint) {
             $changed      = false;
@@ -959,11 +959,11 @@ class SQLitePlatform extends AbstractPlatform
     }
 
     /** @return Index[] */
-    private function getPrimaryIndexInAlteredTable(TableDiff $diff, Table $fromTable): array
+    private function getPrimaryIndexInAlteredTable(TableDiff $diff, Table $oldTable): array
     {
         $primaryIndex = [];
 
-        foreach ($this->getIndexesInAlteredTable($diff, $fromTable) as $index) {
+        foreach ($this->getIndexesInAlteredTable($diff, $oldTable) as $index) {
             if (! $index->isPrimary()) {
                 continue;
             }

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -606,10 +606,10 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function migrateSchema(Schema $toSchema): void
+    public function migrateSchema(Schema $newSchema): void
     {
         $schemaDiff = $this->createComparator()
-            ->compareSchemas($this->introspectSchema(), $toSchema);
+            ->compareSchemas($this->introspectSchema(), $newSchema);
 
         $this->alterSchema($schemaDiff);
     }

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -259,12 +259,12 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $schemaManager = $this->connection->createSchemaManager();
 
-        $fromSchema = $schemaManager->introspectSchema();
-        $toSchema   = clone $fromSchema;
+        $oldSchema = $schemaManager->introspectSchema();
+        $newSchema = clone $oldSchema;
 
-        $toSchema->getTable('"tester"')->dropColumn('"name"');
+        $newSchema->getTable('"tester"')->dropColumn('"name"');
         $diff = $schemaManager->createComparator()
-            ->compareSchemas($fromSchema, $toSchema);
+            ->compareSchemas($oldSchema, $newSchema);
 
         $schemaManager->alterSchema($diff);
 

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -431,19 +431,20 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     /** @dataProvider autoIncrementTypeMigrations */
     public function testAlterTableAutoIncrementIntToBigInt(string $from, string $to, string $expected): void
     {
-        $tableFrom = new Table('autoinc_type_modification');
-        $column    = $tableFrom->addColumn('id', $from);
+        $table  = new Table('autoinc_type_modification');
+        $column = $table->addColumn('id', $from);
         $column->setAutoincrement(true);
-        $this->dropAndCreateTable($tableFrom);
-        $tableFrom = $this->schemaManager->introspectTable('autoinc_type_modification');
-        self::assertTrue($tableFrom->getColumn('id')->getAutoincrement());
+        $this->dropAndCreateTable($table);
 
-        $tableTo = new Table('autoinc_type_modification');
-        $column  = $tableTo->addColumn('id', $to);
+        $oldTable = $this->schemaManager->introspectTable('autoinc_type_modification');
+        self::assertTrue($oldTable->getColumn('id')->getAutoincrement());
+
+        $newTable = new Table('autoinc_type_modification');
+        $column   = $newTable->addColumn('id', $to);
         $column->setAutoincrement(true);
 
         $diff = $this->schemaManager->createComparator()
-            ->diffTable($tableFrom, $tableTo);
+            ->diffTable($oldTable, $newTable);
         self::assertNotNull($diff);
         self::assertSame(
             ['ALTER TABLE autoinc_type_modification ALTER id TYPE ' . $expected],

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -634,30 +634,30 @@ abstract class ComparatorTest extends TestCase
 
     public function testComparesNamespaces(): void
     {
-        $fromSchema = $this->getMockBuilder(Schema::class)
+        $oldSchema = $this->getMockBuilder(Schema::class)
             ->onlyMethods(['getNamespaces', 'hasNamespace'])
             ->getMock();
-        $toSchema   = $this->getMockBuilder(Schema::class)
+        $newSchema = $this->getMockBuilder(Schema::class)
             ->onlyMethods(['getNamespaces', 'hasNamespace'])
             ->getMock();
 
-        $fromSchema->expects(self::once())
+        $oldSchema->expects(self::once())
             ->method('getNamespaces')
             ->willReturn(['foo', 'bar']);
 
-        $fromSchema->method('hasNamespace')
+        $oldSchema->method('hasNamespace')
             ->withConsecutive(['bar'], ['baz'])
             ->willReturnOnConsecutiveCalls(true, false);
 
-        $toSchema->expects(self::once())
+        $newSchema->expects(self::once())
             ->method('getNamespaces')
             ->willReturn(['bar', 'baz']);
 
-        $toSchema->method('hasNamespace')
+        $newSchema->method('hasNamespace')
             ->withConsecutive(['foo'], ['bar'])
             ->willReturnOnConsecutiveCalls(false, true);
 
-        $diff = $this->comparator->compareSchemas($fromSchema, $toSchema);
+        $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 
         self::assertEquals(['baz'], $diff->getCreatedSchemas());
         self::assertEquals(['foo'], $diff->getDroppedSchemas());
@@ -698,7 +698,7 @@ abstract class ComparatorTest extends TestCase
 
     public function testForeignKeyRemovalWithRenamedLocalColumn(): void
     {
-        $fromSchema = new Schema([
+        $oldSchema = new Schema([
             'table1' => new Table(
                 'table1',
                 [
@@ -718,7 +718,7 @@ abstract class ComparatorTest extends TestCase
                 ],
             ),
         ]);
-        $toSchema   = new Schema([
+        $newSchema = new Schema([
             'table2' => new Table(
                 'table2',
                 [
@@ -739,7 +739,7 @@ abstract class ComparatorTest extends TestCase
             ),
         ]);
 
-        $schemaDiff = $this->comparator->compareSchemas($fromSchema, $toSchema);
+        $schemaDiff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 
         $alteredTables = $schemaDiff->getAlteredTables();
         self::assertCount(1, $alteredTables);
@@ -751,7 +751,7 @@ abstract class ComparatorTest extends TestCase
 
     public function testWillNotProduceSchemaDiffOnTableWithAddedCustomSchemaDefinition(): void
     {
-        $fromSchema = new Schema(
+        $oldSchema = new Schema(
             [
                 new Table(
                     'a_table',
@@ -765,7 +765,7 @@ abstract class ComparatorTest extends TestCase
                 ),
             ],
         );
-        $toSchema   = new Schema(
+        $newSchema = new Schema(
             [
                 new Table(
                     'a_table',
@@ -780,7 +780,7 @@ abstract class ComparatorTest extends TestCase
         );
 
         self::assertEmpty(
-            $this->comparator->compareSchemas($fromSchema, $toSchema)
+            $this->comparator->compareSchemas($oldSchema, $newSchema)
                 ->getAlteredTables(),
             'Schema diff is empty, since only `columnDefinition` changed from `null` (not detected) to a defined one',
         );


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

The "from" and "to" prefixes of the diff-related method parameters and variable names are replaced with "old" and "new" respectively. They have equal lengths and are adjectives, which makes code more human-readable.