### PR TITLE
fix(platforms): LOCATE as an argument to SUBSTRING is silently replaced with 0 when converting DQL to SQL

### DIFF
--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -59,11 +59,11 @@ class OraclePlatform extends AbstractPlatform
      */
     public function getSubstringExpression($string, $start, $length = null)
     {
-        if ($length !== null) {
-            return sprintf('SUBSTR(%s, %d, %d)', $string, $start, $length);
+        if ($length === null) {
+            return 'SUBSTR(' . $string . ', ' . $start . ')';
         }
 
-        return sprintf('SUBSTR(%s, %d)', $string, $start);
+        return 'SUBSTR(' . $string . ', ' . $start . ', ' . $length . ')';
     }
 
     /**

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -931,4 +931,24 @@ SQL
         return 'SELECT * FROM (SELECT a.*, ROWNUM AS doctrine_rownum FROM (SELECT * FROM user) a WHERE ROWNUM <= 3)'
             . ' WHERE doctrine_rownum >= 3';
     }
+
+    public function testGetSubstringExpression(): void
+    {
+        self::assertSame(
+            "SUBSTR('foobar', 2)",
+            $this->platform->getSubstringExpression("'foobar'", 2),
+        );
+        self::assertSame(
+            "SUBSTR('foobar', 4, 6)",
+            $this->platform->getSubstringExpression("'foobar'", 4, 6),
+        );
+        self::assertSame(
+            "SUBSTR(pagination, 1, INSTR(pagination, '-') - 1)",
+            $this->platform->getSubstringExpression(
+                'pagination',
+                1,
+                $this->platform->getLocateExpression('pagination', "'-'") . ' - 1',
+            ),
+        );
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #5974
#### Summary

Fix `getSubstringExpression` method for Oracle platform.
