### PR TITLE
Add the PgSQL driver

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -224,13 +224,23 @@ jobs:
           - "7.4"
         postgres-version:
           - "9.4"
-          - "14"
           - "15"
+        extension:
+          - "pgsql"
+          - "pdo_pgsql"
         include:
           - php-version: "8.1"
             postgres-version: "15"
+            extension: "pgsql"
           - php-version: "8.2"
             postgres-version: "15"
+            extension: "pgsql"
+          - php-version: "8.1"
+            postgres-version: "15"
+            extension: "pdo_pgsql"
+          - php-version: "8.2"
+            postgres-version: "15"
+            extension: "pdo_pgsql"
 
     services:
       postgres:
@@ -254,6 +264,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
+          extensions: "pgsql pdo_pgsql"
           coverage: "pcov"
           ini-values: "zend.assertions=1"
 
@@ -263,12 +274,12 @@ jobs:
           composer-options: "--ignore-platform-req=php+"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/pdo_pgsql.xml --coverage-clover=coverage.xml"
+        run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}.xml --coverage-clover=coverage.xml"
 
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v3"
         with:
-          name: "${{ github.job }}-${{ matrix.postgres-version }}-${{ matrix.php-version }}.coverage"
+          name: "${{ github.job }}-${{ matrix.postgres-version }}-${{ matrix.extension }}-${{ matrix.php-version }}.coverage"
           path: "coverage.xml"
 
   phpunit-mariadb:

--- a/ci/github/phpunit/pgsql.xml
+++ b/ci/github/phpunit/pgsql.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         convertDeprecationsToExceptions="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+
+        <var name="db_driver" value="pgsql"/>
+        <var name="db_host" value="localhost" />
+        <var name="db_user" value="postgres" />
+        <var name="db_password" value="postgres" />
+        <var name="db_dbname" value="doctrine_tests" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Doctrine DBAL Test Suite">
+            <directory>../../../tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory suffix=".php">../../../src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -151,6 +151,8 @@ interfaces to use. It can be configured in one of three ways:
    -  ``sqlite3``: An SQLite driver that uses the sqlite3 extension.
    -  ``pdo_pgsql``: A PostgreSQL driver that uses the pdo_pgsql PDO
       extension.
+   -  ``pgsql``: A PostgreSQL driver that uses the pgsql extension. This driver does support loading BLOBs from file
+      resources yet. It is still considered experimental. Use `pdo_pgsql` if you need a stable driver for Postgres.
    -  ``pdo_oci``: An Oracle driver that uses the pdo_oci PDO
       extension.
       **Note that this driver caused problems in our tests. Prefer the oci8 driver if possible.**
@@ -236,8 +238,8 @@ mysqli
 -  ``ssl_cipher`` (string): A list of allowable ciphers to use for SSL encryption.
 -  ``driverOptions`` Any supported flags for mysqli found on `http://www.php.net/manual/en/mysqli.real-connect.php`
 
-pdo_pgsql
-^^^^^^^^^
+pdo_pgsql / pgsql
+^^^^^^^^^^^^^^^^^
 
 -  ``user`` (string): Username to use when connecting to the
    database.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -140,5 +140,18 @@ parameters:
             paths:
                 - src/Schema/PostgreSQLSchemaManager.php
 
+        # PgSql objects are represented as resources in PHP 7.4
+        - '~ expects PgSql\\Connection(:?\|(?:string|null))?, PgSql\\Connection\|resource given\.$~'
+        - '~ expects PgSql\\Result, PgSql\\Result\|resource given\.$~'
+
+        # PHPStan does not understand the array shapes returned by pg_fetch_*() methods.
+        - '~^Parameter #1 \$row of method Doctrine\\DBAL\\Driver\\PgSQL\\Result\:\:mapAssociativeRow\(\) expects array<string, string\|null>, array<int\|string, string\|null> given\.$~'
+        - '~^Parameter #1 \$row of method Doctrine\\DBAL\\Driver\\PgSQL\\Result\:\:mapNumericRow\(\) expects array<int, string\|null>, array<int\|string, string\|null> given\.$~'
+
+        # On PHP 7.4, pg_fetch_all() might return false for empty result sets.
+        -
+            message: '~^Strict comparison using === between array<int, array> and false will always evaluate to false\.$~'
+            paths:
+                - src/Driver/PgSQL/Result.php
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -19,7 +19,6 @@
         <file name="vendor/jetbrains/phpstorm-stubs/ibm_db2/ibm_db2.php" />
         <file name="vendor/jetbrains/phpstorm-stubs/mysqli/mysqli.php" />
         <file name="vendor/jetbrains/phpstorm-stubs/oci8/oci8.php" />
-        <file name="vendor/jetbrains/phpstorm-stubs/pgsql/pgsql.php" />
         <file name="vendor/jetbrains/phpstorm-stubs/sqlsrv/sqlsrv.php" />
     </stubs>
     <issueHandlers>
@@ -567,6 +566,7 @@
                 <file name="src/Cache/QueryCacheProfile.php"/>
                 <file name="src/Connection.php"/>
                 <file name="src/Driver/IBMDB2/Statement.php"/>
+                <directory name="src/Driver/PgSQL"/>
                 <file name="src/DriverManager.php"/>
                 <file name="src/Platforms/AbstractMySQLPlatform.php"/>
                 <file name="src/Platforms/AbstractPlatform.php"/>
