### PR TITLE
Make sure only PDO parameter types are passed to PDO methods

### DIFF
--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -80,7 +80,7 @@ final class Connection implements ServerInfoAwareConnection
      */
     public function quote($value, $type = ParameterType::STRING)
     {
-        return $this->connection->quote($value, $type);
+        return $this->connection->quote($value, ParameterTypeMap::convertParamType($type));
     }
 
     /**

--- a/src/Driver/PDO/ParameterTypeMap.php
+++ b/src/Driver/PDO/ParameterTypeMap.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\PDO;
+
+use Doctrine\DBAL\Driver\Exception\UnknownParameterType;
+use Doctrine\DBAL\ParameterType;
+use PDO;
+
+/** @internal */
+final class ParameterTypeMap
+{
+    private const PARAM_TYPE_MAP = [
+        ParameterType::NULL => PDO::PARAM_NULL,
+        ParameterType::INTEGER => PDO::PARAM_INT,
+        ParameterType::STRING => PDO::PARAM_STR,
+        ParameterType::ASCII => PDO::PARAM_STR,
+        ParameterType::BINARY => PDO::PARAM_LOB,
+        ParameterType::LARGE_OBJECT => PDO::PARAM_LOB,
+        ParameterType::BOOLEAN => PDO::PARAM_BOOL,
+    ];
+
+    /**
+     * Converts DBAL parameter type to PDO parameter type
+     *
+     * @psalm-return PDO::PARAM_*
+     *
+     * @throws UnknownParameterType
+     */
+    public static function convertParamType(int $type): int
+    {
+        if (! isset(self::PARAM_TYPE_MAP[$type])) {
+            throw UnknownParameterType::new($type);
+        }
+
+        return self::PARAM_TYPE_MAP[$type];
+    }
+
+    private function __construct()
+    {
+    }
+
+    private function __clone()
+    {
+    }
+}

--- a/src/Driver/PDO/Result.php
+++ b/src/Driver/PDO/Result.php
@@ -91,7 +91,9 @@ final class Result implements ResultInterface
     }
 
     /**
-     * @return mixed|false
+     * @psalm-param PDO::FETCH_* $mode
+     *
+     * @return mixed
      *
      * @throws Exception
      */
@@ -105,6 +107,8 @@ final class Result implements ResultInterface
     }
 
     /**
+     * @psalm-param PDO::FETCH_* $mode
+     *
      * @return list<mixed>
      *
      * @throws Exception


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

This is a lightweight version of #5863 by @kang8 which we can ship as a bugfix. Let's iterate on this further on the 3.6.x branch.
