### PR TITLE
Improve typing documentation related to `Type` and `Types`

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -26,6 +26,7 @@ use Doctrine\DBAL\Schema\LegacySchemaManagerFactory;
 use Doctrine\DBAL\Schema\SchemaManagerFactory;
 use Doctrine\DBAL\SQL\Parser;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
 use SensitiveParameter;
@@ -568,9 +569,10 @@ class Connection
      * Prepares and executes an SQL query and returns the first row of the result
      * as an associative array.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return array<string, mixed>|false False is returned if no rows are found.
      *
@@ -585,9 +587,10 @@ class Connection
      * Prepares and executes an SQL query and returns the first row of the result
      * as a numerically indexed array.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return list<mixed>|false False is returned if no rows are found.
      *
@@ -602,9 +605,10 @@ class Connection
      * Prepares and executes an SQL query and returns the value of a single column
      * of the first row of the result.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return mixed|false False is returned if no rows are found.
      *
@@ -670,9 +674,10 @@ class Connection
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param string                                                               $table    Table name
-     * @param array<string, mixed>                                                 $criteria Deletion criteria
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
+     * @param string                                  $table    Table name
+     * @param array<string, mixed>                    $criteria Deletion criteria
+     * @param array<int|string, int|string|Type|null> $types    Parameter types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return int|string The number of affected rows.
      *
@@ -739,10 +744,11 @@ class Connection
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param string                                                               $table    Table name
-     * @param array<string, mixed>                                                 $data     Column-value pairs
-     * @param array<string, mixed>                                                 $criteria Update criteria
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
+     * @param string                                  $table    Table name
+     * @param array<string, mixed>                    $data     Column-value pairs
+     * @param array<string, mixed>                    $criteria Update criteria
+     * @param array<int|string, int|string|Type|null> $types    Parameter types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return int|string The number of affected rows.
      *
@@ -775,9 +781,10 @@ class Connection
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param string                                                               $table Table name
-     * @param array<string, mixed>                                                 $data  Column-value pairs
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types Parameter types
+     * @param string                                  $table Table name
+     * @param array<string, mixed>                    $data  Column-value pairs
+     * @param array<int|string, int|string|Type|null> $types Parameter types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return int|string The number of affected rows.
      *