@@ -641,6 +641,27 @@
                 <file name="src/Schema/PostgreSQLSchemaManager.php"/>
             </errorLevel>
         </NullableReturnStatement>
+        <PossiblyInvalidArgument>
+            <errorLevel type="suppress">
+                <!-- PgSql objects are represented as resources in PHP 7.4 -->
+                <referencedFunction name="pg_affected_rows"/>
+                <referencedFunction name="pg_escape_bytea"/>
+                <referencedFunction name="pg_escape_literal"/>
+                <referencedFunction name="pg_fetch_all"/>
+                <referencedFunction name="pg_fetch_all_columns"/>
+                <referencedFunction name="pg_fetch_assoc"/>
+                <referencedFunction name="pg_fetch_row"/>
+                <referencedFunction name="pg_field_name"/>
+                <referencedFunction name="pg_field_type"/>
+                <referencedFunction name="pg_free_result"/>
+                <referencedFunction name="pg_get_result"/>
+                <referencedFunction name="pg_num_fields"/>
+                <referencedFunction name="pg_result_error_field"/>
+                <referencedFunction name="pg_send_execute"/>
+                <referencedFunction name="pg_send_prepare"/>
+                <referencedFunction name="pg_version"/>
+            </errorLevel>
+        </PossiblyInvalidArgument>
         <PossiblyInvalidArrayOffset>
             <errorLevel type="suppress">
                 <!-- $array[key($array)] is safe. -->
@@ -716,6 +737,9 @@
                 -->
                 <file name="src/Platforms/AbstractMySQLPlatform.php"/>
                 <file name="tests/Functional/Driver/AbstractDriverTest.php"/>
+                
+                <!-- We're checking for invalid input. -->
+                <directory name="src/Driver/PgSQL"/>
             </errorLevel>
         </RedundantConditionGivenDocblockType>
         <RedundantPropertyInitializationCheck>
@@ -747,6 +771,12 @@
                 <file name="tests/Platforms/AbstractMySQLPlatformTestCase.php"/>
             </errorLevel>
         </TooManyArguments>
+        <TypeDoesNotContainType>
+            <errorLevel type="suppress">
+                <!-- On PHP 7.4, pg_fetch_all() might return false for empty result sets. -->
+                <file name="src/Driver/PgSQL/Result.php"/>
+            </errorLevel>
+        </TypeDoesNotContainType>
         <UndefinedDocblockClass>
             <errorLevel type="suppress">
                 <!-- See https://github.com/vimeo/psalm/issues/5472 -->

--- a/src/Driver/PgSQL/Connection.php
+++ b/src/Driver/PgSQL/Connection.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PgSQL;
+
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\SQL\Parser;
+use Doctrine\Deprecations\Deprecation;
+use PgSql\Connection as PgSqlConnection;
+use TypeError;
+
+use function assert;
+use function get_class;
+use function gettype;
+use function is_object;
+use function is_resource;
+use function pg_escape_bytea;
+use function pg_escape_literal;
+use function pg_get_result;
+use function pg_result_error;
+use function pg_send_prepare;
+use function pg_version;
+use function sprintf;
+use function uniqid;
+
+final class Connection implements ServerInfoAwareConnection
+{
+    /** @var PgSqlConnection|resource */
+    private $connection;
+
+    private Parser $parser;
+
+    /** @param PgSqlConnection|resource $connection */
+    public function __construct($connection)
+    {
+        if (! is_resource($connection) && ! $connection instanceof PgSqlConnection) {
+            throw new TypeError(sprintf(
+                'Expected connection to be a resource or an instance of %s, got %s.',
+                PgSqlConnection::class,
+                is_object($connection) ? get_class($connection) : gettype($connection),
+            ));
+        }
+
+        $this->connection = $connection;
+        $this->parser     = new Parser(false);
+    }
+
+    public function prepare(string $sql): Statement
+    {
+        $visitor = new ConvertParameters();
+        $this->parser->parse($sql, $visitor);
+
+        $statementName = uniqid('dbal', true);
+        $success       = (bool) pg_send_prepare($this->connection, $statementName, $visitor->getSQL());
+
+        assert($success);
+
+        $result = @pg_get_result($this->connection);
+        assert($result !== false);
+
+        if ((bool) pg_result_error($result)) {
+            throw Exception::fromResult($result);
+        }
+
+        return new Statement($this->connection, $statementName, $visitor->getParameterMap());
+    }
+
+    public function query(string $sql): Result
+    {
+        return $this->prepare($sql)->execute();
+    }
+
+    /** {@inheritdoc} */
+    public function quote($value, $type = ParameterType::STRING)
+    {
+        if ($type === ParameterType::BINARY || $type === ParameterType::LARGE_OBJECT) {
+            return sprintf("'%s'", pg_escape_bytea($this->connection, $value));
+        }
+
+        return pg_escape_literal($this->connection, $value);
+    }
+
+    public function exec(string $sql): int
+    {
+        return $this->prepare($sql)->execute()->rowCount();
+    }
+
+    /** {@inheritdoc} */
+    public function lastInsertId($name = null)
+    {
+        if ($name !== null) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4687',
+                'The usage of Connection::lastInsertId() with a sequence name is deprecated.',
+            );
+
+            return $this->query(sprintf('SELECT CURRVAL(%s)', $this->quote($name)))->fetchOne();
+        }
+
+        return $this->query('SELECT LASTVAL()')->fetchOne();
+    }
+
+    /** @return true */
+    public function beginTransaction(): bool
+    {
+        $this->exec('BEGIN');
+
+        return true;
+    }
+
+    /** @return true */
+    public function commit(): bool
+    {
+        $this->exec('COMMIT');
+
+        return true;
+    }
+
+    /** @return true */
+    public function rollBack(): bool
+    {
+        $this->exec('ROLLBACK');
+
+        return true;
+    }
+
+    public function getServerVersion(): string
+    {
+        return (string) pg_version($this->connection)['server'];
+    }
+
+    /** @return PgSqlConnection|resource */
+    public function getNativeConnection()
+    {
+        return $this->connection;
+    }
+}

