### PR TITLE
Remove irrelevant @throws annotations

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1560,8 +1560,6 @@ abstract class AbstractPlatform
      *          a string that defines the complete column
      *
      * @return string DBMS specific SQL code portion that should be used to declare the column.
-     *
-     * @throws Exception
      */
     public function getColumnDeclarationSQL(string $name, array $column): string
     {
@@ -2401,8 +2399,6 @@ abstract class AbstractPlatform
 
     /**
      * Compares the definitions of the given columns in the context of this platform.
-     *
-     * @throws Exception
      */
     public function columnsEqual(Column $column1, Column $column2): bool
     {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -339,8 +339,6 @@ abstract class AbstractPlatform
 
     /**
      * Gets the Doctrine type that is mapped for the given database column type.
-     *
-     * @throws Exception
      */
     public function getDoctrineTypeMapping(string $dbType): string
     {
@@ -835,8 +833,6 @@ abstract class AbstractPlatform
      * on this platform.
      *
      * @return list<string> The list of SQL statements.
-     *
-     * @throws Exception
      */
     public function getCreateTableSQL(Table $table): array
     {
@@ -847,19 +843,13 @@ abstract class AbstractPlatform
      * @internal
      *
      * @return list<string>
-     *
-     * @throws Exception
      */
     final protected function getCreateTableWithoutForeignKeysSQL(Table $table): array
     {
         return $this->buildCreateTableSQL($table, false);
     }
 
-    /**
-     * @return list<string>
-     *
-     * @throws Exception
-     */
+    /** @return list<string> */
     private function buildCreateTableSQL(Table $table, bool $createForeignKeys): array
     {
         if (count($table->getColumns()) === 0) {
@@ -958,8 +948,6 @@ abstract class AbstractPlatform
      * @param list<Table> $tables
      *
      * @return list<string>
-     *
-     * @throws Exception
      */
     public function getCreateTablesSQL(array $tables): array
     {
@@ -1102,8 +1090,6 @@ abstract class AbstractPlatform
      * Generates SQL statements that can be used to apply the diff.
      *
      * @return list<string>
-     *
-     * @throws Exception
      */
     public function getAlterSchemaSQL(SchemaDiff $diff): array
     {
@@ -2231,8 +2217,6 @@ abstract class AbstractPlatform
 
     /**
      * Adds an driver-specific LIMIT clause to the query.
-     *
-     * @throws Exception
      */
     final public function modifyLimitQuery(string $query, ?int $limit, int $offset = 0): string
     {

--- a/src/Platforms/Exception/NoColumnsSpecifiedForTable.php
+++ b/src/Platforms/Exception/NoColumnsSpecifiedForTable.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\Exception;
 
-use Exception;
+use LogicException;
 
 use function sprintf;
 
 /** @psalm-immutable */
-final class NoColumnsSpecifiedForTable extends Exception implements PlatformException
+final class NoColumnsSpecifiedForTable extends LogicException implements PlatformException
 {
     public static function new(string $tableName): self
     {

--- a/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\SQL\Builder;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
@@ -18,11 +17,7 @@ final class CreateSchemaObjectsSQLBuilder
     {
     }
 
-    /**
-     * @return list<string>
-     *
-     * @throws Exception
-     */
+    /** @return list<string> */
     public function buildSQL(Schema $schema): array
     {
         return array_merge(
@@ -54,8 +49,6 @@ final class CreateSchemaObjectsSQLBuilder
      * @param list<Table> $tables
      *
      * @return list<string>
-     *
-     * @throws Exception
      */
     private function buildTableStatements(array $tables): array
     {

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 use function array_map;
@@ -24,8 +23,6 @@ class Comparator
 
     /**
      * Returns the differences between the schemas.
-     *
-     * @throws Exception
      */
     public function compareSchemas(Schema $oldSchema, Schema $newSchema): SchemaDiff
     {
@@ -143,8 +140,6 @@ class Comparator
 
     /**
      * Compares the tables and returns the difference between them.
-     *
-     * @throws Exception
      */
     public function compareTables(Table $oldTable, Table $newTable): TableDiff
     {
@@ -280,8 +275,6 @@ class Comparator
      * @param array<string,Column> $removedColumns
      *
      * @return array<string,Column>
-     *
-     * @throws Exception
      */
     private function detectRenamedColumns(array &$addedColumns, array &$removedColumns): array
     {
@@ -405,8 +398,6 @@ class Comparator
 
     /**
      * Compares the definitions of the given columns
-     *
-     * @throws Exception
      */
     protected function columnsEqual(Column $column1, Column $column2): bool
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

At the time of its introduction in https://github.com/doctrine/dbal/pull/4746, `Comparator::columnsEqual()` was annotated with `@throws Exception` because the following code flow could result in one: `Comparator::columnsEqual()` → `AbstractPlatform::columnsEqual()` → `AbstractPlatform::getColumnDeclarationSQL()` → `AbstractPlatform::getInlineColumnCommentSQL()`. The last method in the chain would throw an exception if the platform didn't support inline column comments.

As of https://github.com/doctrine/dbal/pull/5727, the `NotSupported` exception is declared as unchecked (extends `LogicException`), so this code path no longer throws a checked exception. In fact, this makes the Comparator API free of checked exceptions.

Additionally, declaring `NoColumnsSpecifiedForTable` as unchecked allows removing most of the `@throws` annotations from the Platform API. The remaining @throws is related to the type registry and is out of the scope of this change.

Note that the recent versions of PHPStan support analyzing the `@throws` (see [Bring your exceptions under control with @throws](https://phpstan.org/blog/bring-your-exceptions-under-control)). We may want to use them on CI in the future.