### PR TITLE
Restore binary offsets of PDOStatement parameters

### DIFF
--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -157,7 +157,13 @@ final class Statement implements StatementInterface
             fclose($handle);
         }
 
-        $this->lobs = [];
+        // Clear parameters bound to closed handles.
+        // $this->lobs itself is not cleared, allowing a
+        // second call to execute without rebinding, which
+        // is supported for other parameter types.
+        foreach ($this->lobs as $param => $value) {
+            unset($this->parameters[$param]);
+        }
 
         if ($result === false) {
             throw StatementError::new($this->stmt);

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -19,11 +19,16 @@ use function assert;
 use function count;
 use function feof;
 use function fread;
+use function fseek;
+use function ftell;
 use function func_num_args;
 use function get_resource_type;
 use function is_int;
 use function is_resource;
 use function str_repeat;
+use function stream_get_meta_data;
+
+use const SEEK_SET;
 
 final class Statement implements StatementInterface
 {
@@ -218,15 +223,26 @@ final class Statement implements StatementInterface
     private function sendLongData(array $streams): void
     {
         foreach ($streams as $paramNr => $stream) {
-            while (! feof($stream)) {
-                $chunk = fread($stream, 8192);
+            $resetTo = false;
+            if (stream_get_meta_data($stream)['seekable']) {
+                $resetTo = ftell($stream);
+            }
 
-                if ($chunk === false) {
-                    throw FailedReadingStreamOffset::new($paramNr);
+            try {
+                while (! feof($stream)) {
+                    $chunk = fread($stream, 8192);
+
+                    if ($chunk === false) {
+                        throw FailedReadingStreamOffset::new($paramNr);
+                    }
+
+                    if (! $this->stmt->send_long_data($paramNr - 1, $chunk)) {
+                        throw StatementError::new($this->stmt);
+                    }
                 }
-
-                if (! $this->stmt->send_long_data($paramNr - 1, $chunk)) {
-                    throw StatementError::new($this->stmt);
+            } finally {
+                if ($resetTo !== false) {
+                    fseek($stream, $resetTo, SEEK_SET);
                 }
             }
         }

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -74,7 +74,7 @@ final class Statement implements StatementInterface
         }
 
         if ($type === ParameterType::BINARY || $type === ParameterType::LARGE_OBJECT) {
-            $this->trackParamResource($value);
+            $this->trackParamResource($param, $value);
         }
 
         return $this->bindParam($param, $value, $type);
@@ -195,16 +195,17 @@ final class Statement implements StatementInterface
      * Track a binary parameter reference at binding time. These
      * are cached for later analysis by the getResourceOffsets.
      *
-     * @param mixed $resource
+     * @param int|string $param
+     * @param mixed      $resource
      */
-    private function trackParamResource($resource): void
+    private function trackParamResource($param, $resource): void
     {
         if (! is_resource($resource)) {
             return;
         }
 
-        $this->paramResources ??= [];
-        $this->paramResources[] = $resource;
+        $this->paramResources       ??= [];
+        $this->paramResources[$param] = $resource;
     }
 
     /**
@@ -256,7 +257,5 @@ final class Statement implements StatementInterface
         foreach ($resourceOffsets as $index => $offset) {
             fseek($this->paramResources[$index], $offset, SEEK_SET);
         }
-
-        $this->paramResources = null;
     }
 }

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -5,15 +5,25 @@ namespace Doctrine\DBAL\Driver\PDO\SQLSrv;
 use Doctrine\DBAL\Driver\Exception\UnknownParameterType;
 use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
 use Doctrine\DBAL\Driver\PDO\Statement as PDOStatement;
+use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
 use PDO;
 
+use function fseek;
+use function ftell;
 use function func_num_args;
+use function is_resource;
+use function stream_get_meta_data;
+
+use const SEEK_SET;
 
 final class Statement extends AbstractStatementMiddleware
 {
     private PDOStatement $statement;
+
+    /** @var mixed[]|null */
+    private ?array $paramResources = null;
 
     /** @internal The statement can be only instantiated by its driver connection. */
     public function __construct(PDOStatement $statement)
@@ -104,6 +114,94 @@ final class Statement extends AbstractStatementMiddleware
             );
         }
 
+        if ($type === ParameterType::LARGE_OBJECT || $type === ParameterType::BINARY) {
+            $this->trackParamResource($value);
+        }
+
         return $this->bindParam($param, $value, $type);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($params = null): Result
+    {
+        $resourceOffsets = $this->getResourceOffsets();
+        try {
+            return parent::execute($params);
+        } finally {
+            if ($resourceOffsets !== null) {
+                $this->restoreResourceOffsets($resourceOffsets);
+            }
+        }
+    }
+
+    /**
+     * Track a binary parameter reference at binding time. These
+     * are cached for later analysis by the getResourceOffsets.
+     *
+     * @param mixed $resource
+     */
+    private function trackParamResource($resource): void
+    {
+        if (! is_resource($resource)) {
+            return;
+        }
+
+        $this->paramResources ??= [];
+        $this->paramResources[] = $resource;
+    }
+
+    /**
+     * Determine the offset that any resource parameters needs to be
+     * restored to after the statement is executed. Call immediately
+     * before execute (not during bindValue) to get the most accurate offset.
+     *
+     * @return int[]|null Return offsets to restore if needed. The array may be sparse.
+     */
+    private function getResourceOffsets(): ?array
+    {
+        if ($this->paramResources === null) {
+            return null;
+        }
+
+        $resourceOffsets = null;
+        foreach ($this->paramResources as $index => $resource) {
+            $position = false;
+            if (stream_get_meta_data($resource)['seekable']) {
+                $position = ftell($resource);
+            }
+
+            if ($position === false) {
+                continue;
+            }
+
+            $resourceOffsets       ??= [];
+            $resourceOffsets[$index] = $position;
+        }
+
+        if ($resourceOffsets === null) {
+            $this->paramResources = null;
+        }
+
+        return $resourceOffsets;
+    }
+
+    /**
+     * Restore resource offsets moved by PDOStatement->execute
+     *
+     * @param int[]|null $resourceOffsets The offsets returned by getResourceOffsets.
+     */
+    private function restoreResourceOffsets(?array $resourceOffsets): void
+    {
+        if ($resourceOffsets === null || $this->paramResources === null) {
+            return;
+        }
+
+        foreach ($resourceOffsets as $index => $offset) {
+            fseek($this->paramResources[$index], $offset, SEEK_SET);
+        }
+
+        $this->paramResources = null;
     }
 }

--- a/src/Driver/PDO/SQLSrv/Statement.php
+++ b/src/Driver/PDO/SQLSrv/Statement.php
@@ -115,7 +115,7 @@ final class Statement extends AbstractStatementMiddleware
         }
 
         if ($type === ParameterType::LARGE_OBJECT || $type === ParameterType::BINARY) {
-            $this->trackParamResource($value);
+            $this->trackParamResource($param, $value);
         }
 
         return $this->bindParam($param, $value, $type);
@@ -140,16 +140,17 @@ final class Statement extends AbstractStatementMiddleware
      * Track a binary parameter reference at binding time. These
      * are cached for later analysis by the getResourceOffsets.
      *
-     * @param mixed $resource
+     * @param int|string $param
+     * @param mixed      $resource
      */
-    private function trackParamResource($resource): void
+    private function trackParamResource($param, $resource): void
     {
         if (! is_resource($resource)) {
             return;
         }
 
-        $this->paramResources ??= [];
-        $this->paramResources[] = $resource;
+        $this->paramResources       ??= [];
+        $this->paramResources[$param] = $resource;
     }
 
     /**
@@ -201,7 +202,5 @@ final class Statement extends AbstractStatementMiddleware
         foreach ($resourceOffsets as $index => $offset) {
             fseek($this->paramResources[$index], $offset, SEEK_SET);
         }
-
-        $this->paramResources = null;
     }
 }

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -7,16 +7,26 @@ use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\Deprecations\Deprecation;
+use PDO;
 use PDOException;
 use PDOStatement;
 
 use function array_slice;
+use function fseek;
+use function ftell;
 use function func_get_args;
 use function func_num_args;
+use function is_resource;
+use function stream_get_meta_data;
+
+use const SEEK_SET;
 
 final class Statement implements StatementInterface
 {
     private PDOStatement $stmt;
+
+    /** @var mixed[]|null */
+    private ?array $paramResources = null;
 
     /** @internal The statement can be only instantiated by its driver connection. */
     public function __construct(PDOStatement $stmt)
@@ -43,6 +53,9 @@ final class Statement implements StatementInterface
         }
 
         $pdoType = ParameterTypeMap::convertParamType($type);