--- a/src/Driver/PgSQL/ConvertParameters.php
+++ b/src/Driver/PgSQL/ConvertParameters.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\PgSQL;
+
+use Doctrine\DBAL\SQL\Parser\Visitor;
+
+use function count;
+use function implode;
+
+final class ConvertParameters implements Visitor
+{
+    /** @var list<string> */
+    private array $buffer = [];
+
+    /** @var array<array-key, int> */
+    private array $parameterMap = [];
+
+    public function acceptPositionalParameter(string $sql): void
+    {
+        $position                      = count($this->parameterMap) + 1;
+        $this->parameterMap[$position] = $position;
+        $this->buffer[]                = '$' . $position;
+    }
+
+    public function acceptNamedParameter(string $sql): void
+    {
+        $position                 = count($this->parameterMap) + 1;
+        $this->parameterMap[$sql] = $position;
+        $this->buffer[]           = '$' . $position;
+    }
+
+    public function acceptOther(string $sql): void
+    {
+        $this->buffer[] = $sql;
+    }
+
+    public function getSQL(): string
+    {
+        return implode('', $this->buffer);
+    }
+
+    /** @return array<array-key, int> */
+    public function getParameterMap(): array
+    {
+        return $this->parameterMap;
+    }
+}

--- a/src/Driver/PgSQL/Driver.php
+++ b/src/Driver/PgSQL/Driver.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PgSQL;
+
+use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+use ErrorException;
+use SensitiveParameter;
+
+use function addslashes;
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_slice;
+use function array_values;
+use function func_get_args;
+use function implode;
+use function pg_connect;
+use function restore_error_handler;
+use function set_error_handler;
+use function sprintf;
+
+use const PGSQL_CONNECT_FORCE_NEW;
+
+final class Driver extends AbstractPostgreSQLDriver
+{
+    /** {@inheritdoc} */
+    public function connect(
+        #[SensitiveParameter]
+        array $params
+    ): Connection {
+        set_error_handler(
+            static function (int $severity, string $message) {
+                throw new ErrorException($message, 0, $severity, ...array_slice(func_get_args(), 2, 2));
+            },
+        );
+
+        try {
+            $connection = pg_connect($this->constructConnectionString($params), PGSQL_CONNECT_FORCE_NEW);
+        } catch (ErrorException $e) {
+            throw new Exception($e->getMessage(), '08006', 0, $e);
+        } finally {
+            restore_error_handler();
+        }
+
+        if ($connection === false) {
+            throw new Exception('Unable to connect to Postgres server.');
+        }
+
+        $driverConnection = new Connection($connection);
+
+        if (isset($params['application_name'])) {
+            $driverConnection->exec('SET application_name = ' . $driverConnection->quote($params['application_name']));
+        }
+
+        return $driverConnection;
+    }
+
+    /**
+     * Constructs the Postgres connection string
+     *
+     * @param array<string, mixed> $params
+     */
+    private function constructConnectionString(
+        #[SensitiveParameter]
+        array $params
+    ): string {
+        $components = array_filter(
+            [
+                'host' => $params['host'] ?? null,
+                'port' => $params['port'] ?? null,
+                'dbname' => $params['dbname'] ?? 'postgres',
+                'user' => $params['user'] ?? null,
+                'password' => $params['password'] ?? null,
+                'sslmode' => $params['sslmode'] ?? null,
+            ],
+            static fn ($value) => $value !== '' && $value !== null,
+        );
+
+        return implode(' ', array_map(
+            static fn ($value, string $key) => sprintf("%s='%s'", $key, addslashes($value)),
+            array_values($components),
+            array_keys($components),
+        ));
+    }
+}

--- a/src/Driver/PgSQL/Exception.php
+++ b/src/Driver/PgSQL/Exception.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PgSQL;
+
+use Doctrine\DBAL\Driver\AbstractException;
+use PgSql\Result as PgSqlResult;
+
+use function pg_result_error_field;
+
+use const PGSQL_DIAG_MESSAGE_PRIMARY;
+use const PGSQL_DIAG_SQLSTATE;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class Exception extends AbstractException
+{
+    /** @param PgSqlResult|resource $result */
+    public static function fromResult($result): self
+    {
+        $sqlstate = pg_result_error_field($result, PGSQL_DIAG_SQLSTATE);
+        if ($sqlstate === false) {
+            $sqlstate = null;
+        }
+
+        return new self((string) pg_result_error_field($result, PGSQL_DIAG_MESSAGE_PRIMARY), $sqlstate);
+    }
+}

--- a/src/Driver/PgSQL/Exception/UnexpectedValue.php
+++ b/src/Driver/PgSQL/Exception/UnexpectedValue.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\PgSQL\Exception;
+
+use Doctrine\DBAL\Driver\Exception;
+use UnexpectedValueException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class UnexpectedValue extends UnexpectedValueException implements Exception
+{
+    public static function new(string $value, string $type): self
+    {
+        return new self(sprintf(
+            'Unexpected value "%s" of type "%s" returned by Postgres',
+            $value,
+            $type,
+        ));
+    }
+
+    /** @return null */
+    public function getSQLState()
+    {
+        return null;
+    }
+}

