### PR TITLE
[MySQL] Timezone support was added on version 8.0.19

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -220,6 +220,36 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     }
 
     /**
+     * Timezone support is not available until MySQL 8.0.19.
+     * MariaDB does not have timezone support.
+     *
+     * @link https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html#date-and-time-string-numeric-literals
+     * @link https://jira.mariadb.org/browse/MDEV-10018
+     * @link https://jira.mariadb.org/browse/MDEV-11829
+     *
+     * {@inheritdoc}
+     */
+    public function getDateTimeTzTypeDeclarationSQL(array $column)
+    {
+        throw Exception::notSupported(__METHOD__);
+    }
+
+    /**
+     * Timezone support is not available until MySQL 8.0.19.
+     * MariaDB does not have timezone support.
+     *
+     * @link https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html#date-and-time-string-numeric-literals
+     * @link https://jira.mariadb.org/browse/MDEV-10018
+     * @link https://jira.mariadb.org/browse/MDEV-11829
+     *
+     * {@inheritdoc}
+     */
+    public function getDateTimeTzFormatString()
+    {
+        throw Exception::notSupported(__METHOD__);
+    }
+
+    /**
      * {@inheritDoc}
      */
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed/*, $lengthOmitted = false*/)

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -4288,7 +4288,7 @@ abstract class AbstractPlatform
      */
     public function getDateTimeTzFormatString()
     {
-        return 'Y-m-d H:i:s';
+        return $this->getDateTimeFormatString();
     }
 
     /**

--- a/src/Platforms/MySQL80Platform.php
+++ b/src/Platforms/MySQL80Platform.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Types\PhpDateTimeMappingType;
 use Doctrine\Deprecations\Deprecation;
 
 /**
@@ -9,6 +10,22 @@ use Doctrine\Deprecations\Deprecation;
  */
 class MySQL80Platform extends MySQL57Platform
 {
+    /** @inheritdoc */
+    public function getDateTimeTzTypeDeclarationSQL(array $column)
+    {
+        return $this->getDateTimeTypeDeclarationSQL($column);
+    }
+
+    /** @inheritdoc */
+    public function getDateTimeTzFormatString(string $target = PhpDateTimeMappingType::CONVERSION_TARGET_DATABASE)
+    {
+        if ($target === PhpDateTimeMappingType::CONVERSION_TARGET_DATABASE) {
+            return 'Y-m-d H:i:sP';
+        }
+
+        return 'Y-m-d H:i:s';
+    }
+
     /**
      * {@inheritdoc}
      *

--- a/src/Types/DateTimeTzType.php
+++ b/src/Types/DateTimeTzType.php
@@ -56,7 +56,7 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
         }
 
         if ($value instanceof DateTimeInterface) {
-            return $value->format($platform->getDateTimeTzFormatString());
+            return $value->format($platform->getDateTimeTzFormatString(self::CONVERSION_TARGET_DATABASE));
         }
 
         throw ConversionException::conversionFailedInvalidType(
@@ -81,7 +81,7 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
             return $value;
         }
 
-        $val = DateTime::createFromFormat($platform->getDateTimeTzFormatString(), $value);
+        $val = DateTime::createFromFormat($platform->getDateTimeTzFormatString(self::CONVERSION_TARGET_PHP), $value);
         if ($val === false) {
             throw ConversionException::conversionFailedFormat(
                 $value,

--- a/src/Types/PhpDateTimeMappingType.php
+++ b/src/Types/PhpDateTimeMappingType.php
@@ -9,4 +9,6 @@ namespace Doctrine\DBAL\Types;
  */
 interface PhpDateTimeMappingType
 {
+    public const CONVERSION_TARGET_DATABASE = 'database';
+    public const CONVERSION_TARGET_PHP      = 'php';
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

This bug was detected after adding the functional test for the timezone aware fields in #6006.

* In MySQL, [support for timezone offsets was added in 8.0.19](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html#date-and-time-string-numeric-literals).
* In MariaDB, there is no support for timezones in timestamps (see [this task](https://jira.mariadb.org/browse/MDEV-10018) and [this task](https://jira.mariadb.org/browse/MDEV-11829));


#### ToDo

- [x] Check how to refactor or split `getDateTimeTzFormatString()` in two methods (one for `convertToDatabaseValue()` and the other for `convertToPHPValue()`) because for `INSERT` / `UPDATE` the timezone offsets are allowed, but on `SELECT` the returned format is always an UTC timestamp (without offset), as it is how MySQL persists the timestamps;
- [ ] Add tests;