+        if ($pdoType === PDO::PARAM_LOB) {
+            $this->trackParamResource($value);
+        }
 
         try {
             return $this->stmt->bindValue($param, $value, $pdoType);
@@ -126,12 +139,86 @@ final class Statement implements StatementInterface
             );
         }
 
+        $resourceOffsets = $this->getResourceOffsets();
         try {
             $this->stmt->execute($params);
         } catch (PDOException $exception) {
             throw Exception::new($exception);
+        } finally {
+            if ($resourceOffsets !== null) {
+                $this->restoreResourceOffsets($resourceOffsets);
+            }
         }
 
         return new Result($this->stmt);
+    }
+
+    /**
+     * Track a binary parameter reference at binding time. These
+     * are cached for later analysis by the getResourceOffsets.
+     *
+     * @param mixed $resource
+     */
+    private function trackParamResource($resource): void
+    {
+        if (! is_resource($resource)) {
+            return;
+        }
+
+        $this->paramResources ??= [];
+        $this->paramResources[] = $resource;
+    }
+
+    /**
+     * Determine the offset that any resource parameters needs to be
+     * restored to after the statement is executed. Call immediately
+     * before execute (not during bindValue) to get the most accurate offset.
+     *
+     * @return int[]|null Return offsets to restore if needed. The array may be sparse.
+     */
+    private function getResourceOffsets(): ?array
+    {
+        if ($this->paramResources === null) {
+            return null;
+        }
+
+        $resourceOffsets = null;
+        foreach ($this->paramResources as $index => $resource) {
+            $position = false;
+            if (stream_get_meta_data($resource)['seekable']) {
+                $position = ftell($resource);
+            }
+
+            if ($position === false) {
+                continue;
+            }
+
+            $resourceOffsets       ??= [];
+            $resourceOffsets[$index] = $position;
+        }
+
+        if ($resourceOffsets === null) {
+            $this->paramResources = null;
+        }
+
+        return $resourceOffsets;
+    }
+
+    /**
+     * Restore resource offsets moved by PDOStatement->execute
+     *
+     * @param int[]|null $resourceOffsets The offsets returned by getResourceOffsets.
+     */
+    private function restoreResourceOffsets(?array $resourceOffsets): void
+    {
+        if ($resourceOffsets === null || $this->paramResources === null) {
+            return;
+        }
+
+        foreach ($resourceOffsets as $index => $offset) {
+            fseek($this->paramResources[$index], $offset, SEEK_SET);
+        }
+
+        $this->paramResources = null;
     }
 }

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -54,7 +54,7 @@ final class Statement implements StatementInterface
 
         $pdoType = ParameterTypeMap::convertParamType($type);
         if ($pdoType === PDO::PARAM_LOB) {
-            $this->trackParamResource($value);
+            $this->trackParamResource($param, $value);
         }
 
         try {
@@ -157,16 +157,17 @@ final class Statement implements StatementInterface
      * Track a binary parameter reference at binding time. These
      * are cached for later analysis by the getResourceOffsets.
      *
-     * @param mixed $resource
+     * @param int|string $param
+     * @param mixed      $resource
      */
-    private function trackParamResource($resource): void
+    private function trackParamResource($param, $resource): void
     {
         if (! is_resource($resource)) {
             return;
         }
 
-        $this->paramResources ??= [];
-        $this->paramResources[] = $resource;
+        $this->paramResources       ??= [];
+        $this->paramResources[$param] = $resource;
     }
 
     /**
@@ -218,7 +219,5 @@ final class Statement implements StatementInterface
         foreach ($resourceOffsets as $index => $offset) {
             fseek($this->paramResources[$index], $offset, SEEK_SET);
         }
-
-        $this->paramResources = null;
     }
 }

--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -110,7 +110,7 @@ final class Statement implements StatementInterface
         }
 
         if ($type === ParameterType::LARGE_OBJECT || $type === ParameterType::BINARY) {
-            $this->trackParamResource($value);
+            $this->trackParamResource($param, $value);
         }
 
         $this->variables[$param] = $value;
@@ -248,16 +248,17 @@ final class Statement implements StatementInterface
      * Track a binary parameter reference at binding time. These
      * are cached for later analysis by the getResourceOffsets.
      *
-     * @param mixed $resource
+     * @param int|string $param
+     * @param mixed      $resource
      */
-    private function trackParamResource($resource): void
+    private function trackParamResource($param, $resource): void
     {
         if (! is_resource($resource)) {
             return;
         }
 
-        $this->paramResources ??= [];
-        $this->paramResources[] = $resource;
+        $this->paramResources       ??= [];
+        $this->paramResources[$param] = $resource;
     }
 
     /**
@@ -309,7 +310,5 @@ final class Statement implements StatementInterface
         foreach ($resourceOffsets as $index => $offset) {
             fseek($this->paramResources[$index], $offset, SEEK_SET);
         }
-
-        $this->paramResources = null;
     }
 }

--- a/src/Driver/SQLite3/Statement.php
+++ b/src/Driver/SQLite3/Statement.php
@@ -10,9 +10,14 @@ use SQLite3;
 use SQLite3Stmt;
 
 use function assert;
+use function fseek;
+use function ftell;
 use function func_num_args;
 use function is_int;
+use function is_resource;
+use function stream_get_meta_data;
 
+use const SEEK_SET;
 use const SQLITE3_BLOB;
 use const SQLITE3_INTEGER;
 use const SQLITE3_NULL;
@@ -32,6 +37,9 @@ final class Statement implements StatementInterface
 
     private SQLite3 $connection;
     private SQLite3Stmt $statement;
+
+    /** @var mixed[]|null */
+    private ?array $paramResources = null;
 
     /** @internal The statement can be only instantiated by its driver connection. */
     public function __construct(SQLite3 $connection, SQLite3Stmt $statement)
@@ -58,7 +66,12 @@ final class Statement implements StatementInterface
             );
         }
 
