### PR TITLE
Wrapping array elements with quotation marks in the "IN"

### DIFF
--- a/src/Query/Expression/ExpressionBuilder.php
+++ b/src/Query/Expression/ExpressionBuilder.php
@@ -289,7 +289,7 @@ class ExpressionBuilder
      */
     public function in($x, $y)
     {
-        return $this->comparison($x, 'IN', '(' . implode(', ', (array) $y) . ')');
+         return $this->comparison($x, 'IN', "('" . implode("', '", $y) . "') ");
     }
 
     /**


### PR DESCRIPTION

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #5792 

#### Summary

<!-- Provide a summary of your change. -->

`\Doctrine\DBAL\Query\Expression\ExpressionBuilder:290`

```php
 return $this->comparison($x, 'IN', "('" . implode("', '", $y) . "') ");
```
