### PR TITLE
[MySQLi] Convert private property `Statement::$paramTypeMap` to class constant `PARAM_TYPE_MAP`

### DIFF
--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -27,8 +27,7 @@ use function str_repeat;
 
 final class Statement implements StatementInterface
 {
-    /** @var string[] */
-    private static array $paramTypeMap = [
+    private const PARAM_TYPE_MAP = [
         ParameterType::ASCII => 's',
         ParameterType::STRING => 's',
         ParameterType::BINARY => 's',
@@ -63,9 +62,11 @@ final class Statement implements StatementInterface
     }
 
     /**
+     * @deprecated Use {@see bindValue()} instead.
+     *
      * {@inheritdoc}
      *
-     * @deprecated Use {@see bindValue()} instead.
+     * @psalm-assert ParameterType::* $type
      */
     public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
@@ -87,18 +88,20 @@ final class Statement implements StatementInterface
             );
         }
 
-        if (! isset(self::$paramTypeMap[$type])) {
+        if (! isset(self::PARAM_TYPE_MAP[$type])) {
             throw UnknownParameterType::new($type);
         }
 
         $this->boundValues[$param] =& $variable;
-        $this->types[$param - 1]   = self::$paramTypeMap[$type];
+        $this->types[$param - 1]   = self::PARAM_TYPE_MAP[$type];
 
         return true;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-assert ParameterType::* $type
      */
     public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
@@ -113,13 +116,13 @@ final class Statement implements StatementInterface
             );
         }
 
-        if (! isset(self::$paramTypeMap[$type])) {
+        if (! isset(self::PARAM_TYPE_MAP[$type])) {
             throw UnknownParameterType::new($type);
         }
 
         $this->values[$param]      = $value;
         $this->boundValues[$param] =& $this->values[$param];
-        $this->types[$param - 1]   = self::$paramTypeMap[$type];
+        $this->types[$param - 1]   = self::PARAM_TYPE_MAP[$type];
 
         return true;
     }
@@ -173,10 +176,10 @@ final class Statement implements StatementInterface
             assert(is_int($parameter));
 
             if (! isset($types[$parameter - 1])) {
-                $types[$parameter - 1] = self::$paramTypeMap[ParameterType::STRING];
+                $types[$parameter - 1] = self::PARAM_TYPE_MAP[ParameterType::STRING];
             }
 
-            if ($types[$parameter - 1] === self::$paramTypeMap[ParameterType::LARGE_OBJECT]) {
+            if ($types[$parameter - 1] === self::PARAM_TYPE_MAP[ParameterType::LARGE_OBJECT]) {
                 if (is_resource($value)) {
                     if (get_resource_type($value) !== 'stream') {
                         throw NonStreamResourceUsedAsLargeObject::new($parameter);
@@ -187,7 +190,7 @@ final class Statement implements StatementInterface
                     continue;
                 }
 
-                $types[$parameter - 1] = self::$paramTypeMap[ParameterType::STRING];
+                $types[$parameter - 1] = self::PARAM_TYPE_MAP[ParameterType::STRING];
             }
 
             $values[$parameter] = $value;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

Follows #6003.

This change makes this mapping consistent with what we have for `PDO` and `SQLite3`:
https://github.com/doctrine/dbal/blob/f04e1b437543944957439f10a56dded7812cb705/src/Driver/PDO/ParameterTypeMap.php#L14-L22
https://github.com/doctrine/dbal/blob/f04e1b437543944957439f10a56dded7812cb705/src/Driver/SQLite3/Statement.php#L23-L31