### PR TITLE
Allow passing url to override params

### DIFF
--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -42,6 +42,7 @@ use function substr;
  *     pdo?: \PDO,
  *     platform?: Platforms\AbstractPlatform,
  *     port?: int,
+ *     url?: string,
  *     user?: string,
  *     unix_socket?: string,
  * }


### PR DESCRIPTION
Update OverrideParams array shape in DriverManager to allow passing url

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | (not otherwise reported)

#### Summary

The url parameter was removed in type hints (probably accidentally in the 3.5 branch as there passing an url should still be allowed, it was only removed for 4.0).

This is similiar to https://github.com/doctrine/dbal/pull/5857, but in the `OverrideParams` the `url` param was still not allowed.
But in fact it should be allowed as it should still be possible to configure e.g replica connections with an url.
