### PR TITLE
Widen the return type of `Result::rowCount()`

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -49,11 +49,6 @@ parameters:
             paths:
                 - src/Driver/OCI8/Statement.php
 
-        -
-            message: '~Method Doctrine\\DBAL\\Driver\\Mysqli\\Result::rowCount\(\) should return int but returns int(:?<0, max>)?\|string\.~'
-            paths:
-                - src/Driver/Mysqli/Result.php
-
         # Removing the (int) cast will make Psalm unhappy.
         -
             message: '~^Casting to int something that''s already int\.$~'
@@ -64,9 +59,6 @@ parameters:
                 - src/Driver/Mysqli/Exception/StatementError.php
 
         # We're testing with invalid input.
-        -
-            message: '~^Unable to resolve the template type T in call to method static method Doctrine\\DBAL\\DriverManager::getConnection\(\)~'
-            path: tests/DriverManagerTest.php
         -
             message: '~array{driver: ''invalid_driver''} given\.$~'
             path: tests/DriverManagerTest.php

--- a/src/Driver/Middleware/AbstractResultMiddleware.php
+++ b/src/Driver/Middleware/AbstractResultMiddleware.php
@@ -51,7 +51,7 @@ abstract class AbstractResultMiddleware implements Result
         return $this->wrappedResult->fetchFirstColumn();
     }
 
-    public function rowCount(): int
+    public function rowCount(): int|string
     {
         return $this->wrappedResult->rowCount();
     }

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -143,7 +143,7 @@ final class Result implements ResultInterface
         return FetchUtils::fetchFirstColumn($this);
     }
 
-    public function rowCount(): int
+    public function rowCount(): int|string
     {
         if ($this->hasColumns) {
             return $this->statement->num_rows;

--- a/src/Driver/Result.php
+++ b/src/Driver/Result.php
@@ -68,11 +68,11 @@ interface Result
      * some database drivers may return the number of rows returned by that query. However, this behaviour
      * is not guaranteed for all drivers and should not be relied on in portable applications.
      *
-     * @return int The number of rows.
+     * If the number of rows exceeds {@see PHP_INT_MAX}, it might be returned as string if the driver supports it.
      *
      * @throws Exception
      */
-    public function rowCount(): int;
+    public function rowCount(): int|string;
 
     /**
      * Returns the number of columns in the result

--- a/src/Result.php
+++ b/src/Result.php
@@ -216,8 +216,18 @@ class Result
         }
     }
 
-    /** @throws Exception */
-    public function rowCount(): int
+    /**
+     * Returns the number of rows affected by the DELETE, INSERT, or UPDATE statement that produced the result.
+     *
+     * If the statement executed a SELECT query or a similar platform-specific SQL (e.g. DESCRIBE, SHOW, etc.),
+     * some database drivers may return the number of rows returned by that query. However, this behaviour
+     * is not guaranteed for all drivers and should not be relied on in portable applications.
+     *
+     * If the number of rows exceeds {@see PHP_INT_MAX}, it might be returned as string if the driver supports it.
+     *
+     * @throws Exception
+     */
+    public function rowCount(): int|string
     {
         try {
             return $this->result->rowCount();

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -122,9 +122,11 @@ class Statement
     /**
      * Executes the statement with the currently bound parameters and return affected rows.
      *
+     * If the number of rows exceeds {@see PHP_INT_MAX}, it might be returned as string if the driver supports it.
+     *
      * @throws Exception
      */
-    public function executeStatement(): int
+    public function executeStatement(): int|string
     {
         return $this->execute()->rowCount();
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

We currently allow `Connection::exec()` to return the number of affected rows as a string, mainly to accommodate the MySQLi driver. However, we don't allow `Result::rowCount()` or `Statement::execute()` to do the same. Here we document `int` as native return type.

In the scenario where MySQLi would report the number of rows as string, we would currently cause a type error because strict types are enabled on 4.0.

I realize that this change is painful for projects that run a static analyzer on code that interfaces with DBAL. However, we have decided that we want to leverage drivers that report large numbers of affected rows as strings for `Connection::exec()` and I believe we should be consistent about that throughout the API.