### PR TITLE
Fix .env.local example "mariadb-10.9.3

### DIFF
--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -69,7 +69,7 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
         $mariadb = stripos($versionString, 'MariaDB') !== false;
         if ($mariadb) {
             $matches = [];
-            if (preg_match('/MariaDB-(.*)/i', $versionString, $matches)) {
+            if (preg_match('/^MariaDB-(.*)$/i', $versionString, $matches)) {
                 return $matches[1];
             }
         }

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -66,6 +66,14 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
      */
     private function getMariaDbMysqlVersionNumber(string $versionString): string
     {
+        $mariadb = stripos($versionString, 'MariaDB') !== false;
+        if ($mariadb) {
+            $matches = [];
+            if (preg_match('/MariaDB-(.*)/i', $versionString, $matches)) {
+                return $matches[1];
+            }
+        }
+        
         if (substr($versionString, 0, 6) === '5.5.5-') {
             return substr($versionString, 6);
         }

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -67,20 +67,16 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
     private function getMariaDbMysqlVersionNumber(string $versionString): string
     {
         $mariadb = stripos($versionString, 'MariaDB') !== false;
-        if ($mariadb) {
+        if (false !== $mariadb) {
             $matches = [];
-            if (preg_match('/^MariaDB-(.*)$/i', $versionString, $matches)) {
+            if (preg_match('/MariaDB-(\d+.\d+.\d+)/i', $versionString, $matches)) {
                 return $matches[1];
             }
         }
         
-        if (substr($versionString, 0, 6) === '5.5.5-') {
-            return substr($versionString, 6);
-        }
-
         return $versionString;
     }
-
+    
     /**
      * {@inheritdoc}
      *

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -73,6 +73,10 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
                 return $matches[1];
             }
         }
+
+        if (substr($versionString, 0, 6) === '5.5.5-') {
+            return substr($versionString, 6);
+        }
         
         return $versionString;
     }

--- a/tests/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Driver/AbstractMySQLDriverTest.php
@@ -60,6 +60,7 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
             ['5.5.5-10.2.8-MariaDB-1~xenial', MariaDb1027Platform::class],
             ['5.5.5-10.2.8-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
             ['10.2.8-MariaDB-1~lenny-log', MariaDb1027Platform::class],
+            ['mariadb-10.9.3', MariaDb1027Platform::class],
         ];
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | 

#### Summary

<!-- Provide a summary of your change. -->
1. Open my own project where I have .env.local mariadb-10.9.3 according documentation https://symfony.com/doc/current/reference/configuration/doctrine.html
2. composer up
3. Got validation error "The metadata storage is not up to date, please run the sync-metadata-storage command to fix this issue."

No issue on version 3.4.6 only on new 3.5.x version