### PR TITLE
Flag parameters as sensitive if they could contain the database password

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -101,6 +101,7 @@ parameters:
             message: '~^Casting to bool something that''s already bool\.$~'
             paths:
                 - src/Connections/PrimaryReadReplicaConnection.php
+                - src/Driver/SQLite3/Driver.php
 
         # Type check for legacy implementations of the Connection interface
         # TODO: remove in 4.0.0

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -25,6 +25,7 @@ use Doctrine\DBAL\SQL\Parser;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
+use SensitiveParameter;
 use Throwable;
 use Traversable;
 
@@ -173,6 +174,7 @@ class Connection
      * @throws Exception
      */
     public function __construct(
+        #[SensitiveParameter]
         array $params,
         Driver $driver,
         ?Configuration $config = null,
@@ -1099,7 +1101,7 @@ class Connection
         }
 
         $connectionParams = $this->params;
-        unset($connectionParams['platform']);
+        unset($connectionParams['platform'], $connectionParams['password'], $connectionParams['url']);
 
         [$cacheKey, $realKey] = $qcp->generateCacheKeys($sql, $params, $types, $connectionParams);
 

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Statement;
 use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
+use SensitiveParameter;
 
 use function array_rand;
 use function count;
@@ -263,8 +264,11 @@ class PrimaryReadReplicaConnection extends Connection
      *
      * @return mixed
      */
