### PR TITLE
Avoid to pass an empty string to `SqliteSchemaManager::extractDoctrineTypeFromComment()`

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -76,7 +76,10 @@ abstract class AbstractPlatform
 
     public const CREATE_FOREIGNKEYS = 2;
 
-    /** @var string[]|null */
+    /**
+     * @var string[]|null
+     * @psalm-var non-empty-string[]|null
+     */
     protected $doctrineTypeMapping;
 
     /**
@@ -393,6 +396,7 @@ abstract class AbstractPlatform
      *
      * @param string $dbType
      * @param string $doctrineType
+     * @psalm-param non-empty-string $doctrineType
      *
      * @return void
      *
@@ -424,8 +428,10 @@ abstract class AbstractPlatform
      * Gets the Doctrine type that is mapped for the given database column type.
      *
      * @param string $dbType
+     * @psalm-param non-empty-string $dbType
      *
      * @return string
+     * @psalm-return non-empty-string
      *
      * @throws Exception
      */

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -1735,13 +1735,17 @@ abstract class AbstractSchemaManager
      *
      * @param string|null $comment
      * @param string      $currentType
+     * @psalm-param non-empty-string $currentType
      *
      * @return string
+     * @psalm-return non-empty-string
      */
     public function extractDoctrineTypeFromComment($comment, $currentType)
     {
-        if ($comment !== null && preg_match('(\(DC2Type:(((?!\)).)+)\))', $comment, $match) === 1) {
-            return $match[1];
+        if ($comment !== null && preg_match('(\(DC2Type:(?<type>(?:(?!\)).)+)\))', $comment, $match) === 1) {
+            assert($match['type'] !== '');
+
+            return $match['type'];
         }
 
         return $currentType;

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -170,7 +170,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
 
         $dbType = strtolower($tableColumn['type']);
         $dbType = strtok($dbType, '(), ');
-        assert(is_string($dbType));
+        assert(is_string($dbType) && $dbType !== '');
 
         $length = $tableColumn['length'] ?? strtok('(), ');
 

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -10,6 +10,7 @@ use Doctrine\Deprecations\Deprecation;
 
 use function array_change_key_case;
 use function array_values;
+use function assert;
 use function implode;
 use function is_string;
 use function preg_match;
@@ -151,6 +152,8 @@ class OracleSchemaManager extends AbstractSchemaManager
                 $dbType = 'timestamp';
             }
         }
+
+        assert($dbType !== '');
 
         $unsigned = $fixed = $precision = $scale = $length = null;
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -426,6 +426,8 @@ SQL,
             $tableColumn['complete_type'] = $tableColumn['domain_complete_type'];
         }
 
+        assert($dbType !== '');
+
         $type                   = $this->_platform->getDoctrineTypeMapping($dbType);
         $type                   = $this->extractDoctrineTypeFromComment($tableColumn['comment'], $type);
         $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -159,6 +159,8 @@ SQL,
             $fixed = true;
         }
 
+        assert($dbType !== '');
+
         $type                   = $this->_platform->getDoctrineTypeMapping($dbType);
         $type                   = $this->extractDoctrineTypeFromComment($tableColumn['comment'], $type);
         $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -103,6 +103,7 @@ abstract class Type
      * @deprecated this method will be removed in Doctrine DBAL 4.0.
      *
      * @return string
+     * @psalm-return non-empty-string
      */
     abstract public function getName();
 
@@ -142,6 +143,7 @@ abstract class Type
      *
      * @param string             $name      The name of the type. This should correspond to what getName() returns.
      * @param class-string<Type> $className The class name of the custom type.
+     * @psalm-param non-empty-string $name
      *
      * @return void
      *
@@ -169,6 +171,7 @@ abstract class Type
      *
      * @param string             $name
      * @param class-string<Type> $className
+     * @psalm-param non-empty-string $name
      *
      * @return void
      *
@@ -197,11 +200,13 @@ abstract class Type
      * type class
      *
      * @return array<string, string>
+     * @psalm-return array<non-empty-string, class-string<self>>
      */
     public static function getTypesMap()
     {
         return array_map(
-            static function (Type $type): string {
+            /** @psalm-return class-string<self> */
+            static function (self $type): string {
                 return get_class($type);
             },
             self::getTypeRegistry()->getMap(),

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -15,10 +15,16 @@ use function in_array;
  */
 final class TypeRegistry
 {
-    /** @var array<string, Type> Map of type names and their corresponding flyweight objects. */
+    /**
+     * @var array<string, Type> Map of type names and their corresponding flyweight objects.
+     * @psalm-var array<non-empty-string, Type>
+     */
     private array $instances;
 
-    /** @param array<string, Type> $instances */
+    /**
+     * @param array<string, Type> $instances
+     * @psalm-param array<non-empty-string, Type> $instances
+     */
     public function __construct(array $instances = [])
     {
         $this->instances = $instances;
@@ -65,6 +71,8 @@ final class TypeRegistry
     /**
      * Registers a custom type to the type map.
      *
+     * @psalm-param non-empty-string $name
+     *
      * @throws Exception
      */
     public function register(string $name, Type $type): void
@@ -82,6 +90,8 @@ final class TypeRegistry
 
     /**
      * Overrides an already defined type to use a different implementation.
+     *
+     * @psalm-param non-empty-string $name
      *
      * @throws Exception
      */
@@ -104,6 +114,7 @@ final class TypeRegistry
      * @internal
      *
      * @return array<string, Type>
+     * @psalm-return array<non-empty-string, Type>
      */
     public function getMap(): array
     {

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1472,6 +1472,9 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     /** @dataProvider commentsProvider */
     public function testExtractDoctrineTypeFromComment(string $comment, string $expected, string $currentType): void
     {
+        self::assertNotEmpty($comment);
+        self::assertNotEmpty($currentType);
+
         $result = $this->schemaManager->extractDoctrineTypeFromComment($comment, $currentType);
 
         self::assertSame($expected, $result);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

Related to #5998. This room for improvement was detected while working on that PR.

#### To Do

- [ ] Based on the questions and suggestions provided in the revision, we need to confirm if the support for empty strings must be avoided at runtime through a deprecation path (`/cc` @derrabus).