### PR TITLE
Use TestLogger instead of mocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "11.1.0",
+        "fig/log-test": "^1",
         "jetbrains/phpstorm-stubs": "2022.3",
         "phpstan/phpstan": "1.9.14",
         "phpstan/phpstan-strict-rules": "^1.4",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

While hunting down calls to the deprecated `withConsecutive()` PHPUnit method, I have replaced our mocked logger from test tests of our logging middleware with the `TestLogger` class from the `fig/log-test` package.