--- a/src/Driver/PgSQL/Exception/UnknownParameter.php
+++ b/src/Driver/PgSQL/Exception/UnknownParameter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PgSQL\Exception;
+
+use Doctrine\DBAL\Driver\AbstractException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class UnknownParameter extends AbstractException
+{
+    public static function new(string $param): self
+    {
+        return new self(
+            sprintf('Could not find parameter %s in the SQL statement', $param),
+        );
+    }
+}

--- a/src/Driver/PgSQL/Result.php
+++ b/src/Driver/PgSQL/Result.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PgSQL;
+
+use Doctrine\DBAL\Driver\FetchUtils;
+use Doctrine\DBAL\Driver\PgSQL\Exception\UnexpectedValue;
+use Doctrine\DBAL\Driver\Result as ResultInterface;
+use PgSql\Result as PgSqlResult;
+use TypeError;
+
+use function array_keys;
+use function array_map;
+use function assert;
+use function get_class;
+use function gettype;
+use function hex2bin;
+use function is_object;
+use function is_resource;
+use function pg_affected_rows;
+use function pg_fetch_all;
+use function pg_fetch_all_columns;
+use function pg_fetch_assoc;
+use function pg_fetch_row;
+use function pg_field_name;
+use function pg_field_type;
+use function pg_free_result;
+use function pg_num_fields;
+use function sprintf;
+use function substr;
+
+use const PGSQL_ASSOC;
+use const PGSQL_NUM;
+use const PHP_INT_SIZE;
+
+final class Result implements ResultInterface
+{
+    /** @var PgSqlResult|resource|null */
+    private $result;
+
+    /** @param PgSqlResult|resource $result */
+    public function __construct($result)
+    {
+        if (! is_resource($result) && ! $result instanceof PgSqlResult) {
+            throw new TypeError(sprintf(
+                'Expected result to be a resource or an instance of %s, got %s.',
+                PgSqlResult::class,
+                is_object($result) ? get_class($result) : gettype($result),
+            ));
+        }
+
+        $this->result = $result;
+    }
+
+    /** {@inheritdoc} */
+    public function fetchNumeric()
+    {
+        if ($this->result === null) {
+            return false;
+        }
+
+        $row = pg_fetch_row($this->result);
+        if ($row === false) {
+            return false;
+        }
+
+        return $this->mapNumericRow($row, $this->fetchNumericColumnTypes());
+    }
+
+    /** {@inheritdoc} */
+    public function fetchAssociative()
+    {
+        if ($this->result === null) {
+            return false;
+        }
+
+        $row = pg_fetch_assoc($this->result);
+        if ($row === false) {
+            return false;
+        }
+
+        return $this->mapAssociativeRow($row, $this->fetchAssociativeColumnTypes());
+    }
+
+    /** {@inheritdoc} */
+    public function fetchOne()
+    {
+        return FetchUtils::fetchOne($this);
+    }
+
+    /** {@inheritdoc} */
+    public function fetchAllNumeric(): array
+    {
+        if ($this->result === null) {
+            return [];
+        }
+
+        $resultSet = pg_fetch_all($this->result, PGSQL_NUM);
+        // On PHP 7.4, pg_fetch_all() might return false for empty result sets.
+        if ($resultSet === false) {
+            return [];
+        }
+
+        $types = $this->fetchNumericColumnTypes();
+
+        return array_map(
+            fn (array $row) => $this->mapNumericRow($row, $types),
+            $resultSet,
+        );
+    }
+
+    /** {@inheritdoc} */
+    public function fetchAllAssociative(): array
+    {
+        if ($this->result === null) {
+            return [];
+        }
+
+        $resultSet = pg_fetch_all($this->result, PGSQL_ASSOC);
+        // On PHP 7.4, pg_fetch_all() might return false for empty result sets.
+        if ($resultSet === false) {
+            return [];
+        }
+
+        $types = $this->fetchAssociativeColumnTypes();
+
+        return array_map(
+            fn (array $row) => $this->mapAssociativeRow($row, $types),
+            $resultSet,
+        );
+    }
+
+    /** {@inheritdoc} */
+    public function fetchFirstColumn(): array
+    {
+        if ($this->result === null) {
+            return [];
+        }
+
+        $postgresType = pg_field_type($this->result, 0);
+
+        return array_map(
+            fn ($value) => $this->mapType($postgresType, $value),
+            pg_fetch_all_columns($this->result),
+        );
+    }
+
+    public function rowCount(): int
+    {
+        if ($this->result === null) {
+            return 0;
+        }
+
+        return pg_affected_rows($this->result);
+    }
+
+    public function columnCount(): int
+    {
+        if ($this->result === null) {
+            return 0;
+        }
+
+        return pg_num_fields($this->result);
+    }
+
+    public function free(): void
+    {
+        if ($this->result === null) {
+            return;
+        }
+
+        pg_free_result($this->result);
+        $this->result = null;
+    }
+
+    /** @return array<int, string> */
+    private function fetchNumericColumnTypes(): array
+    {
+        assert($this->result !== null);
+
+        $types     = [];
+        $numFields = pg_num_fields($this->result);
+        for ($i = 0; $i < $numFields; ++$i) {
+            $types[$i] = pg_field_type($this->result, $i);
+        }
+
+        return $types;
+    }
+
+    /** @return array<string, string> */
+    private function fetchAssociativeColumnTypes(): array
+    {
+        assert($this->result !== null);
+
+        $types     = [];
+        $numFields = pg_num_fields($this->result);
+        for ($i = 0; $i < $numFields; ++$i) {
+            $types[pg_field_name($this->result, $i)] = pg_field_type($this->result, $i);
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param list<string|null>  $row
+     * @param array<int, string> $types
+     *
+     * @return list<mixed>
+     */
+    private function mapNumericRow(array $row, array $types): array
+    {
+        assert($this->result !== null);
+
+        return array_map(
+            fn ($value, $field) => $this->mapType($types[$field], $value),
+            $row,
+            array_keys($row),
+        );
+    }
+
+    /**
+     * @param array<string, string|null> $row
+     * @param array<string, string>      $types
+     *
+     * @return array<string, mixed>
+     */
+    private function mapAssociativeRow(array $row, array $types): array
+    {
+        assert($this->result !== null);
+
+        $mappedRow = [];
+        foreach ($row as $field => $value) {
+            $mappedRow[$field] = $this->mapType($types[$field], $value);
+        }
+
+        return $mappedRow;
+    }
+
+    /** @return string|int|float|bool|null */
+    private function mapType(string $postgresType, ?string $value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        switch ($postgresType) {
+            case 'bool':
+                switch ($value) {
+                    case 't':
+                        return true;
+                    case 'f':
+                        return false;
+                }
+
+                throw UnexpectedValue::new($value, $postgresType);
+
+            case 'bytea':
+                return hex2bin(substr($value, 2));
+
+            case 'float4':
+            case 'float8':
+                return (float) $value;
+
+            case 'int2':
+            case 'int4':
+                return (int) $value;
+
+            case 'int8':
+                return PHP_INT_SIZE >= 8 ? (int) $value : $value;
+        }
+
+        return $value;
+    }
+}

--- a/src/Driver/PgSQL/Statement.php
+++ b/src/Driver/PgSQL/Statement.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Doctrine\DBAL\Driver\PgSQL;
+
+use Doctrine\DBAL\Driver\PgSQL\Exception\UnknownParameter;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\Deprecations\Deprecation;
+use PgSql\Connection as PgSqlConnection;
+use TypeError;
+
+use function assert;
+use function func_num_args;
+use function get_class;
+use function gettype;
+use function is_int;
+use function is_object;
+use function is_resource;
+use function ksort;
+use function pg_escape_bytea;
+use function pg_get_result;
+use function pg_result_error;
+use function pg_send_execute;
+use function sprintf;
+
+final class Statement implements StatementInterface
+{
+    /** @var PgSqlConnection|resource */
+    private $connection;
+
+    private string $name;
+
+    /** @var array<array-key, int> */
+    private array $parameterMap;
+
+    /** @var array<int, mixed> */
+    private array $parameters = [];
+
+    /** @psalm-var array<int, int> */
+    private array $parameterTypes = [];
+
+    /**
+     * @param PgSqlConnection|resource $connection
+     * @param array<array-key, int>    $parameterMap
+     */
+    public function __construct($connection, string $name, array $parameterMap)
+    {
+        if (! is_resource($connection) && ! $connection instanceof PgSqlConnection) {
+            throw new TypeError(sprintf(
+                'Expected connection to be a resource or an instance of %s, got %s.',
+                PgSqlConnection::class,
+                is_object($connection) ? get_class($connection) : gettype($connection),
+            ));
+        }
+
+        $this->connection   = $connection;
+        $this->name         = $name;
+        $this->parameterMap = $parameterMap;
+    }
+
+    /** {@inheritdoc} */
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
+    {
+        if (! isset($this->parameterMap[$param])) {
+            throw UnknownParameter::new((string) $param);
+        }
+
+        $this->parameters[$this->parameterMap[$param]]     = $value;
+        $this->parameterTypes[$this->parameterMap[$param]] = $type;
+
+        return true;
+    }
+
+    /** {@inheritdoc} */
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
+    {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5563',
+            '%s is deprecated. Use bindValue() instead.',
+            __METHOD__,
+        );
+
+        if (func_num_args() < 3) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5558',
+                'Not passing $type to Statement::bindParam() is deprecated.'
+                . ' Pass the type corresponding to the parameter being bound.',
+            );
+        }
+
+        if (func_num_args() > 4) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4533',
+                'The $driverOptions argument of Statement::bindParam() is deprecated.',
+            );
+        }
+
+        if (! isset($this->parameterMap[$param])) {
+            throw UnknownParameter::new((string) $param);
+        }
+
+        $this->parameters[$this->parameterMap[$param]]     = &$variable;
+        $this->parameterTypes[$this->parameterMap[$param]] = $type;
+
+        return true;
+    }
+
+    /** {@inheritdoc} */
+    public function execute($params = null): Result
+    {
+        if ($params !== null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5556',
+                'Passing $params to Statement::execute() is deprecated. Bind parameters using'
+                . ' Statement::bindParam() or Statement::bindValue() instead.',
+            );
+
+            foreach ($params as $param => $value) {
+                if (is_int($param)) {
+                    $this->bindValue($param + 1, $value, ParameterType::STRING);
+                } else {
+                    $this->bindValue($param, $value, ParameterType::STRING);
+                }
+            }
+        }
+
+        ksort($this->parameters);
+
+        $escapedParameters = [];
+        foreach ($this->parameters as $parameter => $value) {
+            switch ($this->parameterTypes[$parameter]) {
+                case ParameterType::BINARY:
+                case ParameterType::LARGE_OBJECT:
+                    $escapedParameters[] = $value === null ? null : pg_escape_bytea($this->connection, $value);
+                    break;
+                default:
+                    $escapedParameters[] = $value;
+            }
+        }
+
+        $success = (bool) pg_send_execute($this->connection, $this->name, $escapedParameters);
+        assert($success);
+
+        $result = @pg_get_result($this->connection);
+        assert($result !== false);
+
+        if ((bool) pg_result_error($result)) {
+            throw Exception::fromResult($result);
+        }
+
+        return new Result($result);
+    }
+}

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\Mysqli;
 use Doctrine\DBAL\Driver\OCI8;
 use Doctrine\DBAL\Driver\PDO;
