### PR TITLE
[CI] Update Docker image location for IBM DB2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -532,7 +532,7 @@ jobs:
 
     services:
       ibm_db2:
-        image: "ibmcom/db2:11.5.0.0"
+        image: "icr.io/db2_community/db2:11.5.8.0"
         env:
           DB2INST1_PASSWORD: "Doctrine2018"
           LICENSE: "accept"
@@ -548,7 +548,7 @@ jobs:
         run: "docker logs -f ${{ job.services.ibm_db2.id }} | sed '/(*) Setup has completed./ q'"
 
       - name: "Create temporary tablespace"
-        run: "docker exec ${{ job.services.ibm_db2.id }} su - db2inst1 -c 'db2 CONNECT TO doctrine && db2 CREATE USER TEMPORARY TABLESPACE doctrine_tbsp PAGESIZE 4 K'"
+        run: "docker exec ${{ job.services.ibm_db2.id }} su - db2inst1 -c 'db2 -t CONNECT TO doctrine; db2 -t CREATE USER TEMPORARY TABLESPACE doctrine_tbsp PAGESIZE 4 K;'"
 
       - name: "Checkout"
         uses: "actions/checkout@v3"


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

The image `ibmcom/db2` will become unavailable in the near future.
See https://hub.docker.com/r/ibmcom/db2.
<!-- Provide a summary of your change. -->
