### PR TITLE
SchemaDiff detecting errors in column definition when using custom type in 4.0.x

### DIFF
--- a/tests/Functional/Schema/MySQL/CustomType.php
+++ b/tests/Functional/Schema/MySQL/CustomType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema\MySQL;
+
+use Doctrine\DBAL\Types\IntegerType;
+
+class CustomType extends IntegerType
+{
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | 0

#### Summary

Added test to prove it got fixed in 4.0.x. [Original issue](https://github.com/doctrine/dbal/pull/5969).
