### PR TITLE
Skip test on Postgres 10/11

### DIFF
--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -568,8 +568,8 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $wrappedConnection = $this->connection->getWrappedConnection();
         assert($wrappedConnection instanceof ServerInfoAwareConnection);
-        if (version_compare($wrappedConnection->getServerVersion(), '10.0', '<')) {
-            self::markTestSkipped('Manually setting the Oid is not supported in 9.4');
+        if (version_compare($wrappedConnection->getServerVersion(), '12.0', '<')) {
+            self::markTestSkipped('Manually setting the Oid is not supported in Postgres 11 and earlier');
         }
 
         $table = 'test_list_table_columns_oid_conflicts';


### PR DESCRIPTION
The test introduced with #5800 which is skipped on Postgres 9 won't run on Postgres 10 or 11 either.

cc @allenisalai