### PR TITLE
Non-nullabe result of comparing tables

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -121,6 +121,36 @@ The "unique" and "check" column properties have been deprecated. Use unique cons
 Relying on the default precision and scale of decimal columns provided by the DBAL is deprecated.
 When declaring decimal columns, specify the precision and scale explicitly.
 
+## Deprecated `Comparator::diffTable()` method.
+
+The `Comparator::diffTable()` method has been deprecated in favor of `Comparator::compareTables()`
+and `TableDiff::isEmpty()`.
+
+Instead of having to check whether the diff is equal to the boolean `false`, you can optionally check
+if the returned table diff is empty.
+
+### Before
+
+```php
+$diff = $comparator->diffTable($oldTable, $newTable);
+
+// mandatory check
+if ($diff !== false) {
+    // we have a diff
+}
+```
+
+### After
+
+```php
+$diff = $comparator->compareTables($oldTable, $newTable);
+
+// optional check
+if (! $diff->isEmpty()) {
+    // we have a diff
+}
+```
+
 ## Deprecated not passing `$fromColumn` to the `TableDiff` constructor.
 
 Not passing `$fromColumn` to the `TableDiff` constructor has been deprecated.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -446,6 +446,10 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\SchemaDiff::toSql"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\Comparator::diffTable"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -5,7 +5,9 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\Deprecation;
 
+use function array_filter;
 use function array_merge;
+use function count;
 
 /**
  * Differences between two schemas.
@@ -120,8 +122,12 @@ class SchemaDiff
         $alteredSequences = [],
         $droppedSequences = []
     ) {
-        $this->newTables         = $newTables;
-        $this->changedTables     = $changedTables;
+        $this->newTables = $newTables;
+
+        $this->changedTables = array_filter($changedTables, static function (TableDiff $diff): bool {
+            return ! $diff->isEmpty();
+        });
+
         $this->removedTables     = $removedTables;
         $this->fromSchema        = $fromSchema;
         $this->newNamespaces     = $createdSchemas;
@@ -177,6 +183,21 @@ class SchemaDiff
     public function getDroppedSequences(): array
     {
         return $this->removedSequences;
+    }
+
+    /**
+     * Returns whether the diff is empty (contains no changes).
+     */
+    public function isEmpty(): bool
+    {
+        return count($this->newNamespaces) === 0
+            && count($this->removedNamespaces) === 0
+            && count($this->newTables) === 0
+            && count($this->changedTables) === 0
+            && count($this->removedTables) === 0
+            && count($this->newSequences) === 0
+            && count($this->changedSequences) === 0
+            && count($this->removedSequences) === 0;
     }
 
     /**

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -7,6 +7,7 @@ use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
 use function array_values;
+use function count;
 
 /**
  * Table Diff.
@@ -338,5 +339,23 @@ class TableDiff
                 return $removedForeignKey !== $foreignKey;
             },
         );
+    }
+
+    /**
+     * Returns whether the diff is empty (contains no changes).
+     */
+    public function isEmpty(): bool
+    {
+        return count($this->addedColumns) === 0
+            && count($this->changedColumns) === 0
+            && count($this->removedColumns) === 0
+            && count($this->renamedColumns) === 0
+            && count($this->addedIndexes) === 0
+            && count($this->changedIndexes) === 0
+            && count($this->removedIndexes) === 0
+            && count($this->renamedIndexes) === 0
+            && count($this->addedForeignKeys) === 0
+            && count($this->changedForeignKeys) === 0
+            && count($this->removedForeignKeys) === 0;
     }
 }

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\UniqueConstraint;
@@ -1388,6 +1389,14 @@ abstract class AbstractPlatformTestCase extends TestCase
 
         self::assertTrue($diff->isEmpty());
         self::assertSame([], $this->platform->getAlterTableSQL($diff));
+    }
+
+    public function testEmptySchemaDiff(): void
+    {
+        $diff = new SchemaDiff();
+
+        self::assertTrue($diff->isEmpty());
+        self::assertSame([], $this->platform->getAlterSchemaSQL($diff));
     }
 
     public function tearDown(): void

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -1382,6 +1382,14 @@ abstract class AbstractPlatformTestCase extends TestCase
         self::assertTrue($this->platform->isCommentedDoctrineType($type));
     }
 
+    public function testEmptyTableDiff(): void
+    {
+        $diff = new TableDiff('test');
+
+        self::assertTrue($diff->isEmpty());
+        self::assertSame([], $this->platform->getAlterTableSQL($diff));
+    }
+
     public function tearDown(): void
     {
         if (! isset($this->backedUpType)) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

Null references are often referred to as "The Billion Dollar Mistake". They require checking the type of the variable at runtime before passing it down the line or, otherwise, its usage may result in a type error.

The number of the assertions like the following in our test suite illustrates that well enough:
```shell
git grep 'assertNotFalse' -- tests | grep -i diff -c
49
```

The need for such assertions could be eliminated if table comparison always resulted in a non-null (currently, non-false) value (this is already the case for `Comparator::compareSchemas()`).

An empty diff can be safely passed down the line and will result in a no-op (see the newly added tests). If the business logic requires checking whether the diff is empty, the newly introduced `isEmpty()` methods could be used for that.