### PR TITLE
[docs] Fix anchor text at `types.rst`

### DIFF
--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -407,6 +407,7 @@ using comma delimited ``explode()`` or ``null`` if no data is present.
     This basically means that every array item other than ``string``
     will lose its type awareness.
 
+.. _json:
 json
 ^^^^
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

The anchors introduced at #6005 seem to be not working as expected:

![image](https://user-images.githubusercontent.com/1231441/232068471-309237c7-4c4d-4dc9-b1a1-498b3a57e6fd.png)

I'm adding an [explicit reference](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-ref) here, but it would be great if you have a setup to confirm if it will fix the issue.
Otherwise, please point me to the command used to build the docs in order to take a chance on my side.