-        return $this->statement->bindValue($param, $value, $this->convertParamType($type));
+        $sqliteType = $this->convertParamType($type);
+        if ($sqliteType === SQLITE3_BLOB) {
+            $this->trackParamResource($value);
+        }
+
+        return $this->statement->bindValue($param, $value, $sqliteType);
     }
 
     /**
@@ -109,10 +122,15 @@ final class Statement implements StatementInterface
             }
         }
 
+        $resourceOffsets = $this->getResourceOffsets();
         try {
             $result = $this->statement->execute();
         } catch (\Exception $e) {
             throw Exception::new($e);
+        } finally {
+            if ($resourceOffsets !== null) {
+                $this->restoreResourceOffsets($resourceOffsets);
+            }
         }
 
         assert($result !== false);
@@ -132,5 +150,74 @@ final class Statement implements StatementInterface
         }
 
         return self::PARAM_TYPE_MAP[$type];
+    }
+
+    /**
+     * Track a binary parameter reference at binding time. These
+     * are cached for later analysis by the getResourceOffsets.
+     *
+     * @param mixed $resource
+     */
+    private function trackParamResource($resource): void
+    {
+        if (! is_resource($resource)) {
+            return;
+        }
+
+        $this->paramResources ??= [];
+        $this->paramResources[] = $resource;
+    }
+
+    /**
+     * Determine the offset that any resource parameters needs to be
+     * restored to after the statement is executed. Call immediately
+     * before execute (not during bindValue) to get the most accurate offset.
+     *
+     * @return int[]|null Return offsets to restore if needed. The array may be sparse.
+     */
+    private function getResourceOffsets(): ?array
+    {
+        if ($this->paramResources === null) {
+            return null;
+        }
+
+        $resourceOffsets = null;
+        foreach ($this->paramResources as $index => $resource) {
+            $position = false;
+            if (stream_get_meta_data($resource)['seekable']) {
+                $position = ftell($resource);
+            }
+
+            if ($position === false) {
+                continue;
+            }
+
+            $resourceOffsets       ??= [];
+            $resourceOffsets[$index] = $position;
+        }
+
+        if ($resourceOffsets === null) {
+            $this->paramResources = null;
+        }
+
+        return $resourceOffsets;
+    }
+
+    /**
+     * Restore resource offsets moved by PDOStatement->execute
+     *
+     * @param int[]|null $resourceOffsets The offsets returned by getResourceOffsets.
+     */
+    private function restoreResourceOffsets(?array $resourceOffsets): void
+    {
+        if ($resourceOffsets === null || $this->paramResources === null) {
+            return;
+        }
+
+        foreach ($resourceOffsets as $index => $offset) {
+            fseek($this->paramResources[$index], $offset, SEEK_SET);
+        }
+
+        $this->paramResources = null;
     }
 }

