### PR TITLE
Optimize pgsql queries without parameters

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -655,10 +655,12 @@
                 <referencedFunction name="pg_field_type"/>
                 <referencedFunction name="pg_free_result"/>
                 <referencedFunction name="pg_get_result"/>
+                <referencedFunction name="pg_last_error"/>
                 <referencedFunction name="pg_num_fields"/>
                 <referencedFunction name="pg_result_error_field"/>
                 <referencedFunction name="pg_send_execute"/>
                 <referencedFunction name="pg_send_prepare"/>
+                <referencedFunction name="pg_send_query"/>
                 <referencedFunction name="pg_version"/>
             </errorLevel>
         </PossiblyInvalidArgument>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follow-up to #5880, replaces #5887

#### Summary

This change should speed up pgsql queries without parameters a little.
