### PR TITLE
Avoid negative values from `Result::rowCount()`

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -89,6 +89,7 @@
         -->
         <exclude-pattern>src/Driver/IBMDB2/Connection.php</exclude-pattern>
         <exclude-pattern>src/Driver/Mysqli/Exception/ConnectionFailed.php</exclude-pattern>
+        <exclude-pattern>tests/Functional/Driver/Mysqli/ResultTest.php</exclude-pattern>
     </rule>
 
     <!-- See https://github.com/squizlabs/PHP_CodeSniffer/issues/2837 -->

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Driver\Mysqli;
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\Mysqli\Exception\ConnectionError;
+use Doctrine\DBAL\Driver\Mysqli\Exception\UnknownAffectedRowsError;
 use mysqli;
 use mysqli_sql_exception;
 
@@ -52,6 +53,7 @@ final class Connection implements ConnectionInterface
         return "'" . $this->connection->escape_string($value) . "'";
     }
 
+    /** @return int<0, max>|numeric-string */
     public function exec(string $sql): int|string
     {
         try {
@@ -62,6 +64,10 @@ final class Connection implements ConnectionInterface
 
         if ($result === false) {
             throw ConnectionError::new($this->connection);
+        }
+
+        if (0 > $this->connection->affected_rows) {
+            throw UnknownAffectedRowsError::new($this->connection);
         }
 
         return $this->connection->affected_rows;

--- a/src/Driver/Mysqli/Exception/UnknownAffectedRowsError.php
+++ b/src/Driver/Mysqli/Exception/UnknownAffectedRowsError.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\Mysqli\Exception;
+
+use Doctrine\DBAL\Driver\AbstractException;
+use mysqli;
+use mysqli_sql_exception;
+use mysqli_stmt;
+use ReflectionProperty;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class UnknownAffectedRowsError extends AbstractException
+{
+    public static function new(mysqli|mysqli_stmt $executedResource): self
+    {
+        return new self($executedResource->error, $executedResource->sqlstate, $executedResource->errno);
+    }
+
+    public static function upcast(mysqli_sql_exception $exception): self
+    {
+        $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
+
+        return new self($exception->getMessage(), $p->getValue($exception), (int) $exception->getCode(), $exception);
+    }
+}

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -150,7 +150,8 @@ final class Result implements ResultInterface
         }
 
         if (0 > $this->statement->affected_rows) {
-            throw StatementError::new($this->statement);
+            // Uncomment when find the way to reproduce the case.
+            // throw StatementError::new($this->statement);
         }
 
         return $this->statement->affected_rows;

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -150,8 +150,7 @@ final class Result implements ResultInterface
         }
 
         if (0 > $this->statement->affected_rows) {
-            // Uncomment when find the way to reproduce the case.
-            // throw StatementError::new($this->statement);
+            throw StatementError::new($this->statement);
         }
 
         return $this->statement->affected_rows;

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -149,6 +149,10 @@ final class Result implements ResultInterface
             return $this->statement->num_rows;
         }
 
+        if (0 > $this->statement->affected_rows) {
+            throw StatementError::new($this->statement);
+        }
+
         return $this->statement->affected_rows;
     }
 

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Driver\Mysqli;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\Mysqli\Exception\StatementError;
+use Doctrine\DBAL\Driver\Mysqli\Exception\UnknownAffectedRowsError;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use mysqli_sql_exception;
 use mysqli_stmt;
@@ -150,7 +151,7 @@ final class Result implements ResultInterface
         }
 
         if (0 > $this->statement->affected_rows) {
-            throw StatementError::new($this->statement);
+            throw UnknownAffectedRowsError::new($this->statement);
         }
 
         return $this->statement->affected_rows;

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -4,59 +4,70 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Driver\Mysqli;
 
-use Doctrine\DBAL\Driver\Mysqli\Exception\ConnectionError;
-use Doctrine\DBAL\Driver\Mysqli\Exception\StatementError;
+use Doctrine\DBAL\Driver\Mysqli\Exception\UnknownAffectedRowsError;
 use Doctrine\DBAL\Driver\Mysqli\Result;
-use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
+use mysqli;
 use mysqli_driver;
