### PR TITLE
Run tests with Postgres 15

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -211,13 +211,13 @@ jobs:
           - "7.4"
         postgres-version:
           - "9.4"
-          - "13"
           - "14"
+          - "15"
         include:
           - php-version: "8.1"
-            postgres-version: "14"
+            postgres-version: "15"
           - php-version: "8.2"
-            postgres-version: "14"
+            postgres-version: "15"
 
     services:
       postgres:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Postgres 15 is the latest stable Postgres release, so we should test against it in our CI. This PR also drops Postgres 13 from the CI matrix.
