### PR TITLE
Raise exception if `pg_send_*()` calls fail

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -655,6 +655,7 @@
                 <referencedFunction name="pg_field_type"/>
                 <referencedFunction name="pg_free_result"/>
                 <referencedFunction name="pg_get_result"/>
+                <referencedFunction name="pg_last_error"/>
                 <referencedFunction name="pg_num_fields"/>
                 <referencedFunction name="pg_result_error_field"/>
                 <referencedFunction name="pg_send_execute"/>

--- a/src/Driver/PgSQL/Connection.php
+++ b/src/Driver/PgSQL/Connection.php
@@ -17,6 +17,7 @@ use function is_resource;
 use function pg_escape_bytea;
 use function pg_escape_literal;
 use function pg_get_result;
+use function pg_last_error;
 use function pg_result_error;
 use function pg_send_prepare;
 use function pg_version;
@@ -51,9 +52,9 @@ final class Connection implements ServerInfoAwareConnection
         $this->parser->parse($sql, $visitor);
 
         $statementName = uniqid('dbal', true);
-        $success       = (bool) pg_send_prepare($this->connection, $statementName, $visitor->getSQL());
-
-        assert($success);
+        if (@pg_send_prepare($this->connection, $statementName, $visitor->getSQL()) !== true) {
+            throw new Exception(pg_last_error($this->connection));
+        }
 
         $result = @pg_get_result($this->connection);
         assert($result !== false);

--- a/src/Driver/PgSQL/Statement.php
+++ b/src/Driver/PgSQL/Statement.php
@@ -19,6 +19,7 @@ use function is_resource;
 use function ksort;
 use function pg_escape_bytea;
 use function pg_get_result;
+use function pg_last_error;
 use function pg_result_error;
 use function pg_send_execute;
 use function sprintf;
@@ -142,8 +143,9 @@ final class Statement implements StatementInterface
             }
         }
 
-        $success = (bool) pg_send_execute($this->connection, $this->name, $escapedParameters);
-        assert($success);
+        if (@pg_send_execute($this->connection, $this->name, $escapedParameters) !== true) {
+            throw new Exception(pg_last_error($this->connection));
+        }
 
         $result = @pg_get_result($this->connection);
         assert($result !== false);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follow-up to #5880 
#### Summary

Raising an exception in those cases is probably better than letting an `assert()` fail. Not sure how to unit-test this though.
