### PR TITLE
Use closures in portability converter

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -221,12 +221,18 @@
             <errorLevel type="suppress">
                 <!-- lastInsertId has a return type that does not match the one defined in the interface-->
                 <file name="src/Driver/Mysqli/Connection.php"/>
+
+                <!-- See https://github.com/vimeo/psalm/issues/5472 -->
+                <file name="src/Portability/Converter.php"/>
             </errorLevel>
         </InvalidReturnStatement>
         <InvalidReturnType>
             <errorLevel type="suppress">
                 <!-- lastInsertId has a return type that does not match the one defined in the interface-->
                 <file name="src/Driver/Mysqli/Connection.php"/>
+
+                <!-- See https://github.com/vimeo/psalm/issues/5472 -->
+                <file name="src/Portability/Converter.php"/>
             </errorLevel>
         </InvalidReturnType>
         <InvalidScalarArgument>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

With first class callable syntax in PHP 8.1, I think we can improve the code of the portability middleware's `Converter` class by turning all callables into actual closures. This also allows us to use typed properties in that file.
