### PR TITLE
Ignore `static-analysis/` in git archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,5 +12,6 @@
 /psalm-strict.xml export-ignore
 /run-all.sh export-ignore
 /SECURITY.md export-ignore
+/static-analysis export-ignore
 /tests export-ignore
 /UPGRADE.md export-ignore


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

AFAIK, this directory should not be included in the public releases.

Related to #5853.