-    protected function chooseConnectionConfiguration($connectionName, $params)
-    {
+    protected function chooseConnectionConfiguration(
+        $connectionName,
+        #[SensitiveParameter]
+        $params
+    ) {
         if ($connectionName === 'primary') {
             return $params['primary'];
         }

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use SensitiveParameter;
 
 /**
  * Driver interface.
@@ -23,7 +24,10 @@ interface Driver
      *
      * @throws Exception
      */
-    public function connect(array $params);
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    );
 
     /**
      * Gets the DatabasePlatform instance that provides all the metadata about

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -12,13 +12,16 @@ use SensitiveParameter;
 /**
  * Driver interface.
  * Interface that all DBAL drivers must implement.
+ *
+ * @psalm-import-type Params from DriverManager
  */
 interface Driver
 {
     /**
      * Attempts to create a connection with the database.
      *
-     * @param mixed[] $params All connection parameters.
+     * @param array<string, mixed> $params All connection parameters.
+     * @psalm-param Params $params All connection parameters.
      *
      * @return DriverConnection The database connection.
      *

--- a/src/Driver/AbstractOracleDriver.php
+++ b/src/Driver/AbstractOracleDriver.php
@@ -54,7 +54,7 @@ abstract class AbstractOracleDriver implements Driver
     /**
      * Returns an appropriate Easy Connect String for the given parameters.
      *
-     * @param mixed[] $params The connection parameters to return the Easy Connect String for.
+     * @param array<string, mixed> $params The connection parameters to return the Easy Connect String for.
      *
      * @return string
      */

--- a/src/Driver/AbstractSQLiteDriver/Middleware/EnableForeignKeys.php
+++ b/src/Driver/AbstractSQLiteDriver/Middleware/EnableForeignKeys.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use SensitiveParameter;
 
 class EnableForeignKeys implements Middleware
 {
@@ -15,8 +16,10 @@ class EnableForeignKeys implements Middleware
             /**
              * {@inheritDoc}
              */
-            public function connect(array $params): Connection
-            {
+            public function connect(
+                #[SensitiveParameter]
+                array $params
+            ): Connection {
                 $connection = parent::connect($params);
 
                 $connection->exec('PRAGMA foreign_keys=ON');

--- a/src/Driver/IBMDB2/DataSourceName.php
+++ b/src/Driver/IBMDB2/DataSourceName.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\IBMDB2;
 
+use SensitiveParameter;
+
 use function implode;
 use function sprintf;
 use function strpos;
@@ -15,8 +17,10 @@ final class DataSourceName
 {
     private string $string;
 
-    private function __construct(string $string)
-    {
+    private function __construct(
+        #[SensitiveParameter]
+        string $string
+    ) {
         $this->string = $string;
     }
 
@@ -30,8 +34,10 @@ final class DataSourceName
      *
      * @param array<string,mixed> $params
      */
-    public static function fromArray(array $params): self
-    {
+    public static function fromArray(
+        #[SensitiveParameter]
+        array $params
+    ): self {
         $chunks = [];
 
         foreach ($params as $key => $value) {
@@ -46,8 +52,10 @@ final class DataSourceName
      *
      * @param array<string,mixed> $params
      */
-    public static function fromConnectionParameters(array $params): self
-    {
+    public static function fromConnectionParameters(
+        #[SensitiveParameter]
+        array $params
+    ): self {
         if (isset($params['dbname']) && strpos($params['dbname'], '=') !== false) {
             return new self($params['dbname']);
         }

--- a/src/Driver/IBMDB2/Driver.php
+++ b/src/Driver/IBMDB2/Driver.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Driver\IBMDB2;
 
 use Doctrine\DBAL\Driver\AbstractDB2Driver;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionFailed;
+use SensitiveParameter;
 
 use function db2_connect;
 use function db2_pconnect;
@@ -15,8 +16,10 @@ final class Driver extends AbstractDB2Driver
      *
      * @return Connection
      */
-    public function connect(array $params)
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ) {
         $dataSourceName = DataSourceName::fromConnectionParameters($params)->toString();
 
         $username      = $params['user'] ?? '';

--- a/src/Driver/Middleware/AbstractDriverMiddleware.php
+++ b/src/Driver/Middleware/AbstractDriverMiddleware.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 use Doctrine\Deprecations\Deprecation;
+use SensitiveParameter;
 
 abstract class AbstractDriverMiddleware implements VersionAwarePlatformDriver
 {
@@ -21,8 +22,10 @@ abstract class AbstractDriverMiddleware implements VersionAwarePlatformDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params)
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ) {
         return $this->wrappedDriver->connect($params);
     }
 

--- a/src/Driver/Mysqli/Initializer/Secure.php
+++ b/src/Driver/Mysqli/Initializer/Secure.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Driver\Mysqli\Initializer;
 
 use Doctrine\DBAL\Driver\Mysqli\Initializer;
 use mysqli;
+use SensitiveParameter;
 
 final class Secure implements Initializer
 {
@@ -15,8 +16,14 @@ final class Secure implements Initializer
     private string $capath;
     private string $cipher;
 
-    public function __construct(string $key, string $cert, string $ca, string $capath, string $cipher)
-    {
+    public function __construct(
+        #[SensitiveParameter]
+        string $key,
+        string $cert,
+        string $ca,
+        string $capath,
+        string $cipher
+    ) {
         $this->key    = $key;
         $this->cert   = $cert;
         $this->ca     = $ca;

--- a/src/Driver/OCI8/Driver.php
+++ b/src/Driver/OCI8/Driver.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Driver\OCI8;
 
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
 use Doctrine\DBAL\Driver\OCI8\Exception\ConnectionFailed;
+use SensitiveParameter;
 
 use function oci_connect;
 use function oci_pconnect;
@@ -20,8 +21,10 @@ final class Driver extends AbstractOracleDriver
      *
      * @return Connection
      */
-    public function connect(array $params)
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ) {
         $username    = $params['user'] ?? '';
         $password    = $params['password'] ?? '';
         $charset     = $params['charset'] ?? '';

--- a/src/Driver/OCI8/Middleware/InitializeSession.php
+++ b/src/Driver/OCI8/Middleware/InitializeSession.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use SensitiveParameter;
 
 class InitializeSession implements Middleware
 {
@@ -15,8 +16,10 @@ class InitializeSession implements Middleware
             /**
              * {@inheritDoc}
              */
-            public function connect(array $params): Connection
-            {
+            public function connect(
+                #[SensitiveParameter]
+                array $params
+            ): Connection {
                 $connection = parent::connect($params);
 
                 $connection->exec(

--- a/src/Driver/PDO/MySQL/Driver.php
+++ b/src/Driver/PDO/MySQL/Driver.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDO\Exception;
 use PDO;
 use PDOException;
+use SensitiveParameter;
 
 final class Driver extends AbstractMySQLDriver
 {
@@ -15,17 +16,22 @@ final class Driver extends AbstractMySQLDriver
      *
      * @return Connection
      */
-    public function connect(array $params)
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ) {
         $driverOptions = $params['driverOptions'] ?? [];
 
         if (! empty($params['persistent'])) {
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
+        $safeParams = $params;
+        unset($safeParams['password'], $safeParams['url']);
+
         try {
             $pdo = new PDO(
-                $this->constructPdoDsn($params),
+                $this->constructPdoDsn($safeParams),
                 $params['user'] ?? '',
                 $params['password'] ?? '',
                 $driverOptions,

--- a/src/Driver/PDO/OCI/Driver.php
+++ b/src/Driver/PDO/OCI/Driver.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDO\Exception;
 use PDO;
 use PDOException;
+use SensitiveParameter;
 
 final class Driver extends AbstractOracleDriver
 {
@@ -15,13 +16,18 @@ final class Driver extends AbstractOracleDriver
      *
      * @return Connection
      */
-    public function connect(array $params)
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ) {
         $driverOptions = $params['driverOptions'] ?? [];
 
         if (! empty($params['persistent'])) {
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
+
+        $safeParams = $params;
+        unset($safeParams['password'], $safeParams['url']);
 
         try {
             $pdo = new PDO(

--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
+use SensitiveParameter;
 
 final class Driver extends AbstractPostgreSQLDriver
 {
@@ -16,17 +17,22 @@ final class Driver extends AbstractPostgreSQLDriver
      *
      * @return Connection
      */
-    public function connect(array $params)
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ) {
         $driverOptions = $params['driverOptions'] ?? [];
 
         if (! empty($params['persistent'])) {
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
+        $safeParams = $params;
+        unset($safeParams['password'], $safeParams['url']);
+
         try {
             $pdo = new PDO(
-                $this->constructPdoDsn($params),
+                $this->constructPdoDsn($safeParams),
                 $params['user'] ?? '',
                 $params['password'] ?? '',
                 $driverOptions,

--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -63,7 +63,7 @@ final class Driver extends AbstractPostgreSQLDriver
     /**
      * Constructs the Postgres PDO DSN.
      *
-     * @param mixed[] $params
+     * @param array<string, mixed> $params
      */
     private function constructPdoDsn(array $params): string
     {

--- a/src/Driver/PDO/SQLSrv/Driver.php
+++ b/src/Driver/PDO/SQLSrv/Driver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
 use Doctrine\DBAL\Driver\PDO\Exception as PDOException;
 use PDO;
+use SensitiveParameter;
 
 use function is_int;
 use function sprintf;
@@ -19,8 +20,10 @@ final class Driver extends AbstractSQLServerDriver
      *
      * @return Connection
      */
-    public function connect(array $params)
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ) {
         $driverOptions = $dsnOptions = [];
 
         if (isset($params['driverOptions'])) {
@@ -37,9 +40,12 @@ final class Driver extends AbstractSQLServerDriver
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
+        $safeParams = $params;
+        unset($safeParams['password'], $safeParams['url']);
+
         try {
             $pdo = new PDO(
-                $this->constructDsn($params, $dsnOptions),
+                $this->constructDsn($safeParams, $dsnOptions),
                 $params['user'] ?? '',
                 $params['password'] ?? '',
                 $driverOptions,

--- a/src/Driver/PDO/SQLite/Driver.php
+++ b/src/Driver/PDO/SQLite/Driver.php
@@ -9,6 +9,9 @@ use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\Deprecations\Deprecation;
 use PDO;
 use PDOException;
+use SensitiveParameter;
+
+use function array_intersect_key;
 
 final class Driver extends AbstractSQLiteDriver
 {
@@ -17,8 +20,10 @@ final class Driver extends AbstractSQLiteDriver
      *
      * @return Connection
      */
-    public function connect(array $params)
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ) {
         $driverOptions        = $params['driverOptions'] ?? [];
         $userDefinedFunctions = [];
 
@@ -36,7 +41,7 @@ final class Driver extends AbstractSQLiteDriver
 
         try {
             $pdo = new PDO(
-                $this->constructPdoDsn($params),
+                $this->constructPdoDsn(array_intersect_key($params, ['path' => true, 'memory' => true])),
                 $params['user'] ?? '',
                 $params['password'] ?? '',
                 $driverOptions,

--- a/src/Driver/PDO/SQLite/Driver.php
+++ b/src/Driver/PDO/SQLite/Driver.php
@@ -61,7 +61,7 @@ final class Driver extends AbstractSQLiteDriver
     /**
      * Constructs the Sqlite PDO DSN.
      *
-     * @param mixed[] $params
+     * @param array<string, mixed> $params
      */
     private function constructPdoDsn(array $params): string
     {

--- a/src/Driver/SQLSrv/Driver.php
+++ b/src/Driver/SQLSrv/Driver.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
 use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
+use SensitiveParameter;
 
 use function sqlsrv_configure;
 use function sqlsrv_connect;
@@ -19,8 +20,10 @@ final class Driver extends AbstractSQLServerDriver
      *
      * @return Connection
      */
-    public function connect(array $params)
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ) {
         $serverName = '';
 
         if (isset($params['host'])) {

--- a/src/Driver/SQLite3/Driver.php
+++ b/src/Driver/SQLite3/Driver.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Driver\SQLite3;
 
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use Doctrine\DBAL\Driver\API\SQLite\UserDefinedFunctions;
+use SensitiveParameter;
 use SQLite3;
 
 final class Driver extends AbstractSQLiteDriver
@@ -11,8 +12,10 @@ final class Driver extends AbstractSQLiteDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params): Connection
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ): Connection {
         $isMemory = (bool) ($params['memory'] ?? false);
 
         if (isset($params['path'])) {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use SensitiveParameter;
 
 use function get_class;
 use function gettype;
@@ -61,8 +62,10 @@ class Exception extends \Exception
     }
 
     /** @param string|null $url The URL that was provided in the connection parameters (if any). */
-    public static function driverRequired(?string $url = null): self
-    {
+    public static function driverRequired(
+        #[SensitiveParameter]
+        ?string $url = null
+    ): self {
         if ($url !== null) {
             return new self(
                 sprintf(

--- a/src/Logging/Driver.php
+++ b/src/Logging/Driver.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Logging;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
 use Psr\Log\LoggerInterface;
+use SensitiveParameter;
 
 final class Driver extends AbstractDriverMiddleware
 {
@@ -23,8 +24,10 @@ final class Driver extends AbstractDriverMiddleware
     /**
      * {@inheritDoc}
      */
-    public function connect(array $params)
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ) {
         $this->logger->info('Connecting with parameters {params}', ['params' => $this->maskPassword($params)]);
 
         return new Connection(
@@ -38,8 +41,10 @@ final class Driver extends AbstractDriverMiddleware
      *
      * @return array<string,mixed>
      */
-    private function maskPassword(array $params): array
-    {
+    private function maskPassword(
+        #[SensitiveParameter]
+        array $params
+    ): array {
         if (isset($params['password'])) {
             $params['password'] = '<redacted>';
         }

--- a/src/Portability/Driver.php
+++ b/src/Portability/Driver.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
 use LogicException;
 use PDO;
+use SensitiveParameter;
 
 use function method_exists;
 
@@ -30,8 +31,10 @@ final class Driver extends AbstractDriverMiddleware
     /**
      * {@inheritDoc}
      */
-    public function connect(array $params)
-    {
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ) {
         $connection = parent::connect($params);
 
         $portability = (new OptimizeFlags())(

--- a/src/Tools/DsnParser.php
+++ b/src/Tools/DsnParser.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tools;
 
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception\MalformedDsnException;
+use SensitiveParameter;
 
 use function array_merge;
 use function assert;
@@ -33,8 +34,10 @@ final class DsnParser
      *
      * @throws MalformedDsnException
      */
-    public function parse(string $dsn): array
-    {
+    public function parse(
+        #[SensitiveParameter]
+        string $dsn
+    ): array {
         // (pdo_)?sqlite3?:///... => (pdo_)?sqlite3?://localhost/... or else the URL will be invalid
         $url = preg_replace('#^((?:pdo_)?sqlite3?):///#', '$1://localhost/', $dsn);
         assert($url !== null);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | N/A

#### Summary

PHP 8.2 introduced a `SensitiveParameter` attribute that allows us to flag parameters that should be redacted in stack traces: https://wiki.php.net/rfc/redact_parameters_in_back_traces

This PR uses this attribute on all parameters (that I could find) which could possibly contain the database password (or an SSL key), which also includes database URLs.