### PR TITLE
Add 3.5 and 4.0 to .doctrine-project.json

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -6,14 +6,23 @@
     "docsSlug": "doctrine-dbal",
     "versions": [
         {
+            "name": "4.0",
+            "branchName": "4.0.x",
+            "slug": "latest",
+            "upcoming": true
+        },
+        {
+            "name": "3.5",
+            "branchName": "3.5.x",
+            "slug": "3.5",
+            "upcoming": true
+        },
+        {
             "name": "3.4",
             "branchName": "3.4.x",
-            "slug": "latest",
+            "slug": "current",
             "current": true,
-            "aliases": [
-                "current",
-                "stable"
-            ]
+            "aliases": ["stable"]
         },
         {
             "name": "3.3",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | documentation
| Fixed issues | N/A

#### Summary

Currently, the documentation for our dev branches in not rendered on the [Doctrine website](https://www.doctrine-project.org/projects/dbal.html). In order to change that I'm proposing to include information about our dev branches in the .doctrine-project.json file.
