### PR TITLE
Add support for SQLite shorthand form in foreign key constraints

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -471,6 +471,16 @@ class SqliteSchemaManager extends AbstractSchemaManager
             $list[$id]['local'][] = $value['from'];
 
             if ($value['to'] === null) {
+                // Inferring a shorthand form for the foreign key constraint, where the "to" field is empty.
+                // @see https://www.sqlite.org/foreignkeys.html#fk_indexes.
+                $foreignTableIndexes = $this->_getPortableTableIndexesList([], $value['table']);
+
+                if (! isset($foreignTableIndexes['primary'])) {
+                    continue;
+                }
+
+                $list[$id]['foreign'] = [...$list[$id]['foreign'], ...$foreignTableIndexes['primary']->getColumns()];
+
                 continue;
             }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | #5941

#### Summary

Introspect the referenced table in order to get the foreign column.

Closes #5941.

#### ToDo

- [x] Check support for composite columns.