### PR TITLE
Remove SchemaDiff::toSql() and SchemaDiff::toSaveSql()

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -42,10 +42,6 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
-                <referencedMethod name="Doctrine\DBAL\Schema\SchemaDiff::toSql"/>
-                <!--
-                    TODO: remove in 4.0.0
-                -->
                 <referencedMethod name="Doctrine\DBAL\Schema\Comparator::diffTable"/>
             </errorLevel>
         </DeprecatedMethod>


### PR DESCRIPTION
The methods being removed were deprecated in https://github.com/doctrine/dbal/pull/5766.