### PR TITLE
Revert to using int as a return type

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -354,11 +354,6 @@ The following abstract methods in the `AbstractSchemaManager` class have been de
 
 Every non-abstract schema manager class must implement them in order to satisfy the API.
 
-# BC Break: The number of affected rows is returned as `int|string`
-
-The signatures of the methods returning the number of affected rows changed as returning `int|string` instead of `int`.
-If the number is greater than `PHP_INT_MAX`, the number of affected rows may be returned as a string if the driver supports it.
-
 # BC Break: Dropped support for `collate` option for MySQL
 
 Use `collation` instead.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -49,6 +49,11 @@ parameters:
             paths:
                 - src/Driver/OCI8/Statement.php
 
+        -
+            message: '~Method Doctrine\\DBAL\\Driver\\Mysqli\\Result::rowCount\(\) should return int but returns int(:?<0, max>)?\|string\.~'
+            paths:
+                - src/Driver/Mysqli/Result.php
+
         # Removing the (int) cast will make Psalm unhappy.
         -
             message: '~^Casting to int something that''s already int\.$~'
@@ -59,6 +64,9 @@ parameters:
                 - src/Driver/Mysqli/Exception/StatementError.php
 
         # We're testing with invalid input.
+        -
+            message: '~^Unable to resolve the template type T in call to method static method Doctrine\\DBAL\\DriverManager::getConnection\(\)~'
+            path: tests/DriverManagerTest.php
         -
             message: '~array{driver: ''invalid_driver''} given\.$~'
             path: tests/DriverManagerTest.php
@@ -74,6 +82,13 @@ parameters:
         -
             message: '~^Parameter #1 \$driverOptions of method Doctrine\\DBAL\\Tests\\Functional\\Driver\\Mysqli\\ConnectionTest\:\:getConnection\(\) expects array<string, mixed>, .* given\.$~'
             path: tests/Functional/Driver/Mysqli/ConnectionTest.php
+
+        # Fixing the issue would cause a BC break.
+        # TODO: fix in 4.0.0
+        -
+            message: '~^Method Doctrine\\DBAL\\Driver\\Mysqli\\Connection::exec\(\) should return int but returns int\|string\.$~'
+            paths:
+                - src/Driver/Mysqli/Connection.php
 
         # DriverManagerTest::testDatabaseUrl() should be refactored as it's too dynamic.
         -

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -378,11 +378,11 @@ class Connection implements ServerVersionProvider
      * @param array<string, mixed>                                                           $criteria
      * @param array<int, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
      *
-     * @return int|string The number of affected rows.
+     * @return int The number of affected rows.
      *
      * @throws Exception
      */
