### PR TITLE
Allow to explicitly set the wrapper class to the default one

### DIFF
--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -16,8 +16,8 @@ use function array_merge;
 use function assert;
 use function class_implements;
 use function in_array;
+use function is_a;
 use function is_string;
-use function is_subclass_of;
 use function parse_str;
 use function parse_url;
 use function preg_replace;
@@ -212,14 +212,9 @@ final class DriverManager
             $driver = $middleware->wrap($driver);
         }
 
-        $wrapperClass = Connection::class;
-        if (isset($params['wrapperClass'])) {
-            if (! is_subclass_of($params['wrapperClass'], $wrapperClass)) {
-                throw Exception::invalidWrapperClass($params['wrapperClass']);
-            }
-
-            /** @var class-string<Connection> $wrapperClass */
-            $wrapperClass = $params['wrapperClass'];
+        $wrapperClass = $params['wrapperClass'] ?? Connection::class;
+        if (! is_a($wrapperClass, Connection::class, true)) {
+            throw Exception::invalidWrapperClass($wrapperClass);
         }
 
         return new $wrapperClass($params, $driver, $config, $eventManager);

--- a/tests/DriverManagerTest.php
+++ b/tests/DriverManagerTest.php
@@ -64,6 +64,18 @@ class DriverManagerTest extends TestCase
         self::assertInstanceOf($wrapperClass, $conn);
     }
 
+    /** @requires extension pdo_sqlite */
+    public function testDefaultWrapper(): void
+    {
+        $options = [
+            'url' => 'sqlite::memory:',
+            'wrapperClass' => Connection::class,
+        ];
+
+        $conn = DriverManager::getConnection($options);
+        self::assertSame(Connection::class, get_class($conn));
+    }
+
     /**
      * @requires extension pdo_sqlite
      * @psalm-suppress InvalidArgument


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

Configuring `Doctrine\DBAL\Connection` as wrapper class results in an error although that's the class DBAL would use by default. It's not really a big deal because I can simply omit the option, but it feels weird nevertheless.