+use mysqli_stmt;
+
+use function sprintf;
+
+use const MYSQLI_REPORT_OFF;
 
 /** @requires extension mysqli */
 class ResultTest extends FunctionalTestCase
 {
+    private const TABLE_NAME = 'tesult_test_table';
+
+    private mysqli $nativeConnection;
+
     protected function setUp(): void
     {
-        if (TestUtil::isDriverOneOf('mysqli')) {
-            $mysqliDriver = new mysqli_driver();
-            $mysqliDriver->report_mode = MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT;
-
-            $this->connection->executeQuery('CREATE TABLE my_table (my_col_1 INT NOT NULL);');
-
-            return;
+        if (! TestUtil::isDriverOneOf('mysqli')) {
+            self::markTestSkipped('This test requires the mysqli driver.');
         }
 
-        self::markTestSkipped('This test requires the mysqli driver.');
+        $nativeConnection = $this->connection->getNativeConnection();
+
+        self::assertInstanceOf(mysqli::class, $nativeConnection);
+
+        $this->nativeConnection = $nativeConnection;
+
+        $table = new Table(self::TABLE_NAME);
+        $table->addColumn('my_col_1', 'integer', ['notnull' => true]);
+
+        $this->dropAndCreateTable($table);
     }
 
     protected function tearDown(): void
     {
-        $this->connection->executeStatement('DROP TABLE IF EXISTS my_table;');
+        $this->dropTableIfExists(self::TABLE_NAME);
     }
 
     public function testSuccessfulRowCountFromAffectedRows(): void
     {
-        // var_dump($this->connection->getNativeConnection()->error);
-        // var_dump($this->connection->getNativeConnection()->error_list);
-        // var_dump($this->connection->getNativeConnection()->info);
-        // self::assertSame(0, $this->connection->getNativeConnection()->affected_rows);
+        $result = $this->connection->executeQuery(sprintf('INSERT INTO %s VALUES(7);', self::TABLE_NAME));
 
-        self::assertSame(0, $this->connection->getNativeConnection()->affected_rows);
-
-        $result = $this->connection->executeQuery('INSERT INTO my_table VALUES(7);');
-
-        self::assertSame(1, $this->connection->getNativeConnection()->affected_rows);
         self::assertSame(1, $result->rowCount());
     }
 
     public function testFailingRowCountFromAffectedRows(): void
     {
-        $mysqliStmt = $this->connection->getNativeConnection()
-            ->prepare('INSERT INTO my_table VALUES(7);');
+        // Ensure report mode configuration is "off" (like the default value for PHP < 8.1).
+        $mysqliDriver              = new mysqli_driver();
+        $mysqliDriver->report_mode = MYSQLI_REPORT_OFF;
 
-        self::assertSame(-1, $mysqliStmt->affected_rows);
+        $mysqliStmt = $this->nativeConnection
+            ->prepare(sprintf('INSERT INTO %s VALUES (NULL);', self::TABLE_NAME));
 
-        $this->expectException(ConnectionError::class);
+        self::assertInstanceOf(mysqli_stmt::class, $mysqliStmt);
+
+        $mysqliStmt->execute();
+
+        $this->expectException(UnknownAffectedRowsError::class);
 
         (new Result($mysqliStmt))->rowCount();
     }

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -6,9 +6,11 @@ namespace Doctrine\DBAL\Tests\Functional\Driver\Mysqli;
 
 use Doctrine\DBAL\Driver\Mysqli\Exception\ConnectionError;
 use Doctrine\DBAL\Driver\Mysqli\Exception\StatementError;
+use Doctrine\DBAL\Driver\Mysqli\Result;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
+use mysqli_driver;
 
 /** @requires extension mysqli */
 class ResultTest extends FunctionalTestCase
@@ -16,6 +18,11 @@ class ResultTest extends FunctionalTestCase
     protected function setUp(): void
     {
         if (TestUtil::isDriverOneOf('mysqli')) {
+            $mysqliDriver = new mysqli_driver();
+            $mysqliDriver->report_mode = MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT;
+
+            $this->connection->executeQuery('CREATE TABLE my_table (my_col_1 INT NOT NULL);');
+
             return;
         }
 
@@ -29,14 +36,12 @@ class ResultTest extends FunctionalTestCase
 
     public function testSuccessfulRowCountFromAffectedRows(): void
     {
-        var_dump($this->connection->getNativeConnection()->error);
-        var_dump($this->connection->getNativeConnection()->error_list);
-        var_dump($this->connection->getNativeConnection()->info);
+        // var_dump($this->connection->getNativeConnection()->error);
+        // var_dump($this->connection->getNativeConnection()->error_list);
+        // var_dump($this->connection->getNativeConnection()->info);
+        // self::assertSame(0, $this->connection->getNativeConnection()->affected_rows);
+
         self::assertSame(0, $this->connection->getNativeConnection()->affected_rows);
-
-        $this->connection->executeQuery('CREATE TABLE my_table (my_col_1 INT NOT NULL);');
-
-        // self::assertSame(-1, $this->connection->getNativeConnection()->affected_rows);
 
         $result = $this->connection->executeQuery('INSERT INTO my_table VALUES(7);');
 
@@ -46,12 +51,13 @@ class ResultTest extends FunctionalTestCase
 
     public function testFailingRowCountFromAffectedRows(): void
     {
-        $result = $this->connection->executeQuery('CREATE TABLE my_table (my_col_1 INT NOT NULL);');
+        $mysqliStmt = $this->connection->getNativeConnection()
+            ->prepare('INSERT INTO my_table VALUES(7);');
 
-        self::assertSame(-1, $this->connection->getNativeConnection()->affected_rows);
+        self::assertSame(-1, $mysqliStmt->affected_rows);
 
         $this->expectException(ConnectionError::class);
 
-        $result->rowCount();
+        (new Result($mysqliStmt))->rowCount();
     }
 }

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -36,8 +36,7 @@ class ResultTest extends FunctionalTestCase
         // Calling `mysqli::get_connection_stats()` after an "INSERT" statement is not producing -1. See https://bugs.php.net/bug.php?id=67348.
         // $this->connection->getNativeConnection()->get_connection_stats();
 
-        // Calling `Connection::close()`.
-        $this->connection->close();
+        $result->fetchOne();
 
         self::assertSame(-1, $result->rowCount());
     }

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Driver\Mysqli;
+
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+
+/** @requires extension mysqli */
+class ResultTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        if (TestUtil::isDriverOneOf('mysqli')) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires the mysqli driver.');
+    }
+
+    public function testRowCount(): void
+    {
+        $result = $this->connection->executeQuery('SELECT 1 FROM nonexisting_table;');
+
+        self::assertSame(-1, $result->rowCount());
+    }
+}

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -36,6 +36,9 @@ class ResultTest extends FunctionalTestCase
         // Calling `mysqli::get_connection_stats()` after an "INSERT" statement is not producing -1. See https://bugs.php.net/bug.php?id=67348.
         // $this->connection->getNativeConnection()->get_connection_stats();
 
