### PR TITLE
PHPUnit 9.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "jetbrains/phpstorm-stubs": "2022.3",
         "phpstan/phpstan": "1.9.14",
         "phpstan/phpstan-strict-rules": "^1.4",
-        "phpunit/phpunit": "9.5.28",
+        "phpunit/phpunit": "9.6.0",
         "psalm/plugin-phpunit": "0.18.4",
         "squizlabs/php_codesniffer": "3.7.1",
         "symfony/cache": "^5.4|^6.0",

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -497,6 +497,9 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Connection::getEventManager"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::setEventManager"/>
+
+                <!-- TODO for PHPUnit 10 -->
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Unfortunately we cannot upgrade to PHPUnit 10 because of a version conflict with Psalm 4. 😢 
