### PR TITLE
Support native UUID type on MariaDB

### DIFF
--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MariaDb1043Platform;
 use Doctrine\DBAL\Platforms\MariaDb1052Platform;
+use Doctrine\DBAL\Platforms\MariaDb1070Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -39,6 +40,10 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
 
         if ($mariadb) {
             $mariaDbVersion = $this->getMariaDbMysqlVersionNumber($version);
+            if (version_compare($mariaDbVersion, '10.7.0', '>=')) {
+                return new MariaDb1070Platform();
+            }
+
             if (version_compare($mariaDbVersion, '10.5.2', '>=')) {
                 return new MariaDb1052Platform();
             }

--- a/src/Platforms/MariaDb1070Platform.php
+++ b/src/Platforms/MariaDb1070Platform.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\Deprecation;
+
+class MariaDb1070Platform extends MariaDb1052Platform
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getGuidTypeDeclarationSQL(array $column)
+    {
+        return 'UUID';
+    }
+
+    /**
+     * Does this platform have native guid type.
+     *
+     * @deprecated
+     *
+     * @return bool
+     */
+    public function hasNativeGuidType()
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5509',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
+        return true;
+    }
+
+    protected function initializeDoctrineTypeMappings(): void
+    {
+        parent::initializeDoctrineTypeMappings();
+
+        $this->doctrineTypeMapping['uuid'] = Types::GUID;
+    }
+}

--- a/tests/Functional/Platform/MariaDB/UuidUpgradeTest.php
+++ b/tests/Functional/Platform/MariaDB/UuidUpgradeTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Platform\MariaDB;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MariaDb1052Platform;
+use Doctrine\DBAL\Platforms\MariaDb1070Platform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\GuidType;
+
+final class UuidUpgradeTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! $this->connection->getDatabasePlatform() instanceof MariaDb1070Platform) {
+            self::markTestSkipped('This test requires MariDB 10.7 or newer');
+        }
+
+        $params             = $this->connection->getParams();
+        $params['platform'] = new MariaDb1052Platform();
+
+        $legacyConnection = DriverManager::getConnection(
+            $params,
+            $this->connection->getConfiguration(),
+        );
+
+        $schemaManager = $legacyConnection->createSchemaManager();
+        try {
+            $schemaManager->dropTable('legacy_uuid');
+        } catch (Exception\TableNotFoundException $e) {
+            // ignore
+        }
+
+        $schemaManager->createTable($this->getTableDefinition());
+
+        $legacyConnection->insert(
+            'legacy_uuid',
+            ['id' => '94829370-f7ba-4536-bbb7-2e63b84492d4'],
+            ['id' => new GuidType()],
+        );
+    }
+
+    public function testReadFromLegacyTable(): void
+    {
+        $type = new GuidType();
+        $uuid = $this->connection->fetchOne(
+            'SELECT id FROM legacy_uuid WHERE id = ?',
+            ['94829370-f7ba-4536-bbb7-2e63b84492d4'],
+            [$type],
+        );
+
+        self::assertSame(
+            '94829370-f7ba-4536-bbb7-2e63b84492d4',
+            $type->convertToPHPValue($uuid, $this->connection->getDatabasePlatform()),
+        );
+    }
+
+    public function testInsertIntoLegacyTable(): void
+    {
+        $type = new GuidType();
+        $this->connection->insert(
+            'legacy_uuid',
+            ['id' => '8e63fb88-facd-4208-abd2-877720242507'],
+            ['id' => new GuidType()],
+        );
+
+        $uuid = $this->connection->fetchOne(
+            'SELECT id FROM legacy_uuid WHERE id = ?',
+            ['8e63fb88-facd-4208-abd2-877720242507'],
+            [$type],
+        );
+
+        self::assertSame(
+            '8e63fb88-facd-4208-abd2-877720242507',
+            $type->convertToPHPValue($uuid, $this->connection->getDatabasePlatform()),
+        );
+    }
+
+    public function testUpgradeTable(): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $comparator    = $schemaManager->createComparator();
+
+        $diff = $comparator->compareTables(
+            $schemaManager->introspectTable('legacy_uuid'),
+            $this->getTableDefinition(),
+        );
+
+        self::assertFalse($diff->isEmpty());
+
+        $schemaManager->alterTable($diff);
+
+        self::assertSame(
+            'uuid',
+            $this->connection->fetchOne(
+                'SELECT DATA_TYPE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
+                [$this->connection->getDatabase(), 'legacy_uuid'],
+            ),
+        );
+
+        $type = new GuidType();
+        $uuid = $this->connection->fetchOne(
+            'SELECT id FROM legacy_uuid WHERE id = ?',
+            ['94829370-f7ba-4536-bbb7-2e63b84492d4'],
+            [$type],
+        );
+
+        self::assertSame(
+            '94829370-f7ba-4536-bbb7-2e63b84492d4',
+            $type->convertToPHPValue($uuid, $this->connection->getDatabasePlatform()),
+        );
+    }
+
+    private function getTableDefinition(): Table
+    {
+        return new Table(
+            'legacy_uuid',
+            [new Column('id', new GuidType())],
+            [new Index('PRIMARY', ['id'], false, true)],
+        );
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | #5804

#### Summary

This PR implements native UUID column support for [MariaDB 10.7.0 and above](https://mariadb.com/kb/en/uuid-data-type/).

Currently, we implement UUIDs on MariaDB as `CHAR(36)`. While this might not have been the most efficient way of storing a UUID is the past, it luckily allows a smooth upgrade. This PR includes a functional test that makes sure old `CHAR(36)` columns:

* … can be queried without migrating them to `UUID`.
* … can be migrated to `UUID` without data loss.
