### PR TITLE
[CI] Test "ibm_db2" driver against PHP 8.x

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -528,6 +528,7 @@ jobs:
       matrix:
         php-version:
           - "7.4"
+          - "8.2"
 
     services:
       ibm_db2:
@@ -559,7 +560,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-          ini-values: "zend.assertions=1,extension=ibm_db2.so, ibm_db2.instance_name=db2inst1"
+          ini-values: "zend.assertions=1, extension=ibm_db2.so, ibm_db2.instance_name=db2inst1"
 
       - name: "Install ibm_db2 extension"
         run: "ci/github/ext/install-ibm_db2.sh ${{ matrix.php-version }}"


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Add PHP 8.2 to the build matrix for the "ibm_db2" driver.