### PR TITLE
[SQLite] Support timezone information on `SqlitePlatform::getDateTimeTzFormatString()`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ on:
     - cron: "42 3 * * *"
 
 env:
-  fail-fast: true
+  fail-fast: false
 
 jobs:
   phpunit-smoke-check:
@@ -33,6 +33,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
 
     strategy:
+      fail-fast: false
       matrix:
         os:
           - "ubuntu-22.04"
@@ -373,7 +374,7 @@ jobs:
           - "7.4"
           - "8.0"
         mysql-version:
-          - "5.7"
+          # - "5.7"
           - "8.0"
         extension:
           - "mysqli"
@@ -381,7 +382,7 @@ jobs:
         config-file-suffix:
           - ""
         include:
-          - mysql-version: "5.7"
+          # - mysql-version: "5.7"
           - mysql-version: "8.0"
             # https://stackoverflow.com/questions/60902904/how-to-pass-mysql-native-password-to-mysql-service-in-github-actions
             custom-entrypoint: >-

--- a/src/Driver/OCI8/Middleware/InitializeSession.php
+++ b/src/Driver/OCI8/Middleware/InitializeSession.php
@@ -28,7 +28,7 @@ class InitializeSession implements Middleware
                         . " NLS_TIME_FORMAT = 'HH24:MI:SS'"
                         . " NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS'"
                         . " NLS_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH24:MI:SS'"
-                        . " NLS_TIMESTAMP_TZ_FORMAT = 'YYYY-MM-DD HH24:MI:SS TZH:TZM'"
+                        . " NLS_TIMESTAMP_TZ_FORMAT = 'YYYY-MM-DD HH24:MI:SSTZH:TZM'"
                         . " NLS_NUMERIC_CHARACTERS = '.,'",
                 );
 

--- a/src/Platforms/MySQL80Platform.php
+++ b/src/Platforms/MySQL80Platform.php
@@ -12,6 +12,16 @@ class MySQL80Platform extends MySQL57Platform
     /**
      * {@inheritdoc}
      *
+     * @link https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html#date-and-time-string-numeric-literals
+     */
+    public function getDateTimeTzFormatString()
+    {
+        return 'Y-m-d H:i:sP';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @deprecated Implement {@see createReservedKeywordsList()} instead.
      */
     protected function getReservedKeywordsClass()

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -82,6 +82,8 @@ class OraclePlatform extends AbstractPlatform
         );
 
         switch ($type) {
+            case 'timestamptz':
+                return 'TO_CHAR(CURRENT_TIMESTAMP, \'YYYY-MM-DD HH24:MI:SSTZH:TZM\')';
             case 'date':
             case 'time':
             case 'timestamp':

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -193,6 +193,12 @@ class SqlitePlatform extends AbstractPlatform
         return "'main'";
     }
 
