### PR TITLE
Allow case sensitive table names for 'tablesExist'

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -136,11 +136,15 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function tablesExist(array $names): bool
+    public function tablesExist(array $names, bool $lowerCase = true): bool
     {
-        $names = array_map('strtolower', $names);
+        if ($lowerCase) {
+            $names      = array_map('strtolower', $names);
+            $tableNames = array_map('strtolower', $this->listTableNames());
+        } else
+            $tableNames = $this->listTableNames();
 
-        return count($names) === count(array_intersect($names, array_map('strtolower', $this->listTableNames())));
+        return count($names) === count(array_intersect($names, $tableNames));
     }
 
     public function tableExists(string $tableName): bool


### PR DESCRIPTION

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

Table names can be case sensitives. Details:
[mysql](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names )
[mariadb](https://mariadb.com/docs/server/ref/mdb/system-variables/lower_case_table_names/)


<!-- Provide a summary of your change. -->