+use Doctrine\DBAL\Driver\PgSQL;
 use Doctrine\DBAL\Driver\SQLite3;
 use Doctrine\DBAL\Driver\SQLSrv;
 use Doctrine\DBAL\Exception\MalformedDsnException;
@@ -83,6 +84,7 @@ final class DriverManager
         'ibm_db2'            => IBMDB2\Driver::class,
         'pdo_sqlsrv'         => PDO\SQLSrv\Driver::class,
         'mysqli'             => Mysqli\Driver::class,
+        'pgsql'              => PgSQL\Driver::class,
         'sqlsrv'             => SQLSrv\Driver::class,
         'sqlite3'            => SQLite3\Driver::class,
     ];

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -16,10 +16,11 @@ class BlobTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        if (TestUtil::isDriverOneOf('pdo_oci')) {
+        if (TestUtil::isDriverOneOf('pdo_oci', 'pgsql')) {
             // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
             // see http://php.net/manual/en/pdo.lobs.php#example-1035
-            self::markTestSkipped("DBAL doesn't support storing LOBs represented as streams using PDO_OCI");
+            // inserting BLOBs as streams with ext-pgsql is not implemented yet.
+            self::markTestSkipped("DBAL doesn't support storing LOBs represented as streams using PDO_OCI or PgSQL");
         }
 
         $table = new Table('blob_table');

--- a/tests/Functional/Driver/AbstractPostgreSQLDriverTest.php
+++ b/tests/Functional/Driver/AbstractPostgreSQLDriverTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Driver;
+
+use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+
+use function array_key_exists;
+use function microtime;
+use function sprintf;
+
+abstract class AbstractPostgreSQLDriverTest extends AbstractDriverTest
+{
+    public function testConnectsWithApplicationNameParameter(): void
+    {
+        $parameters                     = $this->connection->getParams();
+        $parameters['application_name'] = 'doctrine';
+
+        $connection = $this->driver->connect($parameters);
+
+        $hash    = microtime(true); // required to identify the record in the results uniquely
+        $sql     = sprintf('SELECT * FROM pg_stat_activity WHERE %d = %d', $hash, $hash);
+        $records = $connection->query($sql)->fetchAllAssociative();
+
+        foreach ($records as $record) {
+            // The query column is named "current_query" on PostgreSQL < 9.2
+            $queryColumnName = array_key_exists('current_query', $record) ? 'current_query' : 'query';
+
+            if ($record[$queryColumnName] === $sql) {
+                self::assertSame('doctrine', $record['application_name']);
+
+                return;
+            }
+        }
+
+        self::fail(sprintf('Query result does not contain a record where column "query" equals "%s".', $sql));
+    }
+
+    abstract protected function createDriver(): AbstractPostgreSQLDriver;
+
+    protected static function getDatabaseNameForConnectionWithoutDatabaseNameParameter(): ?string
+    {
+        return 'postgres';
+    }
+}

--- a/tests/Functional/Driver/PDO/PgSQL/DriverTest.php
+++ b/tests/Functional/Driver/PDO/PgSQL/DriverTest.php
@@ -3,17 +3,12 @@
 namespace Doctrine\DBAL\Tests\Functional\Driver\PDO\PgSQL;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\PDO\PgSQL\Driver;
-use Doctrine\DBAL\Tests\Functional\Driver\AbstractDriverTest;
+use Doctrine\DBAL\Tests\Functional\Driver\AbstractPostgreSQLDriverTest;
 use Doctrine\DBAL\Tests\TestUtil;
 
-use function array_key_exists;
-use function microtime;
-use function sprintf;
-
 /** @requires extension pdo_pgsql */
-class DriverTest extends AbstractDriverTest
+class DriverTest extends AbstractPostgreSQLDriverTest
 {
     protected function setUp(): void
     {
@@ -73,38 +68,8 @@ class DriverTest extends AbstractDriverTest
         ];
     }
 
-    public function testConnectsWithApplicationNameParameter(): void
-    {
-        $parameters                     = $this->connection->getParams();
-        $parameters['application_name'] = 'doctrine';
-
-        $connection = $this->driver->connect($parameters);
-
-        $hash    = microtime(true); // required to identify the record in the results uniquely
-        $sql     = sprintf('SELECT * FROM pg_stat_activity WHERE %d = %d', $hash, $hash);
-        $records = $connection->query($sql)->fetchAllAssociative();
-
-        foreach ($records as $record) {
-            // The query column is named "current_query" on PostgreSQL < 9.2
-            $queryColumnName = array_key_exists('current_query', $record) ? 'current_query' : 'query';
-
-            if ($record[$queryColumnName] === $sql) {
-                self::assertSame('doctrine', $record['application_name']);
-
-                return;
-            }
-        }
-
-        self::fail(sprintf('Query result does not contain a record where column "query" equals "%s".', $sql));
-    }
-
-    protected function createDriver(): DriverInterface
+    protected function createDriver(): Driver
     {
         return new Driver();
-    }
-
-    protected static function getDatabaseNameForConnectionWithoutDatabaseNameParameter(): ?string
-    {
-        return 'postgres';
     }
 }

