### PR TITLE
Fix normalizer regex at `DsnParser::parse()`

### DIFF
--- a/src/Tools/DsnParser.php
+++ b/src/Tools/DsnParser.php
@@ -38,8 +38,8 @@ final class DsnParser
         #[SensitiveParameter]
         string $dsn
     ): array {
-        // (pdo_)?sqlite3?:///... => (pdo_)?sqlite3?://localhost/... or else the URL will be invalid
-        $url = preg_replace('#^((?:pdo_)?sqlite3?):///#', '$1://localhost/', $dsn);
+        // (pdo-)?sqlite3?:///... => (pdo-)?sqlite3?://localhost/... or else the URL will be invalid
+        $url = preg_replace('#^((?:pdo-)?sqlite3?):///#', '$1://localhost/', $dsn);
         assert($url !== null);
 
         $url = parse_url($url);

--- a/tests/Tools/DsnParserTest.php
+++ b/tests/Tools/DsnParserTest.php
@@ -78,6 +78,14 @@ final class DsnParserTest extends TestCase
                     'driver' => 'sqlite3',
                 ],
             ],
+            'pdo-sqlite relative URL without host' => [
+                'pdo-sqlite:///foo/dbname.sqlite',
+                [
+                    'host' => 'localhost',
+                    'path'   => 'foo/dbname.sqlite',
+                    'driver' => 'pdo_sqlite',
+                ],
+            ],
             'sqlite absolute URL without host' => [
                 'sqlite:////tmp/dbname.sqlite',
                 [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #5906

#### Summary

Fix DSN regex to search for "pdo-sqlite" scheme instead of "pdo_sqlite".

Closes #5906.