### PR TITLE
Restore `Connection::ARRAY_PARAM_OFFSET`

### DIFF
--- a/src/ArrayParameterType.php
+++ b/src/ArrayParameterType.php
@@ -7,22 +7,17 @@ final class ArrayParameterType
     /**
      * Represents an array of ints to be expanded by Doctrine SQL parsing.
      */
-    public const INTEGER = ParameterType::INTEGER + self::ARRAY_PARAM_OFFSET;
+    public const INTEGER = ParameterType::INTEGER + Connection::ARRAY_PARAM_OFFSET;
 
     /**
      * Represents an array of strings to be expanded by Doctrine SQL parsing.
      */
-    public const STRING = ParameterType::STRING + self::ARRAY_PARAM_OFFSET;
+    public const STRING = ParameterType::STRING + Connection::ARRAY_PARAM_OFFSET;
 
     /**
      * Represents an array of ascii strings to be expanded by Doctrine SQL parsing.
      */
-    public const ASCII = ParameterType::ASCII + self::ARRAY_PARAM_OFFSET;
-
-    /**
-     * Offset by which PARAM_* constants are detected as arrays of the param type.
-     */
-    private const ARRAY_PARAM_OFFSET = 100;
+    public const ASCII = ParameterType::ASCII + Connection::ARRAY_PARAM_OFFSET;
 
     /**
      * @internal
@@ -33,7 +28,7 @@ final class ArrayParameterType
      */
     public static function toElementParameterType(int $type): int
     {
-        return $type - self::ARRAY_PARAM_OFFSET;
+        return $type - Connection::ARRAY_PARAM_OFFSET;
     }
 
     private function __construct()

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -70,6 +70,13 @@ class Connection
     public const PARAM_ASCII_STR_ARRAY = ArrayParameterType::ASCII;
 
     /**
+     * Offset by which PARAM_* constants are detected as arrays of the param type.
+     *
+     * @internal Should be used only within the wrapper layer.
+     */
+    public const ARRAY_PARAM_OFFSET = 100;
+
+    /**
      * The wrapped driver connection.
      *
      * @var \Doctrine\DBAL\Driver\Connection|null


### PR DESCRIPTION
I'm restoring an internal constant I've removed with #5838. Apparently the ORM still uses it (see https://github.com/doctrine/dbal/issues/5837#issuecomment-1367679813). It's going to be removed in 4.0 anyway, so let's keep it where it is for now.