### PR TITLE
Protect reserved keywords used as columns

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -721,11 +721,12 @@ class Connection
     public function update($table, array $data, array $criteria, array $types = [])
     {
         $columns = $values = $conditions = $set = [];
+        $keywords = $this->getDatabasePlatform()->getReservedKeywordsList();
 
         foreach ($data as $columnName => $value) {
             $columns[] = $columnName;
             $values[]  = $value;
-            $set[]     = $columnName . ' = ?';
+            $set[]     = $keywords->isKeyword($columnName) ? $this->quoteIdentifier($columnName) : $columnName . ' = ?';
         }
 
         $this->addCriteriaCondition($criteria, $columns, $values, $conditions);
@@ -759,12 +760,13 @@ class Connection
             return $this->executeStatement('INSERT INTO ' . $table . ' () VALUES ()');
         }
 
+        $keywords = $this->getDatabasePlatform()->getReservedKeywordsList();
         $columns = [];
         $values  = [];
         $set     = [];
 
         foreach ($data as $columnName => $value) {
-            $columns[] = $columnName;
+            $columns[] = $keywords->isKeyword($columnName) ? $this->quoteIdentifier($columnName) : $columnName;
             $values[]  = $value;
             $set[]     = '?';
         }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

#### Summary

Protect reserved keywords used as columns in update/insert sql statements.

Project `fusio`, which depends on `dbal`, has column with name  `public`. It is reserved word for MS SQL. Installation failes on inserting data to a table with column `public`. The idea is to filter all the columns and protect the ones which have reserved names.