@@ -810,10 +817,12 @@ class Connection
     /**
      * Extract ordered type list from an ordered column list and type map.
      *
-     * @param array<int, string>                                                   $columnList
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     * @param array<int, string>                      $columnList
+     * @param array<int|string, int|string|Type|null> $types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      *
-     * @return array<int, int|string|Type|null>|array<string, int|string|Type|null>
+     * @return array<int|string, int|string|Type|null>
+     * @psalm-return array<int|string, int|ParameterType::*|Types::*|Type|null>
      */
     private function extractTypeValues(array $columnList, array $types): array
     {
@@ -851,6 +860,7 @@ class Connection
      *
      * @param mixed                $value
      * @param int|string|Type|null $type
+     * @psalm-param int|ParameterType::*|Types::*|Type|null $type
      *
      * @return mixed
      */
@@ -866,9 +876,10 @@ class Connection
     /**
      * Prepares and executes an SQL query and returns the result as an array of numeric arrays.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return list<list<mixed>>
      *
@@ -882,9 +893,10 @@ class Connection
     /**
      * Prepares and executes an SQL query and returns the result as an array of associative arrays.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return list<array<string,mixed>>
      *
@@ -899,9 +911,10 @@ class Connection
      * Prepares and executes an SQL query and returns the result as an associative array with the keys
      * mapped to the first column and the values mapped to the second column.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return array<mixed,mixed>
      *
@@ -917,9 +930,10 @@ class Connection
      * to the first column and the values being an associative array representing the rest of the columns
      * and their values.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return array<mixed,array<string,mixed>>
      *
@@ -933,9 +947,10 @@ class Connection
     /**
      * Prepares and executes an SQL query and returns the result as an array of the first column values.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return list<mixed>
      *
@@ -949,9 +964,10 @@ class Connection
     /**
      * Prepares and executes an SQL query and returns the result as an iterator over rows represented as numeric arrays.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return Traversable<int,list<mixed>>
      *
@@ -966,9 +982,10 @@ class Connection
      * Prepares and executes an SQL query and returns the result as an iterator over rows represented
      * as associative arrays.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return Traversable<int,array<string,mixed>>
      *
@@ -983,9 +1000,10 @@ class Connection
      * Prepares and executes an SQL query and returns the result as an iterator with the keys
      * mapped to the first column and the values mapped to the second column.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return Traversable<mixed,mixed>
      *
@@ -1001,9 +1019,10 @@ class Connection
      * to the first column and the values being an associative array representing the rest of the columns
      * and their values.
      *
-     * @param string                                           $query  SQL query
-     * @param list<mixed>|array<string, mixed>                 $params Query parameters
-     * @param array<int, int|string>|array<string, int|string> $types  Parameter types
+     * @param string                           $query  SQL query
+     * @param list<mixed>|array<string, mixed> $params Query parameters
+     * @param array<int|string, int|string>    $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return Traversable<mixed,array<string,mixed>>
      *
@@ -1017,9 +1036,10 @@ class Connection
     /**
      * Prepares and executes an SQL query and returns the result as an iterator over the first column values.
      *
-     * @param string                                                               $query  SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $query  SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return Traversable<int,mixed>
      *
@@ -1056,9 +1076,10 @@ class Connection
      * If the query is parametrized, a prepared statement is used.
      * If an SQLLogger is configured, the execution is logged.
      *
-     * @param string                                                               $sql    SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $sql    SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      *
      * @throws Exception
      */
@@ -1107,9 +1128,10 @@ class Connection
     /**
      * Executes a caching query.
      *
-     * @param string                                                               $sql    SQL query
-     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $sql    SQL query
+     * @param list<mixed>|array<string, mixed>        $params Query parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      *
      * @throws CacheException
      * @throws Exception
@@ -1166,9 +1188,10 @@ class Connection
      *
      * This method supports PDO binding types as well as DBAL mapping types.
      *
-     * @param string                                                               $sql    SQL statement
-     * @param list<mixed>|array<string, mixed>                                     $params Statement parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param string                                  $sql    SQL statement
+     * @param list<mixed>|array<string, mixed>        $params Statement parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return int|string The number of affected rows.
      *
@@ -1736,6 +1759,7 @@ class Connection
      *
      * @param mixed  $value The value to convert.
      * @param string $type  The name of the DBAL mapping type.
+     * @psalm-param Types::* $type
      *
      * @return mixed The converted value.
      *
@@ -1752,6 +1776,7 @@ class Connection
      *
      * @param mixed  $value The value to convert.
      * @param string $type  The name of the DBAL mapping type.
+     * @psalm-param Types::* $type
      *
      * @return mixed The converted type.
      *
@@ -1766,9 +1791,10 @@ class Connection
      * Binds a set of parameters, some or all of which are typed with a PDO binding type
      * or DBAL mapping type, to a given statement.
      *
-     * @param DriverStatement                                                      $stmt   Prepared statement
-     * @param list<mixed>|array<string, mixed>                                     $params Statement parameters
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param DriverStatement                         $stmt   Prepared statement
+     * @param list<mixed>|array<string, mixed>        $params Statement parameters
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      *
      * @throws Exception
      */
@@ -1828,8 +1854,10 @@ class Connection
      *
      * @param mixed                $value The value to bind.
      * @param int|string|Type|null $type  The type to bind (PDO or DBAL).
+     * @psalm-param int|ParameterType::*|Types::*|Type|null $type
      *
-     * @return array{mixed, int} [0] => the (escaped) value, [1] => the binding type.
+     * @return array<int, mixed|int> [0] => the (escaped) value, [1] => the binding type.
+     * @psalm-return array{0: mixed, 1: ParameterType::*|int}
      *
      * @throws Exception
      */
@@ -1862,8 +1890,9 @@ class Connection
     /**
      * @internal
      *
-     * @param list<mixed>|array<string, mixed>                                     $params
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     * @param list<mixed>|array<string, mixed>        $params
+     * @param array<int|string, int|string|Type|null> $types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      */
     final public function convertExceptionDuringQuery(
         Driver\Exception $e,
@@ -1881,10 +1910,12 @@ class Connection
     }
 
     /**
-     * @param array<int, mixed>|array<string, mixed>                               $params
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     * @param array<int, mixed>|array<string, mixed>  $params
+     * @param array<int|string, int|string|Type|null> $types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      *
-     * @return array{string, list<mixed>, array<int,Type|int|string|null>}
+     * @return array{string, list<mixed>, array<int, Type|int|string|null>}
+     * @psalm-return array{string, list<mixed>, array<int, int|ParameterType::*|Types::*|Type|null>}
      */
     private function expandArrayParameters(string $sql, array $params, array $types): array
     {
@@ -1901,8 +1932,8 @@ class Connection
     }
 
     /**
-     * @param array<int, mixed>|array<string, mixed>                               $params
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     * @param array<int, mixed>|array<string, mixed>  $params
+     * @param array<int|string, int|string|Type|null> $types
      */
     private function needsArrayParameterConversion(array $params, array $types): bool
     {
@@ -1944,6 +1975,7 @@ class Connection
      *
      * @param array<mixed>           $params The query parameters
      * @param array<int|string|null> $types  The parameter types
+     * @psalm-param array<int|ParameterType::*|Types::*|Type|null> $types
      */
     public function executeUpdate(string $sql, array $params = [], array $types = []): int
     {

--- a/src/ExpandArrayParameters.php
+++ b/src/ExpandArrayParameters.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\ArrayParameters\Exception\MissingNamedParameter;
 use Doctrine\DBAL\ArrayParameters\Exception\MissingPositionalParameter;
 use Doctrine\DBAL\SQL\Parser\Visitor;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 use function array_fill;
 use function array_key_exists;
@@ -18,7 +19,10 @@ final class ExpandArrayParameters implements Visitor
     /** @var array<int,mixed>|array<string,mixed> */
     private array $originalParameters;
 
-    /** @var array<int,Type|int|string|null>|array<string,Type|int|string|null> */
+    /**
+     * @var array<int|string, Type|int|string|null>
+     * @psalm-var array<int|string, int|ParameterType::*|Types::*|Type|null>
+     */
     private array $originalTypes;
 
     private int $originalParameterIndex = 0;
@@ -29,12 +33,16 @@ final class ExpandArrayParameters implements Visitor
     /** @var list<mixed> */
     private array $convertedParameters = [];
 
-    /** @var array<int,Type|int|string|null> */
+    /**
+     * @var array<int, Type|int|string|null>
+     * @psalm-var array<int, int|ParameterType::*|Types::*|Type|null>
+     */
     private array $convertedTypes = [];
 
     /**
-     * @param array<int, mixed>|array<string, mixed>                             $parameters
-     * @param array<int,Type|int|string|null>|array<string,Type|int|string|null> $types
+     * @param array<int|string, mixed>                $parameters
+     * @param array<int|string, Type|int|string|null> $types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      */
     public function __construct(array $parameters, array $types)
     {
@@ -116,7 +124,10 @@ final class ExpandArrayParameters implements Visitor
         $this->appendTypedParameter($value, ArrayParameterType::toElementParameterType($type));
     }
 
-    /** @return array<int,Type|int|string|null> */
+    /**
+     * @return array<int, Type|int|string|null>
+     * @psalm-return array<int, int|ParameterType::*|Types::*|Type|null>
+     */
     public function getTypes(): array
     {
         return $this->convertedTypes;
@@ -125,6 +136,7 @@ final class ExpandArrayParameters implements Visitor
     /**
      * @param list<mixed>          $values
      * @param Type|int|string|null $type
+     * @psalm-param int|ParameterType::*|Types::*|Type|null $type
      */
     private function appendTypedParameter(array $values, $type): void
     {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -76,7 +76,10 @@ abstract class AbstractPlatform
 
     public const CREATE_FOREIGNKEYS = 2;
 
-    /** @var string[]|null */
+    /**
+     * @var array<string, string>|null
+     * @psalm-var array<string, Types\Types::*>|null
+     */
     protected $doctrineTypeMapping;
 
     /**
@@ -393,6 +396,7 @@ abstract class AbstractPlatform
      *
      * @param string $dbType
      * @param string $doctrineType
+     * @psalm-param Types\Types::* $doctrineType
      *
      * @return void
      *
@@ -426,6 +430,7 @@ abstract class AbstractPlatform
      * @param string $dbType
      *
      * @return string
+     * @phpstan-return Types\Types::*
      *
      * @throws Exception
      */

--- a/src/Query.php
+++ b/src/Query.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL;
 
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 /**
  * An SQL query together with its bound parameters.
@@ -29,14 +30,14 @@ final class Query
      * The types of the parameters bound to the query.
      *
      * @var array<Type|int|string|null>
+     * @psalm-var array<int|string, int|ParameterType::*|Types::*|Type|null>
      */
     private array $types;
 
     /**
      * @param array<mixed>                $params
      * @param array<Type|int|string|null> $types
-     *
-     * @psalm-suppress ImpurePropertyAssignment
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      */
     public function __construct(string $sql, array $params, array $types)
     {
@@ -56,7 +57,10 @@ final class Query
         return $this->params;
     }
 
-    /** @return array<Type|int|string|null> */
+    /**
+     * @return array<Type|int|string|null>
+     * @psalm-return array<int|string, int|ParameterType::*|Types::*|Type|null>
+     */
     public function getTypes(): array
     {
         return $this->types;

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Statement;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 
 use function array_key_exists;
@@ -99,17 +100,22 @@ class QueryBuilder
     /**
      * The parameter type map of this query.
      *
-     * @var array<int, int|string|Type|null>|array<string, int|string|Type|null>
+     * @var array<int|string, int|string|Type|null>
+     * @psalm-var array<int|string, int|ParameterType::*|Types::*|Type|null>
      */
     private array $paramTypes = [];
 
     /**
-     * The type of query this is. Can be select, update or delete.
+     * The type of query this is. Can be select, update, insert or delete.
+     *
+     * @psalm-var self::SELECT|self::UPDATE|self::INSERT|self::DELETE
      */
     private int $type = self::SELECT;
 
     /**
      * The state of the query object. Can be dirty or clean.
+     *
+     * @psalm-var self::STATE_*
      */
     private int $state = self::STATE_CLEAN;
 
@@ -170,6 +176,7 @@ class QueryBuilder
      * @deprecated If necessary, track the type of the query being built outside of the builder.
      *
      * @return int
+     * @psalm-return self::SELECT|self::UPDATE|self::INSERT|self::DELETE
      */
     public function getType()
     {
@@ -438,6 +445,7 @@ class QueryBuilder
      * @param int|string           $key   Parameter position or name
      * @param mixed                $value Parameter value
      * @param int|string|Type|null $type  Parameter type
+     * @psalm-param int|ParameterType::*|Types::*|Type|null $type
      *
      * @return $this This QueryBuilder instance.
      */
@@ -473,8 +481,9 @@ class QueryBuilder
      *         ));
      * </code>
      *
-     * @param list<mixed>|array<string, mixed>                                     $params Parameters to set
-     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     * @param list<mixed>|array<string, mixed>        $params Parameters to set
+     * @param array<int|string, int|string|Type|null> $types  Parameter types
+     * @psalm-param array<int|string, int|ParameterType::*|Types::*|Type|null> $types
      *
      * @return $this This QueryBuilder instance.
      */
@@ -511,8 +520,8 @@ class QueryBuilder
     /**
      * Gets all defined query parameter types for the query being constructed indexed by parameter index or name.
      *
-     * @return array<int, int|string|Type|null>|array<string, int|string|Type|null> The currently defined
-     *                                                                              query parameter types
+     * @return array<int|string, int|string|Type|null> The currently defined query parameter types
+     * @psalm-return array<int|string, int|ParameterType::*|Types::*|Type|null>
      */
     public function getParameterTypes()
     {
@@ -525,6 +534,7 @@ class QueryBuilder
      * @param int|string $key The key of the bound parameter type
      *
      * @return int|string|Type The value of the bound parameter type
+     * @psalm-return int|ParameterType::*|Types::*|Type
      */
     public function getParameterType($key)
     {
@@ -1487,6 +1497,7 @@ class QueryBuilder
      * @param mixed                $value
      * @param int|string|Type|null $type
      * @param string               $placeHolder The name to bind with. The string must start with a colon ':'.
+     * @psalm-param int|ParameterType::*|Types::*|Type|null $type
      *
      * @return string the placeholder name used.
      */
@@ -1521,6 +1532,7 @@ class QueryBuilder
      *
      * @param mixed                $value
      * @param int|string|Type|null $type
+     * @psalm-param int|ParameterType::*|Types::*|Type|null $type
      *
      * @return string
      */
@@ -1533,8 +1545,8 @@ class QueryBuilder
     }
 
     /**
-     * @param string             $fromAlias
-     * @param array<string,true> $knownAliases
+     * @param string              $fromAlias
+     * @param array<string, true> $knownAliases
      *
      * @throws QueryException
      */

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DatabaseRequired;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 use Throwable;
 
@@ -1735,8 +1736,10 @@ abstract class AbstractSchemaManager
      *
      * @param string|null $comment
      * @param string      $currentType
+     * @psalm-param Types::* $currentType
      *
      * @return string
+     * @psalm-return Types::*
      */
     public function extractDoctrineTypeFromComment($comment, $currentType)
     {
@@ -1752,6 +1755,7 @@ abstract class AbstractSchemaManager
      *
      * @param string|null $comment
      * @param string|null $type
+     * @psalm-param Types::*|null $type
      *
      * @return string|null
      */

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider\CachingCollationMeta
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider\ConnectionCollationMetadataProvider;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 
 use function array_change_key_case;
@@ -311,6 +312,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
      * inferred from a DC2Type comment.
      *
      * @param mixed[] $tableColumn
+     * @psalm-param Types::* $type
      */
     private function expectedDbType(string $type, array $tableColumn): string
     {

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
@@ -332,6 +333,7 @@ class Table extends AbstractAsset
      * @param string  $name
      * @param string  $typeName
      * @param mixed[] $options
+     * @psalm-param Types::* $typeName
      *
      * @return Column
      *

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -4,9 +4,12 @@ namespace Doctrine\DBAL;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 
+use function assert;
 use function func_num_args;
+use function is_int;
 use function is_string;
 
 /**
@@ -32,6 +35,7 @@ class Statement
      * The parameter types.
      *
      * @var int[]|string[]
+     * @psalm-var array<int|ParameterType::*|Types::*|Type|null>
      */
     protected $types = [];
 
@@ -86,6 +90,7 @@ class Statement
      * @param string|int $param The name or position of the parameter.
      * @param mixed      $value The value of the parameter.
      * @param mixed      $type  Either a PDO binding type or a DBAL mapping type name or instance.
+     * @psalm-param int|ParameterType::*|Types::*|Type|null $type
      *
      * @return bool TRUE on success, FALSE on failure.
      *
@@ -111,6 +116,8 @@ class Statement
             }
         }
 
+        assert(is_int($bindingType));
+
         try {
             return $this->stmt->bindValue($param, $value, $bindingType);
         } catch (Driver\Exception $e) {
@@ -130,6 +137,7 @@ class Statement
      * @param int        $type     The binding type.
      * @param int|null   $length   Must be specified when using an OUT bind
      *                             so that PHP allocates enough memory to hold the returned value.
+     * @psalm-param ParameterType::* $type
      *
      * @return bool TRUE on success, FALSE on failure.
      *

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -103,6 +103,7 @@ abstract class Type
      * @deprecated this method will be removed in Doctrine DBAL 4.0.
      *
      * @return string
+     * @psalm-return Types::*
      */
     abstract public function getName();
 
@@ -127,8 +128,9 @@ abstract class Type
      * Type instances are implemented as flyweights.
      *
      * @param string $name The name of the type (as returned by getName()).
+     * @psalm-param Types::* $name
      *
-     * @return Type
+     * @return self
      *
      * @throws Exception
      */
@@ -141,7 +143,8 @@ abstract class Type
      * Adds a custom type to the type map.
      *
      * @param string             $name      The name of the type. This should correspond to what getName() returns.
-     * @param class-string<Type> $className The class name of the custom type.
+     * @param class-string<self> $className The class name of the custom type.
+     * @psalm-param Types::* $name
      *
      * @return void
      *
@@ -156,6 +159,7 @@ abstract class Type
      * Checks if exists support for a type.
      *
      * @param string $name The name of the type.
+     * @psalm-param Types::* $name
      *
      * @return bool TRUE if type is supported; FALSE otherwise.
      */
@@ -168,7 +172,8 @@ abstract class Type
      * Overrides an already defined type to use a different implementation.
      *
      * @param string             $name
-     * @param class-string<Type> $className
+     * @param class-string<self> $className
+     * @psalm-param Types::* $name
      *
      * @return void
      *
@@ -186,6 +191,7 @@ abstract class Type
      * This method should return one of the {@see ParameterType} constants.
      *
      * @return int
+     * @psalm-return ParameterType::*
      */
     public function getBindingType()
     {
@@ -197,11 +203,12 @@ abstract class Type
      * type class
      *
      * @return array<string, string>
+     * @psalm-return array<Types::*, class-string<self>>
      */
     public static function getTypesMap()
     {
         return array_map(
-            static function (Type $type): string {
+            static function (self $type): string {
                 return get_class($type);
             },
             self::getTypeRegistry()->getMap(),

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -15,10 +15,16 @@ use function in_array;
  */
 final class TypeRegistry
 {
-    /** @var array<string, Type> Map of type names and their corresponding flyweight objects. */
+    /**
+     * @var array<string, Type> Map of type names and their corresponding flyweight objects.
+     * @psalm-var array<Types::*, Type>
+     */
     private array $instances;
 
-    /** @param array<string, Type> $instances */
+    /**
+     * @param array<string, Type> $instances
+     * @psalm-param array<Types::*, Type> $instances
+     */
     public function __construct(array $instances = [])
     {
         $this->instances = $instances;
@@ -26,6 +32,8 @@ final class TypeRegistry
 
     /**
      * Finds a type by the given name.
+     *
+     * @psalm-param Types::* $name
      *
      * @throws Exception
      */
@@ -40,6 +48,8 @@ final class TypeRegistry
 
     /**
      * Finds a name for the given type.
+     *
+     * @psalm-return Types::* $name
      *
      * @throws Exception
      */
@@ -56,6 +66,8 @@ final class TypeRegistry
 
     /**
      * Checks if there is a type of the given name.
+     *
+     * @psalm-param Types::* $name
      */
     public function has(string $name): bool
     {
@@ -64,6 +76,8 @@ final class TypeRegistry
 
     /**
      * Registers a custom type to the type map.
+     *
+     * @psalm-param Types::* $name
      *
      * @throws Exception
      */
@@ -82,6 +96,8 @@ final class TypeRegistry
 
     /**
      * Overrides an already defined type to use a different implementation.
+     *
+     * @psalm-param Types::* $name
      *
      * @throws Exception
      */
@@ -104,12 +120,14 @@ final class TypeRegistry
      * @internal
      *
      * @return array<string, Type>
+     * @psalm-return array<Types::*, Type>
      */
     public function getMap(): array
     {
         return $this->instances;
     }
 
+    /** @psalm-return Types::*|null */
     private function findTypeName(Type $type): ?string
     {
         $name = array_search($type, $this->instances, true);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

Add some `@psalm-*` tags.

#### ToDo

- [ ] Add remaining tags;
- [ ] Confirm that the added tags are valid (in most of them, `int|ParameterType::*|Types::*|Type|null` was added, but I'm in doubt about the params from `PDO`, which are the cause for `int` and `ParameterType::*`);
- [ ] Determine if we should use a type alias for the cases with more occurrences;
- [ ] Suppress intentional typing mismatches from tests;