### PR TITLE
Column with schemaDefinition equal to existing column in db keeps generating diff

### DIFF
--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -12,8 +12,6 @@ use Doctrine\DBAL\Tests\Functional\Schema\MySQL\PointType;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Tools\SchemaTool;
-use Fulfillment\WarehouseBundle\Entity\Location;
 
 class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | 0

#### Summary

For some reason, [AbstractPlatform is dropping columnDefinition when comparing columns](https://github.com/doctrine/dbal/blob/3.5.3/src/Platforms/AbstractPlatform.php#L4617-L4618). That causes issues of useless diffs being generated as shown in the failing test. Removing those two lines fixes this issue.

----

The real usecase I'm meeting is that our doctrine entity has discriminator column that needs manual setup of charset and collation and [DiscriminatorColumn](https://github.com/doctrine/orm/blob/2.14.1/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php) does not support the same options as regular [Column](https://github.com/doctrine/orm/blob/2.14.1/lib/Doctrine/ORM/Mapping/Column.php#L87) (to provide charset and collation). With this bug, doctrine migrations keep generating new versions with no change inside.
