### PR TITLE
Use psalm-assert to get rid of `assert()` calls

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -80,7 +80,7 @@ class Connection
     /**
      * The wrapped driver connection.
      *
-     * @var \Doctrine\DBAL\Driver\Connection|null
+     * @var DriverConnection|null
      */
     protected $_conn;
 
@@ -336,6 +336,8 @@ class Connection
      *              the connection is already open.
      *
      * @throws Exception
+     *
+     * @psalm-assert !null $this->_conn
      */
     public function connect()
     {
@@ -1625,8 +1627,6 @@ class Connection
 
         $this->connect();
 
-        assert($this->_conn !== null);
-
         return $this->_conn;
     }
 
@@ -1635,7 +1635,6 @@ class Connection
     {
         $this->connect();
 
-        assert($this->_conn !== null);
         if (! method_exists($this->_conn, 'getNativeConnection')) {
             throw new LogicException(sprintf(
                 'The driver connection %s does not support accessing the native connection.',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | N/A
| Fixed issues | N/A

#### Summary

If we call `Connection::connect()`, we can be sure that the driver connection has been created. I've added an annotation that allows us to drop `assert($this->_conn !== null);` calls.
