### PR TITLE
Explain why the number of affected rows can be a string

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -357,7 +357,7 @@ Every non-abstract schema manager class must implement them in order to satisfy 
 # BC Break: The number of affected rows is returned as `int|string`
 
 The signatures of the methods returning the number of affected rows changed as returning `int|string` instead of `int`.
-If the number is greater than `PHP_INT_MAX`, the number of affected rows will be returned as a `string`.
+If the number is greater than `PHP_INT_MAX`, the number of affected rows may be returned as a string if the driver supports it.
 
 # BC Break: Dropped support for `collate` option for MySQL
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -357,6 +357,7 @@ Every non-abstract schema manager class must implement them in order to satisfy 
 # BC Break: The number of affected rows is returned as `int|string`
 
 The signatures of the methods returning the number of affected rows changed as returning `int|string` instead of `int`.
+If the number is greater than `PHP_INT_MAX`, the number of affected rows will be returned as a `string`.
 
 # BC Break: Dropped support for `collate` option for MySQL
 

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -37,7 +37,7 @@ interface Connection extends ServerVersionProvider
     /**
      * Executes an SQL statement and return the number of affected rows.
      * If the number of affected rows is greater than the maximum int value (PHP_INT_MAX),
-     * the number of affected rows will be returned as a string.
+     * the number of affected rows may be returned as a string.
      *
      * @throws Exception
      */

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -36,6 +36,8 @@ interface Connection extends ServerVersionProvider
 
     /**
      * Executes an SQL statement and return the number of affected rows.
+     * If the number of affected rows is greater than the maximum int value (PHP_INT_MAX),
+     * the number of affected rows will be returned as a string.
      *
      * @throws Exception
      */

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -78,7 +78,7 @@ final class Connection implements ConnectionInterface
      * @throws Exception
      * @throws Parser\Exception
      */
-    public function exec(string $sql): int|string
+    public function exec(string $sql): int
     {
         return $this->prepare($sql)->execute()->rowCount();
     }

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -21,7 +21,7 @@ final class Connection implements ConnectionInterface
         $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     }
 
-    public function exec(string $sql): int|string
+    public function exec(string $sql): int
     {
         try {
             $result = $this->connection->exec($sql);

--- a/src/Driver/SQLSrv/Connection.php
+++ b/src/Driver/SQLSrv/Connection.php
@@ -49,7 +49,7 @@ final class Connection implements ConnectionInterface
         return "'" . str_replace("'", "''", $value) . "'";
     }
 
-    public function exec(string $sql): int|string
+    public function exec(string $sql): int
     {
         $stmt = sqlsrv_query($this->connection, $sql);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | https://github.com/doctrine/dbal/pull/5802#issuecomment-1403239263

#### Summary

Mysqli is the only driver that can return a string when the number of affected rows is greater that `PHP_INT_MAX` ([doc](https://www.php.net/manual/en/mysqli.affected-rows.php))

Adding a comment in order to make clear for users they can safely cast the result of `Connection::executeStatement()` to `(int)` when they don't use this driver, or the executed statement cannot update so many rows.