### PR TITLE
Clean up MySQL version detection logic

### DIFF
--- a/tests/Driver/AbstractDriverTest.php
+++ b/tests/Driver/AbstractDriverTest.php
@@ -5,7 +5,6 @@ namespace Doctrine\DBAL\Tests\Driver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
@@ -60,16 +59,6 @@ abstract class AbstractDriverTest extends TestCase
                 ),
             );
         }
-    }
-
-    public function testThrowsExceptionOnCreatingDatabasePlatformsForInvalidVersion(): void
-    {
-        if (! $this->driver instanceof VersionAwarePlatformDriver) {
-            self::markTestSkipped('This test is only intended for version aware platform drivers.');
-        }
-
-        $this->expectException(Exception::class);
-        $this->driver->createDatabasePlatformForVersion('foo');
     }
 
     public function testReturnsDatabasePlatform(): void

--- a/tests/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Driver/AbstractMySQLDriverTest.php
@@ -48,21 +48,17 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
     {
         return [
             ['5.6.9', MySQLPlatform::class],
-            ['5.7', MySQL57Platform::class],
             ['5.7.0', MySQLPlatform::class],
             ['5.7.8', MySQLPlatform::class],
             ['5.7.9', MySQL57Platform::class],
             ['5.7.10', MySQL57Platform::class],
-            ['8', MySQL80Platform::class],
-            ['8.0', MySQL80Platform::class],
             ['8.0.11', MySQL80Platform::class],
-            ['6', MySQL57Platform::class],
             ['10.0.15-MariaDB-1~wheezy', MySQLPlatform::class],
             ['5.5.5-10.1.25-MariaDB', MySQLPlatform::class],
             ['10.1.2a-MariaDB-a1~lenny-log', MySQLPlatform::class],
             ['5.5.40-MariaDB-1~wheezy', MySQLPlatform::class],
-            ['5.5.5-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
-            ['10.2.8-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
+            ['5.5.5-10.2.8-MariaDB-1~xenial', MariaDb1027Platform::class],
+            ['5.5.5-10.2.8-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
             ['10.2.8-MariaDB-1~lenny-log', MariaDb1027Platform::class],
         ];
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

The logic of MySQL or MariaDB version detection is unnecessarily complicated:
1. We do not need to parse the version using regular expressions. Comparing the version via `version_compare()` is sufficient.
2. As for MariaDB, we just need to detect it by the "MariaDB" substring and strip the "5.5.5-" prefix, which the older MariaDB versions supply for compatibility with Oracle MySQL. See: https://mariadb.com/kb/en/version/