### PR TITLE
Use Native JSON type instead of LONGTEXT for MariaDB

### DIFF
--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Platforms\MariaDb1043Platform;
 use Doctrine\DBAL\Platforms\MariaDb1052Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
@@ -35,10 +36,15 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
     public function createDatabasePlatformForVersion($version)
     {
         $mariadb = stripos($version, 'mariadb') !== false;
+
         if ($mariadb) {
             $mariaDbVersion = $this->getMariaDbMysqlVersionNumber($version);
             if (version_compare($mariaDbVersion, '10.5.2', '>=')) {
                 return new MariaDb1052Platform();
+            }
+
+            if (version_compare($mariaDbVersion, '10.4.3', '>=')) {
+                return new MariaDb1043Platform();
             }
 
             if (version_compare($mariaDbVersion, '10.2.7', '>=')) {

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -396,6 +396,18 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
                ' ORDER BY ORDINAL_POSITION ASC';
     }
 
+    /**
+     * The SQL snippets required to elucidate a column type
+     *
+     * Returns an array of the form [column type SELECT snippet, additional JOIN statement snippet]
+     *
+     * @return array{string, string}
+     */
+    public function getColumnTypeSQLSnippets(string $tableAlias = 'c'): array
+    {
+        return [$tableAlias . '.COLUMN_TYPE', ''];
+    }
+
     /** @deprecated The SQL used for schema introspection is an implementation detail and should not be relied upon. */
     public function getListTableMetadataSQL(string $table, ?string $database = null): string
     {
@@ -1390,7 +1402,7 @@ SQL
         return true;
     }
 
-    private function getDatabaseNameSQL(?string $databaseName): string
+    protected function getDatabaseNameSQL(?string $databaseName): string
     {
         if ($databaseName !== null) {
             return $this->quoteStringLiteral($databaseName);

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -4626,6 +4626,10 @@ abstract class AbstractPlatform
             return false;
         }
 
+        if (! $this->columnDeclarationsMatch($column1, $column2)) {
+            return false;
+        }
+
         // If the platform supports inline comments, all comparison is already done above
         if ($this->supportsInlineColumnComments()) {
             return true;
@@ -4636,6 +4640,17 @@ abstract class AbstractPlatform
         }
 
         return $column1->getType() === $column2->getType();
+    }
+
+    /**
+     * Whether the database data type matches that expected for the doctrine type for the given colunms.
+     */
+    private function columnDeclarationsMatch(Column $column1, Column $column2): bool
+    {
+        return ! (
+            $column1->hasPlatformOption('declarationMismatch') ||
+            $column2->hasPlatformOption('declarationMismatch')
+        );
     }
 
     /**

--- a/src/Platforms/MariaDb1043Platform.php
+++ b/src/Platforms/MariaDb1043Platform.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\DBAL\Types\JsonType;
+
+use function sprintf;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MariaDB 10.4 (10.4.6 GA) database platform.
+ *
+ * Extend deprecated MariaDb1027Platform to ensure correct functions used in MySQLSchemaManager which
+ * tests for MariaDb1027Platform not MariaDBPlatform.
+ */
+class MariaDb1043Platform extends MariaDb1027Platform
+{
+    /**
+     * Use JSON rather than LONGTEXT for json columns. Since it is not a true native type, do not override
+     * hasNativeJsonType() so the DC2Type comment will still be set.
+     *
+     * {@inheritdoc}
+     */
+    public function getJsonTypeDeclarationSQL(array $column): string
+    {
+        return 'JSON';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * From version 10.4.3, MariaDb aliases JSON to LONGTEXT and adds a constraint CHECK (json_valid). Reverse
+     * this process when introspecting tables.
+     *
+     * @see https://mariadb.com/kb/en/information-schema-check_constraints-table/
+     * @see https://mariadb.com/kb/en/json-data-type/
+     * @see https://jira.mariadb.org/browse/MDEV-13916
+     */
+    public function getListTableColumnsSQL($table, $database = null): string
+    {
+        [$columnTypeSQL, $joinCheckConstraintSQL] = $this->getColumnTypeSQLSnippets();
+
+        return sprintf(
+            <<<SQL
+            SELECT c.COLUMN_NAME AS Field,
+                   $columnTypeSQL AS Type,
+                   c.IS_NULLABLE AS `Null`,
+                   c.COLUMN_KEY AS `Key`,
+                   c.COLUMN_DEFAULT AS `Default`,
+                   c.EXTRA AS Extra,
+                   c.COLUMN_COMMENT AS Comment,
+                   c.CHARACTER_SET_NAME AS CharacterSet,
+                   c.COLLATION_NAME AS Collation
+            FROM information_schema.COLUMNS c
+                $joinCheckConstraintSQL
+            WHERE c.TABLE_SCHEMA = %s
+            AND c.TABLE_NAME = %s
+            ORDER BY ORDINAL_POSITION ASC;
+            SQL
+            ,
+            $this->getDatabaseNameSQL($database),
+            $this->quoteStringLiteral($table),
+        );
+    }
+
+    /**
+     * Generate SQL snippets to reverse the aliasing of JSON to LONGTEXT.
+     *
+     * MariaDb aliases columns specified as JSON to LONGTEXT and sets a CHECK constraint to ensure the column
+     * is valid json. This function generates the SQL snippets which reverse this aliasing i.e. report a column
+     * as JSON where it was originally specified as such instead of LONGTEXT.
+     *
+     * The CHECK constraints are stored in information_schema.CHECK_CONSTRAINTS so JOIN that table.
+     *
+     * @return array{string, string}
+     */
+    public function getColumnTypeSQLSnippets(string $tableAlias = 'c'): array
+    {
+        if ($this->getJsonTypeDeclarationSQL([]) !== 'JSON') {
+            return parent::getColumnTypeSQLSnippets($tableAlias);
+        }
+
+        $columnTypeSQL = <<<SQL
+            IF(
+                x.CHECK_CLAUSE IS NOT NULL AND $tableAlias.COLUMN_TYPE = 'longtext',
+                'json',
+                $tableAlias.COLUMN_TYPE
+            )
+        SQL;
+
+        $joinCheckConstraintSQL = <<<SQL
+        LEFT JOIN information_schema.CHECK_CONSTRAINTS x
+            ON (
+                $tableAlias.TABLE_SCHEMA = x.CONSTRAINT_SCHEMA
+                AND $tableAlias.TABLE_NAME = x.TABLE_NAME
+                AND x.CHECK_CLAUSE = CONCAT('json_valid(`', $tableAlias.COLUMN_NAME , '`)')
+            )
+        SQL;
+
+        return [$columnTypeSQL, $joinCheckConstraintSQL];
+    }
+
+    /** {@inheritDoc} */
+    public function getColumnDeclarationSQL($name, array $column)
+    {
+        // MariaDb forces column collation to utf8mb4_bin where the column was declared as JSON so ignore
+        // collation and character set for json columns as attempting to set them can cause an error.
+        if ($this->getJsonTypeDeclarationSQL([]) === 'JSON' && ($column['type'] ?? null) instanceof JsonType) {
+            unset($column['collation']);
+            unset($column['charset']);
+        }
+
+        return parent::getColumnDeclarationSQL($name, $column);
+    }
+}

--- a/src/Platforms/MariaDb1052Platform.php
+++ b/src/Platforms/MariaDb1052Platform.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Schema\TableDiff;
  *
  * Note: Should not be used with versions prior to 10.5.2.
  */
-class MariaDb1052Platform extends MariaDb1027Platform
+class MariaDb1052Platform extends MariaDb1043Platform
 {
     /**
      * {@inheritdoc}

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -405,15 +405,17 @@ SQL;
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
+        [$columnTypeSQL, $joinCheckConstraintSQL] = $this->_platform->getColumnTypeSQLSnippets();
+
         $sql = 'SELECT';
 
         if ($tableName === null) {
             $sql .= ' c.TABLE_NAME,';
         }
 
-        $sql .= <<<'SQL'
+        $sql .= <<<SQL
        c.COLUMN_NAME        AS field,
-       c.COLUMN_TYPE        AS type,
+       $columnTypeSQL       AS type,
        c.IS_NULLABLE        AS `null`,
        c.COLUMN_KEY         AS `key`,
        c.COLUMN_DEFAULT     AS `default`,
@@ -424,6 +426,7 @@ SQL;
 FROM information_schema.COLUMNS c
     INNER JOIN information_schema.TABLES t
         ON t.TABLE_NAME = c.TABLE_NAME
+    $joinCheckConstraintSQL
 SQL;
 
         // The schema name is passed multiple times as a literal in the WHERE clause instead of using a JOIN condition

--- a/tests/Functional/Schema/MySQL/ComparatorTest.php
+++ b/tests/Functional/Schema/MySQL/ComparatorTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Functional\Schema\MySQL;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDb1043Platform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Comparator;
@@ -145,6 +146,24 @@ final class ComparatorTest extends FunctionalTestCase
             $this->comparator,
             $table,
         ));
+    }
+
+    public function testMariaDb1043NativeJsonUpgradeDetected(): void
+    {
+        if (! $this->platform instanceof MariaDb1043Platform) {
+            self::markTestSkipped();
+        }
+
+        $table = new Table('mariadb_json_upgrade');
+
+        $table->addColumn('json_col', 'json');
+        $this->dropAndCreateTable($table);
+
+        // Revert column to old LONGTEXT declaration
+        $sql = 'ALTER TABLE mariadb_json_upgrade CHANGE json_col json_col LONGTEXT NOT NULL COMMENT \'(DC2Type:json)\'';
+        $this->connection->executeStatement($sql);
+
+        ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
     }
 
     /**

--- a/tests/Functional/Schema/MySQL/JsonCollationTest.php
+++ b/tests/Functional/Schema/MySQL/JsonCollationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Schema\MySQL;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDb1043Platform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Iterator;
+
+use function array_filter;
+
+/**
+ * Tests that character set and collation are ignored for columns declared as native JSON in MySQL and
+ * MariaDb and cannot be changed.
+ */
+final class JsonCollationTest extends FunctionalTestCase
+{
+    private AbstractPlatform $platform;
+
+    private AbstractSchemaManager $schemaManager;
+
+    private Comparator $comparator;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->connection->getDatabasePlatform();
+
+        if (! $this->platform instanceof MariaDb1043Platform) {
+            self::markTestSkipped();
+        }
+
+        $this->schemaManager = $this->connection->createSchemaManager();
+        $this->comparator    = $this->schemaManager->createComparator();
+    }
+
+    /**
+     * Generates a number of tables comprising only json columns. The tables are identical but for character
+     * set and collation.
+     *
+     * @return Iterator<array{Table}>
+     */
+    public function tableProvider(): iterable
+    {
+        $tables = [
+            [
+                'name' => 'mariadb_json_column_comparator_test',
+                'columns' => [
+                    ['name' => 'json_1', 'charset' => 'latin1', 'collation' => 'latin1_swedish_ci'],
+                    ['name' => 'json_2', 'charset' => 'utf8', 'collation' => 'utf8_general_ci'],
+                    ['name' => 'json_3'],
+                ],
+                'charset' => 'latin1',
+                'collation' => 'latin1_swedish_ci',
+            ],
+            [
+                'name' => 'mariadb_json_column_comparator_test',
+                'columns' => [
+                    ['name' => 'json_1', 'charset' => 'latin1', 'collation' => 'latin1_swedish_ci'],
+                    ['name' => 'json_2', 'charset' => 'utf8', 'collation' => 'utf8_general_ci'],
+                    ['name' => 'json_3'],
+                ],
+            ],
+            [
+                'name' => 'mariadb_json_column_comparator_test',
+                'columns' => [
+                    ['name' => 'json_1', 'charset' => 'utf8mb4', 'collation' => 'utf8mb4_bin'],
+                    ['name' => 'json_2', 'charset' => 'utf8mb4', 'collation' => 'utf8mb4_bin'],
+                    ['name' => 'json_3', 'charset' => 'utf8mb4', 'collation' => 'utf8mb4_general_ci'],
+                ],
+            ],
+            [
+                'name' => 'mariadb_json_column_comparator_test',
+                'columns' => [
+                    ['name' => 'json_1'],
+                    ['name' => 'json_2'],
+                    ['name' => 'json_3'],
+                ],
+            ],
+        ];
+
+        foreach ($tables as $table) {
+            yield [$this->setUpTable(
+                $table['name'],
+                $table['columns'],
+                $table['charset'] ?? null,
+                $table['collation'] ?? null,
+            ),
+            ];
+        }
+    }
+
+    /** @param array{name: string, type?: string, charset?: string, collation?: string}[] $columns */
+    private function setUpTable(string $name, array $columns, ?string $charset = null, ?string $collation = null): Table
+    {
+        $tableOptions = array_filter(['charset' => $charset, 'collation' => $collation]);
+
+        $table = new Table($name, [], [], [], [], $tableOptions);
+
+        foreach ($columns as $column) {
+            if (! isset($column['charset']) || ! isset($column['collation'])) {
+                $table->addColumn($column['name'], $column['type'] ?? 'json');
+            } else {
+                $table->addColumn($column['name'], $column['type'] ?? 'json')
+                      ->setPlatformOption('charset', $column['charset'])
+                      ->setPlatformOption('collation', $column['collation']);
+            }
+        }
+
+        return $table;
+    }
+
+    /** @dataProvider tableProvider */
+    public function testJsonColumnComparison(Table $table): void
+    {
+        $this->dropAndCreateTable($table);
+
+        $onlineTable = $this->schemaManager->introspectTable('mariadb_json_column_comparator_test');
+        $diff        = $this->comparator->compareTables($table, $onlineTable);
+
+        $this->assertTrue($diff->isEmpty(), 'Tables should be identical.');
+
+        $originalTable = clone $table;
+
+        $table->getColumn('json_1')
+              ->setPlatformOption('charset', 'utf8')
+              ->setPlatformOption('collation', 'utf8_general_ci');
+
+        $diff = $this->comparator->compareTables($table, $onlineTable);
+        $this->assertTrue($diff->isEmpty(), 'Tables should be unchanged after attempted collation change.');
+
+        $diff = $this->comparator->compareTables($table, $originalTable);
+        $this->assertTrue($diff->isEmpty(), 'Tables should be unchanged after attempted collation change.');
+    }
+}

--- a/tests/Functional/Types/JsonTest.php
+++ b/tests/Functional/Types/JsonTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Type;
+
+use function is_resource;
+use function json_decode;
+use function ksort;
+use function stream_get_contents;
+
+class JsonTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $table = new Table('json_test_table');
+        $table->addColumn('id', 'integer');
+
+        $table->addColumn('val', 'json');
+        $table->setPrimaryKey(['id']);
+
+        $this->dropAndCreateTable($table);
+    }
+
+    public function testInsertAndSelect(): void
+    {
+        $id1 = 1;
+        $id2 = 2;
+
+        $value1 = [
+            'firstKey' => 'firstVal',
+            'secondKey' => 'secondVal',
+            'nestedKey' => [
+                'nestedKey1' => 'nestedVal1',
+                'nestedKey2' => 2,
+            ],
+        ];
+        $value2 = json_decode('{"key1":"Val1","key2":2,"key3":"Val3"}', true);
+
+        $this->insert($id1, $value1);
+        $this->insert($id2, $value2);
+
+        $res1 = $this->select($id1);
+        $res2 = $this->select($id2);
+
+        // The returned arrays are not guaranteed to be in the same order so sort them
+        ksort($value1);
+        ksort($value2);
+        ksort($res1);
+        ksort($res2);
+
+        self::assertSame($value1, $res1);
+        self::assertSame($value2, $res2);
+    }
+
+    /** @param array<scalar|array> $value */
+    private function insert(int $id, array $value): void
+    {
+        $result = $this->connection->insert('json_test_table', [
+            'id'  => $id,
+            'val' => $value,
+        ], [
+            ParameterType::INTEGER,
+            Type::getType('json'),
+        ]);
+
+        self::assertSame(1, $result);
+    }
+
+    /** @return array<scalar|array> */
+    private function select(int $id): array
+    {
+        $value = $this->connection->fetchOne(
+            'SELECT val FROM json_test_table WHERE id = ?',
+            [$id],
+            [ParameterType::INTEGER],
+        );
+
+        if (is_resource($value)) {
+            $value = stream_get_contents($value);
+        }
+
+        self::assertIsString($value);
+
+        $value = json_decode($value, true);
+
+        self::assertIsArray($value);
+
+        return $value;
+    }
+}

--- a/tests/Platforms/MariaDb1043PlatformTest.php
+++ b/tests/Platforms/MariaDb1043PlatformTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDb1043Platform;
+use Doctrine\DBAL\Types\Types;
+
+class MariaDb1043PlatformTest extends AbstractMySQLPlatformTestCase
+{
+    public function createPlatform(): AbstractPlatform
+    {
+        return new MariaDb1043Platform();
+    }
+
+    public function testHasNativeJsonType(): void
+    {
+        self::assertFalse($this->platform->hasNativeJsonType());
+    }
+
+    /**
+     * From MariaDB 10.2.7, JSON type is an alias to LONGTEXT however from 10.4.3 setting a column
+     * as JSON adds additional functionality so use JSON.
+     *
+     * @link https://mariadb.com/kb/en/library/json-data-type/
+     */
+    public function testReturnsJsonTypeDeclarationSQL(): void
+    {
+        self::assertSame('JSON', $this->platform->getJsonTypeDeclarationSQL([]));
+    }
+
+    public function testInitializesJsonTypeMapping(): void
+    {
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('json'));
+        self::assertSame(Types::JSON, $this->platform->getDoctrineTypeMapping('json'));
+    }
+
+    public function testIgnoresDifferenceInDefaultValuesForUnsupportedColumnTypes(): void
+    {
+        self::markTestSkipped('MariaDb1043Platform supports default values for BLOB and TEXT columns');
+    }
+}