+        // Calling `Connection::close()`.
+        $this->connection->close();
+
         self::assertSame(-1, $result->rowCount());
     }
 }

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -13,15 +13,23 @@ class ResultTest extends FunctionalTestCase
     protected function setUp(): void
     {
         if (TestUtil::isDriverOneOf('mysqli')) {
+            $this->connection->executeQuery('CREATE TABLE my_table (my_col_1 INT NOT NULL);');
+
             return;
         }
 
         self::markTestSkipped('This test requires the mysqli driver.');
     }
 
+    protected function tearDown(): void
+    {
+        $this->connection->executeStatement('DROP TABLE IF EXISTS my_table;');
+    }
+
     public function testRowCount(): void
     {
-        $result = $this->connection->executeQuery('SELECT 1 FROM nonexisting_table;');
+        $result = $this->connection->getNativeConnection()->query('SELECT 1 FROM my_table;', \MYSQLI_USE_RESULT);
+        // $result = $this->connection->executeQuery('INSERT INTO my_table VALUES(7);');
 
         self::assertSame(-1, $result->rowCount());
     }

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -28,8 +28,9 @@ class ResultTest extends FunctionalTestCase
 
     public function testRowCount(): void
     {
-        $result = $this->connection->getNativeConnection()->query('SELECT 1 FROM my_table;', \MYSQLI_USE_RESULT);
-        // $result = $this->connection->executeQuery('INSERT INTO my_table VALUES(7);');
+        // $result = $this->connection->getNativeConnection()->query('SELECT 1 FROM my_table;', \MYSQLI_USE_RESULT);
+        $result = $this->connection->executeQuery('INSERT INTO my_table VALUES(7);');
+        print_r($result);
 
         self::assertSame(-1, $result->rowCount());
     }

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -29,6 +29,9 @@ class ResultTest extends FunctionalTestCase
 
     public function testSuccessfulRowCountFromAffectedRows(): void
     {
+        var_dump($this->connection->getNativeConnection()->error);
+        var_dump($this->connection->getNativeConnection()->error_list);
+        var_dump($this->connection->getNativeConnection()->info);
         self::assertSame(0, $this->connection->getNativeConnection()->affected_rows);
 
         $this->connection->executeQuery('CREATE TABLE my_table (my_col_1 INT NOT NULL);');

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -30,7 +30,7 @@ class ResultTest extends FunctionalTestCase
     {
         // $result = $this->connection->getNativeConnection()->query('SELECT 1 FROM my_table;', \MYSQLI_USE_RESULT);
         $result = $this->connection->executeQuery('INSERT INTO my_table VALUES(7);');
-        print_r($result);
+        $this->connection->getNativeConnection()->get_connection_stats();
 
         self::assertSame(-1, $result->rowCount());
     }

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -28,9 +28,13 @@ class ResultTest extends FunctionalTestCase
 
     public function testRowCount(): void
     {
+        // Unbuffered query is not producing -1 as "SELECT" statements use `Statement::$num_rows` instead of `Statement::$affected_rows`.
         // $result = $this->connection->getNativeConnection()->query('SELECT 1 FROM my_table;', \MYSQLI_USE_RESULT);
+
         $result = $this->connection->executeQuery('INSERT INTO my_table VALUES(7);');
-        $this->connection->getNativeConnection()->get_connection_stats();
+
+        // Calling `mysqli::get_connection_stats()` after an "INSERT" statement is not producing -1. See https://bugs.php.net/bug.php?id=67348.
+        // $this->connection->getNativeConnection()->get_connection_stats();
 
         self::assertSame(-1, $result->rowCount());
     }

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -27,22 +27,22 @@ class ResultTest extends FunctionalTestCase
         $this->connection->executeStatement('DROP TABLE IF EXISTS my_table;');
     }
 
