### PR TITLE
Close pgsql connection in destructor

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -149,6 +149,7 @@ parameters:
         - '~^Parameter #1 \$row of method Doctrine\\DBAL\\Driver\\PgSQL\\Result\:\:mapNumericRow\(\) expects array<int, string\|null>, array<int\|string, string\|null> given\.$~'
 
         # Ignore isset() checks in destructors.
+        - '~^Property Doctrine\\DBAL\\Driver\\PgSQL\\Connection\:\:\$connection \(PgSql\\Connection\|resource\) in isset\(\) is not nullable\.$~'
         - '~^Property Doctrine\\DBAL\\Driver\\PgSQL\\Statement\:\:\$connection \(PgSql\\Connection\|resource\) in isset\(\) is not nullable\.$~'
 
         # On PHP 7.4, pg_fetch_all() might return false for empty result sets.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -645,6 +645,7 @@
             <errorLevel type="suppress">
                 <!-- PgSql objects are represented as resources in PHP 7.4 -->
                 <referencedFunction name="pg_affected_rows"/>
+                <referencedFunction name="pg_close"/>
                 <referencedFunction name="pg_escape_bytea"/>
                 <referencedFunction name="pg_escape_identifier"/>
                 <referencedFunction name="pg_escape_literal"/>
@@ -752,6 +753,7 @@
                 <directory name="tests"/>
 
                 <!-- Ignore isset() checks in destructors. -->
+                <file name="src/Driver/PgSQL/Connection.php"/>
                 <file name="src/Driver/PgSQL/Statement.php"/>
             </errorLevel>
         </RedundantPropertyInitializationCheck>

--- a/src/Driver/PgSQL/Connection.php
+++ b/src/Driver/PgSQL/Connection.php
@@ -14,6 +14,7 @@ use function get_class;
 use function gettype;
 use function is_object;
 use function is_resource;
+use function pg_close;
 use function pg_escape_bytea;
 use function pg_escape_literal;
 use function pg_get_result;
@@ -45,6 +46,15 @@ final class Connection implements ServerInfoAwareConnection
 
         $this->connection = $connection;
         $this->parser     = new Parser(false);
+    }
+
+    public function __destruct()
+    {
+        if (! isset($this->connection)) {
+            return;
+        }
+
+        @pg_close($this->connection);
     }
 
     public function prepare(string $sql): Statement


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | Follows #5880 

#### Summary

Found while merging up. We usually close a connection by unsetting the driver. Currently, that would keep the a pgsql connection open but inaccessible until the PHP process terminates. With this PR, I'm explicitly closing the connection when the driver connection is destructed.