--- a/tests/Platforms/MariaDb1052PlatformTest.php
+++ b/tests/Platforms/MariaDb1052PlatformTest.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL\Tests\Platforms;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1052Platform;
 
-class MariaDb1052PlatformTest extends MariaDb1027PlatformTest
+class MariaDb1052PlatformTest extends MariaDb1043PlatformTest
 {
     public function createPlatform(): AbstractPlatform
     {

--- a/tests/Platforms/MySQL/MariaDbJsonComparatorTest.php
+++ b/tests/Platforms/MySQL/MariaDbJsonComparatorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Platforms\MySQL;
+
+use Doctrine\DBAL\Platforms\MariaDb1043Platform;
+use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
+use Doctrine\DBAL\Platforms\MySQL\Comparator;
+use Doctrine\DBAL\Schema\Table;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+class MariaDbJsonComparatorTest extends TestCase
+{
+    protected Comparator $comparator;
+
+    /** @var Table[] */
+    private array $tables = [];
+
+    protected function setUp(): void
+    {
+        $this->comparator = new Comparator(
+            new MariaDb1043Platform(),
+            new class implements CollationMetadataProvider {
+                public function getCollationCharset(string $collation): ?string
+                {
+                    return null;
+                }
+            },
+        );
+
+        // TableA has collation set at table level and various column collations
+        $this->tables['A'] = new Table(
+            'foo',
+            [],
+            [],
+            [],
+            [],
+            ['charset' => 'latin1', 'collation' => 'latin1_swedish_ci'],
+        );
+
+        $this->tables['A']->addColumn('json_1', 'json')->setPlatformOption('collation', 'latin1_swedish_ci');
+        $this->tables['A']->addColumn('json_2', 'json')->setPlatformOption('collation', 'utf8_general_ci');
+        $this->tables['A']->addColumn('json_3', 'json');
+
+        // TableB has no table-level collation and various column collations
+        $this->tables['B'] = new Table('foo');
+        $this->tables['B']->addColumn('json_1', 'json')->setPlatformOption('collation', 'latin1_swedish_ci');
+        $this->tables['B']->addColumn('json_2', 'json')->setPlatformOption('collation', 'utf8_general_ci');
+        $this->tables['B']->addColumn('json_3', 'json');
+
+        // Table C has no table-level collation and column collations as MariaDb would return for columns declared
+        // as JSON
+        $this->tables['C'] = new Table('foo');
+        $this->tables['C']->addColumn('json_1', 'json')->setPlatformOption('collation', 'utf8mb4_bin');
+        $this->tables['C']->addColumn('json_2', 'json')->setPlatformOption('collation', 'utf8mb4_bin');
+        $this->tables['C']->addColumn('json_3', 'json')->setPlatformOption('collation', 'utf8mb4_bin');
+
+        // Table D has no table or column collations set
+        $this->tables['D'] = new Table('foo');
+        $this->tables['D']->addColumn('json_1', 'json');
+        $this->tables['D']->addColumn('json_2', 'json');
+        $this->tables['D']->addColumn('json_3', 'json');
+    }
+
+    /** @return array{string, string}[] */
+    public static function providerTableComparisons(): iterable
+    {
+        return [
+            ['A', 'B'],
+            ['A', 'C'],
+            ['A', 'D'],
+            ['B', 'C'],
+            ['B', 'D'],
+            ['C', 'D'],
+        ];
+    }
+
+    /** @dataProvider providerTableComparisons */
+    public function testJsonColumnComparison(string $table1, string $table2): void
+    {
+        $this->assertTrue(
+            $this->comparator->compareTables($this->tables[$table1], $this->tables[$table2])->isEmpty(),
+            sprintf('Tables %s and %s should be identical', $table1, $table2),
+        );
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #3202

#### Summary

Adds a new MariaDb1043Platform with JSON type instead of LONGTEXT to be used for MariaDb versions at or above 10.4.3 when additional functionality specific to JSON columns was added. 

Deals with introspection issue flagged in pull request 5100 (the previous attempt to add this functionality) by inversing the JSON to LONGTEXT aliasing on table introspection (if applicable based on platform and MariaDb version).

Tested against MariaDb 10.6.11.  See commit message for further details. 
