### PR TITLE
[Oracle] Fix handling timestamp with time zone

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,13 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 3.7
+
+# Deprecated using wrong timezone format for Oracle session middleware
+
+The default timezone format ("YYYY-MM-DD HH24:MI:SS TZH:TZM") is wrong. In order to use the proper format
+("YYYY-MM-DD HH24:MI:SSTZH:TZM"),  pass `true` as argument 1 for `InitializeSession::__construct()`.
+
 # Upgrade to 3.6
 
 ## Deprecated not setting a schema manager factory

--- a/src/Driver/OCI8/Middleware/InitializeSession.php
+++ b/src/Driver/OCI8/Middleware/InitializeSession.php
@@ -6,13 +6,43 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use Doctrine\Deprecations\Deprecation;
 use SensitiveParameter;
 
 class InitializeSession implements Middleware
 {
+    /** @var bool */
+    private $useProperTzFormat = false;
+
+    public function __construct(bool $useProperTzFormat = false)
+    {
+        if (! $useProperTzFormat) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6012',
+                'Not passing `true` in argument 1 for "%s()" is deprecated, as this value ensures the proper format for'
+                . ' the "NLS_TIMESTAMP_TZ_FORMAT" session option. This argument will be removed in 4.0 as the proper'
+                . ' behavior will be used by default.',
+                __METHOD__,
+            );
+        }
+
+        $this->useProperTzFormat = $useProperTzFormat;
+    }
+
     public function wrap(Driver $driver): Driver
     {
-        return new class ($driver) extends AbstractDriverMiddleware {
+        return new class ($driver, $this->useProperTzFormat) extends AbstractDriverMiddleware {
+            /** @var bool */
+            private $useProperTzFormat = false;
+
+            public function __construct(Driver $driver, bool $useProperTzFormat = false)
+            {
+                parent::__construct($driver);
+
+                $this->useProperTzFormat = $useProperTzFormat;
+            }
+
             /**
              * {@inheritDoc}
              */
@@ -22,13 +52,16 @@ class InitializeSession implements Middleware
             ): Connection {
                 $connection = parent::connect($params);
 
+                // Use "YYYY-MM-DD HH24:MI:SSTZH:TZM" in 4.0.
+                $tzFormat = $this->useProperTzFormat ? 'YYYY-MM-DD HH24:MI:SSTZH:TZM' : 'YYYY-MM-DD HH24:MI:SS TZH:TZM';
+
                 $connection->exec(
                     'ALTER SESSION SET'
                         . " NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS'"
                         . " NLS_TIME_FORMAT = 'HH24:MI:SS'"
                         . " NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS'"
                         . " NLS_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH24:MI:SS'"
-                        . " NLS_TIMESTAMP_TZ_FORMAT = 'YYYY-MM-DD HH24:MI:SS TZH:TZM'"
+                        . " NLS_TIMESTAMP_TZ_FORMAT = '" . $tzFormat . "'"
                         . " NLS_NUMERIC_CHARACTERS = '.,'",
                 );
 

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -83,6 +83,8 @@ class OraclePlatform extends AbstractPlatform
         );
 
         switch ($type) {
+            case 'timestamptz':
+                return 'TO_CHAR(CURRENT_TIMESTAMP, \'YYYY-MM-DD HH24:MI:SSTZH:TZM\')';
             case 'date':
             case 'time':
             case 'timestamp':

--- a/tests/Functional/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Functional/Types/DateTimeTzImmutableTypeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+
+use function sprintf;
+
+class DateTimeTzImmutableTypeTest extends FunctionalTestCase
+{
+    private const TEST_TABLE = 'datetimetz_test';
+
+    protected function setUp(): void
+    {
+        if (! TestUtil::isDriverOneOf('pdo_oci', 'oci8')) {
+            self::markTestSkipped('This test is only allowed for "pdo_oci" and "oci8" by now.');
+        }
+
+        $table = new Table(self::TEST_TABLE);
+        $table->addColumn('id', Types::INTEGER);
+
+        $table->addColumn('val', Types::DATETIMETZ_IMMUTABLE);
+        $table->setPrimaryKey(['id']);
+
+        $this->dropAndCreateTable($table);
+    }
+
+    public function testInsertAndSelect(): void
+    {
+        $platform                = $this->connection->getDatabasePlatform();
+        $dateTimeTzImmutableType = Type::getType(Types::DATETIMETZ_IMMUTABLE);
+
+        $id1    = 1;
+        $value1 = new DateTimeImmutable('1986-03-22 19:45:30', new DateTimeZone('America/Argentina/Buenos_Aires'));
+
+        $this->insert($id1, $value1);
+
+        $res1 = $this->select($id1);
+
+        $resultDateTimeTzValue = $dateTimeTzImmutableType
+            ->convertToPHPValue($res1, $platform)
+            ->setTimezone(new DateTimeZone('UTC'));
+
+        self::assertInstanceOf(DateTimeImmutable::class, $resultDateTimeTzValue);
+        self::assertSame($value1->getTimestamp(), $resultDateTimeTzValue->getTimestamp());
+        self::assertSame($value1->getTimestamp(), $resultDateTimeTzValue->getTimestamp());
+        self::assertSame('UTC', $resultDateTimeTzValue->format('T'));
+        self::assertSame('1986-03-22T22:45:30+00:00', $resultDateTimeTzValue->format(DateTimeImmutable::ATOM));
+    }
+
+    private function insert(int $id, DateTimeImmutable $value): void
+    {
+        $result = $this->connection->insert(self::TEST_TABLE, [
+            'id'  => $id,
+            'val' => $value,
+        ], [
+            Types::INTEGER,
+            Type::getType(Types::DATETIMETZ_IMMUTABLE),
+        ]);
+
+        self::assertSame(1, $result);
+    }
+
+    private function select(int $id): string
+    {
+        $value = $this->connection->fetchOne(
+            sprintf('SELECT val FROM %s WHERE id = ?', self::TEST_TABLE),
+            [$id],
+            [Types::INTEGER],
+        );
+
+        self::assertIsString($value);
+
+        return $value;
+    }
+}

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -927,6 +927,23 @@ SQL
         ];
     }
 
+    /** @psalm-return iterable<int, array{string, string}> */
+    public function getNowExpressionCases(): iterable
+    {
+        yield ['TO_CHAR(CURRENT_TIMESTAMP, \'YYYY-MM-DD HH24:MI:SSTZH:TZM\')', 'timestamptz'];
+        yield ['TO_CHAR(CURRENT_TIMESTAMP, \'YYYY-MM-DD HH24:MI:SS\')', 'date'];
+        yield ['TO_CHAR(CURRENT_TIMESTAMP, \'YYYY-MM-DD HH24:MI:SS\')', 'time'];
+        yield ['TO_CHAR(CURRENT_TIMESTAMP, \'YYYY-MM-DD HH24:MI:SS\')', 'timestamp'];
+        yield ['TO_CHAR(CURRENT_TIMESTAMP, \'YYYY-MM-DD HH24:MI:SS\')', 'unknown_unsupported_type'];
+    }
+
+    /** @dataProvider getNowExpressionCases */
+    public function testGetNowExpression(string $expected, string $type): void
+    {
+        /** @psalm-suppress DeprecatedMethod */
+        self::assertSame($expected, $this->platform->getNowExpression($type));
+    }
+
     protected function getLimitOffsetCastToIntExpectedQuery(): string
     {
         return 'SELECT * FROM (SELECT a.*, ROWNUM AS doctrine_rownum FROM (SELECT * FROM user) a WHERE ROWNUM <= 3)'

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -148,7 +148,7 @@ class TestUtil
         switch ($driver) {
             case 'pdo_oci':
             case 'oci8':
-                $configuration->setMiddlewares([new InitializeSession()]);
+                $configuration->setMiddlewares([new InitializeSession(true)]);
                 break;
             case 'pdo_sqlite':
             case 'sqlite3':


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

* Fix format produced at `InitializeSession::connect()`, as it was not compatible with what is declared at `OraclePlatform::getDateTimeTzFormatString()`;
* Add missing declaration for "timestamptz" type at `OraclePlatform::getNowExpression()`.

This bug was detected after adding the functional test for the timezone aware fields in #6006.