### PR TITLE
feat: add support for comparing pg `timestamp` and `time` precisions

### DIFF
--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -3,6 +3,8 @@
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
+use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\TimeType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 
@@ -82,6 +84,13 @@ class Column extends AbstractAsset
      */
     public function setOptions(array $options)
     {
+        if (
+            ($this->_type instanceof DateTimeType || $this->_type instanceof TimeType)
+            && ! isset($options['precision'])
+        ) {
+            $options['precision'] = 0;
+        }
+
         foreach ($options as $name => $value) {
             $method = 'set' . $name;
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -503,6 +503,18 @@ SQL,
 
                 break;
 
+            case 'timestamp':
+                if (
+                    preg_match(
+                        '~[A-Za-z]+\((\d+)\)~',
+                        $tableColumn['complete_type'],
+                        $match,
+                    ) === 1
+                ) {
+                    $precision = (int) $match[1];
+                }
+
+                break;
             case 'year':
                 $length = null;
                 break;

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -500,6 +500,23 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         ];
     }
 
+    public function testComparatorSupportsTimestampPrecision(): void
+    {
+        $this->dropTableIfExists('timestamp_tests');
+        $this->connection->executeQuery('CREATE TABLE timestamp_tests (dt timestamp(6) NOT NULL, t time(6) NOT NULL)');
+
+        $table = new Table('timestamp_test');
+        $table->addColumn('dt', 'datetime', ['precision' => 5]);
+        $table->addColumn('t', 'time', ['precision' => 5]);
+
+        $tableDiff = $this->schemaManager->createComparator()
+            ->compareTables($this->schemaManager->introspectTable('timestamp_tests'), $table);
+
+        self::assertCount(2, $tableDiff->changedColumns);
+        self::assertArrayHasKey('dt', $tableDiff->changedColumns);
+        self::assertArrayHasKey('t', $tableDiff->changedColumns);
+    }
+
     /** @dataProvider serialTypes */
     public function testAutoIncrementCreatesSerialDataTypesWithoutADefaultValue(string $type): void
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature

#### Summary

Different precisions in `timestamp` and `time` type are ignored now. This PR adds support for comparing it.

When no precision is set, it defaults to 0.
