### PR TITLE
Add test for `Mysqli\Result`

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -106,6 +106,7 @@
         -->
         <exclude-pattern>src/Driver/IBMDB2/Connection.php</exclude-pattern>
         <exclude-pattern>src/Driver/Mysqli/Exception/ConnectionFailed.php</exclude-pattern>
+        <exclude-pattern>tests/Functional/Driver/Mysqli/ResultTest.php</exclude-pattern>
     </rule>
 
     <!-- See https://github.com/squizlabs/PHP_CodeSniffer/issues/2837 -->

--- a/tests/Functional/Driver/Mysqli/ResultTest.php
+++ b/tests/Functional/Driver/Mysqli/ResultTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Driver\Mysqli;
+
+use Doctrine\DBAL\Driver\Mysqli\Result;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+use mysqli;
+use mysqli_driver;
+use mysqli_sql_exception;
+
+use function sprintf;
+
+use const MYSQLI_REPORT_ERROR;
+use const MYSQLI_REPORT_OFF;
+use const MYSQLI_REPORT_STRICT;
+
+/** @requires extension mysqli */
+final class ResultTest extends FunctionalTestCase
+{
+    private const TABLE_NAME = 'result_test_table';
+
+    private mysqli $nativeConnection;
+
+    protected function setUp(): void
+    {
+        if (! TestUtil::isDriverOneOf('mysqli')) {
+            self::markTestSkipped('This test requires the mysqli driver.');
+
+            return;
+        }
+
+        $nativeConnection = $this->connection->getNativeConnection();
+
+        self::assertInstanceOf(mysqli::class, $nativeConnection);
+
+        $this->nativeConnection = $nativeConnection;
+
+        $table = new Table(self::TABLE_NAME);
+        $table->addColumn('my_col_1', 'integer', ['notnull' => true]);
+
+        $this->dropAndCreateTable($table);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dropTableIfExists(self::TABLE_NAME);
+    }
+
+    public function testIntegerOnFailingRowCountFromAffectedRows(): void
+    {
+        $mysqliStmt = $this->nativeConnection
+            ->prepare(sprintf('INSERT INTO %s VALUES (NULL);', self::TABLE_NAME));
+
+        $mysqliDriver = new mysqli_driver();
+
+        $mysqliReportMode = $mysqliDriver->report_mode;
+
+        // Set MySQL's driver report mode to `MYSQLI_REPORT_OFF` in order to avoid exception on errors.
+        $mysqliDriver->report_mode = MYSQLI_REPORT_OFF;
+
+        try {
+            $mysqliStmt->execute();
+
+            self::assertSame(-1, $mysqliStmt->affected_rows);
+            self::assertSame(-1, (new Result($mysqliStmt))->rowCount());
+        } finally {
+            // Restore default configuration.
+            $mysqliDriver->report_mode = $mysqliReportMode;
+        }
+    }
+
+    public function testExceptionOnFailingRowCountFromAffectedRows(): void
+    {
+        $mysqliStmt = $this->nativeConnection
+            ->prepare(sprintf('INSERT INTO %s VALUES (NULL);', self::TABLE_NAME));
+
+        $mysqliDriver = new mysqli_driver();
+
+        $mysqliReportMode = $mysqliDriver->report_mode;
+
+        // Set MySQL's driver report mode to `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT` in order to throw exception on
+        // errors.
+        $mysqliDriver->report_mode = MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT;
+
+        try {
+            $mysqliStmt->execute();
+        } catch (mysqli_sql_exception $mysqliException) {
+            $this->expectException(mysqli_sql_exception::class);
+            $this->expectExceptionMessage('Column \'my_col_1\' cannot be null');
+
+            new Result($mysqliStmt);
+        } finally {
+            // Restore default configuration.
+            $mysqliDriver->report_mode = $mysqliReportMode;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

This test is required in order to confirm cases like `Result::rowCount()` returning -1.

Related to #5915, #4880, #4870.

#### To-Do

- [x] Find a query or a command sequence capable to reproduce the -1 result.