### PR TITLE
Check table names in upper-camel-lower-title cases

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -309,7 +309,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function tablesExist($names)
+    public function tablesExist($names, $lowerCase = true)
     {
         if (is_string($names)) {
             Deprecation::trigger(
@@ -320,9 +320,13 @@ abstract class AbstractSchemaManager
             );
         }
 
-        $names = array_map('strtolower', (array) $names);
+        if ($lowerCase) {
+            $names      = array_map('strtolower', $names);
+            $tableNames = array_map('strtolower', $this->listTableNames());
+        } else
+            $tableNames = $this->listTableNames();
 
-        return count($names) === count(array_intersect($names, array_map('strtolower', $this->listTableNames())));
+        return count($names) === count(array_intersect($names, $tableNames));
     }
 
     /**

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -309,7 +309,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function tablesExist($names, $lowerCase = true)
+    public function tablesExist($names)
     {
         if (is_string($names)) {
             Deprecation::trigger(
@@ -320,11 +320,7 @@ abstract class AbstractSchemaManager
             );
         }
 
-        if ($lowerCase) {
-            $names      = array_map('strtolower', $names);
-            $tableNames = array_map('strtolower', $this->listTableNames());
-        } else
-            $tableNames = $this->listTableNames();
+        $tableNames = $this->listTableNames();
 
         return count($names) === count(array_intersect($names, $tableNames));
     }


### PR DESCRIPTION
Mysql / MariaDB / Persona allows to use the table name in different cases.

The table names might look like this:

UPPERCASETABLENAME
CamelCaseTableName
lowercasetablename
Titlecasetablename

However, the original implementation of the tablesExist() function searches for existing tables ONLY in lower case:
by using the function:
'strtolower()'

$names = array_map('strtolower', $names);

return count($names) === count(array_intersect($names, $tableNames));

The current pull request allows to search for table names in different registers. Optional argument "$lowerCase = true" - allows to maintain compatibility with previous versions

Thank you

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
