### PR TITLE
Add support for variable precision TIMEs and DATETIMEs

### DIFF
--- a/src/Driver/AbstractOracleDriver.php
+++ b/src/Driver/AbstractOracleDriver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\AbstractOracleDriver\EasyConnectString;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\API\OCI;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\OracleHptPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\OracleSchemaManager;
 use Doctrine\Deprecations\Deprecation;
@@ -19,11 +20,23 @@ use function assert;
  */
 abstract class AbstractOracleDriver implements Driver
 {
+    protected bool $useHighPrecisionTimestamps = false;
+
     /**
      * {@inheritDoc}
      */
     public function getDatabasePlatform()
     {
+        if ($this->useHighPrecisionTimestamps) {
+            return new OracleHptPlatform();
+        }
+
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5961',
+            'InitializeSession. Not enabling high precision timestamps in the OraclePlatform is deprecated.',
+        );
+
         return new OraclePlatform();
     }
 

--- a/src/Driver/AbstractSQLiteDriver.php
+++ b/src/Driver/AbstractSQLiteDriver.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\API\SQLite;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SqliteHptPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use Doctrine\Deprecations\Deprecation;
@@ -18,11 +19,23 @@ use function assert;
  */
 abstract class AbstractSQLiteDriver implements Driver
 {
+    protected bool $useHighPrecisionTimestamps = false;
+
     /**
      * {@inheritDoc}
      */
     public function getDatabasePlatform()
     {
+        if ($this->useHighPrecisionTimestamps) {
+            return new SqliteHptPlatform();
+        }
+
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5961',
+            'Not enabling high precision timestamps in the SqlitePlatform is deprecated.',
+        );
+
         return new SqlitePlatform();
     }
 

--- a/src/Driver/OCI8/Driver.php
+++ b/src/Driver/OCI8/Driver.php
@@ -6,9 +6,11 @@ use Doctrine\DBAL\Driver\AbstractOracleDriver;
 use Doctrine\DBAL\Driver\OCI8\Exception\ConnectionFailed;
 use SensitiveParameter;
 
+use function filter_var;
 use function oci_connect;
 use function oci_pconnect;
 
+use const FILTER_VALIDATE_BOOL;
 use const OCI_NO_AUTO_COMMIT;
 
 /**
@@ -25,6 +27,11 @@ final class Driver extends AbstractOracleDriver
         #[SensitiveParameter]
         array $params
     ) {
+        $this->useHighPrecisionTimestamps = filter_var(
+            $params['driverOptions']['high_precision_timestamps'] ?? false,
+            FILTER_VALIDATE_BOOL,
+        );
+
         $username    = $params['user'] ?? '';
         $password    = $params['password'] ?? '';
         $charset     = $params['charset'] ?? '';

--- a/src/Driver/PDO/OCI/Driver.php
+++ b/src/Driver/PDO/OCI/Driver.php
@@ -9,6 +9,10 @@ use PDO;
 use PDOException;
 use SensitiveParameter;
 
+use function filter_var;
+
+use const FILTER_VALIDATE_BOOL;
+
 final class Driver extends AbstractOracleDriver
 {
     /**
@@ -21,6 +25,11 @@ final class Driver extends AbstractOracleDriver
         array $params
     ) {
         $driverOptions = $params['driverOptions'] ?? [];
+
+        $this->useHighPrecisionTimestamps = filter_var(
+            $driverOptions['high_precision_timestamps'] ?? false,
+            FILTER_VALIDATE_BOOL,
+        );
 
         if (! empty($params['persistent'])) {
             $driverOptions[PDO::ATTR_PERSISTENT] = true;

--- a/src/Driver/PDO/SQLite/Driver.php
+++ b/src/Driver/PDO/SQLite/Driver.php
@@ -12,6 +12,9 @@ use PDOException;
 use SensitiveParameter;
 
 use function array_intersect_key;
+use function filter_var;
+
+use const FILTER_VALIDATE_BOOL;
 
 final class Driver extends AbstractSQLiteDriver
 {
@@ -26,6 +29,11 @@ final class Driver extends AbstractSQLiteDriver
     ) {
         $driverOptions        = $params['driverOptions'] ?? [];
         $userDefinedFunctions = [];
+
+        $this->useHighPrecisionTimestamps = filter_var(
+            $driverOptions['high_precision_timestamps'] ?? false,
+            FILTER_VALIDATE_BOOL,
+        );
 
         if (isset($driverOptions['userDefinedFunctions'])) {
             Deprecation::trigger(

--- a/src/Driver/SQLite3/Driver.php
+++ b/src/Driver/SQLite3/Driver.php
@@ -7,6 +7,10 @@ use Doctrine\DBAL\Driver\API\SQLite\UserDefinedFunctions;
 use SensitiveParameter;
 use SQLite3;
 
+use function filter_var;
+
+use const FILTER_VALIDATE_BOOL;
+
 final class Driver extends AbstractSQLiteDriver
 {
     /**
@@ -17,6 +21,11 @@ final class Driver extends AbstractSQLiteDriver
         array $params
     ): Connection {
         $isMemory = (bool) ($params['memory'] ?? false);
+
+        $this->useHighPrecisionTimestamps = filter_var(
+            $params['driverOptions']['high_precision_timestamps'] ?? false,
+            FILTER_VALIDATE_BOOL,
+        );
 
         if (isset($params['path'])) {
             if ($isMemory) {

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -290,6 +290,14 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getTimeFormatString()
+    {
+        return 'H:i:s';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDateTimeTypeDeclarationSQL(array $column)
     {
         if (isset($column['version']) && $column['version'] === true) {

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Platforms;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\AbstractAsset;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
@@ -290,21 +291,29 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getTimeFormatString()
+    public function getDateTimeTypeDeclarationSQL(array $column)
     {
-        return 'H:i:s';
+        return $this->getDateTimeTypeDeclarationSQLFromSnippets($column);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTypeDeclarationSQL(array $column)
+    protected function getDateTimeTypeDeclarationSQLSnippet(array $column): string
     {
-        if (isset($column['version']) && $column['version'] === true) {
-            return 'TIMESTAMP';
+        return isset($column['version']) && $column['version'] === true ? 'TIMESTAMP' : 'DATETIME';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDateTimeTypePrecisionSQLSnippet(array $column): string
+    {
+        if (empty($column['scale']) || (int) $column['scale'] === Column::DATETIME_SCALE_NOT_SET) {
+            return '';
         }
 
-        return 'DATETIME';
+        return '(' . $column['scale'] . ')';
     }
 
     /**
@@ -319,6 +328,14 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
      * {@inheritDoc}
      */
     public function getTimeTypeDeclarationSQL(array $column)
