### PR TITLE
Deprecate QueryBuilder::getConnection()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -293,6 +293,8 @@ Bind parameters using `Statement::bindParam()` or `Statement::bindValue()` inste
 1. The `QueryBuilder::getState()` method has been deprecated as the builder state is an internal concern.
 2. Relying on the type of the query being built by using `QueryBuilder::getType()` has been deprecated.
    If necessary, track the type of the query being built outside of the builder.
+3. The `QueryBuilder::getConnection()` method has been deprecated. Use the connection used to instantiate the builder
+   instead.
 
 The following `QueryBuilder` constants related to the above methods have been deprecated:
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -450,6 +450,10 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\Comparator::diffTable"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::getConnection"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -186,10 +186,19 @@ class QueryBuilder
     /**
      * Gets the associated DBAL Connection for this query builder.
      *
+     * @deprecated Use the connection used to instantiate the builder instead.
+     *
      * @return Connection
      */
     public function getConnection()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5780',
+            '%s is deprecated. Use the connection used to instantiate the builder instead.',
+            __METHOD__,
+        );
+
         return $this->connection;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The connection is an implementation detail of the query builder that it uses to execute the query. There's no need to expose it via the public API.