### PR TITLE
Narrow responsibilities in datetime related types

### DIFF
--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -278,13 +278,19 @@ or ``null`` if no data is present.
     could cause quite some troubles on platforms that had various
     microtime precision formats.
     Starting with 2.5 whenever the parsing of a date fails with
-    the predefined platform format, the ``date_create()``
-    function will be used to parse the date.
+    the predefined platform format, ``DateTime::__construct()``
+    method will be used to parse the date.
 
     This could cause some troubles when your date format is weird
-    and not parsed correctly by ``date_create()``, however since
+    and not parsed correctly by ``DateTime::__construct()``, however since
     databases are rather strict on dates there should be no problem.
 
+.. warning::
+
+    Passing instances of ``DateTimeImmutable`` to this type is deprecated since 3.7. Use
+    :ref:`datetime_immutable` instead.
+
+.. _datetime_immutable:
 datetime_immutable
 ^^^^^^^^^^^^^^^^^^
 
@@ -301,6 +307,12 @@ information, you should consider using this type.
 Values retrieved from the database are always converted to PHP's ``\DateTime`` object
 or ``null`` if no data is present.
 
+.. warning::
+
+    Passing instances of ``DateTimeImmutable`` to this type is deprecated since 3.7. Use
+    :ref:`datetimetz_immutable` instead.
+
+.. _datetimetz_immutable:
 datetimetz_immutable
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -60,6 +60,13 @@
         <!-- ext-sqlite3 throws generic exceptions. -->
         <!-- Catching \Exception is legit here, and we don't want to widen types to \Throwable. -->
         <exclude-pattern>src/Driver/SQLite3/*</exclude-pattern>
+
+        <!-- Catching \Exception is legit for `\DateTime::__construct()`. -->
+        <exclude-pattern>src/Types/DateTimeType.php</exclude-pattern>
+        <exclude-pattern>src/Types/VarDateTimeType.php</exclude-pattern>
+        <!-- Catching \Exception is legit for `\DateTimeImmutable::__construct()`. -->
+        <exclude-pattern>src/Types/DateTimeImmutableType.php</exclude-pattern>
+        <exclude-pattern>src/Types/VarDateTimeImmutableType.php</exclude-pattern>
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">

--- a/src/Types/DateIntervalType.php
+++ b/src/Types/DateIntervalType.php
@@ -53,7 +53,7 @@ class DateIntervalType extends Type
             return $value->format(self::FORMAT);
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateInterval']);
+        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', DateInterval::class]);
     }
 
     /**

--- a/src/Types/DateTimeImmutableType.php
+++ b/src/Types/DateTimeImmutableType.php
@@ -5,8 +5,7 @@ namespace Doctrine\DBAL\Types;
 use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\Deprecation;
-
-use function date_create_immutable;
+use Exception;
 
 /**
  * Immutable type of {@see DateTimeType}.
@@ -64,19 +63,20 @@ class DateTimeImmutableType extends DateTimeType
 
         $dateTime = DateTimeImmutable::createFromFormat($platform->getDateTimeFormatString(), $value);
 
-        if ($dateTime === false) {
-            $dateTime = date_create_immutable($value);
+        if ($dateTime !== false) {
+            return $dateTime;
         }
 
-        if ($dateTime === false) {
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception $e) {
             throw ConversionException::conversionFailedFormat(
                 $value,
                 $this->getName(),
                 $platform->getDateTimeFormatString(),
+                $e,
             );
         }
-
-        return $dateTime;
     }
 
     /**

--- a/src/Types/DateTimeTzImmutableType.php
+++ b/src/Types/DateTimeTzImmutableType.php
@@ -62,15 +62,15 @@ class DateTimeTzImmutableType extends DateTimeTzType
 
         $dateTime = DateTimeImmutable::createFromFormat($platform->getDateTimeTzFormatString(), $value);
 
-        if ($dateTime === false) {
-            throw ConversionException::conversionFailedFormat(
-                $value,
-                $this->getName(),
-                $platform->getDateTimeTzFormatString(),
-            );
+        if ($dateTime !== false) {
+            return $dateTime;
         }
 
-        return $dateTime;
+        throw ConversionException::conversionFailedFormat(
+            $value,
+            $this->getName(),
+            $platform->getDateTimeTzFormatString(),
+        );
     }
 
     /**

--- a/src/Types/DateType.php
+++ b/src/Types/DateType.php
@@ -3,8 +3,12 @@
 namespace Doctrine\DBAL\Types;
 
 use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
+
+use function get_class;
 
 /**
  * Type that maps an SQL DATE to a PHP Date object.
@@ -43,10 +47,21 @@ class DateType extends Type
         }
 
         if ($value instanceof DateTimeInterface) {
+            if ($value instanceof DateTimeImmutable) {
+                Deprecation::triggerIfCalledFromOutside(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/6017',
+                    'Passing an instance of %s is deprecated, use %s::%s() instead.',
+                    get_class($value),
+                    DateImmutableType::class,
+                    __FUNCTION__,
+                );
+            }
+
             return $value->format($platform->getDateFormatString());
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
+        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', DateTime::class]);
     }
 
     /**
@@ -60,19 +75,30 @@ class DateType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
+        if ($value instanceof DateTimeImmutable) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6017',
+                'Passing an instance of %s is deprecated, use %s::%s() instead.',
+                get_class($value),
+                DateImmutableType::class,
+                __FUNCTION__,
+            );
+        }
+
         if ($value === null || $value instanceof DateTimeInterface) {
             return $value;
         }
 
-        $val = DateTime::createFromFormat('!' . $platform->getDateFormatString(), $value);
-        if ($val === false) {
-            throw ConversionException::conversionFailedFormat(
-                $value,
-                $this->getName(),
-                $platform->getDateFormatString(),
-            );
+        $dateTime = DateTime::createFromFormat('!' . $platform->getDateFormatString(), $value);
+        if ($dateTime !== false) {
+            return $dateTime;
         }
 
-        return $val;
+        throw ConversionException::conversionFailedFormat(
+            $value,
+            $this->getName(),
+            $platform->getDateFormatString(),
+        );
     }
 }

--- a/src/Types/TimeImmutableType.php
+++ b/src/Types/TimeImmutableType.php
@@ -62,15 +62,15 @@ class TimeImmutableType extends TimeType
 
         $dateTime = DateTimeImmutable::createFromFormat('!' . $platform->getTimeFormatString(), $value);
 
-        if ($dateTime === false) {
-            throw ConversionException::conversionFailedFormat(
-                $value,
-                $this->getName(),
-                $platform->getTimeFormatString(),
-            );
+        if ($dateTime !== false) {
+            return $dateTime;
         }
 
-        return $dateTime;
+        throw ConversionException::conversionFailedFormat(
+            $value,
+            $this->getName(),
+            $platform->getTimeFormatString(),
+        );
     }
 
     /**

--- a/src/Types/VarDateTimeImmutableType.php
+++ b/src/Types/VarDateTimeImmutableType.php
@@ -5,8 +5,7 @@ namespace Doctrine\DBAL\Types;
 use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\Deprecation;
-
-use function date_create_immutable;
+use Exception;
 
 /**
  * Immutable type of {@see VarDateTimeType}.
@@ -62,10 +61,10 @@ class VarDateTimeImmutableType extends VarDateTimeType
             return $value;
         }
 
-        $dateTime = date_create_immutable($value);
-
-        if ($dateTime === false) {
-            throw ConversionException::conversionFailed($value, $this->getName());
+        try {
+            $dateTime = new DateTimeImmutable($value);
+        } catch (Exception $e) {
+            throw ConversionException::conversionFailed($value, $this->getName(), $e);
         }
 
         return $dateTime;

--- a/src/Types/VarDateTimeType.php
+++ b/src/Types/VarDateTimeType.php
@@ -5,11 +5,10 @@ namespace Doctrine\DBAL\Types;
 use DateTime;
 use DateTimeInterface;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-
-use function date_create;
+use Exception;
 
 /**
- * Variable DateTime Type using date_create() instead of DateTime::createFromFormat().
+ * Variable DateTime Type using DateTime::__construct() instead of DateTime::createFromFormat().
  *
  * This type has performance implications as it runs twice as long as the regular
  * {@see DateTimeType}, however in certain PostgreSQL configurations with
@@ -32,11 +31,12 @@ class VarDateTimeType extends DateTimeType
             return $value;
         }
 
-        $val = date_create($value);
-        if ($val === false) {
-            throw ConversionException::conversionFailed($value, $this->getName());
+        try {
+            $dateTime = new DateTime($value);
+        } catch (Exception $e) {
+            throw ConversionException::conversionFailed($value, $this->getName(), $e);
         }
 
-        return $val;
+        return $dateTime;
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

* Deprecated passing other type than `DateTime|null` to `DateType`, `TimeType`, `DateTimeType`, `DateTimeTzType` and `VarDateTimeType`;
* `new DateTime()` and `new DateTimeImmutable()` are used as replacement to `date_create()` and `date_create_immutable()` procedural functions.

