### PR TITLE
Add `DB2111Platform`

### DIFF
--- a/ci/github/phpunit/ibm_db2.xml
+++ b/ci/github/phpunit/ibm_db2.xml
@@ -16,6 +16,12 @@
         <var name="db_user" value="db2inst1"/>
         <var name="db_password" value="Doctrine2018"/>
         <var name="db_dbname" value="doctrine"/>
+
+        <var name="tmpdb_driver" value="ibm_db2"/>
+        <var name="tmpdb_host" value="127.0.0.1"/>
+        <var name="tmpdb_user" value="db2inst1"/>
+        <var name="tmpdb_password" value="Doctrine2018"/>
+        <var name="tmpdb_dbname" value="doctrine"/>
     </php>
 
     <testsuites>

--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -61,7 +61,8 @@ PostgreSQL
 IBM DB2
 ^^^^^^^
 
--  ``Db2Platform`` for all versions.
+-  ``Db2Platform`` for version 9.7 and above.
+-  ``Db2111Platform`` for version 11.1 (11.1 GA) and above.
 
 SQLite
 ^^^^^^

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -55,6 +55,7 @@
                 <!--
                     TODO: remove in 4.0.0
                 -->
+                <referencedClass name="Doctrine\DBAL\Platforms\DB2111Platform"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\MariaDb102Keywords"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\PostgreSQL100Keywords"/>

--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -3,20 +3,24 @@
 namespace Doctrine\DBAL\Driver;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\API\IBMDB2\ExceptionConverter;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2111Platform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
+use Doctrine\DBAL\VersionAwarePlatformDriver;
 use Doctrine\Deprecations\Deprecation;
 
 use function assert;
+use function preg_match;
+use function version_compare;
 
 /**
  * Abstract base implementation of the {@see Driver} interface for IBM DB2 based drivers.
  */
-abstract class AbstractDB2Driver implements Driver
+abstract class AbstractDB2Driver implements VersionAwarePlatformDriver
 {
     /**
      * {@inheritdoc}
@@ -48,5 +52,49 @@ abstract class AbstractDB2Driver implements Driver
     public function getExceptionConverter(): ExceptionConverterInterface
     {
         return new ExceptionConverter();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createDatabasePlatformForVersion($version)
+    {
+        if (version_compare($this->getVersionNumber($version), '11.1', '>=')) {
+            return new DB2111Platform();
+        }
+
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5156',
+            'IBM DB2 < 11.1 support is deprecated and will be removed in DBAL 4.'
+                . ' Consider upgrading to IBM DB2 11.1 or later.',
+        );
+
+        return $this->getDatabasePlatform();
+    }
+
+    /**
+     * Detects IBM DB2 server version
+     *
+     * @param string $versionString Version string as returned by IBM DB2 server, i.e. 'DB2/LINUXX8664 11.5.8.0'
+     *
+     * @throws DBALException
+     */
+    private function getVersionNumber(string $versionString): string
+    {
+        if (
+            preg_match(
+                '/^(?:[^\s]+\s)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)/i',
+                $versionString,
+                $versionParts,
+            ) === 0
+        ) {
+            throw DBALException::invalidPlatformVersionSpecified(
+                $versionString,
+                '^(?:[^\s]+\s)?<major_version>.<minor_version>.<patch_version>',
+            );
+        }
+
+        return $versionParts['major'] . '.' . $versionParts['minor'] . '.' . $versionParts['patch'];
     }
 }

--- a/src/Platforms/DB2111Platform.php
+++ b/src/Platforms/DB2111Platform.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\DBAL\Exception;
+
+use function sprintf;
+
+/**
+ * Provides the behavior, features and SQL dialect of the IBM DB2 11.1 (11.1 GA) database platform.
+ *
+ * @deprecated This class will be merged with {@see DB2Platform} in 4.0 because support for IBM DB2
+ *             releases prior to 11.1 will be dropped.
+ *
+ * @see https://www.ibm.com/docs/en/db2/11.1?topic=database-whats-new-db2-version-111-ga
+ */
+class DB2111Platform extends DB2Platform
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see https://www.ibm.com/docs/en/db2/11.1?topic=subselect-fetch-clause
+     */
+    protected function doModifyLimitQuery($query, $limit, $offset)
+    {
+        if ($offset > 0) {
+            $query .= sprintf(' OFFSET %u ROWS', $offset);
+        }
+
+        if ($limit !== null) {
+            if ($limit < 0) {
+                throw new Exception(sprintf('Limit must be a positive integer or zero, %d given', $limit));
+            }
+
+            $query .= sprintf(' FETCH %s %u ROWS ONLY', $offset === 0 ? 'FIRST' : 'NEXT', $limit);
+        }
+
+        return $query;
+    }
+}

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -23,6 +23,9 @@ use function implode;
 use function sprintf;
 use function strpos;
 
