### PR TITLE
SchemaDiff not detecting errors in column definition when using custom type

### DIFF
--- a/tests/Functional/Schema/MySQL/CustomType.php
+++ b/tests/Functional/Schema/MySQL/CustomType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Schema\MySQL;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\IntegerType;
+use Doctrine\DBAL\Types\Type;
+
+use function strtoupper;
+
+class CustomType extends IntegerType
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'custom_type';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+}

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\Functional\Schema\MySQL\CustomType;
 use Doctrine\DBAL\Tests\Functional\Schema\MySQL\PointType;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Type;
@@ -540,5 +541,28 @@ SQL;
         self::assertFalse($onlineTable->hasOption('autoincrement'));
         self::assertEquals('', $onlineTable->getOption('comment'));
         self::assertEquals([], $onlineTable->getOption('create_options'));
+    }
+
+    public function testSchemaDiffWithCustomColumnTypeWhileDatabaseTypeDiffers(): void
+    {
+        Type::addType('custom_type', CustomType::class);
+
+        $metadataTable = new Table('table_with_custom_type');
+        $metadataTable->addColumn('col1', 'custom_type');
+
+        self::assertSame(
+            ['CREATE TABLE table_with_custom_type (col1 INT NOT NULL COMMENT \'(DC2Type:custom_type)\') DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB'],
+            $this->connection->getDatabasePlatform()->getCreateTableSQL($metadataTable)
+        );
+
+        $this->connection->executeStatement('DROP TABLE IF EXISTS table_with_custom_type');
+
+        $this->connection->executeStatement('CREATE TABLE table_with_custom_type (col1 VARCHAR(255) NOT NULL COMMENT \'(DC2Type:custom_type)\')');
+        $onlineTable = $this->schemaManager->introspectTable('table_with_custom_type');
+
+        $comparator = $this->schemaManager->createComparator();
+        $tablesDiff = $comparator->compareTables($onlineTable, $metadataTable);
+
+        self::assertNotSame([], $this->connection->getDatabasePlatform()->getAlterTableSQL($tablesDiff)); // should generate VARCHAR -> INT change
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | 0

#### Summary

As seen in the failing test. When database column definition mismatches SQL definition of a custom type, such diff is not detected.
