### PR TITLE
Trigger a deprecation for versions that will be parsed differently

### DIFF
--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -41,10 +41,28 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
         if (! $mariadb) {
             $oracleMysqlVersion = $this->getOracleMysqlVersionNumber($version);
             if (version_compare($oracleMysqlVersion, '8', '>=')) {
+                if (! version_compare($version, '8.0.0', '>=')) {
+                    Deprecation::trigger(
+                        'doctrine/orm',
+                        'https://github.com/doctrine/dbal/pull/5779',
+                        'Version detection logic for MySQL will change in DBAL 4. '
+                            . 'Please specify the version as the server reports it, e.g. "8.0.31" instead of "8".',
+                    );
+                }
+
                 return new MySQL80Platform();
             }
 
             if (version_compare($oracleMysqlVersion, '5.7.9', '>=')) {
+                if (! version_compare($version, '5.7.9', '>=')) {
+                    Deprecation::trigger(
+                        'doctrine/orm',
+                        'https://github.com/doctrine/dbal/pull/5779',
+                        'Version detection logic for MySQL will change in DBAL 4. '
+                        . 'Please specify the version as the server reports it, e.g. "5.7.40" instead of "5.7".',
+                    );
+                }
+
                 return new MySQL57Platform();
             }
         }
@@ -103,6 +121,16 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
      */
     private function getMariaDbMysqlVersionNumber(string $versionString): string
     {
+        if (stripos($versionString, 'MariaDB') === 0) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/dbal/pull/5779',
+                'Version detection logic for MySQL will change in DBAL 4. '
+                    . 'Please specify the version as the server reports it, '
+                    . 'e.g. "10.9.3-MariaDB" instead of "mariadb-10.9".',
+            );
+        }
+
         if (
             preg_match(
                 '/^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)/i',

--- a/tests/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Driver/AbstractMySQLDriverTest.php
@@ -44,26 +44,42 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
     /**
      * {@inheritDoc}
      */
-    protected function getDatabasePlatformsForVersions(): array
+    public function getDatabasePlatformsForVersions(): array
     {
         return [
-            ['5.6.9', MySQLPlatform::class],
-            ['5.7', MySQL57Platform::class],
-            ['5.7.0', MySQLPlatform::class],
-            ['5.7.8', MySQLPlatform::class],
-            ['5.7.9', MySQL57Platform::class],
-            ['5.7.10', MySQL57Platform::class],
-            ['8', MySQL80Platform::class],
-            ['8.0', MySQL80Platform::class],
-            ['8.0.11', MySQL80Platform::class],
+            ['5.6.9', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
+            ['5.7', MySQL57Platform::class, 'https://github.com/doctrine/dbal/pull/5779', true],
+            ['5.7.0', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
+            ['5.7.8', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
+            ['5.7.9', MySQL57Platform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
+            ['5.7.10', MySQL57Platform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
+            ['8', MySQL80Platform::class, 'https://github.com/doctrine/dbal/pull/5779', true],
+            ['8.0', MySQL80Platform::class, 'https://github.com/doctrine/dbal/pull/5779', true],
+            ['8.0.11', MySQL80Platform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
             ['6', MySQL57Platform::class],
-            ['10.0.15-MariaDB-1~wheezy', MySQLPlatform::class],
-            ['5.5.5-10.1.25-MariaDB', MySQLPlatform::class],
-            ['10.1.2a-MariaDB-a1~lenny-log', MySQLPlatform::class],
-            ['5.5.40-MariaDB-1~wheezy', MySQLPlatform::class],
-            ['5.5.5-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
-            ['10.2.8-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
-            ['10.2.8-MariaDB-1~lenny-log', MariaDb1027Platform::class],
+            ['10.0.15-MariaDB-1~wheezy', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
+            ['5.5.5-10.1.25-MariaDB', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
+            ['10.1.2a-MariaDB-a1~lenny-log', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
+            ['5.5.40-MariaDB-1~wheezy', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
+            [
+                '5.5.5-MariaDB-10.2.8+maria~xenial-log',
+                MariaDb1027Platform::class,
+                'https://github.com/doctrine/dbal/pull/5779',
+                false,
+            ],
+            [
+                '10.2.8-MariaDB-10.2.8+maria~xenial-log',
+                MariaDb1027Platform::class,
+                'https://github.com/doctrine/dbal/pull/5779',
+                false,
+            ],
+            [
+                '10.2.8-MariaDB-1~lenny-log',
+                MariaDb1027Platform::class,
+                'https://github.com/doctrine/dbal/pull/5779',
+                false,
+            ],
+            ['mariadb-10.9.3',MariaDb1027Platform::class, 'https://github.com/doctrine/dbal/pull/5779', true],
         ];
     }
 }

--- a/tests/Driver/AbstractPostgreSQLDriverTest.php
+++ b/tests/Driver/AbstractPostgreSQLDriverTest.php
@@ -43,7 +43,7 @@ class AbstractPostgreSQLDriverTest extends AbstractDriverTest
     /**
      * {@inheritDoc}
      */
-    protected function getDatabasePlatformsForVersions(): array
+    public function getDatabasePlatformsForVersions(): array
     {
         return [
             ['9.4', PostgreSQL94Platform::class],

--- a/tests/Driver/AbstractSQLServerDriverTest.php
+++ b/tests/Driver/AbstractSQLServerDriverTest.php
@@ -36,7 +36,7 @@ abstract class AbstractSQLServerDriverTest extends AbstractDriverTest
     /**
      * {@inheritDoc}
      */
-    protected function getDatabasePlatformsForVersions(): array
+    public function getDatabasePlatformsForVersions(): array
     {
         return [
             ['12', SQLServer2012Platform::class],


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #5813

#### Summary

#5779 simplified the way we parse MySQL/MariaDB version strings. That change had been reverted on the 3.x series but has been kept for 4.0. This PR adds a runtime deprecation if a version is encountered that will be parsed differently by DBAL 4.