+/**
+ * Provides the behavior, features and SQL dialect of the IBM DB2 database platform of the oldest supported version.
+ */
 class DB2Platform extends AbstractPlatform
 {
     /**
@@ -35,7 +38,8 @@ class DB2Platform extends AbstractPlatform
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/issues/3263',
-            'DB2Platform::getCharMaxLength() is deprecated.',
+            '%s() is deprecated.',
+            __METHOD__,
         );
 
         return 254;
@@ -51,7 +55,8 @@ class DB2Platform extends AbstractPlatform
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/issues/3263',
-            'DB2Platform::getBinaryMaxLength() is deprecated.',
+            '%s() is deprecated.',
+            __METHOD__,
         );
 
         return 32704;
@@ -127,7 +132,7 @@ class DB2Platform extends AbstractPlatform
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5058',
-            '%s is deprecated and will be removed in Doctrine DBAL 4.0. Use Type::requiresSQLCommentHint() instead.',
+            '%s() is deprecated and will be removed in Doctrine DBAL 4.0. Use Type::requiresSQLCommentHint() instead.',
             __METHOD__,
         );
 
@@ -192,7 +197,8 @@ class DB2Platform extends AbstractPlatform
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/issues/4749',
-            'DB2Platform::getName() is deprecated. Identify platforms by their class.',
+            '%s() is deprecated. Identify platforms by their class.',
+            __METHOD__,
         );
 
         return 'db2';
@@ -476,7 +482,7 @@ class DB2Platform extends AbstractPlatform
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5513',
-            '%s is deprecated.',
+            '%s() is deprecated.',
             __METHOD__,
         );
 
@@ -653,7 +659,7 @@ class DB2Platform extends AbstractPlatform
                 Deprecation::trigger(
                     'doctrine/dbal',
                     'https://github.com/doctrine/dbal/pull/5663',
-                    'Generation of "rename table" SQL using %s is deprecated. Use getRenameTableSQL() instead.',
+                    'Generation of "rename table" SQL using %s() is deprecated. Use getRenameTableSQL() instead.',
                     __METHOD__,
                 );
 
@@ -939,7 +945,8 @@ class DB2Platform extends AbstractPlatform
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/1519',
-            'DB2Platform::prefersIdentityColumns() is deprecated.',
+            '%s() is deprecated.',
+            __METHOD__,
         );
 
         return true;
@@ -985,8 +992,10 @@ class DB2Platform extends AbstractPlatform
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/issues/4510',
-            'DB2Platform::getReservedKeywordsClass() is deprecated,'
-                . ' use DB2Platform::createReservedKeywordsList() instead.',
+            '%s() is deprecated,'
+                . ' use %s::createReservedKeywordsList() instead.',
+            __METHOD__,
+            static::class,
         );
 
         return Keywords\DB2Keywords::class;

--- a/tests/Driver/AbstractDB2DriverTest.php
+++ b/tests/Driver/AbstractDB2DriverTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\AbstractDB2Driver;
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\API\IBMDB2\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2111Platform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
@@ -36,5 +37,23 @@ class AbstractDB2DriverTest extends AbstractDriverTest
     protected function createExceptionConverter(): ExceptionConverterInterface
     {
         return new ExceptionConverter();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDatabasePlatformsForVersions(): array
+    {
+        return [
+            ['10.1.0', DB2Platform::class, 'https://github.com/doctrine/dbal/pull/5156', true],
+            ['10.1.0.0', DB2Platform::class, 'https://github.com/doctrine/dbal/pull/5156', true],
+            ['DB2/LINUXX8664 10.1.0.0', DB2Platform::class, 'https://github.com/doctrine/dbal/pull/5156', true],
+            ['11.1.0', DB2111Platform::class],
+            ['11.1.0.0', DB2111Platform::class],
+            ['DB2/LINUXX8664 11.1.0.0', DB2111Platform::class],
+            ['11.5.8', DB2111Platform::class],
+            ['11.5.8.0', DB2111Platform::class],
+            ['DB2/LINUXX8664 11.5.8.0', DB2111Platform::class],
+        ];
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | n/a

#### Summary

In order to leverage the features of the more recent IBM DB2 versions without breaking BC with previous implementations, the `DB2111Platform` class is introduced in this PR to track the features from the [11.1 GA](https://www.ibm.com/docs/en/db2/11.1?topic=database-whats-new-db2-version-111-ga) version.

#### ToDo
- [x] Determine the exact version where `NEXT x ROWS` and `OFFSET y ROWS` clauses were introduced (the current assumption is `11.1` based on the lack of documentation for the feature in previous versions: https://www.ibm.com/docs/en/db2/11.1?topic=s-offset-clause). <- Confirmed: https://www.ibm.com/docs/en/db2/11.1?topic=ga-sql-compatibility-enhancements.
- [x] Determine if there are more changes in 11.1 version that need to be tracked. 
