### PR TITLE
Use narrower return types for convertTo*Value methods

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3499,9 +3499,11 @@ abstract class AbstractPlatform
      *
      * The default conversion tries to convert value into bool "(bool)$item"
      *
-     * @param mixed $item
+     * @param T $item
      *
-     * @return bool|null
+     * @return (T is null ? null : bool)
+     *
+     * @template T
      */
     public function convertFromBoolean($item)
     {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -957,6 +957,12 @@ SQL
 
     /**
      * {@inheritDoc}
+     *
+     * @param T $item
+     *
+     * @return (T is null ? null : bool)
+     *
+     * @template T
      */
     public function convertFromBoolean($item)
     {

--- a/src/Types/BigIntType.php
+++ b/src/Types/BigIntType.php
@@ -36,6 +36,12 @@ class BigIntType extends Type implements PhpIntegerMappingType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/BooleanType.php
+++ b/src/Types/BooleanType.php
@@ -30,6 +30,12 @@ class BooleanType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : bool)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/DateImmutableType.php
+++ b/src/Types/DateImmutableType.php
@@ -21,6 +21,12 @@ class DateImmutableType extends DateType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -41,6 +47,12 @@ class DateImmutableType extends DateType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : DateTimeImmutable)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/DateIntervalType.php
+++ b/src/Types/DateIntervalType.php
@@ -36,6 +36,12 @@ class DateIntervalType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -52,6 +58,12 @@ class DateIntervalType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : DateInterval)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/DateTimeImmutableType.php
+++ b/src/Types/DateTimeImmutableType.php
@@ -23,6 +23,12 @@ class DateTimeImmutableType extends DateTimeType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -43,6 +49,12 @@ class DateTimeImmutableType extends DateTimeType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : DateTimeImmutable)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -31,6 +31,12 @@ class DateTimeType extends Type implements PhpDateTimeMappingType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -47,6 +53,12 @@ class DateTimeType extends Type implements PhpDateTimeMappingType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : DateTimeInterface)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/DateTimeTzImmutableType.php
+++ b/src/Types/DateTimeTzImmutableType.php
@@ -21,6 +21,12 @@ class DateTimeTzImmutableType extends DateTimeTzType
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -41,6 +47,12 @@ class DateTimeTzImmutableType extends DateTimeTzType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : DateTimeImmutable)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/DateTimeTzType.php
+++ b/src/Types/DateTimeTzType.php
@@ -42,6 +42,12 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -62,6 +68,12 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : DateTimeInterface)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/DateType.php
+++ b/src/Types/DateType.php
@@ -29,6 +29,12 @@ class DateType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -45,6 +51,12 @@ class DateType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : DateTimeInterface)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/FloatType.php
+++ b/src/Types/FloatType.php
@@ -24,6 +24,12 @@ class FloatType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : float)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/IntegerType.php
+++ b/src/Types/IntegerType.php
@@ -28,6 +28,12 @@ class IntegerType extends Type implements PhpIntegerMappingType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : int)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/JsonType.php
+++ b/src/Types/JsonType.php
@@ -29,6 +29,12 @@ class JsonType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/ObjectType.php
+++ b/src/Types/ObjectType.php
@@ -29,6 +29,10 @@ class ObjectType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @param mixed $value
+     *
+     * @return string
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/SimpleArrayType.php
+++ b/src/Types/SimpleArrayType.php
@@ -29,6 +29,10 @@ class SimpleArrayType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @param mixed $value
+     *
+     * @return string|null
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -41,6 +45,10 @@ class SimpleArrayType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @param mixed $value
+     *
+     * @return list<string>
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/SmallIntType.php
+++ b/src/Types/SmallIntType.php
@@ -28,6 +28,12 @@ class SmallIntType extends Type implements PhpIntegerMappingType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : int)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/TimeImmutableType.php
+++ b/src/Types/TimeImmutableType.php
@@ -21,6 +21,12 @@ class TimeImmutableType extends TimeType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -41,6 +47,12 @@ class TimeImmutableType extends TimeType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : DateTimeImmutable)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/TimeType.php
+++ b/src/Types/TimeType.php
@@ -29,6 +29,12 @@ class TimeType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -45,6 +51,12 @@ class TimeType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : DateTimeInterface)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/VarDateTimeImmutableType.php
+++ b/src/Types/VarDateTimeImmutableType.php
@@ -23,6 +23,12 @@ class VarDateTimeImmutableType extends VarDateTimeType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : string)
+     *
+     * @template T
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -43,6 +49,12 @@ class VarDateTimeImmutableType extends VarDateTimeType
 
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : DateTimeImmutable)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Types/VarDateTimeType.php
+++ b/src/Types/VarDateTimeType.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Types;
 
 use DateTime;
+use DateTimeInterface;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 use function date_create;
@@ -18,6 +19,12 @@ class VarDateTimeType extends DateTimeType
 {
     /**
      * {@inheritdoc}
+     *
+     * @param T $value
+     *
+     * @return (T is null ? null : DateTimeInterface)
+     *
+     * @template T
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Narrows down the `mixed` return type from `Type` in extending classes.
