### PR TITLE
Document tuple return type of `generateCacheKeys()`

### DIFF
--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -113,7 +113,7 @@ class QueryCacheProfile
      * @param array<int, Type|int|string|null>|array<string, Type|int|string|null> $types
      * @param array<string, mixed>                                                 $connectionParams
      *
-     * @return string[]
+     * @return array{string, string}
      */
     public function generateCacheKeys($sql, $params, $types, array $connectionParams = [])
     {
@@ -127,11 +127,7 @@ class QueryCacheProfile
             '&connectionParams=' . hash('sha256', serialize($connectionParams));
 
         // should the key be automatically generated using the inputs or is the cache key set?
-        if ($this->cacheKey === null) {
-            $cacheKey = sha1($realCacheKey);
-        } else {
-            $cacheKey = $this->cacheKey;
-        }
+        $cacheKey = $this->cacheKey ?? sha1($realCacheKey);
 
         return [$cacheKey, $realCacheKey];
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

This fixes a static analysis error in the ORM. `QueryCacheProfile::generateCacheKeys()` always returns a tuple of exactly two strings, but its return type is declared as `string[]`. Let's be more precise here.