### PR TITLE
fix platform comparator issues when using compareTables

### DIFF
--- a/src/Platforms/MySQL/Comparator.php
+++ b/src/Platforms/MySQL/Comparator.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Platforms\MySQL;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Schema\Comparator as BaseComparator;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
 
 use function array_diff_assoc;
 use function array_intersect_key;
@@ -27,6 +28,14 @@ class Comparator extends BaseComparator
         parent::__construct($platform);
 
         $this->collationMetadataProvider = $collationMetadataProvider;
+    }
+
+    public function compareTables(Table $fromTable, Table $toTable): TableDiff
+    {
+        return parent::compareTables(
+            $this->normalizeColumns($fromTable),
+            $this->normalizeColumns($toTable),
+        );
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | https://github.com/doctrine/migrations/issues/1302
#### Summary

Fixes an issue I reported on `doctrine/migrations`: https://github.com/doctrine/migrations/issues/1302#issuecomment-1379221322

When using the non-deprecated `compareTables` we basically did not normalize anything with the Mysql (and other platforms) Comparator implementation.
