### PR TITLE
Use a narrower return type for DriverManager::getAvailableDrivers()

### DIFF
--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -222,6 +222,7 @@ final class DriverManager
      * Returns the list of supported drivers.
      *
      * @return string[]
+     * @psalm-return list<key-of<self::DRIVER_MAP>>
      */
     public static function getAvailableDrivers(): array
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Adds a `@psalm-return` annotation to `DriverManager::getAvailableDrivers()` so the return type is narrower than just `array<array-key, string>`.
