### PR TITLE
Remove the APIs deprecated in DBAL 3.x

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,6 +45,7 @@ or `createFunction()` on the PDO or SQLite3 connection.
 
 The following `Table` methods have been removed:
 
+- `changeColumn()`,
 - `getForeignKeyColumns()`,
 - `getPrimaryKeyColumns()`,
 - `hasPrimaryKey()`.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -45,14 +45,6 @@
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::changeColumn"/>
             </errorLevel>
         </DeprecatedMethod>
-        <DeprecatedProperty>
-            <errorLevel type="suppress">
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedProperty name="Doctrine\DBAL\Schema\SchemaDiff::$orphanedForeignKeys"/>
-            </errorLevel>
-        </DeprecatedProperty>
         <DocblockTypeContradiction>
             <errorLevel type="suppress">
                 <!--

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -39,10 +39,6 @@
                     See https://github.com/doctrine/dbal/pull/4317
                 -->
                 <file name="tests/Functional/LegacyAPITest.php"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\Table::changeColumn"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -13,7 +13,6 @@ use Doctrine\DBAL\Schema\Exception\IndexNameInvalid;
 use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function array_values;
@@ -264,25 +263,6 @@ class Table extends AbstractAsset
         $this->_addColumn($column);
 
         return $column;
-    }
-
-    /**
-     * Change Column Details.
-     *
-     * @deprecated Use {@link modifyColumn()} instead.
-     *
-     * @param array<string, mixed> $options
-     */
-    public function changeColumn(string $name, array $options): self
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5747',
-            '%s is deprecated. Use modifyColumn() instead.',
-            __METHOD__,
-        );
-
-        return $this->modifyColumn($name, $options);
     }
 
     /** @param array<string, mixed> $options */

--- a/src/Types/Types.php
+++ b/src/Types/Types.php
@@ -9,9 +9,6 @@ namespace Doctrine\DBAL\Types;
  */
 final class Types
 {
-    /** @deprecated Use {@link Types::JSON} instead. */
-    public const ARRAY = 'array';
-
     public const ASCII_STRING         = 'ascii_string';
     public const BIGINT               = 'bigint';
     public const BINARY               = 'binary';
@@ -29,16 +26,12 @@ final class Types
     public const GUID                 = 'guid';
     public const INTEGER              = 'integer';
     public const JSON                 = 'json';
-
-    /** @deprecated Use {@link Types::JSON} instead. */
-    public const OBJECT = 'object';
-
-    public const SIMPLE_ARRAY   = 'simple_array';
-    public const SMALLINT       = 'smallint';
-    public const STRING         = 'string';
-    public const TEXT           = 'text';
-    public const TIME_MUTABLE   = 'time';
-    public const TIME_IMMUTABLE = 'time_immutable';
+    public const SIMPLE_ARRAY         = 'simple_array';
+    public const SMALLINT             = 'smallint';
+    public const STRING               = 'string';
+    public const TEXT                 = 'text';
+    public const TIME_MUTABLE         = 'time';
+    public const TIME_IMMUTABLE       = 'time_immutable';
 
     /** @codeCoverageIgnore */
     private function __construct()

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -54,8 +54,8 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($columns['bar']->getNotnull());
 
         $diffTable = clone $table;
-        $diffTable->changeColumn('foo', ['notnull' => false]);
-        $diffTable->changeColumn('bar', ['length' => 1024]);
+        $diffTable->modifyColumn('foo', ['notnull' => false]);
+        $diffTable->modifyColumn('bar', ['length' => 1024]);
 
         $diff = $this->schemaManager->createComparator()
             ->diffTable($table, $diffTable);

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1000,10 +1000,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $newTable = clone $oldTable;
 
-        $newTable->changeColumn('column1', ['default' => '']);
-        $newTable->changeColumn('column2', ['default' => null]);
-        $newTable->changeColumn('column3', ['default' => 'default2']);
-        $newTable->changeColumn('column4', ['default' => null]);
+        $newTable->modifyColumn('column1', ['default' => '']);
+        $newTable->modifyColumn('column2', ['default' => null]);
+        $newTable->modifyColumn('column3', ['default' => 'default2']);
+        $newTable->modifyColumn('column4', ['default' => null]);
 
         $diff = $this->schemaManager->createComparator()
             ->diffTable(

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -538,10 +538,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         );
 
         $diffTable = clone $table;
-        $diffTable->changeColumn('def_text', ['default' => null]);
-        $diffTable->changeColumn('def_text_null', ['default' => null]);
-        $diffTable->changeColumn('def_blob', ['default' => null]);
-        $diffTable->changeColumn('def_blob_null', ['default' => null]);
+        $diffTable->modifyColumn('def_text', ['default' => null]);
+        $diffTable->modifyColumn('def_text_null', ['default' => null]);
+        $diffTable->modifyColumn('def_blob', ['default' => null]);
+        $diffTable->modifyColumn('def_blob_null', ['default' => null]);
 
         self::assertNull($this->createComparator()->diffTable($table, $diffTable));
     }


### PR DESCRIPTION
1. The suppression of the usage of `SchemaDiff::$orphanedForeighKeys` should have been removed in https://github.com/doctrine/dbal/pull/5763.
2. The `array` and `object` column types were removed in https://github.com/doctrine/dbal/pull/5477. They may have been reintroduced to the codebase by mistake during a conflict resolution.
3. `Table::changeColumn` was deprecated in https://github.com/doctrine/dbal/pull/5747.