### PR TITLE
Remove QueryBuilder::getConnection()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -430,7 +430,8 @@ The following `QueryBuilder` methods have been removed:
 
 1. `execute()`,
 2. `getState()`,
-3. `getType()`.
+3. `getType()`,
+4. `getConnection()`.
 
 The following `QueryBuilder` constants have been removed:
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -180,23 +180,6 @@ class QueryBuilder
     }
 
     /**
-     * Gets the associated DBAL Connection for this query builder.
-     *
-     * @deprecated Use the connection used to instantiate the builder instead.
-     */
-    public function getConnection(): Connection
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5780',
-            '%s is deprecated. Use the connection used to instantiate the builder instead.',
-            __METHOD__,
-        );
-
-        return $this->connection;
-    }
-
-    /**
      * Prepares and executes an SQL query and returns the first row of the result
      * as an associative array.
      *

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -474,12 +474,6 @@ class QueryBuilderTest extends TestCase
         self::assertEquals('INSERT INTO users (foo, bar) VALUES(?, ?)', (string) $qb);
     }
 
-    public function testGetConnection(): void
-    {
-        $qb = new QueryBuilder($this->conn);
-        self::assertSame($this->conn, $qb->getConnection());
-    }
-
     /** @dataProvider maxResultsProvider */
     public function testSetMaxResults(?int $maxResults): void
     {


### PR DESCRIPTION
The method being removed was deprecated in https://github.com/doctrine/dbal/pull/5780.