### PR TITLE
Make PDO transaction methods throw `PDOException&DriverException`

### DIFF
--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Driver\PDO;
 
+use Doctrine\DBAL\Driver\PDO\PDOException as DriverPDOException;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
@@ -107,17 +108,29 @@ final class Connection implements ServerInfoAwareConnection
 
     public function beginTransaction(): bool
     {
-        return $this->connection->beginTransaction();
+        try {
+            return $this->connection->beginTransaction();
+        } catch (PDOException $exception) {
+            throw DriverPDOException::new($exception);
+        }
     }
 
     public function commit(): bool
     {
-        return $this->connection->commit();
+        try {
+            return $this->connection->commit();
+        } catch (PDOException $exception) {
+            throw DriverPDOException::new($exception);
+        }
     }
 
     public function rollBack(): bool
     {
-        return $this->connection->rollBack();
+        try {
+            return $this->connection->rollBack();
+        } catch (PDOException $exception) {
+            throw DriverPDOException::new($exception);
+        }
     }
 
     public function getNativeConnection(): PDO

--- a/src/Driver/PDO/PDOException.php
+++ b/src/Driver/PDO/PDOException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\PDO;
+
+use Doctrine\DBAL\Driver\Exception as DriverException;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class PDOException extends \PDOException implements DriverException
+{
+    private ?string $sqlState = null;
+
+    public static function new(\PDOException $previous): self
+    {
+        $exception = new self($previous->message, 0, $previous);
+
+        $exception->errorInfo = $previous->errorInfo;
+        $exception->code      = $previous->code;
+        $exception->sqlState  = $previous->errorInfo[0] ?? null;
+
+        return $exception;
+    }
+
+    public function getSQLState(): ?string
+    {
+        return $this->sqlState;
+    }
+}

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Functional;
 
+use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use PDOException;
@@ -30,6 +31,8 @@ class TransactionTest extends FunctionalTestCase
         try {
             self::assertFalse(@$this->connection->commit()); // we will ignore `MySQL server has gone away` warnings
         } catch (PDOException $e) {
+            self::assertInstanceOf(DriverException::class, $e);
+
             /* For PDO, we are using ERRMODE EXCEPTION, so this catch should be
              * necessary as the equivalent of the error control operator above.
              * This seems to be the case only since PHP 8 */


### PR DESCRIPTION
Fixes to match `\Doctrine\DBAL\Driver\Connection`: `beginTransaction`, `commit` and `rollBack` must throw  `\Doctrine\DBAL\Driver\Exception`. For backwards compatibility `\PDOException` has been keep for version 3.*. Replace https://github.com/doctrine/dbal/pull/5886

Previous behavior:

````php
try {
   $connection->beginTransaction();
} catch(\PDOException) {
  // The code can be executed
}
````


````php
try {
   $connection->beginTransaction();
} catch(\Doctrine\DBAL\Driver\Exception) {
  // The code will never be executed :(
}
````

Current behavior:

````php
try {
   $connection->beginTransaction();
} catch(\PDOException) {
  // The code can be executed
}
````


````php
try {
   $connection->beginTransaction();
} catch(\Doctrine\DBAL\Driver\Exception) {
  // The code can be executed :)
}
````