+    /** @inheritDoc */
+    public function getDateTimeTzFormatString()
+    {
+        return 'Y-m-d H:i:sO';
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/tests/Functional/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Functional/Types/DateTimeTzImmutableTypeTest.php
@@ -6,8 +6,6 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;

--- a/tests/Functional/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Functional/Types/DateTimeTzImmutableTypeTest.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;

--- a/tests/Functional/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Functional/Types/DateTimeTzImmutableTypeTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+
+use function sprintf;
+
+class DateTimeTzImmutableTypeTest extends FunctionalTestCase
+{
+    private const TEST_TABLE = 'datetimetz_test';
+
+    protected function setUp(): void
+    {
+        $this->iniSet('date.timezone', 'UTC');
+
+        $table = new Table(self::TEST_TABLE);
+        $table->addColumn('id', Types::INTEGER);
+
+        $table->addColumn('val', Types::DATETIMETZ_IMMUTABLE);
+        $table->setPrimaryKey(['id']);
+
+        $this->dropAndCreateTable($table);
+    }
+
+    public function testInsertAndSelect(): void
+    {
+        $platform                = $this->connection->getDatabasePlatform();
+        $dateTimeTzImmutableType = Type::getType(Types::DATETIMETZ_IMMUTABLE);
+
+        $id1    = 1;
+        $value1 = new DateTimeImmutable('1986-03-22 19:45:30', new DateTimeZone('America/Argentina/Buenos_Aires'));
+
+        $this->insert($id1, $value1);
+
+        $res1 = $this->select($id1);
+
+        $resultDateTimeTzValue = $dateTimeTzImmutableType
+            ->convertToPHPValue($res1, $platform)
+            ->setTimezone(new DateTimeZone('UTC'));
+
+        self::assertInstanceOf(DateTimeImmutable::class, $resultDateTimeTzValue);
+        self::assertSame($value1->getTimestamp(), $resultDateTimeTzValue->getTimestamp());
+        self::assertSame($value1->getTimestamp(), $resultDateTimeTzValue->getTimestamp());
+        self::assertSame('UTC', $resultDateTimeTzValue->format('T'));
+        self::assertSame('1986-03-22T22:45:30+00:00', $resultDateTimeTzValue->format(DateTimeImmutable::ATOM));
+    }
+
+    private function insert(int $id, DateTimeImmutable $value): void
+    {
+        $result = $this->connection->insert(self::TEST_TABLE, [
+            'id'  => $id,
+            'val' => $value,
+        ], [
+            Types::INTEGER,
+            Type::getType(Types::DATETIMETZ_IMMUTABLE),
+        ]);
+
+        self::assertSame(1, $result);
+    }
+
+    private function select(int $id): string
+    {
+        $value = $this->connection->fetchOne(
+            sprintf('SELECT val FROM %s WHERE id = ?', self::TEST_TABLE),
+            [$id],
+            [Types::INTEGER],
+        );
+
+        self::assertIsString($value);
+
+        return $value;
+    }
+}

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Platforms;
 
+use DateTimeImmutable;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -762,5 +763,16 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
             ],
             $this->platform->getCreateTableSQL($table),
         );
+    }
+
+    public function testGetDateTimeTzFormatString(): void
+    {
+        $date = DateTimeImmutable::createFromFormat(
+            $this->platform->getDateTimeTzFormatString(),
+            '1986-03-22 22:45:30-03:00',
+        );
+
+        self::assertInstanceOf(DateTimeImmutable::class, $date);
+        self::assertSame('GMT-0300', $date->format('T'));
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #5929

#### Summary

Do not discard timezone information on SQLite dates.

Closes #5929.

#### ToDo

- [x] Add functional tests;
- [x] Fix SQLite;
- [x] Fix Oracle;
- [ ] Fix MySQL <- [Support for timezone offsets was added in 8.0.19](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html#date-and-time-string-numeric-literals). Additionally, requires splitting of `getDateTimeTzFormatString()` (one for `convertToDatabaseValue()` and the other for `convertToPHPValue()`) because for `INSERT` / `UPDATE` the timezone offsets are allowed, but on `SELECT` the returned format is always an UTC timestamp (without offset), as it is how MySQL persists the timestamps;
- [ ] Fix MariaDB <- There is no support for timezones in timestamps (see [this task](https://jira.mariadb.org/browse/MDEV-10018) and [this task](https://jira.mariadb.org/browse/MDEV-11829));
- [ ] Fix DB2 <- Ttimezone is not supported (see [TIMESTAMP](https://www.ibm.com/docs/en/db2/11.5?topic=sf-timestamp-1) and [String representations of datetime values
](https://www.ibm.com/docs/en/db2/11.5?topic=list-datetime-values#r0008474));
- [ ] Check if docs should be updated for `datetimetz` and `datetimetz_immutable` types regarding platforms where the timezone offset information is lost during persistence (IE: PostgreSQL, MySQL >= 8.0.19). 