### PR TITLE
Fix bug where text type changes are ignored in MYSQL

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -17,6 +17,7 @@ use function array_unique;
 use function assert;
 use function count;
 use function get_class;
+use function in_array;
 use function sprintf;
 use function strtolower;
 
@@ -624,7 +625,8 @@ class Comparator
             $changedProperties[] = 'type';
         }
 
-        if (!in_array('type', $changedProperties, true) &&
+        if (
+            ! in_array('type', $changedProperties, true) &&
             $this->diffTextType($column1, $column2)
         ) {
             $changedProperties[] = 'type';
@@ -716,7 +718,7 @@ class Comparator
      */
     public function diffTextType(Column $column1, Column $column2)
     {
-        if (!$column1->getType() instanceof Types\TextType || !$column2->getType() instanceof Types\TextType) {
+        if (! $column1->getType() instanceof Types\TextType || ! $column2->getType() instanceof Types\TextType) {
             return false;
         }
 

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -624,6 +624,12 @@ class Comparator
             $changedProperties[] = 'type';
         }
 
+        if (!in_array('type', $changedProperties, true) &&
+            $this->diffTextType($column1, $column2)
+        ) {
+            $changedProperties[] = 'type';
+        }
+
         foreach (['notnull', 'unsigned', 'autoincrement'] as $property) {
             if ($properties1[$property] === $properties2[$property]) {
                 continue;
@@ -697,6 +703,27 @@ class Comparator
         }
 
         return array_unique($changedProperties);
+    }
+
+    /**
+     * Compares text type columns for length changes
+     *
+     * If length is different, type needs to change.
+     *
+     * Possible types in MYSQL are: tinytext, text, mediumtext and longtext.
+     *
+     * @return bool
+     */
+    public function diffTextType(Column $column1, Column $column2)
+    {
+        if (!$column1->getType() instanceof Types\TextType || !$column2->getType() instanceof Types\TextType) {
+            return false;
+        }
+
+        $length1 = $column1->getLength();
+        $length2 = $column2->getLength();
+
+        return $length1 !== $length2;
     }
 
     /**

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -13,7 +13,6 @@ use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
-use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
@@ -1336,5 +1337,38 @@ class ComparatorTest extends TestCase
         $diff = $this->comparator->compareSchemas($schema1, $schema2);
 
         self::assertEmpty($diff->orphanedForeignKeys);
+    }
+
+    public function testDiffTextTypeValidChange(): void
+    {
+        $column1 = new Column('col1', Type::getType('text'));
+        $column1->setLength(65536);
+
+        $column2 = new Column('col2', Type::getType('text'));
+        $column2->setLength(16777216);
+
+        self::assertTrue($this->comparator->diffTextType($column1, $column2));
+    }
+
+    public function testDiffTextTypeInvalidType(): void
+    {
+        $column1 = new Column('col1', Type::getType('string'));
+        $column1->setLength(255);
+
+        $column2 = new Column('col2', Type::getType('text'));
+        $column2->setLength(16777216);
+
+        self::assertFalse($this->comparator->diffTextType($column1, $column2));
+    }
+
+    public function testDiffTextTypeNoChange(): void
+    {
+        $column1 = new Column('col1', Type::getType('text'));
+        $column1->setLength(65536);
+
+        $column2 = new Column('col2', Type::getType('text'));
+        $column2->setLength(65536);
+
+        self::assertFalse($this->comparator->diffTextType($column1, $column2));
     }
 }


### PR DESCRIPTION
Changing a text type column to a `largetext`, `mediumtext` or `tinytext` are ignored.


|      Q       |   A
|------------- | -----------
| Type         |  bug
| Fixed issues | ?

#### Summary

This bug became apparent in Laravel 10 using `DBAL 3.6.1`.

When generating a migration that's initially a `text` type to a `medium` or `longtext` in `MYSQL`, the comparator doesn't believe the type has changed as the `ENUM` for all `text` types are the same is the same, but the length values are different. 

To solve this, when a column is a `text` type, compare the two columns to ensure no length sizes have changed. If changes are present, the type field is marked as changed. Once reaching the driver level, `MYSQL` will correctly set the new type.

Example project of bug present in a Laravel 10 project: https://github.com/liamh101/laravel-column-bug

Original bug reported in Laravel: https://github.com/laravel/framework/issues/46492



