### PR TITLE
Fix type assumptions about `Connection::lastInsertId()`

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -878,8 +878,6 @@ class Connection implements ServerVersionProvider
      *
      * If the underlying driver does not support identity columns, an exception is thrown.
      *
-     * @return int|string The last insert ID, as an integer or a numeric string.
-     *
      * @throws Exception
      */
     public function lastInsertId(): int|string

--- a/src/Driver/Connection.php
+++ b/src/Driver/Connection.php
@@ -46,7 +46,7 @@ interface Connection extends ServerVersionProvider
     /**
      * Returns the ID of the last inserted row.
      *
-     * This method returns an integer or a numeric string representing the value of the auto-increment column
+     * This method returns an integer or a string representing the value of the auto-increment column
      * from the last row inserted into the database, if any, or throws an exception if a value cannot be returned,
      * in particular when:
      *
@@ -54,10 +54,8 @@ interface Connection extends ServerVersionProvider
      * - the last statement dit not return an identity (caution: see note below).
      *
      * Note: if the last statement was not an INSERT to an autoincrement column, this method MAY return an ID from a
-     * previous statement. DO NOT RELY ON THIS BEHAVIOR which is driver-dependent: always use getLastInsertId() right
-     * after executing an INSERT statement.
-     *
-     * @return int|string The last insert ID, as an integer or a numeric string.
+     * previous statement. DO NOT RELY ON THIS BEHAVIOR which is driver-dependent: always call this method right after
+     * executing an INSERT statement.
      *
      * @throws Exception
      */

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -77,7 +77,7 @@ final class Connection implements ConnectionInterface
         return db2_num_rows($stmt);
     }
 
-    public function lastInsertId(): int|string
+    public function lastInsertId(): string
     {
         $lastInsertId = db2_last_insert_id($this->connection);
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

See:
* https://github.com/doctrine/dbal/pull/5905#discussion_r1098667153;
* https://www.php.net/manual/en/function.db2-last-insert-id.php.

#### To-Do:
- [x] Check the error `Method Doctrine\DBAL\Driver\PDO\Connection::lastInsertId() should return int|numeric-string but returns non-falsy-string.`
