### PR TITLE
Trigger runtime deprecations for legacy API

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -51,6 +51,7 @@
                 -->
                 <referencedClass name="Doctrine\DBAL\Driver\ServerInfoAwareConnection"/>
                 <referencedClass name="Doctrine\DBAL\VersionAwarePlatformDriver"/>
+                <referencedClass name="Doctrine\DBAL\FetchMode"/>
                 <!--
                     TODO: remove in 4.0.0
                 -->
@@ -604,6 +605,7 @@
         <InvalidArgument>
             <errorLevel type="suppress">
                 <!-- We're testing with invalid input here. -->
+                <file name="tests/Functional/LegacyAPITest.php"/>
                 <file name="tests/Platforms/AbstractPlatformTestCase.php"/>
             </errorLevel>
         </InvalidArgument>
@@ -748,6 +750,7 @@
                 
                 <!-- We're checking for invalid input. -->
                 <directory name="src/Driver/PgSQL"/>
+                <file name="src/Result.php"/>
             </errorLevel>
         </RedundantConditionGivenDocblockType>
         <RedundantPropertyInitializationCheck>

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1953,20 +1953,34 @@ class Connection
     /**
      * BC layer for a wide-spread use-case of old DBAL APIs
      *
-     * @deprecated This API is deprecated and will be removed after 2022
+     * @deprecated Use {@see executeQuery()} instead
      */
     public function query(string $sql): Result
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4163',
+            '%s is deprecated, please use executeQuery() instead.',
+            __METHOD__,
+        );
+
         return $this->executeQuery($sql);
     }
 
     /**
      * BC layer for a wide-spread use-case of old DBAL APIs
      *
-     * @deprecated This API is deprecated and will be removed after 2022
+     * @deprecated please use {@see executeStatement()} instead
      */
     public function exec(string $sql): int
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4163',
+            '%s is deprecated, please use executeStatement() instead.',
+            __METHOD__,
+        );
+
         return $this->executeStatement($sql);
     }
 }

--- a/src/FetchMode.php
+++ b/src/FetchMode.php
@@ -4,6 +4,8 @@ namespace Doctrine\DBAL;
 
 /**
  * Legacy Class that keeps BC for using the legacy APIs fetch()/fetchAll().
+ *
+ * @deprecated Use the dedicated fetch*() methods for the desired fetch mode instead.
  */
 class FetchMode
 {

--- a/src/Result.php
+++ b/src/Result.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL;
 use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Driver\Result as DriverResult;
 use Doctrine\DBAL\Exception\NoKeyValue;
+use Doctrine\Deprecations\Deprecation;
 use LogicException;
 use Traversable;
 
@@ -261,7 +262,9 @@ class Result
     /**
      * BC layer for a wide-spread use-case of old DBAL APIs
      *
-     * @deprecated This API is deprecated and will be removed after 2022
+     * @deprecated Use {@see fetchNumeric()}, {@see fetchAssociative()} or {@see fetchOne()} instead.
+     *
+     * @psalm-param FetchMode::* $mode
      *
      * @return mixed
      *
@@ -269,6 +272,13 @@ class Result
      */
     public function fetch(int $mode = FetchMode::ASSOCIATIVE)
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4007',
+            '%s is deprecated, please use fetchNumeric(), fetchAssociative() or fetchOne() instead.',
+            __METHOD__,
+        );
+
         if (func_num_args() > 1) {
             throw new LogicException('Only invocations with one argument are still supported by this legacy API.');
         }
@@ -291,7 +301,9 @@ class Result
     /**
      * BC layer for a wide-spread use-case of old DBAL APIs
      *
-     * @deprecated This API is deprecated and will be removed after 2022
+     * @deprecated Use {@see fetchAllNumeric()}, {@see fetchAllAssociative()} or {@see fetchFirstColumn()} instead.
+     *
+     * @psalm-param FetchMode::* $mode
      *
      * @return list<mixed>
      *
@@ -299,6 +311,13 @@ class Result
      */
     public function fetchAll(int $mode = FetchMode::ASSOCIATIVE): array
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/4007',
+            '%s is deprecated, please use fetchAllNumeric(), fetchAllAssociative() or fetchFirstColumn() instead.',
+            __METHOD__,
+        );
+
         if (func_num_args() > 1) {
             throw new LogicException('Only invocations with one argument are still supported by this legacy API.');
         }