--- a/tests/Functional/Driver/PgSQL/DriverTest.php
+++ b/tests/Functional/Driver/PgSQL/DriverTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Driver\PgSQL;
+
+use Doctrine\DBAL\Driver\PgSQL\Driver;
+use Doctrine\DBAL\Tests\Functional\Driver\AbstractPostgreSQLDriverTest;
+use Doctrine\DBAL\Tests\TestUtil;
+
+/** @requires extension pgsql */
+class DriverTest extends AbstractPostgreSQLDriverTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (TestUtil::isDriverOneOf('pgsql')) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires the pgsql driver.');
+    }
+
+    protected function createDriver(): Driver
+    {
+        return new Driver();
+    }
+}

--- a/tests/Functional/Driver/PgSQL/ResultTest.php
+++ b/tests/Functional/Driver/PgSQL/ResultTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Driver\PgSQL;
+
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+use Doctrine\DBAL\Types\Types;
+use Generator;
+
+use function chr;
+
+class ResultTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (TestUtil::isDriverOneOf('pgsql')) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires the pgsql driver.');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->connection->executeStatement('DROP TABLE IF EXISTS types_test');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS types_test2');
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param mixed $expectedValue
+     *
+     * @dataProvider provideTypedValues
+     */
+    public function testTypeConversionFetchAssociative(string $postgresType, $expectedValue, string $dbalType): void
+    {
+        $id = $this->prepareTypesTestTable($postgresType, $expectedValue, $dbalType);
+
+        $result = $this->connection->fetchAssociative(
+            'SELECT my_value, my_null FROM types_test WHERE id = ?',
+            [$id],
+        );
+
+        self::assertSame(['my_value' => $expectedValue, 'my_null' => null], $result);
+    }
+
+    /**
+     * @param mixed $expectedValue
+     *
+     * @dataProvider provideTypedValues
+     */
+    public function testTypeConversionFetchAllAssociative(string $postgresType, $expectedValue, string $dbalType): void
+    {
+        $id = $this->prepareTypesTestTable($postgresType, $expectedValue, $dbalType);
+
+        $result = $this->connection->fetchAllAssociative(
+            'SELECT my_value, my_null FROM types_test WHERE id = ?',
+            [$id],
+        );
+
+        self::assertSame([['my_value' => $expectedValue, 'my_null' => null]], $result);
+    }
+
+    /**
+     * @param mixed $expectedValue
+     *
+     * @dataProvider provideTypedValues
+     */
+    public function testTypeConversionFetchNumeric(string $postgresType, $expectedValue, string $dbalType): void
+    {
+        $id = $this->prepareTypesTestTable($postgresType, $expectedValue, $dbalType);
+
+        $result = $this->connection->fetchNumeric(
+            'SELECT my_value, my_null FROM types_test WHERE id = ?',
+            [$id],
+        );
+
+        self::assertSame([$expectedValue, null], $result);
+    }
+
+    /**
+     * @param mixed $expectedValue
+     *
+     * @dataProvider provideTypedValues
+     */
+    public function testTypeConversionFetchAllNumeric(string $postgresType, $expectedValue, string $dbalType): void
+    {
+        $id = $this->prepareTypesTestTable($postgresType, $expectedValue, $dbalType);
+
+        $result = $this->connection->fetchAllNumeric(
+            'SELECT my_value, my_null FROM types_test WHERE id = ?',
+            [$id],
+        );
+
+        self::assertSame([[$expectedValue, null]], $result);
+    }
+
+    /**
+     * @param mixed $expectedValue
+     *
+     * @dataProvider provideTypedValues
+     */
+    public function testTypeConversionFetchOne(string $postgresType, $expectedValue, string $dbalType): void
+    {
+        $id = $this->prepareTypesTestTable($postgresType, $expectedValue, $dbalType);
+
+        $result = $this->connection->fetchOne(
+            'SELECT my_value FROM types_test WHERE id = ?',
+            [$id],
+        );
+
+        self::assertSame($expectedValue, $result);
+    }
+
+    /**
+     * @param mixed $expectedValue
+     *
+     * @dataProvider provideTypedValues
+     */
+    public function testTypeConversionFetchFirstColumn(string $postgresType, $expectedValue, string $dbalType): void
+    {
+        $id = $this->prepareTypesTestTable($postgresType, $expectedValue, $dbalType);
+
+        $result = $this->connection->fetchFirstColumn(
+            'SELECT my_value FROM types_test WHERE id = ?',
+            [$id],
+        );
+
+        self::assertSame([$expectedValue], $result);
+    }
+
+    /** @psalm-return Generator<string, array{string, mixed, (Types::*)}> */
+    public function provideTypedValues(): Generator
+    {
+        yield 'integer' => ['INTEGER', 4711, Types::INTEGER];
+        yield 'negative integer' => ['INTEGER', -4711, Types::INTEGER];
+        yield 'bigint' => ['BIGINT', 4711, Types::BIGINT];
+        yield 'smallint' => ['SMALLINT', 4711, Types::SMALLINT];
+        yield 'string' => ['CHARACTER VARYING (100)', 'some value', Types::STRING];
+        yield 'numeric string' => ['CHARACTER VARYING (100)', '4711', Types::STRING];
+        yield 'text' => ['TEXT', 'some value', Types::STRING];
+        yield 'boolean true' => ['BOOLEAN', true, Types::BOOLEAN];
+        yield 'boolean false' => ['BOOLEAN', false, Types::BOOLEAN];
+        yield 'float' => ['REAL', 47.11, Types::FLOAT];
+        yield 'negative float with exponent' => ['REAL', -8.15e10, Types::FLOAT];
+        yield 'double' => ['DOUBLE PRECISION', 47.11, Types::FLOAT];
+        yield 'decimal' => ['NUMERIC (6, 2)', '47.11', Types::DECIMAL];
+        yield 'binary' => ['BYTEA', chr(0x8b), Types::BINARY];
+    }
+
+    /** @param mixed $expectedValue */
+    private function prepareTypesTestTable(string $postgresType, $expectedValue, string $dbalType): int
+    {
+        $sql = <<< SQL
+            CREATE TABLE types_test (
+                id BIGSERIAL PRIMARY KEY,
+                my_value {$postgresType} NOT NULL,
+                my_null {$postgresType} DEFAULT NULL
+            )
+            SQL;
+
+        $this->connection->executeStatement($sql);
+
+        $this->connection->insert(
+            'types_test',
+            ['my_value' => $expectedValue],
+            ['my_value' => $dbalType],
+        );
+
+        $id = $this->connection->lastInsertId();
+        self::assertIsInt($id);
+
+        return $id;
+    }
+
+    public function testTypeConversionWithDuplicateFieldNames(): void
+    {
+        $this->connection->executeStatement(<<< 'SQL'
+            CREATE TABLE types_test (
+                id INT PRIMARY KEY,
+                my_value VARCHAR (20) NOT NULL
+            )
+            SQL);
+
+        $this->connection->executeStatement(<<< 'SQL'
+            CREATE TABLE types_test2 (
+                id INT PRIMARY KEY,
+                my_other_value VARCHAR (20) NOT NULL
+            )
+            SQL);
+
+        $this->connection->insert('types_test', ['id' => 4711, 'my_value' => 'some value']);
+        $this->connection->insert('types_test2', ['id' => 42, 'my_other_value' => 'another value']);
+
+        self::assertSame(
+            ['id' => 42, 'my_value' => 'some value', 'my_other_value' => 'another value'],
+            $this->connection->fetchAssociative('SELECT a.*, b.* FROM types_test a, types_test2 b'),
+        );
+        self::assertSame(
+            [['id' => 42, 'my_value' => 'some value', 'my_other_value' => 'another value']],
+            $this->connection->fetchAllAssociative('SELECT a.*, b.* FROM types_test a, types_test2 b'),
+        );
+        self::assertSame(
+            [4711, 'some value', 42, 'another value'],
+            $this->connection->fetchNumeric('SELECT a.*, b.* FROM types_test a, types_test2 b'),
+        );
+        self::assertSame(
+            [[4711, 'some value', 42, 'another value']],
+            $this->connection->fetchAllNumeric('SELECT a.*, b.* FROM types_test a, types_test2 b'),
+        );
+        self::assertSame(
+            4711,
+            $this->connection->fetchOne('SELECT a.*, b.* FROM types_test a, types_test2 b'),
+        );
+        self::assertSame(
+            [4711],
+            $this->connection->fetchFirstColumn('SELECT a.*, b.* FROM types_test a, types_test2 b'),
+        );
+    }
+}

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -241,7 +241,7 @@ EOF
 
     public function testBindInvalidNamedParameter(): void
     {
-        if (TestUtil::isDriverOneOf('ibm_db2', 'mysqli', 'sqlsrv')) {
+        if (TestUtil::isDriverOneOf('ibm_db2', 'mysqli', 'pgsql', 'sqlsrv')) {
             self::markTestSkipped('The driver does not support named statement parameters');
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | N/A

#### Summary

This PR introduces a new Postgres driver that leverages PHP's `pgsql` extension. Postgres is currently the last database that we only support through PDO. This driver closes the gap.

`ext-pgsql` has a rather verbose API. Unlike other database extensions, it does not even bother to cast result types: It returns everything as a string. Except for `null` values: Those are really `null`!

However, we get information on the database type of all result fields, so we are able to perform those casts ourselves. This is why I decided to perform very basic type mappings in the driver already. Otherwise, the result sets produced by `ext-pgsql` would have been a permanent edge case: Booleans come as `'t'` and `'f'`, binary data is returned as hex string prefixed with `0x`. Not casting those would cause a lot of functional tests to fail.

The type casts that I perform in the driver should be similar to what `PDO_pgsql` does internally as well. That should make a potential switch from PDO to the native extension rather seamless.

In PHP 8.1, all resource types used by the extensions have been changed to objects. This is why you will see a couple of type annotations with a union of `resource` and some class from the `PgSql` namespace. This PR currently targets DBAL 3.6 and PHP 7.4. Once this code hits the 4.x branch, we can simplify a lot of type declarations.

The one big limitation though is that I haven't implemented support for loading BLOBs from resources yet. That topic is a bit complex, so I'd like to work on that in a follow-up. For now, I think we can ship this driver without BLOB support.