### PR TITLE
Add missing doc blocks to Index and UniqueConstraint

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -356,7 +356,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         $diffModified    = false;
 
         if (isset($addedIndexes['primary'])) {
-            $keyColumns   = array_unique(array_values($addedIndexes['primary']->getColumns()));
+            $keyColumns   = array_values(array_unique($addedIndexes['primary']->getColumns()));
             $queryParts[] = 'ADD PRIMARY KEY (' . implode(', ', $keyColumns) . ')';
             unset($addedIndexes['primary']);
             $diffModified = true;
@@ -366,7 +366,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
             // Necessary in case the new primary key includes a new auto_increment column
             foreach ($modifiedIndexes['primary']->getColumns() as $columnName) {
                 if (isset($addedColumns[$columnName]) && $addedColumns[$columnName]->getAutoincrement()) {
-                    $keyColumns   = array_unique(array_values($modifiedIndexes['primary']->getColumns()));
+                    $keyColumns   = array_values(array_unique($modifiedIndexes['primary']->getColumns()));
                     $queryParts[] = 'DROP PRIMARY KEY';
                     $queryParts[] = 'ADD PRIMARY KEY (' . implode(', ', $keyColumns) . ')';
                     unset($modifiedIndexes['primary']);

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1533,17 +1533,7 @@ abstract class AbstractPlatform
             $chunks[] = 'CLUSTERED';
         }
 
-        $columnSQL = [];
-
-        foreach ($columns as $column => $definition) {
-            if (is_array($definition)) {
-                $columnSQL[] = $column;
-            } else {
-                $columnSQL[] = $definition;
-            }
-        }
-
-        $chunks[] = sprintf('(%s)', implode(', ', $columnSQL));
+        $chunks[] = sprintf('(%s)', implode(', ', $columns));
 
         return implode(' ', $chunks);
     }

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -71,7 +71,9 @@ class Index extends AbstractAsset
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the names of the referencing table columns the constraint is associated with.
+     *
+     * @return list<string>
      */
     public function getColumns(): array
     {
@@ -79,7 +81,15 @@ class Index extends AbstractAsset
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the quoted representation of the column names the constraint is associated with.
+     *
+     * But only if they were defined with one or a column name
+     * is a keyword reserved by the platform.
+     * Otherwise, the plain unquoted value as inserted is returned.
+     *
+     * @param AbstractPlatform $platform The platform to use for quotation.
+     *
+     * @return list<string>
      */
     public function getQuotedColumns(AbstractPlatform $platform): array
     {

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -52,7 +52,9 @@ class UniqueConstraint extends AbstractAsset
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the names of the referencing table columns the constraint is associated with.
+     *
+     * @return list<string>
      */
     public function getColumns(): array
     {
@@ -60,7 +62,15 @@ class UniqueConstraint extends AbstractAsset
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the quoted representation of the column names the constraint is associated with.
+     *
+     * But only if they were defined with one or a column name
+     * is a keyword reserved by the platform.
+     * Otherwise, the plain unquoted value as inserted is returned.
+     *
+     * @param AbstractPlatform $platform The platform to use for quotation.
+     *
+     * @return list<string>
      */
     public function getQuotedColumns(AbstractPlatform $platform): array
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Since the removal of the `Constraint` interface in #4842, the `Index` and `UniqueConstraint` classes were left with `@inheritdoc` blocks that point nowhere.

This PR restores the original doc blocks and fixes follow-up issues reported by PHPStan and Psalm.
