### PR TITLE
Getting a list of tables with partitioned tables in PostgreSQL

### DIFF
--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -655,7 +655,7 @@ SQL;
 
         $conditions = array_merge([
             'a.attnum > 0',
-            "c.relkind = 'r'",
+            "c.relkind IN ('r', 'p')",
             'd.refobjid IS NULL',
         ], $this->buildQueryConditions($tableName));
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

<!-- Provide a summary of your change. -->
In PostgreSQL SchemaManager::list Tables() did not output partitioned tables. As a result, when executing doctrine:migrations:diff, existing tables were added to the migration.