### PR TITLE
Use "numeric-string" return type for methods that return integers as strings

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -95,6 +95,22 @@ parameters:
         - '~^Parameter #1 \$row of method Doctrine\\DBAL\\Driver\\PgSQL\\Result\:\:mapAssociativeRow\(\) expects array<string, string\|null>, array<int\|string, string\|null> given\.$~'
         - '~^Parameter #1 \$row of method Doctrine\\DBAL\\Driver\\PgSQL\\Result\:\:mapNumericRow\(\) expects array<int, string\|null>, array<int\|string, string\|null> given\.$~'
 
+        # https://github.com/phpstan/phpstan-src/pull/2224
+        -
+            message: '~^Method Doctrine\\DBAL\\Driver\\Mysqli\\Connection\:\:exec\(\) should return int\|numeric\-string but returns int\|string\.$~'
+            count: 1
+            path: src/Driver/Mysqli/Connection.php
+
+        -
+            message: '~^Method Doctrine\\DBAL\\Driver\\Mysqli\\Result\:\:rowCount\(\) should return int\|numeric\-string but returns int\<0, max\>\|string\.$~'
+            count: 1
+            path: src/Driver/Mysqli/Result.php
+
+        -
+            message: '~^Method Doctrine\\DBAL\\Driver\\Mysqli\\Result\:\:rowCount\(\) should return int\|numeric\-string but returns int\|string\.$~'
+            count: 1
+            path: src/Driver/Mysqli/Result.php
+
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -378,7 +378,7 @@ class Connection implements ServerVersionProvider
      * @param array<string, mixed>                                                           $criteria
      * @param array<int, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
      *
-     * @return int|string The number of affected rows.
+     * @return int|numeric-string The number of affected rows.
      *
      * @throws Exception
      */
@@ -445,7 +445,7 @@ class Connection implements ServerVersionProvider
      * @param array<string, mixed>                                                           $criteria
      * @param array<int, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
      *
-     * @return int|string The number of affected rows.
+     * @return int|numeric-string The number of affected rows.
      *
      * @throws Exception
      */
@@ -482,7 +482,7 @@ class Connection implements ServerVersionProvider
      * @param array<string, mixed>                                                           $data
      * @param array<int, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
      *
-     * @return int|string The number of affected rows.
+     * @return int|numeric-string The number of affected rows.
      *
      * @throws Exception
      */
@@ -838,6 +838,8 @@ class Connection implements ServerVersionProvider
      *
      * @param list<mixed>|array<string, mixed> $params
      * @psalm-param WrapperParameterTypeArray $types
+     *
+     * @return int|numeric-string
      *
      * @throws Exception
      */
@@ -1369,6 +1371,8 @@ class Connection implements ServerVersionProvider
      * @param array<int, mixed>|array<string, mixed> $params
      * @psalm-param WrapperParameterTypeArray $types
      *
+     * @return int|numeric-string
+     *
      * @throws Exception
      */
     public function executeUpdate(string $sql, array $params = [], array $types = []): int|string
@@ -1390,6 +1394,8 @@ class Connection implements ServerVersionProvider
      * BC layer for a wide-spread use-case of old DBAL APIs
      *
      * @deprecated This API is deprecated and will be removed after 2022
+     *
+     * @return int|numeric-string
      */
     public function exec(string $sql): int|string
     {

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -39,6 +39,8 @@ interface Connection extends ServerVersionProvider
      * If the number of affected rows is greater than the maximum int value (PHP_INT_MAX),
      * the number of affected rows may be returned as a string.
      *
+     * @return int|numeric-string
+     *
      * @throws Exception
      */
     public function exec(string $sql): int|string;

--- a/src/Driver/Result.php
+++ b/src/Driver/Result.php
@@ -70,6 +70,8 @@ interface Result
      *
      * If the number of rows exceeds {@see PHP_INT_MAX}, it might be returned as string if the driver supports it.
      *
+     * @return int|numeric-string
+     *
      * @throws Exception
      */
     public function rowCount(): int|string;

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -303,7 +303,7 @@ class QueryBuilder
      *
      * Should be used for INSERT, UPDATE and DELETE
      *
-     * @return int|string The number of affected rows.
+     * @return int|numeric-string The number of affected rows.
      *
      * @throws Exception
      */

--- a/src/Result.php
+++ b/src/Result.php
@@ -225,6 +225,8 @@ class Result
      *
      * If the number of rows exceeds {@see PHP_INT_MAX}, it might be returned as string if the driver supports it.
      *
+     * @return int|numeric-string
+     *
      * @throws Exception
      */
     public function rowCount(): int|string

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -124,6 +124,8 @@ class Statement
      *
      * If the number of rows exceeds {@see PHP_INT_MAX}, it might be returned as string if the driver supports it.
      *
+     * @return int|numeric-string
+     *
      * @throws Exception
      */
     public function executeStatement(): int|string


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

Follow up of https://github.com/doctrine/dbal/pull/5879#issuecomment-1409179906.

#### To-Do

- [x] ~~Wait for vimeo/psalm#9226;~~ <- It will be omitted in order to not block the merge.
- [x] ~~Confirm if all drivers guarantee non negative integers for the affected rows.~~ <- Will be analyzed in a different PR.
