### PR TITLE
Fix reference to removed DATE_INTERVAL_UNIT_* constants

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1705,7 +1705,7 @@ abstract class AbstractPlatform
      * @param string             $operator The arithmetic operator (+ or -).
      * @param int|numeric-string $interval The interval that shall be calculated into the date.
      * @param string             $unit     The unit of the interval that shall be calculated into the date.
-     *                                     One of the DATE_INTERVAL_UNIT_* constants.
+     *                                     One of the {@see DateIntervalUnit} constants.
      *
      * @return string
      *


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | documentation
| Fixed issues | N/A

#### Summary

These constants have been removed in #4082.
