### PR TITLE
Remove table restriction for PostgreSQL column listing

### DIFF
--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -655,7 +655,6 @@ SQL;
 
         $conditions = array_merge([
             'a.attnum > 0',
-            "c.relkind = 'r'",
             'd.refobjid IS NULL',
         ], $this->buildQueryConditions($tableName));
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues |#5821, #5671

#### Summary

Removes the restriction from PostgreSQL when listing columns to only take into consideration "table" type table sources and not include views and other table sources.

As described in #5821, the bug was introduced in https://github.com/doctrine/dbal/commit/194c6eb7b78173fb8ae0ece8bc85be80d0364d89.

The change in the mentioned commit was a breaking change that was not mentioned in the PR containing the commit (#5268). Nor was it mentioned in the changelog as a breaking commit. This, together with the fact that this behavior is inconsistent with SQL Server's `SQLServerSchemaManager` (i.e. that one _does_ return columns from views) I believe we can safely say that the breaking change was _not_ intentional, and should be corrected to its pre-breaking state and to be consistent with SQL Server (and potentially other database types).

In case there is a doubt that view columns should be listable here: table type tables can only contain table type columns. View type tables can only contain view type columns. The restriction to table type tables serve no other purpose than to make scanning of columns for view type tables useless (returning an empty list of columns). _Not allowing view-type columns to be listed from a regular table wouldn't do anything extra, because normal tables only contain table-type columns either way._