--- a/tests/Functional/LegacyAPITest.php
+++ b/tests/Functional/LegacyAPITest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use LogicException;
 
 use function array_change_key_case;
@@ -14,6 +15,8 @@ use const CASE_LOWER;
 
 class LegacyAPITest extends FunctionalTestCase
 {
+    use VerifyDeprecations;
+
     protected function setUp(): void
     {
         $table = new Table('legacy_table');
@@ -39,7 +42,10 @@ class LegacyAPITest extends FunctionalTestCase
         $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
 
         $stmt = $this->connection->executeQuery($sql);
-        $row  = array_change_key_case($stmt->fetch(FetchMode::ASSOCIATIVE), CASE_LOWER);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4007');
+
+        $row = array_change_key_case($stmt->fetch(FetchMode::ASSOCIATIVE), CASE_LOWER);
         self::assertEquals(1, $row['test_int']);
     }
 
@@ -48,7 +54,10 @@ class LegacyAPITest extends FunctionalTestCase
         $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
 
         $stmt = $this->connection->executeQuery($sql);
-        $row  = $stmt->fetch(FetchMode::NUMERIC);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4007');
+
+        $row = $stmt->fetch(FetchMode::NUMERIC);
         self::assertEquals(1, $row[0]);
     }
 
@@ -57,7 +66,10 @@ class LegacyAPITest extends FunctionalTestCase
         $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
 
         $stmt = $this->connection->executeQuery($sql);
-        $row  = $stmt->fetch(FetchMode::COLUMN);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4007');
+
+        $row = $stmt->fetch(FetchMode::COLUMN);
         self::assertEquals(1, $row);
     }
 
@@ -89,6 +101,8 @@ class LegacyAPITest extends FunctionalTestCase
 
         $stmt = $this->connection->executeQuery($sql);
 
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4007');
+
         $rows = $stmt->fetchAll(FetchMode::ASSOCIATIVE);
         $rows = array_map(static function ($row) {
             return array_change_key_case($row, CASE_LOWER);
@@ -102,6 +116,9 @@ class LegacyAPITest extends FunctionalTestCase
         $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
 
         $stmt = $this->connection->executeQuery($sql);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4007');
+
         $rows = $stmt->fetchAll(FetchMode::NUMERIC);
         self::assertEquals([[0 => 1]], $rows);
     }
@@ -111,6 +128,9 @@ class LegacyAPITest extends FunctionalTestCase
         $sql = 'SELECT test_int FROM legacy_table WHERE test_int = 1';
 
         $stmt = $this->connection->executeQuery($sql);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4007');
+
         $rows = $stmt->fetchAll(FetchMode::COLUMN);
         self::assertEquals([1], $rows);
     }
@@ -148,12 +168,17 @@ class LegacyAPITest extends FunctionalTestCase
         $sql = 'SELECT test_string FROM legacy_table';
 
         $stmt = $this->connection->executeQuery($sql);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4007');
+
         $rows = $stmt->fetchAll(FetchMode::COLUMN);
         self::assertEquals(['foo', 'bar'], $rows);
     }
 
     public function testQuery(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4163');
+
         $stmt = $this->connection->query('SELECT test_string FROM legacy_table WHERE test_int = 1');
 
         $this->assertEquals('foo', $stmt->fetchOne());
@@ -165,6 +190,8 @@ class LegacyAPITest extends FunctionalTestCase
             'test_int' => 2,
             'test_string' => 'bar',
         ]);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4163');
 
         $count = $this->connection->exec('DELETE FROM legacy_table WHERE test_int > 1');
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

I'd like to remove the legacy API in 4.0. We intended to remove it "after 2022" which kinda is now. Besides that, we're going to maintain 3.x for quite a while and the upgrade path for each of the deprecated methods should be pretty easy.