-    public function testFailingRowCount(): void
+    public function testSuccessfulRowCountFromAffectedRows(): void
     {
-        // self::assertSame(0, $this->connection->getNativeConnection()->affected_rows);
+        self::assertSame(0, $this->connection->getNativeConnection()->affected_rows);
 
-        // $result = $this->connection->executeQuery('INSERT INTO my_table VALUES(7);');
+        $this->connection->executeQuery('CREATE TABLE my_table (my_col_1 INT NOT NULL);');
 
-        // self::assertSame(1, $this->connection->getNativeConnection()->affected_rows);
-        // self::assertSame(1, $result->rowCount());
+        // self::assertSame(-1, $this->connection->getNativeConnection()->affected_rows);
 
-        // try {
-        //     $result->fetchOne();
-        // } catch (DriverException $e) {
-        //     self::assertInstanceOf(StatementError::class, $e->getPrevious());
-        //     self::assertSame('Commands out of sync; you can\'t run this command now', $e->getPrevious()->getMessage());
-        // }
+        $result = $this->connection->executeQuery('INSERT INTO my_table VALUES(7);');
 
+        self::assertSame(1, $this->connection->getNativeConnection()->affected_rows);
+        self::assertSame(1, $result->rowCount());
+    }
+
+    public function testFailingRowCountFromAffectedRows(): void
+    {
         $result = $this->connection->executeQuery('CREATE TABLE my_table (my_col_1 INT NOT NULL);');
 
         self::assertSame(-1, $this->connection->getNativeConnection()->affected_rows);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

To me, returning `-1` from a method that should count affected records is counter-intuitive.
IMO, the errors must be reported with a proper exception mechanism, not using arbitrary values (negative integers in this case) in methods that are intended to return something else. This way, we can have confident results.

<!-- Provide a summary of your change. -->
Related to https://github.com/doctrine/dbal/pull/5905#discussion_r1098641602.
Depends on #5917.

#### To-Do

- [ ] Wait for #5917.