### PR TITLE
Run tests with MariaDB 10.10

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -297,6 +297,7 @@ jobs:
           - "10.5"
           - "10.7"
           - "10.9"
+          - "10.10"
         extension:
           - "mysqli"
           - "pdo_mysql"
@@ -308,16 +309,16 @@ jobs:
             mariadb-version: "10.7"
             extension: "pdo_mysql"
           - php-version: "8.1"
-            mariadb-version: "10.9"
+            mariadb-version: "10.10"
             extension: "mysqli"
           - php-version: "8.1"
-            mariadb-version: "10.9"
+            mariadb-version: "10.10"
             extension: "pdo_mysql"
           - php-version: "8.2"
-            mariadb-version: "10.9"
+            mariadb-version: "10.10"
             extension: "mysqli"
           - php-version: "8.2"
-            mariadb-version: "10.9"
+            mariadb-version: "10.10"
             extension: "pdo_mysql"
 
     services:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

We should run our tests with the latest MariaDB version.