+    {
+        return $this->getTimeTypeDeclarationSQLFromSnippets($column);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTimeTypeDeclarationSQLSnippet(array $column): string
     {
         return 'TIME';
     }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3841,6 +3841,19 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Obtains DBMS specific SQL to be used to create date columns in statements
+     * like CREATE TABLE from declaration snippets.
+     *
+     * @param mixed[] $column
+     */
+    protected function getDateTimeTypeDeclarationSQLFromSnippets(array $column): string
+    {
+        return $this->getDateTimeTypeDeclarationSQLSnippet($column)
+             . $this->getDateTimeTypePrecisionSQLSnippet($column)
+             . $this->getDateTimeTypeSQLSuffix($column);
+    }
+
+    /**
      * Obtains DBMS specific SQL to be used to create datetime with timezone offset columns.
      *
      * @param mixed[] $column
@@ -3850,6 +3863,19 @@ abstract class AbstractPlatform
     public function getDateTimeTzTypeDeclarationSQL(array $column)
     {
         return $this->getDateTimeTypeDeclarationSQL($column);
+    }
+
+    /**
+     * Obtains DBMS specific SQL to be used to create datetime with timezone offset columns
+     * from declaration snippets.
+     *
+     * @param mixed[] $column
+     */
+    protected function getDateTimeTzTypeDeclarationSQLFromSnippets(array $column): string
+    {
+        return $this->getDateTimeTzTypeDeclarationSQLSnippet($column)
+             . $this->getDateTimeTzTypePrecisionSQLSnippet($column)
+             . $this->getDateTimeTzTypeSQLSuffix($column);
     }
 
     /**
@@ -3880,6 +3906,132 @@ abstract class AbstractPlatform
     public function getTimeTypeDeclarationSQL(array $column)
     {
         throw Exception::notSupported(__METHOD__);
+    }
+
+    /**
+     * Obtains DBMS specific SQL to be used to create time columns in statements
+     * like CREATE TABLE from declaration snippets.
+     *
+     * @param mixed[] $column
+     */
+    protected function getTimeTypeDeclarationSQLFromSnippets(array $column): string
+    {
+        return $this->getTimeTypeDeclarationSQLSnippet($column)
+             . $this->getTimeTypePrecisionSQLSnippet($column)
+             . $this->getTimeTypeSQLSuffix($column);
+    }
+
+    /**
+     * Obtains DBMS specific SQL declaration snippet to be used to create datetime columns in statements
+     * like CREATE TABLE.
+     *
+     * @param mixed[] $column
+     *
+     * @throws Exception If not supported on this platform.
+     */
+    protected function getDateTimeTypeDeclarationSQLSnippet(array $column): string
+    {
+        throw Exception::notSupported(__METHOD__);
+    }
+
+    /**
+     * Obtains DBMS specific SQL declaration snippet to be used to create datetimetz columns in statements
+     * like CREATE TABLE.
+     *
+     * @param mixed[] $column
+     */
+    protected function getDateTimeTzTypeDeclarationSQLSnippet(array $column): string
+    {
+        return $this->getDateTimeTypeDeclarationSQLSnippet($column);
+    }
+
+    /**
+     * Obtains DBMS specific SQL declaration snippet to be used to create time columns in statements
+     * like CREATE TABLE.
+     *
+     * @param mixed[] $column
+     *
+     * @throws Exception If not supported on this platform.
+     */
+    protected function getTimeTypeDeclarationSQLSnippet(array $column): string
+    {
+        throw Exception::notSupported(__METHOD__);
+    }
+
+    /**
+     * Obtains DBMS specific suffix to add to SQL declaration to create datetime columns in statements
+     * like CREATE TABLE, for example ' WITHOUT TIME ZONE'.
+     *
+     * Requires a leading space unless empty.
+     *
+     * @param mixed[] $column
+     */
+    protected function getDateTimeTypeSQLSuffix(array $column): string
+    {
+        return '';
+    }
+
+    /**
+     * Obtains DBMS specific suffix to add to SQL declaration to create datetimetz columns in statements
+     * like CREATE TABLE, for example ' WITH TIME ZONE'.
+     *
+     * Requires a leading space unless empty.
+     *
+     * @param mixed[] $column
+     */
+    protected function getDateTimeTzTypeSQLSuffix(array $column): string
+    {
+        return '';
+    }
+
+    /**
+     * Obtains DBMS specific suffix to add to SQL declaration to create time columns in statements
+     * like CREATE TABLE, for example ' WITHOUT TIME ZONE'.
+     *
+     * Requires a leading space unless empty.
+     *
+     * @param mixed[] $column
+     */
+    protected function getTimeTypeSQLSuffix(array $column): string
+    {
+        return '';
+    }
+
+    /**
+     * Obtains DBMS specific precision specifier to add to SQL declaration to create datetime columns in statements
+     * like CREATE TABLE.
+     *
+     * @param mixed[] $column
+     */
+    protected function getDateTimeTypePrecisionSQLSnippet(array $column): string
+    {
+        $scale = empty($column['scale']) || (int) $column['scale'] === Column::DATETIME_SCALE_NOT_SET
+                 ? '0'
+                 : $column['scale'];
+
+        return '(' . $scale . ')';
+    }
+
+    /**
+     * Obtains DBMS specific precision specifier to add to SQL declaration to create datetimetz columns in statements
+     * like CREATE TABLE.
+     *
+     * @param mixed[] $column
+     */
+    protected function getDateTimeTzTypePrecisionSQLSnippet(array $column): string
+    {
+        return $this->getDateTimeTypePrecisionSQLSnippet($column);
+    }
+
+    /**
+     * Obtains DBMS specific precision specifier to add to SQL declaration to create time columns in statements
+     * like CREATE TABLE.
+     *
+     * @param mixed[] $column
+     */
+    protected function getTimeTypePrecisionSQLSnippet(array $column): string
+    {
+        return $this->getDateTimeTypePrecisionSQLSnippet($column);
     }
 
     /**
@@ -4281,6 +4433,19 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Gets the format string, as accepted by the date() function, that describes the format of a stored datetime
+     * value of this platform excluding any microsecond specifier to use where conversion with
+     * getDateTimeFormatString() fails.
+     *
+     * Conversion will fail where the format string returned by getDateTimeFormatString() contains a
+     * microsecond specifier (.u) but the string to be converted has no decimal digits.
+     */
+    public function getFallbackDateTimeFormatString(): string
+    {
+        return $this->getDateFormatString() . ' ' . $this->getFallbackTimeFormatString();
+    }
+
+    /**
      * Gets the format string, as accepted by the date() function, that describes
      * the format of a stored datetime with timezone value of this platform.
      *
@@ -4289,6 +4454,19 @@ abstract class AbstractPlatform
     public function getDateTimeTzFormatString()
     {
         return 'Y-m-d H:i:s';
+    }
+
+    /**
+     * Gets the format string, as accepted by the date() function, that describes the format of a stored datetime
+     * with timezone value of this platform excluding any microsecond specifier to use where conversion with
+     * getDateTimeFormatString() fails.
+     *
+     * Conversion will fail where the format string returned by getDateTimeTzFormatString() contains a
+     * microsecond specifier (.u) but the string to be converted has no decimal digits.
+     */
+    public function getFallbackDateTimeTzFormatString(): string
+    {
+        return $this->getFallbackDateTimeFormatString();
     }
 
     /**
@@ -4309,6 +4487,19 @@ abstract class AbstractPlatform
      * @return string The format string.
      */
     public function getTimeFormatString()
+    {
+        return 'H:i:s';
+    }
+
+    /**
+     * Gets the format string, as accepted by the date() function, that describes the format of a stored time
+     * value of this platform excluding any microsecond specifier to use where conversion with
+     * getTimeFormatString() fails.
+     *
+     * Conversion will fail where the format string returned by getTimeFormatString() contains a
+     * microsecond specifier (.u) but the string to be converted has no decimal digits.
+     */
+    public function getFallbackTimeFormatString(): string
     {
         return 'H:i:s';
     }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -4429,7 +4429,7 @@ abstract class AbstractPlatform
      */
     public function getDateTimeFormatString()
     {
-        return 'Y-m-d H:i:s';
+        return $this->getDateFormatString() . ' ' . $this->getTimeFormatString();
     }
 
     /**
@@ -4453,7 +4453,7 @@ abstract class AbstractPlatform
      */
     public function getDateTimeTzFormatString()
     {
-        return 'Y-m-d H:i:s';
+        return $this->getDateTimeFormatString();
     }
 
     /**
@@ -4488,7 +4488,7 @@ abstract class AbstractPlatform
      */
     public function getTimeFormatString()
     {
-        return 'H:i:s';
+        return 'H:i:s.u';
     }
 
     /**

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -315,21 +315,25 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getTimeFormatString()
+    public function getDateTimeTypeDeclarationSQL(array $column)
     {
-        return 'H:i:s';
+        return $this->getDateTimeTypeDeclarationSQLFromSnippets($column);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTypeDeclarationSQL(array $column)
+    protected function getDateTimeTypeDeclarationSQLSnippet(array $column): string
     {
-        if (isset($column['version']) && $column['version'] === true) {
-            return 'TIMESTAMP(0) WITH DEFAULT';
-        }
+        return 'TIMESTAMP';
+    }
 
-        return 'TIMESTAMP(0)';
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDateTimeTypeSQLSuffix(array $column): string
+    {
+        return isset($column['version']) && $column['version'] === true ? ' WITH DEFAULT' : '';
     }
 
     /**
@@ -342,10 +346,40 @@ class DB2Platform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * TIME does not support precision greater than one second on DB2
      */
     public function getTimeTypeDeclarationSQL(array $column)
     {
         return 'TIME';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Gets the format string, as accepted by the date() function, that describes
+     * the format of a stored time value of this platform.
+     *
+     * Db2 does not support high precision time format strings (only datetime format strings)
+     *
+     * @return string The format string.
+     */
+    public function getTimeFormatString()
+    {
+        return 'H:i:s';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeFormatString()
+    {
+        return 'Y-m-d H:i:s.u';
+    }
+
+    public function getFallbackDateTimeFormatString(): string
+    {
+        return 'Y-m-d H:i:s';
     }
 
     /**

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -315,6 +315,14 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getTimeFormatString()
+    {
+        return 'H:i:s';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDateTimeTypeDeclarationSQL(array $column)
     {
         if (isset($column['version']) && $column['version'] === true) {

--- a/src/Platforms/OracleHptPlatform.php
+++ b/src/Platforms/OracleHptPlatform.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms;
+
+/**
+ * OracleHptPlatform.
+ *
+ * An Oracle platform that supports high precision timestamps.
+ */
+class OracleHptPlatform extends OraclePlatform
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeFormatString()
+    {
+        return 'Y-m-d H:i:s.u';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDateTimeTzFormatString()
+    {
+        return 'Y-m-d H:i:s.u P';
+    }
+}

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -1170,6 +1170,14 @@ SQL
     /**
      * {@inheritDoc}
      */
+    public function getDateTimeFormatString()
+    {
+        return 'Y-m-d H:i:s';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDateTimeTzFormatString()
     {
         return 'Y-m-d H:i:sP';

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -320,7 +320,15 @@ class OraclePlatform extends AbstractPlatform
      */
     public function getDateTimeTypeDeclarationSQL(array $column)
     {
-        return 'TIMESTAMP(0)';
+        return $this->getDateTimeTypeDeclarationSQLFromSnippets($column);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDateTimeTypeDeclarationSQLSnippet(array $column): string
+    {
+        return 'TIMESTAMP';
     }
 
     /**
@@ -328,7 +336,15 @@ class OraclePlatform extends AbstractPlatform
      */
     public function getDateTimeTzTypeDeclarationSQL(array $column)
     {
-        return 'TIMESTAMP(0) WITH TIME ZONE';
+        return $this->getDateTimeTzTypeDeclarationSQLFromSnippets($column);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDateTimeTzTypeSQLSuffix(array $column): string
+    {
+        return ' WITH TIME ZONE';
     }
 
     /**
@@ -341,6 +357,8 @@ class OraclePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * DATE columns do not support fractional seconds.
      */
     public function getTimeTypeDeclarationSQL(array $column)
     {
@@ -1175,12 +1193,22 @@ SQL
         return 'Y-m-d H:i:s';
     }
 
+    public function getFallbackDateTimeFormatString(): string
+    {
+        return 'Y-m-d H:i:s';
+    }
+
     /**
      * {@inheritDoc}
      */
     public function getDateTimeTzFormatString()
     {
-        return 'Y-m-d H:i:sP';
+        return 'Y-m-d H:i:s P';
+    }
+
+    public function getFallbackDateTimeTzFormatString(): string
+    {
+        return 'Y-m-d H:i:s P';
     }
 
     /**
@@ -1195,6 +1223,11 @@ SQL
      * {@inheritDoc}
      */
     public function getTimeFormatString()
+    {
+        return '1900-01-01 H:i:s';
+    }
+
+    public function getFallbackTimeFormatString(): string
     {
         return '1900-01-01 H:i:s';
     }

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -1158,6 +1158,14 @@ SQL
     /**
      * {@inheritDoc}
      */
+    public function getTimeFormatString()
+    {
+        return 'H:i:s';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDateTimeTzFormatString()
     {
         return 'Y-m-d H:i:sO';

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -1081,7 +1081,23 @@ SQL
      */
     public function getDateTimeTypeDeclarationSQL(array $column)
     {
-        return 'TIMESTAMP(0) WITHOUT TIME ZONE';
+        return $this->getDateTimeTypeDeclarationSQLFromSnippets($column);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDateTimeTypeDeclarationSQLSnippet(array $column): string
+    {
+        return 'TIMESTAMP';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDateTimeTypeSQLSuffix(array $column): string
+    {
+        return ' WITHOUT TIME ZONE';
     }
 
     /**
@@ -1089,7 +1105,15 @@ SQL
      */
     public function getDateTimeTzTypeDeclarationSQL(array $column)
     {
-        return 'TIMESTAMP(0) WITH TIME ZONE';
+        return $this->getDateTimeTzTypeDeclarationSQLFromSnippets($column);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDateTimeTzTypeSQLSuffix(array $column): string
+    {
+        return ' WITH TIME ZONE';
     }
 
     /**
@@ -1105,7 +1129,23 @@ SQL
      */
     public function getTimeTypeDeclarationSQL(array $column)
     {
-        return 'TIME(0) WITHOUT TIME ZONE';
+        return $this->getTimeTypeDeclarationSQLFromSnippets($column);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTimeTypeDeclarationSQLSnippet(array $column): string
+    {
+        return 'TIME';
+    }
+
+   /**
+    * {@inheritDoc}
+    */
+    protected function getTimeTypeSQLSuffix(array $column): string
+    {
+        return ' WITHOUT TIME ZONE';
     }
 
     /**
@@ -1158,15 +1198,12 @@ SQL
     /**
      * {@inheritDoc}
      */
-    public function getTimeFormatString()
+    public function getDateTimeTzFormatString()
     {
-        return 'H:i:s';
+        return 'Y-m-d H:i:s.uO';
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getDateTimeTzFormatString()
+    public function getFallbackDateTimeTzFormatString(): string
     {
         return 'Y-m-d H:i:sO';
     }

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1277,14 +1277,6 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeTzTypeDeclarationSQL(array $column)
-    {
-        return 'DATETIMEOFFSET(6)';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getAsciiStringTypeDeclarationSQL(array $column): string
     {
         $length = $column['length'] ?? null;
@@ -1371,9 +1363,29 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getDateTimeTypeDeclarationSQL(array $column)
     {
-        // 3 - microseconds precision length
-        // http://msdn.microsoft.com/en-us/library/ms187819.aspx
-        return 'DATETIME2(6)';
+        return $this->getDateTimeTypeDeclarationSQLFromSnippets($column);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDateTimeTypeDeclarationSQLSnippet(array $column): string
+    {
+        return 'DATETIME2';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDateTimeTypePrecisionSQLSnippet(array $column): string
+    {
+        if (! isset($column['scale']) || (int) $column['scale'] === Column::DATETIME_SCALE_NOT_SET) {
+            // 3 - microseconds precision length
+            // http://msdn.microsoft.com/en-us/library/ms187819.aspx
+            return '(6)';
+        }
+
+        return '(' . $column['scale'] . ')';
     }
 
     /**
@@ -1387,9 +1399,45 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getDateTimeTzTypeDeclarationSQL(array $column)
+    {
+        return $this->getDateTimeTzTypeDeclarationSQLFromSnippets($column);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDateTimeTzTypeDeclarationSQLSnippet(array $column): string
+    {
+        return 'DATETIMEOFFSET';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getTimeTypeDeclarationSQL(array $column)
     {
-        return 'TIME(0)';
+        return $this->getTimeTypeDeclarationSQLFromSnippets($column);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTimeTypeDeclarationSQLSnippet(array $column): string
+    {
+        return 'TIME';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTimeTypePrecisionSQLSnippet(array $column): string
+    {
+        $scale = empty($column['scale']) || (int) $column['scale'] === Column::DATETIME_SCALE_NOT_SET
+                  ? '0'
+                  : $column['scale'];
+
+        return '(' . $scale . ')';
     }
 
     /**
@@ -1475,14 +1523,6 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getDateTimeFormatString()
-    {
-        return 'Y-m-d H:i:s.u';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getDateFormatString()
     {
         return 'Y-m-d';
@@ -1491,17 +1531,14 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getTimeFormatString()
-    {
-        return 'H:i:s';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getDateTimeTzFormatString()
     {
         return 'Y-m-d H:i:s.u P';
+    }
+
+    public function getFallbackDateTimeTzFormatString(): string
+    {
+        return 'Y-m-d H:i:s P';
     }
 
     /**

--- a/src/Platforms/SqliteHptPlatform.php
+++ b/src/Platforms/SqliteHptPlatform.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms;
+
+/**
+ * SqliteHptPlatform.
+ *
+ * An Sqlite platform that supports high precision timestamps.
+ */
+class SqliteHptPlatform extends SqlitePlatform
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getTimeFormatString()
+    {
+        return 'H:i:s.u';
+    }
+}

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -353,6 +353,14 @@ class SqlitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function getTimeFormatString()
+    {
+        return 'H:i:s';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     protected function _getCommonIntegerTypeDeclarationSQL(array $column)
     {
         // sqlite autoincrement is only possible for the primary key

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -3,6 +3,9 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
+use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\DateTimeTzType;
+use Doctrine\DBAL\Types\TimeType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 
@@ -15,6 +18,8 @@ use function method_exists;
  */
 class Column extends AbstractAsset
 {
+    public const DATETIME_SCALE_NOT_SET = -1;
+
     /** @var Type */
     protected $_type;
 
@@ -70,6 +75,18 @@ class Column extends AbstractAsset
     {
         $this->_setName($name);
         $this->setType($type);
+
+        if (
+            ! isset($options['scale']) &&
+            (
+                $type instanceof DateTimeType ||
+                $type instanceof DateTimeTzType ||
+                $type instanceof TimeType
+            )
+        ) {
+            $options['scale'] = self::DATETIME_SCALE_NOT_SET;
+        }
+
         $this->setOptions($options);
     }
 

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -138,6 +138,10 @@ class DB2SchemaManager extends AbstractSchemaManager
                 $length = $tableColumn['length'];
                 break;
 
+            case 'timestamp':
+                $scale = $tableColumn['scale'];
+                break;
+
             case 'decimal':
             case 'double':
             case 'real':
@@ -160,6 +164,10 @@ class DB2SchemaManager extends AbstractSchemaManager
         if ($scale !== null && $precision !== null) {
             $options['scale']     = $scale;
             $options['precision'] = $precision;
+        }
+
+        if (strtolower($tableColumn['typename']) === 'timestamp') {
+            $options['scale'] = $scale;
         }
 
         return new Column($tableColumn['colname'], Type::getType($type), $options);

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -16,6 +16,7 @@ use function array_shift;
 use function assert;
 use function explode;
 use function implode;
+use function in_array;
 use function is_string;
 use function preg_match;
 use function strpos;
@@ -222,6 +223,12 @@ class MySQLSchemaManager extends AbstractSchemaManager
 
                 break;
 
+            case 'datetime':
+            case 'time':
+            case 'timestamp':
+                $scale = $length === false ? Column::DATETIME_SCALE_NOT_SET : $length;
+                break;
+
             case 'tinytext':
                 $length = AbstractMySQLPlatform::LENGTH_LIMIT_TINYTEXT;
                 break;
@@ -280,6 +287,10 @@ class MySQLSchemaManager extends AbstractSchemaManager
         if ($scale !== null && $precision !== null) {
             $options['scale']     = (int) $scale;
             $options['precision'] = (int) $precision;
+        }
+
+        if (in_array($dbType, ['datetime', 'time', 'timestamp'], true)) {
+            $options['scale'] = (int) $scale;
         }
 
         $column = new Column($tableColumn['field'], Type::getType($type), $options);

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -478,6 +478,15 @@ SQL,
                 $fixed = true;
                 break;
 
+            case 'datetime':
+            case 'time':
+            case 'timetz':
+            case 'timestamp':
+            case 'timestamptz':
+                $columnHasScale = preg_match('/\w*time\w*\((\d+)\)?/', $tableColumn['complete_type'], $matches);
+                $scale          = $columnHasScale === 1 ? $matches[1] : Column::DATETIME_SCALE_NOT_SET;
+                break;
+
             case 'float':
             case 'float4':
             case 'float8':

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -153,6 +153,17 @@ SQL,
                 }
 
                 break;
+
+            case 'smalldatetime':
+                $tableColumn['scale'] = 0;
+                break;
+
+            case 'datetime':
+            case 'datetime2':
+            case 'datetimeoffset':
+            case 'time':
+                $tableColumn['scale'] ??= 0;
+                break;
         }
 
         if ($dbType === 'char' || $dbType === 'nchar' || $dbType === 'binary') {

--- a/src/Types/DateTimeImmutableType.php
+++ b/src/Types/DateTimeImmutableType.php
@@ -67,6 +67,15 @@ class DateTimeImmutableType extends DateTimeType
             return $dateTime;
         }
 
+        $dateTime = DateTimeImmutable::createFromFormat(
+            $platform->getFallbackDateTimeFormatString(),
+            $value,
+        );
+
+        if ($dateTime !== false) {
+            return $dateTime;
+        }
+
         try {
             return new DateTimeImmutable($value);
         } catch (Exception $e) {

--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -101,6 +101,12 @@ class DateTimeType extends Type implements PhpDateTimeMappingType
             return $dateTime;
         }
 
+        $dateTime = DateTime::createFromFormat($platform->getFallbackDateTimeFormatString(), $value);
+
+        if ($dateTime !== false) {
+            return $dateTime;
+        }
+
         try {
             return new DateTime($value);
         } catch (Exception $e) {

--- a/src/Types/DateTimeTzType.php
+++ b/src/Types/DateTimeTzType.php
@@ -108,6 +108,13 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
         }
 
         $dateTime = DateTime::createFromFormat($platform->getDateTimeTzFormatString(), $value);
+
+        if ($dateTime !== false) {
+            return $dateTime;
+        }
+
+        $dateTime = DateTime::createFromFormat($platform->getFallbackDateTimeTzFormatString(), $value);
+
         if ($dateTime !== false) {
             return $dateTime;
         }

--- a/src/Types/TimeImmutableType.php
+++ b/src/Types/TimeImmutableType.php
@@ -66,6 +66,15 @@ class TimeImmutableType extends TimeType
             return $dateTime;
         }
 
+        $dateTime = DateTimeImmutable::createFromFormat(
+            '!' . $platform->getFallbackTimeFormatString(),
+            $value,
+        );
+
+        if ($dateTime !== false) {
+            return $dateTime;
+        }
+
         throw ConversionException::conversionFailedFormat(
             $value,
             $this->getName(),

--- a/src/Types/TimeType.php
+++ b/src/Types/TimeType.php
@@ -91,6 +91,13 @@ class TimeType extends Type
         }
 
         $dateTime = DateTime::createFromFormat('!' . $platform->getTimeFormatString(), $value);
+
+        if ($dateTime !== false) {
+            return $dateTime;
+        }
+
+        $dateTime = DateTime::createFromFormat('!' . $platform->getFallbackTimeFormatString(), $value);
+
         if ($dateTime !== false) {
             return $dateTime;
         }

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Functional;
 use DateTime;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\SqliteHptPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\TrimMode;
 use Doctrine\DBAL\Schema\Table;
@@ -25,6 +26,10 @@ class DataAccessTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
+        $datetimeString = $this->connection->getDatabasePlatform() instanceof SqliteHptPlatform
+        ? '2010-01-01 10:10:10.000000'
+        : '2010-01-01 10:10:10';
+
         $table = new Table('fetch_table');
         $table->addColumn('test_int', Types::INTEGER);
         $table->addColumn('test_string', Types::STRING);
@@ -36,7 +41,7 @@ class DataAccessTest extends FunctionalTestCase
         $this->connection->insert('fetch_table', [
             'test_int' => 1,
             'test_string' => 'foo',
-            'test_datetime' => '2010-01-01 10:10:10',
+            'test_datetime' => $datetimeString,
         ]);
     }
 

--- a/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
+++ b/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Schema;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\DateTimeTzType;
+use Doctrine\DBAL\Types\DateType;
+use Doctrine\DBAL\Types\TimeType;
+use Doctrine\DBAL\Types\Types;
+use Iterator;
+
+use function count;
+use function get_class;
+use function sprintf;
+
+class VariableDateTimePrecisionIntrospectionTest extends FunctionalTestCase
+{
+    protected AbstractPlatform $platform;
+
+    protected AbstractSchemaManager $schemaManager;
+
+    protected Comparator $comparator;
+
+    protected function setup(): void
+    {
+        $this->platform = $this->connection->getDatabasePlatform();
+
+        if (
+            $this->platform instanceof SqlitePlatform ||
+            $this->platform instanceof AbstractMySQLPlatform ||
+            $this->platform instanceof DB2Platform ||
+            $this->platform instanceof OraclePlatform ||
+            $this->platform instanceof PostgreSQLPlatform ||
+            $this->platform instanceof SQLServerPlatform
+        ) {
+            self::markTestSkipped(sprintf(
+                "Platform %s doesn't support variable precision time",
+                get_class($this->platform),
+            ));
+        }
+
+        $this->schemaManager = $this->connection->createSchemaManager();
+        $this->comparator    = $this->schemaManager->createComparator();
+    }
+
+    /** @return Iterator<string[]> */
+    public static function columnTypeProvider(): Iterator
+    {
+        foreach (
+            [
+                Types::DATETIME_MUTABLE,
+                Types::DATETIME_IMMUTABLE,
+                Types::DATETIMETZ_MUTABLE,
+                Types::DATETIMETZ_IMMUTABLE,
+                Types::TIME_MUTABLE,
+                Types::TIME_IMMUTABLE,
+            ] as $type
+        ) {
+            yield [$type];
+        }
+    }
+
+    /** @dataProvider columnTypeProvider */
+    public function testTableIntrospection(string $type): void
+    {
+        $tableName = 'test_time_prec_intros';
+
+        $table = new Table($tableName);
+
+        $table->addColumn('col_' . $type . '_0', $type, ['length' => 0]);
+        $table->addColumn('col_' . $type . '_3', $type, ['length' => 3]);
+        $table->addColumn('col_' . $type . '_6', $type, ['length' => 6]);
+
+        $this->dropAndCreateTable($table);
+
+        $onlineTable = $this->schemaManager->introspectTable($tableName);
+
+        $diff = $this->comparator->compareTables($table, $onlineTable);
+
+        /*
+         * On the Db2 platform, the comparator cannot identify an introspected column as DateTimeTz because the column
+         * uses TIMESTAMP, is not commented and so is returned as DateTimeType.
+         *
+         * On the Oracle platform, the comparator connot identify an introspected column as TimeType because the
+         * column uses DATE, is not commented and so is returned as DateType.
+         *
+         * Where a diff arises on these platforms for this test, ensure it is only an expected type difference and, if
+         * so, ignore it because it is not caused by variable precision time.
+         */
+        $result = $this->platform instanceof DB2Platform || $this->platform instanceof OraclePlatform ?
+                  $this->typeOnlyDiff($diff, $this->platform) :
+                  $diff->isEmpty();
+
+        self::assertTrue(
+            $result,
+            sprintf('Tables with columns of type %s should be identical on %s.', $type, get_class($this->platform)),
+        );
+    }
+
+    /**
+     * Whether a comparator difference is caused by a column data type that maps to more than one doctrine type
+     * on the given platforms.
+     */
+    private function typeOnlyDiff(TableDiff $diff, AbstractPlatform $platform): bool
+    {
+        if (
+            $diff->getAddedColumns()        !== [] ||
+            $diff->getRenamedColumns()      !== [] ||
+            $diff->getDroppedColumns()      !== [] ||
+            $diff->getAddedIndexes()        !== [] ||
+            $diff->getModifiedIndexes()     !== [] ||
+            $diff->getRenamedIndexes()      !== [] ||
+            $diff->getDroppedIndexes()      !== [] ||
+            $diff->getAddedForeignKeys()    !== [] ||
+            $diff->getModifiedForeignKeys() !== [] ||
+            $diff->getDroppedForeignKeys()  !== []
+        ) {
+            return false;
+        }
+
+        foreach ($diff->changedColumns as $columnDiff) {
+            if (count($columnDiff->changedProperties) === 1 && $columnDiff->changedProperties[0] === 'type') {
+                $oldColumn = $columnDiff->getOldColumn();
+
+                if ($oldColumn === null) {
+                    return false;
+                }
+
+                $oldType = $oldColumn->getType();
+                $newType = $columnDiff->getNewColumn()->getType();
+
+                if ($platform instanceof DB2Platform) {
+                    if ($oldType instanceof DateTimeTzType && $newType instanceof DateTimeType) {
+                        continue;
+                    }
+                }
+
+                if ($platform instanceof OraclePlatform) {
+                    if ($oldType instanceof TimeType && $newType instanceof DateType) {
+                        continue;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
+++ b/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
@@ -5,7 +5,6 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -40,7 +39,6 @@ class VariableDateTimePrecisionIntrospectionTest extends FunctionalTestCase
             $this->platform instanceof SqlitePlatform ||
             $this->platform instanceof DB2Platform ||
             $this->platform instanceof OraclePlatform ||
-            $this->platform instanceof PostgreSQLPlatform ||
             $this->platform instanceof SQLServerPlatform
         ) {
             self::markTestSkipped(sprintf(

--- a/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
+++ b/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
@@ -34,10 +34,7 @@ class VariableDateTimePrecisionIntrospectionTest extends FunctionalTestCase
     {
         $this->platform = $this->connection->getDatabasePlatform();
 
-        if (
-            $this->platform instanceof SqlitePlatform ||
-            $this->platform instanceof OraclePlatform
-        ) {
+        if ($this->platform instanceof SqlitePlatform) {
             self::markTestSkipped(sprintf(
                 "Platform %s doesn't support variable precision time",
                 get_class($this->platform),

--- a/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
+++ b/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
@@ -38,8 +37,7 @@ class VariableDateTimePrecisionIntrospectionTest extends FunctionalTestCase
         if (
             $this->platform instanceof SqlitePlatform ||
             $this->platform instanceof DB2Platform ||
-            $this->platform instanceof OraclePlatform ||
-            $this->platform instanceof SQLServerPlatform
+            $this->platform instanceof OraclePlatform
         ) {
             self::markTestSkipped(sprintf(
                 "Platform %s doesn't support variable precision time",

--- a/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
+++ b/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
@@ -36,7 +36,6 @@ class VariableDateTimePrecisionIntrospectionTest extends FunctionalTestCase
 
         if (
             $this->platform instanceof SqlitePlatform ||
-            $this->platform instanceof DB2Platform ||
             $this->platform instanceof OraclePlatform
         ) {
             self::markTestSkipped(sprintf(

--- a/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
+++ b/tests/Functional/Schema/VariableDateTimePrecisionIntrospectionTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
-use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
@@ -39,7 +38,6 @@ class VariableDateTimePrecisionIntrospectionTest extends FunctionalTestCase
 
         if (
             $this->platform instanceof SqlitePlatform ||
-            $this->platform instanceof AbstractMySQLPlatform ||
             $this->platform instanceof DB2Platform ||
             $this->platform instanceof OraclePlatform ||
             $this->platform instanceof PostgreSQLPlatform ||

--- a/tests/Functional/Types/DateTimeTest.php
+++ b/tests/Functional/Types/DateTimeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use DateTimeInterface;
+use Doctrine\DBAL\Platforms\OracleHptPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Table;
@@ -56,7 +57,7 @@ final class DateTimeTest extends FunctionalTestCase
 
         if (
             $platform instanceof SqlitePlatform ||
-            $platform instanceof OraclePlatform
+            ($platform instanceof OraclePlatform && ! $platform instanceof OracleHptPlatform)
         ) {
             self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));
         }

--- a/tests/Functional/Types/DateTimeTest.php
+++ b/tests/Functional/Types/DateTimeTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use DateTimeInterface;
-use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Table;
@@ -57,7 +56,6 @@ final class DateTimeTest extends FunctionalTestCase
 
         if (
             $platform instanceof SqlitePlatform ||
-            $platform instanceof DB2Platform ||
             $platform instanceof OraclePlatform
         ) {
             self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));

--- a/tests/Functional/Types/DateTimeTest.php
+++ b/tests/Functional/Types/DateTimeTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 use DateTimeInterface;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Table;
@@ -61,7 +60,6 @@ final class DateTimeTest extends FunctionalTestCase
             $platform instanceof SqlitePlatform ||
             $platform instanceof DB2Platform ||
             $platform instanceof OraclePlatform ||
-            $platform instanceof PostgreSQLPlatform ||
             $platform instanceof SQLServerPlatform
         ) {
             self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));

--- a/tests/Functional/Types/DateTimeTest.php
+++ b/tests/Functional/Types/DateTimeTest.php
@@ -8,7 +8,6 @@ use DateTimeInterface;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
@@ -59,8 +58,7 @@ final class DateTimeTest extends FunctionalTestCase
         if (
             $platform instanceof SqlitePlatform ||
             $platform instanceof DB2Platform ||
-            $platform instanceof OraclePlatform ||
-            $platform instanceof SQLServerPlatform
+            $platform instanceof OraclePlatform
         ) {
             self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));
         }

--- a/tests/Functional/Types/DateTimeTest.php
+++ b/tests/Functional/Types/DateTimeTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 use DateTimeInterface;
 use Doctrine\DBAL\Platforms\OracleHptPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\SqliteHptPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -56,7 +57,7 @@ final class DateTimeTest extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform();
 
         if (
-            $platform instanceof SqlitePlatform ||
+            ($platform instanceof SqlitePlatform && ! $platform instanceof SqliteHptPlatform) ||
             ($platform instanceof OraclePlatform && ! $platform instanceof OracleHptPlatform)
         ) {
             self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));

--- a/tests/Functional/Types/DateTimeTest.php
+++ b/tests/Functional/Types/DateTimeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use DateTimeInterface;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Iterator;
+
+use function date_create;
+use function get_class;
+use function sprintf;
+
+final class DateTimeTest extends FunctionalTestCase
+{
+    /** @return Iterator<DateTimeInterface[]> */
+    public static function dataValuesProvider(): Iterator
+    {
+        $datetimeList = [
+            ['2013-04-15 10:10:10.1234567'],
+            ['2013-04-15 10:10:10.123456'],
+            ['2013-04-15 10:10:10.12345'],
+            ['2013-04-15 10:10:10.1234'],
+            ['2013-04-15 10:10:10.123'],
+            ['2013-04-15 10:10:10.12'],
+            ['2013-04-15 10:10:10.1'],
+            ['2013-04-15 10:10:10'],
+
+            ['2013-04-15 10:10:10.9876543'],
+            ['2013-04-15 10:10:10.9876549'],
+            ['2013-04-15 10:10:10.987654'],
+            ['2013-04-15 10:10:10.98765'],
+            ['2013-04-15 10:10:10.9876'],
+            ['2013-04-15 10:10:10.987'],
+            ['2013-04-15 10:10:10.98'],
+            ['2013-04-15 10:10:10.9'],
+
+            ['1999-12-31 23:59:59.99999'],
+        ];
+
+        foreach ($datetimeList as $datetime) {
+            yield [date_create($datetime[0])];
+        }
+    }
+
+    /** @dataProvider dataValuesProvider */
+    public function testInsertAndRetrieveDateTime(DateTimeInterface $expected): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (
+            $platform instanceof SqlitePlatform ||
+            $platform instanceof AbstractMySQLPlatform ||
+            $platform instanceof DB2Platform ||
+            $platform instanceof OraclePlatform ||
+            $platform instanceof PostgreSQLPlatform ||
+            $platform instanceof SQLServerPlatform
+        ) {
+            self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));
+        }
+
+        $table = new Table('datetime_test_table');
+
+        $vals  = [];
+        $types = [];
+
+        for ($i = 0; $i <= 6; $i++) {
+            $table->addColumn('val' . $i, Types::DATETIME_MUTABLE, ['scale' => $i]);
+            $vals['val' . $i]  = Type::getType(Types::DATETIME_MUTABLE)
+                                     ->convertToDatabaseValue($expected, $platform);
+            $types['val' . $i] = Types::STRING;
+        }
+
+        $this->dropAndCreateTable($table);
+
+        $this->connection->insert('datetime_test_table', $vals, $types);
+
+        for ($i = 0; $i <= 6; $i++) {
+            $value = Type::getType(Types::DATETIME_MUTABLE)->convertToPHPValue(
+                $this->connection->fetchOne('SELECT val' . $i . ' FROM datetime_test_table'),
+                $platform,
+            );
+
+            // PHP stores datetimes with microsecond precision so there will be a difference when column precision is
+            // less than 6.
+            self::assertEqualsWithDelta($expected, $value, 10 ** -$i);
+        }
+    }
+}

--- a/tests/Functional/Types/DateTimeTest.php
+++ b/tests/Functional/Types/DateTimeTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use DateTimeInterface;
-use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
@@ -60,7 +59,6 @@ final class DateTimeTest extends FunctionalTestCase
 
         if (
             $platform instanceof SqlitePlatform ||
-            $platform instanceof AbstractMySQLPlatform ||
             $platform instanceof DB2Platform ||
             $platform instanceof OraclePlatform ||
             $platform instanceof PostgreSQLPlatform ||

--- a/tests/Functional/Types/DateTimeTzTest.php
+++ b/tests/Functional/Types/DateTimeTzTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use DateTimeInterface;
-use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -72,7 +71,6 @@ final class DateTimeTzTest extends FunctionalTestCase
 
         if (
             $platform instanceof SqlitePlatform ||
-            $platform instanceof DB2Platform ||
             $platform instanceof OraclePlatform
         ) {
             self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));

--- a/tests/Functional/Types/DateTimeTzTest.php
+++ b/tests/Functional/Types/DateTimeTzTest.php
@@ -73,8 +73,7 @@ final class DateTimeTzTest extends FunctionalTestCase
         if (
             $platform instanceof SqlitePlatform ||
             $platform instanceof DB2Platform ||
-            $platform instanceof OraclePlatform ||
-            $platform instanceof SQLServerPlatform
+            $platform instanceof OraclePlatform
         ) {
             self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));
         }

--- a/tests/Functional/Types/DateTimeTzTest.php
+++ b/tests/Functional/Types/DateTimeTzTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use DateTimeInterface;
+use Doctrine\DBAL\Platforms\OracleHptPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -71,7 +72,7 @@ final class DateTimeTzTest extends FunctionalTestCase
 
         if (
             $platform instanceof SqlitePlatform ||
-            $platform instanceof OraclePlatform
+            ($platform instanceof OraclePlatform && ! $platform instanceof OracleHptPlatform)
         ) {
             self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));
         }

--- a/tests/Functional/Types/DateTimeTzTest.php
+++ b/tests/Functional/Types/DateTimeTzTest.php
@@ -74,7 +74,6 @@ final class DateTimeTzTest extends FunctionalTestCase
             $platform instanceof SqlitePlatform ||
             $platform instanceof DB2Platform ||
             $platform instanceof OraclePlatform ||
-            $platform instanceof PostgreSQLPlatform ||
             $platform instanceof SQLServerPlatform
         ) {
             self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));

--- a/tests/Functional/Types/DateTimeTzTest.php
+++ b/tests/Functional/Types/DateTimeTzTest.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Doctrine\DBAL\Platforms\OracleHptPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqliteHptPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Table;
@@ -71,7 +72,7 @@ final class DateTimeTzTest extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform();
 
         if (
-            $platform instanceof SqlitePlatform ||
+            ($platform instanceof SqlitePlatform && ! $platform instanceof SqliteHptPlatform) ||
             ($platform instanceof OraclePlatform && ! $platform instanceof OracleHptPlatform)
         ) {
             self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));

--- a/tests/Functional/Types/DateTimeTzTest.php
+++ b/tests/Functional/Types/DateTimeTzTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use DateTimeInterface;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Iterator;
+
+use function date_create;
+use function get_class;
+use function sprintf;
+use function timezone_open;
+
+/**
+ * Tests inserting and selecting datetime format string with varying precisions of decimal seconds in different
+ * timezones.
+ *
+ * Only PostgreSQL, Oracle and SQL server support storing timezone information in the database. On other platforms,
+ * the timezone is lost and only the time is stored the timezone is ignored in these cases.
+ */
+final class DateTimeTzTest extends FunctionalTestCase
+{
+    /** @return Iterator<DateTimeInterface[]> */
+    public static function dataValuesProvider(): Iterator
+    {
+        $datetimeTzList = [
+            ['2013-04-15 10:10:10.1234567', '+00:00'],
+            ['2013-04-15 10:10:10.123456', '+01:00'],
+            ['2013-04-15 10:10:10.12345', '+06:00'],
+            ['2013-04-15 10:10:10.1234', '+11:00'],
+            ['2013-04-15 10:10:10.123', '-11:00'],
+            ['2013-04-15 10:10:10.12', '-06:00'],
+            ['2013-04-15 10:10:10.1', '-01:00'],
+            ['2013-04-15 10:10:10', '+00:00'],
+
+            ['2013-04-15 10:10:10.9876543', '+00:00'],
+            ['2013-04-15 10:10:10.9876549', '-01:00'],
+            ['2013-04-15 10:10:10.987654', '-06:00'],
+            ['2013-04-15 10:10:10.98765', '-11:00'],
+            ['2013-04-15 10:10:10.9876', '+11:00'],
+            ['2013-04-15 10:10:10.987', '+06:00'],
+            ['2013-04-15 10:10:10.98', '+01:00'],
+            ['2013-04-15 10:10:10.9', '+00:00'],
+
+            ['1999-12-31 23:59:59.99999', '+03:00'],
+        ];
+
+        foreach ($datetimeTzList as $datetimeTz) {
+            yield [
+                date_create($datetimeTz[0], timezone_open($datetimeTz[1])),
+                date_create($datetimeTz[0]),
+            ];
+        }
+    }
+
+    /** @dataProvider dataValuesProvider */
+    public function testInsertAndRetrieveDateTimeTz(
+        DateTimeInterface $datetimeTz,
+        DateTimeInterface $datetimeNoTz
+    ): void {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (
+            $platform instanceof SqlitePlatform ||
+            $platform instanceof AbstractMySQLPlatform ||
+            $platform instanceof DB2Platform ||
+            $platform instanceof OraclePlatform ||
+            $platform instanceof PostgreSQLPlatform ||
+            $platform instanceof SQLServerPlatform
+        ) {
+            self::markTestSkipped(sprintf("Platform %s doesn't support variable precision time", get_class($platform)));
+        }
+
+        $table = new Table('datetimetz_test_table');
+
+        $vals  = [];
+        $types = [];
+
+        for ($i = 0; $i <= 6; $i++) {
+            $table->addColumn('val' . $i, Types::DATETIMETZ_MUTABLE, ['scale' => $i]);
+            $vals['val' . $i]  = Type::getType(Types::DATETIMETZ_MUTABLE)
+                                     ->convertToDatabaseValue($datetimeTz, $platform);
+            $types['val' . $i] = Types::STRING;
+        }
+
+        $this->dropAndCreateTable($table);
+
+        $this->connection->insert('datetimetz_test_table', $vals, $types);
+
+        for ($i = 0; $i <= 6; $i++) {
+            $value = Type::getType(Types::DATETIMETZ_MUTABLE)->convertToPHPValue(
+                $this->connection->fetchOne('SELECT val' . $i . ' FROM datetimetz_test_table'),
+                $platform,
+            );
+
+            $expected =
+                $platform instanceof PostgreSQLPlatform ||
+                $platform instanceof SQLServerPlatform ||
+                $platform instanceof OraclePlatform
+            ? $datetimeTz : $datetimeNoTz;
+
+            // PHP stores datetimes with microsecond precision so there will be a difference when column precision is
+            // less than 6.
+            self::assertEqualsWithDelta($expected, $value, 10 ** -$i);
+        }
+    }
+}

--- a/tests/Functional/Types/DateTimeTzTest.php
+++ b/tests/Functional/Types/DateTimeTzTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use DateTimeInterface;
-use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
@@ -73,7 +72,6 @@ final class DateTimeTzTest extends FunctionalTestCase
 
         if (
             $platform instanceof SqlitePlatform ||
-            $platform instanceof AbstractMySQLPlatform ||
             $platform instanceof DB2Platform ||
             $platform instanceof OraclePlatform ||
             $platform instanceof PostgreSQLPlatform ||

--- a/tests/Functional/Types/TimeTest.php
+++ b/tests/Functional/Types/TimeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+
+use function get_class;
+use function sprintf;
+
+final class TimeTest extends FunctionalTestCase
+{
+    /** @return string[][] */
+    public static function dataValuesProvider(): array
+    {
+        return [
+            ['10:10:10.123456'],
+            ['10:10:10.12345'],
+            ['10:10:10.1234'],
+            ['10:10:10.123'],
+            ['10:10:10.12'],
+            ['10:10:10.1'],
+            ['10:10:10'],
+
+            ['22:10:10.987654'],
+            ['22:10:10.98765'],
+            ['22:10:10.9876'],
+            ['22:10:10.987'],
+            ['22:10:10.98'],
+            ['22:10:10.9'],
+
+            ['23:59:59.99999'],
+        ];
+    }
+
+    /** @dataProvider dataValuesProvider */
+    public function testInsertAndRetrieveTime(string $expected): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (
+            $platform instanceof SqlitePlatform ||
+            $platform instanceof AbstractMySQLPlatform ||
+            $platform instanceof DB2Platform ||
+            $platform instanceof OraclePlatform ||
+            $platform instanceof PostgreSQLPlatform ||
+            $platform instanceof SQLServerPlatform
+        ) {
+            self::markTestSkipped(sprintf(
+                "Platform %s doesn't support variable precision TIME columns",
+                get_class($platform),
+            ));
+        }
+
+        $table = new Table('time_test_table');
+
+        $vals  = [];
+        $types = [];
+
+        for ($i = 0; $i <= 6; $i++) {
+            $table->addColumn('val' . $i, Types::TIME_MUTABLE, ['scale' => $i]);
+            $vals['val' . $i]  = $expected;
+            $types['val' . $i] = Types::STRING;
+        }
+
+        $this->dropAndCreateTable($table);
+
+        $this->connection->insert('time_test_table', $vals, $types);
+
+        for ($i = 0; $i <= 6; $i++) {
+            $value = Type::getType(Types::TIME_MUTABLE)->convertToPHPValue(
+                $this->connection->fetchOne('SELECT val' . $i . ' FROM time_test_table'),
+                $platform,
+            );
+
+            $expected = Type::getType(Types::TIME_MUTABLE)->convertToPHPValue(
+                $expected,
+                $platform,
+            );
+
+            // PHP stores datetimes with microsecond precision so there will be a difference when column precision is
+            // less than 6.
+            self::assertEqualsWithDelta($expected, $value, 10 ** -$i);
+        }
+    }
+}

--- a/tests/Functional/Types/TimeTest.php
+++ b/tests/Functional/Types/TimeTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
-use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
@@ -50,7 +49,6 @@ final class TimeTest extends FunctionalTestCase
 
         if (
             $platform instanceof SqlitePlatform ||
-            $platform instanceof AbstractMySQLPlatform ||
             $platform instanceof DB2Platform ||
             $platform instanceof OraclePlatform ||
             $platform instanceof PostgreSQLPlatform ||

--- a/tests/Functional/Types/TimeTest.php
+++ b/tests/Functional/Types/TimeTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\SqliteHptPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -46,7 +47,7 @@ final class TimeTest extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform();
 
         if (
-            $platform instanceof SqlitePlatform ||
+            ($platform instanceof SqlitePlatform && ! $platform instanceof SqliteHptPlatform) ||
             $platform instanceof DB2Platform ||
             $platform instanceof OraclePlatform
         ) {

--- a/tests/Functional/Types/TimeTest.php
+++ b/tests/Functional/Types/TimeTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Table;
@@ -51,7 +50,6 @@ final class TimeTest extends FunctionalTestCase
             $platform instanceof SqlitePlatform ||
             $platform instanceof DB2Platform ||
             $platform instanceof OraclePlatform ||
-            $platform instanceof PostgreSQLPlatform ||
             $platform instanceof SQLServerPlatform
         ) {
             self::markTestSkipped(sprintf(

--- a/tests/Functional/Types/TimeTest.php
+++ b/tests/Functional/Types/TimeTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
@@ -49,8 +48,7 @@ final class TimeTest extends FunctionalTestCase
         if (
             $platform instanceof SqlitePlatform ||
             $platform instanceof DB2Platform ||
-            $platform instanceof OraclePlatform ||
-            $platform instanceof SQLServerPlatform
+            $platform instanceof OraclePlatform
         ) {
             self::markTestSkipped(sprintf(
                 "Platform %s doesn't support variable precision TIME columns",

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -200,6 +200,25 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         self::assertEquals('DATETIME', $this->platform->getDateTimeTypeDeclarationSQL(['version' => false]));
         self::assertEquals('TIMESTAMP', $this->platform->getDateTimeTypeDeclarationSQL(['version' => true]));
         self::assertEquals('DATETIME', $this->platform->getDateTimeTypeDeclarationSQL([]));
+        self::assertEquals('DATETIME', $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '0']));
+        self::assertEquals(
+            'TIMESTAMP',
+            $this->platform->getDateTimeTypeDeclarationSQL(['version' => true, 'scale' => 0]),
+        );
+        self::assertEquals('DATETIME(6)', $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '6']));
+    }
+
+    public function testGetTimeTypeDeclarationSql(): void
+    {
+        self::assertEquals('TIME', $this->platform->getTimeTypeDeclarationSQL(['version' => false]));
+        self::assertEquals('TIME', $this->platform->getTimeTypeDeclarationSQL(['version' => true]));
+        self::assertEquals('TIME', $this->platform->getTimeTypeDeclarationSQL([]));
+        self::assertEquals('TIME', $this->platform->getTimeTypeDeclarationSQL(['scale' => '0']));
+        self::assertEquals(
+            'TIME',
+            $this->platform->getTimeTypeDeclarationSQL(['version' => true, 'scale' => 0]),
+        );
+        self::assertEquals('TIME(6)', $this->platform->getTimeTypeDeclarationSQL(['scale' => '6']));
     }
 
     /**

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -273,6 +273,65 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         self::assertEquals('TIME', $this->platform->getTimeTypeDeclarationSQL($fullColumnDef));
     }
 
+    public function testGeneratesTypeDeclarationForDatetimes(): void
+    {
+        self::assertEquals('TIMESTAMP(0)', $this->platform->getDateTimeTypeDeclarationSQL([]));
+        self::assertEquals(
+            'TIMESTAMP(0)',
+            $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '0']),
+        );
+        self::assertEquals(
+            'TIMESTAMP(6)',
+            $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '6']),
+        );
+
+        self::assertEquals('TIMESTAMP(0)', $this->platform->getDateTimeTzTypeDeclarationSQL([]));
+        self::assertEquals(
+            'TIMESTAMP(0)',
+            $this->platform->getDateTimeTzTypeDeclarationSQL(['scale' => '0']),
+        );
+        self::assertEquals(
+            'TIMESTAMP(6)',
+            $this->platform->getDateTimeTzTypeDeclarationSQL(['scale' => '6']),
+        );
+    }
+
+    public function testGeneratesTypeDeclarationForDatetimesWithVersion(): void
+    {
+        self::assertEquals(
+            'TIMESTAMP(0) WITH DEFAULT',
+            $this->platform->getDateTimeTypeDeclarationSQL(['version' => true]),
+        );
+        self::assertEquals(
+            'TIMESTAMP(0) WITH DEFAULT',
+            $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '0', 'version' => true]),
+        );
+        self::assertEquals(
+            'TIMESTAMP(6) WITH DEFAULT',
+            $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '6', 'version' => true]),
+        );
+
+        self::assertEquals(
+            'TIMESTAMP(0) WITH DEFAULT',
+            $this->platform->getDateTimeTzTypeDeclarationSQL(['version' => true]),
+        );
+        self::assertEquals(
+            'TIMESTAMP(0) WITH DEFAULT',
+            $this->platform->getDateTimeTzTypeDeclarationSQL(['scale' => '0', 'version' => true]),
+        );
+        self::assertEquals(
+            'TIMESTAMP(6) WITH DEFAULT',
+            $this->platform->getDateTimeTzTypeDeclarationSQL(['scale' => '6', 'version' => true]),
+        );
+    }
+
+    public function testGeneratesTypeDeclarationForTimes(): void
+    {
+        self::assertEquals('TIME', $this->platform->getTimeTypeDeclarationSQL([]));
+        self::assertEquals('TIME', $this->platform->getTimeTypeDeclarationSQL(['scale' => '0']));
+        self::assertEquals('TIME', $this->platform->getTimeTypeDeclarationSQL(['scale' => '6']));
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -692,5 +751,10 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     {
         return 'SELECT db22.* FROM (SELECT db21.*, ROW_NUMBER() OVER() AS DC_ROWNUM'
             . ' FROM (SELECT * FROM user) db21) db22 WHERE db22.DC_ROWNUM >= 3 AND db22.DC_ROWNUM <= 3';
+    }
+
+    public function testGetTimeFormatString(): void
+    {
+        self::assertEquals('H:i:s', $this->platform->getTimeFormatString());
     }
 }

--- a/tests/Platforms/OracleHptPlatformTest.php
+++ b/tests/Platforms/OracleHptPlatformTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\OracleHptPlatform;
+
+class OracleHptPlatformTest extends OraclePlatformTest
+{
+    public function createPlatform(): AbstractPlatform
+    {
+        return new OracleHptPlatform();
+    }
+
+    public function testGetDateTimeTzFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:s.u P', $this->platform->getDateTimeTzFormatString());
+    }
+
+    public function testGetDateTimeFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:s.u', $this->platform->getDateTimeFormatString());
+    }
+}

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -177,6 +177,36 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function testGeneratesTypeDeclarationForDatetimes(): void
+    {
+        self::assertEquals('TIMESTAMP(0)', $this->platform->getDateTimeTypeDeclarationSQL([]));
+        self::assertEquals(
+            'TIMESTAMP(0)',
+            $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '0']),
+        );
+        self::assertEquals(
+            'TIMESTAMP(6)',
+            $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '6']),
+        );
+
+        self::assertEquals('TIMESTAMP(0) WITH TIME ZONE', $this->platform->getDateTimeTzTypeDeclarationSQL([]));
+        self::assertEquals(
+            'TIMESTAMP(0) WITH TIME ZONE',
+            $this->platform->getDateTimeTzTypeDeclarationSQL(['scale' => '0']),
+        );
+        self::assertEquals(
+            'TIMESTAMP(6) WITH TIME ZONE',
+            $this->platform->getDateTimeTzTypeDeclarationSQL(['scale' => '6']),
+        );
+    }
+
+    public function testGeneratesTypeDeclarationForTimes(): void
+    {
+        self::assertEquals('DATE', $this->platform->getTimeTypeDeclarationSQL([]));
+        self::assertEquals('DATE', $this->platform->getTimeTypeDeclarationSQL(['scale' => '0']));
+        self::assertEquals('DATE', $this->platform->getTimeTypeDeclarationSQL(['scale' => '6']));
+    }
+
     public function testPrefersIdentityColumns(): void
     {
         self::assertFalse($this->platform->prefersIdentityColumns());
@@ -931,5 +961,25 @@ SQL
     {
         return 'SELECT * FROM (SELECT a.*, ROWNUM AS doctrine_rownum FROM (SELECT * FROM user) a WHERE ROWNUM <= 3)'
             . ' WHERE doctrine_rownum >= 3';
+    }
+
+    public function testGetDateTimeTzFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:s P', $this->platform->getDateTimeTzFormatString());
+    }
+
+    public function testGetFallbackDateTimeTzFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:s P', $this->platform->getFallbackDateTimeTzFormatString());
+    }
+
+    public function testGetTimeFormatString(): void
+    {
+        self::assertEquals('1900-01-01 H:i:s', $this->platform->getTimeFormatString());
+    }
+
+    public function testGetFallbackTimeFormatString(): void
+    {
+        self::assertEquals('1900-01-01 H:i:s', $this->platform->getFallbackTimeFormatString());
     }
 }

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -284,6 +284,36 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function testGeneratesTypeDeclarationForDatetimes(): void
+    {
+        self::assertEquals('TIMESTAMP(0) WITHOUT TIME ZONE', $this->platform->getDateTimeTypeDeclarationSQL([]));
+        self::assertEquals(
+            'TIMESTAMP(0) WITHOUT TIME ZONE',
+            $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '0']),
+        );
+        self::assertEquals(
+            'TIMESTAMP(6) WITHOUT TIME ZONE',
+            $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '6']),
+        );
+
+        self::assertEquals('TIMESTAMP(0) WITH TIME ZONE', $this->platform->getDateTimeTzTypeDeclarationSQL([]));
+        self::assertEquals(
+            'TIMESTAMP(0) WITH TIME ZONE',
+            $this->platform->getDateTimeTzTypeDeclarationSQL(['scale' => '0']),
+        );
+        self::assertEquals(
+            'TIMESTAMP(6) WITH TIME ZONE',
+            $this->platform->getDateTimeTzTypeDeclarationSQL(['scale' => '6']),
+        );
+    }
+
+    public function testGeneratesTypeDeclarationForTimes(): void
+    {
+        self::assertEquals('TIME(0) WITHOUT TIME ZONE', $this->platform->getTimeTypeDeclarationSQL([]));
+        self::assertEquals('TIME(0) WITHOUT TIME ZONE', $this->platform->getTimeTypeDeclarationSQL(['scale' => '0']));
+        self::assertEquals('TIME(6) WITHOUT TIME ZONE', $this->platform->getTimeTypeDeclarationSQL(['scale' => '6']));
+    }
+
     public function getGenerateUniqueIndexSql(): string
     {
         return 'CREATE UNIQUE INDEX index_name ON test (test, test2)';
@@ -1068,5 +1098,15 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         self::assertEquals(Types::JSON, $this->platform->getDoctrineTypeMapping('json'));
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('jsonb'));
         self::assertEquals(Types::JSON, $this->platform->getDoctrineTypeMapping('jsonb'));
+    }
+
+    public function testGetDateTimeTzFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:s.uO', $this->platform->getDateTimeTzFormatString());
+    }
+
+    public function testGetFallbackDateTimeTzFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:sO', $this->platform->getFallbackDateTimeTzFormatString());
     }
 }

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1817,14 +1817,53 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         ];
     }
 
+    public function testGeneratesTypeDeclarationForDateTime(): void
+    {
+        self::assertEquals('DATETIME2(6)', $this->platform->getDateTimeTypeDeclarationSQL([]));
+        self::assertEquals(
+            'DATETIME2(0)',
+            $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '0']),
+        );
+        self::assertEquals(
+            'DATETIME2(6)',
+            $this->platform->getDateTimeTypeDeclarationSQL(['scale' => '6']),
+        );
+    }
+
     public function testGeneratesTypeDeclarationForDateTimeTz(): void
     {
         self::assertEquals('DATETIMEOFFSET(6)', $this->platform->getDateTimeTzTypeDeclarationSQL([]));
+
+        self::assertEquals(
+            'DATETIMEOFFSET(0)',
+            $this->platform->getDateTimeTzTypeDeclarationSQL(['scale' => '0']),
+        );
+        self::assertEquals(
+            'DATETIMEOFFSET(6)',
+            $this->platform->getDateTimeTzTypeDeclarationSQL(['scale' => '6']),
+        );
+    }
+
+    public function testGeneratesTypeDeclarationForTime(): void
+    {
+        self::assertEquals('TIME(0)', $this->platform->getTimeTypeDeclarationSQL([]));
+        self::assertEquals('TIME(0)', $this->platform->getTimeTypeDeclarationSQL(['scale' => '0']));
+        self::assertEquals('TIME(6)', $this->platform->getTimeTypeDeclarationSQL(['scale' => '6']));
     }
 
     public function testDropIndexSQLRequiresTable(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->platform->getDropIndexSQL('foo');
+    }
+
+    public function testGetDateTimeTzFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:s.u P', $this->platform->getDateTimeTzFormatString());
+    }
+
+    public function testGetFallbackDateTimeTzFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:s P', $this->platform->getFallbackDateTimeTzFormatString());
     }
 }

--- a/tests/Platforms/SqliteHptPlatformTest.php
+++ b/tests/Platforms/SqliteHptPlatformTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SqliteHptPlatform;
+
+class SqliteHptPlatformTest extends SqlitePlatformTest
+{
+    public function createPlatform(): AbstractPlatform
+    {
+        return new SqliteHptPlatform();
+    }
+
+    public function testGetDateTimeTzFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:s.u', $this->platform->getDateTimeTzFormatString());
+    }
+
+    public function testGetDateTimeFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:s.u', $this->platform->getDateTimeFormatString());
+    }
+
+    public function testGetTimeFormatString(): void
+    {
+        self::assertEquals('H:i:s.u', $this->platform->getTimeFormatString());
+    }
+}

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -768,4 +768,19 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             $this->platform->getCreateTableSQL($table),
         );
     }
+
+    public function testGetDateTimeFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:s', $this->platform->getDateTimeFormatString());
+    }
+
+    public function testGetDateTimeTzFormatString(): void
+    {
+        self::assertEquals('Y-m-d H:i:s', $this->platform->getDateTimeFormatString());
+    }
+
+    public function testGetTimeFormatString(): void
+    {
+        self::assertEquals('H:i:s', $this->platform->getTimeFormatString());
+    }
 }

--- a/tests/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Types/DateTimeImmutableTypeTest.php
@@ -107,6 +107,32 @@ class DateTimeImmutableTypeTest extends TestCase
         self::assertSame('2016-01-01 15:58:59', $date->format('Y-m-d H:i:s'));
     }
 
+    public function testConvertsDateTimeStringWithMicrosecondsFormatToPHPValue(): void
+    {
+        $this->platform->expects(self::any())
+            ->method('getDateTimeFormatString')
+            ->willReturn('Y-m-d H:i:s.u');
+
+        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59.123456', $this->platform);
+
+        self::assertSame('2016-01-01 15:58:59.123456', $date->format('Y-m-d H:i:s.u'));
+    }
+
+    public function testConvertsDateTimeStringWithoutMicrosecondsToPHPValue(): void
+    {
+        $this->platform->expects(self::any())
+            ->method('getDateTimeFormatString')
+            ->willReturn('Y-m-d H:i:s.u');
+
+        $this->platform->expects(self::any())
+            ->method('getFallbackTimeFormatString')
+            ->willReturn('Y-m-d H:i:s');
+
+        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59', $this->platform);
+
+        self::assertSame('2016-01-01 15:58:59.000000', $date->format('Y-m-d H:i:s.u'));
+    }
+
     public function testThrowsExceptionDuringConversionToPHPValueWithInvalidDateTimeString(): void
     {
         $this->platform->expects(self::atLeastOnce())

--- a/tests/Types/TimeImmutableTypeTest.php
+++ b/tests/Types/TimeImmutableTypeTest.php
@@ -95,6 +95,34 @@ class TimeImmutableTypeTest extends TestCase
         self::assertSame('15:58:59', $date->format('H:i:s'));
     }
 
+    public function testConvertsTimeStringWithMicrosecondsToPHPValue(): void
+    {
+        $this->platform->expects(self::once())
+            ->method('getTimeFormatString')
+            ->willReturn('H:i:s.u');
+
+        $date = $this->type->convertToPHPValue('15:58:59.123456', $this->platform);
+
+        self::assertInstanceOf(DateTimeImmutable::class, $date);
+        self::assertSame('15:58:59.123456', $date->format('H:i:s.u'));
+    }
+
+    public function testConvertsTimeStringWithoutMicrosecondsToPHPValue(): void
+    {
+        $this->platform->expects(self::any())
+            ->method('getTimeFormatString')
+            ->willReturn('H:i:s.u');
+
+        $this->platform->expects(self::any())
+            ->method('getFallbackTimeFormatString')
+            ->willReturn('H:i:s');
+
+        $date = $this->type->convertToPHPValue('15:58:59', $this->platform);
+
+        self::assertInstanceOf(DateTimeImmutable::class, $date);
+        self::assertSame('15:58:59.000000', $date->format('H:i:s.u'));
+    }
+
     public function testResetDateFractionsWhenConvertingToPHPValue(): void
     {
         $this->platform->expects(self::any())

--- a/tests/Types/VarDateTimeImmutableTypeTest.php
+++ b/tests/Types/VarDateTimeImmutableTypeTest.php
@@ -41,11 +41,11 @@ class VarDateTimeImmutableTypeTest extends TestCase
 
         $date->expects(self::once())
             ->method('format')
-            ->with('Y-m-d H:i:s')
-            ->willReturn('2016-01-01 15:58:59');
+            ->with('Y-m-d H:i:s.u')
+            ->willReturn('2016-01-01 15:58:59.000000');
 
         self::assertSame(
-            '2016-01-01 15:58:59',
+            '2016-01-01 15:58:59.000000',
             $this->type->convertToDatabaseValue($date, $this->platform),
         );
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | #2873

#### Summary

Adds support for high time precision times and datetimes where supported by the platform.

The feature is enabled by default for all platforms except SQLite and Oracle where the feature is opt-in (see below). Neither Oracle nor db2 can support high precision time columns without changing the column type used and so only high precision datetimes are supported on these platforms.  

#### Use

To add high precision time to a column, add `column['scale']` to the column specification to specify the number of decimal digits to include in the time. The maximum is platform specific. Since php's datetime objects hold a maximum of six decimal places, this is the effective practical maximum scale. Where fewer than six decimal digits are specified for a column, the time will be truncated or rounded depending on the platform.

#### Notes

PHP returns an error attempting to convert, for example, a time such as '10:10:10' (without decimal seconds) to a datetime object with a format of 'H:i:s.u' (with decimal seconds). To deal with columns specified as just `DATETIME` or `DATETIME(0)`, there is a fallback attempt to convert using 'H:i:s' should 'H:i:s.u' fail.

#### SQLite

SQLite stores `DATETIME`s as strings which can have arbitrary precision irrespective of column definition. This means a table could return any number of decimal places of precision for rows of one particular `DATETIME` column. This may be an issue because 10:10:10 != 10:10:10.0 as far as SQLite is concerned. Use of high precision times is therefore opt-in for SQLite. 

To enable high precision datetimes and times in SQLite, add `driverOption['high_precision_timestamps'] = true`.

This driver option selects between the existing `SQLitePlatform` and a new `SqliteHptPlatform` which uses a high precision time format string. 

#### Oracle

The format of datetimes returned by the database to DBAL is configured in driver middleware. The format does not include decimal digits. A driver configuration parameter has been added to change the underlying datetime format and enable high precision times.

To enable high precision datetimes and times in Oracle, add `driverOption['high_precision_timestamps'] = true`.

This driver option configures the middleware to add six decimal digits to `NLS_TIMESTAMP_FORMAT` and `NLS_TIMESTAMP_TZ_FORMAT` (i.e. .FF6) and selects a new `OracleHptPlatform` which uses high precision time format strings. 
