### PR TITLE
No PDOException

### DIFF
--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -107,17 +107,29 @@ final class Connection implements ServerInfoAwareConnection
 
     public function beginTransaction(): bool
     {
-        return $this->connection->beginTransaction();
+        try {
+            return $this->connection->beginTransaction();
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
     }
 
     public function commit(): bool
     {
-        return $this->connection->commit();
+        try {
+            return $this->connection->commit();
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
     }
 
     public function rollBack(): bool
     {
-        return $this->connection->rollBack();
+        try {
+            return $this->connection->rollBack();
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
     }
 
     public function getNativeConnection(): PDO

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\DBAL\Tests\Functional;
 
+use Doctrine\DBAL\Driver\PDO\Exception as PDOException;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
-use PDOException;
 
 use function sleep;
 


### PR DESCRIPTION
Fixes to match `\Doctrine\DBAL\Driver\Connection`: `beginTransaction`, `commit` and `rollBack` must throw  `\Doctrine\DBAL\Driver\Exception`.