### PR TITLE
Support RENAME INDEX on MariaDB

### DIFF
--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Platforms\MariaDb1052Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -34,11 +35,16 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
     public function createDatabasePlatformForVersion($version)
     {
         $mariadb = stripos($version, 'mariadb') !== false;
-        if ($mariadb && version_compare($this->getMariaDbMysqlVersionNumber($version), '10.2.7', '>=')) {
-            return new MariaDb1027Platform();
-        }
+        if ($mariadb) {
+            $mariaDbVersion = $this->getMariaDbMysqlVersionNumber($version);
+            if (version_compare($mariaDbVersion, '10.5.2', '>=')) {
+                return new MariaDb1052Platform();
+            }
 
-        if (! $mariadb) {
+            if (version_compare($mariaDbVersion, '10.2.7', '>=')) {
+                return new MariaDb1027Platform();
+            }
+        } else {
             $oracleMysqlVersion = $this->getOracleMysqlVersionNumber($version);
             if (version_compare($oracleMysqlVersion, '8', '>=')) {
                 if (! version_compare($version, '8.0.0', '>=')) {

--- a/src/Platforms/MariaDb1052Platform.php
+++ b/src/Platforms/MariaDb1052Platform.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\TableDiff;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MariaDB 10.5 (10.5.2 GA) database platform.
+ *
+ * Note: Should not be used with versions prior to 10.5.2.
+ */
+class MariaDb1052Platform extends MariaDb1027Platform
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getPostAlterTableRenameIndexForeignKeySQL(TableDiff $diff)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getRenameIndexSQL($oldIndexName, Index $index, $tableName)
+    {
+        return ['ALTER TABLE ' . $tableName . ' RENAME INDEX ' . $oldIndexName . ' TO ' . $index->getQuotedName($this)];
+    }
+}

--- a/tests/Driver/AbstractMySQLDriverTest.php
+++ b/tests/Driver/AbstractMySQLDriverTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\API\MySQL;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Platforms\MariaDb1052Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -79,7 +80,13 @@ class AbstractMySQLDriverTest extends AbstractDriverTest
                 'https://github.com/doctrine/dbal/pull/5779',
                 false,
             ],
-            ['mariadb-10.9.3',MariaDb1027Platform::class, 'https://github.com/doctrine/dbal/pull/5779', true],
+            ['mariadb-10.9.3',MariaDb1052Platform::class, 'https://github.com/doctrine/dbal/pull/5779', true],
+            [
+                '10.5.2-MariaDB-1~lenny-log',
+                MariaDb1052Platform::class,
+                'https://github.com/doctrine/dbal/pull/5779',
+                false,
+            ],
         ];
     }
 }

--- a/tests/Platforms/MariaDb1052PlatformTest.php
+++ b/tests/Platforms/MariaDb1052PlatformTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDb1052Platform;
+
+class MariaDb1052PlatformTest extends MariaDb1027PlatformTest
+{
+    public function createPlatform(): AbstractPlatform
+    {
+        return new MariaDb1052Platform();
+    }
+
+    /** @return string[] */
+    protected function getAlterTableRenameIndexSQL(): array
+    {
+        return ['ALTER TABLE mytable RENAME INDEX idx_foo TO idx_bar'];
+    }
+
+    /** @return string[] */
+    protected function getQuotedAlterTableRenameIndexSQL(): array
+    {
+        return [
+            'ALTER TABLE `table` RENAME INDEX `create` TO `select`',
+            'ALTER TABLE `table` RENAME INDEX `foo` TO `bar`',
+        ];
+    }
+
+    /** @return string[] */
+    protected function getAlterTableRenameIndexInSchemaSQL(): array
+    {
+        return ['ALTER TABLE myschema.mytable RENAME INDEX idx_foo TO idx_bar'];
+    }
+
+    /** @return string[] */
+    protected function getQuotedAlterTableRenameIndexInSchemaSQL(): array
+    {
+        return [
+            'ALTER TABLE `schema`.`table` RENAME INDEX `create` TO `select`',
+            'ALTER TABLE `schema`.`table` RENAME INDEX `foo` TO `bar`',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL(): array
+    {
+        return ['ALTER TABLE mytable RENAME INDEX idx_foo TO idx_foo_renamed'];
+    }
+}


### PR DESCRIPTION
to support RENAME INDEX syntax

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | #5940 

#### Summary

Add support for MariaDB's RENAME INDEX syntax available with version 10.5.2. https://mariadb.com/kb/en/alter-table/#rename-indexkey
