### PR TITLE
Automatically create index name

### DIFF
--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -76,7 +76,15 @@ class Table extends AbstractAsset
         }
 
         foreach ($indexes as $idx) {
-            $this->_addIndex($idx);
+            $idxName = $idx->getName() === '' ? null : $idx->getName();
+
+            if ($idx->isPrimary()) {
+                $this->setPrimaryKey($idx->getColumns(), $idxName);
+            } elseif ($idx->isUnique()) {
+                $this->addUniqueIndex($idx->getColumns(), $idxName, $idx->getOptions());
+            } else {
+                $this->addIndex($idx->getColumns(), $idxName, $idx->getFlags(), $idx->getOptions());
+            }
         }
 
         foreach ($uniqueConstraints as $uniqueConstraint) {

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -167,6 +167,23 @@ class TableTest extends TestCase
         self::assertSame('bar_idx', $table->getIndex('bar_idx')->getName());
     }
 
+    public function testCreateTableWithUnnamedIndexes(): void
+    {
+        $type    = Type::getType('integer');
+        $columns = [
+            new Column('foo', $type),
+            new Column('bar', $type),
+        ];
+        $indexes = [
+            new Index(null, ['foo']),
+            new Index(null, ['bar']),
+        ];
+        $table   = new Table('foo', $columns, $indexes);
+
+        self::assertTrue($table->hasIndex('IDX_8C7365218C736521'));
+        self::assertTrue($table->hasIndex('IDX_8C73652176FF8CAA'));
+    }
+
     public function testGetUnknownIndexThrowsException(): void
     {
         $this->expectException(SchemaException::class);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug

#### Summary

If I add an un-named index to a table using `$table->addIndex(['col1'])`, then an index name is created automatically.
This happens [here](https://github.com/doctrine/dbal/blob/d12da23c3b295911c5e7067321841976e772c01c/src/Schema/Table.php#L150-L154).

But if I add un-named indexes using `Table::__construct`, this does not happen and I get an error.

```
$table = new Table(
            name: 't',
            columns: [
                new Column(name: 'col1', type: new IntegerType()),
                new Column(name: 'col2', type: new IntegerType()),
            ],
            indexes: [
                new Index(name: null, columns: ['col1']),
                new Index(name: null, columns: ['col2']),
            ],
        );
```

`Doctrine\DBAL\Schema\Exception\IndexAlreadyExists: An index with name "" was already defined on table`

This PR copies the same logic for creating index names to the table constructor.