--- a/src/Driver/SQLite3/Statement.php
+++ b/src/Driver/SQLite3/Statement.php
@@ -68,7 +68,7 @@ final class Statement implements StatementInterface
 
         $sqliteType = $this->convertParamType($type);
         if ($sqliteType === SQLITE3_BLOB) {
-            $this->trackParamResource($value);
+            $this->trackParamResource($param, $value);
         }
 
         return $this->statement->bindValue($param, $value, $sqliteType);
@@ -156,16 +156,17 @@ final class Statement implements StatementInterface
      * Track a binary parameter reference at binding time. These
      * are cached for later analysis by the getResourceOffsets.
      *
-     * @param mixed $resource
+     * @param int|string $param
+     * @param mixed      $resource
      */
-    private function trackParamResource($resource): void
+    private function trackParamResource($param, $resource): void
     {
         if (! is_resource($resource)) {
             return;
         }
 
-        $this->paramResources ??= [];
-        $this->paramResources[] = $resource;
+        $this->paramResources       ??= [];
+        $this->paramResources[$param] = $resource;
     }
 
     /**
@@ -217,7 +218,5 @@ final class Statement implements StatementInterface
         foreach ($resourceOffsets as $index => $offset) {
             fseek($this->paramResources[$index], $offset, SEEK_SET);
         }
-
-        $this->paramResources = null;
     }
 }

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -13,6 +13,7 @@ use function array_map;
 use function assert;
 use function fopen;
 use function fseek;
+use function ftell;
 use function fwrite;
 use function str_repeat;
 use function stream_get_contents;
@@ -239,6 +240,15 @@ class BlobTest extends FunctionalTestCase
         );
 
         self::assertSame([[1, 'test'], [2, 'test'], [3, 'test']], $rows);
+
+        // Executing this multiple times assures that the same bound stream is written
+        // multiple times. However, that is not the primary issue being tested. The impetus
+        // for this test is that reading the stream to extract the value moves the stream
+        // pointer, so that using the stream with a new statement (and hence a new call
+        // to bindValue and a new initial call to execute*) causes a different value to
+        // be read from the stream results. All that we have learned so far is that bindValue
+        // reuses the value obtained during the first execution of the statement.
+        self::assertEquals(2, ftell($stream), 'Resource parameter should be reset to position before execute.');
     }
 
     private function assertBlobContains(string $text): void

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -13,7 +13,6 @@ use function array_map;
 use function assert;
 use function fopen;
 use function fseek;
-use function ftell;
 use function fwrite;
 use function str_repeat;
 use function stream_get_contents;
@@ -229,10 +228,12 @@ class BlobTest extends FunctionalTestCase
         $stmt->bindValue(1, 3, ParameterType::INTEGER);
         $stmt->executeStatement();
 
-        $rows = array_map(
-            function (array $row): array {
+        $blobType = Type::getType(Types::BLOB);
+        $platform = $this->connection->getDatabasePlatform();
+        $rows     = array_map(
+            function (array $row) use ($blobType, $platform): array {
                 $row[0] = $this->connection->convertToPHPValue($row[0], Types::INTEGER);
-                $row[1] = $this->connection->convertToPHPValue($row[1], Types::STRING);
+                $row[1] = stream_get_contents($blobType->convertToPHPValue($row[1], $platform));
 
                 return $row;
             },
@@ -246,9 +247,12 @@ class BlobTest extends FunctionalTestCase
         // for this test is that reading the stream to extract the value moves the stream
         // pointer, so that using the stream with a new statement (and hence a new call
         // to bindValue and a new initial call to execute*) causes a different value to
-        // be read from the stream results. All that we have learned so far is that bindValue
-        // reuses the value obtained during the first execution of the statement.
-        self::assertEquals(2, ftell($stream), 'Resource parameter should be reset to position before execute.');
+        // be read from the stream results. Currently, we have verified one of two things:
+        // either the stream is reset with each execute, or that bindValue reuses the value
+        // obtained during the first execution of the statement. Which of these holds is not
+        // consistent across implementations. For example, the default pdo_sqlite test target
+        // does not reread the stream on subsequent executes, but pdo_pgsql does.
+        self::assertEquals('test', stream_get_contents($stream));
     }
 
     private function assertBlobContains(string $text): void


### PR DESCRIPTION
Entity identifiers that are PHP resource streams need to work for all references, not just the first one. PDOStatement->execute is reading the binary resources but not restoring the original offsets. No other code is restoring these streams to their original position so that they can be reused.

Examples of failures include empty collections on read (the first lazy load collection on an entity populates correctly, the second is empty) and foreign-key violations while persisting changes (the first entity join produces the correct SQL, the second has no data to read and the FK is violated with the missing binary data).

Making this change as close as possible to the external code that moves the stream pointer eliminates the need to do this in calling code.

This might also be an issue with other driver's Statement implementations. This request just handles the PDO driver. I have also not attempted to fix the deprecated bindParam code path. I do not believe this is called by the current Doctrine code, and is regardless much harder to patch because of the binding to variables that may or may not be populated when they are bound.

#5895
