### PR TITLE
Implement binary array parameter type

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -248,10 +248,11 @@ SQL injection possibilities if not handled carefully.
 Doctrine DBAL implements a very powerful parsing process that will make this kind of prepared
 statement possible natively in the binding type system.
 The parsing necessarily comes with a performance overhead, but only if you really use a list of parameters.
-There are two special binding types that describe a list of integers or strings:
+There are three special binding types that describe a list of integers, regular strings or binary strings:
 
 -   ``\Doctrine\DBAL\ArrayParameterType::INTEGER``
 -   ``\Doctrine\DBAL\ArrayParameterType::STRING``
+-   ``\Doctrine\DBAL\ArrayParameterType::BINARY``
 
 Using one of these constants as a type you can activate the SQLParser inside Doctrine that rewrites
 the SQL and flattens the specified values into the set of parameters. Consider our previous example:

--- a/src/ArrayParameterType.php
+++ b/src/ArrayParameterType.php
@@ -21,6 +21,11 @@ enum ArrayParameterType
      */
     case ASCII;
 
+    /**
+     * Represents an array of binary strings to be expanded by Doctrine SQL parsing.
+     */
+    case BINARY;
+
     /** @internal */
     public static function toElementParameterType(self $type): ParameterType
     {
@@ -28,6 +33,7 @@ enum ArrayParameterType
             self::INTEGER => ParameterType::INTEGER,
             self::STRING => ParameterType::STRING,
             self::ASCII => ParameterType::ASCII,
+            self::BINARY => ParameterType::BINARY,
         };
     }
 }

--- a/tests/Connection/ExpandArrayParametersTest.php
+++ b/tests/Connection/ExpandArrayParametersTest.php
@@ -14,6 +14,8 @@ use Doctrine\DBAL\SQL\Parser;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
 
+use function hex2bin;
+
 /** @psalm-import-type WrapperParameterTypeArray from Connection */
 class ExpandArrayParametersTest extends TestCase
 {
@@ -107,16 +109,24 @@ class ExpandArrayParametersTest extends TestCase
                 [1 => ParameterType::STRING, 2 => ParameterType::STRING],
             ],
             'Positional: explicit keys for array params and array types' => [
-                'SELECT * FROM Foo WHERE foo IN (?) AND bar IN (?) AND baz = ? AND bax IN (?)',
-                [1 => ['bar1', 'bar2'], 2 => true, 0 => [1, 2, 3], ['bax1', 'bax2']],
+                'SELECT * FROM Foo WHERE foo IN (?) AND bar IN (?) AND baz = ? AND bax IN (?) AND bay IN (?)',
                 [
+                    1 => ['bar1', 'bar2'],
+                    2 => true,
+                    0 => [1, 2, 3],
+                    ['bax1', 'bax2'],
+                    4 => [hex2bin('DEADBEEF'), hex2bin('C0DEF00D')],
+                ],
+                [
+                    4 => ArrayParameterType::BINARY,
                     3 => ArrayParameterType::ASCII,
                     2 => ParameterType::BOOLEAN,
                     1 => ArrayParameterType::STRING,
                     0 => ArrayParameterType::INTEGER,
                 ],
-                'SELECT * FROM Foo WHERE foo IN (?, ?, ?) AND bar IN (?, ?) AND baz = ? AND bax IN (?, ?)',
-                [1, 2, 3, 'bar1', 'bar2', true, 'bax1', 'bax2'],
+                'SELECT * FROM Foo WHERE foo IN (?, ?, ?) AND bar IN (?, ?) AND baz = ? AND bax IN (?, ?) ' .
+                    'AND bay IN (?, ?)',
+                [1, 2, 3, 'bar1', 'bar2', true, 'bax1', 'bax2', hex2bin('DEADBEEF'), hex2bin('C0DEF00D')],
                 [
                     ParameterType::INTEGER,
                     ParameterType::INTEGER,
@@ -126,6 +136,8 @@ class ExpandArrayParametersTest extends TestCase
                     ParameterType::BOOLEAN,
                     ParameterType::ASCII,
                     ParameterType::ASCII,
+                    ParameterType::BINARY,
+                    ParameterType::BINARY,
                 ],
             ],
             'Named: Very simple with param int' => [
@@ -322,6 +334,22 @@ class ExpandArrayParametersTest extends TestCase
                 'SELECT NULL FROM dummy WHERE ? IN (?, ?)',
                 ['foo', 'bar', 'baz'],
                 [1 => ParameterType::STRING, ParameterType::STRING],
+            ],
+            'Named: Binary array with explicit types' => [
+                'SELECT * FROM Foo WHERE foo IN (:foo) OR bar IN (:bar)',
+                [
+                    'foo' => [hex2bin('DEADBEEF'), hex2bin('C0DEF00D')],
+                    'bar' => [hex2bin('DEADBEEF'), hex2bin('C0DEF00D')],
+                ],
+                ['foo' => ArrayParameterType::BINARY, 'bar' => ArrayParameterType::BINARY],
+                'SELECT * FROM Foo WHERE foo IN (?, ?) OR bar IN (?, ?)',
+                [hex2bin('DEADBEEF'), hex2bin('C0DEF00D'), hex2bin('DEADBEEF'), hex2bin('C0DEF00D')],
+                [
+                    ParameterType::BINARY,
+                    ParameterType::BINARY,
+                    ParameterType::BINARY,
+                    ParameterType::BINARY,
+                ],
             ],
         ];
     }

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -16,6 +16,8 @@ use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+use function hex2bin;
+
 /** @psalm-import-type WrapperParameterTypeArray from Connection */
 class QueryBuilderTest extends TestCase
 {
@@ -814,12 +816,17 @@ class QueryBuilderTest extends TestCase
         $qb->andWhere('name IN (:names)');
         $qb->setParameter('names', ['john', 'jane'], ArrayParameterType::STRING);
 
+        $qb->andWhere('hash IN (:hashes)');
+        $qb->setParameter('hashes', [hex2bin('DEADBEEF'), hex2bin('C0DEF00D')], ArrayParameterType::BINARY);
+
         self::assertSame(ArrayParameterType::INTEGER, $qb->getParameterType('ids'));
         self::assertSame(ArrayParameterType::STRING, $qb->getParameterType('names'));
+        self::assertSame(ArrayParameterType::BINARY, $qb->getParameterType('hashes'));
 
         self::assertSame([
             'ids'   => ArrayParameterType::INTEGER,
             'names' => ArrayParameterType::STRING,
+            'hashes' => ArrayParameterType::BINARY,
         ], $qb->getParameterTypes());
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

Doctrine does not support ArrayParameterType::BINARY, thus when trying to query data with binary parameters (some hash for example) - you get no results. 

Spotted this when I was working with Sqlite3 driver and trying to query data by binary id column.