### PR TITLE
Introduce the `SchemaManagerFactory` interface

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,25 @@ awareness about deprecated code.
 
 # Upgrade to 3.6
 
+## Deprecated not setting a schema manager factory
+
+DBAL 4 will change the way the schema manager is created. To opt in to the new
+behavior, please configure the schema manager factory:
+
+```php
+$configuration = new Configuration();
+$configuration->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
+
+$connection = DriverManager::getConnection(
+    [/* your parameters */],
+    $configuration,
+);
+```
+
+If you use a custom platform implementation, please make sure it implements
+the `createSchemaManager()`method . Otherwise, the connection will fail to
+create a schema manager.
+
 ## Deprecated the `url` connection parameter
 
 DBAL ships with a new and configurable DSN parser that can be used to parse a

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Logging\SQLLogger;
+use Doctrine\DBAL\Schema\SchemaManagerFactory;
 use Doctrine\Deprecations\Deprecation;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -54,6 +55,8 @@ class Configuration
      * @var bool
      */
     protected $autoCommit = true;
+
+    private ?SchemaManagerFactory $schemaManagerFactory = null;
 
     public function __construct()
     {
@@ -224,5 +227,18 @@ class Configuration
     public function getMiddlewares(): array
     {
         return $this->middlewares;
+    }
+
+    public function getSchemaManagerFactory(): ?SchemaManagerFactory
+    {
+        return $this->schemaManagerFactory;
+    }
+
+    /** @return $this */
+    public function setSchemaManagerFactory(SchemaManagerFactory $schemaManagerFactory): self
+    {
+        $this->schemaManagerFactory = $schemaManagerFactory;
+
+        return $this;
     }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -21,6 +21,9 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
+use Doctrine\DBAL\Schema\LegacySchemaManagerFactory;
+use Doctrine\DBAL\Schema\SchemaManagerFactory;
 use Doctrine\DBAL\SQL\Parser;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
@@ -160,6 +163,8 @@ class Connection
      */
     private bool $isRollbackOnly = false;
 
+    private SchemaManagerFactory $schemaManagerFactory;
+
     /**
      * Initializes a new instance of the Connection class.
      *
@@ -209,6 +214,21 @@ class Connection
         $this->_expr = $this->createExpressionBuilder();
 
         $this->autoCommit = $config->getAutoCommit();
+
+        $schemaManagerFactory = $config->getSchemaManagerFactory();
+        if ($schemaManagerFactory === null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/5812',
+                'Not configuring a schema manager factory is deprecated.'
+                    . ' Use %s which is going to be the default in DBAL 4.',
+                DefaultSchemaManagerFactory::class,
+            );
+
+            $schemaManagerFactory = new LegacySchemaManagerFactory();
+        }
+
+        $this->schemaManagerFactory = $schemaManagerFactory;
     }
 
     /**
@@ -1654,10 +1674,7 @@ class Connection
      */
     public function createSchemaManager(): AbstractSchemaManager
     {
-        return $this->_driver->getSchemaManager(
-            $this,
-            $this->getDatabasePlatform(),
-        );
+        return $this->schemaManagerFactory->createSchemaManager($this);
     }
 
     /**

--- a/src/Schema/DefaultSchemaManagerFactory.php
+++ b/src/Schema/DefaultSchemaManagerFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+
+/**
+ * A schema manager factory that returns the default schema manager for the given platform.
+ */
+final class DefaultSchemaManagerFactory implements SchemaManagerFactory
+{
+    /** @throws Exception If the platform does not support creating schema managers yet. */
+    public function createSchemaManager(Connection $connection): AbstractSchemaManager
+    {
+        return $connection->getDatabasePlatform()->createSchemaManager($connection);
+    }
+}

--- a/src/Schema/LegacySchemaManagerFactory.php
+++ b/src/Schema/LegacySchemaManagerFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Connection;
+
+/** @internal Will be removed in 4.0. */
+final class LegacySchemaManagerFactory implements SchemaManagerFactory
+{
+    public function createSchemaManager(Connection $connection): AbstractSchemaManager
+    {
+        return $connection->getDriver()->getSchemaManager(
+            $connection,
+            $connection->getDatabasePlatform(),
+        );
+    }
+}

--- a/src/Schema/SchemaManagerFactory.php
+++ b/src/Schema/SchemaManagerFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Creates a schema manager for the given connection.
+ *
+ * This interface is an extension point for applications that need to override schema managers.
+ */
+interface SchemaManagerFactory
+{
+    public function createSchemaManager(Connection $connection): AbstractSchemaManager;
+}

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -66,7 +66,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             self::markTestSkipped(sprintf('Skipping since connected to %s', get_class($platform)));
         }
 
-        $this->schemaManager = $this->connection->getSchemaManager();
+        $this->schemaManager = $this->connection->createSchemaManager();
     }
 
     protected function tearDown(): void

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use PHPUnit\Framework\Assert;
 
 use function array_keys;
@@ -154,6 +155,8 @@ class TestUtil
                 $configuration->setMiddlewares([new EnableForeignKeys()]);
                 break;
         }
+
+        $configuration->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
 
         return $configuration;
     }


### PR DESCRIPTION
… to allow apps to override the default schema managers

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | Fixes #5812

#### Summary

This PR introduces a new interface `SchemaManagerFactory` that can be implemented by apps that need to override the schema manager. It also ships with two implementations:

##### `LegacySchemaManagerFactory`

This factory implements the current and deprecated way of letting the driver create the schema manager. If no factory is configured, we fall back to this implementation.

##### `DefaultSchemaManagerFactory`

This factory implements the new way of letting the platform class create the schema manager. This way was introduced by #5458. Configuring `DefaultSchemaManagerFactory` as factory will allow apps to opt-in to the behavior that we have on the 4.0.x branch.

The factory can be configured through the `Configuration` class:

```
$configuration = new Configuration();
$configuration->setSchemaManagerFactory($mySchemaManagerFactory);

$connection = DriverManager::getConnection([/* your connection parameters */], $configuration);
```