-    public function delete(string $table, array $criteria = [], array $types = []): int|string
+    public function delete(string $table, array $criteria = [], array $types = []): int
     {
         $columns = $values = $conditions = [];
 
@@ -445,11 +445,11 @@ class Connection implements ServerVersionProvider
      * @param array<string, mixed>                                                           $criteria
      * @param array<int, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
      *
-     * @return int|string The number of affected rows.
+     * @return int The number of affected rows.
      *
      * @throws Exception
      */
-    public function update(string $table, array $data, array $criteria = [], array $types = []): int|string
+    public function update(string $table, array $data, array $criteria = [], array $types = []): int
     {
         $columns = $values = $conditions = $set = [];
 
@@ -482,11 +482,11 @@ class Connection implements ServerVersionProvider
      * @param array<string, mixed>                                                           $data
      * @param array<int, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
      *
-     * @return int|string The number of affected rows.
+     * @return int The number of affected rows.
      *
      * @throws Exception
      */
-    public function insert(string $table, array $data, array $types = []): int|string
+    public function insert(string $table, array $data, array $types = []): int
     {
         if (count($data) === 0) {
             return $this->executeStatement('INSERT INTO ' . $table . ' () VALUES ()');
@@ -841,7 +841,7 @@ class Connection implements ServerVersionProvider
      *
      * @throws Exception
      */
-    public function executeStatement(string $sql, array $params = [], array $types = []): int|string
+    public function executeStatement(string $sql, array $params = [], array $types = []): int
     {
         $connection = $this->connect();
 
@@ -1373,7 +1373,7 @@ class Connection implements ServerVersionProvider
      *
      * @throws Exception
      */
-    public function executeUpdate(string $sql, array $params = [], array $types = []): int|string
+    public function executeUpdate(string $sql, array $params = [], array $types = []): int
     {
         return $this->executeStatement($sql, $params, $types);
     }
@@ -1393,7 +1393,7 @@ class Connection implements ServerVersionProvider
      *
      * @deprecated This API is deprecated and will be removed after 2022
      */
-    public function exec(string $sql): int|string
+    public function exec(string $sql): int
     {
         return $this->executeStatement($sql);
     }

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -257,7 +257,7 @@ class PrimaryReadReplicaConnection extends Connection
     /**
      * {@inheritDoc}
      */
-    public function executeStatement(string $sql, array $params = [], array $types = []): int|string
+    public function executeStatement(string $sql, array $params = [], array $types = []): int
     {
         $this->ensureConnectedToPrimary();
 

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -41,7 +41,7 @@ interface Connection extends ServerVersionProvider
      *
      * @throws Exception
      */
-    public function exec(string $sql): int|string;
+    public function exec(string $sql): int;
 
     /**
      * Returns the ID of the last inserted row.

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -66,7 +66,7 @@ final class Connection implements ConnectionInterface
         return "'" . db2_escape_string($value) . "'";
     }
 
-    public function exec(string $sql): int|string
+    public function exec(string $sql): int
     {
         $stmt = @db2_exec($this->connection, $sql);
 

--- a/src/Driver/Middleware/AbstractConnectionMiddleware.php
+++ b/src/Driver/Middleware/AbstractConnectionMiddleware.php
@@ -29,7 +29,7 @@ abstract class AbstractConnectionMiddleware implements Connection
         return $this->wrappedConnection->quote($value);
     }
 
-    public function exec(string $sql): int|string
+    public function exec(string $sql): int
     {
         return $this->wrappedConnection->exec($sql);
     }

--- a/src/Driver/Middleware/AbstractResultMiddleware.php
+++ b/src/Driver/Middleware/AbstractResultMiddleware.php
@@ -51,7 +51,7 @@ abstract class AbstractResultMiddleware implements Result
         return $this->wrappedResult->fetchFirstColumn();
     }
 
-    public function rowCount(): int|string
+    public function rowCount(): int
     {
         return $this->wrappedResult->rowCount();
     }

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -52,7 +52,7 @@ final class Connection implements ConnectionInterface
         return "'" . $this->connection->escape_string($value) . "'";
     }
 
-    public function exec(string $sql): int|string
+    public function exec(string $sql): int
     {
         try {
             $result = $this->connection->query($sql);

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -143,7 +143,7 @@ final class Result implements ResultInterface
         return FetchUtils::fetchFirstColumn($this);
     }
 
-    public function rowCount(): int|string
+    public function rowCount(): int
     {
         if ($this->hasColumns) {
             return $this->statement->num_rows;

--- a/src/Driver/Result.php
+++ b/src/Driver/Result.php
@@ -68,11 +68,11 @@ interface Result
      * some database drivers may return the number of rows returned by that query. However, this behaviour
      * is not guaranteed for all drivers and should not be relied on in portable applications.
      *
-     * If the number of rows exceeds {@see PHP_INT_MAX}, it might be returned as string if the driver supports it.
+     * @return int The number of rows.
      *
      * @throws Exception
      */
-    public function rowCount(): int|string;
+    public function rowCount(): int;
 
     /**
      * Returns the number of columns in the result

--- a/src/Logging/Connection.php
+++ b/src/Logging/Connection.php
@@ -39,7 +39,7 @@ final class Connection extends AbstractConnectionMiddleware
         return parent::query($sql);
     }
 
-    public function exec(string $sql): int|string
+    public function exec(string $sql): int
     {
         $this->logger->debug('Executing statement: {sql}', ['sql' => $sql]);
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -303,11 +303,11 @@ class QueryBuilder
      *
      * Should be used for INSERT, UPDATE and DELETE
      *
-     * @return int|string The number of affected rows.
+     * @return int The number of affected rows.
      *
      * @throws Exception
      */
-    public function executeStatement(): int|string
+    public function executeStatement(): int
     {
         return $this->connection->executeStatement($this->getSQL(), $this->params, $this->types);
     }

--- a/src/Result.php
+++ b/src/Result.php
@@ -223,11 +223,9 @@ class Result
      * some database drivers may return the number of rows returned by that query. However, this behaviour
      * is not guaranteed for all drivers and should not be relied on in portable applications.
      *
-     * If the number of rows exceeds {@see PHP_INT_MAX}, it might be returned as string if the driver supports it.
-     *
      * @throws Exception
      */
-    public function rowCount(): int|string
+    public function rowCount(): int
     {
         try {
             return $this->result->rowCount();

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -122,11 +122,9 @@ class Statement
     /**
      * Executes the statement with the currently bound parameters and return affected rows.
      *
-     * If the number of rows exceeds {@see PHP_INT_MAX}, it might be returned as string if the driver supports it.
-     *
      * @throws Exception
      */
-    public function executeStatement(): int|string
+    public function executeStatement(): int
     {
         return $this->execute()->rowCount();
     }


### PR DESCRIPTION
The only known case where this might affect users of this libary is:

- if more than PHP_INT_MAX rows are returned
- if mysqli is in use

The docs about PHP_INT_MAX state:

> Usually int(2147483647) in 32 bit systems and int(9223372036854775807)
in 64 bit systems.

If you have 2 billion rows in your database, you're either doing good enough to afford a 64 bit system, or you have a serious issue in your code.

One might say this is to satisfy static analysis tools, but in general, I'd say that more often that not, static analysis improvements makes things clearer for humans doing static analysis with their eyes as well. In our case, one might wonder why on earth we would return a string here.

Follow-up to https://github.com/doctrine/dbal/pull/5879#issuecomment-1415779244 , cc @derrabus @gromnan